### PR TITLE
matrix-sdk: Use futures-timer's wasm-bindgen feature

### DIFF
--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0.53"
 thiserror = "1.0.18"
 tracing = "0.1.14"
 url = "2.1.1"
-futures-timer = "3.0.2"
+futures-timer = { version = "3.0.2", features = ["wasm-bindgen"] }
 
 
 matrix-sdk-common = { version = "0.1.0", path = "../matrix_sdk_common" }

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -858,7 +858,6 @@ impl Client {
             let response = if let Ok(r) = response {
                 r
             } else {
-                #[cfg(not(target_arch = "wasm32"))]
                 sleep::new(Duration::from_secs(1)).await;
 
                 continue;
@@ -892,12 +891,9 @@ impl Client {
             // If the last sync happened less than a second ago, sleep for a
             // while to not hammer out requests if the server doesn't respect
             // the sync timeout.
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                if let Some(t) = last_sync_time {
-                    if now - t <= Duration::from_secs(1) {
-                        sleep::new(Duration::from_secs(1)).await;
-                    }
+            if let Some(t) = last_sync_time {
+                if now - t <= Duration::from_secs(1) {
+                    sleep::new(Duration::from_secs(1)).await;
                 }
             }
 


### PR DESCRIPTION
Use futures-timer's `wasm-bindgen` feature for the WASM target and re-enable (the no longer panic'ing) sleep.