### PR TITLE
chore: cleanup clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
         command: clippy
         args: --all-targets -- -D warnings
 
+    - name: Clippy without default features
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        # TODO: add `--all-targets` once all warnings in examples are resolved
+        args: --no-default-features --features native-tls -- -D warnings
+
   check-wasm:
     name: Check if WASM support compiles
     needs: [clippy]

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -95,7 +95,7 @@ use matrix_sdk_common::{
         uiaa::AuthData,
     },
     assign,
-    identifiers::{DeviceIdBox, EventId, RoomId, RoomIdOrAliasId, ServerName, UserId},
+    identifiers::{DeviceIdBox, RoomId, RoomIdOrAliasId, ServerName, UserId},
     instant::{Duration, Instant},
     locks::RwLock,
     presence::PresenceState,
@@ -104,11 +104,14 @@ use matrix_sdk_common::{
 };
 
 #[cfg(feature = "encryption")]
-use matrix_sdk_common::api::r0::{
-    keys::{get_keys, upload_keys, upload_signing_keys::Request as UploadSigningKeysRequest},
-    to_device::send_event_to_device::{
-        Request as RumaToDeviceRequest, Response as ToDeviceResponse,
+use matrix_sdk_common::{
+    api::r0::{
+        keys::{get_keys, upload_keys, upload_signing_keys::Request as UploadSigningKeysRequest},
+        to_device::send_event_to_device::{
+            Request as RumaToDeviceRequest, Response as ToDeviceResponse,
+        },
     },
+    identifiers::EventId,
 };
 
 use matrix_sdk_common::locks::Mutex;

--- a/matrix_sdk/src/room/joined.rs
+++ b/matrix_sdk/src/room/joined.rs
@@ -1,5 +1,8 @@
 use crate::{room::Common, BaseRoom, Client, Result, RoomType};
-use std::{io::Read, ops::Deref, sync::Arc};
+use std::{io::Read, ops::Deref};
+
+#[cfg(feature = "encryption")]
+use std::sync::Arc;
 
 use matrix_sdk_common::{
     api::r0::{

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -31,10 +31,7 @@ use matrix_sdk_common::{
     },
     events::{
         presence::PresenceEvent,
-        room::{
-            history_visibility::HistoryVisibility,
-            member::{MemberEventContent, MembershipState},
-        },
+        room::member::{MemberEventContent, MembershipState},
         AnyBasicEvent, AnyStrippedStateEvent, AnySyncRoomEvent, AnySyncStateEvent,
         AnyToDeviceEvent, EventContent, StateEvent,
     },
@@ -46,7 +43,10 @@ use matrix_sdk_common::{
 #[cfg(feature = "encryption")]
 use matrix_sdk_common::{
     api::r0::keys::claim_keys::Request as KeysClaimRequest,
-    events::{room::encrypted::EncryptedEventContent, AnyMessageEventContent, AnySyncMessageEvent},
+    events::{
+        room::{encrypted::EncryptedEventContent, history_visibility::HistoryVisibility},
+        AnyMessageEventContent, AnySyncMessageEvent,
+    },
     identifiers::DeviceId,
     locks::Mutex,
     uuid::Uuid,
@@ -427,6 +427,7 @@ impl BaseClient {
         for event in ruma_timeline.events {
             match hoist_room_event_prev_content(&event) {
                 Ok(mut e) => {
+                    #[allow(clippy::single_match)]
                     match &mut e {
                         AnySyncRoomEvent::State(s) => match s {
                             AnySyncStateEvent::RoomMember(member) => {

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -15,9 +15,11 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     ops::Deref,
-    path::Path,
     sync::Arc,
 };
+
+#[cfg(feature = "sled_state_store")]
+use std::path::Path;
 
 use dashmap::DashMap;
 use matrix_sdk_common::{


### PR DESCRIPTION
Those warnings currently pop up with `cargo clippy --no-default-features --features native-tls`

Also adds a CI task that executes clippy without default features (just native-tls) and without `--all-targets` (because properly cleaning up examples is hard)