### PR TITLE
Clean up ruma dependency

### DIFF
--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -21,7 +21,7 @@ js_int = "0.1.9"
 [dependencies.ruma]
 version = "0.0.1"
 git = "https://github.com/ruma/ruma"
-rev = "d16fd4b2c1be1b06fd9be99373a3e77d74fadff3"
+rev = "ee4280cea2f8d24c7f747fd57776fe72d50ce744"
 features = ["client-api", "unstable-pre-spec"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -22,7 +22,7 @@ js_int = "0.1.9"
 version = "0.0.1"
 git = "https://github.com/ruma/ruma"
 rev = "d16fd4b2c1be1b06fd9be99373a3e77d74fadff3"
-features = ["client-api", "unstable-pre-spec", "unstable-synapse-quirks"]
+features = ["client-api", "unstable-pre-spec"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { version = "0.8.1", default-features = false, features = ["v4", "serde"] }

--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -22,7 +22,6 @@ js_int = "0.1.9"
 version = "0.0.1"
 git = "https://github.com/ruma/ruma"
 rev = "d16fd4b2c1be1b06fd9be99373a3e77d74fadff3"
-default-features = false
 features = ["client-api", "unstable-pre-spec", "unstable-synapse-quirks"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
I noticed some oddities in the ruma dependency, so went and fixed them.

The upgrade doesn't include a lot, but noticably it includes (under `unstable-pre-spec`) the URL in `m.room.avatar` being optional, such that it can be unset.