### PR TITLE
Remove a bunch of double indirections

### DIFF
--- a/matrix_sdk_base/src/rooms/normal.rs
+++ b/matrix_sdk_base/src/rooms/normal.rs
@@ -52,7 +52,7 @@ pub struct Room {
     room_id: Arc<RoomId>,
     own_user_id: Arc<UserId>,
     inner: Arc<SyncRwLock<RoomInfo>>,
-    store: Arc<Box<dyn StateStore>>,
+    store: Arc<dyn StateStore>,
 }
 
 /// The room summary containing member counts and members that should be used to
@@ -83,7 +83,7 @@ pub enum RoomType {
 impl Room {
     pub(crate) fn new(
         own_user_id: &UserId,
-        store: Arc<Box<dyn StateStore>>,
+        store: Arc<dyn StateStore>,
         room_id: &RoomId,
         room_type: RoomType,
     ) -> Self {
@@ -104,7 +104,7 @@ impl Room {
 
     pub(crate) fn restore(
         own_user_id: &UserId,
-        store: Arc<Box<dyn StateStore>>,
+        store: Arc<dyn StateStore>,
         room_info: RoomInfo,
     ) -> Self {
         Self {

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -289,7 +289,7 @@ pub trait StateStore: AsyncTraitDeps {
 /// `StateStore` implementation.
 #[derive(Debug, Clone)]
 pub struct Store {
-    inner: Arc<Box<dyn StateStore>>,
+    inner: Arc<dyn StateStore>,
     pub(crate) session: Arc<RwLock<Option<Session>>>,
     pub(crate) sync_token: Arc<RwLock<Option<String>>>,
     rooms: Arc<DashMap<RoomId, Room>>,
@@ -405,10 +405,10 @@ impl Store {
 }
 
 impl Deref for Store {
-    type Target = Box<dyn StateStore>;
+    type Target = dyn StateStore;
 
     fn deref(&self) -> &Self::Target {
-        &self.inner
+        &*self.inner
     }
 }
 

--- a/matrix_sdk_crypto/src/identities/device.rs
+++ b/matrix_sdk_crypto/src/identities/device.rs
@@ -184,7 +184,7 @@ impl Device {
         event_type: EventType,
         content: Value,
     ) -> OlmResult<(Session, EncryptedEventContent)> {
-        self.inner.encrypt(&**self.verification_machine.store, event_type, content).await
+        self.inner.encrypt(&*self.verification_machine.store, event_type, content).await
     }
 
     /// Encrypt the given inbound group session as a forwarded room key for this

--- a/matrix_sdk_crypto/src/identities/device.rs
+++ b/matrix_sdk_crypto/src/identities/device.rs
@@ -55,7 +55,7 @@ use crate::{OlmMachine, ReadOnlyAccount};
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ReadOnlyDevice {
     user_id: Arc<UserId>,
-    device_id: Arc<DeviceIdBox>,
+    device_id: Arc<DeviceId>,
     algorithms: Arc<[EventEncryptionAlgorithm]>,
     keys: Arc<BTreeMap<DeviceKeyId, String>>,
     pub(crate) signatures: Arc<BTreeMap<UserId, BTreeMap<DeviceKeyId, String>>>,
@@ -301,7 +301,7 @@ impl ReadOnlyDevice {
     ) -> Self {
         Self {
             user_id: Arc::new(user_id),
-            device_id: Arc::new(device_id),
+            device_id: device_id.into(),
             display_name: Arc::new(display_name),
             trust_state: Arc::new(Atomic::new(trust_state)),
             signatures: Arc::new(signatures),
@@ -546,7 +546,7 @@ impl TryFrom<&DeviceKeys> for ReadOnlyDevice {
     fn try_from(device_keys: &DeviceKeys) -> Result<Self, Self::Error> {
         let device = Self {
             user_id: Arc::new(device_keys.user_id.clone()),
-            device_id: Arc::new(device_keys.device_id.clone()),
+            device_id: device_keys.device_id.clone().into(),
             algorithms: device_keys.algorithms.as_slice().into(),
             signatures: Arc::new(device_keys.signatures.clone()),
             keys: Arc::new(device_keys.keys.clone()),

--- a/matrix_sdk_crypto/src/identities/manager.rs
+++ b/matrix_sdk_crypto/src/identities/manager.rs
@@ -423,14 +423,10 @@ pub(crate) mod test {
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id())));
         let user_id = Arc::new(user_id());
         let account = ReadOnlyAccount::new(&user_id, &device_id());
-        let store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(MemoryStore::new()));
+        let store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
         let verification = VerificationMachine::new(account, identity.clone(), store);
-        let store = Store::new(
-            user_id.clone(),
-            identity,
-            Arc::new(Box::new(MemoryStore::new())),
-            verification,
-        );
+        let store =
+            Store::new(user_id.clone(), identity, Arc::new(MemoryStore::new()), verification);
         IdentityManager::new(user_id, device_id().into(), store)
     }
 

--- a/matrix_sdk_crypto/src/identities/user.rs
+++ b/matrix_sdk_crypto/src/identities/user.rs
@@ -758,7 +758,7 @@ pub(crate) mod test {
         let verification_machine = VerificationMachine::new(
             ReadOnlyAccount::new(second.user_id(), second.device_id()),
             private_identity.clone(),
-            Arc::new(Box::new(MemoryStore::new())),
+            Arc::new(MemoryStore::new()),
         );
 
         let first = Device {
@@ -801,7 +801,7 @@ pub(crate) mod test {
         let verification_machine = VerificationMachine::new(
             ReadOnlyAccount::new(device.user_id(), device.device_id()),
             id.clone(),
-            Arc::new(Box::new(MemoryStore::new())),
+            Arc::new(MemoryStore::new()),
         );
 
         let public_identity = identity.as_public_identity().await.unwrap();

--- a/matrix_sdk_crypto/src/key_request.rs
+++ b/matrix_sdk_crypto/src/key_request.rs
@@ -125,7 +125,7 @@ impl WaitQueue {
 #[derive(Debug, Clone)]
 pub(crate) struct KeyRequestMachine {
     user_id: Arc<UserId>,
-    device_id: Arc<DeviceIdBox>,
+    device_id: Arc<DeviceId>,
     store: Store,
     outbound_group_sessions: GroupSessionCache,
     outgoing_to_device_requests: Arc<DashMap<Uuid, OutgoingRequest>>,
@@ -210,7 +210,7 @@ fn wrap_key_request_content(
 impl KeyRequestMachine {
     pub fn new(
         user_id: Arc<UserId>,
-        device_id: Arc<DeviceIdBox>,
+        device_id: Arc<DeviceId>,
         store: Store,
         outbound_group_sessions: GroupSessionCache,
         users_for_key_claim: Arc<DashMap<UserId, DashSet<DeviceIdBox>>>,
@@ -854,7 +854,7 @@ mod test {
 
         KeyRequestMachine::new(
             user_id,
-            Arc::new(bob_device_id()),
+            bob_device_id().into(),
             store,
             session_cache,
             Arc::new(DashMap::new()),
@@ -862,7 +862,7 @@ mod test {
     }
 
     async fn get_machine() -> KeyRequestMachine {
-        let user_id = Arc::new(alice_id());
+        let user_id: Arc<UserId> = alice_id().into();
         let account = ReadOnlyAccount::new(&user_id, &alice_device_id());
         let device = ReadOnlyDevice::from_account(&account).await;
         let store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(MemoryStore::new()));
@@ -874,7 +874,7 @@ mod test {
 
         KeyRequestMachine::new(
             user_id,
-            Arc::new(alice_device_id()),
+            alice_device_id().into(),
             store,
             session_cache,
             Arc::new(DashMap::new()),

--- a/matrix_sdk_crypto/src/key_request.rs
+++ b/matrix_sdk_crypto/src/key_request.rs
@@ -846,7 +846,7 @@ mod test {
     fn bob_machine() -> KeyRequestMachine {
         let user_id = Arc::new(bob_id());
         let account = ReadOnlyAccount::new(&user_id, &alice_device_id());
-        let store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(MemoryStore::new()));
+        let store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(bob_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
         let store = Store::new(user_id.clone(), identity, store, verification);
@@ -865,7 +865,7 @@ mod test {
         let user_id: Arc<UserId> = alice_id().into();
         let account = ReadOnlyAccount::new(&user_id, &alice_device_id());
         let device = ReadOnlyDevice::from_account(&account).await;
-        let store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(MemoryStore::new()));
+        let store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
         let store = Store::new(user_id.clone(), identity, store, verification);

--- a/matrix_sdk_crypto/src/machine.rs
+++ b/matrix_sdk_crypto/src/machine.rs
@@ -144,7 +144,7 @@ impl OlmMachine {
         let user_id = Arc::new(user_id.clone());
         let user_identity = Arc::new(Mutex::new(user_identity));
 
-        let store = Arc::new(store);
+        let store: Arc<dyn CryptoStore> = store.into();
         let verification_machine =
             VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
         let store =

--- a/matrix_sdk_crypto/src/machine.rs
+++ b/matrix_sdk_crypto/src/machine.rs
@@ -71,7 +71,7 @@ pub struct OlmMachine {
     /// The unique user id that owns this account.
     user_id: Arc<UserId>,
     /// The unique device id of the device that holds this account.
-    device_id: Arc<Box<DeviceId>>,
+    device_id: Arc<DeviceId>,
     /// Our underlying Olm Account holding our identity keys.
     account: Account,
     /// The private part of our cross signing identity.
@@ -149,7 +149,7 @@ impl OlmMachine {
             VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
         let store =
             Store::new(user_id.clone(), user_identity.clone(), store, verification_machine.clone());
-        let device_id: Arc<DeviceIdBox> = Arc::new(device_id);
+        let device_id: Arc<DeviceId> = device_id.into();
         let users_for_key_claim = Arc::new(DashMap::new());
 
         let account = Account { inner: account, store: store.clone() };

--- a/matrix_sdk_crypto/src/olm/account.rs
+++ b/matrix_sdk_crypto/src/olm/account.rs
@@ -431,7 +431,7 @@ impl Account {
 #[derive(Clone)]
 pub struct ReadOnlyAccount {
     pub(crate) user_id: Arc<UserId>,
-    pub(crate) device_id: Arc<Box<DeviceId>>,
+    pub(crate) device_id: Arc<DeviceId>,
     inner: Arc<Mutex<OlmAccount>>,
     pub(crate) identity_keys: Arc<IdentityKeys>,
     shared: Arc<AtomicBool>,
@@ -502,7 +502,7 @@ impl ReadOnlyAccount {
 
         Self {
             user_id: Arc::new(user_id.to_owned()),
-            device_id: Arc::new(device_id.into()),
+            device_id: device_id.to_owned().into(),
             inner: Arc::new(Mutex::new(account)),
             identity_keys: Arc::new(identity_keys),
             shared: Arc::new(AtomicBool::new(false)),
@@ -676,7 +676,7 @@ impl ReadOnlyAccount {
 
         Ok(Self {
             user_id: Arc::new(pickle.user_id),
-            device_id: Arc::new(pickle.device_id),
+            device_id: pickle.device_id.into(),
             inner: Arc::new(Mutex::new(account)),
             identity_keys: Arc::new(identity_keys),
             shared: Arc::new(AtomicBool::from(pickle.shared)),
@@ -700,7 +700,7 @@ impl ReadOnlyAccount {
 
         DeviceKeys::new(
             (*self.user_id).clone(),
-            (*self.device_id).clone(),
+            (*self.device_id).to_owned(),
             Self::ALGORITHMS.iter().map(|a| (&**a).clone()).collect(),
             keys,
             BTreeMap::new(),

--- a/matrix_sdk_crypto/src/olm/group_sessions/outbound.rs
+++ b/matrix_sdk_crypto/src/olm/group_sessions/outbound.rs
@@ -118,7 +118,7 @@ impl EncryptionSettings {
 #[derive(Clone)]
 pub struct OutboundGroupSession {
     inner: Arc<Mutex<OlmOutboundGroupSession>>,
-    device_id: Arc<DeviceIdBox>,
+    device_id: Arc<DeviceId>,
     account_identity_keys: Arc<IdentityKeys>,
     session_id: Arc<str>,
     room_id: Arc<RoomId>,
@@ -148,7 +148,7 @@ impl OutboundGroupSession {
     /// * `settings` - Settings determining the algorithm and rotation period of
     /// the outbound group session.
     pub fn new(
-        device_id: Arc<DeviceIdBox>,
+        device_id: Arc<DeviceId>,
         identity_keys: Arc<IdentityKeys>,
         room_id: &RoomId,
         settings: EncryptionSettings,
@@ -450,7 +450,7 @@ impl OutboundGroupSession {
     /// * `pickle_mode` - The mode that was used to pickle the session, either
     /// an unencrypted mode or an encrypted using passphrase.
     pub fn from_pickle(
-        device_id: Arc<DeviceIdBox>,
+        device_id: Arc<DeviceId>,
         identity_keys: Arc<IdentityKeys>,
         pickle: PickledOutboundGroupSession,
         pickling_mode: PicklingMode,

--- a/matrix_sdk_crypto/src/olm/session.rs
+++ b/matrix_sdk_crypto/src/olm/session.rs
@@ -45,7 +45,7 @@ use crate::{
 #[derive(Clone)]
 pub struct Session {
     pub(crate) user_id: Arc<UserId>,
-    pub(crate) device_id: Arc<Box<DeviceId>>,
+    pub(crate) device_id: Arc<DeviceId>,
     pub(crate) our_identity_keys: Arc<IdentityKeys>,
     pub(crate) inner: Arc<Mutex<OlmSession>>,
     pub(crate) session_id: Arc<str>,
@@ -214,7 +214,7 @@ impl Session {
     /// an unencrypted mode or an encrypted using passphrase.
     pub fn from_pickle(
         user_id: Arc<UserId>,
-        device_id: Arc<Box<DeviceId>>,
+        device_id: Arc<DeviceId>,
         our_identity_keys: Arc<IdentityKeys>,
         pickle: PickledSession,
         pickle_mode: PicklingMode,

--- a/matrix_sdk_crypto/src/session_manager/sessions.rs
+++ b/matrix_sdk_crypto/src/session_manager/sessions.rs
@@ -339,7 +339,7 @@ mod test {
             VerificationMachine::new(account.clone(), identity.clone(), store.clone());
 
         let user_id = Arc::new(user_id);
-        let device_id = Arc::new(device_id);
+        let device_id = device_id.into();
 
         let store = Store::new(user_id.clone(), identity, store, verification);
 

--- a/matrix_sdk_crypto/src/session_manager/sessions.rs
+++ b/matrix_sdk_crypto/src/session_manager/sessions.rs
@@ -332,7 +332,7 @@ mod test {
 
         let users_for_key_claim = Arc::new(DashMap::new());
         let account = ReadOnlyAccount::new(&user_id, &device_id);
-        let store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(MemoryStore::new()));
+        let store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
         store.save_account(account.clone()).await.unwrap();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id.clone())));
         let verification =

--- a/matrix_sdk_crypto/src/store/mod.rs
+++ b/matrix_sdk_crypto/src/store/mod.rs
@@ -94,7 +94,7 @@ pub type Result<T, E = CryptoStoreError> = std::result::Result<T, E>;
 pub(crate) struct Store {
     user_id: Arc<UserId>,
     identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
-    inner: Arc<Box<dyn CryptoStore>>,
+    inner: Arc<dyn CryptoStore>,
     verification_machine: VerificationMachine,
 }
 
@@ -140,7 +140,7 @@ impl Store {
     pub fn new(
         user_id: Arc<UserId>,
         identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         verification_machine: VerificationMachine,
     ) -> Self {
         Self { user_id, identity, inner: store, verification_machine }
@@ -238,7 +238,7 @@ impl Deref for Store {
     type Target = dyn CryptoStore;
 
     fn deref(&self) -> &Self::Target {
-        &**self.inner
+        &*self.inner
     }
 }
 

--- a/matrix_sdk_crypto/src/store/sled.rs
+++ b/matrix_sdk_crypto/src/store/sled.rs
@@ -117,7 +117,7 @@ impl EncodeKey for (&str, &str, &str) {
 #[derive(Clone, Debug)]
 pub struct AccountInfo {
     user_id: Arc<UserId>,
-    device_id: Arc<DeviceIdBox>,
+    device_id: Arc<DeviceId>,
     identity_keys: Arc<IdentityKeys>,
 }
 

--- a/matrix_sdk_crypto/src/verification/machine.rs
+++ b/matrix_sdk_crypto/src/verification/machine.rs
@@ -40,7 +40,7 @@ use crate::{
 pub struct VerificationMachine {
     account: ReadOnlyAccount,
     private_identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
-    pub(crate) store: Arc<Box<dyn CryptoStore>>,
+    pub(crate) store: Arc<dyn CryptoStore>,
     verifications: VerificationCache,
     requests: Arc<DashMap<String, VerificationRequest>>,
 }
@@ -49,7 +49,7 @@ impl VerificationMachine {
     pub(crate) fn new(
         account: ReadOnlyAccount,
         identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
     ) -> Self {
         Self {
             account,
@@ -358,9 +358,9 @@ mod test {
         store.save_devices(vec![bob_device]).await;
         bob_store.save_devices(vec![alice_device.clone()]).await;
 
-        let bob_store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(bob_store));
+        let bob_store: Arc<dyn CryptoStore> = Arc::new(bob_store);
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
-        let machine = VerificationMachine::new(alice, identity, Arc::new(Box::new(store)));
+        let machine = VerificationMachine::new(alice, identity, Arc::new(store));
         let (bob_sas, start_content) = Sas::start(
             bob,
             PrivateCrossSigningIdentity::empty(bob_id()),
@@ -383,7 +383,7 @@ mod test {
         let alice = ReadOnlyAccount::new(&alice_id(), &alice_device_id());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let store = MemoryStore::new();
-        let _ = VerificationMachine::new(alice, identity, Arc::new(Box::new(store)));
+        let _ = VerificationMachine::new(alice, identity, Arc::new(store));
     }
 
     #[tokio::test]

--- a/matrix_sdk_crypto/src/verification/mod.rs
+++ b/matrix_sdk_crypto/src/verification/mod.rs
@@ -208,7 +208,7 @@ pub enum VerificationResult {
 #[derive(Clone, Debug)]
 pub struct IdentitiesBeingVerified {
     private_identity: PrivateCrossSigningIdentity,
-    store: Arc<Box<dyn CryptoStore>>,
+    store: Arc<dyn CryptoStore>,
     device_being_verified: ReadOnlyDevice,
     identity_being_verified: Option<UserIdentities>,
 }

--- a/matrix_sdk_crypto/src/verification/requests.rs
+++ b/matrix_sdk_crypto/src/verification/requests.rs
@@ -68,7 +68,7 @@ impl VerificationRequest {
         cache: VerificationCache,
         account: ReadOnlyAccount,
         private_cross_signing_identity: PrivateCrossSigningIdentity,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         room_id: &RoomId,
         event_id: &EventId,
         other_user: &UserId,
@@ -99,7 +99,7 @@ impl VerificationRequest {
         cache: VerificationCache,
         account: ReadOnlyAccount,
         private_cross_signing_identity: PrivateCrossSigningIdentity,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         other_user: &UserId,
     ) -> Self {
         let flow_id = Uuid::new_v4().to_string().into();
@@ -178,7 +178,7 @@ impl VerificationRequest {
         cache: VerificationCache,
         account: ReadOnlyAccount,
         private_cross_signing_identity: PrivateCrossSigningIdentity,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         sender: &UserId,
         flow_id: FlowId,
         content: &RequestContent,
@@ -377,7 +377,7 @@ struct RequestState<S: Clone> {
     account: ReadOnlyAccount,
     private_cross_signing_identity: PrivateCrossSigningIdentity,
     verification_cache: VerificationCache,
-    store: Arc<Box<dyn CryptoStore>>,
+    store: Arc<dyn CryptoStore>,
     flow_id: Arc<FlowId>,
 
     /// The id of the user which is participating in this verification request.
@@ -418,7 +418,7 @@ impl RequestState<Created> {
         account: ReadOnlyAccount,
         private_identity: PrivateCrossSigningIdentity,
         cache: VerificationCache,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         other_user_id: &UserId,
         flow_id: &FlowId,
     ) -> Self {
@@ -479,7 +479,7 @@ impl RequestState<Requested> {
         account: ReadOnlyAccount,
         private_identity: PrivateCrossSigningIdentity,
         cache: VerificationCache,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         sender: &UserId,
         flow_id: &FlowId,
         content: &RequestContent,
@@ -626,7 +626,7 @@ impl RequestState<Ready> {
 
     fn start_sas(
         self,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         account: ReadOnlyAccount,
         private_identity: PrivateCrossSigningIdentity,
         other_device: ReadOnlyDevice,

--- a/matrix_sdk_crypto/src/verification/sas/mod.rs
+++ b/matrix_sdk_crypto/src/verification/sas/mod.rs
@@ -106,7 +106,7 @@ impl Sas {
         account: ReadOnlyAccount,
         private_identity: PrivateCrossSigningIdentity,
         other_device: ReadOnlyDevice,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         other_identity: Option<UserIdentities>,
     ) -> Sas {
         let flow_id = inner_sas.verification_flow_id();
@@ -140,7 +140,7 @@ impl Sas {
         account: ReadOnlyAccount,
         private_identity: PrivateCrossSigningIdentity,
         other_device: ReadOnlyDevice,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         other_identity: Option<UserIdentities>,
         transaction_id: Option<String>,
     ) -> (Sas, OutgoingContent) {
@@ -180,7 +180,7 @@ impl Sas {
         account: ReadOnlyAccount,
         private_identity: PrivateCrossSigningIdentity,
         other_device: ReadOnlyDevice,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         other_identity: Option<UserIdentities>,
     ) -> (Sas, OutgoingContent) {
         let (inner, content) = InnerSas::start_in_room(
@@ -218,7 +218,7 @@ impl Sas {
     pub(crate) fn from_start_event(
         flow_id: FlowId,
         content: &StartContent,
-        store: Arc<Box<dyn CryptoStore>>,
+        store: Arc<dyn CryptoStore>,
         account: ReadOnlyAccount,
         private_identity: PrivateCrossSigningIdentity,
         other_device: ReadOnlyDevice,
@@ -522,12 +522,12 @@ mod test {
         let bob = ReadOnlyAccount::new(&bob_id(), &bob_device_id());
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
-        let alice_store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(MemoryStore::new()));
+        let alice_store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
         let bob_store = MemoryStore::new();
 
         bob_store.save_devices(vec![alice_device.clone()]).await;
 
-        let bob_store: Arc<Box<dyn CryptoStore>> = Arc::new(Box::new(bob_store));
+        let bob_store: Arc<dyn CryptoStore> = Arc::new(bob_store);
 
         let (alice, content) = Sas::start(
             alice,


### PR DESCRIPTION
I also saw lots of `Arc<Box<dyn CryptoStore>>` but didn't bother with that. Maybe there's a good reason for it?

This change will introduce an extra string copy whereever `Box<DeviceId>` is converted to `Arc<DeviceId>` (and in two places where `&DeviceId` is converted to `Arc<DeviceId>`, but that [is fixable](https://github.com/ruma/ruma/issues/615)), but remove the double indirection and also remove a few (tiny) allocations.