### PR TITLE
matrix-sdk: fix building without encryption feature

### DIFF
--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 [features]
 default = ["encryption", "sled_cryptostore", "sled_state_store", "native-tls"]
 
-encryption = ["matrix-sdk-base/encryption", "dashmap"]
+encryption = ["matrix-sdk-base/encryption"]
 sled_state_store = ["matrix-sdk-base/sled_state_store"]
 sled_cryptostore = ["matrix-sdk-base/sled_cryptostore"]
 unstable-synapse-quirks = ["matrix-sdk-base/unstable-synapse-quirks"]
@@ -30,7 +30,7 @@ sso_login = ["warp", "rand", "tokio-stream"]
 docs = ["encryption", "sled_cryptostore", "sled_state_store", "sso_login"]
 
 [dependencies]
-dashmap = { version = "4.0.2", optional = true }
+dashmap = "4.0.2"
 futures = "0.3.12"
 http = "0.2.3"
 serde_json = "1.0.61"

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -31,7 +31,6 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(feature = "encryption")]
 use dashmap::DashMap;
 use futures_timer::Delay as sleep;
 use http::HeaderValue;
@@ -116,18 +115,17 @@ use matrix_sdk_common::locks::Mutex;
 
 use crate::{
     error::HttpError,
+    event_handler::Handler,
     http_client::{client_with_config, HttpClient, HttpSend},
-    room, Error, OutgoingRequest, Result,
+    room, Error, EventHandler, OutgoingRequest, Result,
 };
 
 #[cfg(feature = "encryption")]
 use crate::{
     device::{Device, UserDevices},
-    event_handler::Handler,
     identifiers::DeviceId,
     sas::Sas,
     verification_request::VerificationRequest,
-    EventHandler,
 };
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -1525,7 +1523,6 @@ impl Client {
         content: impl Into<AnyMessageEventContent>,
         txn_id: Option<Uuid>,
     ) -> Result<send_message_event::Response> {
-        #[cfg(feature = "encryption")]
         if let Some(room) = self.get_joined_room(room_id) {
             room.send(content, txn_id).await
         } else {

--- a/matrix_sdk_base/Cargo.toml
+++ b/matrix_sdk_base/Cargo.toml
@@ -25,7 +25,7 @@ markdown = ["matrix-sdk-common/markdown"]
 docs = ["encryption", "sled_cryptostore"]
 
 [dependencies]
-dashmap= "4.0.2"
+dashmap = "4.0.2"
 serde = { version = "1.0.122", features = ["rc"] }
 serde_json = "1.0.61"
 tracing = "0.1.22"


### PR DESCRIPTION
`cargo build --no-default-features --features native-tls` currently fails on `master`