### PR TITLE
Return joined members in a room from the correct Sled tree.

### DIFF
--- a/matrix_sdk/src/room/common.rs
+++ b/matrix_sdk/src/room/common.rs
@@ -245,7 +245,7 @@ impl Common {
     pub async fn joined_members_no_sync(&self) -> Result<Vec<RoomMember>> {
         Ok(self
             .inner
-            .members()
+            .joined_members()
             .await?
             .into_iter()
             .map(|member| RoomMember::new(self.client.clone(), member))


### PR DESCRIPTION
This fixes a problem where asking for joined members in a room will attempt to deserialize user IDs from the `members` Sled tree, but entries in that tree are serialized member event JSON values, and thus an "identifier too long" error is returned.