### PR TITLE
Implement display name resolving

### DIFF
--- a/matrix_sdk_base/src/models/room.rs
+++ b/matrix_sdk_base/src/models/room.rs
@@ -251,7 +251,7 @@ impl Room {
     }
 
     /// Get the resolved display name for a member of this room.
-    pub fn resolved_display_name(&self, id: &UserId) -> Option<&str> {
+    pub fn member_display_name(&self, id: &UserId) -> Option<&str> {
         self.display_names.get(id).map(|s| s.as_str())
     }
 

--- a/matrix_sdk_base/src/models/room.rs
+++ b/matrix_sdk_base/src/models/room.rs
@@ -640,6 +640,48 @@ mod test {
     }
 
     #[async_test]
+    async fn test_member_display_name() {
+        let client = get_client();
+
+        let client_2 = {
+            let session = Session {
+                access_token: "1234".to_owned(),
+                user_id: UserId::try_from("@example:hostlocal").unwrap(),
+                device_id: "DEVICEID".to_owned(),
+            };
+            BaseClient::new(Some(session)).unwrap()
+        };
+        let room_id = get_room_id();
+        let user_id = UserId::try_from("@example:localhost").unwrap();
+
+        let mut response = EventBuilder::default()
+            .add_room_event(EventsFile::Member, RoomEvent::RoomMember)
+            .build_sync_response();
+
+        client.receive_sync_response(&mut response).await.unwrap();
+
+        let room = client.get_joined_room(&room_id).await.unwrap();
+        let room = room.read().await;
+
+        let display_name = room.member_display_name(&user_id).unwrap();
+        assert_eq!("example", display_name);
+
+        let mut response = EventBuilder::default()
+            .add_room_event(EventsFile::Member, RoomEvent::RoomMember)
+            .build_sync_response();
+
+        client_2.receive_sync_response(&mut response).await.unwrap();
+
+        let room_2 = client_2.get_joined_room(&room_id).await.unwrap();
+        let room_2 = room_2.read().await;
+
+        let display_name_2 = room_2.member_display_name(&user_id).unwrap();
+
+        // TODO: this should change
+        assert_eq!("example", display_name_2);
+    }
+
+    #[async_test]
     async fn room_events() {
         let client = get_client();
         let room_id = get_room_id();

--- a/matrix_sdk_base/src/models/room.rs
+++ b/matrix_sdk_base/src/models/room.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryFrom;
 
@@ -251,8 +252,20 @@ impl Room {
     }
 
     /// Get the resolved display name for a member of this room.
-    pub fn member_display_name(&self, id: &UserId) -> Option<&str> {
-        self.display_names.get(id).map(|s| s.as_str())
+    pub fn member_display_name<'a>(&'a self, id: &UserId) -> Option<Cow<'a, str>> {
+        self.display_names
+            .get(id)
+            .map(|s| s.as_str().into())
+            .or_else(|| {
+                self.members.get(id).map(|member| {
+                    member
+                        .display_name
+                        .as_ref()
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("{}", member.user_id))
+                        .into()
+                })
+            })
     }
 
     fn add_member(&mut self, event: &MemberEvent) -> bool {
@@ -280,17 +293,8 @@ impl Room {
             .cloned()
             .collect();
 
-        // if there is no other user with the same display name -> just use the display name
-        if users_with_same_name.is_empty() {
-            let display_name = member
-                .display_name
-                .as_ref()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| format!("{}", member.user_id));
-            self.display_names
-                .insert(member.user_id.clone(), display_name);
-        } else {
-            // else user `display_name (userid)`
+        // if there is a other user with the same display name -> use `display_name (userid)`
+        if !users_with_same_name.is_empty() {
             let users_with_same_name = users_with_same_name
                 .into_iter()
                 .filter_map(|id| {

--- a/matrix_sdk_base/src/state/mod.rs
+++ b/matrix_sdk_base/src/state/mod.rs
@@ -127,57 +127,59 @@ mod test {
 
         #[cfg(not(feature = "messages"))]
         assert_eq!(
-            r#"{
-  "!roomid:example.com": {
-    "room_id": "!roomid:example.com",
-    "room_name": {
-      "name": null,
-      "canonical_alias": null,
-      "aliases": [],
-      "heroes": [],
-      "joined_member_count": null,
-      "invited_member_count": null
-    },
-    "own_user_id": "@example:example.com",
-    "creator": null,
-    "members": {},
-    "typing_users": [],
-    "power_levels": null,
-    "encrypted": false,
-    "unread_highlight": null,
-    "unread_notifications": null,
-    "tombstone": null
-  }
-}"#,
-            serde_json::to_string_pretty(&joined_rooms).unwrap()
+            serde_json::json!({
+                "!roomid:example.com": {
+                    "room_id": "!roomid:example.com",
+                    "room_name": {
+                        "name": null,
+                        "canonical_alias": null,
+                        "aliases": [],
+                        "heroes": [],
+                        "joined_member_count": null,
+                        "invited_member_count": null
+                    },
+                    "own_user_id": "@example:example.com",
+                    "creator": null,
+                    "members": {},
+                    "display_names": {},
+                    "typing_users": [],
+                    "power_levels": null,
+                    "encrypted": false,
+                    "unread_highlight": null,
+                    "unread_notifications": null,
+                    "tombstone": null
+                }
+            }),
+            serde_json::to_value(&joined_rooms).unwrap()
         );
 
         #[cfg(feature = "messages")]
         assert_eq!(
-            r#"{
-  "!roomid:example.com": {
-    "room_id": "!roomid:example.com",
-    "room_name": {
-      "name": null,
-      "canonical_alias": null,
-      "aliases": [],
-      "heroes": [],
-      "joined_member_count": null,
-      "invited_member_count": null
-    },
-    "own_user_id": "@example:example.com",
-    "creator": null,
-    "members": {},
-    "messages": [],
-    "typing_users": [],
-    "power_levels": null,
-    "encrypted": false,
-    "unread_highlight": null,
-    "unread_notifications": null,
-    "tombstone": null
-  }
-}"#,
-            serde_json::to_string_pretty(&joined_rooms).unwrap()
+            serde_json::json!({
+                "!roomid:example.com": {
+                    "room_id": "!roomid:example.com",
+                    "display_names": {},
+                    "room_name": {
+                        "name": null,
+                        "canonical_alias": null,
+                        "aliases": [],
+                        "heroes": [],
+                        "joined_member_count": null,
+                        "invited_member_count": null
+                    },
+                    "own_user_id": "@example:example.com",
+                    "creator": null,
+                    "members": {},
+                    "messages": [],
+                    "typing_users": [],
+                    "power_levels": null,
+                    "encrypted": false,
+                    "unread_highlight": null,
+                    "unread_notifications": null,
+                    "tombstone": null
+                }
+            }),
+            serde_json::to_value(&joined_rooms).unwrap()
         );
     }
 


### PR DESCRIPTION
As discussed with @poljar in https://github.com/poljar/weechat-matrix-rs/pull/11, this tries to resolve the username on each membership change and exposes a function to get the resolved username for a room member.

If there are two members with the same display name, the name is resolved to `display_name (user_id)`.

This is a draft because I'm not quite happy about the amount of cloning that is performed but it's the best I can come up with for now. But maybe anyone has an idea how to get rid of some of the clones.