### PR TITLE
matrix-sdk-common: Switch futures-locks to crates.io version

### DIFF
--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -30,5 +30,5 @@ default-features = false
 features = ["sync", "time", "fs"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-futures-locks = { git = "https://github.com/asomers/futures-locks", default-features = false }
+futures-locks = { version = "0.6.0", default-features = false }
 uuid = { version = "0.8.1", features = ["v4", "wasm-bindgen"] }


### PR DESCRIPTION
Part of #35 