### PR TITLE
matrix-sdk: Export matrix-sdk-base Error type as BaseError

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -483,7 +483,6 @@ impl Client {
         info!("Registering to {}", self.homeserver);
 
         let request = registration.into();
-        println!("{:#?}", request);
         self.send_uiaa(request).await
     }
 

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -36,6 +36,7 @@
     unused_qualifications
 )]
 
+pub use matrix_sdk_base::Error as BaseError;
 #[cfg(not(target_arch = "wasm32"))]
 pub use matrix_sdk_base::JsonStore;
 pub use matrix_sdk_base::{CustomOrRawEvent, EventEmitter, Room, Session, SyncRoom};


### PR DESCRIPTION
Allows for more specific error types when the `BaseClient` Errors.