### PR TITLE
Bump ruma to 2f1b9f097930bf7908ca539f2ab7bb0ccf5d8b25

### DIFF
--- a/matrix_sdk/examples/get_profiles.rs
+++ b/matrix_sdk/examples/get_profiles.rs
@@ -2,11 +2,16 @@ use std::{convert::TryFrom, env, process::exit};
 
 use url::Url;
 
-use matrix_sdk::{self, api::r0::profile, identifiers::UserId, Client, Result as MatrixResult};
+use matrix_sdk::{
+    self,
+    api::r0::profile,
+    identifiers::{MxcUri, UserId},
+    Client, Result as MatrixResult,
+};
 
 #[derive(Debug)]
 struct UserProfile {
-    avatar_url: Option<String>,
+    avatar_url: Option<MxcUri>,
     displayname: Option<String>,
 }
 

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -56,8 +56,8 @@ use tracing::{debug, warn};
 use tracing::{error, info, instrument};
 
 use matrix_sdk_base::{
-    deserialized_responses::SyncResponse, events::AnyMessageEventContent, BaseClient,
-    BaseClientConfig, Session, Store,
+    deserialized_responses::SyncResponse, events::AnyMessageEventContent, identifiers::MxcUri,
+    BaseClient, BaseClientConfig, Session, Store,
 };
 
 #[cfg(feature = "encryption")]
