### PR TITLE
Request retrying

### DIFF
--- a/contrib/mitmproxy/failures.py
+++ b/contrib/mitmproxy/failures.py
@@ -1,0 +1,47 @@
+"""
+A mitmproxy script that introduces certain request failures in a deterministic
+way.
+
+Used mainly for Matrix style requests.
+
+To run execute it with mitmproxy:
+
+    >>> mitmproxy -s failures.py`
+
+"""
+import time
+import json
+
+from mitmproxy import http
+from mitmproxy.script import concurrent
+
+REQUEST_COUNT = 0
+
+
+@concurrent
+def request(flow):
+    global REQUEST_COUNT
+
+    REQUEST_COUNT += 1
+
+    if REQUEST_COUNT % 2 == 0:
+        return
+    elif REQUEST_COUNT % 3 == 0:
+        flow.response = http.HTTPResponse.make(
+            500,
+            b"Gateway error",
+        )
+    elif REQUEST_COUNT % 7 == 0:
+        if "sync" in flow.request.pretty_url:
+            time.sleep(60)
+        else:
+            time.sleep(30)
+    else:
+        flow.response = http.HTTPResponse.make(
+            429,
+            json.dumps({
+                "errcode": "M_LIMIT_EXCEEDED",
+                "error": "Too many requests",
+                "retry_after_ms": 2000
+            })
+        )

--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -50,7 +50,7 @@ default_features = false
 version = "0.11.0"
 default_features = false
 
-[dependencies.backoff]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.backoff]
 git = "https://github.com/ihrwein/backoff"
 features = ["tokio"]
 rev = "fa3fb91431729ce871d29c62b93425b8aec740f4"

--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -53,6 +53,7 @@ default_features = false
 [dependencies.backoff]
 git = "https://github.com/ihrwein/backoff"
 features = ["tokio"]
+rev = "fa3fb91431729ce871d29c62b93425b8aec740f4"
 
 [dependencies.tracing-futures]
 version = "0.2.4"

--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -50,6 +50,10 @@ default_features = false
 version = "0.11.0"
 default_features = false
 
+[dependencies.backoff]
+git = "https://github.com/ihrwein/backoff"
+features = ["tokio"]
+
 [dependencies.tracing-futures]
 version = "0.2.4"
 default-features = false

--- a/matrix_sdk/examples/get_profiles.rs
+++ b/matrix_sdk/examples/get_profiles.rs
@@ -19,7 +19,7 @@ async fn get_profile(client: Client, mxid: &UserId) -> MatrixResult<UserProfile>
     let request = profile::get_profile::Request::new(mxid);
 
     // Start the request using matrix_sdk::Client::send
-    let resp = client.send(request).await?;
+    let resp = client.send(request, None).await?;
 
     // Use the response and construct a UserProfile struct.
     // See https://docs.rs/ruma-client-api/0.9.0/ruma_client_api/r0/profile/get_profile/struct.Response.html

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -132,6 +132,10 @@ use crate::{
 };
 
 const DEFAULT_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
+/// Give the sync a bit more time than the default request timeout does.
+const SYNC_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+/// A conservative upload speed of 1Mbps
+const DEFAULT_UPLOAD_SPEED: u64 = 125_000;
 
 /// An async/await enabled Matrix client.
 ///
