### PR TITLE
EventEmitter trait implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.1.0"
 
 [features]
 default = []
-encryption = ["olm-rs", "serde/derive", "serde_json", "cjson", "async-trait"]
+encryption = ["olm-rs", "serde/derive", "serde_json", "cjson"]
 sqlite-cryptostore = ["sqlx", "zeroize"]
 
 [dependencies]
@@ -20,11 +20,13 @@ futures = "0.3.4"
 reqwest = "0.10.4"
 http = "0.2.1"
 url = "2.1.1"
+async-trait = "0.1.26"
+
 
 # Ruma dependencies
 js_int = "0.1.3"
 ruma-api = "0.15.0-dev.1"
-ruma-client-api = { version = "0.6.0", git = "https://github.com/matrix-org/ruma-client-api/" }
+ruma-client-api = { git = "https://github.com/matrix-org/ruma-client-api/", version = "0.6.0" }
 ruma-events = { git = "https://github.com/matrix-org/ruma-events", version = "0.17.0" }
 ruma-identifiers = "0.14.1"
 
@@ -37,7 +39,6 @@ zeroize = { version = "1.1.0", optional = true }
 
 # Misc dependencies
 thiserror = "1.0.13"
-async-trait = { version = "0.1.26", optional = true }
 tracing = "0.1.13"
 
 [dependencies.tracing-futures]
@@ -61,3 +62,4 @@ tokio = { version = "0.2.13", features = ["rt-threaded", "macros"] }
 tracing-subscriber = "0.2.3"
 tempfile = "3.1.0"
 mockito = "0.23.3"
