### PR TITLE
client: PUT /_matrix/client/r0/rooms/{roomId}/redact/{eventId}/{txnId}

### DIFF
--- a/matrix_sdk/src/room/joined.rs
+++ b/matrix_sdk/src/room/joined.rs
@@ -587,9 +587,9 @@ impl Joined {
     /// # let homeserver = url::Url::parse("http://localhost:8080").unwrap();
     /// # let mut client = matrix_sdk::Client::new(homeserver).unwrap();
     /// # let room_id = matrix_sdk::identifiers::room_id!("!test:localhost");
-    /// let room = client
-    ///    .get_joined_room(&room_id)
-    ///    .unwrap();
+    /// # let room = client
+    /// #   .get_joined_room(&room_id)
+    /// #   .unwrap();
     /// let event_id = matrix_sdk::identifiers::event_id!("$xxxxxx:example.org");
     /// let reason = Some("Indecent material");
     /// room.redact(&event_id, reason, None).await.unwrap();


### PR DESCRIPTION
Implement redaction for client [`PUT /_matrix/client/r0/rooms/{roomId}/redact/{eventId}/{txnId}`](https://matrix.org/docs/spec/client_server/r0.6.1#id276).