### PR TITLE
Bump ruma to e2728a70812412aade9322f6ad832731978a4240

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -646,11 +646,11 @@ impl Client {
         if let Some(url) = self.avatar_url().await? {
             if let (Some(width), Some(height)) = (width, height) {
                 let request =
-                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into());
+                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into())?;
                 let response = self.send(request, None).await?;
                 Ok(Some(response.file))
             } else {
-                let request = get_content::Request::from_url(&url);
+                let request = get_content::Request::from_url(&url)?;
                 let response = self.send(request, None).await?;
                 Ok(Some(response.file))
             }

--- a/matrix_sdk/src/error.rs
+++ b/matrix_sdk/src/error.rs
@@ -21,6 +21,7 @@ use matrix_sdk_common::{
         r0::uiaa::{UiaaInfo, UiaaResponse as UiaaError},
         Error as RumaClientError,
     },
+    identifiers::Error as IdentifierError,
     FromHttpResponseError, IntoHttpError, ServerError,
 };
 use reqwest::Error as ReqwestError;
@@ -106,6 +107,10 @@ pub enum Error {
     /// An error occured in the state store.
     #[error(transparent)]
     StateStore(#[from] StoreError),
+
+    /// An error encountered when trying to parse an invalid identifier string.
+    #[error(transparent)]
+    Identifier(#[from] IdentifierError),
 }
 
 impl Error {

--- a/matrix_sdk/src/error.rs
+++ b/matrix_sdk/src/error.rs
@@ -108,7 +108,7 @@ pub enum Error {
     #[error(transparent)]
     StateStore(#[from] StoreError),
 
-    /// An error encountered when trying to parse an invalid identifier string.
+    /// An error encountered when trying to parse an identifier.
     #[error(transparent)]
     Identifier(#[from] IdentifierError),
 }

--- a/matrix_sdk/src/room/common.rs
+++ b/matrix_sdk/src/room/common.rs
@@ -97,11 +97,11 @@ impl Common {
         if let Some(url) = self.avatar_url() {
             if let (Some(width), Some(height)) = (width, height) {
                 let request =
-                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into());
+                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into())?;
                 let response = self.client.send(request, None).await?;
                 Ok(Some(response.file))
             } else {
-                let request = get_content::Request::from_url(&url);
+                let request = get_content::Request::from_url(&url)?;
                 let response = self.client.send(request, None).await?;
                 Ok(Some(response.file))
             }

--- a/matrix_sdk/src/room_member.rs
+++ b/matrix_sdk/src/room_member.rs
@@ -66,11 +66,11 @@ impl RoomMember {
         if let Some(url) = self.avatar_url() {
             if let (Some(width), Some(height)) = (width, height) {
                 let request =
-                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into());
+                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into())?;
                 let response = self.client.send(request, None).await?;
                 Ok(Some(response.file))
             } else {
-                let request = get_content::Request::from_url(url);
+                let request = get_content::Request::from_url(url)?;
                 let response = self.client.send(request, None).await?;
                 Ok(Some(response.file))
             }

--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1.42"
 [dependencies.ruma]
 version = "0.0.2"
 git = "https://github.com/ruma/ruma"
-rev = "2f1b9f097930bf7908ca539f2ab7bb0ccf5d8b25"
+rev = "e2728a70812412aade9322f6ad832731978a4240"
 features = ["client-api", "compat", "unstable-pre-spec"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/matrix_sdk_crypto/src/olm/group_sessions/mod.rs
+++ b/matrix_sdk_crypto/src/olm/group_sessions/mod.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use matrix_sdk_common::{
-    events::forwarded_room_key::ForwardedRoomKeyToDeviceEventContent,
+    events::forwarded_room_key::{
+        ForwardedRoomKeyToDeviceEventContent, ForwardedRoomKeyToDeviceEventContentInit,
+    },
     identifiers::{DeviceKeyAlgorithm, EventEncryptionAlgorithm, RoomId},
 };
 use serde::{Deserialize, Serialize};
@@ -87,7 +89,7 @@ impl TryInto<ForwardedRoomKeyToDeviceEventContent> for ExportedRoomKey {
                 return Err(());
             }
 
-            Ok(ForwardedRoomKeyToDeviceEventContent {
+            Ok(ForwardedRoomKeyToDeviceEventContentInit {
                 algorithm: self.algorithm,
                 room_id: self.room_id,
                 sender_key: self.sender_key,
@@ -95,7 +97,8 @@ impl TryInto<ForwardedRoomKeyToDeviceEventContent> for ExportedRoomKey {
                 session_key: self.session_key.0.clone(),
                 sender_claimed_ed25519_key: claimed_key.to_owned(),
                 forwarding_curve25519_key_chain: self.forwarding_curve25519_key_chain,
-            })
+            }
+            .into())
         }
     }
 }


### PR DESCRIPTION
Yet another version bumping… This is to have the more flexible `MxcUri`.

- Added an error variant to handle `identifiers::Error` because of request constructors that return that error.
- Fixed a new non-exhaustive type.