### PR TITLE
Do wasm sepcific changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ members = [
     "matrix_sdk_test_macros",
     "matrix_sdk_crypto",
     "matrix_sdk_common",
+    "matrix_sdk_common_macros",
 ]

--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.14"
 url = "2.1.1"
 futures-timer = { version = "3.0.2", features = ["wasm-bindgen"] }
 
-
+matrix-sdk-common-macros = { version = "0.1.0", path = "../matrix_sdk_common_macros" }
 matrix-sdk-common = { version = "0.1.0", path = "../matrix_sdk_common" }
 
 [dependencies.matrix-sdk-base]

--- a/matrix_sdk/examples/command_bot.rs
+++ b/matrix_sdk/examples/command_bot.rs
@@ -5,6 +5,7 @@ use matrix_sdk::{
     events::room::message::{MessageEvent, MessageEventContent, TextMessageEventContent},
     Client, ClientConfig, EventEmitter, JsonStore, SyncRoom, SyncSettings,
 };
+use matrix_sdk_common_macros::async_trait;
 use url::Url;
 
 struct CommandBot {
@@ -19,7 +20,7 @@ impl CommandBot {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl EventEmitter for CommandBot {
     async fn on_room_message(&self, room: SyncRoom, event: &MessageEvent) {
         if let SyncRoom::Joined(room) = room {

--- a/matrix_sdk/examples/login.rs
+++ b/matrix_sdk/examples/login.rs
@@ -6,10 +6,11 @@ use matrix_sdk::{
     events::room::message::{MessageEvent, MessageEventContent, TextMessageEventContent},
     Client, ClientConfig, EventEmitter, SyncRoom, SyncSettings,
 };
+use matrix_sdk_common_macros::async_trait;
 
 struct EventCallback;
 
-#[async_trait::async_trait]
+#[async_trait]
 impl EventEmitter for EventCallback {
     async fn on_room_message(&self, room: SyncRoom, event: &MessageEvent) {
         if let SyncRoom::Joined(room) = room {

--- a/matrix_sdk_base/Cargo.toml
+++ b/matrix_sdk_base/Cargo.toml
@@ -22,6 +22,7 @@ serde = "1.0.110"
 serde_json = "1.0.53"
 zeroize = "1.1.0"
 
+matrix-sdk-common-macros = { version = "0.1.0", path = "../matrix_sdk_common_macros" }
 matrix-sdk-common = { version = "0.1.0", path = "../matrix_sdk_common" }
 matrix-sdk-crypto = { version = "0.1.0", path = "../matrix_sdk_crypto", optional = true }
 

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -1768,6 +1768,7 @@ mod test {
         BaseClient, Session,
     };
     use matrix_sdk_test::{async_test, EventBuilder, EventsFile};
+    use matrix_sdk_common_macros::async_trait;
     use serde_json::json;
     use std::convert::TryFrom;
 
@@ -1933,7 +1934,7 @@ mod test {
         };
 
         struct EE(Arc<AtomicBool>);
-        #[async_trait::async_trait]
+        #[async_trait]
         impl EventEmitter for EE {
             async fn on_room_member(&self, room: SyncRoom, event: &MemberEvent) {
                 if let SyncRoom::Joined(_) = room {
@@ -2029,7 +2030,7 @@ mod test {
         };
 
         struct EE(Arc<AtomicBool>);
-        #[async_trait::async_trait]
+        #[async_trait]
         impl EventEmitter for EE {
             async fn on_unrecognized_event(&self, room: SyncRoom, event: &CustomOrRawEvent<'_>) {
                 if let SyncRoom::Joined(_) = room {
@@ -2125,7 +2126,7 @@ mod test {
         };
 
         struct EE(Arc<AtomicBool>);
-        #[async_trait::async_trait]
+        #[async_trait]
         impl EventEmitter for EE {
             async fn on_unrecognized_event(&self, room: SyncRoom, event: &CustomOrRawEvent<'_>) {
                 if let SyncRoom::Joined(_) = room {

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -1767,8 +1767,8 @@ mod test {
         events::{collections::all::RoomEvent, stripped::AnyStrippedStateEvent},
         BaseClient, Session,
     };
-    use matrix_sdk_test::{async_test, EventBuilder, EventsFile};
     use matrix_sdk_common_macros::async_trait;
+    use matrix_sdk_test::{async_test, EventBuilder, EventsFile};
     use serde_json::json;
     use std::convert::TryFrom;
 

--- a/matrix_sdk_base/src/event_emitter/mod.rs
+++ b/matrix_sdk_base/src/event_emitter/mod.rs
@@ -202,9 +202,9 @@ pub trait EventEmitter: Send + Sync {
 mod test {
     use super::*;
     use matrix_sdk_common::locks::Mutex;
+    use matrix_sdk_common_macros::async_trait;
     use matrix_sdk_test::{async_test, sync_response, SyncResponseFile};
     use std::sync::Arc;
-    use matrix_sdk_common_macros::async_trait;
 
     #[cfg(target_arch = "wasm32")]
     pub use wasm_bindgen_test::*;

--- a/matrix_sdk_base/src/event_emitter/mod.rs
+++ b/matrix_sdk_base/src/event_emitter/mod.rs
@@ -43,6 +43,7 @@ use crate::events::{
     CustomEvent, CustomRoomEvent, CustomStateEvent,
 };
 use crate::{Room, RoomState};
+use matrix_sdk_common_macros::async_trait;
 
 /// Type alias for `RoomState` enum when passed to `EventEmitter` methods.
 pub type SyncRoom = RoomState<Arc<RwLock<Room>>>;
@@ -78,10 +79,11 @@ pub enum CustomOrRawEvent<'c> {
 /// #     EventEmitter, SyncRoom
 /// # };
 /// # use matrix_sdk_common::locks::RwLock;
+/// # use matrix_sdk_common_macros::async_trait;
 ///
 /// struct EventCallback;
 ///
-/// #[async_trait::async_trait]
+/// #[async_trait]
 /// impl EventEmitter for EventCallback {
 ///     async fn on_room_message(&self, room: SyncRoom, event: &MessageEvent) {
 ///         if let SyncRoom::Joined(room) = room {
@@ -106,7 +108,7 @@ pub enum CustomOrRawEvent<'c> {
 ///     }
 /// }
 /// ```
-#[async_trait::async_trait]
+#[async_trait]
 pub trait EventEmitter: Send + Sync {
     // ROOM EVENTS from `IncomingTimeline`
     /// Fires when `Client` receives a `RoomEvent::RoomMember` event.
@@ -202,6 +204,7 @@ mod test {
     use matrix_sdk_common::locks::Mutex;
     use matrix_sdk_test::{async_test, sync_response, SyncResponseFile};
     use std::sync::Arc;
+    use matrix_sdk_common_macros::async_trait;
 
     #[cfg(target_arch = "wasm32")]
     pub use wasm_bindgen_test::*;
@@ -209,7 +212,7 @@ mod test {
     #[derive(Clone)]
     pub struct EvEmitterTest(Arc<Mutex<Vec<String>>>);
 
-    #[async_trait::async_trait]
+    #[async_trait]
     impl EventEmitter for EvEmitterTest {
         async fn on_room_member(&self, _: SyncRoom, _: &MemberEvent) {
             self.0.lock().await.push("member".to_string())

--- a/matrix_sdk_base/src/models/room.rs
+++ b/matrix_sdk_base/src/models/room.rs
@@ -42,8 +42,7 @@ use crate::identifiers::{RoomAliasId, RoomId, UserId};
 
 use crate::js_int::{Int, UInt};
 use serde::{Deserialize, Serialize};
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize, Clone)]
 /// `RoomName` allows the calculation of a text room name.
 pub struct RoomName {
     /// The displayed name of the room.
@@ -65,8 +64,7 @@ pub struct RoomName {
     pub invited_member_count: Option<UInt>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct PowerLevels {
     /// The level required to ban a user.
     pub ban: Int,
@@ -137,8 +135,7 @@ impl From<&EncryptionEvent> for EncryptionInfo {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct Tombstone {
     /// A server-defined message.
     body: String,
@@ -146,8 +143,7 @@ pub struct Tombstone {
     replacement: RoomId,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 /// A Matrix room.
 pub struct Room {
     /// The unique id of the room.

--- a/matrix_sdk_base/src/models/room_member.rs
+++ b/matrix_sdk_base/src/models/room_member.rs
@@ -27,8 +27,7 @@ use crate::js_int::{Int, UInt};
 use serde::{Deserialize, Serialize};
 // Notes: if Alice invites Bob into a room we will get an event with the sender as Alice and the state key as Bob.
 
-#[derive(Debug, Serialize, Deserialize)]
-#[cfg_attr(test, derive(Clone))]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 /// A Matrix room member.
 ///
 pub struct RoomMember {

--- a/matrix_sdk_base/src/state/mod.rs
+++ b/matrix_sdk_base/src/state/mod.rs
@@ -27,6 +27,9 @@ use crate::events::push_rules::Ruleset;
 use crate::identifiers::{RoomId, UserId};
 use crate::{Result, Room, RoomState, Session};
 
+#[cfg(not(target_arch = "wasm32"))]
+use matrix_sdk_common_macros::send_sync;
+
 /// `ClientState` holds all the information to restore a `BaseClient`
 /// except the `access_token` as the default store is not secure.
 ///
@@ -85,7 +88,8 @@ pub struct AllRooms {
 
 /// Abstraction around the data store to avoid unnecessary request on client initialization.
 #[async_trait::async_trait]
-pub trait StateStore: Send + Sync {
+#[cfg_attr(not(target_arch = "wasm32"), send_sync)]
+pub trait StateStore {
     /// Loads the state of `BaseClient` through `ClientState` type.
     ///
     /// An `Option::None` should be returned only if the `StateStore` tries to

--- a/matrix_sdk_common_macros/Cargo.toml
+++ b/matrix_sdk_common_macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+description = "Helper macros for the Matrix SDK"
+authors = ["MTRnord <mtrnord1@gmail.com>"]
+edition = "2018"
+homepage = "https://github.com/matrix-org/matrix-rust-sdk"
+keywords = ["matrix", "chat", "messaging", "ruma"]
+license = "Apache-2.0"
+name = "matrix-sdk-common-macros"
+readme = "README.md"
+repository = "https://github.com/matrix-org/matrix-rust-sdk"
+version = "0.1.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"

--- a/matrix_sdk_common_macros/src/lib.rs
+++ b/matrix_sdk_common_macros/src/lib.rs
@@ -1,0 +1,30 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, parse_quote, ItemTrait};
+
+/// Attribute to use `Send + Sync` for everything but wasm32
+#[proc_macro_attribute]
+pub fn send_sync(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let mut input = parse_macro_input!(input as ItemTrait);
+
+    let send_trait_bound = parse_quote!(std::marker::Send);
+    let sync_trait_bound = parse_quote!(std::marker::Sync);
+    input.supertraits.push(send_trait_bound);
+    input.supertraits.push(sync_trait_bound);
+
+    TokenStream::from(quote!(#input))
+}
+
+/// A wasm32 compatible wrapper for the async_trait::async_trait macro
+#[proc_macro_attribute]
+pub fn async_trait(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attrs = r#"
+        #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+        #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    "#;
+
+    let mut out: TokenStream = attrs.parse().unwrap();
+    out.extend(item);
+    out
+}

--- a/matrix_sdk_crypto/Cargo.toml
+++ b/matrix_sdk_crypto/Cargo.toml
@@ -17,6 +17,7 @@ sqlite-cryptostore = ["sqlx"]
 [dependencies]
 async-trait = "0.1.31"
 
+matrix-sdk-common-macros = { version = "0.1.0", path = "../matrix_sdk_common_macros" }
 matrix-sdk-common = { version = "0.1.0", path = "../matrix_sdk_common" }
 
 olm-rs = { version = "0.5.0", features = ["serde"] }

--- a/matrix_sdk_crypto/src/store/mod.rs
+++ b/matrix_sdk_crypto/src/store/mod.rs
@@ -27,8 +27,8 @@ use super::device::Device;
 use super::memory_stores::UserDevices;
 use super::olm::{Account, InboundGroupSession, Session};
 use matrix_sdk_common::identifiers::{DeviceId, RoomId, UserId};
-use olm_rs::errors::{OlmAccountError, OlmGroupSessionError, OlmSessionError};
 use matrix_sdk_common_macros::send_sync;
+use olm_rs::errors::{OlmAccountError, OlmGroupSessionError, OlmSessionError};
 
 pub mod memorystore;
 

--- a/matrix_sdk_crypto/src/store/mod.rs
+++ b/matrix_sdk_crypto/src/store/mod.rs
@@ -28,11 +28,15 @@ use super::memory_stores::UserDevices;
 use super::olm::{Account, InboundGroupSession, Session};
 use matrix_sdk_common::identifiers::{DeviceId, RoomId, UserId};
 use olm_rs::errors::{OlmAccountError, OlmGroupSessionError, OlmSessionError};
+use matrix_sdk_common_macros::send_sync;
 
 pub mod memorystore;
+
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(feature = "sqlite-cryptostore")]
 pub mod sqlite;
 
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(feature = "sqlite-cryptostore")]
 use sqlx::Error as SqlxError;
 
@@ -83,9 +87,10 @@ pub enum CryptoStoreError {
 pub type Result<T> = std::result::Result<T, CryptoStoreError>;
 
 #[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), send_sync)]
 /// Trait abstracting a store that the `OlmMachine` uses to store cryptographic
 /// keys.
-pub trait CryptoStore: Debug + Send + Sync {
+pub trait CryptoStore: Debug {
     /// Load an account that was previously stored.
     async fn load_account(&mut self) -> Result<Option<Account>>;
 


### PR DESCRIPTION
- Only use send+sync when not using wasm
- Use wasm capable async_trait wrapper macro
- Make room and room_member specific structs always clonable

The first two are discussed in the wasm tracking issue (#35) the third was from a discussion in the matrix room. 

All changes were tested in Daydream.