### PR TITLE
Reintroduce CI for WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,9 @@ jobs:
         override: true
 
     - name: Check
-      uses: actions-rs/cargo@v1
       run: |
         cd matrix_sdk/examples/wasm_command_bot
-      with:
-        command: check
-        args: --target wasm32-unknown-unknown
+        cargo check --target wasm32-unknown-unknown
 
   test:
     name: ${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
         profile: minimal
         override: true
 
+    - name: Install emscripten
+      uses: mymindstorm/setup-emsdk@v7
+
     - name: Check
       run: |
         cd matrix_sdk/examples/wasm_command_bot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        target: wasm32-unknown-unknown
         profile: minimal
         override: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,10 @@ jobs:
         profile: minimal
         override: true
 
-    - name: Change the directory
-      run: |
-        cd matrix_sdk/examples/wasm_command_bot
-
     - name: Check
       uses: actions-rs/cargo@v1
+      run: |
+        cd matrix_sdk/examples/wasm_command_bot
       with:
         command: check
         args: --target wasm32-unknown-unknown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
   check-wasm:
     name: Check if WASM support compiles
     needs: [clippy]
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout the repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,31 @@ jobs:
         command: clippy
         args: --all-targets -- -D warnings
 
+  check-wasm:
+    name: Check if WASM support compiles
+    needs: [clippy]
+
+    steps:
+    - name: Checkout the repo
+      uses: actions/checkout@v2
+
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+
+    - name: Change the directory
+      run: |
+        cd matrix_sdk/examples/wasm_command_bot
+
+    - name: Check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --target wasm32-unknown-unknown
+
   test:
     name: ${{ matrix.name }}
     needs: [clippy]

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -1048,7 +1048,7 @@ impl Client {
     /// );
     ///
     /// let txn_id = Uuid::new_v4();
-    /// client.send(room_id, content, Some(txn_id)).await.unwrap();
+    /// client.room_send(&room_id, content, Some(txn_id)).await.unwrap();
     /// # })
     /// ```
     pub async fn room_send(

--- a/matrix_sdk/src/room/common.rs
+++ b/matrix_sdk/src/room/common.rs
@@ -1,8 +1,10 @@
-use matrix_sdk_common::api::r0::{
-    membership::{get_member_events, join_room_by_id, leave_room},
-    message::get_message_events,
+use matrix_sdk_common::{
+    api::r0::{
+        membership::{get_member_events, join_room_by_id, leave_room},
+        message::get_message_events,
+    },
+    locks::Mutex,
 };
-use matrix_sdk_common::locks::Mutex;
 
 use std::{ops::Deref, sync::Arc};
 

--- a/matrix_sdk/src/room/mod.rs
+++ b/matrix_sdk/src/room/mod.rs
@@ -7,10 +7,7 @@ mod invited;
 mod joined;
 mod left;
 
-pub use self::common::Common;
-pub use self::invited::Invited;
-pub use self::joined::Joined;
-pub use self::left::Left;
+pub use self::{common::Common, invited::Invited, joined::Joined, left::Left};
 
 /// An enum that abstracts over the different states a room can be in.
 #[derive(Debug, Clone)]

--- a/matrix_sdk/src/sas.rs
+++ b/matrix_sdk/src/sas.rs
@@ -39,15 +39,24 @@ impl Sas {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # use matrix_sdk::Client;
+    /// # use futures::executor::block_on;
+    /// # use url::Url;
     /// use matrix_sdk::Sas;
     /// use matrix_sdk_base::crypto::AcceptSettings;
     /// use matrix_sdk::events::key::verification::ShortAuthenticationString;
+    /// # let homeserver = Url::parse("http://example.com").unwrap();
+    /// # let client = Client::new(homeserver).unwrap();
+    /// # let flow_id = "someID";
+    /// # block_on(async {
+    /// let sas = client.get_verification(flow_id).await.unwrap();
     ///
     /// let only_decimal = AcceptSettings::with_allowed_methods(
     ///     vec![ShortAuthenticationString::Decimal]
     /// );
-    /// sas.accept_with_settings(only_decimal);
+    /// sas.accept_with_settings(only_decimal).await.unwrap();
+    /// # });
     /// ```
     pub async fn accept_with_settings(&self, settings: AcceptSettings) -> Result<()> {
         if let Some(req) = self.inner.accept_with_settings(settings) {


### PR DESCRIPTION
CI still fails because the `room_send()` method was removed from the `Client`. I'm inclined to just reintroduce it since it seems to be generally useful for it to exists since not everybody will care about room state, e.g. bots that send messages to a hard-coded room.