### PR TITLE
Support for encryption info, take two.

### DIFF
--- a/matrix_sdk/examples/emoji_verification.rs
+++ b/matrix_sdk/examples/emoji_verification.rs
@@ -81,7 +81,12 @@ async fn login(
             let client = &client_ref;
             let initial = &initial_ref;
 
-            for event in &response.to_device.events {
+            for event in response
+                .to_device
+                .events
+                .iter()
+                .filter_map(|e| e.deserialize().ok())
+            {
                 match event {
                     AnyToDeviceEvent::KeyVerificationStart(e) => {
                         let sas = client
@@ -124,7 +129,12 @@ async fn login(
 
             if !initial.load(Ordering::SeqCst) {
                 for (_room_id, room_info) in response.rooms.join {
-                    for event in room_info.timeline.events {
+                    for event in room_info
+                        .timeline
+                        .events
+                        .iter()
+                        .filter_map(|e| e.event.deserialize().ok())
+                    {
                         if let AnySyncRoomEvent::Message(event) = event {
                             match event {
                                 AnySyncMessageEvent::RoomMessage(m) => {

--- a/matrix_sdk/examples/wasm_command_bot/src/lib.rs
+++ b/matrix_sdk/examples/wasm_command_bot/src/lib.rs
@@ -58,7 +58,7 @@ impl WasmBot {
 
         for (room_id, room) in response.rooms.join {
             for event in room.timeline.events {
-                if let AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(ev)) = event {
+                if let Ok(AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(ev))) = event.event.deserialize() {
                     self.on_room_message(&room_id, &ev).await
                 }
             }

--- a/matrix_sdk/src/event_handler/mod.rs
+++ b/matrix_sdk/src/event_handler/mod.rs
@@ -75,50 +75,95 @@ impl Handler {
     pub(crate) async fn handle_sync(&self, response: &SyncResponse) {
         for (room_id, room_info) in &response.rooms.join {
             if let Some(room) = self.get_room(room_id) {
-                for event in &room_info.ephemeral.events {
-                    self.handle_ephemeral_event(room.clone(), event).await;
+                for event in room_info
+                    .ephemeral
+                    .events
+                    .iter()
+                    .filter_map(|e| e.deserialize().ok())
+                {
+                    self.handle_ephemeral_event(room.clone(), &event).await;
                 }
 
-                for event in &room_info.account_data.events {
-                    self.handle_account_data_event(room.clone(), event).await;
+                for event in room_info
+                    .account_data
+                    .events
+                    .iter()
+                    .filter_map(|e| e.deserialize().ok())
+                {
+                    self.handle_account_data_event(room.clone(), &event).await;
                 }
 
-                for event in &room_info.state.events {
-                    self.handle_state_event(room.clone(), event).await;
+                for event in room_info
+                    .state
+                    .events
+                    .iter()
+                    .filter_map(|e| e.deserialize().ok())
+                {
+                    self.handle_state_event(room.clone(), &event).await;
                 }
 
-                for event in &room_info.timeline.events {
-                    self.handle_timeline_event(room.clone(), event).await;
+                for event in room_info
+                    .timeline
+                    .events
+                    .iter()
+                    .filter_map(|e| e.event.deserialize().ok())
+                {
+                    self.handle_timeline_event(room.clone(), &event).await;
                 }
             }
         }
 
         for (room_id, room_info) in &response.rooms.leave {
             if let Some(room) = self.get_room(room_id) {
-                for event in &room_info.account_data.events {
-                    self.handle_account_data_event(room.clone(), event).await;
+                for event in room_info
+                    .account_data
+                    .events
+                    .iter()
+                    .filter_map(|e| e.deserialize().ok())
+                {
+                    self.handle_account_data_event(room.clone(), &event).await;
                 }
 
-                for event in &room_info.state.events {
-                    self.handle_state_event(room.clone(), event).await;
+                for event in room_info
+                    .state
+                    .events
+                    .iter()
+                    .filter_map(|e| e.deserialize().ok())
+                {
+                    self.handle_state_event(room.clone(), &event).await;
                 }
 
-                for event in &room_info.timeline.events {
-                    self.handle_timeline_event(room.clone(), event).await;
+                for event in room_info
+                    .timeline
+                    .events
+                    .iter()
+                    .filter_map(|e| e.event.deserialize().ok())
+                {
+                    self.handle_timeline_event(room.clone(), &event).await;
                 }
             }
         }
 
         for (room_id, room_info) in &response.rooms.invite {
             if let Some(room) = self.get_room(room_id) {
-                for event in &room_info.invite_state.events {
-                    self.handle_stripped_state_event(room.clone(), event).await;
+                for event in room_info
+                    .invite_state
+                    .events
+                    .iter()
+                    .filter_map(|e| e.deserialize().ok())
+                {
+                    self.handle_stripped_state_event(room.clone(), &event).await;
                 }
             }
         }
 
-        for event in &response.presence.events {
-            self.on_presence_event(event).await;
+        for event in response
+            .presence
+            .events
+            .iter()
+            .filter_map(|e| e.deserialize().ok())
+        {
+            self.on_presence_event(&event).await;
         }
 
         for (room_id, notifications) in &response.notifications {

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -37,15 +37,13 @@ use matrix_sdk_common::{
 use matrix_sdk_common::{
     api::r0::{self as api, push::get_notifications::Notification},
     deserialized_responses::{
-        AccountData, AmbiguityChanges, Ephemeral, InviteState, InvitedRoom, JoinedRoom, LeftRoom,
-        MemberEvent, MembersResponse, Presence, Rooms, State, StrippedMemberEvent, SyncResponse,
-        Timeline,
+        AmbiguityChanges, JoinedRoom, LeftRoom, MemberEvent, MembersResponse, Rooms,
+        StrippedMemberEvent, SyncResponse, SyncRoomEvent, Timeline,
     },
     events::{
-        presence::PresenceEvent,
         room::member::{MemberEventContent, MembershipState},
-        AnyBasicEvent, AnyStrippedStateEvent, AnySyncRoomEvent, AnySyncStateEvent,
-        AnyToDeviceEvent, EventContent, EventType, StateEvent,
+        AnyBasicEvent, AnyStrippedStateEvent, AnySyncRoomEvent, AnySyncStateEvent, EventContent,
+        EventType, StateEvent,
     },
     identifiers::{RoomId, UserId},
     instant::Instant,
@@ -432,15 +430,12 @@ impl BaseClient {
         let mut push_context = self.get_push_room_context(room, room_info, changes).await?;
 
         for event in ruma_timeline.events {
-            match hoist_room_event_prev_content(&event) {
-                Ok(mut e) => {
-                    #[cfg(not(feature = "encryption"))]
-                    let raw_event = event;
-                    #[cfg(feature = "encryption")]
-                    let mut raw_event = event;
+            let mut event: SyncRoomEvent = event.into();
 
+            match hoist_room_event_prev_content(&event.event) {
+                Ok(e) => {
                     #[allow(clippy::single_match)]
-                    match &mut e {
+                    match &e {
                         AnySyncRoomEvent::State(s) => match s {
                             AnySyncStateEvent::RoomMember(member) => {
                                 if let Ok(member) = MemberEvent::try_from(member.clone()) {
@@ -487,18 +482,10 @@ impl BaseClient {
                             encrypted,
                         )) => {
                             if let Some(olm) = self.olm_machine().await {
-                                if let Ok(raw_decrypted) =
+                                if let Ok(decrypted) =
                                     olm.decrypt_room_event(encrypted, room_id).await
                                 {
-                                    match raw_decrypted.deserialize() {
-                                        Ok(decrypted) => {
-                                            e = decrypted;
-                                            raw_event = raw_decrypted;
-                                        }
-                                        Err(e) => {
-                                            warn!("Error deserializing a decrypted event {:?} ", e)
-                                        }
-                                    }
+                                    event = decrypted;
                                 }
                             }
                         }
@@ -517,14 +504,14 @@ impl BaseClient {
                     }
 
                     if let Some(context) = &push_context {
-                        let actions = push_rules.get_actions(&raw_event, &context).to_vec();
+                        let actions = push_rules.get_actions(&event.event, &context).to_vec();
 
                         if actions.iter().any(|a| matches!(a, Action::Notify)) {
                             changes.add_notification(
                                 room_id,
                                 Notification::new(
                                     actions,
-                                    raw_event,
+                                    event.event.clone(),
                                     false,
                                     room_id.clone(),
                                     SystemTime::now(),
@@ -537,13 +524,13 @@ impl BaseClient {
                         // Requires the possibility to associate custom data with events and to
                         // store them.
                     }
-
-                    timeline.events.push(e);
                 }
                 Err(e) => {
                     warn!("Error deserializing event {:?}", e);
                 }
             }
+
+            timeline.events.push(event);
         }
 
         Ok(timeline)
@@ -552,19 +539,17 @@ impl BaseClient {
     #[allow(clippy::type_complexity)]
     fn handle_invited_state(
         &self,
-        events: Vec<Raw<AnyStrippedStateEvent>>,
+        events: &[Raw<AnyStrippedStateEvent>],
         room_info: &mut RoomInfo,
     ) -> (
-        InviteState,
         BTreeMap<UserId, StrippedMemberEvent>,
         BTreeMap<String, BTreeMap<String, AnyStrippedStateEvent>>,
     ) {
-        events.into_iter().fold(
-            (InviteState::default(), BTreeMap::new(), BTreeMap::new()),
-            |(mut state, mut members, mut state_events), e| {
+        events.iter().fold(
+            (BTreeMap::new(), BTreeMap::new()),
+            |(mut members, mut state_events), e| {
                 match e.deserialize() {
                     Ok(e) => {
-                        state.events.push(e.clone());
 
                         if let AnyStrippedStateEvent::RoomMember(member) = e {
                             match StrippedMemberEvent::try_from(member) {
@@ -591,7 +576,7 @@ impl BaseClient {
                         );
                     }
                 }
-                (state, members, state_events)
+                (members, state_events)
             },
         )
     }
@@ -600,10 +585,9 @@ impl BaseClient {
         &self,
         changes: &mut StateChanges,
         ambiguity_cache: &mut AmbiguityCache,
-        events: Vec<Raw<AnySyncStateEvent>>,
+        events: &[Raw<AnySyncStateEvent>],
         room_info: &mut RoomInfo,
-    ) -> StoreResult<(State, BTreeSet<UserId>)> {
-        let mut state = State::default();
+    ) -> StoreResult<BTreeSet<UserId>> {
         let mut members = BTreeMap::new();
         let mut state_events = BTreeMap::new();
         let mut user_ids = BTreeSet::new();
@@ -611,21 +595,19 @@ impl BaseClient {
 
         let room_id = room_info.room_id.clone();
 
-        for event in
-            events
-                .into_iter()
-                .filter_map(|e| match hoist_and_deserialize_state_event(&e) {
-                    Ok(e) => Some(e),
-                    Err(err) => {
-                        warn!(
-                            "Couldn't deserialize state event for room {}: {:?} {:#?}",
-                            room_id, err, e
-                        );
-                        None
-                    }
-                })
+        for event in events
+            .iter()
+            .filter_map(|e| match hoist_and_deserialize_state_event(&e) {
+                Ok(e) => Some(e),
+                Err(err) => {
+                    warn!(
+                        "Couldn't deserialize state event for room {}: {:?} {:#?}",
+                        room_id, err, e
+                    );
+                    None
+                }
+            })
         {
-            state.events.push(event.clone());
             room_info.handle_state_event(&event.content());
 
             if let AnySyncStateEvent::RoomMember(member) = event {
@@ -667,7 +649,7 @@ impl BaseClient {
         changes.profiles.insert(room_id.as_ref().clone(), profiles);
         changes.state.insert(room_id.as_ref().clone(), state_events);
 
-        Ok((state, user_ids))
+        Ok(user_ids)
     }
 
     async fn handle_room_account_data(
@@ -675,22 +657,16 @@ impl BaseClient {
         room_id: &RoomId,
         events: &[Raw<AnyBasicEvent>],
         changes: &mut StateChanges,
-    ) -> AccountData {
+    ) {
         let events: Vec<AnyBasicEvent> =
             events.iter().filter_map(|e| e.deserialize().ok()).collect();
 
         for event in &events {
             changes.add_room_account_data(room_id, event.clone());
         }
-
-        AccountData { events }
     }
 
-    async fn handle_account_data(
-        &self,
-        events: Vec<Raw<AnyBasicEvent>>,
-        changes: &mut StateChanges,
-    ) {
+    async fn handle_account_data(&self, events: &[Raw<AnyBasicEvent>], changes: &mut StateChanges) {
         let events: Vec<AnyBasicEvent> =
             events.iter().filter_map(|e| e.deserialize().ok()).collect();
 
@@ -769,29 +745,17 @@ impl BaseClient {
                 // decryptes to-device events, but leaves room events alone.
                 // This makes sure that we have the deryption keys for the room
                 // events at hand.
-                o.receive_sync_changes(&to_device, &device_lists, &device_one_time_keys_count)
+                o.receive_sync_changes(to_device, &device_lists, &device_one_time_keys_count)
                     .await?
             } else {
                 to_device
-                    .events
-                    .into_iter()
-                    .filter_map(|e| e.deserialize().ok())
-                    .collect::<Vec<AnyToDeviceEvent>>()
-                    .into()
             }
         };
-        #[cfg(not(feature = "encryption"))]
-        let to_device = to_device
-            .events
-            .into_iter()
-            .filter_map(|e| e.deserialize().ok())
-            .collect::<Vec<AnyToDeviceEvent>>()
-            .into();
 
         let mut changes = StateChanges::new(next_batch.clone());
         let mut ambiguity_cache = AmbiguityCache::new(self.store.clone());
 
-        self.handle_account_data(account_data.events, &mut changes)
+        self.handle_account_data(&account_data.events, &mut changes)
             .await;
 
         let push_rules = self.get_push_rules(&changes).await?;
@@ -809,11 +773,11 @@ impl BaseClient {
             room_info.update_summary(&new_info.summary);
             room_info.set_prev_batch(new_info.timeline.prev_batch.as_deref());
 
-            let (state, mut user_ids) = self
+            let mut user_ids = self
                 .handle_state(
                     &mut changes,
                     &mut ambiguity_cache,
-                    new_info.state.events,
+                    &new_info.state.events,
                     &mut room_info,
                 )
                 .await?;
@@ -834,8 +798,7 @@ impl BaseClient {
                 )
                 .await?;
 
-            let account_data = self
-                .handle_room_account_data(&room_id, &new_info.account_data.events, &mut changes)
+            self.handle_room_account_data(&room_id, &new_info.account_data.events, &mut changes)
                 .await;
 
             #[cfg(feature = "encryption")]
@@ -859,18 +822,15 @@ impl BaseClient {
             let notification_count = new_info.unread_notifications.into();
             room_info.update_notification_count(notification_count);
 
-            let ephemeral = Ephemeral {
-                events: new_info
-                    .ephemeral
-                    .events
-                    .into_iter()
-                    .filter_map(|e| e.deserialize().ok())
-                    .collect(),
-            };
-
             new_rooms.join.insert(
                 room_id,
-                JoinedRoom::new(timeline, state, account_data, ephemeral, notification_count),
+                JoinedRoom::new(
+                    timeline,
+                    new_info.state,
+                    new_info.account_data,
+                    new_info.ephemeral,
+                    notification_count,
+                ),
             );
 
             changes.add_room(room_info);
@@ -884,11 +844,11 @@ impl BaseClient {
             let mut room_info = room.clone_info();
             room_info.mark_as_left();
 
-            let (state, mut user_ids) = self
+            let mut user_ids = self
                 .handle_state(
                     &mut changes,
                     &mut ambiguity_cache,
-                    new_info.state.events,
+                    &new_info.state.events,
                     &mut room_info,
                 )
                 .await?;
@@ -905,14 +865,14 @@ impl BaseClient {
                 )
                 .await?;
 
-            let account_data = self
-                .handle_room_account_data(&room_id, &new_info.account_data.events, &mut changes)
+            self.handle_room_account_data(&room_id, &new_info.account_data.events, &mut changes)
                 .await;
 
             changes.add_room(room_info);
-            new_rooms
-                .leave
-                .insert(room_id, LeftRoom::new(timeline, state, account_data));
+            new_rooms.leave.insert(
+                room_id,
+                LeftRoom::new(timeline, new_info.state, new_info.account_data),
+            );
         }
 
         for (room_id, new_info) in rooms.invite {
@@ -929,30 +889,24 @@ impl BaseClient {
             let room = self.store.get_or_create_stripped_room(&room_id).await;
             let mut room_info = room.clone_info();
 
-            let (state, members, state_events) =
-                self.handle_invited_state(new_info.invite_state.events, &mut room_info);
+            let (members, state_events) =
+                self.handle_invited_state(&new_info.invite_state.events, &mut room_info);
 
             changes.stripped_members.insert(room_id.clone(), members);
             changes.stripped_state.insert(room_id.clone(), state_events);
             changes.add_stripped_room(room_info);
 
-            let room = InvitedRoom {
-                invite_state: state,
-            };
-
-            new_rooms.invite.insert(room_id, room);
+            new_rooms.invite.insert(room_id, new_info);
         }
 
-        let presence: BTreeMap<UserId, PresenceEvent> = presence
+        changes.presence = presence
             .events
-            .into_iter()
+            .iter()
             .filter_map(|e| {
                 let event = e.deserialize().ok()?;
                 Some((event.sender.clone(), event))
             })
             .collect();
-
-        changes.presence = presence;
 
         changes.ambiguity_maps = ambiguity_cache.cache;
 
@@ -965,12 +919,8 @@ impl BaseClient {
         let response = SyncResponse {
             next_batch,
             rooms: new_rooms,
-            presence: Presence {
-                events: changes.presence.into_iter().map(|(_, v)| v).collect(),
-            },
-            account_data: AccountData {
-                events: changes.account_data.into_iter().map(|(_, e)| e).collect(),
-            },
+            presence,
+            account_data,
             to_device,
             device_lists,
             device_one_time_keys_count: device_one_time_keys_count

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -430,6 +430,7 @@ impl BaseClient {
         let mut push_context = self.get_push_room_context(room, room_info, changes).await?;
 
         for event in ruma_timeline.events {
+            #[allow(unused_mut)]
             let mut event: SyncRoomEvent = event.into();
 
             match hoist_room_event_prev_content(&event.event) {

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -1350,7 +1350,7 @@ impl BaseClient {
     pub async fn get_push_rules(&self, changes: &StateChanges) -> Result<Ruleset> {
         if let Some(AnyBasicEvent::PushRules(event)) = changes
             .account_data
-            .get(&EventType::PushRules.to_string())
+            .get(EventType::PushRules.as_str())
             .and_then(|e| e.deserialize().ok())
         {
             Ok(event.content.global)

--- a/matrix_sdk_base/src/rooms/normal.rs
+++ b/matrix_sdk_base/src/rooms/normal.rs
@@ -393,7 +393,11 @@ impl Room {
                 return Ok(None);
             };
 
-        let presence = self.store.get_presence_event(user_id).await?;
+        let presence = self
+            .store
+            .get_presence_event(user_id)
+            .await?
+            .and_then(|e| e.deserialize().ok());
         let profile = self.store.get_profile(self.room_id(), user_id).await?;
         let max_power_level = self.max_power_level();
         let is_room_creator = self
@@ -410,6 +414,7 @@ impl Room {
             .store
             .get_state_event(self.room_id(), EventType::RoomPowerLevels, "")
             .await?
+            .and_then(|e| e.deserialize().ok())
             .and_then(|e| {
                 if let AnySyncStateEvent::RoomPowerLevels(e) = e {
                     Some(e)

--- a/matrix_sdk_common/src/deserialized_responses.rs
+++ b/matrix_sdk_common/src/deserialized_responses.rs
@@ -89,7 +89,7 @@ pub struct EncryptionInfo {
     pub verification_state: VerificationState,
 }
 
-/// A customized version of a room event comming from a sync that holds optional
+/// A customized version of a room event coming from a sync that holds optional
 /// decryption info.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SyncRoomEvent {

--- a/matrix_sdk_common/src/deserialized_responses.rs
+++ b/matrix_sdk_common/src/deserialized_responses.rs
@@ -90,7 +90,7 @@ pub struct EncryptionInfo {
 }
 
 /// A customized version of a room event coming from a sync that holds optional
-/// decryption info.
+/// encryption info.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SyncRoomEvent {
     /// The actual event.

--- a/matrix_sdk_crypto/src/machine.rs
+++ b/matrix_sdk_crypto/src/machine.rs
@@ -1872,7 +1872,7 @@ pub(crate) mod test {
             if let MessageType::Text(c) = &content.msgtype {
                 assert_eq!(&c.body, plaintext);
             } else {
-                panic!("Decrypted event has a missmatched content");
+                panic!("Decrypted event has a mismatched content");
             }
         } else {
             panic!("Decrypted room event has the wrong type")

--- a/matrix_sdk_crypto/src/machine.rs
+++ b/matrix_sdk_crypto/src/machine.rs
@@ -27,14 +27,13 @@ use matrix_sdk_common::{
             upload_keys,
             upload_signatures::Request as UploadSignaturesRequest,
         },
-        sync::sync_events::{DeviceLists, ToDevice as RumaToDevice},
+        sync::sync_events::{DeviceLists, ToDevice},
     },
     assign,
-    deserialized_responses::ToDevice,
+    deserialized_responses::{AlgorithmInfo, EncryptionInfo, SyncRoomEvent, VerificationState},
     events::{
         room::encrypted::EncryptedEventContent, room_key::RoomKeyEventContent,
-        AnyMessageEventContent, AnySyncRoomEvent, AnyToDeviceEvent, SyncMessageEvent,
-        ToDeviceEvent,
+        AnyMessageEventContent, AnyToDeviceEvent, SyncMessageEvent, ToDeviceEvent,
     },
     identifiers::{
         DeviceId, DeviceIdBox, DeviceKeyAlgorithm, EventEncryptionAlgorithm, EventId, RoomId,
@@ -42,7 +41,7 @@ use matrix_sdk_common::{
     },
     locks::Mutex,
     uuid::Uuid,
-    Raw, UInt,
+    UInt,
 };
 
 #[cfg(feature = "sled_cryptostore")]
@@ -802,7 +801,7 @@ impl OlmMachine {
     /// [`decrypt_room_event`]: #method.decrypt_room_event
     pub async fn receive_sync_changes(
         &self,
-        to_device_events: &RumaToDevice,
+        to_device_events: ToDevice,
         changed_devices: &DeviceLists,
         one_time_keys_counts: &BTreeMap<DeviceKeyAlgorithm, UInt>,
     ) -> OlmResult<ToDevice> {
@@ -826,14 +825,14 @@ impl OlmMachine {
 
         let mut events = Vec::new();
 
-        for event_result in &to_device_events.events {
-            let mut event = match event_result.deserialize() {
+        for mut raw_event in to_device_events.events {
+            let event = match raw_event.deserialize() {
                 Ok(e) => e,
                 Err(e) => {
                     // Skip invalid events.
                     warn!(
                         "Received an invalid to-device event {:?} {:?}",
-                        e, event_result
+                        e, raw_event
                     );
                     continue;
                 }
@@ -841,9 +840,9 @@ impl OlmMachine {
 
             info!("Received a to-device event {:?}", event);
 
-            match &mut event {
+            match event {
                 AnyToDeviceEvent::RoomEncrypted(e) => {
-                    let decrypted = match self.decrypt_to_device_event(e).await {
+                    let decrypted = match self.decrypt_to_device_event(&e).await {
                         Ok(e) => e,
                         Err(err) => {
                             warn!(
@@ -885,12 +884,10 @@ impl OlmMachine {
                         changes.inbound_group_sessions.push(group_session);
                     }
 
-                    if let Some(e) = decrypted.deserialized_event {
-                        event = e;
-                    }
+                    raw_event = decrypted.event;
                 }
                 AnyToDeviceEvent::RoomKeyRequest(e) => {
-                    self.key_request_machine.receive_incoming_key_request(e)
+                    self.key_request_machine.receive_incoming_key_request(&e)
                 }
                 AnyToDeviceEvent::KeyVerificationAccept(..)
                 | AnyToDeviceEvent::KeyVerificationCancel(..)
@@ -903,7 +900,7 @@ impl OlmMachine {
                 _ => continue,
             }
 
-            events.push(event);
+            events.push(raw_event);
         }
 
         let changed_sessions = self
@@ -915,7 +912,10 @@ impl OlmMachine {
 
         self.store.save_changes(changes).await?;
 
-        Ok(ToDevice { events })
+        let mut to_device = ToDevice::new();
+        to_device.events = events;
+
+        Ok(to_device)
     }
 
     /// Request a room key from our devices.
@@ -950,6 +950,44 @@ impl OlmMachine {
             .await?)
     }
 
+    async fn get_encryption_info(
+        &self,
+        session: &InboundGroupSession,
+        sender: &UserId,
+        device_id: &DeviceId,
+    ) -> StoreResult<EncryptionInfo> {
+        let verification_state = if let Some(device) =
+            self.get_device(sender, device_id).await?.filter(|d| {
+                d.get_key(DeviceKeyAlgorithm::Curve25519)
+                    .map(|k| k == session.sender_key())
+                    .unwrap_or(false)
+            }) {
+            if (self.user_id() == device.user_id() && self.device_id() == device.device_id())
+                || device.is_trusted()
+            {
+                VerificationState::Trusted
+            } else {
+                VerificationState::Untrusted
+            }
+        } else {
+            VerificationState::UnknownDevice
+        };
+
+        let sender = sender.clone();
+        let device_id = device_id.to_owned();
+
+        Ok(EncryptionInfo {
+            sender,
+            sender_device: device_id,
+            algorithm_info: AlgorithmInfo::MegolmV1AesSha2 {
+                curve25519_key: session.sender_key().to_owned(),
+                sender_claimed_keys: session.signing_keys().to_owned(),
+                forwarding_curve25519_key_chain: session.forwading_key_chain().to_vec(),
+            },
+            verification_state,
+        })
+    }
+
     /// Decrypt an event from a room timeline.
     ///
     /// # Arguments
@@ -961,7 +999,7 @@ impl OlmMachine {
         &self,
         event: &SyncMessageEvent<EncryptedEventContent>,
         room_id: &RoomId,
-    ) -> MegolmResult<Raw<AnySyncRoomEvent>> {
+    ) -> MegolmResult<SyncRoomEvent> {
         let content = match &event.content {
             EncryptedEventContent::MegolmV1AesSha2(c) => c,
             _ => return Err(EventError::UnsupportedAlgorithm.into()),
@@ -989,8 +1027,6 @@ impl OlmMachine {
             "Successfully decrypted a Megolm event {:?}",
             decrypted_event
         );
-        // TODO set the encryption info on the event (is it verified, was it
-        // decrypted, sender key...)
 
         if let Ok(e) = decrypted_event.deserialize() {
             self.verification_machine
@@ -998,7 +1034,14 @@ impl OlmMachine {
                 .await?;
         }
 
-        Ok(decrypted_event)
+        let encryption_info = self
+            .get_encryption_info(&session, &event.sender, &content.device_id)
+            .await?;
+
+        Ok(SyncRoomEvent {
+            encryption_info: Some(encryption_info),
+            event: decrypted_event,
+        })
     }
 
     /// Update the tracked users.
@@ -1815,23 +1858,24 @@ pub(crate) mod test {
             .decrypt_room_event(&event, &room_id)
             .await
             .unwrap()
+            .event
             .deserialize()
             .unwrap();
 
-        match decrypted_event {
-            AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(SyncMessageEvent {
-                sender,
-                content,
-                ..
-            })) => {
-                assert_eq!(&sender, alice.user_id());
-                if let MessageType::Text(c) = &content.msgtype {
-                    assert_eq!(&c.body, plaintext);
-                } else {
-                    panic!("Decrypted event has a missmatched content");
-                }
+        if let AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(SyncMessageEvent {
+            sender,
+            content,
+            ..
+        })) = decrypted_event
+        {
+            assert_eq!(&sender, alice.user_id());
+            if let MessageType::Text(c) = &content.msgtype {
+                assert_eq!(&c.body, plaintext);
+            } else {
+                panic!("Decrypted event has a missmatched content");
             }
-            _ => panic!("Decrypted room event has the wrong type"),
+        } else {
+            panic!("Decrypted room event has the wrong type")
         }
     }
 


### PR DESCRIPTION
This should supersede #136, we now have much less custom response and event types so this is nice, though the trade off is that the API has become a serialized form.

This was discussed in the Matrix room and is necessary due to the lossy nature of the deserialization/serialization cycle of Ruma events.