### PR TITLE
matrix-sdk-base: MessageQueue properly handles redacted events

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,16 +14,16 @@ repos:
         types: [file, rust]
         entry: cargo fmt -- --check
 
-      # - id: clippy
-      #   name: clippy
-      #   language: system
-      #   types: [file, rust]
-      #   entry: cargo clippy --all-targets --all
-      #   pass_filenames: false
+      - id: clippy
+        name: clippy
+        language: system
+        types: [file, rust]
+        entry: cargo clippy --all-targets --all
+        pass_filenames: false
 
-      # - id: test
-      #   name: test
-      #   language: system
-      #   files: '\.rs$'
-      #   entry: cargo test --lib
-      #   pass_filenames: false
+      - id: test
+        name: test
+        language: system
+        files: '\.rs$'
+        entry: cargo test --lib
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,16 +14,16 @@ repos:
         types: [file, rust]
         entry: cargo fmt -- --check
 
-      - id: clippy
-        name: clippy
-        language: system
-        types: [file, rust]
-        entry: cargo clippy --all-targets --all
-        pass_filenames: false
+      # - id: clippy
+      #   name: clippy
+      #   language: system
+      #   types: [file, rust]
+      #   entry: cargo clippy --all-targets --all
+      #   pass_filenames: false
 
-      - id: test
-        name: test
-        language: system
-        files: '\.rs$'
-        entry: cargo test --lib
-        pass_filenames: false
+      # - id: test
+      #   name: test
+      #   language: system
+      #   files: '\.rs$'
+      #   entry: cargo test --lib
+      #   pass_filenames: false

--- a/matrix_sdk/examples/autojoin.rs
+++ b/matrix_sdk/examples/autojoin.rs
@@ -2,7 +2,7 @@ use std::{env, process::exit};
 
 use matrix_sdk::{
     self,
-    events::{room::member::MemberEventContent, StrippedStateEventStub},
+    events::{room::member::MemberEventContent, StrippedStateEvent},
     Client, ClientConfig, EventEmitter, SyncRoom, SyncSettings,
 };
 use matrix_sdk_common_macros::async_trait;
