### PR TITLE
Improve our sync methods and the docs for the login.

### DIFF
--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -68,6 +68,7 @@ features = ["wasm-bindgen"]
 
 [dev-dependencies]
 async-trait = "0.1.40"
+async-std = { version = "*", features = ["unstable"] }
 dirs = "3.0.1"
 matrix-sdk-test = { version = "0.1.0", path = "../matrix_sdk_test" }
 tokio = { version = "0.2.22", features = ["rt-threaded", "macros"] }

--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -68,7 +68,7 @@ features = ["wasm-bindgen"]
 
 [dev-dependencies]
 async-trait = "0.1.40"
-async-std = { version = "*", features = ["unstable"] }
+async-std = { version = "1.6.5", features = ["unstable"] }
 dirs = "3.0.1"
 matrix-sdk-test = { version = "0.1.0", path = "../matrix_sdk_test" }
 tokio = { version = "0.2.22", features = ["rt-threaded", "macros"] }

--- a/matrix_sdk/examples/autojoin.rs
+++ b/matrix_sdk/examples/autojoin.rs
@@ -64,9 +64,7 @@ async fn login_and_sync(
         .add_event_emitter(Box::new(AutoJoinBot::new(client.clone())))
         .await;
 
-    client
-        .sync_forever(SyncSettings::default(), |_| async {})
-        .await;
+    client.sync(SyncSettings::default()).await;
 
     Ok(())
 }