+

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -17,12 +17,12 @@ struct EventCallback;
 
 #[async_trait::async_trait]
 impl EventEmitter for EventCallback {
-    async fn on_room_message(&mut self, room: Arc<Mutex<Room>>, event: Arc<Mutex<RoomEvent>>) {
-        if let RoomEvent::RoomMessage(MessageEvent {
+    async fn on_room_message(&mut self, room: Arc<Mutex<Room>>, event: Arc<Mutex<MessageEvent>>) {
+        if let MessageEvent {
             content: MessageEventContent::Text(TextMessageEventContent { body: msg_body, .. }),
             sender,
             ..
-        }) = event.lock().await.deref()
+        } = event.lock().await.deref()
         {
             let rooms = room.lock().await;
             let member = rooms.members.get(&sender.to_string()).unwrap();

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -1,6 +1,6 @@
+use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, RwLock};
 use std::{env, process::exit};
-use std::ops::{Deref, DerefMut};
 use url::Url;
 
 use matrix_sdk::{

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -1,14 +1,11 @@
-use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, RwLock};
+use std::ops::Deref;
+use std::sync::Arc;
 use std::{env, process::exit};
 use url::Url;
 
 use matrix_sdk::{
     self,
-    events::{
-        collections::all::RoomEvent,
-        room::message::{MessageEvent, MessageEventContent, TextMessageEventContent},
-    },
+    events::room::message::{MessageEvent, MessageEventContent, TextMessageEventContent},
     AsyncClient, AsyncClientConfig, EventEmitter, Room, SyncSettings,
 };
 use tokio::sync::Mutex;

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -270,7 +270,9 @@ impl AsyncClient {
         self.base_client.write().await.event_emitter = Some(emitter);
     }
 
-    /// Calculates the room name from a `RoomId`, returning a string.
+    /// Returns an `Option` of the room name from a `RoomId`.
+    ///
+    /// This is a human readable room name.
     pub async fn get_room_name(&self, room_id: &str) -> Option<String> {
         self.base_client
             .read()
@@ -279,19 +281,18 @@ impl AsyncClient {
             .await
     }
 
-    /// Calculates the room names this client knows about.
+    /// Returns a `Vec` of the room names this client knows about.
+    ///
+    /// This is a human readable list of room names.
     pub async fn get_room_names(&self) -> Vec<String> {
         self.base_client.read().await.calculate_room_names().await
     }
 
-    /// Calculates the room names this client knows about.
+    /// Returns the rooms this client knows about.
+    ///
+    /// A `HashMap` of room id to `matrix::models::Room`
     pub async fn get_rooms(&self) -> HashMap<String, Arc<tokio::sync::Mutex<Room>>> {
         self.base_client.read().await.joined_rooms.clone()
-    }
-
-    /// Calculates the room that the client last interacted with.
-    pub async fn current_room_id(&self) -> Option<RoomId> {
-        self.base_client.read().await.current_room_id()
     }
 
     /// Login to the server.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -20,7 +20,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures::future::{BoxFuture, Future, FutureExt};
+use futures::future::Future;
 use tokio::sync::RwLock;
 use tokio::time::delay_for as sleep;
 use tracing::{debug, info, instrument, trace};

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::result::Result as StdResult;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::future::{BoxFuture, Future, FutureExt};
@@ -263,13 +263,20 @@ impl AsyncClient {
     /// Add `EventEmitter` to `AsyncClient`.
     ///
     /// The methods of `EventEmitter` are called when the respective `RoomEvents` occur.
-    pub async fn add_event_emitter(&mut self, emitter: Arc<tokio::sync::Mutex<Box<dyn EventEmitter>>>) {
+    pub async fn add_event_emitter(
+        &mut self,
+        emitter: Arc<tokio::sync::Mutex<Box<dyn EventEmitter>>>,
+    ) {
         self.base_client.write().await.event_emitter = Some(emitter);
     }
 
     /// Calculates the room name from a `RoomId`, returning a string.
     pub async fn get_room_name(&self, room_id: &str) -> Option<String> {
-        self.base_client.read().await.calculate_room_name(room_id).await
+        self.base_client
+            .read()
+            .await
+            .calculate_room_name(room_id)
+            .await
     }
 
     /// Calculates the room names this client knows about.

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -23,7 +23,7 @@ use std::time::{Duration, Instant};
 use futures::future::{BoxFuture, Future, FutureExt};
 use tokio::sync::RwLock;
 use tokio::time::delay_for as sleep;
-use tracing::{info, instrument, trace};
+use tracing::{debug, info, instrument, trace};
 
 use http::Method as HttpMethod;
 use http::Response as HttpResponse;

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -367,7 +367,6 @@ impl AsyncClient {
                 client.get_or_create_room(&room_id_string).clone()
             };
 
-            // TODO should we determine if anything room state has changed before calling
             // re looping is not ideal here
             for event in &mut room.state.events {
                 if let EventResult::Ok(e) = event {
@@ -386,7 +385,6 @@ impl AsyncClient {
                     *event = e;
                 }
 
-                // TODO should we determine if any room state has changed before calling
                 if let EventResult::Ok(e) = event {
                     client.emit_timeline_event(room_id, e).await;
                 }
@@ -398,7 +396,6 @@ impl AsyncClient {
                     if let EventResult::Ok(e) = account_data {
                         client.receive_account_data(&room_id_string, e).await;
 
-                        // TODO should we determine if anything room state has changed before calling
                         client.emit_account_data_event(room_id, e).await;
                     }
                 }
@@ -414,7 +411,6 @@ impl AsyncClient {
                     if let EventResult::Ok(e) = presence {
                         client.receive_presence_event(&room_id_string, e).await;
 
-                        // TODO should we determine if any room state has changed before calling
                         client.emit_presence_event(room_id, e).await;
                     }
                 }

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -393,7 +393,7 @@ impl Client {
                 // part where we already iterate through the rooms to avoid yet
                 // another room loop.
                 for room in self.joined_rooms.values() {
-                    let room = room.read().unwrap();
+                    let room = room.lock().await;
                     if !room.is_encrypted() {
                         continue;
                     }

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -16,7 +16,7 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::fmt;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 #[cfg(feature = "encryption")]
 use std::result::Result as StdResult;
@@ -302,10 +302,7 @@ impl Client {
                     }
                 }
 
-                let mut room = self
-                    .get_or_create_room(&room_id.to_string())
-                    .lock()
-                    .await;
+                let mut room = self.get_or_create_room(&room_id.to_string()).lock().await;
                 room.receive_timeline_event(e);
                 decrypted_event
             }
@@ -527,7 +524,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_canonical_alias(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_canonical_alias(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -567,7 +567,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_message_feedback(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_message_feedback(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -577,7 +580,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_redaction(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_redaction(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -587,7 +593,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_power_levels(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_power_levels(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -623,7 +632,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_state_canonical_alias(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_state_canonical_alias(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -633,7 +645,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_state_aliases(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_state_aliases(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -653,7 +668,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_state_power_levels(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_state_power_levels(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -663,7 +681,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_state_join_rules(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_state_join_rules(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -683,7 +704,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_account_presence(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_account_presence(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -693,7 +717,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_account_ignored_users(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_account_ignored_users(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -703,7 +730,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_account_push_rules(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_account_push_rules(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }
@@ -713,7 +743,10 @@ impl Client {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_account_data_fully_read(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_account_data_fully_read(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(event.clone())),
+                            )
                             .await;
                     }
                 }

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -499,103 +499,106 @@ impl Client {
     
     pub(crate) async fn emit_timeline_event(&mut self, room_id: &RoomId, event: &mut RoomEvent) {
         match event {
-            RoomEvent::RoomMember(_) => {
+            RoomEvent::RoomMember(mem) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_member(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_member(Arc::clone(&room), Arc::new(Mutex::new(mem.clone())))
                             .await;
                     }
                 }
             }
-            RoomEvent::RoomName(_) => {
+            RoomEvent::RoomName(name) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_name(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_name(Arc::clone(&room), Arc::new(Mutex::new(name.clone())))
                             .await;
                     }
                 }
             }
-            RoomEvent::RoomCanonicalAlias(_) => {
+            RoomEvent::RoomCanonicalAlias(canonical) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_room_canonical_alias(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(canonical.clone())),
                             )
                             .await;
                     }
                 }
             }
-            RoomEvent::RoomAliases(_) => {
+            RoomEvent::RoomAliases(aliases) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_aliases(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_aliases(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(aliases.clone())),
+                            )
                             .await;
                     }
                 }
             }
-            RoomEvent::RoomAvatar(_) => {
+            RoomEvent::RoomAvatar(avatar) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_avatar(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_avatar(Arc::clone(&room), Arc::new(Mutex::new(avatar.clone())))
                             .await;
                     }
                 }
             }
-            RoomEvent::RoomMessage(_) => {
+            RoomEvent::RoomMessage(msg) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_room_message(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_room_message(Arc::clone(&room), Arc::new(Mutex::new(msg.clone())))
                             .await;
                     }
                 }
             }
-            RoomEvent::RoomMessageFeedback(_) => {
+            RoomEvent::RoomMessageFeedback(msg_feedback) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_room_message_feedback(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(msg_feedback.clone())),
                             )
                             .await;
                     }
                 }
             }
-            RoomEvent::RoomRedaction(_) => {
+            RoomEvent::RoomRedaction(redaction) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_room_redaction(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(redaction.clone())),
                             )
                             .await;
                     }
                 }
             }
-            RoomEvent::RoomPowerLevels(_) => {
+            RoomEvent::RoomPowerLevels(power) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_room_power_levels(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(power.clone())),
                             )
                             .await;
                     }
@@ -607,83 +610,89 @@ impl Client {
 
     pub(crate) async fn emit_state_event(&mut self, room_id: &RoomId, event: &mut StateEvent) {
         match event {
-            StateEvent::RoomMember(_) => {
+            StateEvent::RoomMember(member) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_state_member(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_state_member(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(member.clone())),
+                            )
                             .await;
                     }
                 }
             }
-            StateEvent::RoomName(_) => {
+            StateEvent::RoomName(name) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_state_name(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_state_name(Arc::clone(&room), Arc::new(Mutex::new(name.clone())))
                             .await;
                     }
                 }
             }
-            StateEvent::RoomCanonicalAlias(_) => {
+            StateEvent::RoomCanonicalAlias(canonical) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_state_canonical_alias(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(canonical.clone())),
                             )
                             .await;
                     }
                 }
             }
-            StateEvent::RoomAliases(_) => {
+            StateEvent::RoomAliases(aliases) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_state_aliases(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(aliases.clone())),
                             )
                             .await;
                     }
                 }
             }
-            StateEvent::RoomAvatar(_) => {
+            StateEvent::RoomAvatar(avatar) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
-                            .on_state_avatar(Arc::clone(&room), Arc::new(Mutex::new(event.clone())))
+                            .on_state_avatar(
+                                Arc::clone(&room),
+                                Arc::new(Mutex::new(avatar.clone())),
+                            )
                             .await;
                     }
                 }
             }
-            StateEvent::RoomPowerLevels(_) => {
+            StateEvent::RoomPowerLevels(power) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_state_power_levels(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(power.clone())),
                             )
                             .await;
                     }
                 }
             }
-            StateEvent::RoomJoinRules(_) => {
+            StateEvent::RoomJoinRules(rules) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_state_join_rules(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(rules.clone())),
                             )
                             .await;
                     }
@@ -699,53 +708,53 @@ impl Client {
         event: &mut NonRoomEvent,
     ) {
         match event {
-            NonRoomEvent::Presence(_) => {
+            NonRoomEvent::Presence(presence) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_account_presence(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(presence.clone())),
                             )
                             .await;
                     }
                 }
             }
-            NonRoomEvent::IgnoredUserList(_) => {
+            NonRoomEvent::IgnoredUserList(ignored) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_account_ignored_users(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(ignored.clone())),
                             )
                             .await;
                     }
                 }
             }
