### PR TITLE
sdk-base: Remove MessageWrapper and do not order messages in queue

### DIFF
--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -41,7 +41,7 @@ pub use matrix_sdk_base::Error as BaseError;
 pub use matrix_sdk_base::JsonStore;
 pub use matrix_sdk_base::{CustomOrRawEvent, EventEmitter, Room, Session, SyncRoom};
 #[cfg(feature = "messages")]
-pub use matrix_sdk_base::{MessageQueue, MessageWrapper, PossiblyRedactedExt};
+pub use matrix_sdk_base::{MessageQueue, PossiblyRedactedExt};
 pub use matrix_sdk_base::{RoomState, StateStore};
 pub use matrix_sdk_common::*;
 pub use reqwest::header::InvalidHeaderValue;

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -2397,7 +2397,7 @@ mod test {
             let queue = &room.read().await.messages;
             if let crate::events::AnyPossiblyRedactedSyncMessageEvent::Redacted(
                 crate::events::AnyRedactedSyncMessageEvent::RoomMessage(event),
-            ) = &queue.msgs[0].deref()
+            ) = &queue.msgs[0]
             {
                 // this is the id from the message event in the sync response
                 assert_eq!(
@@ -2425,7 +2425,7 @@ mod test {
             let queue = &room.read().await.messages;
             if let crate::events::AnyPossiblyRedactedSyncMessageEvent::Redacted(
                 crate::events::AnyRedactedSyncMessageEvent::RoomMessage(event),
-            ) = &queue.msgs[0].deref()
+            ) = &queue.msgs[0]
             {
                 // this is the id from the message event in the sync response
                 assert_eq!(

--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -55,7 +55,7 @@ pub use matrix_sdk_crypto::{Device, TrustState};
 
 #[cfg(feature = "messages")]
 #[cfg_attr(docsrs, doc(cfg(feature = "messages")))]
-pub use models::{MessageQueue, MessageWrapper, PossiblyRedactedExt};
+pub use models::{MessageQueue, PossiblyRedactedExt};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use state::JsonStore;

--- a/matrix_sdk_base/src/models/mod.rs
+++ b/matrix_sdk_base/src/models/mod.rs
@@ -6,6 +6,6 @@ mod room_member;
 
 #[cfg(feature = "messages")]
 #[cfg_attr(docsrs, doc(cfg(feature = "messages")))]
-pub use message::{MessageQueue, MessageWrapper, PossiblyRedactedExt};
+pub use message::{MessageQueue, PossiblyRedactedExt};
 pub use room::{Room, RoomName};
 pub use room_member::RoomMember;

--- a/matrix_sdk_base/src/models/room.rs
+++ b/matrix_sdk_base/src/models/room.rs
@@ -673,14 +673,14 @@ impl Room {
         use crate::identifiers::RoomVersionId;
         use crate::models::message::PossiblyRedactedExt;
 
-        if let Some(msg) = self
+        if let Some(mut msg) = self
             .messages
             .iter_mut()
             .find(|msg| &redacted_event.redacts == msg.event_id())
         {
             match msg.deref_mut() {
                 AnyPossiblyRedactedSyncMessageEvent::Regular(event) => {
-                    msg.0 = AnyPossiblyRedactedSyncMessageEvent::Redacted(
+                    *msg = AnyPossiblyRedactedSyncMessageEvent::Redacted(
                         event
                             .clone()
                             .redact(redacted_event.clone(), RoomVersionId::Version6),
@@ -1655,7 +1655,7 @@ mod test {
             let queue = &room.read().await.messages;
             if let crate::events::AnyPossiblyRedactedSyncMessageEvent::Redacted(
                 crate::events::AnyRedactedSyncMessageEvent::RoomMessage(event),
-            ) = &queue.msgs[0].deref()
+            ) = &queue.msgs[0]
             {
                 // this is the id from the message event in the sync response
                 assert_eq!(


### PR DESCRIPTION
As discussed on matrix in the rust-sdk room we should not be sorting the messages and a simpler duplicate checking only the `event_id`.