### PR TITLE
Exhaustive sync_events::Response conversion

### DIFF
--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.42"
 version = "0.0.3"
 git = "https://github.com/ruma/ruma"
 rev = "c816630058ab625d93ebab294e9e6c02dd9d866c"
-features = ["client-api", "compat", "unstable-pre-spec"]
+features = ["client-api-c", "compat", "unstable-pre-spec"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 uuid = { version = "0.8.2", default-features = false, features = ["v4", "serde"] }

--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -20,9 +20,9 @@ serde = "1.0.122"
 async-trait = "0.1.42"
 
 [dependencies.ruma]
-version = "0.0.2"
+version = "0.0.3"
 git = "https://github.com/ruma/ruma"
-rev = "47d6b458574247545f8836b9421800f0089f3008"
+rev = "c816630058ab625d93ebab294e9e6c02dd9d866c"
 features = ["client-api", "compat", "unstable-pre-spec"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
Unfortunately I had to duplicate the entire destructuring statement for `sync_events::Response` since attributes on field patterns or `..` rest-field patterns are not supported. (cc https://github.com/rust-lang/rust/issues/81282#issuecomment-822376089)

From here it should be easy to add `EncryptionInfo` as discussed without further changes to Ruma, right? If so, this closes ruma/ruma#35.