### PR TITLE
Rename `EventEmitter` to `EventHandler`

### DIFF
--- a/design.md
+++ b/design.md
@@ -22,7 +22,7 @@ In addition to Http, the `AsyncClient` passes along methods from the `BaseClient
 Given a Matrix response the crypto machine will update its own internal state, along with encryption information. `BaseClient` and the crypto machine together keep track of when to encrypt. It knows when encryption needs to happen based on signals from the `BaseClient`. The crypto state machine is given responses that relate to encryption and can create encrypted request bodies for encryption-related requests. Basically it tells the `BaseClient` to send to-device messages out, and the `BaseClient` is responsible for notifying the crypto state machine when it sent the message so crypto can update state.
 
 #### Client State/Room and RoomMember
-The `BaseClient` is responsible for keeping state in sync through the `IncomingResponse`s of `AsyncClient` or querying the `StateStore`. By processing and then delegating incoming `RoomEvent`s, `StateEvent`s, `PresenceEvent`, `IncomingAccountData` and `EphemeralEvent`s to the correct `Room` in the base clients `HashMap<RoomId, Room>` or further to `Room`'s `RoomMember` via the members `HashMap<UserId, RoomMember>`. The `BaseClient` is also responsible for emitting the incoming events to the `EventEmitter` trait.
+The `BaseClient` is responsible for keeping state in sync through the `IncomingResponse`s of `AsyncClient` or querying the `StateStore`. By processing and then delegating incoming `RoomEvent`s, `StateEvent`s, `PresenceEvent`, `IncomingAccountData` and `EphemeralEvent`s to the correct `Room` in the base clients `HashMap<RoomId, Room>` or further to `Room`'s `RoomMember` via the members `HashMap<UserId, RoomMember>`. The `BaseClient` is also responsible for forwarding the incoming events to the `EventHandler` trait.
 
 ```rust
 /// A Matrix room.
@@ -95,6 +95,6 @@ The `BaseClient` also has access to a `dyn StateStore` this is an abstraction ar
 
 The state store will restore our client state in the `BaseClient` and client authors can just get the latest state that they want to present from the client object. No need to ask the state store for it, this may change if custom setups request this. `StateStore`'s main purpose is to provide load/store functionality and, internally to the crate, update the `BaseClient`.
 
-#### Event Emitter
-The consumer of this crate can implement the `EventEmitter` trait for full control over how incoming events are handled by their client. If that isn't enough, it is possible to receive every incoming response with the `AsyncClient::sync_forever` callback.
-  - list the methods for `EventEmitter`?
+#### Event Handler
+The consumer of this crate can implement the `EventHandler` trait for full control over how incoming events are handled by their client. If that isn't enough, it is possible to receive every incoming response with the `AsyncClient::sync_forever` callback.
+  - list the methods for `EventHandler`?

