### PR TITLE
Fix step 3 of room naming algorithm

### DIFF
--- a/matrix_sdk_base/src/rooms/mod.rs
+++ b/matrix_sdk_base/src/rooms/mod.rs
@@ -171,8 +171,28 @@ fn calculate_room_name(
 
         // TODO: What length does the spec want us to use here and in
         // the `else`?
-        format!("{}, and {} others", names.join(", "), (joined_member_count + invited_member_count))
+        format!("{}, and {} others", names.join(", "), (invited_joined - heroes_count))
     } else {
         "Empty room".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+
+    fn test_calculate_room_name() {
+        let mut actual = calculate_room_name(2, 0, vec!["a"]);
+        assert_eq!("a", actual);
+
+        actual = calculate_room_name(3, 0, vec!["a", "b"]);
+        assert_eq!("a, b", actual);
+
+        actual = calculate_room_name(4, 0, vec!["a", "b", "c"]);
+        assert_eq!("a, b, c", actual);
+
+        actual = calculate_room_name(5, 0, vec!["a", "b", "c"]);
+        assert_eq!("a, b, c, and 2 others", actual);
     }
 }

--- a/matrix_sdk_base/src/rooms/mod.rs
+++ b/matrix_sdk_base/src/rooms/mod.rs
@@ -63,14 +63,15 @@ impl BaseRoomInfo {
         heroes: Vec<RoomMember>,
     ) -> String {
         let heroes_count = heroes.len() as u64;
-        let invited_joined = (invited_member_count + joined_member_count).saturating_sub(1);
+        let invited_joined = invited_member_count + joined_member_count;
+        let invited_joined_minus_one = invited_joined.saturating_sub(1);
 
-        if heroes_count >= invited_joined {
+        if heroes_count >= invited_joined_minus_one {
             let mut names = heroes.iter().take(3).map(|mem| mem.name()).collect::<Vec<&str>>();
             // stabilize ordering
             names.sort_unstable();
             names.join(", ")
-        } else if heroes_count < invited_joined && invited_joined > 1 {
+        } else if heroes_count < invited_joined_minus_one && invited_joined > 1 {
             let mut names = heroes.iter().take(3).map(|mem| mem.name()).collect::<Vec<&str>>();
             names.sort_unstable();
 

--- a/matrix_sdk_base/src/rooms/mod.rs
+++ b/matrix_sdk_base/src/rooms/mod.rs
@@ -160,7 +160,7 @@ fn calculate_room_name(
     let invited_joined = invited_member_count + joined_member_count;
     let invited_joined_minus_one = invited_joined.saturating_sub(1);
 
-    if heroes_count >= invited_joined_minus_one {
+    let names = if heroes_count >= invited_joined_minus_one {
         let mut names = heroes;
         // stabilize ordering
         names.sort_unstable();
@@ -173,7 +173,18 @@ fn calculate_room_name(
         // the `else`?
         format!("{}, and {} others", names.join(", "), (invited_joined - heroes_count))
     } else {
-        "Empty room".to_string()
+        "".to_string()
+    };
+
+    // User is alone.
+    if invited_joined <= 1 {
+        if names.is_empty() {
+            "Empty room".to_string()
+        } else {
+            format!("Empty room (was {})", names)
+        }
+    } else {
+        names
     }
 }
 
@@ -194,5 +205,23 @@ mod tests {
 
         actual = calculate_room_name(5, 0, vec!["a", "b", "c"]);
         assert_eq!("a, b, c, and 2 others", actual);
+
+        actual = calculate_room_name(0, 0, vec![]);
+        assert_eq!("Empty room", actual);
+
+        actual = calculate_room_name(1, 0, vec![]);
+        assert_eq!("Empty room", actual);
+
+        actual = calculate_room_name(0, 1, vec![]);
+        assert_eq!("Empty room", actual);
+
+        actual = calculate_room_name(1, 0, vec!["a"]);
+        assert_eq!("Empty room (was a)", actual);
+
+        actual = calculate_room_name(1, 0, vec!["a", "b"]);
+        assert_eq!("Empty room (was a, b)", actual);
+
+        actual = calculate_room_name(1, 0, vec!["a", "b", "c"]);
+        assert_eq!("Empty room (was a, b, c)", actual);
     }
 }


### PR DESCRIPTION
This pull request addresses implementation errors in step 3 of the room naming algorithm[0]. They are: 

 1. Empty room naming
 2. Bound check in step 3.ii
 3. Room member count in step 3.ii

To do this, this PR contains a small refactor of the step 3 logic into a low-level function using simple Rust data types. This changes improves testing as the Matrix data types are more cumbersome to initialize. Now the implementation has unit tests verifying expected behavior.

Fixes #133 

[0] https://matrix.org/docs/spec/client_server/latest#calculating-the-display-name-for-a-room