### PR TITLE
state_store: move room file when room state changes, test room_state_…

### DIFF
--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -318,17 +318,13 @@ impl BaseClient {
         // hashmaps.
         if self.invited_rooms.write().await.remove(room_id).is_some() {
             if let Some(store) = self.state_store.read().await.as_ref() {
-                store
-                    .room_state_change(RoomState::Joined(room_id), RoomState::Invited(room_id))
-                    .await?;
+                store.room_state_change(RoomState::Invited(room_id)).await?;
             }
         }
 
         if self.left_rooms.write().await.remove(room_id).is_some() {
             if let Some(store) = self.state_store.read().await.as_ref() {
-                store
-                    .room_state_change(RoomState::Invited(room_id), RoomState::Left(room_id))
-                    .await?;
+                store.room_state_change(RoomState::Left(room_id)).await?;
             }
         }
 
@@ -373,9 +369,7 @@ impl BaseClient {
         // spec can't happen.
         if self.left_rooms.write().await.remove(room_id).is_some() {
             if let Some(store) = self.state_store.read().await.as_ref() {
-                store
-                    .room_state_change(RoomState::Invited(room_id), RoomState::Left(room_id))
-                    .await?;
+                store.room_state_change(RoomState::Left(room_id)).await?;
             }
         }
 
@@ -420,17 +414,13 @@ impl BaseClient {
         // hashmaps.
         if self.invited_rooms.write().await.remove(room_id).is_some() {
             if let Some(store) = self.state_store.read().await.as_ref() {
-                store
-                    .room_state_change(RoomState::Left(room_id), RoomState::Invited(room_id))
-                    .await?;
+                store.room_state_change(RoomState::Invited(room_id)).await?;
             }
         }
 
         if self.joined_rooms.write().await.remove(room_id).is_some() {
             if let Some(store) = self.state_store.read().await.as_ref() {
-                store
-                    .room_state_change(RoomState::Left(room_id), RoomState::Joined(room_id))
-                    .await?;
+                store.room_state_change(RoomState::Joined(room_id)).await?;
             }
         }
 

--- a/matrix_sdk_base/src/error.rs
+++ b/matrix_sdk_base/src/error.rs
@@ -32,11 +32,16 @@ pub enum Error {
     #[error("the queried endpoint requires authentication but was called before logging in")]
     AuthenticationRequired,
 
-    /// An error de/serializing type for the `StateStore`
+    /// A generic error returned when the state store fails not due to
+    /// IO or (de)serialization.
+    #[error("state store: {0}")]
+    StateStore(String),
+
+    /// An error when (de)serializing JSON.
     #[error(transparent)]
     SerdeJson(#[from] JsonError),
 
-    /// An error de/serializing type for the `StateStore`
+    /// An error representing IO errors.
     #[error(transparent)]
     IoError(#[from] IoError),
 

--- a/matrix_sdk_base/src/state/mod.rs
+++ b/matrix_sdk_base/src/state/mod.rs
@@ -54,6 +54,7 @@ impl ClientState {
     ///
     /// This enables non sensitive information to be saved by `JsonStore`.
     #[allow(clippy::eval_order_dependence)]
+    // TODO is this ok ^^^?? https://github.com/rust-lang/rust-clippy/issues/4637
     pub async fn from_base_client(client: &BaseClient) -> ClientState {
         let BaseClient {
             sync_token,

--- a/matrix_sdk_base/src/state/mod.rs
+++ b/matrix_sdk_base/src/state/mod.rs
@@ -50,6 +50,10 @@ impl PartialEq for ClientState {
 }
 
 impl ClientState {
+    /// Create a JSON serialize-able `ClientState`.
+    ///
+    /// This enables non sensitive information to be saved by `JsonStore`.
+    #[allow(clippy::eval_order_dependence)]
     pub async fn from_base_client(client: &BaseClient) -> ClientState {
         let BaseClient {
             sync_token,
@@ -94,6 +98,15 @@ pub trait StateStore: Send + Sync {
     async fn store_client_state(&self, _: ClientState) -> Result<()>;
     /// Save the state a single `Room`.
     async fn store_room_state(&self, _: RoomState<&Room>) -> Result<()>;
+    /// Signals to the `StateStore` a room has changed state.
+    ///
+    /// This enables implementing types to update the database when `RoomState` changes.
+    /// A `RoomState` change is when a user joins, is invited, or leaves a room.
+    async fn room_state_change(
+        &self,
+        _current: RoomState<&RoomId>,
+        _previous: RoomState<&RoomId>,
+    ) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/matrix_sdk_base/src/state/mod.rs
+++ b/matrix_sdk_base/src/state/mod.rs
@@ -103,11 +103,7 @@ pub trait StateStore: Send + Sync {
     ///
     /// This enables implementing types to update the database when `RoomState` changes.
     /// A `RoomState` change is when a user joins, is invited, or leaves a room.
-    async fn room_state_change(
-        &self,
-        _current: RoomState<&RoomId>,
-        _previous: RoomState<&RoomId>,
-    ) -> Result<()>;
+    async fn room_state_change(&self, _previous: RoomState<&RoomId>) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/test_data/leave_event_sync.json
+++ b/test_data/leave_event_sync.json
@@ -1,0 +1,64 @@
+{
+    "account_data": {
+        "events": []
+    },
+    "to_device": {
+        "events": []
+    },
+    "device_lists": {
+        "changed": [],
+        "left": []
+    },
+    "presence": {
+        "events": []
+    },
+    "rooms": {
+        "join": {},
+        "invite": {},
+        "leave": {
+            "!SVkFJHzfwvuaIEawgC:localhost": {
+                "timeline": {
+                    "events": [
+                        {
+                            "content": {
+                                "membership": "leave"
+                            },
+                            "origin_server_ts": 1589578095276,
+                            "sender": "@example:localhost",
+                            "state_key": "@example:localhost",
+                            "type": "m.room.member",
+                            "unsigned": {
+                                "replaces_state": "$blahblah",
+                                "prev_content": {
+                                    "avatar_url": null,
+                                    "displayname": "me",
+                                    "membership": "invite"
+                                },
+                                "prev_sender": "@2example:localhost",
+                                "age": 1757
+                            },
+                            "event_id": "$lQQ116Y-XqcjpSUGpuz36rNntUvOSpTjuaIvmtQ2AwA"
+                        }
+                    ],
+                    "prev_batch": "tokenTOKEN",
+                    "limited": false
+                },
+                "state": {
+                    "events": []
+                },
+                "account_data": {
+                    "events": []
+                }
+            }
+        }
+    },
+    "groups": {
+        "join": {},
+        "invite": {},
+        "leave": {}
+    },
+    "device_one_time_keys_count": {
+        "signed_curve25519": 50
+    },
+    "next_batch": "s1380317562_757269739_1655566_503953763_334052043_1209862_55290918_65705002_101146"
+}


### PR DESCRIPTION
…change method, doc edits

The new `StateStore::room_state_change` method returns a `Result<()>` so the corresponding `BaseClient::get_or_create_*_room` now returns a result of the `Arc<RwLock<Room>>`. I'm not sure this is the best way to do this, although `unwrap`ing wouldn't be ok either?