@@ -452,7 +456,7 @@ impl Client {
     pub async fn display_name(&self) -> Result<Option<String>> {
         let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
         let request = get_display_name::Request::new(&user_id);
-        let response = self.send(request).await?;
+        let response = self.send(request, None).await?;
         Ok(response.displayname)
     }
 
@@ -475,7 +479,7 @@ impl Client {
     pub async fn set_display_name(&self, name: Option<&str>) -> Result<()> {
         let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
         let request = set_display_name::Request::new(&user_id, name);
-        self.send(request).await?;
+        self.send(request, None).await?;
         Ok(())
     }
 
@@ -500,7 +504,7 @@ impl Client {
     pub async fn avatar_url(&self) -> Result<Option<String>> {
         let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
         let request = get_avatar_url::Request::new(&user_id);
-        let response = self.send(request).await?;
+        let response = self.send(request, None).await?;
         Ok(response.avatar_url)
     }
 
@@ -513,7 +517,7 @@ impl Client {
     pub async fn set_avatar_url(&self, url: Option<&str>) -> Result<()> {
         let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
         let request = set_avatar_url::Request::new(&user_id, url);
-        self.send(request).await?;
+        self.send(request, None).await?;
         Ok(())
     }
 
@@ -672,7 +676,7 @@ impl Client {
             }
         );
 
-        let response = self.send(request).await?;
+        let response = self.send(request, None).await?;
         self.base_client.receive_login_response(&response).await?;
 
         Ok(response)
@@ -734,7 +738,7 @@ impl Client {
         info!("Registering to {}", self.homeserver);
 
         let request = registration.into();
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Get or upload a sync filter.
@@ -748,7 +752,7 @@ impl Client {
         } else {
             let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
             let request = FilterUploadRequest::new(&user_id, definition);
-            let response = self.send(request).await?;
+            let response = self.send(request, None).await?;
 
             self.base_client
                 .receive_filter_upload(filter_name, &response)
@@ -768,7 +772,7 @@ impl Client {
     /// * `room_id` - The `RoomId` of the room to be joined.
     pub async fn join_room_by_id(&self, room_id: &RoomId) -> Result<join_room_by_id::Response> {
         let request = join_room_by_id::Request::new(room_id);
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Join a room by `RoomId`.
@@ -788,7 +792,7 @@ impl Client {
         let request = assign!(join_room_by_id_or_alias::Request::new(alias), {
             server_name: server_names,
         });
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Forget a room by `RoomId`.
@@ -800,7 +804,7 @@ impl Client {
     /// * `room_id` - The `RoomId` of the room to be forget.
     pub async fn forget_room_by_id(&self, room_id: &RoomId) -> Result<forget_room::Response> {
         let request = forget_room::Request::new(room_id);
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Ban a user from a room by `RoomId` and `UserId`.
@@ -821,7 +825,7 @@ impl Client {
         reason: Option<&str>,
     ) -> Result<ban_user::Response> {
         let request = assign!(ban_user::Request::new(room_id, user_id), { reason });
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Kick a user out of the specified room.
@@ -842,7 +846,7 @@ impl Client {
         reason: Option<&str>,
     ) -> Result<kick_user::Response> {
         let request = assign!(kick_user::Request::new(room_id, user_id), { reason });
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Leave the specified room.
@@ -854,7 +858,7 @@ impl Client {
     /// * `room_id` - The `RoomId` of the room to leave.
     pub async fn leave_room(&self, room_id: &RoomId) -> Result<leave_room::Response> {
         let request = leave_room::Request::new(room_id);
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Invite the specified user by `UserId` to the given room.
@@ -874,7 +878,7 @@ impl Client {
         let recipient = InvitationRecipient::UserId { user_id };
 
         let request = invite_user::Request::new(room_id, recipient);
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Invite the specified user by third party id to the given room.
@@ -893,7 +897,7 @@ impl Client {
     ) -> Result<invite_user::Response> {
         let recipient = InvitationRecipient::ThirdPartyId(invite_id);
         let request = invite_user::Request::new(room_id, recipient);
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Search the homeserver's directory of public rooms.
@@ -939,7 +943,7 @@ impl Client {
             since,
             server,
         });
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Search the homeserver's directory of public rooms with a filter.
@@ -977,7 +981,7 @@ impl Client {
         room_search: impl Into<get_public_rooms_filtered::Request<'_>>,
     ) -> Result<get_public_rooms_filtered::Response> {
         let request = room_search.into();
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Create a room using the `RoomBuilder` and send the request.
@@ -1009,7 +1013,7 @@ impl Client {
         room: impl Into<create_room::Request<'_>>,
     ) -> Result<create_room::Response> {
         let request = room.into();
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Sends a request to `/_matrix/client/r0/rooms/{room_id}/messages` and returns
@@ -1044,8 +1048,8 @@ impl Client {
         &self,
         request: impl Into<get_message_events::Request<'_>>,
     ) -> Result<get_message_events::Response> {
-        let req = request.into();
-        self.send(req).await
+        let request = request.into();
+        self.send(request, None).await
     }
 
     /// Send a request to notify the room of a user typing.
@@ -1088,7 +1092,7 @@ impl Client {
         let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
         let request = TypingRequest::new(&user_id, room_id, typing.into());
 
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Send a request to notify the room the user has read specific event.
@@ -1107,7 +1111,7 @@ impl Client {
     ) -> Result<create_receipt::Response> {
         let request =
             create_receipt::Request::new(room_id, create_receipt::ReceiptType::Read, event_id);
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Send a request to notify the room user has read up to specific event.
@@ -1130,7 +1134,7 @@ impl Client {
         let request = assign!(set_read_marker::Request::new(room_id, fully_read), {
             read_receipt
         });
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Share a group session for the given room.
@@ -1261,7 +1265,7 @@ impl Client {
         let txn_id = txn_id.unwrap_or_else(Uuid::new_v4).to_string();
         let request = send_message_event::Request::new(&room_id, &txn_id, &content);
 
-        let response = self.send(request).await?;
+        let response = self.send(request, None).await?;
         Ok(response)
     }
 
@@ -1448,11 +1452,13 @@ impl Client {
         let mut data = Vec::new();
         reader.read_to_end(&mut data)?;
 
+        let timeout = Duration::from_secs(data.len() as u64 / DEFAULT_UPLOAD_SPEED);
+
         let request = assign!(create_content::Request::new(data), {
             content_type: Some(content_type.essence_str()),
         });
 
-        Ok(self.http_client.upload(request).await?)
+        Ok(self.http_client.upload(request, Some(timeout)).await?)
     }
 
     /// Send an arbitrary request to the server, without updating client state.
@@ -1465,6 +1471,9 @@ impl Client {
     /// # Arguments
     ///
     /// * `request` - A filled out and valid request for the endpoint to be hit
+    ///
+    /// * `timeout` - An optional request timeout setting, this overrides the
+    /// default request setting if one was set.
     ///
     /// # Example
     ///
@@ -1486,18 +1495,22 @@ impl Client {
     /// let request = profile::get_profile::Request::new(&user_id);
     ///
     /// // Start the request using Client::send()
-    /// let response = client.send(request).await.unwrap();
+    /// let response = client.send(request, None).await.unwrap();
     ///
     /// // Check the corresponding Response struct to find out what types are
     /// // returned
     /// # })
     /// ```
-    pub async fn send<Request>(&self, request: Request) -> Result<Request::IncomingResponse>
+    pub async fn send<Request>(
+        &self,
+        request: Request,
+        timeout: Option<Duration>,
+    ) -> Result<Request::IncomingResponse>
     where
         Request: OutgoingRequest + Debug,
         HttpError: From<FromHttpResponseError<Request::EndpointError>>,
     {
-        Ok(self.http_client.send(request).await?)
+        Ok(self.http_client.send(request, timeout).await?)
     }
 
     #[cfg(feature = "encryption")]
@@ -1512,7 +1525,7 @@ impl Client {
             request.messages.clone(),
         );
 
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Get information of all our own devices.
@@ -1541,7 +1554,7 @@ impl Client {
     pub async fn devices(&self) -> Result<get_devices::Response> {
         let request = get_devices::Request::new();
 
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Delete the given devices from the server.
@@ -1606,13 +1619,13 @@ impl Client {
         let mut request = delete_devices::Request::new(devices);
         request.auth = auth_data;
 
-        self.send(request).await
+        self.send(request, None).await
     }
 
     /// Get the room members for the given room.
     pub async fn room_members(&self, room_id: &RoomId) -> Result<MembersResponse> {
         let request = get_member_events::Request::new(room_id);
-        let response = self.send(request).await?;
+        let response = self.send(request, None).await?;
 
         Ok(self.base_client.receive_members(room_id, &response).await?)
     }
@@ -1638,7 +1651,12 @@ impl Client {
             timeout: sync_settings.timeout,
         });
 
-        let response = self.send(request).await?;
+        let timeout = sync_settings
+            .timeout
+            .unwrap_or_else(|| Duration::from_secs(0))
+            + SYNC_REQUEST_TIMEOUT;
+
+        let response = self.send(request, Some(timeout)).await?;
 
         Ok(self.base_client.receive_sync_response(response).await?)
     }
@@ -1779,7 +1797,7 @@ impl Client {
                         }
                         OutgoingRequests::SignatureUpload(request) => {
                             // TODO remove this unwrap.
-                            if let Ok(resp) = self.send(request.clone()).await {
+                            if let Ok(resp) = self.send(request.clone(), None).await {
                                 self.base_client
                                     .mark_request_as_sent(&r.request_id(), &resp)
                                     .await
@@ -1839,7 +1857,7 @@ impl Client {
         let _lock = self.key_claim_lock.lock().await;
 
         if let Some((request_id, request)) = self.base_client.get_missing_sessions(users).await? {
-            let response = self.send(request).await?;
+            let response = self.send(request, None).await?;
             self.base_client
                 .mark_request_as_sent(&request_id, &response)
                 .await?;
@@ -1898,7 +1916,7 @@ impl Client {
             request.one_time_keys.as_ref().map_or(0, |k| k.len())
         );
 
-        let response = self.send(request.clone()).await?;
+        let response = self.send(request.clone(), None).await?;
         self.base_client
             .mark_request_as_sent(request_id, &response)
             .await?;
@@ -1927,7 +1945,7 @@ impl Client {
     ) -> Result<get_keys::Response> {
         let request = assign!(get_keys::Request::new(), { device_keys });
 
-        let response = self.send(request).await?;
+        let response = self.send(request, None).await?;
         self.base_client
             .mark_request_as_sent(request_id, &response)
             .await?;
@@ -2080,8 +2098,8 @@ impl Client {
             user_signing_key: request.user_signing_key,
         });
 
-        self.send(request).await?;
-        self.send(signature_request).await?;
+        self.send(request, None).await?;
+        self.send(signature_request, None).await?;
 
         Ok(())
     }

--- a/matrix_sdk/src/error.rs
+++ b/matrix_sdk/src/error.rs
@@ -14,6 +14,7 @@
 
 //! Error conditions.
 
+use http::StatusCode;
 use matrix_sdk_base::{Error as MatrixError, StoreError};
 use matrix_sdk_common::{
     api::{
@@ -64,6 +65,14 @@ pub enum HttpError {
     /// represents an error with information about how to authenticate the user.
     #[error(transparent)]
     UiaaError(#[from] FromHttpResponseError<UiaaError>),
+
+    /// The server returned a status code that should be retried.
+    #[error("Server returned an error {0}")]
+    Server(StatusCode),
+
+    /// The given request can't be cloned and thus can't be retried.
+    #[error("The request cannot be cloned")]
+    UnableToCloneRequest,
 }
 
 /// Internal representation of errors.

--- a/matrix_sdk/src/error.rs
+++ b/matrix_sdk/src/error.rs
@@ -20,7 +20,7 @@ use matrix_sdk_common::{
         r0::uiaa::{UiaaInfo, UiaaResponse as UiaaError},
         Error as RumaClientError,
     },
-    FromHttpResponseError as RumaResponseError, IntoHttpError as RumaIntoHttpError, ServerError,
+    FromHttpResponseError, IntoHttpError, ServerError,
 };
 use reqwest::Error as ReqwestError;
 use serde_json::Error as JsonError;
@@ -33,9 +33,14 @@ use matrix_sdk_base::crypto::store::CryptoStoreError;
 /// Result type of the rust-sdk.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Internal representation of errors.
+/// An HTTP error, representing either a connection error or an error while
+/// converting the raw HTTP response into a Matrix response.
 #[derive(Error, Debug)]
-pub enum Error {
+pub enum HttpError {
+    /// An error at the HTTP layer.
+    #[error(transparent)]
+    Reqwest(#[from] ReqwestError),
+
     /// Queried endpoint requires authentication but was called on an anonymous client.
     #[error("the queried endpoint requires authentication but was called before logging in")]
     AuthenticationRequired,
@@ -44,9 +49,33 @@ pub enum Error {
     #[error("the queried endpoint is not meant for clients")]
     NotClientRequest,
 
-    /// An error at the HTTP layer.
+    /// An error converting between ruma_client_api types and Hyper types.
     #[error(transparent)]
-    Reqwest(#[from] ReqwestError),
+    FromHttpResponse(#[from] FromHttpResponseError<RumaClientError>),
+
+    /// An error converting between ruma_client_api types and Hyper types.
+    #[error(transparent)]
+    IntoHttp(#[from] IntoHttpError),
+
+    /// An error occurred while authenticating.
+    ///
+    /// When registering or authenticating the Matrix server can send a `UiaaResponse`
+    /// as the error type, this is a User-Interactive Authentication API response. This
+    /// represents an error with information about how to authenticate the user.
+    #[error(transparent)]
+    UiaaError(#[from] FromHttpResponseError<UiaaError>),
+}
+
+/// Internal representation of errors.
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Error doing an HTTP request.
+    #[error(transparent)]
+    Http(#[from] HttpError),
+
+    /// Queried endpoint requires authentication but was called on an anonymous client.
+    #[error("the queried endpoint requires authentication but was called before logging in")]
+    AuthenticationRequired,
 
     /// An error de/serializing type for the `StateStore`
     #[error(transparent)]
@@ -55,14 +84,6 @@ pub enum Error {
     /// An IO error happened.
     #[error(transparent)]
     IO(#[from] IoError),
-
-    /// An error converting between ruma_client_api types and Hyper types.
-    #[error("can't parse the JSON response as a Matrix response")]
-    RumaResponse(RumaResponseError<RumaClientError>),
-
-    /// An error converting between ruma_client_api types and Hyper types.
-    #[error("can't convert between ruma_client_api and hyper types.")]
-    IntoHttp(RumaIntoHttpError),
 
     /// An error occurred in the Matrix client library.
     #[error(transparent)]
@@ -76,14 +97,6 @@ pub enum Error {
     /// An error occured in the state store.
     #[error(transparent)]
     StateStore(#[from] StoreError),
-
-    /// An error occurred while authenticating.
-    ///
-    /// When registering or authenticating the Matrix server can send a `UiaaResponse`
-    /// as the error type, this is a User-Interactive Authentication API response. This
-    /// represents an error with information about how to authenticate the user.
-    #[error("User-Interactive Authentication required.")]
-    UiaaError(RumaResponseError<UiaaError>),
 }
 
 impl Error {
@@ -99,9 +112,9 @@ impl Error {
     /// This method is an convenience method to get to the info the server
     /// returned on the first, failed request.
     pub fn uiaa_response(&self) -> Option<&UiaaInfo> {
-        if let Error::UiaaError(RumaResponseError::Http(ServerError::Known(
+        if let Error::Http(HttpError::UiaaError(FromHttpResponseError::Http(ServerError::Known(
             UiaaError::AuthResponse(i),
-        ))) = self
+        )))) = self
         {
             Some(i)
         } else {
@@ -110,20 +123,8 @@ impl Error {
     }
 }
 
-impl From<RumaResponseError<UiaaError>> for Error {
-    fn from(error: RumaResponseError<UiaaError>) -> Self {
-        Self::UiaaError(error)
-    }
-}
-
-impl From<RumaResponseError<RumaClientError>> for Error {
-    fn from(error: RumaResponseError<RumaClientError>) -> Self {
-        Self::RumaResponse(error)
-    }
-}
-
-impl From<RumaIntoHttpError> for Error {
-    fn from(error: RumaIntoHttpError) -> Self {
-        Self::IntoHttp(error)
+impl From<ReqwestError> for Error {
+    fn from(e: ReqwestError) -> Self {
+        Error::Http(HttpError::Reqwest(e))
     }
 }

--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -182,7 +182,8 @@ pub(crate) fn client_with_config(config: &ClientConfig) -> Result<Client, HttpEr
 
         let user_agent = match &config.user_agent {
             Some(a) => a.clone(),
-            None => HeaderValue::from_str(&format!("matrix-rust-sdk {}", crate::VERSION)).unwrap(),
+            None => HeaderValue::from_str(&format!("matrix-rust-sdk {}", crate::VERSION))
+                .expect("Can't construct the version header"),
         };
 
         headers.insert(reqwest::header::USER_AGENT, user_agent);
@@ -203,7 +204,9 @@ async fn response_to_http_response(
     let status = response.status();
 
     let mut http_builder = HttpResponse::builder().status(status);
-    let headers = http_builder.headers_mut().unwrap();
+    let headers = http_builder
+        .headers_mut()
+        .expect("Can't get the response builder headers");
 
     for (k, v) in response.headers_mut().drain() {
         if let Some(key) = k {
@@ -213,7 +216,9 @@ async fn response_to_http_response(
 
     let body = response.bytes().await?.as_ref().to_owned();
 
-    Ok(http_builder.body(body).unwrap())
+    Ok(http_builder
+        .body(body)
+        .expect("Can't construct a response using the given body"))
 }
 
 #[cfg(test)]

--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -51,6 +51,7 @@ pub trait HttpSend: AsyncTraitDeps {
     /// ```
     /// use std::convert::TryFrom;
     /// use matrix_sdk::{HttpSend, async_trait, HttpError};
+    /// # use std::time::Duration;
     ///
     /// #[derive(Debug)]
     /// struct Client(reqwest::Client);
@@ -67,7 +68,11 @@ pub trait HttpSend: AsyncTraitDeps {
     ///
     /// #[async_trait]
     /// impl HttpSend for Client {
-    ///     async fn send_request(&self, request: http::Request<Vec<u8>>) -> Result<http::Response<Vec<u8>>, HttpError> {
+    ///     async fn send_request(
+    ///         &self,
+    ///         request: http::Request<Vec<u8>>,
+    ///         timeout: Option<Duration>,
+    ///     ) -> Result<http::Response<Vec<u8>>, HttpError> {
     ///         Ok(self
     ///             .response_to_http_response(
     ///                 self.0

--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -14,9 +14,9 @@
 
 use std::{convert::TryFrom, fmt::Debug, sync::Arc};
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(target_arch = "wasm32")))]
 use backoff::{future::retry, Error as RetryError, ExponentialBackoff};
-#[cfg(not(test))]
+#[cfg(all(not(test), not(target_arch = "wasm32")))]
 use http::StatusCode;
 use http::{HeaderValue, Method as HttpMethod, Response as HttpResponse};
 use reqwest::{Client, Response};
@@ -30,7 +30,9 @@ use matrix_sdk_common::{
 
 use crate::{error::HttpError, ClientConfig, OutgoingRequest, Session};
 
+#[cfg(not(target_arch = "wasm32"))]
 const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(not(target_arch = "wasm32"))]
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Abstraction around the http layer. The allows implementors to use different
@@ -235,7 +237,7 @@ async fn response_to_http_response(
         .expect("Can't construct a response using the given body"))
 }
 
-#[cfg(test)]
+#[cfg(any(test, target_arch = "wasm32"))]
 async fn send_request(
     client: &Client,
     request: http::Request<Vec<u8>>,
@@ -247,7 +249,7 @@ async fn send_request(
     Ok(response_to_http_response(response).await?)
 }
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(target_arch = "wasm32")))]
 async fn send_request(
     client: &Client,
     request: http::Request<Vec<u8>>,

--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -15,7 +15,7 @@
 use std::{convert::TryFrom, fmt::Debug, sync::Arc};
 
 #[cfg(not(test))]
-use backoff::{tokio::retry, Error as RetryError, ExponentialBackoff};
+use backoff::{future::retry, Error as RetryError, ExponentialBackoff};
 #[cfg(not(test))]
 use http::StatusCode;
 use http::{HeaderValue, Method as HttpMethod, Response as HttpResponse};

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -90,7 +90,7 @@ pub use client::{Client, ClientConfig, LoopCtrl, SyncSettings};
 #[cfg(feature = "encryption")]
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
 pub use device::Device;
-pub use error::{Error, Result};
+pub use error::{Error, HttpError, Result};
 pub use http_client::HttpSend;
 #[cfg(feature = "encryption")]
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]

--- a/matrix_sdk/src/sas.rs
+++ b/matrix_sdk/src/sas.rs
@@ -54,7 +54,7 @@ impl Sas {
         }
 
         if let Some(s) = signature {
-            self.client.send(s).await?;
+            self.client.send(s, None).await?;
         }
 
         Ok(())


### PR DESCRIPTION
This PR adds logic to the client to retry requests in a smart way depending on the status code.

Stuff that needs to be done before this can be merged:
- [x] Retry requests by default
- [ ] <del>WASM support</del> (needs support in backoff)
- [x] Set sensible timeouts depending on the type of the request