--- a/matrix_sdk/examples/command_bot.rs
+++ b/matrix_sdk/examples/command_bot.rs
@@ -91,7 +91,7 @@ async fn login_and_sync(
     // An initial sync to set up state and so our bot doesn't respond to old messages.
     // If the `StateStore` finds saved state in the location given the initial sync will
     // be skipped in favor of loading state from the store
-    client.sync(SyncSettings::default()).await.unwrap();
+    client.sync_once(SyncSettings::default()).await.unwrap();
     // add our CommandBot to be notified of incoming messages, we do this after the initial
     // sync to avoid responding to messages before the bot was running.
     client
@@ -102,7 +102,7 @@ async fn login_and_sync(
     // `sync_forever`
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
     // this keeps state from the server streaming in to CommandBot via the EventEmitter trait
-    client.sync_forever(settings, |_| async {}).await;
+    client.sync(settings).await;
 
     Ok(())
 }

--- a/matrix_sdk/examples/command_bot.rs
+++ b/matrix_sdk/examples/command_bot.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 struct CommandBot {
     /// This clone of the `Client` will send requests to the server,
-    /// while the other keeps us in sync with the server using `sync_forever`.
+    /// while the other keeps us in sync with the server using `sync`.
     client: Client,
 }
 
@@ -98,8 +98,8 @@ async fn login_and_sync(
         .add_event_emitter(Box::new(CommandBot::new(client.clone())))
         .await;
 
-    // since we called sync before we `sync_forever` we must pass that sync token to
-    // `sync_forever`
+    // since we called `sync_once` before we entered our sync loop we must pass
+    // that sync token to `sync`
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
     // this keeps state from the server streaming in to CommandBot via the EventEmitter trait
     client.sync(settings).await;

--- a/matrix_sdk/examples/emoji_verification.rs
+++ b/matrix_sdk/examples/emoji_verification.rs
@@ -69,7 +69,7 @@ async fn login(
     let client_ref = &client;
 
     client
-        .sync_forever(SyncSettings::new(), |response| async move {
+        .sync_with_callback(SyncSettings::new(), |response| async move {
             let client = &client_ref;
 
             for event in &response.to_device.events {
@@ -116,6 +116,8 @@ async fn login(
                     _ => (),
                 }
             }
+
+            false
         })
         .await;
 

--- a/matrix_sdk/examples/emoji_verification.rs
+++ b/matrix_sdk/examples/emoji_verification.rs
@@ -2,7 +2,8 @@ use std::{env, io, process::exit};
 use url::Url;
 
 use matrix_sdk::{
-    self, events::AnyToDeviceEvent, identifiers::UserId, Client, ClientConfig, Sas, SyncSettings,
+    self, events::AnyToDeviceEvent, identifiers::UserId, Client, ClientConfig, LoopCtrl, Sas,
+    SyncSettings,
 };
 
 async fn wait_for_confirmation(client: Client, sas: Sas) {
@@ -117,7 +118,7 @@ async fn login(
                 }
             }
 
-            false
+            LoopCtrl::Continue
         })
         .await;
 

--- a/matrix_sdk/examples/image_bot.rs
+++ b/matrix_sdk/examples/image_bot.rs
@@ -81,13 +81,13 @@ async fn login_and_sync(
         .login(&username, &password, None, Some("command bot"))
         .await?;
 
-    client.sync(SyncSettings::default()).await.unwrap();
+    client.sync_once(SyncSettings::default()).await.unwrap();
     client
         .add_event_emitter(Box::new(ImageBot::new(client.clone(), image)))
         .await;
 
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
-    client.sync_forever(settings, |_| async {}).await;
+    client.sync(settings).await;
 
     Ok(())
 }

--- a/matrix_sdk/examples/login.rs
+++ b/matrix_sdk/examples/login.rs
@@ -52,7 +52,7 @@ async fn login(
     client
         .login(username, password, None, Some("rust-sdk"))
         .await?;
-    client.sync_forever(SyncSettings::new(), |_| async {}).await;
+    client.sync(SyncSettings::new()).await;
 
     Ok(())
 }

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -503,7 +503,9 @@ impl Client {
     /// # block_on(async {
     /// let client = Client::new(homeserver).unwrap();
     /// let user = "example";
-    /// let response = client.login(user, "wordpass", None, Some("My bot")).await;
+    /// let response = client
+    ///     .login(user, "wordpass", None, Some("My bot")).await
+    ///     .unwrap();
     ///
     /// println!("Logged in as {}, got device_id {} and access_token {}",
     ///          user, response.device_id, response.access_token);

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -491,6 +491,25 @@ impl Client {
     ///     device_id from a previous login call. Note that this should be done
     ///     only if the client also holds the encryption keys for this device.
     ///
+    /// # Example
+    /// ```no_run
+    /// # use std::convert::TryFrom;
+    /// # use matrix_sdk::Client;
+    /// # use matrix_sdk::identifiers::DeviceId;
+    /// # use matrix_sdk_common::assign;
+    /// # use futures::executor::block_on;
+    /// # use url::Url;
+    /// # let homeserver = Url::parse("http://example.com").unwrap();
+    /// # block_on(async {
+    /// let client = Client::new(homeserver).unwrap();
+    /// let user = "example";
+    /// let response = client.login(user, "wordpass", None, Some("My bot")).await;
+    ///
+    /// println!("Logged in as {}, got device_id {} and access_token {}",
+    ///          user, response.device_id, response.access_token);
+    /// # })
+    /// ```
+    ///
     /// [`restore_login`]: #method.restore_login
     #[instrument(skip(password))]
     pub async fn login(

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -47,6 +47,20 @@ use matrix_sdk_base::crypto::{
     AttachmentEncryptor, OutgoingRequests, ToDeviceRequest,
 };
 
+/// Enum controlling if a loop running callbacks should continue or abort.
+///
+/// This is mainly used in the [`sync_with_callback`] method, the return value
+/// of the provided callback controls if the sync loop should be exited.
+///
+/// [`sync_with_callback`]: #method.sync_with_callback
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoopCtrl {
+    /// Continue running the loop.
+    Continue,
+    /// Break out of the loop.
+    Break,
+}
+
 use matrix_sdk_common::{
     api::r0::{
         account::register,
@@ -1410,7 +1424,7 @@ impl Client {
     ///
     /// [`sync_with_callback`]: #method.sync_with_callback
     pub async fn sync(&self, sync_settings: SyncSettings<'_>) {
-        self.sync_with_callback(sync_settings, |_| async { false })
+        self.sync_with_callback(sync_settings, |_| async { LoopCtrl::Continue })
             .await
     }
 
@@ -1435,18 +1449,17 @@ impl Client {
     ///
     /// ```compile_fail,E0658
     /// # use matrix_sdk::events::{
-    /// #     collections::all::RoomEvent,
     /// #     room::message::{MessageEvent, MessageEventContent, TextMessageEventContent},
-    /// #     EventResult,
     /// # };
     /// # use matrix_sdk::Room;
     /// # use std::sync::{Arc, RwLock};
-    /// # use matrix_sdk::{Client, SyncSettings};
+    /// # use std::time::Duration;
+    /// # use matrix_sdk::{Client, SyncSettings, LoopCtrl};
     /// # use url::Url;
     /// # use futures::executor::block_on;
     /// # block_on(async {
     /// # let homeserver = Url::parse("http://localhost:8080").unwrap();
-    /// # let mut client = Client::new(homeserver, None).unwrap();
+    /// # let mut client = Client::new(homeserver).unwrap();
     ///
     /// use async_std::sync::channel;
     ///
@@ -1454,22 +1467,21 @@ impl Client {
     ///
     /// let sync_channel = &tx;
     /// let sync_settings = SyncSettings::new()
-    ///     .timeout(30_000)
-    ///     .unwrap();
+    ///     .timeout(Duration::from_secs(30));
     ///
     /// client
-    ///     .sync_forever(sync_settings, async move |response| {
+    ///     .sync_with_callback(sync_settings, async move |response| {
     ///         let channel = sync_channel;
     ///
     ///         for (room_id, room) in response.rooms.join {
     ///             for event in room.timeline.events {
-    ///                 if let EventResult::Ok(e) = event {
+    ///                 if let Ok(e) = event.deserialize() {
     ///                     channel.send(e).await;
     ///                 }
     ///             }
     ///         }
     ///
-    ///         false
+    ///         LoopCtrl::Continue
     ///     })
     ///     .await;
     /// })
@@ -1480,7 +1492,7 @@ impl Client {
         sync_settings: SyncSettings<'_>,
         callback: impl Fn(sync_events::Response) -> C,
     ) where
-        C: Future<Output = bool>,
+        C: Future<Output = LoopCtrl>,
     {
         let mut sync_settings = sync_settings;
         let filter = sync_settings.filter;
@@ -1531,7 +1543,7 @@ impl Client {
                 }
             }
 
-            if callback(response).await {
+            if callback(response).await == LoopCtrl::Break {
                 return;
             }
 

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -477,7 +477,7 @@ impl Client {
     /// If this isn't the first login a device id should be provided to restore
     /// the correct stores.
     ///
-    /// Alternatively the `restore_login()` method can be used to restore a
+    /// Alternatively the [`restore_login`] method can be used to restore a
     /// logged in client without the password.
     ///
     /// # Arguments
@@ -490,6 +490,8 @@ impl Client {
     ///     not given the homeserver will create one. Can be an existing
     ///     device_id from a previous login call. Note that this should be done
     ///     only if the client also holds the encryption keys for this device.
+    ///
+    /// [`restore_login`]: #method.restore_login
     #[instrument(skip(password))]
     pub async fn login(
         &self,
@@ -521,13 +523,15 @@ impl Client {
     /// This can be used to restore the client to a logged in state, loading all
     /// the stored state and encryption keys.
     ///
-    /// Alternatively, if the whole session isn't stored the `login()` method
+    /// Alternatively, if the whole session isn't stored the [`login`] method
     /// can be used with a device id.
     ///
     /// # Arguments
     ///
     /// * `session` - A session that the user already has from a
     /// previous login call.
+    ///
+    /// [`login`]: #method.login
     pub async fn restore_login(&self, session: Session) -> Result<()> {
         Ok(self.base_client.restore_login(session).await?)
     }

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -1799,7 +1799,10 @@ impl Client {
     /// ```
     #[cfg(feature = "encryption")]
     #[cfg(not(target_arch = "wasm32"))]
-    #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
+    #[cfg_attr(
+        feature = "docs",
+        doc(cfg(all(encryption, not(target_arch = "wasm32"))))
+    )]
     pub async fn export_keys(
         &self,
         path: PathBuf,
@@ -1849,7 +1852,10 @@ impl Client {
     /// ```
     #[cfg(feature = "encryption")]
     #[cfg(not(target_arch = "wasm32"))]
-    #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
+    #[cfg_attr(
+        feature = "docs",
+        doc(cfg(all(encryption, not(target_arch = "wasm32"))))
+    )]
     pub async fn import_keys(&self, path: PathBuf, passphrase: &str) -> Result<()> {
         let olm = self
             .base_client

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -71,7 +71,7 @@ mod device;
 #[cfg(feature = "encryption")]
 mod sas;
 
-pub use client::{Client, ClientConfig, SyncSettings};
+pub use client::{Client, ClientConfig, LoopCtrl, SyncSettings};
 #[cfg(feature = "encryption")]
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
 pub use device::Device;


### PR DESCRIPTION
This attempts to fix a bunch of issues presented in https://github.com/matrix-org/matrix-rust-sdk/issues/98.

Mainly the sync loop can be aborted by providing a boolean value in the callback, the login method has an example and we link restore_login from login and vice versa.