-            NonRoomEvent::PushRules(_) => {
+            NonRoomEvent::PushRules(rules) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_account_push_rules(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(rules.clone())),
                             )
                             .await;
                     }
                 }
             }
-            NonRoomEvent::FullyRead(_) => {
+            NonRoomEvent::FullyRead(full_read) => {
                 if let Some(ee) = &self.event_emitter {
                     if let Some(room) = self.get_room(&room_id.to_string()) {
                         ee.lock()
                             .await
                             .on_account_data_fully_read(
                                 Arc::clone(&room),
-                                Arc::new(Mutex::new(event.clone())),
+                                Arc::new(Mutex::new(full_read.clone())),
                             )
                             .await;
                     }

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 use std::collections::{HashMap, HashSet};
-use std::convert::TryFrom;
 use std::fmt;
 use std::sync::Arc;
 
@@ -30,7 +29,7 @@ use crate::events::collections::only::Event as NonRoomEvent;
 use crate::events::ignored_user_list::IgnoredUserListEvent;
 use crate::events::push_rules::{PushRulesEvent, Ruleset};
 use crate::events::EventResult;
-use crate::identifiers::{RoomAliasId, UserId as Uid};
+use crate::identifiers::RoomAliasId;
 use crate::models::Room;
 use crate::session::Session;
 use crate::EventEmitter;

--- a/src/base_client.rs
+++ b/src/base_client.rs
@@ -496,7 +496,7 @@ impl Client {
         // TODO notify our callers of new devices via some callback.
         Ok(())
     }
-    
+
     pub(crate) async fn emit_timeline_event(&mut self, room_id: &RoomId, event: &mut RoomEvent) {
         match event {
             RoomEvent::RoomMember(mem) => {

--- a/src/event_emitter/mod.rs
+++ b/src/event_emitter/mod.rs
@@ -15,9 +15,50 @@
 
 use std::sync::Arc;
 
-use crate::events::collections::all::{RoomEvent, StateEvent};
-use crate::events::collections::only::Event as NonRoomEvent;
-use crate::events::presence::PresenceEvent;
+use crate::events::{
+    call::{
+        answer::AnswerEvent, candidates::CandidatesEvent, hangup::HangupEvent, invite::InviteEvent,
+    },
+    direct::DirectEvent,
+    dummy::DummyEvent,
+    forwarded_room_key::ForwardedRoomKeyEvent,
+    fully_read::FullyReadEvent,
+    ignored_user_list::IgnoredUserListEvent,
+    key::verification::{
+        accept::AcceptEvent, cancel::CancelEvent, key::KeyEvent, mac::MacEvent,
+        request::RequestEvent, start::StartEvent,
+    },
+    presence::PresenceEvent,
+    push_rules::PushRulesEvent,
+    receipt::ReceiptEvent,
+    room::{
+        aliases::AliasesEvent,
+        avatar::AvatarEvent,
+        canonical_alias::CanonicalAliasEvent,
+        create::CreateEvent,
+        encrypted::EncryptedEvent,
+        encryption::EncryptionEvent,
+        guest_access::GuestAccessEvent,
+        history_visibility::HistoryVisibilityEvent,
+        join_rules::JoinRulesEvent,
+        member::MemberEvent,
+        message::{feedback::FeedbackEvent, MessageEvent},
+        name::NameEvent,
+        pinned_events::PinnedEventsEvent,
+        power_levels::PowerLevelsEvent,
+        redaction::RedactionEvent,
+        server_acl::ServerAclEvent,
+        third_party_invite::ThirdPartyInviteEvent,
+        tombstone::TombstoneEvent,
+        topic::TopicEvent,
+    },
+    room_key::RoomKeyEvent,
+    room_key_request::RoomKeyRequestEvent,
+    sticker::StickerEvent,
+    tag::TagEvent,
+    typing::TypingEvent,
+    CustomEvent, CustomRoomEvent, CustomStateEvent,
+};
 use crate::models::Room;
 
 use tokio::sync::Mutex;
@@ -26,53 +67,78 @@ use tokio::sync::Mutex;
 pub trait EventEmitter: Send + Sync {
     // ROOM EVENTS from `IncomingTimeline`
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomMember` event.
-    async fn on_room_member(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_member(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<MemberEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomName` event.
-    async fn on_room_name(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_name(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NameEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomCanonicalAlias` event.
-    async fn on_room_canonical_alias(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_canonical_alias(
+        &mut self,
+        _: Arc<Mutex<Room>>,
+        _: Arc<Mutex<CanonicalAliasEvent>>,
+    ) {
+    }
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomAliases` event.
-    async fn on_room_aliases(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_aliases(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<AliasesEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomAvatar` event.
-    async fn on_room_avatar(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_avatar(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<AvatarEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomMessage` event.
-    async fn on_room_message(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_message(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<MessageEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomMessageFeedback` event.
-    async fn on_room_message_feedback(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_message_feedback(
+        &mut self,
+        _: Arc<Mutex<Room>>,
+        _: Arc<Mutex<FeedbackEvent>>,
+    ) {
+    }
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomRedaction` event.
-    async fn on_room_redaction(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_redaction(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RedactionEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomPowerLevels` event.
-    async fn on_room_power_levels(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_power_levels(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<PowerLevelsEvent>>) {
+    }
 
     // `RoomEvent`s from `IncomingState`
     /// Fires when `AsyncClient` receives a `StateEvent::RoomMember` event.
-    async fn on_state_member(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_member(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<MemberEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomName` event.
-    async fn on_state_name(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_name(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NameEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomCanonicalAlias` event.
-    async fn on_state_canonical_alias(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_canonical_alias(
+        &mut self,
+        _: Arc<Mutex<Room>>,
+        _: Arc<Mutex<CanonicalAliasEvent>>,
+    ) {
+    }
     /// Fires when `AsyncClient` receives a `StateEvent::RoomAliases` event.
-    async fn on_state_aliases(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_aliases(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<AliasesEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomAvatar` event.
-    async fn on_state_avatar(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_avatar(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<AvatarEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomPowerLevels` event.
-    async fn on_state_power_levels(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_power_levels(
+        &mut self,
+        _: Arc<Mutex<Room>>,
+        _: Arc<Mutex<PowerLevelsEvent>>,
+    ) {
+    }
     /// Fires when `AsyncClient` receives a `StateEvent::RoomJoinRules` event.
-    async fn on_state_join_rules(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_join_rules(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<JoinRulesEvent>>) {}
 
     // `NonRoomEvent` (this is a type alias from ruma_events) from `IncomingAccountData`
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomMember` event.
-    async fn on_account_presence(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    async fn on_account_presence(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<PresenceEvent>>) {}
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomName` event.
-    async fn on_account_ignored_users(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {
+    async fn on_account_ignored_users(
+        &mut self,
+        _: Arc<Mutex<Room>>,
+        _: Arc<Mutex<IgnoredUserListEvent>>,
+    ) {
     }
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomCanonicalAlias` event.
-    async fn on_account_push_rules(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    async fn on_account_push_rules(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<PushRulesEvent>>) {}
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomAliases` event.
     async fn on_account_data_fully_read(
         &mut self,
         _: Arc<Mutex<Room>>,
-        _: Arc<Mutex<NonRoomEvent>>,
+        _: Arc<Mutex<FullyReadEvent>>,
     ) {
     }
 

--- a/src/event_emitter/mod.rs
+++ b/src/event_emitter/mod.rs
@@ -1,0 +1,76 @@
+// Copyright 2020 Damir Jelić
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, RwLock};
+
+use crate::events::collections::all::{RoomEvent, StateEvent};
+use crate::events::collections::only::Event as NonRoomEvent;
+use crate::events::presence::PresenceEvent;
+use crate::models::Room;
+
+use tokio::sync::Mutex;
+///
+#[async_trait::async_trait]
+pub trait EventEmitter: Send + Sync {
+    // ROOM EVENTS from `IncomingTimeline`
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomMember` event.
+    async fn on_room_member(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomName` event.
+    async fn on_room_name(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomCanonicalAlias` event.
+    async fn on_room_canonical_alias(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomAliases` event.
+    async fn on_room_aliases(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomAvatar` event.
+    async fn on_room_avatar(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomMessage` event.
+    async fn on_room_message(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomMessageFeedback` event.
+    async fn on_room_message_feedback(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomRedaction` event.
+    async fn on_room_redaction(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `RoomEvent::RoomPowerLevels` event.
+    async fn on_room_power_levels(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+
+    // `RoomEvent`s from `IncomingState`
+    /// Fires when `AsyncClient` receives a `StateEvent::RoomMember` event.
+    async fn on_state_member(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    /// Fires when `AsyncClient` receives a `StateEvent::RoomName` event.
+    async fn on_state_name(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    /// Fires when `AsyncClient` receives a `StateEvent::RoomCanonicalAlias` event.
+    async fn on_state_canonical_alias(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    /// Fires when `AsyncClient` receives a `StateEvent::RoomAliases` event.
+    async fn on_state_aliases(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    /// Fires when `AsyncClient` receives a `StateEvent::RoomAvatar` event.
+    async fn on_state_avatar(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    /// Fires when `AsyncClient` receives a `StateEvent::RoomPowerLevels` event.
+    async fn on_state_power_levels(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    /// Fires when `AsyncClient` receives a `StateEvent::RoomJoinRules` event.
+    async fn on_state_join_rules(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+
+    // `NonRoomEvent` (this is a type alias from ruma_events) from `IncomingAccountData`
+    /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomMember` event.
+    async fn on_account_presence(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomName` event.
+    async fn on_account_ignored_users(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomCanonicalAlias` event.
+    async fn on_account_push_rules(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomAliases` event.
+    async fn on_account_data_fully_read(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+
+    // `PresenceEvent` is a struct so there is only the one method
+    /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomAliases` event.
+    async fn on_presence_event(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<PresenceEvent>>) {}
+}

--- a/src/event_emitter/mod.rs
+++ b/src/event_emitter/mod.rs
@@ -64,11 +64,17 @@ pub trait EventEmitter: Send + Sync {
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomMember` event.
     async fn on_account_presence(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomName` event.
-    async fn on_account_ignored_users(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    async fn on_account_ignored_users(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {
+    }
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomCanonicalAlias` event.
     async fn on_account_push_rules(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomAliases` event.
-    async fn on_account_data_fully_read(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    async fn on_account_data_fully_read(
+        &mut self,
+        _: Arc<Mutex<Room>>,
+        _: Arc<Mutex<NonRoomEvent>>,
+    ) {
+    }
 
     // `PresenceEvent` is a struct so there is only the one method
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomAliases` event.

--- a/src/event_emitter/mod.rs
+++ b/src/event_emitter/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use crate::events::collections::all::{RoomEvent, StateEvent};
 use crate::events::collections::only::Event as NonRoomEvent;
@@ -26,51 +26,51 @@ use tokio::sync::Mutex;
 pub trait EventEmitter: Send + Sync {
     // ROOM EVENTS from `IncomingTimeline`
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomMember` event.
-    async fn on_room_member(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_member(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomName` event.
-    async fn on_room_name(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_name(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomCanonicalAlias` event.
-    async fn on_room_canonical_alias(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_canonical_alias(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomAliases` event.
-    async fn on_room_aliases(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_aliases(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomAvatar` event.
-    async fn on_room_avatar(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_avatar(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomMessage` event.
-    async fn on_room_message(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_message(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomMessageFeedback` event.
-    async fn on_room_message_feedback(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_message_feedback(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomRedaction` event.
-    async fn on_room_redaction(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_redaction(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `RoomEvent::RoomPowerLevels` event.
-    async fn on_room_power_levels(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<RoomEvent>>) {}
+    async fn on_room_power_levels(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<RoomEvent>>) {}
 
     // `RoomEvent`s from `IncomingState`
     /// Fires when `AsyncClient` receives a `StateEvent::RoomMember` event.
-    async fn on_state_member(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_member(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomName` event.
-    async fn on_state_name(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_name(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomCanonicalAlias` event.
-    async fn on_state_canonical_alias(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_canonical_alias(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomAliases` event.
-    async fn on_state_aliases(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_aliases(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomAvatar` event.
-    async fn on_state_avatar(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_avatar(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomPowerLevels` event.
-    async fn on_state_power_levels(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_power_levels(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
     /// Fires when `AsyncClient` receives a `StateEvent::RoomJoinRules` event.
-    async fn on_state_join_rules(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<StateEvent>>) {}
+    async fn on_state_join_rules(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<StateEvent>>) {}
 
     // `NonRoomEvent` (this is a type alias from ruma_events) from `IncomingAccountData`
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomMember` event.
-    async fn on_account_presence(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    async fn on_account_presence(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomName` event.
-    async fn on_account_ignored_users(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    async fn on_account_ignored_users(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomCanonicalAlias` event.
-    async fn on_account_push_rules(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    async fn on_account_push_rules(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomAliases` event.
-    async fn on_account_data_fully_read(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
+    async fn on_account_data_fully_read(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<NonRoomEvent>>) {}
 
     // `PresenceEvent` is a struct so there is only the one method
     /// Fires when `AsyncClient` receives a `NonRoomEvent::RoomAliases` event.
-    async fn on_presence_event(&mut self, _: Arc<RwLock<Room>>, _: Arc<Mutex<PresenceEvent>>) {}
+    async fn on_presence_event(&mut self, _: Arc<Mutex<Room>>, _: Arc<Mutex<PresenceEvent>>) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,10 @@
 
 pub use crate::{error::Error, error::Result, session::Session};
 pub use reqwest::header::InvalidHeaderValue;
+pub use ruma_api;
 pub use ruma_client_api as api;
 pub use ruma_events as events;
 pub use ruma_identifiers as identifiers;
-
-pub use ruma_api as ruma_traits;
 
 mod async_client;
 mod base_client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,12 @@ pub use ruma_client_api as api;
 pub use ruma_events as events;
 pub use ruma_identifiers as identifiers;
 
+pub use ruma_api as ruma_traits;
+
 mod async_client;
 mod base_client;
 mod error;
+mod event_emitter;
 mod models;
 mod session;
 
@@ -43,6 +46,7 @@ mod crypto;
 
 pub use async_client::{AsyncClient, AsyncClientConfig, SyncSettings};
 pub use base_client::Client;
+pub use event_emitter::EventEmitter;
 pub use models::Room;
 
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,5 +6,6 @@ pub use room::{Room, RoomName};
 pub use room_member::RoomMember;
 pub use user::User;
 
+#[allow(dead_code)]
 pub type Token = String;
 pub type UserId = String;

--- a/src/models/room.rs
+++ b/src/models/room.rs
@@ -14,11 +14,11 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
 
-use super::{RoomMember, User, UserId};
+use super::{RoomMember, UserId};
 
 use crate::events::collections::all::{RoomEvent, StateEvent};
+use crate::events::presence::PresenceEvent;
 use crate::events::room::{
     aliases::AliasesEvent,
     canonical_alias::CanonicalAliasEvent,
@@ -27,12 +27,7 @@ use crate::events::room::{
     name::NameEvent,
     power_levels::PowerLevelsEvent,
 };
-use crate::events::{
-    presence::{PresenceEvent, PresenceEventContent},
-    EventResult,
-};
 use crate::identifiers::RoomAliasId;
-use crate::session::Session;
 
 use js_int::UInt;
 
@@ -317,14 +312,11 @@ impl Room {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     use crate::events::room::member::MembershipState;
     use crate::identifiers::UserId;
     use crate::{AsyncClient, Session, SyncSettings};
 
     use mockito::{mock, Matcher};
-    use tokio::runtime::Runtime;
     use url::Url;
 
     use std::convert::TryFrom;
@@ -363,7 +355,7 @@ mod test {
             .unwrap();
 
         assert_eq!(2, room.members.len());
-        for (id, member) in &room.members {
+        for (_id, member) in &room.members {
             assert_eq!(MembershipState::Join, member.membership);
         }
     }

--- a/src/models/room.rs
+++ b/src/models/room.rs
@@ -140,7 +140,7 @@ impl Room {
         }
     }
 
-    /// Calculate and return the display name of the room.
+    /// Return the display name of the room.
     pub fn calculate_name(&self) -> String {
         self.room_name.calculate_name(&self.room_id, &self.members)
     }
@@ -237,7 +237,7 @@ impl Room {
         }
     }
 
-    fn handle_encryption_event(&mut self, event: &EncryptionEvent) -> bool {
+    fn handle_encryption_event(&mut self, _event: &EncryptionEvent) -> bool {
         self.encrypted = true;
         true
     }

--- a/src/models/room.rs
+++ b/src/models/room.rs
@@ -351,8 +351,8 @@ mod test {
         let room = &rooms
             .get("!SVkFJHzfwvuaIEawgC:localhost")
             .unwrap()
-            .read()
-            .unwrap();
+            .lock()
+            .await;
 
         assert_eq!(2, room.members.len());
         for (_id, member) in &room.members {

--- a/src/models/room_member.rs
+++ b/src/models/room_member.rs
@@ -16,20 +16,14 @@
 use std::convert::TryFrom;
 
 use super::User;
-use crate::api::r0 as api;
-use crate::events::collections::all::{Event, RoomEvent, StateEvent};
+use crate::events::collections::all::Event;
 use crate::events::room::{
-    aliases::AliasesEvent,
-    canonical_alias::CanonicalAliasEvent,
-    member::{MemberEvent, MemberEventContent, MembershipChange, MembershipState},
-    name::NameEvent,
+    member::{MemberEvent, MembershipChange, MembershipState},
     power_levels::PowerLevelsEvent,
 };
-use crate::events::EventResult;
-use crate::identifiers::{RoomAliasId, UserId};
-use crate::session::Session;
+use crate::identifiers::UserId;
 
-use js_int::{Int, UInt};
+use js_int::Int;
 #[cfg(feature = "encryption")]
 use tokio::sync::Mutex;
 
@@ -108,7 +102,7 @@ impl RoomMember {
             max_power = *power.max(&max_power);
         }
 
-        let mut changed = false;
+        let changed;
         if let Some(user_power) = event.content.users.get(&self.user_id) {
             changed = self.power_level != Some(*user_power);
             self.power_level = Some(*user_power);
@@ -134,7 +128,6 @@ mod test {
 
     use js_int::{Int, UInt};
     use mockito::{mock, Matcher};
-    use tokio::runtime::Runtime;
     use url::Url;
 
     use std::collections::HashMap;
@@ -177,7 +170,7 @@ mod test {
             .write()
             .unwrap();
 
-        for (id, member) in &mut room.members {
+        for (_id, member) in &mut room.members {
             let power = power_levels();
             assert!(member.update_power(&power));
             assert_eq!(MembershipState::Join, member.membership);

--- a/src/models/room_member.rs
+++ b/src/models/room_member.rs
@@ -167,8 +167,8 @@ mod test {
         let mut room = rooms
             .get_mut("!SVkFJHzfwvuaIEawgC:localhost")
             .unwrap()
-            .write()
-            .unwrap();
+            .lock()
+            .await;
 
         for (_id, member) in &mut room.members {
             let power = power_levels();

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -13,22 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
-
-use super::UserId;
-use crate::api::r0 as api;
-use crate::events::collections::all::{Event, RoomEvent, StateEvent};
+use crate::events::collections::all::Event;
 use crate::events::presence::{PresenceEvent, PresenceEventContent, PresenceState};
-use crate::events::room::{
-    aliases::AliasesEvent,
-    canonical_alias::CanonicalAliasEvent,
-    member::{MemberEvent, MembershipState},
-    name::NameEvent,
-};
-use crate::events::EventResult;
-use crate::identifiers::RoomAliasId;
-use crate::session::Session;
+use crate::events::room::member::MemberEvent;
 
 use js_int::UInt;
 #[cfg(feature = "encryption")]

--- a/tests/async_client_tests.rs
+++ b/tests/async_client_tests.rs
@@ -2,7 +2,6 @@ use matrix_sdk::identifiers::UserId;
 use matrix_sdk::{AsyncClient, Session, SyncSettings};
 
 use mockito::{mock, Matcher};
-use tokio::runtime::Runtime;
 use url::Url;
 
 use std::convert::TryFrom;

--- a/tests/async_client_tests.rs
+++ b/tests/async_client_tests.rs
@@ -87,33 +87,3 @@ async fn room_names() {
         client.get_room_name("!SVkFJHzfwvuaIEawgC:localhost").await
     );
 }
-
-#[tokio::test]
-async fn current_room() {
-    let homeserver = Url::from_str(&mockito::server_url()).unwrap();
-
-    let session = Session {
-        access_token: "1234".to_owned(),
-        user_id: UserId::try_from("@example:localhost").unwrap(),
-        device_id: "DEVICEID".to_owned(),
-    };
-
-    let _m = mock(
-        "GET",
-        Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_string()),
-    )
-    .with_status(200)
-    .with_body_from_file("tests/data/sync.json")
-    .create();
-
-    let mut client = AsyncClient::new(homeserver, Some(session)).unwrap();
-
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    let _response = client.sync(sync_settings).await.unwrap();
-
-    assert_eq!(
-        Some("!SVkFJHzfwvuaIEawgC:localhost".into()),
-        client.current_room_id().await.map(|id| id.to_string())
-    );
-}


### PR DESCRIPTION
Sorry I didn't break the PR up more.

This works in an async `spawn` environment now, you were right no references and we have to use `Arc<tokio::Mutex<...` in order for it to be `Future` safe. 