@@ -516,7 +516,7 @@ impl Client {
     /// }
     /// # })
     /// ```
-    pub async fn avatar_url(&self) -> Result<Option<String>> {
+    pub async fn avatar_url(&self) -> Result<Option<MxcUri>> {
         let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
         let request = get_avatar_url::Request::new(&user_id);
         let response = self.send(request, None).await?;
@@ -553,22 +553,14 @@ impl Client {
     /// ```
     pub async fn avatar(&self, width: Option<u32>, height: Option<u32>) -> Result<Option<Vec<u8>>> {
         // TODO: try to offer the avatar from cache, requires avatar cache
-        if let Some((server_name, media_id)) = self
-            .avatar_url()
-            .await?
-            .and_then(|url| crate::parse_mxc(&url))
-        {
+        if let Some(url) = self.avatar_url().await? {
             if let (Some(width), Some(height)) = (width, height) {
-                let request = get_content_thumbnail::Request::new(
-                    &media_id,
-                    &server_name,
-                    width.into(),
-                    height.into(),
-                );
+                let request =
+                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into());
                 let response = self.send(request, None).await?;
                 Ok(Some(response.file))
             } else {
-                let request = get_content::Request::new(&media_id, &server_name);
+                let request = get_content::Request::from_url(&url);
                 let response = self.send(request, None).await?;
                 Ok(Some(response.file))
             }
@@ -583,7 +575,7 @@ impl Client {
     }
 
     /// Sets the mxc avatar url of the client's owner. The avatar gets unset if `url` is `None`.
-    pub async fn set_avatar_url(&self, url: Option<&str>) -> Result<()> {
+    pub async fn set_avatar_url(&self, url: Option<&MxcUri>) -> Result<()> {
         let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
         let request = set_avatar_url::Request::new(&user_id, url);
         self.send(request, None).await?;
@@ -2261,7 +2253,7 @@ mod test {
         get_public_rooms, get_public_rooms_filtered, register::RegistrationKind, Client, Session,
         SyncSettings, Url,
     };
-    use matrix_sdk_base::RoomMember;
+    use matrix_sdk_base::{identifiers::mxc_uri, RoomMember};
     use matrix_sdk_common::{
         api::r0::{
             account::register::Request as RegistrationRequest,
@@ -3044,9 +3036,9 @@ mod test {
 
         let room = client.get_joined_room(&room_id).unwrap();
 
-        let avatar_url = "https://example.org/avatar";
+        let avatar_url = mxc_uri!("mxc://example.org/avA7ar");
         let member_event = MemberEventContent {
-            avatar_url: Some(avatar_url.to_string()),
+            avatar_url: Some(avatar_url),
             membership: MembershipState::Join,
             is_direct: None,
             displayname: None,

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -106,20 +106,3 @@ pub use sas::Sas;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-// TODO: remove this function once we can use the Mxc type: https://github.com/ruma/ruma/pull/439
-pub(crate) fn parse_mxc(url: &str) -> Option<(identifiers::ServerNameBox, String)> {
-    use std::convert::TryFrom;
-    if let Ok(url) = url::Url::parse(&url) {
-        if url.scheme() == "mxc" {
-            if let Some(server_name) = url
-                .host_str()
-                .and_then(|host| <identifiers::ServerNameBox>::try_from(host).ok())
-            {
-                let media_id = url.path().to_owned();
-                return Some((server_name, media_id));
-            }
-        }
-    }
-    None
-}

--- a/matrix_sdk/src/room/common.rs
+++ b/matrix_sdk/src/room/common.rs
@@ -94,20 +94,14 @@ impl Common {
     /// ```
     pub async fn avatar(&self, width: Option<u32>, height: Option<u32>) -> Result<Option<Vec<u8>>> {
         // TODO: try to offer the avatar from cache, requires avatar cache
-        if let Some((server_name, media_id)) =
-            self.avatar_url().and_then(|url| crate::parse_mxc(&url))
-        {
+        if let Some(url) = self.avatar_url() {
             if let (Some(width), Some(height)) = (width, height) {
-                let request = get_content_thumbnail::Request::new(
-                    &media_id,
-                    &server_name,
-                    width.into(),
-                    height.into(),
-                );
+                let request =
+                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into());
                 let response = self.client.send(request, None).await?;
                 Ok(Some(response.file))
             } else {
-                let request = get_content::Request::new(&media_id, &server_name);
+                let request = get_content::Request::from_url(&url);
                 let response = self.client.send(request, None).await?;
                 Ok(Some(response.file))
             }

--- a/matrix_sdk/src/room/joined.rs
+++ b/matrix_sdk/src/room/joined.rs
@@ -12,7 +12,7 @@ use matrix_sdk_common::{
         read_marker::set_read_marker,
         receipt::create_receipt,
         redact::redact_event,
-        state::send_state_event_for_key,
+        state::send_state_event,
         typing::create_typing_event::{Request as TypingRequest, Typing},
     },
     assign,
@@ -560,18 +560,21 @@ impl Joined {
     /// # Example
     ///
     /// ```no_run
-    /// use matrix_sdk::events::{
-    ///     AnyStateEventContent,
-    ///     room::member::{MemberEventContent, MembershipState},
+    /// use matrix_sdk::{
+    ///     events::{
+    ///         AnyStateEventContent,
+    ///         room::member::{MemberEventContent, MembershipState},
+    ///     },
+    ///     identifiers::mxc_uri,
     /// };
     /// # futures::executor::block_on(async {
     /// # let homeserver = url::Url::parse("http://localhost:8080").unwrap();
     /// # let mut client = matrix_sdk::Client::new(homeserver).unwrap();
     /// # let room_id = matrix_sdk::identifiers::room_id!("!test:localhost");
     ///
-    /// let avatar_url = "https://example.org/avatar";
+    /// let avatar_url = mxc_uri!("mxc://example.org/avatar");
     /// let member_event = MemberEventContent {
-    ///    avatar_url: Some(avatar_url.to_string()),
+    ///    avatar_url: Some(avatar_url),
     ///    membership: MembershipState::Join,
     ///    is_direct: None,
     ///    displayname: None,
@@ -589,10 +592,9 @@ impl Joined {
         &self,
         content: impl Into<AnyStateEventContent>,
         state_key: &str,
-    ) -> Result<send_state_event_for_key::Response> {
+    ) -> Result<send_state_event::Response> {
         let content = content.into();
-        let request =
-            send_state_event_for_key::Request::new(self.inner.room_id(), state_key, &content);
+        let request = send_state_event::Request::new(self.inner.room_id(), state_key, &content);
 
         self.client.send(request, None).await
     }

--- a/matrix_sdk_base/src/rooms/members.rs
+++ b/matrix_sdk_base/src/rooms/members.rs
@@ -20,7 +20,7 @@ use matrix_sdk_common::{
         room::{member::MemberEventContent, power_levels::PowerLevelsEventContent},
         SyncStateEvent,
     },
-    identifiers::UserId,
+    identifiers::{MxcUri, UserId},
 };
 
 use crate::deserialized_responses::MemberEvent;
@@ -65,10 +65,10 @@ impl RoomMember {
     }
 
     /// Get the avatar url of the member, if there is one.
-    pub fn avatar_url(&self) -> Option<&str> {
+    pub fn avatar_url(&self) -> Option<&MxcUri> {
         match self.profile.as_ref() {
-            Some(p) => p.avatar_url.as_deref(),
-            None => self.event.content.avatar_url.as_deref(),
+            Some(p) => p.avatar_url.as_ref(),
+            None => self.event.content.avatar_url.as_ref(),
         }
     }
 

--- a/matrix_sdk_base/src/rooms/mod.rs
+++ b/matrix_sdk_base/src/rooms/mod.rs
@@ -6,7 +6,7 @@ use matrix_sdk_common::{
         create::CreateEventContent, guest_access::GuestAccess,
         history_visibility::HistoryVisibility, join_rules::JoinRule,
     },
-    identifiers::UserId,
+    identifiers::{MxcUri, UserId},
 };
 pub use normal::{Room, RoomInfo, RoomType};
 
@@ -29,7 +29,7 @@ use matrix_sdk_common::{
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BaseRoomInfo {
     /// The avatar URL of this room.
-    pub avatar_url: Option<String>,
+    pub avatar_url: Option<MxcUri>,
     /// The canonical alias of this room.
     pub canonical_alias: Option<RoomAliasId>,
     /// The `m.room.create` event content of this room.

--- a/matrix_sdk_base/src/rooms/normal.rs
+++ b/matrix_sdk_base/src/rooms/normal.rs
@@ -31,7 +31,7 @@ use matrix_sdk_common::{
         },
         AnyStateEventContent, AnySyncStateEvent, EventType,
     },
-    identifiers::{RoomAliasId, RoomId, UserId},
+    identifiers::{MxcUri, RoomAliasId, RoomId, UserId},
 };
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -148,7 +148,7 @@ impl Room {
     }
 
     /// Get the avatar url of this room.
-    pub fn avatar_url(&self) -> Option<String> {
+    pub fn avatar_url(&self) -> Option<MxcUri> {
         self.inner.read().unwrap().base_info.avatar_url.clone()
     }
 

--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1.42"
 [dependencies.ruma]
 version = "0.0.2"
 git = "https://github.com/ruma/ruma"
-rev = "92ee92ad7eb90b3c80abbd7eb116d886c79bf4fd"
+rev = "2f1b9f097930bf7908ca539f2ab7bb0ccf5d8b25"
 features = ["client-api", "compat", "unstable-pre-spec"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/matrix_sdk_crypto/src/error.rs
+++ b/matrix_sdk_crypto/src/error.rs
@@ -174,6 +174,11 @@ pub(crate) enum SessionCreationError {
         one-time key is missing"
     )]
     OneTimeKeyMissing(UserId, Box<DeviceId>),
+    #[error(
+        "Tried to create a new Olm session for {0} {1}, but the one-time \
+        key algorithm is unsupported"
+    )]
+    OneTimeKeyUnknown(UserId, Box<DeviceId>),
     #[error("Failed to verify the one-time key signatures for {0} {1}: {2:?}")]
     InvalidSignature(UserId, Box<DeviceId>, SignatureError),
     #[error(

--- a/matrix_sdk_crypto/src/olm/account.rs
+++ b/matrix_sdk_crypto/src/olm/account.rs
@@ -800,10 +800,7 @@ impl ReadOnlyAccount {
             let mut signatures = BTreeMap::new();
             signatures.insert((*self.user_id).clone(), signature_map);
 
-            let signed_key = SignedKey {
-                key: key.to_owned(),
-                signatures,
-            };
+            let signed_key = SignedKey::new(key.to_owned(), signatures);
 
             one_time_key_map.insert(
                 DeviceKeyId::from_parts(
@@ -890,6 +887,12 @@ impl ReadOnlyAccount {
             OneTimeKey::SignedKey(k) => k,
             OneTimeKey::Key(_) => {
                 return Err(SessionCreationError::OneTimeKeyNotSigned(
+                    device.user_id().to_owned(),
+                    device.device_id().into(),
+                ));
+            }
+            _ => {
+                return Err(SessionCreationError::OneTimeKeyUnknown(
                     device.user_id().to_owned(),
                     device.device_id().into(),
                 ));

--- a/matrix_sdk_crypto/src/olm/mod.rs
+++ b/matrix_sdk_crypto/src/olm/mod.rs
@@ -99,10 +99,7 @@ pub(crate) mod test {
             .unwrap()
             .1
             .to_owned();
-        let one_time_key = SignedKey {
-            key: one_time_key,
-            signatures: BTreeMap::new(),
-        };
+        let one_time_key = SignedKey::new(one_time_key, BTreeMap::new());
         let sender_key = bob.identity_keys().curve25519().to_owned();
         let session = alice
             .create_outbound_session_helper(&sender_key, &one_time_key)
@@ -177,10 +174,7 @@ pub(crate) mod test {
             .1
             .to_owned();
 
-        let one_time_key = SignedKey {
-            key: one_time_key,
-            signatures: BTreeMap::new(),
-        };
+        let one_time_key = SignedKey::new(one_time_key, BTreeMap::new());
 
         let mut bob_session = bob
             .create_outbound_session_helper(alice_keys.curve25519(), &one_time_key)

--- a/matrix_sdk_crypto/src/olm/signing/pk_signing.rs
+++ b/matrix_sdk_crypto/src/olm/signing/pk_signing.rs
@@ -384,12 +384,7 @@ impl Signing {
             self.public_key().to_string(),
         );
 
-        CrossSigningKey {
-            user_id,
-            usage: vec![usage],
-            keys,
-            signatures: BTreeMap::new(),
-        }
+        CrossSigningKey::new(user_id, vec![usage], keys, BTreeMap::new())
     }
 
     #[cfg(test)]

--- a/matrix_sdk_crypto/src/store/sled.rs
+++ b/matrix_sdk_crypto/src/store/sled.rs
@@ -729,10 +729,7 @@ mod test {
             .unwrap()
             .1
             .to_owned();
-        let one_time_key = SignedKey {
-            key: one_time_key,
-            signatures: BTreeMap::new(),
-        };
+        let one_time_key = SignedKey::new(one_time_key, BTreeMap::new());
         let sender_key = bob.identity_keys().curve25519().to_owned();
         let session = alice
             .create_outbound_session_helper(&sender_key, &one_time_key)

--- a/matrix_sdk_test/src/test_json/events.rs
+++ b/matrix_sdk_test/src/test_json/events.rs
@@ -407,7 +407,7 @@ lazy_static! {
 lazy_static! {
     pub static ref PRESENCE: JsonValue = json!({
         "content": {
-            "avatar_url": "mxc://localhost:wefuiwegh8742w",
+            "avatar_url": "mxc://localhost/wefuiwegh8742w",
             "currently_active": false,
             "last_active_ago": 1,
             "presence": "online",

--- a/matrix_sdk_test/src/test_json/sync.rs
+++ b/matrix_sdk_test/src/test_json/sync.rs
@@ -210,7 +210,7 @@ lazy_static! {
                                 "content": {
                                 "membership": "leave",
                                 "reason": "offline",
-                                "avatar_url": "avatar.com",
+                                "avatar_url": "mxc://avatar.com/d0dV9jLpe",
                                 "displayname": "example"
                                 },
                                 "event_id": "$1585345508297748AIUBh:matrix.org",
@@ -221,7 +221,7 @@ lazy_static! {
                                 "unsigned": {
                                 "replaces_state": "$1585345354296486IGZfp:localhost",
                                 "prev_content": {
-                                    "avatar_url": "avatar.com",
+                                    "avatar_url": "mxc://avatar.com/d0dV9jLpe",
                                     "displayname": "example",
                                     "membership": "join"
                                 },
@@ -268,7 +268,7 @@ lazy_static! {
             "events": [
                 {
                     "content": {
-                        "avatar_url": "mxc://localhost:wefuiwegh8742w",
+                        "avatar_url": "mxc://localhost/wefuiwegh8742w",
                         "currently_active": false,
                         "last_active_ago": 1,
                         "presence": "online",
@@ -526,7 +526,7 @@ lazy_static! {
             "events": [
                 {
                     "content": {
-                        "avatar_url": "mxc://localhost:wefuiwegh8742w",
+                        "avatar_url": "mxc://localhost/wefuiwegh8742w",
                         "currently_active": false,
                         "last_active_ago": 1,
                         "presence": "online",
@@ -743,7 +743,7 @@ lazy_static! {
             "events": [
                 {
                     "content": {
-                        "avatar_url": "mxc://localhost:wefuiwegh8742w",
+                        "avatar_url": "mxc://localhost/wefuiwegh8742w",
                         "currently_active": false,
                         "last_active_ago": 1,
                         "presence": "online",
@@ -966,7 +966,7 @@ lazy_static! {
                                 "content": {
                                   "membership": "leave",
                                   "reason": "offline",
-                                  "avatar_url": "avatar.com",
+                                  "avatar_url": "mxc://avatar.com/ursn982srs2S",
                                   "displayname": "example"
                                 },
                                 "event_id": "$1585345508297748AIUBh:matrix.org",
@@ -977,7 +977,7 @@ lazy_static! {
                                 "unsigned": {
                                   "replaces_state": "$1585345354296486IGZfp:localhost",
                                   "prev_content": {
-                                    "avatar_url": "avatar.com",
+                                    "avatar_url": "mxc://avatar.com/ursn982srs2S",
                                     "displayname": "example",
                                     "membership": "join"
                                   },
@@ -1023,7 +1023,7 @@ lazy_static! {
             "events": [
                 {
                     "content": {
-                        "avatar_url": "mxc://localhost:wefuiwegh8742w",
+                        "avatar_url": "mxc://localhost/wefuiwegh8742w",
                         "currently_active": false,
                         "last_active_ago": 1,
                         "presence": "online",


### PR DESCRIPTION
I need it to work on push rules but there are quite a few changes so I think it's better to do this separately:

- Use `MxcUri` instead of `String` for media URLs.
- Fix wrong MXC URIs in tests.
- Remove method `parse_mxc` no longer useful.
- Apply new non-exhaustive types: `CrossSigningKey`, `OneTimeKey` and `SignedKey`.
- Apply endpoint name change: `send_state_event_for_key` to `send_state_event`