### PR TITLE
Export CustomEvent and StateChanges add docs to StateChanges

### DIFF
--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -68,8 +68,8 @@ compile_error!("only one of 'native-tls' or 'rustls-tls' features can be enabled
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
 pub use matrix_sdk_base::crypto::LocalTrust;
 pub use matrix_sdk_base::{
-    Error as BaseError, EventEmitter, InvitedRoom, JoinedRoom, LeftRoom, RoomInfo, RoomMember,
-    RoomState, Session, StoreError,
+    CustomEvent, Error as BaseError, EventEmitter, InvitedRoom, JoinedRoom, LeftRoom, RoomInfo,
+    RoomMember, RoomState, Session, StateChanges, StoreError,
 };
 
 pub use matrix_sdk_common::*;

--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -51,12 +51,12 @@ mod rooms;
 mod session;
 mod store;
 
-pub use event_emitter::EventEmitter;
+pub use event_emitter::{CustomEvent, EventEmitter};
 pub use rooms::{
     InvitedRoom, JoinedRoom, LeftRoom, Room, RoomInfo, RoomMember, RoomState, StrippedRoom,
     StrippedRoomInfo,
 };
-pub use store::{StateStore, Store, StoreError};
+pub use store::{StateChanges, StateStore, Store, StoreError};
 
 pub use client::{BaseClient, BaseClientConfig, RoomStateType};
 


### PR DESCRIPTION
Not sure if `StateChanges` should be exported but everything was pub so :shrug:. In order to impl all the `EventEmitter` trait methods the `CustomEvent` needed to be exported.