### PR TITLE
base_client: emit typing events and test using EventEmitter

### DIFF
--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -1628,6 +1628,7 @@ impl BaseClient {
             NonRoomEvent::FullyRead(full_read) => {
                 event_emitter.on_non_room_fully_read(room, &full_read).await
             }
+            NonRoomEvent::Typing(typing) => event_emitter.on_non_room_typing(room, &typing).await,
             _ => {}
         }
     }
@@ -1684,6 +1685,7 @@ impl BaseClient {
             NonRoomEvent::FullyRead(full_read) => {
                 event_emitter.on_non_room_fully_read(room, &full_read).await
             }
+            NonRoomEvent::Typing(typing) => event_emitter.on_non_room_typing(room, &typing).await,
             _ => {}
         }
     }

--- a/matrix_sdk_test/src/lib.rs
+++ b/matrix_sdk_test/src/lib.rs
@@ -329,6 +329,7 @@ impl EventBuilder {
 
 /// Embedded sync reponse files
 pub enum SyncResponseFile {
+    All,
     Default,
     DefaultWithSummary,
     Invite,
@@ -338,6 +339,7 @@ pub enum SyncResponseFile {
 /// Get specific API responses for testing
 pub fn sync_response(kind: SyncResponseFile) -> SyncResponse {
     let data = match kind {
+        SyncResponseFile::All => include_bytes!("../test_data/more_sync.json").to_vec(),
         SyncResponseFile::Default => include_bytes!("../test_data/sync.json").to_vec(),
         SyncResponseFile::DefaultWithSummary => {
             include_bytes!("../test_data/sync_with_summary.json").to_vec()

--- a/matrix_sdk_test/test_data/more_sync.json
+++ b/matrix_sdk_test/test_data/more_sync.json
@@ -1,0 +1,151 @@
+{
+    "device_one_time_keys_count": {},
+    "next_batch": "s526_47314_0_7_1_1_1_11444_1",
+    "device_lists": {
+        "changed": [
+            "@example:example.org"
+        ],
+        "left": []
+    },
+    "rooms": {
+        "invite": {},
+        "join": {
+            "!SVkFJHzfwvuaIEawgC:localhost": {
+                "summary": {},
+                "account_data": {
+                    "events": []
+                },
+                "ephemeral": {
+                    "events": [
+                        {
+                            "content": {
+                                "$151680659217152dPKjd:localhost": {
+                                    "m.read": {
+                                        "@example:localhost": {
+                                            "ts": 1516809890615
+                                        }
+                                    }
+                                }
+                            },
+                            "type": "m.receipt"
+                        },
+                        {
+                            "content": {
+                                "user_ids": [
+                                    "@alice:matrix.org",
+                                    "@bob:example.com"
+                                ]
+                            },
+                            "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
+                            "type": "m.typing"
+                        }
+                    ]
+                },
+                "state": {
+                    "events": []
+                },
+                "timeline": {
+                    "events": [
+                        {
+                            "content": {
+                                "body": "baba",
+                                "format": "org.matrix.custom.html",
+                                "formatted_body": "<strong>baba</strong>",
+                                "msgtype": "m.text"
+                            },
+                            "event_id": "$152037280074GZeOm:localhost",
+                            "origin_server_ts": 1520372800469,
+                            "sender": "@example:localhost",
+                            "type": "m.room.message",
+                            "unsigned": {
+                                "age": 598971425
+                            }
+                        },
+                        {
+                            "content": {
+                                "body": " * edited message",
+                                "m.new_content": {
+                                    "body": "edited message",
+                                    "msgtype": "m.text"
+                                },
+                                "m.relates_to": {
+                                    "event_id": "some event id",
+                                    "rel_type": "m.replace"
+                                },
+                                "msgtype": "m.text"
+                            },
+                            "event_id": "edit event id",
+                            "origin_server_ts": 1590262659984,
+                            "sender": "@alice:matrix.org",
+                            "type": "m.room.message",
+                            "unsigned": {
+                                "age": 85
+                            }
+                        },
+                        {
+                            "content": {
+                                "reason": "😀"
+                            },
+                            "event_id": "$151957878228ssqrJ:localhost",
+                            "origin_server_ts": 1519578782185,
+                            "sender": "@example:localhost",
+                            "type": "m.room.redaction",
+                            "redacts": "$151957878228ssqrj:localhost"
+                        },
+                        {
+                            "content": {},
+                            "event_id": "$15275046980maRLj:localhost",
+                            "origin_server_ts": 1527504698685,
+                            "sender": "@example:localhost",
+                            "type": "m.room.message",
+                            "unsigned": {
+                                "age": 19334,
+                                "redacted_because": {
+                                    "content": {},
+                                    "event_id": "$15275047031IXQRi:localhost",
+                                    "origin_server_ts": 1527504703496,
+                                    "redacts": "$15275046980maRLj:localhost",
+                                    "sender": "@example:localhost",
+                                    "type": "m.room.redaction",
+                                    "unsigned": {
+                                        "age": 14523
+                                    }
+                                },
+                                "redacted_by": "$15275047031IXQRi:localhost"
+                            }
+                        },
+                        {
+                            "content": {
+                                "m.relates_to": {
+                                    "event_id": "some event id",
+                                    "key": "👍",
+                                    "rel_type": "m.annotation"
+                                }
+                            },
+                            "event_id": "event id",
+                            "origin_server_ts": 1590275813161,
+                            "sender": "@alice:matrix.org",
+                            "type": "m.reaction",
+                            "unsigned": {
+                                "age": 85
+                            }
+                        }
+                    ],
+                    "limited": true,
+                    "prev_batch": "t392-516_47314_0_7_1_1_1_11444_1"
+                },
+                "unread_notifications": {
+                    "highlight_count": 0,
+                    "notification_count": 11
+                }
+            }
+        },
+        "leave": {}
+    },
+    "to_device": {
+        "events": []
+    },
+    "presence": {
+        "events": []
+    }
+}

--- a/test_data/events/message_edit.json
+++ b/test_data/events/message_edit.json
@@ -1,19 +1,19 @@
 {
     "content": {
-        "body": " * f fjkdslasdf $$$$$$$$$$$$$$$$$$$$$$$$$$$$",
+        "body": " * edited message",
         "m.new_content": {
-            "body": "f fjkdslasdf $$$$$$$$$$$$$$$$$$$$$$$$$$$$",
+            "body": "edited message",
             "msgtype": "m.text"
         },
         "m.relates_to": {
-            "event_id": "$MbS0nMfvub-CPbytp7KRmExAp3oVfdjWOvf2ifG1zWI",
+            "event_id": "some event id",
             "rel_type": "m.replace"
         },
         "msgtype": "m.text"
     },
-    "event_id": "$xXL9cVB_10jkpxUFTsubeusygV0yv5b_63ADjgiQnOA",
+    "event_id": "edit event id",
     "origin_server_ts": 1590262659984,
-    "sender": "@devinr528:matrix.org",
+    "sender": "@alice:matrix.org",
     "type": "m.room.message",
     "unsigned": {
         "age": 85

--- a/test_data/events/reaction.json
+++ b/test_data/events/reaction.json
@@ -1,12 +1,12 @@
 {
     "content": {
         "m.relates_to": {
-            "event_id": "$MDit176PkuBlpP7S6c64iuf74KC2HqZ3peV1NrV4PKA",
+            "event_id": "$MDitXXXXXXuBlpP7S6c6XXXXXXXC2HqZ3peV1NrV4PKA",
             "key": "👍",
             "rel_type": "m.annotation"
         }
     },
-    "event_id": "$QZn9xEx72PUfd2tAGFH-FFgsffZlVMobk47Tl5Lpdtg",
+    "event_id": "$QZn9xEXXXXXfd2tAGFH-XXgsffZlVMobk47Tl5Lpdtg",
     "origin_server_ts": 1590275813161,
     "sender": "@devinr528:matrix.org",
     "type": "m.reaction",

--- a/test_data/more_sync.json
+++ b/test_data/more_sync.json
@@ -1,0 +1,129 @@
+{
+    "device_one_time_keys_count": {},
+    "next_batch": "s526_47314_0_7_1_1_1_11444_1",
+    "device_lists": {
+        "changed": [
+            "@example:example.org"
+        ],
+        "left": []
+    },
+    "rooms": {
+        "invite": {},
+        "join": {
+            "!SVkFJHzfwvuaIEawgC:localhost": {
+                "summary": {},
+                "account_data": {
+                    "events": []
+                },
+                "ephemeral": {
+                    "events": [
+                        {
+                            "content": {
+                                "$151680659217152dPKjd:localhost": {
+                                    "m.read": {
+                                        "@example:localhost": {
+                                            "ts": 1516809890615
+                                        }
+                                    }
+                                }
+                            },
+                            "type": "m.receipt"
+                        },
+                        {
+                            "content": {
+                                "user_ids": [
+                                    "@alice:matrix.org",
+                                    "@bob:example.com"
+                                ]
+                            },
+                            "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
+                            "type": "m.typing"
+                        }
+                    ]
+                },
+                "state": {
+                    "events": []
+                },
+                "timeline": {
+                    "events": [
+                        {
+                            "content": {
+                                "body": "baba",
+                                "format": "org.matrix.custom.html",
+                                "formatted_body": "<strong>baba</strong>",
+                                "msgtype": "m.text"
+                            },
+                            "event_id": "$152037280074GZeOm:localhost",
+                            "origin_server_ts": 1520372800469,
+                            "sender": "@example:localhost",
+                            "type": "m.room.message",
+                            "unsigned": {
+                                "age": 598971425
+                            }
+                        },
+                        {
+                            "content": {
+                                "body": " * edited message",
+                                "m.new_content": {
+                                    "body": "edited message",
+                                    "msgtype": "m.text"
+                                },
+                                "m.relates_to": {
+                                    "event_id": "some event id",
+                                    "rel_type": "m.replace"
+                                },
+                                "msgtype": "m.text"
+                            },
+                            "event_id": "edit event id",
+                            "origin_server_ts": 1590262659984,
+                            "sender": "@alice:matrix.org",
+                            "type": "m.room.message",
+                            "unsigned": {
+                                "age": 85
+                            }
+                        },
+                        {
+                            "content": {
+                                "reason": "😀"
+                            },
+                            "event_id": "$151957878228ssqrJ:localhost",
+                            "origin_server_ts": 1519578782185,
+                            "sender": "@example:localhost",
+                            "type": "m.room.redaction",
+                            "redacts": "$151957878228ssqrj:localhost"
+                        },
+                        {
+                            "content": {
+                                "m.relates_to": {
+                                    "event_id": "some event id",
+                                    "key": "👍",
+                                    "rel_type": "m.annotation"
+                                }
+                            },
+                            "event_id": "event id",
+                            "origin_server_ts": 1590275813161,
+                            "sender": "@alice:matrix.org",
+                            "type": "m.reaction",
+                            "unsigned": {
+                                "age": 85
+                            }
+                        }
+                    ],
+                    "limited": true,
+                    "prev_batch": "t392-516_47314_0_7_1_1_1_11444_1"
+                },
+                "unread_notifications": {
+                    "highlight_count": 0,
+                    "notification_count": 11
+                }
+            }
+        },
+        "leave": {}
+    },
+    "to_device": {
+        "events": []
+    },
+    "presence": {
+        "events": []
+    }
+}


### PR DESCRIPTION
We had everything already implemented to do this just wasn't actually hooked up.

Would a PR to remove one of the `test_data` folders be wanted?