--- a/matrix_sdk/examples/autojoin.rs
+++ b/matrix_sdk/examples/autojoin.rs
@@ -78,7 +78,7 @@ async fn login_and_sync(
     println!("logged in as {}", username);
 
     client
-        .add_event_emitter(Box::new(AutoJoinBot::new(client.clone())))
+        .set_event_emitter(Box::new(AutoJoinBot::new(client.clone())))
         .await;
 
     client.sync(SyncSettings::default()).await;

--- a/matrix_sdk/examples/autojoin.rs
+++ b/matrix_sdk/examples/autojoin.rs
@@ -4,7 +4,7 @@ use tokio::time::{sleep, Duration};
 use matrix_sdk::{
     self, async_trait,
     events::{room::member::MemberEventContent, StrippedStateEvent},
-    Client, ClientConfig, EventEmitter, RoomState, SyncSettings,
+    Client, ClientConfig, EventHandler, RoomState, SyncSettings,
 };
 use url::Url;
 
@@ -19,7 +19,7 @@ impl AutoJoinBot {
 }
 
 #[async_trait]
-impl EventEmitter for AutoJoinBot {
+impl EventHandler for AutoJoinBot {
     async fn on_stripped_state_member(
         &self,
         room: RoomState,
@@ -78,7 +78,7 @@ async fn login_and_sync(
     println!("logged in as {}", username);
 
     client
-        .set_event_emitter(Box::new(AutoJoinBot::new(client.clone())))
+        .set_event_handler(Box::new(AutoJoinBot::new(client.clone())))
         .await;
 
     client.sync(SyncSettings::default()).await;

--- a/matrix_sdk/examples/command_bot.rs
+++ b/matrix_sdk/examples/command_bot.rs
@@ -88,7 +88,7 @@ async fn login_and_sync(
     // add our CommandBot to be notified of incoming messages, we do this after the initial
     // sync to avoid responding to messages before the bot was running.
     client
-        .add_event_emitter(Box::new(CommandBot::new(client.clone())))
+        .set_event_emitter(Box::new(CommandBot::new(client.clone())))
         .await;
 
     // since we called `sync_once` before we entered our sync loop we must pass

--- a/matrix_sdk/examples/command_bot.rs
+++ b/matrix_sdk/examples/command_bot.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
         room::message::{MessageEventContent, TextMessageEventContent},
         AnyMessageEventContent, SyncMessageEvent,
     },
-    Client, ClientConfig, EventEmitter, RoomState, SyncSettings,
+    Client, ClientConfig, EventHandler, RoomState, SyncSettings,
 };
 use url::Url;
 
@@ -23,7 +23,7 @@ impl CommandBot {
 }
 
 #[async_trait]
-impl EventEmitter for CommandBot {
+impl EventHandler for CommandBot {
     async fn on_room_message(
         &self,
         room: RoomState,
@@ -88,13 +88,13 @@ async fn login_and_sync(
     // add our CommandBot to be notified of incoming messages, we do this after the initial
     // sync to avoid responding to messages before the bot was running.
     client
-        .set_event_emitter(Box::new(CommandBot::new(client.clone())))
+        .set_event_handler(Box::new(CommandBot::new(client.clone())))
         .await;
 
     // since we called `sync_once` before we entered our sync loop we must pass
     // that sync token to `sync`
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
-    // this keeps state from the server streaming in to CommandBot via the EventEmitter trait
+    // this keeps state from the server streaming in to CommandBot via the EventHandler trait
     client.sync(settings).await;
 
     Ok(())

--- a/matrix_sdk/examples/image_bot.rs
+++ b/matrix_sdk/examples/image_bot.rs
@@ -86,7 +86,7 @@ async fn login_and_sync(
 
     client.sync_once(SyncSettings::default()).await.unwrap();
     client
-        .add_event_emitter(Box::new(ImageBot::new(client.clone(), image)))
+        .set_event_emitter(Box::new(ImageBot::new(client.clone(), image)))
         .await;
 
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());

--- a/matrix_sdk/examples/image_bot.rs
+++ b/matrix_sdk/examples/image_bot.rs
@@ -14,7 +14,7 @@ use matrix_sdk::{
         room::message::{MessageEventContent, TextMessageEventContent},
         SyncMessageEvent,
     },
-    Client, EventEmitter, RoomState, SyncSettings,
+    Client, EventHandler, RoomState, SyncSettings,
 };
 use url::Url;
 
@@ -31,7 +31,7 @@ impl ImageBot {
 }
 
 #[async_trait]
-impl EventEmitter for ImageBot {
+impl EventHandler for ImageBot {
     async fn on_room_message(
         &self,
         room: RoomState,
@@ -86,7 +86,7 @@ async fn login_and_sync(
 
     client.sync_once(SyncSettings::default()).await.unwrap();
     client
-        .set_event_emitter(Box::new(ImageBot::new(client.clone(), image)))
+        .set_event_handler(Box::new(ImageBot::new(client.clone(), image)))
         .await;
 
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());

--- a/matrix_sdk/examples/login.rs
+++ b/matrix_sdk/examples/login.rs
@@ -44,7 +44,7 @@ async fn login(
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).unwrap();
 
-    client.add_event_emitter(Box::new(EventCallback)).await;
+    client.set_event_emitter(Box::new(EventCallback)).await;
 
     client
         .login(username, password, None, Some("rust-sdk"))

--- a/matrix_sdk/examples/login.rs
+++ b/matrix_sdk/examples/login.rs
@@ -7,13 +7,13 @@ use matrix_sdk::{
         room::message::{MessageEventContent, TextMessageEventContent},
         SyncMessageEvent,
     },
-    Client, EventEmitter, RoomState, SyncSettings,
+    Client, EventHandler, RoomState, SyncSettings,
 };
 
 struct EventCallback;
 
 #[async_trait]
-impl EventEmitter for EventCallback {
+impl EventHandler for EventCallback {
     async fn on_room_message(
         &self,
         room: RoomState,
@@ -44,7 +44,7 @@ async fn login(
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).unwrap();
 
-    client.set_event_emitter(Box::new(EventCallback)).await;
+    client.set_event_handler(Box::new(EventCallback)).await;
 
     client
         .login(username, password, None, Some("rust-sdk"))

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -556,8 +556,8 @@ impl Client {
     /// Add `EventEmitter` to `Client`.
     ///
     /// The methods of `EventEmitter` are called when the respective `RoomEvents` occur.
-    pub async fn add_event_emitter(&self, emitter: Box<dyn EventEmitter>) {
-        self.base_client.add_event_emitter(emitter).await;
+    pub async fn set_event_emitter(&self, emitter: Box<dyn EventEmitter>) {
+        self.base_client.set_event_emitter(emitter).await;
     }
 
     /// Returns the joined rooms this client knows about.

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -41,7 +41,7 @@ use tracing::{error, info, instrument};
 
 use matrix_sdk_base::{
     deserialized_responses::{MembersResponse, SyncResponse},
-    BaseClient, BaseClientConfig, EventEmitter, InvitedRoom, JoinedRoom, LeftRoom, Session, Store,
+    BaseClient, BaseClientConfig, EventHandler, InvitedRoom, JoinedRoom, LeftRoom, Session, Store,
 };
 
 #[cfg(feature = "encryption")]
@@ -553,11 +553,11 @@ impl Client {
         Ok(())
     }
 
-    /// Add `EventEmitter` to `Client`.
+    /// Add `EventHandler` to `Client`.
     ///
-    /// The methods of `EventEmitter` are called when the respective `RoomEvents` occur.
-    pub async fn set_event_emitter(&self, emitter: Box<dyn EventEmitter>) {
-        self.base_client.set_event_emitter(emitter).await;
+    /// The methods of `EventHandler` are called when the respective `RoomEvents` occur.
+    pub async fn set_event_handler(&self, handler: Box<dyn EventHandler>) {
+        self.base_client.set_event_handler(handler).await;
     }
 
     /// Returns the joined rooms this client knows about.

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -68,7 +68,7 @@ compile_error!("only one of 'native-tls' or 'rustls-tls' features can be enabled
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
 pub use matrix_sdk_base::crypto::LocalTrust;
 pub use matrix_sdk_base::{
-    CustomEvent, Error as BaseError, EventEmitter, InvitedRoom, JoinedRoom, LeftRoom, RoomInfo,
+    CustomEvent, Error as BaseError, EventHandler, InvitedRoom, JoinedRoom, LeftRoom, RoomInfo,
     RoomMember, RoomState, Session, StateChanges, StoreError,
 };
 

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -430,7 +430,7 @@ impl BaseClient {
     /// Add `EventEmitter` to `Client`.
     ///
     /// The methods of `EventEmitter` are called when the respective `RoomEvents` occur.
-    pub async fn add_event_emitter(&self, emitter: Box<dyn EventEmitter>) {
+    pub async fn set_event_emitter(&self, emitter: Box<dyn EventEmitter>) {
         let emitter = Emitter {
             inner: emitter,
             store: self.store.clone(),

--- a/matrix_sdk_base/src/event_emitter/mod.rs
+++ b/matrix_sdk_base/src/event_emitter/mod.rs
@@ -746,7 +746,7 @@ mod test {
         let emitter = Box::new(EvEmitterTest(vec));
 
         let client = get_client().await;
-        client.add_event_emitter(emitter).await;
+        client.set_event_emitter(emitter).await;
 
         let response = sync_response(SyncResponseFile::Default);
         client.receive_sync_response(response).await.unwrap();
@@ -778,7 +778,7 @@ mod test {
         let emitter = Box::new(EvEmitterTest(vec));
 
         let client = get_client().await;
-        client.add_event_emitter(emitter).await;
+        client.set_event_emitter(emitter).await;
 
         let response = sync_response(SyncResponseFile::Invite);
         client.receive_sync_response(response).await.unwrap();
@@ -801,7 +801,7 @@ mod test {
         let emitter = Box::new(EvEmitterTest(vec));
 
         let client = get_client().await;
-        client.add_event_emitter(emitter).await;
+        client.set_event_emitter(emitter).await;
 
         let response = sync_response(SyncResponseFile::Leave);
         client.receive_sync_response(response).await.unwrap();
@@ -831,7 +831,7 @@ mod test {
         let emitter = Box::new(EvEmitterTest(vec));
 
         let client = get_client().await;
-        client.add_event_emitter(emitter).await;
+        client.set_event_emitter(emitter).await;
 
         let response = sync_response(SyncResponseFile::All);
         client.receive_sync_response(response).await.unwrap();
@@ -856,7 +856,7 @@ mod test {
         let emitter = Box::new(EvEmitterTest(vec));
 
         let client = get_client().await;
-        client.add_event_emitter(emitter).await;
+        client.set_event_emitter(emitter).await;
 
         let response = sync_response(SyncResponseFile::Voip);
         client.receive_sync_response(response).await.unwrap();

--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -46,12 +46,12 @@ pub use matrix_sdk_common::*;
 
 mod client;
 mod error;
-mod event_emitter;
+mod event_handler;
 mod rooms;
 mod session;
 mod store;
 
-pub use event_emitter::{CustomEvent, EventEmitter};
+pub use event_handler::{CustomEvent, EventHandler};
 pub use rooms::{
     InvitedRoom, JoinedRoom, LeftRoom, Room, RoomInfo, RoomMember, RoomState, StrippedRoom,
     StrippedRoomInfo,


### PR DESCRIPTION
Quite a breaking change, but the SDK breaks quite often anyways so we might as well do it now.