### PR TITLE
Expose the Client::send method, adding a brief doccomment

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -916,7 +916,17 @@ impl Client {
         }
     }
 
-    async fn send<Request: Endpoint<ResponseError = crate::api::Error> + std::fmt::Debug>(
+    /// Send an arbitrary request to the server, without updating client state
+    ///
+    /// **Warning:** Because this method *does not* update the client state, it is
+    /// important to make sure than you account for this yourself, and use wrapper methods
+    /// where available.  This method should *only* be used if a wrapper method for the
+    /// endpoint you'd like to use is not available.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - A filled out and valid request for the endpoint to be hit
+    pub async fn send<Request: Endpoint<ResponseError = crate::api::Error> + std::fmt::Debug>(
         &self,
         request: Request,
     ) -> Result<Request::Response> {


### PR DESCRIPTION
This was briefly discussed in the Matrix room, but I believe that exposing the `Client::send` at least until the 1.0 release may be beneficial, as the ruma api is extensive and fairly easy to use, thus greatly extending the functionality of this library until more wrapper methods are complete.  The doccomment used for this method indicates that it is not recommended to use this method while a wrapper method exists for the same purpose, and warns that this method will not update client state.