### PR TITLE
Key share improvements

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -1839,7 +1839,16 @@ impl Client {
                     warn!("Error while claiming one-time keys {:?}", e);
                 }
 
-                for r in self.base_client.outgoing_requests().await {
+                // TODO we should probably abort if we get an cryptostore error here
+                let outgoing_requests = match self.base_client.outgoing_requests().await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        warn!("Could not fetch the outgoing requests {:?}", e);
+                        vec![]
+                    }
+                };
+
+                for r in outgoing_requests {
                     match r.request() {
                         OutgoingRequests::KeysQuery(request) => {
                             if let Err(e) = self

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -1069,12 +1069,12 @@ impl BaseClient {
     /// [`mark_request_as_sent`]: #method.mark_request_as_sent
     #[cfg(feature = "encryption")]
     #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
-    pub async fn outgoing_requests(&self) -> Vec<OutgoingRequest> {
+    pub async fn outgoing_requests(&self) -> Result<Vec<OutgoingRequest>, CryptoStoreError> {
         let olm = self.olm.lock().await;
 
         match &*olm {
             Some(o) => o.outgoing_requests().await,
-            None => vec![],
+            None => Ok(vec![]),
         }
     }
 

--- a/matrix_sdk_crypto/benches/crypto_bench.rs
+++ b/matrix_sdk_crypto/benches/crypto_bench.rs
@@ -213,7 +213,7 @@ pub fn room_key_sharing(c: &mut Criterion) {
                 .await
                 .unwrap();
 
-            assert!(requests.len() >= 8);
+            assert!(!requests.is_empty());
 
             for request in requests {
                 machine
@@ -249,7 +249,7 @@ pub fn room_key_sharing(c: &mut Criterion) {
                 .await
                 .unwrap();
 
-            assert!(requests.len() >= 8);
+            assert!(!requests.is_empty());
 
             for request in requests {
                 machine

--- a/matrix_sdk_crypto/src/identities/device.rs
+++ b/matrix_sdk_crypto/src/identities/device.rs
@@ -258,6 +258,14 @@ impl UserDevices {
         })
     }
 
+    /// Returns true if there is at least one devices of this user that is
+    /// considered to be verified, false otherwise.
+    pub fn is_any_verified(&self) -> bool {
+        self.inner
+            .values()
+            .any(|d| d.trust_state(&self.own_identity, &self.device_owner_identity))
+    }
+
     /// Iterator over all the device ids of the user devices.
     pub fn keys(&self) -> impl Iterator<Item = &DeviceIdBox> {
         self.inner.keys()

--- a/matrix_sdk_crypto/src/key_request.rs
+++ b/matrix_sdk_crypto/src/key_request.rs
@@ -516,11 +516,10 @@ impl KeyRequestMachine {
     ) -> Result<Option<u32>, KeyshareDecision> {
         let outbound_session = self
             .outbound_group_sessions
-            .get_or_load(session.room_id())
+            .get_with_id(session.room_id(), session.session_id())
             .await
             .ok()
-            .flatten()
-            .filter(|o| session.session_id() == o.session_id());
+            .flatten();
 
         let own_device_check = || {
             if device.trust_state() {

--- a/matrix_sdk_crypto/src/machine.rs
+++ b/matrix_sdk_crypto/src/machine.rs
@@ -245,9 +245,10 @@ impl OlmMachine {
             }
         };
 
-        Ok(OlmMachine::new_helper(
-            &user_id, device_id, store, account, identity,
-        ))
+        let mut machine = OlmMachine::new_helper(&user_id, device_id, store, account, identity);
+        machine.key_request_machine.load_outgoing_requests().await?;
+
+        Ok(machine)
     }
 
     /// Create a new machine with the default crypto store.

--- a/matrix_sdk_crypto/src/machine.rs
+++ b/matrix_sdk_crypto/src/machine.rs
@@ -751,7 +751,7 @@ impl OlmMachine {
     async fn mark_to_device_request_as_sent(&self, request_id: &Uuid) -> StoreResult<()> {
         self.verification_machine.mark_request_as_sent(request_id);
         self.key_request_machine
-            .mark_outgoing_request_as_sent(request_id)
+            .mark_outgoing_request_as_sent(*request_id)
             .await?;
         self.group_session_manager
             .mark_request_as_sent(request_id)

--- a/matrix_sdk_crypto/src/machine.rs
+++ b/matrix_sdk_crypto/src/machine.rs
@@ -156,21 +156,22 @@ impl OlmMachine {
             verification_machine.clone(),
         );
         let device_id: Arc<DeviceIdBox> = Arc::new(device_id);
-        let outbound_group_sessions = Arc::new(DashMap::new());
         let users_for_key_claim = Arc::new(DashMap::new());
-
-        let key_request_machine = KeyRequestMachine::new(
-            user_id.clone(),
-            device_id.clone(),
-            store.clone(),
-            outbound_group_sessions,
-            users_for_key_claim.clone(),
-        );
 
         let account = Account {
             inner: account,
             store: store.clone(),
         };
+
+        let group_session_manager = GroupSessionManager::new(account.clone(), store.clone());
+
+        let key_request_machine = KeyRequestMachine::new(
+            user_id.clone(),
+            device_id.clone(),
+            store.clone(),
+            group_session_manager.session_cache(),
+            users_for_key_claim.clone(),
+        );
 
         let session_manager = SessionManager::new(
             account.clone(),
@@ -178,7 +179,6 @@ impl OlmMachine {
             key_request_machine.clone(),
             store.clone(),
         );
-        let group_session_manager = GroupSessionManager::new(account.clone(), store.clone());
         let identity_manager =
             IdentityManager::new(user_id.clone(), device_id.clone(), store.clone());
 

--- a/matrix_sdk_crypto/src/session_manager/group_sessions.rs
+++ b/matrix_sdk_crypto/src/session_manager/group_sessions.rs
@@ -62,6 +62,12 @@ impl GroupSessionCache {
         self.sessions.insert(session.room_id().to_owned(), session);
     }
 
+    /// Either get a session for the given room from the cache or load it from
+    /// the store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room this session is used for.
     pub async fn get_or_load(&self, room_id: &RoomId) -> StoreResult<Option<OutboundGroupSession>> {
         // Get the cached session, if there isn't one load one from the store
         // and put it in the cache.
@@ -88,6 +94,21 @@ impl GroupSessionCache {
     /// group session.
     fn get(&self, room_id: &RoomId) -> Option<OutboundGroupSession> {
         self.sessions.get(room_id).map(|s| s.clone())
+    }
+
+    /// Get or load the session for the given room with the given session id.
+    ///
+    /// This is the same as [get_or_load()](#method.get_or_load) but it will
+    /// filter out the session if it doesn't match the given session id.
+    pub async fn get_with_id(
+        &self,
+        room_id: &RoomId,
+        session_id: &str,
+    ) -> StoreResult<Option<OutboundGroupSession>> {
+        Ok(self
+            .get_or_load(room_id)
+            .await?
+            .filter(|o| session_id == o.session_id()))
     }
 }
 

--- a/matrix_sdk_crypto/src/session_manager/group_sessions.rs
+++ b/matrix_sdk_crypto/src/session_manager/group_sessions.rs
@@ -40,6 +40,57 @@ use crate::{
     Device, EncryptionSettings, OlmError, ToDeviceRequest,
 };
 
+#[derive(Clone, Debug)]
+pub(crate) struct GroupSessionCache {
+    store: Store,
+    sessions: Arc<DashMap<RoomId, OutboundGroupSession>>,
+    /// A map from the request id to the group session that the request belongs
+    /// to. Used to mark requests belonging to the session as shared.
+    sessions_being_shared: Arc<DashMap<Uuid, OutboundGroupSession>>,
+}
+
+impl GroupSessionCache {
+    pub(crate) fn new(store: Store) -> Self {
+        Self {
+            store,
+            sessions: DashMap::new().into(),
+            sessions_being_shared: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub(crate) fn insert(&self, session: OutboundGroupSession) {
+        self.sessions.insert(session.room_id().to_owned(), session);
+    }
+
+    pub async fn get_or_load(&self, room_id: &RoomId) -> StoreResult<Option<OutboundGroupSession>> {
+        // Get the cached session, if there isn't one load one from the store
+        // and put it in the cache.
+        if let Some(s) = self.sessions.get(room_id) {
+            Ok(Some(s.clone()))
+        } else if let Some(s) = self.store.get_outbound_group_sessions(room_id).await? {
+            for request_id in s.pending_request_ids() {
+                self.sessions_being_shared.insert(request_id, s.clone());
+            }
+
+            self.sessions.insert(room_id.clone(), s.clone());
+
+            Ok(Some(s))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Get an outbound group session for a room, if one exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which we should get the outbound
+    /// group session.
+    fn get(&self, room_id: &RoomId) -> Option<OutboundGroupSession> {
+        self.sessions.get(room_id).map(|s| s.clone())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct GroupSessionManager {
     account: Account,
@@ -48,10 +99,7 @@ pub struct GroupSessionManager {
     /// without the need to create new keys.
     store: Store,
     /// The currently active outbound group sessions.
-    outbound_group_sessions: Arc<DashMap<RoomId, OutboundGroupSession>>,
-    /// A map from the request id to the group session that the request belongs
-    /// to. Used to mark requests belonging to the session as shared.
-    outbound_sessions_being_shared: Arc<DashMap<Uuid, OutboundGroupSession>>,
+    sessions: GroupSessionCache,
 }
 
 impl GroupSessionManager {
@@ -60,14 +108,13 @@ impl GroupSessionManager {
     pub(crate) fn new(account: Account, store: Store) -> Self {
         Self {
             account,
-            store,
-            outbound_group_sessions: Arc::new(DashMap::new()),
-            outbound_sessions_being_shared: Arc::new(DashMap::new()),
+            store: store.clone(),
+            sessions: GroupSessionCache::new(store),
         }
     }
 
     pub async fn invalidate_group_session(&self, room_id: &RoomId) -> StoreResult<bool> {
-        if let Some(s) = self.outbound_group_sessions.get(room_id) {
+        if let Some(s) = self.sessions.get(room_id) {
             s.invalidate_session();
 
             let mut changes = Changes::default();
@@ -81,7 +128,7 @@ impl GroupSessionManager {
     }
 
     pub async fn mark_request_as_sent(&self, request_id: &Uuid) -> StoreResult<()> {
-        if let Some((_, s)) = self.outbound_sessions_being_shared.remove(request_id) {
+        if let Some((_, s)) = self.sessions.sessions_being_shared.remove(request_id) {
             s.mark_request_as_sent(request_id);
 
             let mut changes = Changes::default();
@@ -97,15 +144,9 @@ impl GroupSessionManager {
         Ok(())
     }
 
-    /// Get an outbound group session for a room, if one exists.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room for which we should get the outbound
-    /// group session.
+    #[cfg(test)]
     pub fn get_outbound_group_session(&self, room_id: &RoomId) -> Option<OutboundGroupSession> {
-        #[allow(clippy::map_clone)]
-        self.outbound_group_sessions.get(room_id).map(|s| s.clone())
+        self.sessions.get(room_id)
     }
 
     pub async fn encrypt(
@@ -113,7 +154,7 @@ impl GroupSessionManager {
         room_id: &RoomId,
         content: AnyMessageEventContent,
     ) -> MegolmResult<EncryptedEventContent> {
-        let session = if let Some(s) = self.get_outbound_group_session(room_id) {
+        let session = if let Some(s) = self.sessions.get(room_id) {
             s
         } else {
             panic!("Session wasn't created nor shared");
@@ -147,9 +188,7 @@ impl GroupSessionManager {
             .await
             .map_err(|_| EventError::UnsupportedAlgorithm)?;
 
-        let _ = self
-            .outbound_group_sessions
-            .insert(room_id.to_owned(), outbound.clone());
+        self.sessions.insert(outbound.clone());
         Ok((outbound, inbound))
     }
 
@@ -158,23 +197,7 @@ impl GroupSessionManager {
         room_id: &RoomId,
         settings: EncryptionSettings,
     ) -> OlmResult<(OutboundGroupSession, Option<InboundGroupSession>)> {
-        // Get the cached session, if there isn't one load one from the store
-        // and put it in the cache.
-        let outbound_session = if let Some(s) = self.outbound_group_sessions.get(room_id) {
-            Some(s.clone())
-        } else if let Some(s) = self.store.get_outbound_group_sessions(room_id).await? {
-            for request_id in s.pending_request_ids() {
-                self.outbound_sessions_being_shared
-                    .insert(request_id, s.clone());
-            }
-
-            self.outbound_group_sessions
-                .insert(room_id.clone(), s.clone());
-
-            Some(s)
-        } else {
-            None
-        };
+        let outbound_session = self.sessions.get_or_load(&room_id).await?;
 
         // If there is no session or the session has expired or is invalid,
         // create a new one.
@@ -388,6 +411,10 @@ impl GroupSessionManager {
         Ok(used_sessions)
     }
 
+    pub(crate) fn session_cache(&self) -> GroupSessionCache {
+        self.sessions.clone()
+    }
+
     /// Get to-device requests to share a group session with users in a room.
     ///
     /// # Arguments
@@ -489,7 +516,7 @@ impl GroupSessionManager {
                     key_content.clone(),
                     outbound.clone(),
                     message_index,
-                    self.outbound_sessions_being_shared.clone(),
+                    self.sessions.sessions_being_shared.clone(),
                 ))
             })
             .collect();

--- a/matrix_sdk_crypto/src/session_manager/mod.rs
+++ b/matrix_sdk_crypto/src/session_manager/mod.rs
@@ -15,5 +15,5 @@
 mod group_sessions;
 mod sessions;
 
-pub(crate) use group_sessions::GroupSessionManager;
+pub(crate) use group_sessions::{GroupSessionCache, GroupSessionManager};
 pub(crate) use sessions::SessionManager;

--- a/matrix_sdk_crypto/src/session_manager/sessions.rs
+++ b/matrix_sdk_crypto/src/session_manager/sessions.rs
@@ -322,6 +322,7 @@ mod test {
         identities::ReadOnlyDevice,
         key_request::KeyRequestMachine,
         olm::{Account, PrivateCrossSigningIdentity, ReadOnlyAccount},
+        session_manager::GroupSessionCache,
         store::{CryptoStore, MemoryStore, Store},
         verification::VerificationMachine,
     };
@@ -342,7 +343,6 @@ mod test {
         let user_id = user_id();
         let device_id = device_id();
 
-        let outbound_sessions = Arc::new(DashMap::new());
         let users_for_key_claim = Arc::new(DashMap::new());
         let account = ReadOnlyAccount::new(&user_id, &device_id);
         let store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(MemoryStore::new()));
@@ -363,11 +363,13 @@ mod test {
             store: store.clone(),
         };
 
+        let session_cache = GroupSessionCache::new(store.clone());
+
         let key_request = KeyRequestMachine::new(
             user_id,
             device_id,
             store.clone(),
-            outbound_sessions,
+            session_cache,
             users_for_key_claim.clone(),
         );
 

--- a/matrix_sdk_crypto/src/store/memorystore.rs
+++ b/matrix_sdk_crypto/src/store/memorystore.rs
@@ -268,6 +268,14 @@ impl CryptoStore for MemoryStore {
             .and_then(|i| self.outgoing_key_requests.get(&i).map(|r| r.clone())))
     }
 
+    async fn get_outgoing_key_requests(&self) -> Result<Vec<OutgoingKeyRequest>> {
+        Ok(self
+            .outgoing_key_requests
+            .iter()
+            .map(|i| i.value().clone())
+            .collect())
+    }
+
     async fn delete_outgoing_key_request(&self, request_id: Uuid) -> Result<()> {
         self.outgoing_key_requests
             .remove(&request_id)

--- a/matrix_sdk_crypto/src/store/memorystore.rs
+++ b/matrix_sdk_crypto/src/store/memorystore.rs
@@ -268,10 +268,11 @@ impl CryptoStore for MemoryStore {
             .and_then(|i| self.outgoing_key_requests.get(&i).map(|r| r.clone())))
     }
 
-    async fn get_outgoing_key_requests(&self) -> Result<Vec<OutgoingKeyRequest>> {
+    async fn get_unsent_key_requests(&self) -> Result<Vec<OutgoingKeyRequest>> {
         Ok(self
             .outgoing_key_requests
             .iter()
+            .filter(|i| !i.value().sent_out)
             .map(|i| i.value().clone())
             .collect())
     }

--- a/matrix_sdk_crypto/src/store/memorystore.rs
+++ b/matrix_sdk_crypto/src/store/memorystore.rs
@@ -39,7 +39,7 @@ use crate::{
 fn encode_key_info(info: &RequestedKeyInfo) -> String {
     format!(
         "{}{}{}{}",
-        &info.room_id, &info.sender_key, &info.algorithm, &info.session_id
+        info.room_id, info.sender_key, info.algorithm, info.session_id
     )
 }
 

--- a/matrix_sdk_crypto/src/store/memorystore.rs
+++ b/matrix_sdk_crypto/src/store/memorystore.rs
@@ -20,8 +20,10 @@ use std::{
 use dashmap::{DashMap, DashSet};
 use matrix_sdk_common::{
     async_trait,
+    events::room_key_request::RequestedKeyInfo,
     identifiers::{DeviceId, DeviceIdBox, RoomId, UserId},
     locks::Mutex,
+    uuid::Uuid,
 };
 
 use super::{
@@ -30,8 +32,16 @@ use super::{
 };
 use crate::{
     identities::{ReadOnlyDevice, UserIdentities},
+    key_request::OutgoingKeyRequest,
     olm::{OutboundGroupSession, PrivateCrossSigningIdentity},
 };
+
+fn encode_key_info(info: &RequestedKeyInfo) -> String {
+    format!(
+        "{}{}{}{}",
+        &info.room_id, &info.sender_key, &info.algorithm, &info.session_id
+    )
+}
 
 /// An in-memory only store that will forget all the E2EE key once it's dropped.
 #[derive(Debug, Clone)]
@@ -43,7 +53,8 @@ pub struct MemoryStore {
     olm_hashes: Arc<DashMap<String, DashSet<String>>>,
     devices: DeviceStore,
     identities: Arc<DashMap<UserId, UserIdentities>>,
-    values: Arc<DashMap<String, String>>,
+    outgoing_key_requests: Arc<DashMap<Uuid, OutgoingKeyRequest>>,
+    key_requests_by_info: Arc<DashMap<String, Uuid>>,
 }
 
 impl Default for MemoryStore {
@@ -56,7 +67,8 @@ impl Default for MemoryStore {
             olm_hashes: Arc::new(DashMap::new()),
             devices: DeviceStore::new(),
             identities: Arc::new(DashMap::new()),
-            values: Arc::new(DashMap::new()),
+            outgoing_key_requests: Arc::new(DashMap::new()),
+            key_requests_by_info: Arc::new(DashMap::new()),
         }
     }
 }
@@ -103,6 +115,10 @@ impl CryptoStore for MemoryStore {
         Ok(())
     }
 
+    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
+        Ok(None)
+    }
+
     async fn save_changes(&self, mut changes: Changes) -> Result<()> {
         self.save_sessions(changes.sessions).await;
         self.save_inbound_group_sessions(changes.inbound_group_sessions)
@@ -130,6 +146,14 @@ impl CryptoStore for MemoryStore {
                 .insert(hash.hash.clone());
         }
 
+        for key_request in changes.key_requests {
+            let id = key_request.request_id;
+            let info_string = encode_key_info(&key_request.info);
+
+            self.outgoing_key_requests.insert(id, key_request);
+            self.key_requests_by_info.insert(info_string, id);
+        }
+
         Ok(())
     }
 
@@ -152,9 +176,11 @@ impl CryptoStore for MemoryStore {
         Ok(self.inbound_group_sessions.get_all())
     }
 
-    fn users_for_key_query(&self) -> HashSet<UserId> {
-        #[allow(clippy::map_clone)]
-        self.users_for_key_query.iter().map(|u| u.clone()).collect()
+    async fn get_outbound_group_sessions(
+        &self,
+        _: &RoomId,
+    ) -> Result<Option<OutboundGroupSession>> {
+        Ok(None)
     }
 
     fn is_user_tracked(&self, user_id: &UserId) -> bool {
@@ -163,6 +189,11 @@ impl CryptoStore for MemoryStore {
 
     fn has_users_for_key_query(&self) -> bool {
         !self.users_for_key_query.is_empty()
+    }
+
+    fn users_for_key_query(&self) -> HashSet<UserId> {
+        #[allow(clippy::map_clone)]
+        self.users_for_key_query.iter().map(|u| u.clone()).collect()
     }
 
     async fn update_tracked_user(&self, user: &UserId, dirty: bool) -> Result<bool> {
@@ -207,24 +238,6 @@ impl CryptoStore for MemoryStore {
         Ok(self.identities.get(user_id).map(|i| i.clone()))
     }
 
-    async fn save_value(&self, key: String, value: String) -> Result<()> {
-        self.values.insert(key, value);
-        Ok(())
-    }
-
-    async fn remove_value(&self, key: &str) -> Result<()> {
-        self.values.remove(key);
-        Ok(())
-    }
-
-    async fn get_value(&self, key: &str) -> Result<Option<String>> {
-        Ok(self.values.get(key).map(|v| v.to_owned()))
-    }
-
-    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
-        Ok(None)
-    }
-
     async fn is_message_known(&self, message_hash: &crate::olm::OlmMessageHash) -> Result<bool> {
         Ok(self
             .olm_hashes
@@ -233,11 +246,37 @@ impl CryptoStore for MemoryStore {
             .contains(&message_hash.hash))
     }
 
-    async fn get_outbound_group_sessions(
+    async fn get_outgoing_key_request(
         &self,
-        _: &RoomId,
-    ) -> Result<Option<OutboundGroupSession>> {
-        Ok(None)
+        request_id: Uuid,
+    ) -> Result<Option<OutgoingKeyRequest>> {
+        Ok(self
+            .outgoing_key_requests
+            .get(&request_id)
+            .map(|r| r.clone()))
+    }
+
+    async fn get_key_request_by_info(
+        &self,
+        key_info: &RequestedKeyInfo,
+    ) -> Result<Option<OutgoingKeyRequest>> {
+        let key_info_string = encode_key_info(key_info);
+
+        Ok(self
+            .key_requests_by_info
+            .get(&key_info_string)
+            .and_then(|i| self.outgoing_key_requests.get(&i).map(|r| r.clone())))
+    }
+
+    async fn delete_outgoing_key_request(&self, request_id: Uuid) -> Result<()> {
+        self.outgoing_key_requests
+            .remove(&request_id)
+            .and_then(|(_, i)| {
+                let key_info_string = encode_key_info(&i.info);
+                self.key_requests_by_info.remove(&key_info_string)
+            });
+
+        Ok(())
     }
 }
 

--- a/matrix_sdk_crypto/src/store/mod.rs
+++ b/matrix_sdk_crypto/src/store/mod.rs
@@ -450,7 +450,7 @@ pub trait CryptoStore: AsyncTraitDeps {
     ) -> Result<Option<OutgoingKeyRequest>>;
 
     /// Get all outgoing key requests that we have in the store.
-    async fn get_outgoing_key_requests(&self) -> Result<Vec<OutgoingKeyRequest>>;
+    async fn get_unsent_key_requests(&self) -> Result<Vec<OutgoingKeyRequest>>;
 
     /// Delete an outoing key request that we created that matches the given
     /// request id.

--- a/matrix_sdk_crypto/src/store/mod.rs
+++ b/matrix_sdk_crypto/src/store/mod.rs
@@ -449,6 +449,9 @@ pub trait CryptoStore: AsyncTraitDeps {
         key_info: &RequestedKeyInfo,
     ) -> Result<Option<OutgoingKeyRequest>>;
 
+    /// Get all outgoing key requests that we have in the store.
+    async fn get_outgoing_key_requests(&self) -> Result<Vec<OutgoingKeyRequest>>;
+
     /// Delete an outoing key request that we created that matches the given
     /// request id.
     ///

--- a/matrix_sdk_crypto/src/store/sled.rs
+++ b/matrix_sdk_crypto/src/store/sled.rs
@@ -1346,7 +1346,7 @@ mod test {
 
     #[async_test]
     async fn key_request_saving() {
-        let (_, store, _dir) = get_loaded_store().await;
+        let (account, store, _dir) = get_loaded_store().await;
 
         let id = Uuid::new_v4();
         let info = RequestedKeyInfo {
@@ -1357,6 +1357,7 @@ mod test {
         };
 
         let request = OutgoingKeyRequest {
+            request_recipient: account.user_id().to_owned(),
             request_id: id,
             info: info.clone(),
             sent_out: false,
@@ -1378,6 +1379,7 @@ mod test {
         assert!(!store.get_unsent_key_requests().await.unwrap().is_empty());
 
         let request = OutgoingKeyRequest {
+            request_recipient: account.user_id().to_owned(),
             request_id: id,
             info: info.clone(),
             sent_out: true,

--- a/matrix_sdk_crypto/src/store/sled.rs
+++ b/matrix_sdk_crypto/src/store/sled.rs
@@ -29,9 +29,12 @@ use sled::{
 
 use matrix_sdk_common::{
     async_trait,
+    events::room_key_request::RequestedKeyInfo,
     identifiers::{DeviceId, DeviceIdBox, RoomId, UserId},
     locks::Mutex,
+    uuid,
 };
+use uuid::Uuid;
 
 use super::{
     caches::SessionStore, Changes, CryptoStore, CryptoStoreError, InboundGroupSession, PickleKey,
@@ -39,6 +42,7 @@ use super::{
 };
 use crate::{
     identities::{ReadOnlyDevice, UserIdentities},
+    key_request::OutgoingKeyRequest,
     olm::{OutboundGroupSession, PickledInboundGroupSession, PrivateCrossSigningIdentity},
 };
 
@@ -49,6 +53,28 @@ const DEFAULT_PICKLE: &str = "DEFAULT_PICKLE_PASSPHRASE_123456";
 trait EncodeKey {
     const SEPARATOR: u8 = 0xff;
     fn encode(&self) -> Vec<u8>;
+}
+
+impl EncodeKey for Uuid {
+    fn encode(&self) -> Vec<u8> {
+        self.as_u128().to_be_bytes().to_vec()
+    }
+}
+
+impl EncodeKey for &RequestedKeyInfo {
+    fn encode(&self) -> Vec<u8> {
+        [
+            self.room_id.as_bytes(),
+            &[Self::SEPARATOR],
+            self.sender_key.as_bytes(),
+            &[Self::SEPARATOR],
+            self.algorithm.as_ref().as_bytes(),
+            &[Self::SEPARATOR],
+            self.session_id.as_bytes(),
+            &[Self::SEPARATOR],
+        ]
+        .concat()
+    }
 }
 
 impl EncodeKey for &UserId {
@@ -122,12 +148,14 @@ pub struct SledStore {
     inbound_group_sessions: Tree,
     outbound_group_sessions: Tree,
 
+    outgoing_key_requests: Tree,
+    key_requests_by_info: Tree,
+
     devices: Tree,
     identities: Tree,
 
     tracked_users: Tree,
     users_for_key_query: Tree,
-    values: Tree,
 }
 
 impl std::fmt::Debug for SledStore {
@@ -178,13 +206,16 @@ impl SledStore {
         let sessions = db.open_tree("session")?;
         let inbound_group_sessions = db.open_tree("inbound_group_sessions")?;
         let outbound_group_sessions = db.open_tree("outbound_group_sessions")?;
+
         let tracked_users = db.open_tree("tracked_users")?;
         let users_for_key_query = db.open_tree("users_for_key_query")?;
         let olm_hashes = db.open_tree("olm_hashes")?;
 
         let devices = db.open_tree("devices")?;
         let identities = db.open_tree("identities")?;
-        let values = db.open_tree("values")?;
+
+        let outgoing_key_requests = db.open_tree("outgoing_key_requests")?;
+        let key_requests_by_info = db.open_tree("key_requests_by_info")?;
 
         let session_cache = SessionStore::new();
 
@@ -208,12 +239,13 @@ impl SledStore {
             users_for_key_query_cache: DashSet::new().into(),
             inbound_group_sessions,
             outbound_group_sessions,
+            outgoing_key_requests,
+            key_requests_by_info,
             devices,
             tracked_users,
             users_for_key_query,
             olm_hashes,
             identities,
-            values,
         })
     }
 
@@ -332,6 +364,7 @@ impl SledStore {
 
         let identity_changes = changes.identities;
         let olm_hashes = changes.message_hashes;
+        let key_requests = changes.key_requests;
 
         let ret: Result<(), TransactionError<serde_json::Error>> = (
             &self.account,
@@ -342,6 +375,8 @@ impl SledStore {
             &self.inbound_group_sessions,
             &self.outbound_group_sessions,
             &self.olm_hashes,
+            &self.outgoing_key_requests,
+            &self.key_requests_by_info,
         )
             .transaction(
                 |(
@@ -353,6 +388,8 @@ impl SledStore {
                     inbound_sessions,
                     outbound_sessions,
                     hashes,
+                    outgoing_key_requests,
+                    key_requests_by_info,
                 )| {
                     if let Some(a) = &account_pickle {
                         account.insert(
@@ -420,6 +457,19 @@ impl SledStore {
                         )?;
                     }
 
+                    for key_request in &key_requests {
+                        key_requests_by_info.insert(
+                            (&key_request.info).encode(),
+                            key_request.request_id.encode(),
+                        )?;
+
+                        outgoing_key_requests.insert(
+                            key_request.request_id.encode(),
+                            serde_json::to_vec(&key_request)
+                                .map_err(ConflictableTransactionError::Abort)?,
+                        )?;
+                    }
+
                     Ok(())
                 },
             );
@@ -470,6 +520,19 @@ impl CryptoStore for SledStore {
         };
 
         self.save_changes(changes).await
+    }
+
+    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
+        if let Some(i) = self.private_identity.get("identity".encode())? {
+            let pickle = serde_json::from_slice(&i)?;
+            Ok(Some(
+                PrivateCrossSigningIdentity::from_pickle(pickle, self.get_pickle_key())
+                    .await
+                    .map_err(|_| CryptoStoreError::UnpicklingError)?,
+            ))
+        } else {
+            Ok(None)
+        }
     }
 
     async fn save_changes(&self, changes: Changes) -> Result<()> {
@@ -539,12 +602,11 @@ impl CryptoStore for SledStore {
             .collect())
     }
 
-    fn users_for_key_query(&self) -> HashSet<UserId> {
-        #[allow(clippy::map_clone)]
-        self.users_for_key_query_cache
-            .iter()
-            .map(|u| u.clone())
-            .collect()
+    async fn get_outbound_group_sessions(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Option<OutboundGroupSession>> {
+        self.load_outbound_group_session(room_id).await
     }
 
     fn is_user_tracked(&self, user_id: &UserId) -> bool {
@@ -553,6 +615,14 @@ impl CryptoStore for SledStore {
 
     fn has_users_for_key_query(&self) -> bool {
         !self.users_for_key_query_cache.is_empty()
+    }
+
+    fn users_for_key_query(&self) -> HashSet<UserId> {
+        #[allow(clippy::map_clone)]
+        self.users_for_key_query_cache
+            .iter()
+            .map(|u| u.clone())
+            .collect()
     }
 
     async fn update_tracked_user(&self, user: &UserId, dirty: bool) -> Result<bool> {
@@ -605,48 +675,62 @@ impl CryptoStore for SledStore {
             .transpose()?)
     }
 
-    async fn save_value(&self, key: String, value: String) -> Result<()> {
-        self.values.insert(key.as_str().encode(), value.as_str())?;
-        self.inner.flush_async().await?;
-        Ok(())
-    }
-
-    async fn remove_value(&self, key: &str) -> Result<()> {
-        self.values.remove(key.encode())?;
-        Ok(())
-    }
-
-    async fn get_value(&self, key: &str) -> Result<Option<String>> {
-        Ok(self
-            .values
-            .get(key.encode())?
-            .map(|v| String::from_utf8_lossy(&v).to_string()))
-    }
-
-    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
-        if let Some(i) = self.private_identity.get("identity".encode())? {
-            let pickle = serde_json::from_slice(&i)?;
-            Ok(Some(
-                PrivateCrossSigningIdentity::from_pickle(pickle, self.get_pickle_key())
-                    .await
-                    .map_err(|_| CryptoStoreError::UnpicklingError)?,
-            ))
-        } else {
-            Ok(None)
-        }
-    }
-
     async fn is_message_known(&self, message_hash: &crate::olm::OlmMessageHash) -> Result<bool> {
         Ok(self
             .olm_hashes
             .contains_key(serde_json::to_vec(message_hash)?)?)
     }
 
-    async fn get_outbound_group_sessions(
+    async fn get_outgoing_key_request(
         &self,
-        room_id: &RoomId,
-    ) -> Result<Option<OutboundGroupSession>> {
-        self.load_outbound_group_session(room_id).await
+        request_id: Uuid,
+    ) -> Result<Option<OutgoingKeyRequest>> {
+        Ok(self
+            .outgoing_key_requests
+            .get(request_id.encode())?
+            .map(|r| serde_json::from_slice(&r))
+            .transpose()?)
+    }
+
+    async fn get_key_request_by_info(
+        &self,
+        key_info: &RequestedKeyInfo,
+    ) -> Result<Option<OutgoingKeyRequest>> {
+        let id = self.key_requests_by_info.get(key_info.encode())?;
+
+        if let Some(id) = id {
+            Ok(self
+                .outgoing_key_requests
+                .get(id)?
+                .map(|r| serde_json::from_slice(&r))
+                .transpose()?)
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn delete_outgoing_key_request(&self, request_id: Uuid) -> Result<()> {
+        let ret: Result<(), TransactionError<serde_json::Error>> =
+            (&self.outgoing_key_requests, &self.key_requests_by_info).transaction(
+                |(outgoing_key_requests, key_requests_by_info)| {
+                    let request: Option<OutgoingKeyRequest> = outgoing_key_requests
+                        .remove(request_id.encode())?
+                        .map(|r| serde_json::from_slice(&r))
+                        .transpose()
+                        .map_err(ConflictableTransactionError::Abort)?;
+
+                    if let Some(request) = request {
+                        key_requests_by_info.remove((&request.info).encode())?;
+                    }
+
+                    Ok(())
+                },
+            );
+
+        ret?;
+        self.inner.flush_async().await?;
+
+        Ok(())
     }
 }
 
@@ -665,14 +749,16 @@ mod test {
     };
     use matrix_sdk_common::{
         api::r0::keys::SignedKey,
-        identifiers::{room_id, user_id, DeviceId, UserId},
+        events::room_key_request::RequestedKeyInfo,
+        identifiers::{room_id, user_id, DeviceId, EventEncryptionAlgorithm, UserId},
+        uuid::Uuid,
     };
     use matrix_sdk_test::async_test;
     use olm_rs::outbound_group_session::OlmOutboundGroupSession;
     use std::collections::BTreeMap;
     use tempfile::tempdir;
 
-    use super::{CryptoStore, SledStore};
+    use super::{CryptoStore, OutgoingKeyRequest, SledStore};
 
     fn alice_id() -> UserId {
         user_id!("@alice:example.org")
@@ -1185,21 +1271,6 @@ mod test {
     }
 
     #[async_test]
-    async fn key_value_saving() {
-        let (_, store, _dir) = get_loaded_store().await;
-        let key = "test_key".to_string();
-        let value = "secret value".to_string();
-
-        store.save_value(key.clone(), value.clone()).await.unwrap();
-        let stored_value = store.get_value(&key).await.unwrap().unwrap();
-
-        assert_eq!(value, stored_value);
-
-        store.remove_value(&key).await.unwrap();
-        assert!(store.get_value(&key).await.unwrap().is_none());
-    }
-
-    #[async_test]
     async fn olm_hash_saving() {
         let (_, store, _dir) = get_loaded_store().await;
 
@@ -1214,5 +1285,46 @@ mod test {
         assert!(!store.is_message_known(&hash).await.unwrap());
         store.save_changes(changes).await.unwrap();
         assert!(store.is_message_known(&hash).await.unwrap());
+    }
+
+    #[async_test]
+    async fn key_request_saving() {
+        let (_, store, _dir) = get_loaded_store().await;
+
+        let id = Uuid::new_v4();
+        let info = RequestedKeyInfo {
+            algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+            room_id: room_id!("!test:localhost"),
+            sender_key: "test_sender_key".to_string(),
+            session_id: "test_session_id".to_string(),
+        };
+
+        let request = OutgoingKeyRequest {
+            request_id: id,
+            info: info.clone(),
+            sent_out: false,
+        };
+
+        assert!(store.get_outgoing_key_request(id).await.unwrap().is_none());
+
+        let mut changes = Changes::default();
+        changes.key_requests.push(request.clone());
+        store.save_changes(changes).await.unwrap();
+
+        let request = Some(request);
+
+        let stored_request = store.get_outgoing_key_request(id).await.unwrap();
+        assert_eq!(request, stored_request);
+
+        let stored_request = store.get_key_request_by_info(&info).await.unwrap();
+        assert_eq!(request, stored_request);
+
+        store.delete_outgoing_key_request(id).await.unwrap();
+
+        let stored_request = store.get_outgoing_key_request(id).await.unwrap();
+        assert_eq!(None, stored_request);
+
+        let stored_request = store.get_key_request_by_info(&info).await.unwrap();
+        assert_eq!(None, stored_request);
     }
 }


### PR DESCRIPTION
This PR improves key sharing and key requesting in a couple of ways:

1. Correctly honor requests if we have an outbound group session and the list of recipients
2. Add a public method so users can request and re-request room keys manually
3. Add specialized cryptostore methods to handle key requests
4. Only request room keys if we have a verified device to avoid room key request spam on initial sync