### PR TITLE
base: Correctly update the room info for invited rooms

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -3421,6 +3421,7 @@ mod test {
             .with_status(200)
             .match_header("authorization", "Bearer 1234")
             .with_body(test_json::SYNC.to_string())
+            .expect_at_least(1)
             .create();
 
         let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -3430,6 +3431,19 @@ mod test {
         let room = client.get_joined_room(&room_id!("!SVkFJHzfwvuaIEawgC:localhost")).unwrap();
 
         assert_eq!("tutorial".to_string(), room.display_name().await.unwrap());
+
+        let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_string()))
+            .with_status(200)
+            .match_header("authorization", "Bearer 1234")
+            .with_body(test_json::INVITE_SYNC.to_string())
+            .expect_at_least(1)
+            .create();
+
+        let _response = client.sync_once(SyncSettings::new()).await.unwrap();
+
+        let invited_room = client.get_invited_room(&room_id!("!696r7674:example.com")).unwrap();
+
+        assert_eq!("My Room Name".to_string(), invited_room.display_name().await.unwrap());
     }
 
     #[tokio::test]

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -685,7 +685,7 @@ impl BaseClient {
                     for room_id in rooms {
                         if let Some(room) = changes.room_infos.get_mut(room_id) {
                             room.base_info.dm_target = Some(user_id.clone());
-                        } else if let Some(room) = self.store.get_bare_room(room_id) {
+                        } else if let Some(room) = self.store.get_room(room_id) {
                             let mut info = room.clone_info();
                             info.base_info.dm_target = Some(user_id.clone());
                             changes.add_room(info);
@@ -931,7 +931,7 @@ impl BaseClient {
 
     async fn apply_changes(&self, changes: &StateChanges) {
         for (room_id, room_info) in &changes.room_infos {
-            if let Some(room) = self.store.get_bare_room(&room_id) {
+            if let Some(room) = self.store.get_room(&room_id) {
                 room.update_summary(room_info.clone())
             }
         }
@@ -958,7 +958,7 @@ impl BaseClient {
             .collect();
         let mut ambiguity_cache = AmbiguityCache::new(self.store.clone());
 
-        if let Some(room) = self.store.get_bare_room(room_id) {
+        if let Some(room) = self.store.get_room(room_id) {
             let mut room_info = room.clone_info();
             room_info.mark_members_synced();
 

--- a/matrix_sdk_test/src/test_json/sync.rs
+++ b/matrix_sdk_test/src/test_json/sync.rs
@@ -720,7 +720,7 @@ lazy_static! {
 lazy_static! {
     pub static ref INVITE_SYNC: JsonValue = json!({
         "device_one_time_keys_count": {},
-        "next_batch": "s526_47314_0_7_1_1_1_11444_1",
+        "next_batch": "s526_47314_0_7_1_1_1_11444_2",
         "device_lists": {
             "changed": [
                 "@example:example.org"


### PR DESCRIPTION
Once upon a time we had different types for the stripped room infos and for the non-stripped ones. The different types were removed since we could handle all the infos the same way, though we still keep them in different buckets in the store since they per spec need to be stored separately.

The removal of the types didn't account for those different buckets and invited (or stripped) room infos we're never updated in its respective bucket.

This PR fixes this, and possibly #133.