### PR TITLE
appservice: Improve API

### DIFF
--- a/matrix_sdk_appservice/examples/actix_autojoin.rs
+++ b/matrix_sdk_appservice/examples/actix_autojoin.rs
@@ -37,7 +37,7 @@ impl EventHandler for AppserviceEventHandler {
             let mut appservice = self.appservice.clone();
             appservice.register(user_id.localpart()).await.unwrap();
 
-            let client = appservice.client(Some(user_id.localpart())).await.unwrap();
+            let client = appservice.virtual_user(user_id.localpart()).await.unwrap();
 
             client.join_room_by_id(room.room_id()).await.unwrap();
         }

--- a/matrix_sdk_appservice/tests/tests.rs
+++ b/matrix_sdk_appservice/tests/tests.rs
@@ -87,14 +87,14 @@ async fn test_event_handler() -> Result<()> {
         events,
     );
 
-    appservice.client(None).await?.receive_transaction(incoming).await?;
+    appservice.get_cached_client(None)?.receive_transaction(incoming).await?;
 
     Ok(())
 }
 
 #[async_test]
 async fn test_transaction() -> Result<()> {
-    let mut appservice = appservice(None).await?;
+    let appservice = appservice(None).await?;
 
     let event = serde_json::from_value::<AnyStateEvent>(member_json()).unwrap();
     let event: Raw<AnyRoomEvent> = AnyRoomEvent::State(event).into();
@@ -105,7 +105,7 @@ async fn test_transaction() -> Result<()> {
         events,
     );
 
-    appservice.client(None).await?.receive_transaction(incoming).await?;
+    appservice.get_cached_client(None)?.receive_transaction(incoming).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Having both `new_with_client_config` and `client_with_config` was confusing. This refactoring tries to make the difference between "main user" and "virtual user" more obvious.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/228