### PR TITLE
Abstract the http layer out of the Client

### DIFF
--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -17,6 +17,7 @@ encryption = ["matrix-sdk-base/encryption"]
 sqlite-cryptostore = ["matrix-sdk-base/sqlite-cryptostore"]
 
 [dependencies]
+async-trait = "0.1.36"
 http = "0.2.1"
 reqwest = "0.10.6"
 serde_json = "1.0.56"

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -312,6 +312,33 @@ impl Client {
     /// * `homeserver_url` - The homeserver that the client should connect to.
     ///
     /// * `config` - Configuration for the client.
+    pub fn new_with_client<U: TryInto<Url>>(
+        homeserver_url: U,
+        config: ClientConfig,
+        http_client: Arc<dyn HttpClient>,
+    ) -> Result<Self> {
+        #[allow(clippy::match_wild_err_arm)]
+        let homeserver: Url = match homeserver_url.try_into() {
+            Ok(u) => u,
+            Err(_e) => panic!("Error parsing homeserver url"),
+        };
+
+        let base_client = BaseClient::new_with_config(config.base_config)?;
+
+        Ok(Self {
+            homeserver,
+            http_client,
+            base_client,
+        })
+    }
+
+    /// Create a new client with the given configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `homeserver_url` - The homeserver that the client should connect to.
+    ///
+    /// * `config` - Configuration for the client.
     pub fn new_with_config<U: TryInto<Url>>(
         homeserver_url: U,
         config: ClientConfig,

--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -12,34 +12,106 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{convert::TryFrom, sync::Arc};
-
-use http::{Method as HttpMethod, Response as HttpResponse};
-use reqwest::{header::AUTHORIZATION, Client, Response};
-use tracing::trace;
-use url::Url;
+use std::{fmt::Debug, sync::Arc};
 
 use matrix_sdk_common::locks::RwLock;
 
-use crate::{api::r0::uiaa::UiaaResponse, Endpoint, Error, Result, Session};
+use http::Method as HttpMethod;
+use reqwest::header::{HeaderValue, AUTHORIZATION};
+use url::Url;
 
-#[derive(Clone, Debug)]
-pub(crate) struct HttpClient {
-    pub(crate) inner: Client,
-    pub(crate) homeserver: Arc<Url>,
-}
+use matrix_sdk_base::Session;
+use matrix_sdk_common_macros::async_trait;
 
-impl HttpClient {
+use crate::{ClientConfig, Error, Result};
+
+/// Abstract the http layer.
+#[async_trait]
+pub trait HttpClient: Sync + Send {
+    /// The method abstracting sending request types and receiving response types.
     async fn send_request(
         &self,
         requires_auth: bool,
+        homeserver: &Url,
+        session: &Arc<RwLock<Option<Session>>>,
         method: HttpMethod,
         request: http::Request<Vec<u8>>,
-        session: Arc<RwLock<Option<Session>>>,
-    ) -> Result<Response> {
+    ) -> Result<reqwest::Response>;
+}
+
+/// Default http client used if none is specified using `Client::with_client`.
+#[derive(Clone, Debug)]
+pub struct DefaultHttpClient {
+    inner: reqwest::Client,
+}
+
+impl Default for DefaultHttpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DefaultHttpClient {
+    /// Returns a `DefaultHttpClient` built with the default config.
+    pub fn new() -> Self {
+        Self::with_config(&ClientConfig::default()).unwrap()
+    }
+
+    /// Build a client with the specified configuration.
+    pub fn with_config(config: &ClientConfig) -> Result<Self> {
+        let http_client = reqwest::Client::builder();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let http_client = {
+            let http_client = match config.timeout {
+                Some(x) => http_client.timeout(x),
+                None => http_client,
+            };
+
+            let http_client = if config.disable_ssl_verification {
+                http_client.danger_accept_invalid_certs(true)
+            } else {
+                http_client
+            };
+
+            let http_client = match &config.proxy {
+                Some(p) => http_client.proxy(p.clone()),
+                None => http_client,
+            };
+
+            let mut headers = reqwest::header::HeaderMap::new();
+
+            let user_agent = match &config.user_agent {
+                Some(a) => a.clone(),
+                None => {
+                    HeaderValue::from_str(&format!("matrix-rust-sdk {}", crate::VERSION)).unwrap()
+                }
+            };
+
+            headers.insert(reqwest::header::USER_AGENT, user_agent);
+
+            http_client.default_headers(headers)
+        };
+
+        Ok(Self {
+            inner: http_client.build()?,
+        })
+    }
+}
+
+#[async_trait]
+impl HttpClient for DefaultHttpClient {
+    async fn send_request(
+        &self,
+        requires_auth: bool,
+        homeserver: &Url,
+        session: &Arc<RwLock<Option<Session>>>,
+        method: http::Method,
+        request: http::Request<Vec<u8>>,
+    ) -> Result<reqwest::Response> {
         let url = request.uri();
         let path_and_query = url.path_and_query().unwrap();
-        let mut url = (&*self.homeserver).clone();
+        let mut url = homeserver.clone();
 
         url.set_path(path_and_query.path());
         url.set_query(path_and_query.query());
@@ -82,68 +154,5 @@ impl HttpClient {
         };
 
         Ok(request_builder.send().await?)
-    }
-
-    async fn response_to_http_response(
-        &self,
-        mut response: Response,
-    ) -> Result<http::Response<Vec<u8>>> {
-        let status = response.status();
-        let mut http_builder = HttpResponse::builder().status(status);
-        let headers = http_builder.headers_mut().unwrap();
-
-        for (k, v) in response.headers_mut().drain() {
-            if let Some(key) = k {
-                headers.insert(key, v);
-            }
-        }
-        let body = response.bytes().await?.as_ref().to_owned();
-        Ok(http_builder.body(body).unwrap())
-    }
-
-    pub async fn send<Request: Endpoint<ResponseError = crate::api::Error> + std::fmt::Debug>(
-        &self,
-        request: Request,
-        session: Arc<RwLock<Option<Session>>>,
-    ) -> Result<Request::Response> {
-        let request: http::Request<Vec<u8>> = request.try_into()?;
-        let response = self
-            .send_request(
-                Request::METADATA.requires_authentication,
-                Request::METADATA.method,
-                request,
-                session,
-            )
-            .await?;
-
-        trace!("Got response: {:?}", response);
-
-        let response = self.response_to_http_response(response).await?;
-
-        Ok(<Request::Response>::try_from(response)?)
-    }
-
-    pub async fn send_uiaa<Request: Endpoint<ResponseError = UiaaResponse> + std::fmt::Debug>(
-        &self,
-        request: Request,
-        session: Arc<RwLock<Option<Session>>>,
-    ) -> Result<Request::Response> {
-        let request: http::Request<Vec<u8>> = request.try_into()?;
-        let response = self
-            .send_request(
-                Request::METADATA.requires_authentication,
-                Request::METADATA.method,
-                request,
-                session,
-            )
-            .await?;
-
-        trace!("Got response: {:?}", response);
-
-        let response = self.response_to_http_response(response).await?;
-
-        let uiaa: Result<_> = <Request::Response>::try_from(response).map_err(Into::into);
-
-        Ok(uiaa?)
     }
 }

--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -25,10 +25,13 @@ use matrix_sdk_common_macros::async_trait;
 
 use crate::{ClientConfig, Error, Result};
 
-/// Abstract the http layer.
+/// Abstraction around the http layer. The allows implementors to use different
+/// http libraries.
 #[async_trait]
 pub trait HttpClient: Sync + Send {
     /// The method abstracting sending request types and receiving response types.
+    ///
+    /// This is called by the client every time it wants to send anything to a homeserver.
     async fn send_request(
         &self,
         requires_auth: bool,

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -58,6 +58,7 @@ mod sas;
 
 pub use client::{Client, ClientConfig, SyncSettings};
 pub use error::{Error, Result};
+pub use http_client::{DefaultHttpClient, HttpClient};
 pub use request_builder::{
     MessagesRequestBuilder, RegistrationBuilder, RoomBuilder, RoomListFilterBuilder,
 };

--- a/matrix_sdk_common/src/lib.rs
+++ b/matrix_sdk_common/src/lib.rs
@@ -4,7 +4,7 @@ pub use ruma::{
     api::{
         client as api,
         error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, ServerError},
-        Endpoint, EndpointError,
+        Endpoint, EndpointError, Metadata,
     },
     events, identifiers, presence, push, Raw,
 };


### PR DESCRIPTION
This would allow a user to implement the specifics of sending requests. The point of the, however far fetched or lofty my idea is, is to allow a P2P mode in `rumatui`. The idea is to use [conduit](https://git.koesters.xyz/timo/conduit/commit/e6a1b0b66f78d6b77f3a462d7420ae2bd2421e7f) as the "server" by calling the various route functions in the new `HttpClient::send_request` trait method.

I know you talked some about abstracting over the http library, how compatible are the various http libraries `Request/Response` types would this accomplish that also? If your interested here is a VERY rough idea https://github.com/DevinR528/matrix-p2p-client