### PR TITLE
Replace IncomingToDeviceRequest with customized request type

### DIFF
--- a/matrix_sdk/src/device.rs
+++ b/matrix_sdk/src/device.rs
@@ -64,7 +64,7 @@ impl Device {
         let (sas, request) = self.inner.start_verification().await?;
         let request = ToDeviceRequest {
             event_type: request.event_type,
-            txn_id: &request.txn_id,
+            txn_id: &request.txn_id.to_string(),
             messages: request.messages,
         };
 

--- a/matrix_sdk/src/sas.rs
+++ b/matrix_sdk/src/sas.rs
@@ -30,7 +30,7 @@ impl Sas {
         if let Some(req) = self.inner.accept() {
             let request = ToDeviceRequest {
                 event_type: req.event_type,
-                txn_id: &req.txn_id,
+                txn_id: &req.txn_id.to_string(),
                 messages: req.messages,
             };
 
@@ -44,7 +44,7 @@ impl Sas {
         if let Some(req) = self.inner.confirm().await? {
             let request = ToDeviceRequest {
                 event_type: req.event_type,
-                txn_id: &req.txn_id,
+                txn_id: &req.txn_id.to_string(),
                 messages: req.messages,
             };
 
@@ -56,10 +56,10 @@ impl Sas {
 
     /// Cancel the interactive verification flow.
     pub async fn cancel(&self) -> Result<()> {
-        if let Some((_, req)) = self.inner.cancel() {
+        if let Some(req) = self.inner.cancel() {
             let request = ToDeviceRequest {
                 event_type: req.event_type,
-                txn_id: &req.txn_id,
+                txn_id: &req.txn_id.to_string(),
                 messages: req.messages,
             };
 

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -39,7 +39,6 @@ use matrix_sdk_common::{
 #[cfg(feature = "encryption")]
 use matrix_sdk_common::{
     api::r0::keys::claim_keys::Request as KeysClaimRequest,
-    api::r0::to_device::send_event_to_device::IncomingRequest as OwnedToDeviceRequest,
     events::{room::encrypted::EncryptedEventContent, AnyMessageEventContent},
     identifiers::DeviceId,
     uuid::Uuid,
@@ -47,7 +46,7 @@ use matrix_sdk_common::{
 #[cfg(feature = "encryption")]
 use matrix_sdk_crypto::{
     CryptoStore, CryptoStoreError, Device, IncomingResponse, OlmError, OlmMachine, OutgoingRequest,
-    Sas, UserDevices,
+    Sas, ToDeviceRequest, UserDevices,
 };
 use zeroize::Zeroizing;
 
@@ -1304,7 +1303,7 @@ impl BaseClient {
     /// Get a to-device request that will share a group session for a room.
     #[cfg(feature = "encryption")]
     #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
-    pub async fn share_group_session(&self, room_id: &RoomId) -> Result<Vec<OwnedToDeviceRequest>> {
+    pub async fn share_group_session(&self, room_id: &RoomId) -> Result<Vec<ToDeviceRequest>> {
         let room = self.get_joined_room(room_id).await.expect("No room found");
         let olm = self.olm.lock().await;
 

--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -58,7 +58,7 @@ pub use state::{AllRooms, ClientState};
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
 pub use matrix_sdk_crypto::{
     CryptoStoreError, Device, IncomingResponse, LocalTrust, OutgoingRequest, OutgoingRequests,
-    ReadOnlyDevice, Sas, UserDevices,
+    ReadOnlyDevice, Sas, ToDeviceRequest, UserDevices,
 };
 
 #[cfg(feature = "messages")]

--- a/matrix_sdk_crypto/src/device.rs
+++ b/matrix_sdk_crypto/src/device.rs
@@ -24,9 +24,7 @@ use std::{
 
 use atomic::Atomic;
 use matrix_sdk_common::{
-    api::r0::{
-        keys::SignedKey, to_device::send_event_to_device::IncomingRequest as OwnedToDeviceRequest,
-    },
+    api::r0::keys::SignedKey,
     encryption::DeviceKeys,
     events::{room::encrypted::EncryptedEventContent, EventType},
     identifiers::{DeviceId, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, UserId},
@@ -43,7 +41,7 @@ use crate::{
     store::Result as StoreResult,
     user_identity::{OwnUserIdentity, UserIdentities},
     verification::VerificationMachine,
-    verify_json, ReadOnlyUserDevices, Sas,
+    verify_json, ReadOnlyUserDevices, Sas, ToDeviceRequest,
 };
 
 /// A read-only version of a `Device`.
@@ -80,7 +78,7 @@ impl Device {
     /// Start a interactive verification with this `Device`
     ///
     /// Returns a `Sas` object and to-device request that needs to be sent out.
-    pub async fn start_verification(&self) -> StoreResult<(Sas, OwnedToDeviceRequest)> {
+    pub async fn start_verification(&self) -> StoreResult<(Sas, ToDeviceRequest)> {
         self.verification_machine
             .start_sas(self.inner.clone())
             .await

--- a/matrix_sdk_crypto/src/lib.rs
+++ b/matrix_sdk_crypto/src/lib.rs
@@ -44,7 +44,7 @@ pub use machine::OlmMachine;
 pub use memory_stores::ReadOnlyUserDevices;
 pub(crate) use olm::Account;
 pub use olm::EncryptionSettings;
-pub use requests::{IncomingResponse, OutgoingRequest, OutgoingRequests};
+pub use requests::{IncomingResponse, OutgoingRequest, OutgoingRequests, ToDeviceRequest};
 #[cfg(feature = "sqlite_cryptostore")]
 pub use store::sqlite::SqliteStore;
 pub use store::{CryptoStore, CryptoStoreError};

--- a/matrix_sdk_crypto/src/verification/mod.rs
+++ b/matrix_sdk_crypto/src/verification/mod.rs
@@ -20,19 +20,15 @@ pub use sas::Sas;
 
 #[cfg(test)]
 pub(crate) mod test {
-    use crate::requests::{OutgoingRequest, OutgoingRequests};
+    use crate::requests::{OutgoingRequest, OutgoingRequests, ToDeviceRequest};
     use serde_json::Value;
 
     use matrix_sdk_common::{
-        api::r0::to_device::send_event_to_device::IncomingRequest as OwnedToDeviceRequest,
         events::{AnyToDeviceEvent, AnyToDeviceEventContent, EventType, ToDeviceEvent},
         identifiers::UserId,
     };
 
-    pub(crate) fn request_to_event(
-        sender: &UserId,
-        request: &OwnedToDeviceRequest,
-    ) -> AnyToDeviceEvent {
+    pub(crate) fn request_to_event(sender: &UserId, request: &ToDeviceRequest) -> AnyToDeviceEvent {
         let content = get_content_from_request(request);
         wrap_any_to_device_content(sender, content)
     }
@@ -81,9 +77,7 @@ pub(crate) mod test {
         }
     }
 
-    pub(crate) fn get_content_from_request(
-        request: &OwnedToDeviceRequest,
-    ) -> AnyToDeviceEventContent {
+    pub(crate) fn get_content_from_request(request: &ToDeviceRequest) -> AnyToDeviceEventContent {
         let json: Value = serde_json::from_str(
             request
                 .messages

--- a/matrix_sdk_crypto/src/verification/sas/helpers.rs
+++ b/matrix_sdk_crypto/src/verification/sas/helpers.rs
@@ -19,9 +19,7 @@ use tracing::{trace, warn};
 use olm_rs::sas::OlmSas;
 
 use matrix_sdk_common::{
-    api::r0::to_device::{
-        send_event_to_device::IncomingRequest as OwnedToDeviceRequest, DeviceIdOrAllDevices,
-    },
+    api::r0::to_device::DeviceIdOrAllDevices,
     events::{
         key::verification::{cancel::CancelCode, mac::MacEventContent},
         AnyToDeviceEventContent, EventType, ToDeviceEvent,
@@ -30,7 +28,7 @@ use matrix_sdk_common::{
     uuid::Uuid,
 };
 
-use crate::{user_identity::UserIdentities, Account, ReadOnlyDevice};
+use crate::{user_identity::UserIdentities, Account, ReadOnlyDevice, ToDeviceRequest};
 
 #[derive(Clone, Debug)]
 pub struct SasIds {
@@ -464,7 +462,7 @@ pub fn content_to_request(
     recipient: &UserId,
     recipient_device: &DeviceId,
     content: AnyToDeviceEventContent,
-) -> (Uuid, OwnedToDeviceRequest) {
+) -> ToDeviceRequest {
     let mut messages = BTreeMap::new();
     let mut user_messages = BTreeMap::new();
 
@@ -483,16 +481,11 @@ pub fn content_to_request(
         _ => unreachable!(),
     };
 
-    let request_id = Uuid::new_v4();
-
-    (
-        request_id,
-        OwnedToDeviceRequest {
-            txn_id: request_id.to_string(),
-            event_type,
-            messages,
-        },
-    )
+    ToDeviceRequest {
+        txn_id: Uuid::new_v4(),
+        event_type,
+        messages,
+    }
 }
 
 #[cfg(test)]

--- a/matrix_sdk_crypto/src/verification/sas/mod.rs
+++ b/matrix_sdk_crypto/src/verification/sas/mod.rs
@@ -22,7 +22,6 @@ use std::sync::{Arc, Mutex};
 use tracing::{info, trace, warn};
 
 use matrix_sdk_common::{
-    api::r0::to_device::send_event_to_device::IncomingRequest as OwnedToDeviceRequest,
     events::{
         key::verification::{
             accept::AcceptEventContent, cancel::CancelCode, mac::MacEventContent,
@@ -31,12 +30,11 @@ use matrix_sdk_common::{
         AnyToDeviceEvent, AnyToDeviceEventContent, ToDeviceEvent,
     },
     identifiers::{DeviceId, UserId},
-    uuid::Uuid,
 };
 
 use crate::{
     user_identity::UserIdentities, Account, CryptoStore, CryptoStoreError, LocalTrust,
-    ReadOnlyDevice,
+    ReadOnlyDevice, ToDeviceRequest,
 };
 
 pub use helpers::content_to_request;
@@ -166,10 +164,10 @@ impl Sas {
     ///
     /// This does nothing if the verification was already accepted, otherwise it
     /// returns an `AcceptEventContent` that needs to be sent out.
-    pub fn accept(&self) -> Option<OwnedToDeviceRequest> {
+    pub fn accept(&self) -> Option<ToDeviceRequest> {
         self.inner.lock().unwrap().accept().map(|c| {
             let content = AnyToDeviceEventContent::KeyVerificationAccept(c);
-            self.content_to_request(content).1
+            self.content_to_request(content)
         })
     }
 
@@ -180,7 +178,7 @@ impl Sas {
     /// Does nothing if we're not in a state where we can confirm the short auth
     /// string, otherwise returns a `MacEventContent` that needs to be sent to
     /// the server.
-    pub async fn confirm(&self) -> Result<Option<OwnedToDeviceRequest>, CryptoStoreError> {
+    pub async fn confirm(&self) -> Result<Option<ToDeviceRequest>, CryptoStoreError> {
         let (content, done) = {
             let mut guard = self.inner.lock().unwrap();
             let sas: InnerSas = (*guard).clone();
@@ -195,7 +193,7 @@ impl Sas {
             // else branch and only after the identity was verified as well. We
             // dont' want to verify one without the other.
             if !self.mark_device_as_verified().await? {
-                return Ok(self.cancel().map(|r| r.1));
+                return Ok(self.cancel());
             } else {
                 self.mark_identity_as_verified().await?;
             }
@@ -203,7 +201,7 @@ impl Sas {
 
         Ok(content.map(|c| {
             let content = AnyToDeviceEventContent::KeyVerificationMac(c);
-            self.content_to_request(content).1
+            self.content_to_request(content)
         }))
     }
 
@@ -328,7 +326,7 @@ impl Sas {
     ///
     /// Returns None if the `Sas` object is already in a canceled state,
     /// otherwise it returns a request that needs to be sent out.
-    pub fn cancel(&self) -> Option<(Uuid, OwnedToDeviceRequest)> {
+    pub fn cancel(&self) -> Option<ToDeviceRequest> {
         let mut guard = self.inner.lock().unwrap();
         let sas: InnerSas = (*guard).clone();
         let (sas, content) = sas.cancel(CancelCode::User);
@@ -337,7 +335,7 @@ impl Sas {
         content.map(|c| self.content_to_request(c))
     }
 
-    pub(crate) fn cancel_if_timed_out(&self) -> Option<(Uuid, OwnedToDeviceRequest)> {
+    pub(crate) fn cancel_if_timed_out(&self) -> Option<ToDeviceRequest> {
         if self.is_canceled() || self.is_done() {
             None
         } else if self.timed_out() {
@@ -408,10 +406,7 @@ impl Sas {
         self.inner.lock().unwrap().verified_identities()
     }
 
-    pub(crate) fn content_to_request(
-        &self,
-        content: AnyToDeviceEventContent,
-    ) -> (Uuid, OwnedToDeviceRequest) {
+    pub(crate) fn content_to_request(&self, content: AnyToDeviceEventContent) -> ToDeviceRequest {
         content_to_request(self.other_user_id(), self.other_device_id(), content)
     }
 }


### PR DESCRIPTION
I was planning to also bump ruma, but that's a bit more involved than I had hoped. You will probably need your own copies of `IncomingKeysUploadRequest` and `IncomingKeysQueryRequest` too for the next bump.

I wasn't too sure where to put the `ToDeviceRequest` type. Let me know if there is a better place.