### PR TITLE
mark state::AllRooms and state::ClientState as public

### DIFF
--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -50,6 +50,8 @@ pub use event_emitter::{EventEmitter, SyncRoom};
 #[cfg(feature = "encryption")]
 pub use matrix_sdk_crypto::{Device, TrustState};
 pub use models::Room;
+pub use state::AllRooms;
+pub use state::ClientState;
 #[cfg(not(target_arch = "wasm32"))]
 pub use state::JsonStore;
 pub use state::StateStore;


### PR DESCRIPTION
Mark `AllRooms` and `ClientState` as `pub` in `matrix-sdk-basd` so that the `StateStore` trait can be implemented in a local crate.

The trait `StateStore` has

```rust
    async fn load_client_state(&self, _: &Session) -> Result<Option<ClientState>>;
    async fn load_all_rooms(&self) -> Result<AllRooms>;
```

which reference the currently private `ClientState` and `AllRooms`. Implementing this trait is not possible currently (afaik), since it references those types. This PR marks them as `pub` so they can be used in the trait impl.