### PR TITLE
ci: clippy check without default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
         command: clippy
         args: --all-targets -- -D warnings
 
+    - name: Clippy without default features
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --no-default-features --features native-tls --all-targets -- -D warnings
+
   check-wasm:
     name: Check if WASM support compiles
     needs: [clippy]


### PR DESCRIPTION
Follow-up for https://github.com/matrix-org/matrix-rust-sdk/pull/211 which tries to catch some more warnings