### PR TITLE
Group session sharing code refactoring

### DIFF
--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -1159,24 +1159,24 @@ impl BaseClient {
 
         match &*olm {
             Some(o) => {
-                let (history_visiblity, settings) = self
+                let (history_visibility, settings) = self
                     .get_room(room_id)
-                    .map(|r| (r.history_visiblity(), r.encryption_settings()))
+                    .map(|r| (r.history_visibility(), r.encryption_settings()))
                     .unwrap_or((HistoryVisibility::Joined, None));
 
                 let joined = self.store.get_joined_user_ids(room_id).await?;
                 let invited = self.store.get_invited_user_ids(room_id).await?;
 
                 // Don't share the group session with members that are invited
-                // if the history visiblity is set to `Joined`
-                let members = if history_visiblity == HistoryVisibility::Joined {
+                // if the history visibility is set to `Joined`
+                let members = if history_visibility == HistoryVisibility::Joined {
                     joined.iter().chain(&[])
                 } else {
                     joined.iter().chain(&invited)
                 };
 
                 let settings = settings.ok_or(MegolmError::EncryptionNotEnabled)?;
-                let settings = EncryptionSettings::new(settings, history_visiblity);
+                let settings = EncryptionSettings::new(settings, history_visibility);
 
                 Ok(o.share_group_session(room_id, members, settings).await?)
             }

--- a/matrix_sdk_base/src/rooms/mod.rs
+++ b/matrix_sdk_base/src/rooms/mod.rs
@@ -80,8 +80,8 @@ impl RoomState {
         }
     }
 
-    /// Get the history visiblity policy of this room.
-    pub fn history_visiblity(&self) -> HistoryVisibility {
+    /// Get the history visibility policy of this room.
+    pub fn history_visibility(&self) -> HistoryVisibility {
         match self {
             RoomState::Joined(r) => r.inner.history_visibility(),
             RoomState::Left(r) => r.inner.history_visibility(),
@@ -169,7 +169,7 @@ pub struct BaseRoomInfo {
     pub encryption: Option<EncryptionEventContent>,
     /// The guest access policy of this room.
     pub guest_access: GuestAccess,
-    /// The history visiblity policy of this room.
+    /// The history visibility policy of this room.
     pub history_visibility: HistoryVisibility,
     /// The join rule policy of this room.
     pub join_rule: JoinRule,

--- a/matrix_sdk_base/src/rooms/normal.rs
+++ b/matrix_sdk_base/src/rooms/normal.rs
@@ -197,7 +197,7 @@ impl Room {
         self.inner.read().unwrap().base_info.guest_access.clone()
     }
 
-    /// Get the history visiblity policy of this room.
+    /// Get the history visibility policy of this room.
     pub fn history_visibility(&self) -> HistoryVisibility {
         self.inner
             .read()

--- a/matrix_sdk_base/src/rooms/stripped.rs
+++ b/matrix_sdk_base/src/rooms/stripped.rs
@@ -105,7 +105,7 @@ impl StrippedRoom {
         self.inner.lock().unwrap().base_info.encryption.clone()
     }
 
-    /// Get the history visiblity policy of this room.
+    /// Get the history visibility policy of this room.
     pub fn history_visibility(&self) -> HistoryVisibility {
         self.inner
             .lock()

--- a/matrix_sdk_crypto/src/olm/account.rs
+++ b/matrix_sdk_crypto/src/olm/account.rs
@@ -991,7 +991,7 @@ impl ReadOnlyAccount {
             return Err(());
         }
 
-        let visiblity = settings.history_visibility.clone();
+        let visibility = settings.history_visibility.clone();
 
         let outbound = OutboundGroupSession::new(
             self.device_id.clone(),
@@ -1009,7 +1009,7 @@ impl ReadOnlyAccount {
             signing_key,
             &room_id,
             outbound.session_key().await,
-            Some(visiblity),
+            Some(visibility),
         )
         .expect("Can't create inbound group session from a newly created outbound group session");
 

--- a/matrix_sdk_crypto/src/olm/group_sessions/inbound.rs
+++ b/matrix_sdk_crypto/src/olm/group_sessions/inbound.rs
@@ -383,7 +383,7 @@ pub struct PickledInboundGroupSession {
     /// Flag remembering if the session was dirrectly sent to us by the sender
     /// or if it was imported.
     pub imported: bool,
-    /// History visiblity of the room when the session was created.
+    /// History visibility of the room when the session was created.
     pub history_visibility: Option<HistoryVisibility>,
 }
 

--- a/matrix_sdk_crypto/src/olm/group_sessions/outbound.rs
+++ b/matrix_sdk_crypto/src/olm/group_sessions/outbound.rs
@@ -98,7 +98,7 @@ impl Default for EncryptionSettings {
 
 impl EncryptionSettings {
     /// Create new encryption settings using an `EncryptionEventContent` and a
-    /// history visiblity.
+    /// history visibility.
     pub fn new(content: EncryptionEventContent, history_visibility: HistoryVisibility) -> Self {
         let rotation_period: Duration = content
             .rotation_period_ms

--- a/matrix_sdk_crypto/src/session_manager/group_sessions.rs
+++ b/matrix_sdk_crypto/src/session_manager/group_sessions.rs
@@ -242,7 +242,7 @@ impl GroupSessionManager {
             .collect::<HashSet<_>>()
             .is_empty();
 
-        let visiblity_changed = outbound.settings().history_visibility != history_visibility;
+        let visibility_changed = outbound.settings().history_visibility != history_visibility;
 
         // To protect the room history we need to rotate the session if either:
         //
@@ -251,7 +251,7 @@ impl GroupSessionManager {
         // 3. The history visibility changed.
         //
         // This is calculated in the following code and stored in this variable.
-        let mut should_rotate = user_left || visiblity_changed;
+        let mut should_rotate = user_left || visibility_changed;
 
         for user_id in users {
             let user_devices = self.store.get_user_devices(&user_id).await?;

--- a/matrix_sdk_crypto/src/session_manager/group_sessions.rs
+++ b/matrix_sdk_crypto/src/session_manager/group_sessions.rs
@@ -256,9 +256,9 @@ impl GroupSessionManager {
         for user_id in users {
             let user_devices = self.store.get_user_devices(&user_id).await?;
             let non_blacklisted_devices: Vec<Device> = user_devices
-                    .devices()
-                    .filter(|d| !d.is_blacklisted())
-                    .collect();
+                .devices()
+                .filter(|d| !d.is_blacklisted())
+                .collect();
 
             // If we haven't already concluded that the session should be rotated for other
             // reasons, we also need to check whether any of the devices in the session got deleted
@@ -288,8 +288,7 @@ impl GroupSessionManager {
                         .difference(&non_blacklisted_device_ids)
                         .collect::<HashSet<_>>();
 
-                    if !newly_deleted_or_blacklisted.is_empty()
-                    {
+                    if !newly_deleted_or_blacklisted.is_empty() {
                         should_rotate = true;
                     }
                 };

--- a/matrix_sdk_crypto/src/session_manager/group_sessions.rs
+++ b/matrix_sdk_crypto/src/session_manager/group_sessions.rs
@@ -213,10 +213,10 @@ impl GroupSessionManager {
         Ok((id, request, changed_sessions))
     }
 
-    /// Given a list of user and an outbound session get the list of users and
-    /// devices that this session should be shared with.
+    /// Given a list of user and an outbound session, return the list of users and
+    /// their devices that this session should be shared with.
     ///
-    /// Returns a boolean indicating that the session needs to be rotated and
+    /// Returns a boolean indicating whether the session needs to be rotated and
     /// the list of users/devices that should receive the session.
     pub async fn collect_session_recipients(
         &self,


### PR DESCRIPTION
This is meant to come after #130.

This fixes some typos and refactors the group session sharing code to increase readability.