### PR TITLE
Update ruma and fix failing message edit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Cargo.lock
 target
+master.zip
+emsdk-*

--- a/matrix_sdk/examples/wasm_command_bot/src/lib.rs
+++ b/matrix_sdk/examples/wasm_command_bot/src/lib.rs
@@ -32,7 +32,7 @@ impl WasmBot {
         console::log_1(&format!("Received message event {:?}", &msg_body).into());
 
         if msg_body.starts_with("!party") {
-            let content = MessageEventContent::Text(TextMessageEventContent::new_plain(
+            let content = MessageEventContent::Text(TextMessageEventContent::plain(
                 "🎉🎊🥳 let's PARTY with wasm!! 🥳🎊🎉".to_string(),
             ));
 

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -39,8 +39,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 pub use matrix_sdk_base::JsonStore;
 pub use matrix_sdk_base::{
-    CustomEvent, Error as BaseError, EventEmitter, Room, RoomState, Session, StateStore,
-    SyncRoom,
+    CustomEvent, Error as BaseError, EventEmitter, Room, RoomState, Session, StateStore, SyncRoom,
 };
 #[cfg(feature = "encryption")]
 pub use matrix_sdk_base::{Device, TrustState};

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -39,7 +39,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 pub use matrix_sdk_base::JsonStore;
 pub use matrix_sdk_base::{
-    CustomOrRawEvent, Error as BaseError, EventEmitter, Room, RoomState, Session, StateStore,
+    CustomEvent, Error as BaseError, EventEmitter, Room, RoomState, Session, StateStore,
     SyncRoom,
 };
 #[cfg(feature = "encryption")]

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -1877,6 +1877,7 @@ mod test {
     use matrix_sdk_test::{async_test, test_json, EventBuilder, EventsJson};
     use serde_json::json;
     use std::convert::TryFrom;
+    #[cfg(not(target_arch = "wasm32"))]
     use tempfile::tempdir;
 
     #[cfg(target_arch = "wasm32")]

--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -49,7 +49,7 @@ mod session;
 mod state;
 
 pub use client::{BaseClient, BaseClientConfig, RoomState, RoomStateType};
-pub use event_emitter::{CustomOrRawEvent, EventEmitter, SyncRoom};
+pub use event_emitter::{CustomEvent, EventEmitter, SyncRoom};
 pub use models::Room;
 pub use state::{AllRooms, ClientState};
 

--- a/matrix_sdk_base/src/models/room.rs
+++ b/matrix_sdk_base/src/models/room.rs
@@ -1129,6 +1129,7 @@ mod test {
         assert!(room.deref().power_levels.is_some())
     }
 
+    #[cfg(feature = "messages")]
     #[test]
     fn message_edit_deser() {
         let json = matrix_sdk_test::test_json::MESSAGE_EDIT.deref();

--- a/matrix_sdk_base/src/models/room.rs
+++ b/matrix_sdk_base/src/models/room.rs
@@ -1129,6 +1129,23 @@ mod test {
         assert!(room.deref().power_levels.is_some())
     }
 
+    #[test]
+    fn message_edit_deser() {
+        let json = matrix_sdk_test::test_json::MESSAGE_EDIT.deref();
+        let event = serde_json::from_value::<Raw<AnySyncMessageEvent>>(json.clone()).unwrap();
+
+        if let Ok(AnySyncMessageEvent::RoomMessage(ev)) = event.deserialize() {
+            if let matrix_sdk_common::events::room::message::MessageEventContent::Text(content) =
+                ev.content
+            {
+                assert_eq!(content.body, " * edited message");
+                assert!(content.relates_to.is_some());
+            }
+        } else {
+            panic!("{:?}", event);
+        }
+    }
+
     #[async_test]
     async fn member_is_not_both_invited_and_joined() {
         let client = get_client().await;

--- a/matrix_sdk_base/src/models/room.rs
+++ b/matrix_sdk_base/src/models/room.rs
@@ -1080,13 +1080,16 @@ impl Describe for MembershipChange {
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(not(target_arch = "wasm32"))]
     use crate::{
         events::{room::encryption::EncryptionEventContent, Unsigned},
-        identifiers::{EventId, UserId},
-        BaseClient, Raw, Session,
+        identifiers::EventId,
+        Raw,
     };
+    use crate::{identifiers::UserId, BaseClient, Session};
     use matrix_sdk_test::{async_test, sync_response, EventBuilder, EventsJson, SyncResponseFile};
 
+    #[cfg(not(target_arch = "wasm32"))]
     use std::time::SystemTime;
 
     #[cfg(target_arch = "wasm32")]

--- a/matrix_sdk_crypto/src/verification/sas/mod.rs
+++ b/matrix_sdk_crypto/src/verification/sas/mod.rs
@@ -442,19 +442,11 @@ impl InnerSas {
     }
 
     fn is_done(&self) -> bool {
-        if let InnerSas::Done(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, InnerSas::Done(_))
     }
 
     fn is_canceled(&self) -> bool {
-        if let InnerSas::Canceled(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, InnerSas::Canceled(_))
     }
 
     fn verification_flow_id(&self) -> Arc<String> {

--- a/matrix_sdk_test/src/test_json/events.rs
+++ b/matrix_sdk_test/src/test_json/events.rs
@@ -269,12 +269,12 @@ lazy_static! {
                 "msgtype": "m.text"
             },
             "m.relates_to": {
-                "event_id": "some event id",
+                "event_id": "$someeventid:foo",
                 "rel_type": "m.replace"
             },
             "msgtype": "m.text"
         },
-        "event_id": "edit event id",
+        "event_id": "$eventid:foo",
         "origin_server_ts": 159026265,
         "sender": "@alice:matrix.org",
         "type": "m.room.message",

--- a/matrix_sdk_test/src/test_json/sync.rs
+++ b/matrix_sdk_test/src/test_json/sync.rs
@@ -614,12 +614,12 @@ lazy_static! {
                                         "msgtype": "m.text"
                                     },
                                     "m.relates_to": {
-                                        "event_id": "some event id",
+                                        "event_id": "$someeventid:localhost",
                                         "rel_type": "m.replace"
                                     },
                                     "msgtype": "m.text"
                                 },
-                                "event_id": "edit event id",
+                                "event_id": "$editevid:localhost",
                                 "origin_server_ts": 159026265,
                                 "sender": "@alice:matrix.org",
                                 "type": "m.room.message",


### PR DESCRIPTION
~~I don't think it is possible for a valid event to fail deserialization, all the cases I can think of become custom events. The message edit event was failing because of an invalid `EventId` value in the JSON. I wonder if we should remove the `EventEmitter::on_unrecognized_event` trait method? Or is the just incase still useful?~~

The `CustomOrRawEvent::RawJson` variant is what could possibly be removed and the `EventEmitter::on_unrecognized_event` trait method renamed to `on_custom_event` maybe?