### PR TITLE
Allow Result aliases to be used with two type parameters

### DIFF
--- a/matrix_sdk_base/src/error.rs
+++ b/matrix_sdk_base/src/error.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 use matrix_sdk_crypto::{CryptoStoreError, MegolmError, OlmError};
 
 /// Result type of the rust-sdk.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Internal representation of errors.
 #[derive(Error, Debug)]

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -76,7 +76,7 @@ pub enum StoreError {
 }
 
 /// A `StateStore` specific result type.
-pub type Result<T> = std::result::Result<T, StoreError>;
+pub type Result<T, E = StoreError> = std::result::Result<T, E>;
 
 /// An abstract state store trait that can be used to implement different stores
 /// for the SDK.

--- a/matrix_sdk_base/src/store/sled_store/mod.rs
+++ b/matrix_sdk_base/src/store/sled_store/mod.rs
@@ -249,10 +249,7 @@ impl SledStore {
         SledStore::open_helper(db, Some(path), None)
     }
 
-    fn serialize_event(
-        &self,
-        event: &impl Serialize,
-    ) -> std::result::Result<Vec<u8>, SerializationError> {
+    fn serialize_event(&self, event: &impl Serialize) -> Result<Vec<u8>, SerializationError> {
         if let Some(key) = &*self.store_key {
             let encrypted = key.encrypt(event)?;
             Ok(serde_json::to_vec(&encrypted)?)
@@ -264,7 +261,7 @@ impl SledStore {
     fn deserialize_event<T: for<'b> Deserialize<'b>>(
         &self,
         event: &[u8],
-    ) -> std::result::Result<T, SerializationError> {
+    ) -> Result<T, SerializationError> {
         if let Some(key) = &*self.store_key {
             let encrypted: EncryptedEvent = serde_json::from_slice(&event)?;
             Ok(key.decrypt(encrypted)?)
@@ -297,7 +294,7 @@ impl SledStore {
     pub async fn save_changes(&self, changes: &StateChanges) -> Result<()> {
         let now = SystemTime::now();
 
-        let ret: std::result::Result<(), TransactionError<SerializationError>> = (
+        let ret: Result<(), TransactionError<SerializationError>> = (
             &self.session,
             &self.account_data,
             &self.members,

--- a/matrix_sdk_crypto/src/store/mod.rs
+++ b/matrix_sdk_crypto/src/store/mod.rs
@@ -82,7 +82,7 @@ use crate::{
 };
 
 /// A `CryptoStore` specific result type.
-pub type Result<T> = std::result::Result<T, CryptoStoreError>;
+pub type Result<T, E = CryptoStoreError> = std::result::Result<T, E>;
 
 /// A wrapper for our CryptoStore trait object.
 ///

--- a/matrix_sdk_crypto/src/store/sled.rs
+++ b/matrix_sdk_crypto/src/store/sled.rs
@@ -333,7 +333,7 @@ impl SledStore {
         let identity_changes = changes.identities;
         let olm_hashes = changes.message_hashes;
 
-        let ret: std::result::Result<(), TransactionError<serde_json::Error>> = (
+        let ret: Result<(), TransactionError<serde_json::Error>> = (
             &self.account,
             &self.private_identity,
             &self.devices,


### PR DESCRIPTION
I left out the public-facing rust-sdk `Result` type since it's not used internally and I don't imagine consumer `use`ing it, but if you prefer I can update that one too.