### PR TITLE
HTTP timeout

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -105,7 +105,7 @@ pub struct ClientConfig {
     user_agent: Option<HeaderValue>,
     disable_ssl_verification: bool,
     base_config: BaseClientConfig,
-	timeout: Duration
+    timeout: Duration,
 }
 
 // #[cfg_attr(tarpaulin, skip)]
@@ -200,11 +200,11 @@ impl ClientConfig {
         self
     }
 
-	/// Set a timeout duration for all HTTP requests. The default is no timeout.
-	pub fn timeout(mut self, timeout: Duration) -> Self {
-		self.timeout = timeout;
-		self
-	}
+    /// Set a timeout duration for all HTTP requests. The default is no timeout.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -105,6 +105,7 @@ pub struct ClientConfig {
     user_agent: Option<HeaderValue>,
     disable_ssl_verification: bool,
     base_config: BaseClientConfig,
+	timeout: Duration
 }
 
 // #[cfg_attr(tarpaulin, skip)]
@@ -198,6 +199,12 @@ impl ClientConfig {
         self.base_config = self.base_config.passphrase(passphrase);
         self
     }
+
+	/// Set a timeout duration for all HTTP requests. The default is no timeout.
+	pub fn timeout(mut self, timeout: Duration) -> Self {
+		self.timeout = timeout;
+		self
+	}
 }
 
 #[derive(Debug, Default, Clone)]
@@ -298,7 +305,7 @@ impl Client {
             Err(_e) => panic!("Error parsing homeserver url"),
         };
 
-        let http_client = reqwest::Client::builder();
+        let http_client = reqwest::Client::builder().timeout(config.timeout);
 
         #[cfg(not(target_arch = "wasm32"))]
         let http_client = {

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -105,7 +105,7 @@ pub struct ClientConfig {
     user_agent: Option<HeaderValue>,
     disable_ssl_verification: bool,
     base_config: BaseClientConfig,
-    timeout: Duration,
+    timeout: Option<Duration>,
 }
 
 // #[cfg_attr(tarpaulin, skip)]
@@ -202,7 +202,7 @@ impl ClientConfig {
 
     /// Set a timeout duration for all HTTP requests. The default is no timeout.
     pub fn timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = timeout;
+        self.timeout = Some(timeout);
         self
     }
 }
@@ -305,7 +305,12 @@ impl Client {
             Err(_e) => panic!("Error parsing homeserver url"),
         };
 
-        let http_client = reqwest::Client::builder().timeout(config.timeout);
+        let http_client = reqwest::Client::builder();
+
+        let http_client = match (config.timeout) {
+            Some(x) => http_client.timeout(x),
+            None => http_client,
+        };
 
         #[cfg(not(target_arch = "wasm32"))]
         let http_client = {

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -307,13 +307,13 @@ impl Client {
 
         let http_client = reqwest::Client::builder();
 
-        let http_client = match config.timeout {
-            Some(x) => http_client.timeout(x),
-            None => http_client,
-        };
-
         #[cfg(not(target_arch = "wasm32"))]
         let http_client = {
+            let http_client = match config.timeout {
+                Some(x) => http_client.timeout(x),
+                None => http_client,
+            };
+
             let http_client = if config.disable_ssl_verification {
                 http_client.danger_accept_invalid_certs(true)
             } else {

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -307,7 +307,7 @@ impl Client {
 
         let http_client = reqwest::Client::builder();
 
-        let http_client = match (config.timeout) {
+        let http_client = match config.timeout {
             Some(x) => http_client.timeout(x),
             None => http_client,
         };


### PR DESCRIPTION
Added an HTTP timeout, which will allow the client to automatically reconnect instead of hanging indefinitely.

Note: I have not tested this locally (Need to rewrite my bot for it to work with the latest changes) but it compiles. Someone else will need to test this.