### PR TITLE
Create Timeline struct to hold event chunks from /sync and /messages

### DIFF
--- a/matrix_sdk_crypto/Cargo.toml
+++ b/matrix_sdk_crypto/Cargo.toml
@@ -22,7 +22,7 @@ docs = ["sled_cryptostore"]
 [dependencies]
 matrix-sdk-common = { version = "0.2.0", path = "../matrix_sdk_common" }
 
-olm-rs = { version = "1.0.0", features = ["serde"] }
+olm-rs = { version = "1.0.1", features = ["serde"] }
 getrandom = "0.2.2"
 serde = { version = "1.0.122", features = ["derive", "rc"] }
 serde_json = "1.0.61"


### PR DESCRIPTION
I'm opening a new PR so I can refer to the old one, this approach of starting with the `Timeline` struct is different enough it makes sense to me.

We need to keep the `Timeline` struct around from sync/messages to sync/messages we need it to be complete all the time every time. I'm somewhat assuming that the sled store will be the fallback so if the `Timeline` doesn't have some info it asks the store?

I added a `next_token` slice map so `BTreeMap<NextBatchToken, SliceIdx>`. We needed a way of saying I have an incoming /sync with a `prev_batch` token get the `SliceIdx` with the previous `next_batch` token (basically I see no way of not tracking both tokens, other than linear search every time?). 

It's really early but better to know what I'm doing wrong now. A look over the `handle_messages_response` method would be helpful are my assumptions about missing prev/next_batch tokens right?

May resolve #138