@@ -23,7 +23,7 @@ impl EventEmitter for AutoJoinBot {
     async fn on_stripped_state_member(
         &self,
         room: SyncRoom,
-        room_member: &StrippedStateEventStub<MemberEventContent>,
+        room_member: &StrippedStateEvent<MemberEventContent>,
         _: Option<MemberEventContent>,
     ) {
         if room_member.state_key != self.client.user_id().await.unwrap() {

--- a/matrix_sdk/examples/command_bot.rs
+++ b/matrix_sdk/examples/command_bot.rs
@@ -4,7 +4,7 @@ use matrix_sdk::{
     self,
     events::{
         room::message::{MessageEventContent, TextMessageEventContent},
-        MessageEventStub,
+        SyncMessageEvent,
     },
     Client, ClientConfig, EventEmitter, JsonStore, SyncRoom, SyncSettings,
 };
@@ -25,9 +25,9 @@ impl CommandBot {
 
 #[async_trait]
 impl EventEmitter for CommandBot {
-    async fn on_room_message(&self, room: SyncRoom, event: &MessageEventStub<MessageEventContent>) {
+    async fn on_room_message(&self, room: SyncRoom, event: &SyncMessageEvent<MessageEventContent>) {
         if let SyncRoom::Joined(room) = room {
-            let msg_body = if let MessageEventStub {
+            let msg_body = if let SyncMessageEvent {
                 content: MessageEventContent::Text(TextMessageEventContent { body: msg_body, .. }),
                 ..
             } = event

--- a/matrix_sdk/examples/login.rs
+++ b/matrix_sdk/examples/login.rs
@@ -5,7 +5,7 @@ use matrix_sdk::{
     self,
     events::{
         room::message::{MessageEventContent, TextMessageEventContent},
-        MessageEventStub,
+        SyncMessageEvent,
     },
     Client, ClientConfig, EventEmitter, SyncRoom, SyncSettings,
 };
@@ -15,9 +15,9 @@ struct EventCallback;
 
 #[async_trait]
 impl EventEmitter for EventCallback {
-    async fn on_room_message(&self, room: SyncRoom, event: &MessageEventStub<MessageEventContent>) {
+    async fn on_room_message(&self, room: SyncRoom, event: &SyncMessageEvent<MessageEventContent>) {
         if let SyncRoom::Joined(room) = room {
-            if let MessageEventStub {
+            if let SyncMessageEvent {
                 content: MessageEventContent::Text(TextMessageEventContent { body: msg_body, .. }),
                 sender,
                 ..

--- a/matrix_sdk/examples/wasm_command_bot/src/lib.rs
+++ b/matrix_sdk/examples/wasm_command_bot/src/lib.rs
@@ -2,7 +2,7 @@ use matrix_sdk::{
     api::r0::sync::sync_events::Response as SyncResponse,
     events::{
         room::message::{MessageEventContent, TextMessageEventContent},
-        AnyMessageEventStub, AnyRoomEventStub, MessageEventStub,
+        AnySyncMessageEvent, AnySyncRoomEvent, SyncMessageEvent,
     },
     identifiers::RoomId,
     Client, ClientConfig, SyncSettings,
@@ -17,9 +17,9 @@ impl WasmBot {
     async fn on_room_message(
         &self,
         room_id: &RoomId,
-        event: MessageEventStub<MessageEventContent>,
+        event: SyncMessageEvent<MessageEventContent>,
     ) {
-        let msg_body = if let MessageEventStub {
+        let msg_body = if let SyncMessageEvent {
             content: MessageEventContent::Text(TextMessageEventContent { body: msg_body, .. }),
             ..
         } = event
@@ -45,7 +45,7 @@ impl WasmBot {
         for (room_id, room) in response.rooms.join {
             for event in room.timeline.events {
                 if let Ok(event) = event.deserialize() {
-                    if let AnyRoomEventStub::Message(AnyMessageEventStub::RoomMessage(ev)) = event {
+                    if let AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(ev)) = event {
                         self.on_room_message(&room_id, ev).await
                     }
                 }

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -472,7 +472,7 @@ impl Client {
             login_info: login::LoginInfo::Password {
                 password: password.into(),
             },
-            device_id: device_id.map(|d| d.into()),
+            device_id: device_id.map(|d| d.into().into_boxed_str()),
             initial_device_display_name: initial_device_display_name.map(|d| d.into()),
         };
 
@@ -1407,7 +1407,7 @@ impl Client {
     #[instrument]
     async fn claim_one_time_keys(
         &self,
-        one_time_keys: BTreeMap<UserId, BTreeMap<DeviceId, KeyAlgorithm>>,
+        one_time_keys: BTreeMap<UserId, BTreeMap<Box<DeviceId>, KeyAlgorithm>>,
     ) -> Result<claim_keys::Response> {
         let request = claim_keys::Request {
             timeout: None,
@@ -1511,7 +1511,7 @@ impl Client {
             users_for_query
         );
 
-        let mut device_keys: BTreeMap<UserId, Vec<DeviceId>> = BTreeMap::new();
+        let mut device_keys: BTreeMap<UserId, Vec<Box<DeviceId>>> = BTreeMap::new();
 
         for user in users_for_query.drain() {
             device_keys.insert(user, Vec::new());

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -40,6 +40,8 @@ pub use matrix_sdk_base::Error as BaseError;
 #[cfg(not(target_arch = "wasm32"))]
 pub use matrix_sdk_base::JsonStore;
 pub use matrix_sdk_base::{CustomOrRawEvent, EventEmitter, Room, Session, SyncRoom};
+#[cfg(feature = "messages")]
+pub use matrix_sdk_base::{FullOrRedactedEvent, MessageQueue, MessageWrapper};
 pub use matrix_sdk_base::{RoomState, StateStore};
 pub use matrix_sdk_common::*;
 pub use reqwest::header::InvalidHeaderValue;

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -41,7 +41,7 @@ pub use matrix_sdk_base::Error as BaseError;
 pub use matrix_sdk_base::JsonStore;
 pub use matrix_sdk_base::{CustomOrRawEvent, EventEmitter, Room, Session, SyncRoom};
 #[cfg(feature = "messages")]
-pub use matrix_sdk_base::{FullOrRedactedEvent, MessageQueue, MessageWrapper};
+pub use matrix_sdk_base::{MessageQueue, MessageWrapper, PossiblyRedactedExt};
 pub use matrix_sdk_base::{RoomState, StateStore};
 pub use matrix_sdk_common::*;
 pub use reqwest::header::InvalidHeaderValue;

--- a/matrix_sdk/src/request_builder.rs
+++ b/matrix_sdk/src/request_builder.rs
@@ -275,7 +275,7 @@ impl Into<get_message_events::Request> for MessagesRequestBuilder {
 pub struct RegistrationBuilder {
     password: Option<String>,
     username: Option<String>,
-    device_id: Option<DeviceId>,
+    device_id: Option<Box<DeviceId>>,
     initial_device_display_name: Option<String>,
     auth: Option<AuthData>,
     kind: Option<RegistrationKind>,
@@ -309,7 +309,7 @@ impl RegistrationBuilder {
     ///
     /// If this does not correspond to a known client device, a new device will be created.
     /// The server will auto-generate a device_id if this is not specified.
-    pub fn device_id<S: Into<String>>(&mut self, device_id: S) -> &mut Self {
+    pub fn device_id<S: Into<Box<str>>>(&mut self, device_id: S) -> &mut Self {
         self.device_id = Some(device_id.into());
         self
     }

--- a/matrix_sdk_base/src/event_emitter/mod.rs
+++ b/matrix_sdk_base/src/event_emitter/mod.rs
@@ -33,11 +33,11 @@ use crate::events::{
         message::{feedback::FeedbackEventContent, MessageEventContent as MsgEventContent},
         name::NameEventContent,
         power_levels::PowerLevelsEventContent,
-        redaction::RedactionEventStub,
+        redaction::SyncRedactionEvent,
         tombstone::TombstoneEventContent,
     },
     typing::TypingEventContent,
-    BasicEvent, EphemeralRoomEvent, MessageEventStub, StateEventStub, StrippedStateEventStub,
+    BasicEvent, EphemeralRoomEvent, StrippedStateEvent, SyncMessageEvent, SyncStateEvent,
 };
 use crate::{Room, RoomState};
 use matrix_sdk_common_macros::async_trait;
@@ -55,11 +55,11 @@ pub enum CustomOrRawEvent<'c> {
     /// A custom basic event.
     EphemeralRoom(&'c EphemeralRoomEvent<CustomEventContent>),
     /// A custom room event.
-    Message(&'c MessageEventStub<CustomEventContent>),
+    Message(&'c SyncMessageEvent<CustomEventContent>),
     /// A custom state event.
-    State(&'c StateEventStub<CustomEventContent>),
+    State(&'c SyncStateEvent<CustomEventContent>),
     /// A custom stripped state event.
-    StrippedState(&'c StrippedStateEventStub<CustomEventContent>),
+    StrippedState(&'c StrippedStateEvent<CustomEventContent>),
 }
 
 /// This trait allows any type implementing `EventEmitter` to specify event callbacks for each event.
@@ -74,7 +74,7 @@ pub enum CustomOrRawEvent<'c> {
 /// #     self,
 /// #     events::{
 /// #         room::message::{MessageEventContent, TextMessageEventContent},
-/// #         MessageEventStub
+/// #         SyncMessageEvent
 /// #     },
 /// #     EventEmitter, SyncRoom
 /// # };
@@ -85,9 +85,9 @@ pub enum CustomOrRawEvent<'c> {
 ///
 /// #[async_trait]
 /// impl EventEmitter for EventCallback {
-///     async fn on_room_message(&self, room: SyncRoom, event: &MessageEventStub<MessageEventContent>) {
+///     async fn on_room_message(&self, room: SyncRoom, event: &SyncMessageEvent<MessageEventContent>) {
 ///         if let SyncRoom::Joined(room) = room {
-///             if let MessageEventStub {
+///             if let SyncMessageEvent {
 ///                 content: MessageEventContent::Text(TextMessageEventContent { body: msg_body, .. }),
 ///                 sender,
 ///                 ..
@@ -112,114 +112,109 @@ pub enum CustomOrRawEvent<'c> {
 pub trait EventEmitter: Send + Sync {
     // ROOM EVENTS from `IncomingTimeline`
     /// Fires when `Client` receives a `RoomEvent::RoomMember` event.
-    async fn on_room_member(&self, _: SyncRoom, _: &StateEventStub<MemberEventContent>) {}
+    async fn on_room_member(&self, _: SyncRoom, _: &SyncStateEvent<MemberEventContent>) {}
     /// Fires when `Client` receives a `RoomEvent::RoomName` event.
-    async fn on_room_name(&self, _: SyncRoom, _: &StateEventStub<NameEventContent>) {}
+    async fn on_room_name(&self, _: SyncRoom, _: &SyncStateEvent<NameEventContent>) {}
     /// Fires when `Client` receives a `RoomEvent::RoomCanonicalAlias` event.
     async fn on_room_canonical_alias(
         &self,
         _: SyncRoom,
-        _: &StateEventStub<CanonicalAliasEventContent>,
+        _: &SyncStateEvent<CanonicalAliasEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `RoomEvent::RoomAliases` event.
-    async fn on_room_aliases(&self, _: SyncRoom, _: &StateEventStub<AliasesEventContent>) {}
+    async fn on_room_aliases(&self, _: SyncRoom, _: &SyncStateEvent<AliasesEventContent>) {}
     /// Fires when `Client` receives a `RoomEvent::RoomAvatar` event.
-    async fn on_room_avatar(&self, _: SyncRoom, _: &StateEventStub<AvatarEventContent>) {}
+    async fn on_room_avatar(&self, _: SyncRoom, _: &SyncStateEvent<AvatarEventContent>) {}
     /// Fires when `Client` receives a `RoomEvent::RoomMessage` event.
-    async fn on_room_message(&self, _: SyncRoom, _: &MessageEventStub<MsgEventContent>) {}
+    async fn on_room_message(&self, _: SyncRoom, _: &SyncMessageEvent<MsgEventContent>) {}
     /// Fires when `Client` receives a `RoomEvent::RoomMessageFeedback` event.
     async fn on_room_message_feedback(
         &self,
         _: SyncRoom,
-        _: &MessageEventStub<FeedbackEventContent>,
+        _: &SyncMessageEvent<FeedbackEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `RoomEvent::RoomRedaction` event.
-    async fn on_room_redaction(&self, _: SyncRoom, _: &RedactionEventStub) {}
+    async fn on_room_redaction(&self, _: SyncRoom, _: &SyncRedactionEvent) {}
     /// Fires when `Client` receives a `RoomEvent::RoomPowerLevels` event.
-    async fn on_room_power_levels(&self, _: SyncRoom, _: &StateEventStub<PowerLevelsEventContent>) {
+    async fn on_room_power_levels(&self, _: SyncRoom, _: &SyncStateEvent<PowerLevelsEventContent>) {
     }
     /// Fires when `Client` receives a `RoomEvent::Tombstone` event.
-    async fn on_room_join_rules(&self, _: SyncRoom, _: &StateEventStub<JoinRulesEventContent>) {}
+    async fn on_room_join_rules(&self, _: SyncRoom, _: &SyncStateEvent<JoinRulesEventContent>) {}
     /// Fires when `Client` receives a `RoomEvent::Tombstone` event.
-    async fn on_room_tombstone(&self, _: SyncRoom, _: &StateEventStub<TombstoneEventContent>) {}
+    async fn on_room_tombstone(&self, _: SyncRoom, _: &SyncStateEvent<TombstoneEventContent>) {}
 
     // `RoomEvent`s from `IncomingState`
     /// Fires when `Client` receives a `StateEvent::RoomMember` event.
-    async fn on_state_member(&self, _: SyncRoom, _: &StateEventStub<MemberEventContent>) {}
+    async fn on_state_member(&self, _: SyncRoom, _: &SyncStateEvent<MemberEventContent>) {}
     /// Fires when `Client` receives a `StateEvent::RoomName` event.
-    async fn on_state_name(&self, _: SyncRoom, _: &StateEventStub<NameEventContent>) {}
+    async fn on_state_name(&self, _: SyncRoom, _: &SyncStateEvent<NameEventContent>) {}
     /// Fires when `Client` receives a `StateEvent::RoomCanonicalAlias` event.
     async fn on_state_canonical_alias(
         &self,
         _: SyncRoom,
-        _: &StateEventStub<CanonicalAliasEventContent>,
+        _: &SyncStateEvent<CanonicalAliasEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `StateEvent::RoomAliases` event.
-    async fn on_state_aliases(&self, _: SyncRoom, _: &StateEventStub<AliasesEventContent>) {}
+    async fn on_state_aliases(&self, _: SyncRoom, _: &SyncStateEvent<AliasesEventContent>) {}
     /// Fires when `Client` receives a `StateEvent::RoomAvatar` event.
-    async fn on_state_avatar(&self, _: SyncRoom, _: &StateEventStub<AvatarEventContent>) {}
+    async fn on_state_avatar(&self, _: SyncRoom, _: &SyncStateEvent<AvatarEventContent>) {}
     /// Fires when `Client` receives a `StateEvent::RoomPowerLevels` event.
     async fn on_state_power_levels(
         &self,
         _: SyncRoom,
-        _: &StateEventStub<PowerLevelsEventContent>,
+        _: &SyncStateEvent<PowerLevelsEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `StateEvent::RoomJoinRules` event.
-    async fn on_state_join_rules(&self, _: SyncRoom, _: &StateEventStub<JoinRulesEventContent>) {}
+    async fn on_state_join_rules(&self, _: SyncRoom, _: &SyncStateEvent<JoinRulesEventContent>) {}
 
     // `AnyStrippedStateEvent`s
     /// Fires when `Client` receives a `AnyStrippedStateEvent::StrippedRoomMember` event.
     async fn on_stripped_state_member(
         &self,
         _: SyncRoom,
-        _: &StrippedStateEventStub<MemberEventContent>,
+        _: &StrippedStateEvent<MemberEventContent>,
         _: Option<MemberEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `AnyStrippedStateEvent::StrippedRoomName` event.
-    async fn on_stripped_state_name(
-        &self,
-        _: SyncRoom,
-        _: &StrippedStateEventStub<NameEventContent>,
-    ) {
-    }
+    async fn on_stripped_state_name(&self, _: SyncRoom, _: &StrippedStateEvent<NameEventContent>) {}
     /// Fires when `Client` receives a `AnyStrippedStateEvent::StrippedRoomCanonicalAlias` event.
     async fn on_stripped_state_canonical_alias(
         &self,
         _: SyncRoom,
-        _: &StrippedStateEventStub<CanonicalAliasEventContent>,
+        _: &StrippedStateEvent<CanonicalAliasEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `AnyStrippedStateEvent::StrippedRoomAliases` event.
     async fn on_stripped_state_aliases(
         &self,
         _: SyncRoom,
-        _: &StrippedStateEventStub<AliasesEventContent>,
+        _: &StrippedStateEvent<AliasesEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `AnyStrippedStateEvent::StrippedRoomAvatar` event.
     async fn on_stripped_state_avatar(
         &self,
         _: SyncRoom,
-        _: &StrippedStateEventStub<AvatarEventContent>,
+        _: &StrippedStateEvent<AvatarEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `AnyStrippedStateEvent::StrippedRoomPowerLevels` event.
     async fn on_stripped_state_power_levels(
         &self,
         _: SyncRoom,
-        _: &StrippedStateEventStub<PowerLevelsEventContent>,
+        _: &StrippedStateEvent<PowerLevelsEventContent>,
     ) {
     }
     /// Fires when `Client` receives a `AnyStrippedStateEvent::StrippedRoomJoinRules` event.
     async fn on_stripped_state_join_rules(
         &self,
         _: SyncRoom,
-        _: &StrippedStateEventStub<JoinRulesEventContent>,
+        _: &StrippedStateEvent<JoinRulesEventContent>,
     ) {
     }
 
@@ -276,79 +271,79 @@ mod test {
 
     #[async_trait]
     impl EventEmitter for EvEmitterTest {
-        async fn on_room_member(&self, _: SyncRoom, _: &StateEventStub<MemberEventContent>) {
+        async fn on_room_member(&self, _: SyncRoom, _: &SyncStateEvent<MemberEventContent>) {
             self.0.lock().await.push("member".to_string())
         }
-        async fn on_room_name(&self, _: SyncRoom, _: &StateEventStub<NameEventContent>) {
+        async fn on_room_name(&self, _: SyncRoom, _: &SyncStateEvent<NameEventContent>) {
             self.0.lock().await.push("name".to_string())
         }
         async fn on_room_canonical_alias(
             &self,
             _: SyncRoom,
-            _: &StateEventStub<CanonicalAliasEventContent>,
+            _: &SyncStateEvent<CanonicalAliasEventContent>,
         ) {
             self.0.lock().await.push("canonical".to_string())
         }
-        async fn on_room_aliases(&self, _: SyncRoom, _: &StateEventStub<AliasesEventContent>) {
+        async fn on_room_aliases(&self, _: SyncRoom, _: &SyncStateEvent<AliasesEventContent>) {
             self.0.lock().await.push("aliases".to_string())
         }
-        async fn on_room_avatar(&self, _: SyncRoom, _: &StateEventStub<AvatarEventContent>) {
+        async fn on_room_avatar(&self, _: SyncRoom, _: &SyncStateEvent<AvatarEventContent>) {
             self.0.lock().await.push("avatar".to_string())
         }
-        async fn on_room_message(&self, _: SyncRoom, _: &MessageEventStub<MsgEventContent>) {
+        async fn on_room_message(&self, _: SyncRoom, _: &SyncMessageEvent<MsgEventContent>) {
             self.0.lock().await.push("message".to_string())
         }
         async fn on_room_message_feedback(
             &self,
             _: SyncRoom,
-            _: &MessageEventStub<FeedbackEventContent>,
+            _: &SyncMessageEvent<FeedbackEventContent>,
         ) {
             self.0.lock().await.push("feedback".to_string())
         }
-        async fn on_room_redaction(&self, _: SyncRoom, _: &RedactionEventStub) {
+        async fn on_room_redaction(&self, _: SyncRoom, _: &SyncRedactionEvent) {
             self.0.lock().await.push("redaction".to_string())
         }
         async fn on_room_power_levels(
             &self,
             _: SyncRoom,
-            _: &StateEventStub<PowerLevelsEventContent>,
+            _: &SyncStateEvent<PowerLevelsEventContent>,
         ) {
             self.0.lock().await.push("power".to_string())
         }
-        async fn on_room_tombstone(&self, _: SyncRoom, _: &StateEventStub<TombstoneEventContent>) {
+        async fn on_room_tombstone(&self, _: SyncRoom, _: &SyncStateEvent<TombstoneEventContent>) {
             self.0.lock().await.push("tombstone".to_string())
         }
 
-        async fn on_state_member(&self, _: SyncRoom, _: &StateEventStub<MemberEventContent>) {
+        async fn on_state_member(&self, _: SyncRoom, _: &SyncStateEvent<MemberEventContent>) {
             self.0.lock().await.push("state member".to_string())
         }
-        async fn on_state_name(&self, _: SyncRoom, _: &StateEventStub<NameEventContent>) {
+        async fn on_state_name(&self, _: SyncRoom, _: &SyncStateEvent<NameEventContent>) {
             self.0.lock().await.push("state name".to_string())
         }
         async fn on_state_canonical_alias(
             &self,
             _: SyncRoom,
-            _: &StateEventStub<CanonicalAliasEventContent>,
+            _: &SyncStateEvent<CanonicalAliasEventContent>,
         ) {
             self.0.lock().await.push("state canonical".to_string())
         }
-        async fn on_state_aliases(&self, _: SyncRoom, _: &StateEventStub<AliasesEventContent>) {
+        async fn on_state_aliases(&self, _: SyncRoom, _: &SyncStateEvent<AliasesEventContent>) {
             self.0.lock().await.push("state aliases".to_string())
         }
-        async fn on_state_avatar(&self, _: SyncRoom, _: &StateEventStub<AvatarEventContent>) {
+        async fn on_state_avatar(&self, _: SyncRoom, _: &SyncStateEvent<AvatarEventContent>) {
             self.0.lock().await.push("state avatar".to_string())
         }
         async fn on_state_power_levels(
             &self,
             _: SyncRoom,
-            _: &StateEventStub<PowerLevelsEventContent>,
+            _: &SyncStateEvent<PowerLevelsEventContent>,
         ) {
             self.0.lock().await.push("state power".to_string())
         }
         async fn on_state_join_rules(
             &self,
             _: SyncRoom,
-            _: &StateEventStub<JoinRulesEventContent>,
+            _: &SyncStateEvent<JoinRulesEventContent>,
         ) {
             self.0.lock().await.push("state rules".to_string())
         }
@@ -358,7 +353,7 @@ mod test {
         async fn on_stripped_state_member(
             &self,
             _: SyncRoom,
-            _: &StrippedStateEventStub<MemberEventContent>,
+            _: &StrippedStateEvent<MemberEventContent>,
             _: Option<MemberEventContent>,
         ) {
             self.0
@@ -370,7 +365,7 @@ mod test {
         async fn on_stripped_state_name(
             &self,
             _: SyncRoom,
-            _: &StrippedStateEventStub<NameEventContent>,
+            _: &StrippedStateEvent<NameEventContent>,
         ) {
             self.0.lock().await.push("stripped state name".to_string())
         }
@@ -378,7 +373,7 @@ mod test {
         async fn on_stripped_state_canonical_alias(
             &self,
             _: SyncRoom,
-            _: &StrippedStateEventStub<CanonicalAliasEventContent>,
+            _: &StrippedStateEvent<CanonicalAliasEventContent>,
         ) {
             self.0
                 .lock()
@@ -389,7 +384,7 @@ mod test {
         async fn on_stripped_state_aliases(
             &self,
             _: SyncRoom,
-            _: &StrippedStateEventStub<AliasesEventContent>,
+            _: &StrippedStateEvent<AliasesEventContent>,
         ) {
             self.0
                 .lock()
@@ -400,7 +395,7 @@ mod test {
         async fn on_stripped_state_avatar(
             &self,
             _: SyncRoom,
-            _: &StrippedStateEventStub<AvatarEventContent>,
+            _: &StrippedStateEvent<AvatarEventContent>,
         ) {
             self.0
                 .lock()
@@ -411,7 +406,7 @@ mod test {
         async fn on_stripped_state_power_levels(
             &self,
             _: SyncRoom,
-            _: &StrippedStateEventStub<PowerLevelsEventContent>,
+            _: &StrippedStateEvent<PowerLevelsEventContent>,
         ) {
             self.0.lock().await.push("stripped state power".to_string())
         }
@@ -419,7 +414,7 @@ mod test {
         async fn on_stripped_state_join_rules(
             &self,
             _: SyncRoom,
-            _: &StrippedStateEventStub<JoinRulesEventContent>,
+            _: &StrippedStateEvent<JoinRulesEventContent>,
         ) {
             self.0.lock().await.push("stripped state rules".to_string())
         }

--- a/matrix_sdk_base/src/event_emitter/mod.rs
+++ b/matrix_sdk_base/src/event_emitter/mod.rs
@@ -581,7 +581,7 @@ mod test {
                 "unrecognized event",
                 "redaction",
                 "unrecognized event",
-                "unrecognized event",
+                // "unrecognized event", this is actually a redacted "m.room.messages" event
                 "receipt event",
                 "typing event"
             ],

--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -47,11 +47,16 @@ mod state;
 
 pub use client::{BaseClient, BaseClientConfig, RoomState, RoomStateType};
 pub use event_emitter::{CustomOrRawEvent, EventEmitter, SyncRoom};
+pub use models::Room;
+pub use state::{AllRooms, ClientState};
+
 #[cfg(feature = "encryption")]
 pub use matrix_sdk_crypto::{Device, TrustState};
-pub use models::Room;
-pub use state::AllRooms;
-pub use state::ClientState;
+
+#[cfg(feature = "messages")]
+#[cfg_attr(docsrs, doc(cfg(feature = "messages")))]
+pub use models::{FullOrRedactedEvent, MessageQueue, MessageWrapper};
+
 #[cfg(not(target_arch = "wasm32"))]
 pub use state::JsonStore;
 pub use state::StateStore;

--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -55,7 +55,7 @@ pub use matrix_sdk_crypto::{Device, TrustState};
 
 #[cfg(feature = "messages")]
 #[cfg_attr(docsrs, doc(cfg(feature = "messages")))]
-pub use models::{FullOrRedactedEvent, MessageQueue, MessageWrapper};
+pub use models::{MessageQueue, MessageWrapper, PossiblyRedactedExt};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use state::JsonStore;

--- a/matrix_sdk_base/src/models/message.rs
+++ b/matrix_sdk_base/src/models/message.rs
@@ -13,7 +13,7 @@ use std::{
 use matrix_sdk_common::identifiers::EventId;
 use serde::{de, ser, Deserialize, Serialize};
 
-use crate::events::{AnyMessageEventStub, AnyRedactedMessageEventStub};
+use crate::events::{AnyRedactedSyncMessageEvent, AnySyncMessageEvent};
 
 /// Represents either a redacted event or a non-redacted event.
 ///
@@ -21,9 +21,9 @@ use crate::events::{AnyMessageEventStub, AnyRedactedMessageEventStub};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum FullOrRedactedEvent {
     /// A non-redacted event.
-    Full(AnyMessageEventStub),
+    Full(AnySyncMessageEvent),
     /// An event that has been redacted.
-    Redacted(AnyRedactedMessageEventStub),
+    Redacted(AnyRedactedSyncMessageEvent),
 }
 
 impl FullOrRedactedEvent {
@@ -228,7 +228,7 @@ mod test {
 
         let json: &serde_json::Value = &test_json::MESSAGE_TEXT;
         let msg = FullOrRedactedEvent::Full(
-            serde_json::from_value::<AnyMessageEventStub>(json.clone()).unwrap(),
+            serde_json::from_value::<AnySyncMessageEvent>(json.clone()).unwrap(),
         );
 
         let mut msgs = MessageQueue::new();
@@ -275,7 +275,7 @@ mod test {
 
         let json: &serde_json::Value = &test_json::MESSAGE_TEXT;
         let msg = FullOrRedactedEvent::Full(
-            serde_json::from_value::<AnyMessageEventStub>(json.clone()).unwrap(),
+            serde_json::from_value::<AnySyncMessageEvent>(json.clone()).unwrap(),
         );
 
         let mut msgs = MessageQueue::new();

--- a/matrix_sdk_base/src/models/mod.rs
+++ b/matrix_sdk_base/src/models/mod.rs
@@ -6,6 +6,6 @@ mod room_member;
 
 #[cfg(feature = "messages")]
 #[cfg_attr(docsrs, doc(cfg(feature = "messages")))]
-pub use message::{FullOrRedactedEvent, MessageQueue, MessageWrapper};
+pub use message::{MessageQueue, MessageWrapper, PossiblyRedactedExt};
 pub use room::{Room, RoomName};
 pub use room_member::RoomMember;

--- a/matrix_sdk_base/src/models/mod.rs
+++ b/matrix_sdk_base/src/models/mod.rs
@@ -4,5 +4,8 @@ mod message;
 mod room;
 mod room_member;
 
+#[cfg(feature = "messages")]
+#[cfg_attr(docsrs, doc(cfg(feature = "messages")))]
+pub use message::{FullOrRedactedEvent, MessageQueue, MessageWrapper};
 pub use room::{Room, RoomName};
 pub use room_member::RoomMember;

--- a/matrix_sdk_base/src/models/room_member.rs
+++ b/matrix_sdk_base/src/models/room_member.rs
@@ -15,12 +15,15 @@
 
 use std::convert::TryFrom;
 
-use crate::events::presence::{PresenceEvent, PresenceState};
-use crate::events::room::member::MemberEventContent;
-use crate::events::StateEventStub;
-use crate::identifiers::{RoomId, UserId};
-
-use crate::js_int::{Int, UInt};
+use matrix_sdk_common::{
+    events::{
+        presence::{PresenceEvent, PresenceState},
+        room::member::MemberEventContent,
+        SyncStateEvent,
+    },
+    identifiers::{RoomId, UserId},
+    js_int::{Int, UInt},
+};
 use serde::{Deserialize, Serialize};
 
 // Notes: if Alice invites Bob into a room we will get an event with the sender as Alice and the state key as Bob.
@@ -64,7 +67,7 @@ pub struct RoomMember {
     //
     // Needs design.
     /// The events that created the state of this room member.
-    pub events: Vec<StateEventStub<MemberEventContent>>,
+    pub events: Vec<SyncStateEvent<MemberEventContent>>,
     /// The `PresenceEvent`s connected to this user.
     pub presence_events: Vec<PresenceEvent>,
 }
@@ -83,7 +86,7 @@ impl PartialEq for RoomMember {
 }
 
 impl RoomMember {
-    pub fn new(event: &StateEventStub<MemberEventContent>, room_id: &RoomId) -> Self {
+    pub fn new(event: &SyncStateEvent<MemberEventContent>, room_id: &RoomId) -> Self {
         Self {
             name: event.state_key.clone(),
             room_id: room_id.clone(),

--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -17,7 +17,7 @@ js_int = "0.1.8"
 [dependencies.ruma]
 git = "https://github.com/ruma/ruma"
 features = ["client-api"]
-rev = "c19bcaab"
+rev = "5e428ac"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -17,7 +17,7 @@ js_int = "0.1.8"
 [dependencies.ruma]
 git = "https://github.com/ruma/ruma"
 features = ["client-api"]
-rev = "848b225"
+rev = "848b22568106d05c5444f3fe46070d5aa16e422b"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -17,7 +17,7 @@ js_int = "0.1.8"
 [dependencies.ruma]
 git = "https://github.com/ruma/ruma"
 features = ["client-api"]
-rev = "5e428ac"
+rev = "848b225"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/matrix_sdk_crypto/src/error.rs
+++ b/matrix_sdk_crypto/src/error.rs
@@ -128,21 +128,21 @@ pub(crate) enum SessionCreationError {
         "Failed to create a new Olm session for {0} {1}, the requested \
         one-time key isn't a signed curve key"
     )]
-    OneTimeKeyNotSigned(UserId, DeviceId),
+    OneTimeKeyNotSigned(UserId, Box<DeviceId>),
     #[error(
         "Tried to create a new Olm session for {0} {1}, but the signed \
         one-time key is missing"
     )]
-    OneTimeKeyMissing(UserId, DeviceId),
+    OneTimeKeyMissing(UserId, Box<DeviceId>),
     #[error("Failed to verify the one-time key signatures for {0} {1}: {2:?}")]
-    InvalidSignature(UserId, DeviceId, SignatureError),
+    InvalidSignature(UserId, Box<DeviceId>, SignatureError),
     #[error(
         "Tried to create an Olm session for {0} {1}, but the device is missing \
         a curve25519 key"
     )]
-    DeviceMissingCurveKey(UserId, DeviceId),
+    DeviceMissingCurveKey(UserId, Box<DeviceId>),
     #[error("Error creating new Olm session for {0} {1}: {2:?}")]
-    OlmError(UserId, DeviceId, OlmSessionError),
+    OlmError(UserId, Box<DeviceId>, OlmSessionError),
 }
 
 impl From<CjsonError> for SignatureError {

--- a/matrix_sdk_crypto/src/lib.rs
+++ b/matrix_sdk_crypto/src/lib.rs
@@ -82,7 +82,7 @@ pub(crate) fn verify_json(
         json_object.insert("unsigned".to_string(), u);
     }
 
-    let key_id = AlgorithmAndDeviceId(KeyAlgorithm::Ed25519, key_id.to_string());
+    let key_id = AlgorithmAndDeviceId(KeyAlgorithm::Ed25519, key_id.into());
 
     let signatures = signatures.ok_or(SignatureError::NoSignatureFound)?;
     let signature_object = signatures

--- a/matrix_sdk_crypto/src/memory_stores.rs
+++ b/matrix_sdk_crypto/src/memory_stores.rs
@@ -197,18 +197,12 @@ impl DeviceStore {
     }
 
     /// Get a read-only view over all devices of the given user.
-    #[allow(clippy::map_clone)]
     pub fn user_devices(&self, user_id: &UserId) -> UserDevices {
         if !self.entries.contains_key(user_id) {
             self.entries.insert(user_id.clone(), DashMap::new());
         }
         UserDevices {
-            entries: self
-                .entries
-                .get(user_id)
-                .map(|map| map.clone()) // TODO I'm sure this is not ok but I'm not sure what to do??
-                .unwrap()
-                .into_read_only(),
+            entries: self.entries.get(user_id).unwrap().clone().into_read_only(),
         }
     }
 }

--- a/matrix_sdk_crypto/src/memory_stores.rs
+++ b/matrix_sdk_crypto/src/memory_stores.rs
@@ -199,6 +199,7 @@ impl DeviceStore {
     }
 
     /// Get a read-only view over all devices of the given user.
+    #[allow(clippy::map_clone)]
     pub fn user_devices(&self, user_id: &UserId) -> UserDevices {
         if !self.entries.contains_key(user_id) {
             self.entries.insert(user_id.clone(), DashMap::new());
@@ -207,7 +208,7 @@ impl DeviceStore {
             entries: self
                 .entries
                 .get(user_id)
-                .map(|d| d.clone()) // TODO I'm sure this is not ok but I'm not sure what to do??
+                .map(|map| map.clone()) // TODO I'm sure this is not ok but I'm not sure what to do??
                 .unwrap()
                 .into_read_only(),
         }

--- a/matrix_sdk_crypto/src/memory_stores.rs
+++ b/matrix_sdk_crypto/src/memory_stores.rs
@@ -175,8 +175,6 @@ impl DeviceStore {
         let device_map = self.entries.get_mut(&user_id).unwrap();
 
         device_map
-            // TODO this is ok if this is for sure a valid device_id otherwise
-            // Box::<DeviceId>::try_from(&str) is the validated version
             .insert(device.device_id().into(), device)
             .is_none()
     }

--- a/matrix_sdk_crypto/src/store/sqlite.rs
+++ b/matrix_sdk_crypto/src/store/sqlite.rs
@@ -469,14 +469,14 @@ impl SqliteStore {
                 let key = &row.1;
 
                 keys.insert(
-                    AlgorithmAndDeviceId(algorithm, device_id.clone()),
+                    AlgorithmAndDeviceId(algorithm, device_id.as_str().into()),
                     key.to_owned(),
                 );
             }
 
             let device = Device::new(
                 user_id,
-                device_id.to_owned(),
+                device_id.as_str().into(),
                 display_name.clone(),
                 trust_state,
                 algorithms,
@@ -840,16 +840,16 @@ mod test {
         UserId::try_from("@alice:example.org").unwrap()
     }
 
-    fn alice_device_id() -> DeviceId {
-        "ALICEDEVICE".to_string()
+    fn alice_device_id() -> Box<DeviceId> {
+        "ALICEDEVICE".into()
     }
 
     fn bob_id() -> UserId {
         UserId::try_from("@bob:example.org").unwrap()
     }
 
-    fn bob_device_id() -> DeviceId {
-        "BOBDEVICE".to_string()
+    fn bob_device_id() -> Box<DeviceId> {
+        "BOBDEVICE".into()
     }
 
     fn get_account() -> Account {

--- a/matrix_sdk_test/src/lib.rs
+++ b/matrix_sdk_test/src/lib.rs
@@ -6,8 +6,8 @@ use http::Response;
 
 use matrix_sdk_common::api::r0::sync::sync_events::Response as SyncResponse;
 use matrix_sdk_common::events::{
-    presence::PresenceEvent, AnyBasicEvent, AnyEphemeralRoomEventStub, AnyRoomEventStub,
-    AnyStateEventStub,
+    presence::PresenceEvent, AnyBasicEvent, AnySyncEphemeralRoomEvent, AnySyncRoomEvent,
+    AnySyncStateEvent,
 };
 use matrix_sdk_common::identifiers::RoomId;
 use serde_json::Value as JsonValue;
@@ -80,17 +80,17 @@ pub enum EventsJson {
 #[derive(Default)]
 pub struct EventBuilder {
     /// The events that determine the state of a `Room`.
-    joined_room_events: HashMap<RoomId, Vec<AnyRoomEventStub>>,
+    joined_room_events: HashMap<RoomId, Vec<AnySyncRoomEvent>>,
     /// The events that determine the state of a `Room`.
-    invited_room_events: HashMap<RoomId, Vec<AnyStateEventStub>>,
+    invited_room_events: HashMap<RoomId, Vec<AnySyncStateEvent>>,
     /// The events that determine the state of a `Room`.
-    left_room_events: HashMap<RoomId, Vec<AnyRoomEventStub>>,
+    left_room_events: HashMap<RoomId, Vec<AnySyncRoomEvent>>,
     /// The presence events that determine the presence state of a `RoomMember`.
     presence_events: Vec<PresenceEvent>,
     /// The state events that determine the state of a `Room`.
-    state_events: Vec<AnyStateEventStub>,
+    state_events: Vec<AnySyncStateEvent>,
     /// The ephemeral room events that determine the state of a `Room`.
-    ephemeral: Vec<AnyEphemeralRoomEventStub>,
+    ephemeral: Vec<AnySyncEphemeralRoomEvent>,
     /// The account data events that determine the state of a `Room`.
     account_data: Vec<AnyBasicEvent>,
     /// Internal counter to enable the `prev_batch` and `next_batch` of each sync response to vary.
@@ -110,7 +110,7 @@ impl EventBuilder {
             _ => panic!("unknown ephemeral event {:?}", json),
         };
 
-        let event = serde_json::from_value::<AnyEphemeralRoomEventStub>(val.clone()).unwrap();
+        let event = serde_json::from_value::<AnySyncEphemeralRoomEvent>(val.clone()).unwrap();
         self.ephemeral.push(event);
         self
     }
@@ -136,7 +136,7 @@ impl EventBuilder {
             _ => panic!("unknown room event json {:?}", json),
         };
 
-        let event = serde_json::from_value::<AnyRoomEventStub>(val.clone()).unwrap();
+        let event = serde_json::from_value::<AnySyncRoomEvent>(val.clone()).unwrap();
 
         self.add_joined_event(
             &RoomId::try_from("!SVkFJHzfwvuaIEawgC:localhost").unwrap(),
@@ -150,12 +150,12 @@ impl EventBuilder {
         room_id: &RoomId,
         event: serde_json::Value,
     ) -> &mut Self {
-        let event = serde_json::from_value::<AnyRoomEventStub>(event).unwrap();
+        let event = serde_json::from_value::<AnySyncRoomEvent>(event).unwrap();
         self.add_joined_event(room_id, event);
         self
     }
 
-    fn add_joined_event(&mut self, room_id: &RoomId, event: AnyRoomEventStub) {
+    fn add_joined_event(&mut self, room_id: &RoomId, event: AnySyncRoomEvent) {
         self.joined_room_events
             .entry(room_id.clone())
             .or_insert_with(Vec::new)
@@ -167,7 +167,7 @@ impl EventBuilder {
         room_id: &RoomId,
         event: serde_json::Value,
     ) -> &mut Self {
-        let event = serde_json::from_value::<AnyStateEventStub>(event).unwrap();
+        let event = serde_json::from_value::<AnySyncStateEvent>(event).unwrap();
         self.invited_room_events
             .entry(room_id.clone())
             .or_insert_with(Vec::new)
@@ -180,7 +180,7 @@ impl EventBuilder {
         room_id: &RoomId,
         event: serde_json::Value,
     ) -> &mut Self {
-        let event = serde_json::from_value::<AnyRoomEventStub>(event).unwrap();
+        let event = serde_json::from_value::<AnySyncRoomEvent>(event).unwrap();
         self.left_room_events
             .entry(room_id.clone())
             .or_insert_with(Vec::new)
@@ -199,7 +199,7 @@ impl EventBuilder {
             _ => panic!("unknown state event {:?}", json),
         };
 
-        let event = serde_json::from_value::<AnyStateEventStub>(val.clone()).unwrap();
+        let event = serde_json::from_value::<AnySyncStateEvent>(val.clone()).unwrap();
         self.state_events.push(event);
         self
     }


### PR DESCRIPTION
This also bumps the rev of ruma to the commit that adds redacted event support.