### PR TITLE
matrix-sdk: Get notifications locally on sync

### DIFF
--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -434,6 +434,9 @@ impl BaseClient {
         for event in ruma_timeline.events {
             match hoist_room_event_prev_content(&event) {
                 Ok(mut e) => {
+                    #[cfg(not(feature = "encryption"))]
+                    let raw_event = event;
+                    #[cfg(feature = "encryption")]
                     let mut raw_event = event;
 
                     #[allow(clippy::single_match)]

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -517,24 +517,16 @@ impl BaseClient {
                         let actions = push_rules.get_actions(&raw_event, &context).to_vec();
 
                         if actions.iter().any(|a| matches!(a, Action::Notify)) {
-                            let notification = Notification::new(
-                                actions,
-                                raw_event,
-                                false,
-                                room_id.clone(),
-                                SystemTime::now(),
+                            changes.add_notification(
+                                room_id,
+                                Notification::new(
+                                    actions,
+                                    raw_event,
+                                    false,
+                                    room_id.clone(),
+                                    SystemTime::now(),
+                                ),
                             );
-
-                            match changes.notifications.get_mut(room_id) {
-                                Some(room) => {
-                                    room.push(notification);
-                                }
-                                None => {
-                                    changes
-                                        .notifications
-                                        .insert(room_id.clone(), vec![notification]);
-                                }
-                            }
                         }
                         // TODO send and store the highlight tweak value with the event.
                         // Needs to associate custom data with events and to store them.

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -20,26 +20,9 @@ use std::{
     path::{Path, PathBuf},
     result::Result as StdResult,
     sync::Arc,
+    time::SystemTime,
 };
 
-use matrix_sdk_common::{
-    api::r0 as api,
-    deserialized_responses::{
-        AccountData, AmbiguityChanges, Ephemeral, InviteState, InvitedRoom, JoinedRoom, LeftRoom,
-        MemberEvent, MembersResponse, Presence, Rooms, State, StrippedMemberEvent, SyncResponse,
-        Timeline,
-    },
-    events::{
-        presence::PresenceEvent,
-        room::member::{MemberEventContent, MembershipState},
-        AnyBasicEvent, AnyStrippedStateEvent, AnySyncRoomEvent, AnySyncStateEvent,
-        AnyToDeviceEvent, EventContent, StateEvent,
-    },
-    identifiers::{RoomId, UserId},
-    instant::Instant,
-    locks::RwLock,
-    Raw,
-};
 #[cfg(feature = "encryption")]
 use matrix_sdk_common::{
     api::r0::keys::claim_keys::Request as KeysClaimRequest,
@@ -50,6 +33,25 @@ use matrix_sdk_common::{
     identifiers::DeviceId,
     locks::Mutex,
     uuid::Uuid,
+};
+use matrix_sdk_common::{
+    api::r0::{self as api, push::get_notifications::Notification},
+    deserialized_responses::{
+        AccountData, AmbiguityChanges, Ephemeral, InviteState, InvitedRoom, JoinedRoom, LeftRoom,
+        MemberEvent, MembersResponse, Presence, Rooms, State, StrippedMemberEvent, SyncResponse,
+        Timeline,
+    },
+    events::{
+        presence::PresenceEvent,
+        room::member::{MemberEventContent, MembershipState},
+        AnyBasicEvent, AnyStrippedStateEvent, AnySyncRoomEvent, AnySyncStateEvent,
+        AnyToDeviceEvent, EventContent, EventType, StateEvent,
+    },
+    identifiers::{RoomId, UserId},
+    instant::Instant,
+    locks::RwLock,
+    push::{Action, PushConditionRoomCtx, Ruleset},
+    Raw, UInt,
 };
 #[cfg(feature = "encryption")]
 use matrix_sdk_crypto::{
@@ -413,20 +415,27 @@ impl BaseClient {
         self.sync_token.read().await.clone()
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_timeline(
         &self,
-        room_id: &RoomId,
+        room: &Room,
         ruma_timeline: api::sync::sync_events::Timeline,
+        push_rules: &Ruleset,
         room_info: &mut RoomInfo,
         changes: &mut StateChanges,
         ambiguity_cache: &mut AmbiguityCache,
         user_ids: &mut BTreeSet<UserId>,
-    ) -> StoreResult<Timeline> {
+    ) -> Result<Timeline> {
+        let room_id = room.room_id();
+        let user_id = room.own_user_id();
         let mut timeline = Timeline::new(ruma_timeline.limited, ruma_timeline.prev_batch.clone());
+        let mut push_context = self.get_push_room_context(room, room_info, changes).await?;
 
         for event in ruma_timeline.events {
             match hoist_room_event_prev_content(&event) {
                 Ok(mut e) => {
+                    let mut raw_event = event;
+
                     #[allow(clippy::single_match)]
                     match &mut e {
                         AnySyncRoomEvent::State(s) => match s {
@@ -475,11 +484,14 @@ impl BaseClient {
                             encrypted,
                         )) => {
                             if let Some(olm) = self.olm_machine().await {
-                                if let Ok(decrypted) =
+                                if let Ok(raw_decrypted) =
                                     olm.decrypt_room_event(encrypted, room_id).await
                                 {
-                                    match decrypted.deserialize() {
-                                        Ok(decrypted) => e = decrypted,
+                                    match raw_decrypted.deserialize() {
+                                        Ok(decrypted) => {
+                                            e = decrypted;
+                                            raw_event = raw_decrypted;
+                                        }
                                         Err(e) => {
                                             warn!("Error deserializing a decrypted event {:?} ", e)
                                         }
@@ -492,6 +504,40 @@ impl BaseClient {
                         // requests that are needed to be called to heal this
                         // redacted state.
                         _ => (),
+                    }
+
+                    if let Some(context) = &mut push_context {
+                        self.update_push_room_context(context, user_id, room_info, changes)
+                            .await;
+                    } else {
+                        push_context = self.get_push_room_context(room, room_info, changes).await?;
+                    }
+
+                    if let Some(context) = &push_context {
+                        let actions = push_rules.get_actions(&raw_event, &context).to_vec();
+
+                        if actions.iter().any(|a| matches!(a, Action::Notify)) {
+                            let notification = Notification::new(
+                                actions,
+                                raw_event,
+                                false,
+                                room_id.clone(),
+                                SystemTime::now(),
+                            );
+
+                            match changes.notifications.get_mut(room_id) {
+                                Some(room) => {
+                                    room.push(notification);
+                                }
+                                None => {
+                                    changes
+                                        .notifications
+                                        .insert(room_id.clone(), vec![notification]);
+                                }
+                            }
+                        }
+                        // TODO send and store the highlight tweak value with the event.
+                        // Needs to associate custom data with events and to store them.
                     }
 
                     timeline.events.push(e);
@@ -747,6 +793,11 @@ impl BaseClient {
         let mut changes = StateChanges::new(next_batch.clone());
         let mut ambiguity_cache = AmbiguityCache::new(self.store.clone());
 
+        self.handle_account_data(account_data.events, &mut changes)
+            .await;
+
+        let push_rules = self.get_push_rules(&changes).await;
+
         let mut new_rooms = Rooms::default();
 
         for (room_id, new_info) in rooms.join {
@@ -775,8 +826,9 @@ impl BaseClient {
 
             let timeline = self
                 .handle_timeline(
-                    &room_id,
+                    &room,
                     new_info.timeline,
+                    &push_rules,
                     &mut room_info,
                     &mut changes,
                     &mut ambiguity_cache,
@@ -845,8 +897,9 @@ impl BaseClient {
 
             let timeline = self
                 .handle_timeline(
-                    &room_id,
+                    &room,
                     new_info.timeline,
+                    &push_rules,
                     &mut room_info,
                     &mut changes,
                     &mut ambiguity_cache,
@@ -903,9 +956,6 @@ impl BaseClient {
 
         changes.presence = presence;
 
-        self.handle_account_data(account_data.events, &mut changes)
-            .await;
-
         changes.ambiguity_maps = ambiguity_cache.cache;
 
         self.store.save_changes(&changes).await?;
@@ -932,6 +982,7 @@ impl BaseClient {
             ambiguity_changes: AmbiguityChanges {
                 changes: ambiguity_cache.changes,
             },
+            notifications: changes.notifications,
         };
 
         Ok(response)
@@ -1339,6 +1390,130 @@ impl BaseClient {
     pub async fn olm_machine(&self) -> Option<OlmMachine> {
         let olm = self.olm.lock().await;
         olm.as_ref().cloned()
+    }
+
+    /// Get the push rules.
+    ///
+    /// Gets the push rules from `changes` if they have been updated, otherwise get them from the
+    /// store. As a fallback, uses `Ruleset::server_default`.
+    pub async fn get_push_rules(&self, changes: &StateChanges) -> Ruleset {
+        if let Some(AnyBasicEvent::PushRules(event)) =
+            changes.account_data.get(&EventType::PushRules.to_string())
+        {
+            event.content.global.clone()
+        } else if let Some(AnyBasicEvent::PushRules(event)) = self
+            .store
+            .get_account_data_event(EventType::PushRules)
+            .await
+            .unwrap()
+        {
+            event.content.global
+        } else {
+            // FIXME don't panic if the user is not logged in?
+            let session = self.get_session().await.unwrap();
+            Ruleset::server_default(&session.user_id)
+        }
+    }
+
+    /// Get the push context for the given room.
+    ///
+    /// Tries to get the data from `changes` or the up to date `room_info`. Loads the data from the
+    /// store otherwise.
+    ///
+    /// Returns `None` if some data couldn't be found. This should only happen in brand new rooms,
+    /// while we process its state.
+    pub async fn get_push_room_context(
+        &self,
+        room: &Room,
+        room_info: &RoomInfo,
+        changes: &StateChanges,
+    ) -> Result<Option<PushConditionRoomCtx>> {
+        let room_id = room.room_id();
+        let user_id = room.own_user_id();
+
+        let member_count = room_info.active_members_count();
+
+        let user_display_name = if let Some(member) = changes
+            .members
+            .get(room_id)
+            .and_then(|members| members.get(user_id))
+        {
+            let member = member.clone();
+            member
+                .content
+                .displayname
+                .unwrap_or_else(|| user_id.localpart().to_owned())
+        } else if let Some(member) = room.get_member(user_id).await? {
+            member.name().to_owned()
+        } else {
+            return Ok(None);
+        };
+
+        let room_power_levels = if let Some(AnySyncStateEvent::RoomPowerLevels(event)) = changes
+            .state
+            .get(room_id)
+            .and_then(|types| types.get(&EventType::RoomPowerLevels.to_string()))
+            .and_then(|events| events.get(""))
+        {
+            event.content.clone()
+        } else if let Some(AnySyncStateEvent::RoomPowerLevels(event)) = self
+            .store
+            .get_state_event(room_id, EventType::RoomPowerLevels, "")
+            .await?
+        {
+            event.content
+        } else {
+            return Ok(None);
+        };
+
+        Ok(Some(PushConditionRoomCtx {
+            room_id: room_id.clone(),
+            member_count: UInt::new(member_count).unwrap(),
+            user_display_name,
+            users_power_levels: room_power_levels.users,
+            default_power_level: room_power_levels.users_default,
+            notification_power_levels: room_power_levels.notifications,
+        }))
+    }
+
+    /// Update the push context for the given room.
+    ///
+    /// Updates the context data from `changes` or `room_info`.
+    pub async fn update_push_room_context(
+        &self,
+        push_rules: &mut PushConditionRoomCtx,
+        user_id: &UserId,
+        room_info: &RoomInfo,
+        changes: &StateChanges,
+    ) {
+        let room_id = &room_info.room_id;
+
+        push_rules.member_count = UInt::new(room_info.active_members_count()).unwrap();
+
+        if let Some(member) = changes
+            .members
+            .get(room_id)
+            .and_then(|members| members.get(user_id))
+        {
+            let member = member.clone();
+            push_rules.user_display_name = member
+                .content
+                .displayname
+                .unwrap_or_else(|| user_id.localpart().to_owned())
+        }
+
+        if let Some(AnySyncStateEvent::RoomPowerLevels(event)) = changes
+            .state
+            .get(room_id)
+            .and_then(|types| types.get(&EventType::RoomPowerLevels.to_string()))
+            .and_then(|events| events.get(""))
+        {
+            let room_power_levels = event.content.clone();
+
+            push_rules.users_power_levels = room_power_levels.users;
+            push_rules.default_power_level = room_power_levels.users_default;
+            push_rules.notification_power_levels = room_power_levels.notifications;
+        }
     }
 }
 

--- a/matrix_sdk_base/src/rooms/normal.rs
+++ b/matrix_sdk_base/src/rooms/normal.rs
@@ -535,7 +535,11 @@ impl RoomInfo {
     }
 
     /// The number of active members (invited + joined) in the room.
+    ///
+    /// The return value is saturated at `u64::MAX`.
     pub fn active_members_count(&self) -> u64 {
-        self.summary.joined_member_count + self.summary.invited_member_count
+        self.summary
+            .joined_member_count
+            .saturating_add(self.summary.invited_member_count)
     }
 }

--- a/matrix_sdk_base/src/rooms/normal.rs
+++ b/matrix_sdk_base/src/rooms/normal.rs
@@ -533,4 +533,9 @@ impl RoomInfo {
 
         changed
     }
+
+    /// The number of active members (invited + joined) in the room.
+    pub fn active_members_count(&self) -> u64 {
+        self.summary.joined_member_count + self.summary.invited_member_count
+    }
 }

--- a/matrix_sdk_base/src/store/memory_store.rs
+++ b/matrix_sdk_base/src/store/memory_store.rs
@@ -303,6 +303,13 @@ impl MemoryStore {
         #[allow(clippy::map_clone)]
         self.stripped_room_info.iter().map(|r| r.clone()).collect()
     }
+
+    async fn get_account_data_event(&self, event_type: EventType) -> Result<Option<AnyBasicEvent>> {
+        Ok(self
+            .account_data
+            .get(event_type.as_ref())
+            .map(|e| e.clone()))
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -384,5 +391,9 @@ impl StateStore for MemoryStore {
             .get(room_id)
             .and_then(|d| d.get(display_name).map(|d| d.clone()))
             .unwrap_or_default())
+    }
+
+    async fn get_account_data_event(&self, event_type: EventType) -> Result<Option<AnyBasicEvent>> {
+        self.get_account_data_event(event_type).await
     }
 }

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -442,4 +442,12 @@ impl StateChanges {
             .or_insert_with(BTreeMap::new)
             .insert(event.state_key().to_string(), event);
     }
+
+    /// Update the `StateChanges` struct with the given room with a new `Notification`.
+    pub fn add_notification(&mut self, room_id: &RoomId, notification: Notification) {
+        self.notifications
+            .entry(room_id.to_owned())
+            .or_insert_with(Vec::new)
+            .push(notification);
+    }
 }

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 
 use dashmap::DashMap;
 use matrix_sdk_common::{
+    api::r0::push::get_notifications::Notification,
     async_trait,
     events::{
         presence::PresenceEvent, room::member::MemberEventContent, AnyBasicEvent,
@@ -185,6 +186,13 @@ pub trait StateStore: AsyncTraitDeps {
         room_id: &RoomId,
         display_name: &str,
     ) -> Result<BTreeSet<UserId>>;
+
+    /// Get an event out of the account data store.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The event type of the account data event.
+    async fn get_account_data_event(&self, event_type: EventType) -> Result<Option<AnyBasicEvent>>;
 }
 
 /// A state store wrapper for the SDK.
@@ -360,6 +368,9 @@ pub struct StateChanges {
     pub stripped_members: BTreeMap<RoomId, BTreeMap<UserId, StrippedMemberEvent>>,
     /// A map of `RoomId` to `RoomInfo`.
     pub invited_room_info: BTreeMap<RoomId, RoomInfo>,
+
+    /// A map of `RoomId` to a vector of `Notification`s
+    pub notifications: BTreeMap<RoomId, Vec<Notification>>,
 }
 
 impl StateChanges {

--- a/matrix_sdk_base/src/store/sled_store/mod.rs
+++ b/matrix_sdk_base/src/store/sled_store/mod.rs
@@ -31,7 +31,7 @@ use matrix_sdk_common::{
     events::{
         presence::PresenceEvent,
         room::member::{MemberEventContent, MembershipState},
-        AnySyncStateEvent, EventContent, EventType,
+        AnyBasicEvent, AnySyncStateEvent, EventContent, EventType,
     },
     identifiers::{RoomId, UserId},
 };
@@ -587,6 +587,17 @@ impl SledStore {
             .transpose()?
             .unwrap_or_default())
     }
+
+    pub async fn get_account_data_event(
+        &self,
+        event_type: EventType,
+    ) -> Result<Option<AnyBasicEvent>> {
+        Ok(self
+            .account_data
+            .get(event_type.to_string().as_str().encode())?
+            .map(|m| self.deserialize_event(&m))
+            .transpose()?)
+    }
 }
 
 #[async_trait]
@@ -663,6 +674,10 @@ impl StateStore for SledStore {
     ) -> Result<BTreeSet<UserId>> {
         self.get_users_with_display_name(room_id, display_name)
             .await
+    }
+
+    async fn get_account_data_event(&self, event_type: EventType) -> Result<Option<AnyBasicEvent>> {
+        self.get_account_data_event(event_type).await
     }
 }
 

--- a/matrix_sdk_base/src/store/sled_store/mod.rs
+++ b/matrix_sdk_base/src/store/sled_store/mod.rs
@@ -134,6 +134,12 @@ impl EncodeKey for (&str, &str, &str) {
     }
 }
 
+impl EncodeKey for EventType {
+    fn encode(&self) -> Vec<u8> {
+        self.as_str().encode()
+    }
+}
+
 #[derive(Clone)]
 pub struct SledStore {
     path: Option<PathBuf>,
@@ -495,7 +501,7 @@ impl SledStore {
     ) -> Result<Option<AnySyncStateEvent>> {
         Ok(self
             .room_state
-            .get((room_id.as_str(), event_type.to_string().as_str(), state_key).encode())?
+            .get((room_id.as_str(), event_type.as_str(), state_key).encode())?
             .map(|e| self.deserialize_event(&e))
             .transpose()?)
     }
@@ -594,7 +600,7 @@ impl SledStore {
     ) -> Result<Option<AnyBasicEvent>> {
         Ok(self
             .account_data
-            .get(event_type.to_string().as_str().encode())?
+            .get(event_type.encode())?
             .map(|m| self.deserialize_event(&m))
             .transpose()?)
     }

--- a/matrix_sdk_common/src/deserialized_responses.rs
+++ b/matrix_sdk_common/src/deserialized_responses.rs
@@ -2,8 +2,11 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, convert::TryFrom, time::SystemTime};
 
 use super::{
-    api::r0::sync::sync_events::{
-        DeviceLists, UnreadNotificationsCount as RumaUnreadNotificationsCount,
+    api::r0::{
+        push::get_notifications::Notification,
+        sync::sync_events::{
+            DeviceLists, UnreadNotificationsCount as RumaUnreadNotificationsCount,
+        },
     },
     events::{
         presence::PresenceEvent, room::member::MemberEventContent, AnyBasicEvent,
@@ -55,6 +58,8 @@ pub struct SyncResponse {
     pub device_one_time_keys_count: BTreeMap<DeviceKeyAlgorithm, u64>,
     /// Collection of ambiguioty changes that room member events trigger.
     pub ambiguity_changes: AmbiguityChanges,
+    /// New notifications per room.
+    pub notifications: BTreeMap<RoomId, Vec<Notification>>,
 }
 
 impl SyncResponse {

--- a/matrix_sdk_test/src/test_json/sync.rs
+++ b/matrix_sdk_test/src/test_json/sync.rs
@@ -543,7 +543,7 @@ lazy_static! {
 lazy_static! {
     pub static ref MORE_SYNC: JsonValue = json!({
         "device_one_time_keys_count": {},
-        "next_batch": "s526_47314_0_7_1_1_1_11444_1",
+        "next_batch": "s526_47314_0_7_1_1_1_11444_2",
         "device_lists": {
             "changed": [
                 "@example:example.org"
@@ -676,7 +676,22 @@ lazy_static! {
                                 "unsigned": {
                                     "age": 85
                                 }
-                            }
+                            },
+                            {
+                                "content": {
+                                    "body": "This is a notice",
+                                    "format": "org.matrix.custom.html",
+                                    "formatted_body": "<em>This is a notice</em>",
+                                    "msgtype": "m.notice"
+                                },
+                                "event_id": "$098237280074GZeOm:localhost",
+                                "origin_server_ts": 162037280,
+                                "sender": "@bot:localhost",
+                                "type": "m.room.message",
+                                "unsigned": {
+                                    "age": 25
+                                }
+                            },
                         ],
                         "limited": true,
                         "prev_batch": "t392-516_47314_0_7_1_1_1_11444_1"


### PR DESCRIPTION
This matches all events received in room timelines during sync against push rules. You can use the new `EventHandler` method `on_room_notification` to get the notifications.

There are small issues to handle before merging:

- [x] A new clippy warning: `this function has too many arguments (8/7)` for `handle_timeline` because I had to add the push rules as an argument. I'm not sure what the best option to solve this is.
- [ ] It should probably be activatable, to optimize the sync process a bit. Ideally it could be changeable at all times if, for example, in a client, the user decides to disable all notifications.

Fixes #184.

**Improvements to be added later:**

- It does not handle yet the `read` field of the notification because we need to be able to know if an event is before or after the user's `m.read` receipt.
- The "highlight" tweak should be passed with the event for display.
