### PR TITLE
travis: fail-fast for wasm target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
       name: wasm32-unknown-unknown
       before_script:
           - |
+            set -e
             cargo install wasm-bindgen-cli
             rustup target add wasm32-unknown-unknown
             wget https://github.com/emscripten-core/emsdk/archive/master.zip
@@ -32,6 +33,7 @@ jobs:
             ./emsdk-master/emsdk activate latest
       script:
           - |
+            set -e
             source emsdk-master/emsdk_env.sh
             cd matrix_sdk/examples/wasm_command_bot
             cargo build --target wasm32-unknown-unknown

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -44,6 +44,7 @@ use crate::Endpoint;
 use crate::identifiers::DeviceId;
 
 use crate::api;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::VERSION;
 use crate::{Error, EventEmitter, Result};
 use matrix_sdk_base::BaseClient;

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -53,4 +53,5 @@ pub use client::{Client, ClientConfig, SyncSettings};
 pub use error::{Error, Result};
 pub use request_builder::{MessagesRequestBuilder, RoomBuilder};
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
Travis doesn't fail by default when any script before the last fails: https://github.com/travis-ci/travis-ci/issues/1066

This change fixes that (and the build).