### PR TITLE
WIP: Improve the room API

### DIFF
--- a/matrix_sdk/src/room/invited.rs
+++ b/matrix_sdk/src/room/invited.rs
@@ -1,4 +1,4 @@
-use crate::{room::Common, Client, Result, Room, RoomType};
+use crate::{room::{Common, Joined}, Client, Result, Room, RoomType};
 use std::ops::Deref;
 
 /// A room in the invited state.
@@ -30,11 +30,12 @@ impl Invited {
 
     /// Reject the invitation.
     pub async fn reject_invitation(&self) -> Result<()> {
-        self.inner.leave().await
+        self.inner.leave().await?;
+        Ok(())
     }
 
     /// Accept the invitation.
-    pub async fn accept_invitation(&self) -> Result<()> {
+    pub async fn accept_invitation(&self) -> Result<Joined> {
         self.inner.join().await
     }
 }

--- a/matrix_sdk/src/room/joined.rs
+++ b/matrix_sdk/src/room/joined.rs
@@ -1,4 +1,4 @@
-use crate::{room::Common, Client, Result, Room, RoomType};
+use crate::{room::{Common, Left}, Client, Result, Room, RoomType};
 use std::{io::Read, ops::Deref, sync::Arc};
 
 use matrix_sdk_common::{
@@ -76,7 +76,7 @@ impl Joined {
     }
 
     /// Leave this room.
-    pub async fn leave(&self) -> Result<()> {
+    pub async fn leave(&self) -> Result<Left> {
         self.inner.leave().await
     }
 

--- a/matrix_sdk/src/room/left.rs
+++ b/matrix_sdk/src/room/left.rs
@@ -1,4 +1,4 @@
-use crate::{room::Common, Client, Result, Room, RoomType};
+use crate::{room, room::Common, Client, Result, Room, RoomType};
 use std::ops::Deref;
 
 use matrix_sdk_common::api::r0::membership::forget_room;
@@ -31,7 +31,7 @@ impl Left {
     }
 
     /// Join this room.
-    pub async fn join(&self) -> Result<()> {
+    pub async fn join(&self) -> Result<room::Joined> {
         self.inner.join().await
     }
 

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -955,6 +955,34 @@ impl BaseClient {
     ///
     /// # Arguments
     ///
+    /// * `room_id` - The room id this state change belongs to.
+    ///
+    /// * `room_type` - The new state of the given room.
+    pub async fn receive_room_state_change(
+        &self,
+        room_id: &RoomId,
+        room_type: RoomType,
+    ) -> Result<()> {
+        let room = self
+            .store
+            .get_or_create_room(room_id, room_type.clone())
+            .await;
+        let mut changes = StateChanges::default();
+        let mut room_info = room.clone_info();
+        room_info.room_type = room_type;
+        changes.add_room(room_info);
+        self.store.save_changes(&changes).await?;
+        self.apply_changes(&changes).await;
+
+        Ok(())
+    }
+
+    /// Receive a get member events response and convert it to a deserialized
+    /// `MembersResponse`
+    ///
+    ///
+    /// # Arguments
+    ///
     /// * `room_id` - The room id this response belongs to.
     ///
     /// * `response` - The raw response that was received from the server.


### PR DESCRIPTION
Room methods that change the room state should return the room in the new state. E.g.  calling `room::Left::join()` should return a `room::Joined` if the request was successful. 