### PR TITLE
matrix-sdk: use media cache for avatar requests

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -781,20 +781,20 @@ impl Client {
 
     /// Gets the avatar of the owner of the client, if set.
     ///
-    /// Returns the avatar. No guarantee on the size of the image is given.
-    /// If no size is given the full-sized avatar will be returned.
+    /// Returns the avatar.
+    /// If a thumbnail is requested no guarantee on the size of the image is
+    /// given.
     ///
     /// # Arguments
     ///
-    /// * `width` - The desired width of the avatar.
-    ///
-    /// * `height` - The desired height of the avatar.
+    /// * `format` - The desired format of the avatar.
     ///
     /// # Example
     /// ```no_run
     /// # use futures::executor::block_on;
     /// # use matrix_sdk::Client;
     /// # use matrix_sdk::identifiers::room_id;
+    /// # use matrix_sdk::media::MediaFormat;
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
     /// # block_on(async {
@@ -802,24 +802,15 @@ impl Client {
     /// let client = Client::new(homeserver).unwrap();
     /// client.login(user, "password", None, None).await.unwrap();
     ///
-    /// if let Some(avatar) = client.avatar(Some(96), Some(96)).await.unwrap() {
+    /// if let Some(avatar) = client.avatar(MediaFormat::File).await.unwrap() {
     ///     std::fs::write("avatar.png", avatar);
     /// }
     /// # })
     /// ```
-    pub async fn avatar(&self, width: Option<u32>, height: Option<u32>) -> Result<Option<Vec<u8>>> {
-        // TODO: try to offer the avatar from cache, requires avatar cache
+    pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         if let Some(url) = self.avatar_url().await? {
-            if let (Some(width), Some(height)) = (width, height) {
-                let request =
-                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into())?;
-                let response = self.send(request, None).await?;
-                Ok(Some(response.file))
-            } else {
-                let request = get_content::Request::from_url(&url)?;
-                let response = self.send(request, None).await?;
-                Ok(Some(response.file))
-            }
+            let request = MediaRequest { media_type: MediaType::Uri(url), format };
+            Ok(Some(self.get_media_content(&request, true).await?))
         } else {
             Ok(None)
         }

--- a/matrix_sdk/src/room/common.rs
+++ b/matrix_sdk/src/room/common.rs
@@ -4,14 +4,16 @@ use matrix_sdk_base::deserialized_responses::MembersResponse;
 use matrix_sdk_common::locks::Mutex;
 use ruma::{
     api::client::r0::{
-        media::{get_content, get_content_thumbnail},
         membership::{get_member_events, join_room_by_id, leave_room},
         message::get_message_events,
     },
     UserId,
 };
 
-use crate::{BaseRoom, Client, Result, RoomMember};
+use crate::{
+    media::{MediaFormat, MediaRequest, MediaType},
+    BaseRoom, Client, Result, RoomMember,
+};
 
 /// A struct containing methods that are common for Joined, Invited and Left
 /// Rooms
@@ -63,20 +65,20 @@ impl Common {
 
     /// Gets the avatar of this room, if set.
     ///
-    /// Returns the avatar. No guarantee on the size of the image is given.
-    /// If no size is given the full-sized avatar will be returned.
+    /// Returns the avatar.
+    /// If a thumbnail is requested no guarantee on the size of the image is
+    /// given.
     ///
     /// # Arguments
     ///
-    /// * `width` - The desired width of the avatar.
-    ///
-    /// * `height` - The desired height of the avatar.
+    /// * `format` - The desired format of the avatar.
     ///
     /// # Example
     /// ```no_run
     /// # use futures::executor::block_on;
     /// # use matrix_sdk::Client;
     /// # use matrix_sdk::identifiers::room_id;
+    /// # use matrix_sdk::media::MediaFormat;
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
     /// # block_on(async {
@@ -87,24 +89,15 @@ impl Common {
     /// let room = client
     ///     .get_joined_room(&room_id)
     ///     .unwrap();
-    /// if let Some(avatar) = room.avatar(Some(96), Some(96)).await.unwrap() {
+    /// if let Some(avatar) = room.avatar(MediaFormat::File).await.unwrap() {
     ///     std::fs::write("avatar.png", avatar);
     /// }
     /// # })
     /// ```
-    pub async fn avatar(&self, width: Option<u32>, height: Option<u32>) -> Result<Option<Vec<u8>>> {
-        // TODO: try to offer the avatar from cache, requires avatar cache
+    pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         if let Some(url) = self.avatar_url() {
-            if let (Some(width), Some(height)) = (width, height) {
-                let request =
-                    get_content_thumbnail::Request::from_url(&url, width.into(), height.into())?;
-                let response = self.client.send(request, None).await?;
-                Ok(Some(response.file))
-            } else {
-                let request = get_content::Request::from_url(&url)?;
-                let response = self.client.send(request, None).await?;
-                Ok(Some(response.file))
-            }
+            let request = MediaRequest { media_type: MediaType::Uri(url.clone()), format };
+            Ok(Some(self.client.get_media_content(&request, true).await?))
         } else {
             Ok(None)
         }

--- a/matrix_sdk/src/room_member.rs
+++ b/matrix_sdk/src/room_member.rs
@@ -1,8 +1,9 @@
 use std::ops::Deref;
 
-use ruma::api::client::r0::media::{get_content, get_content_thumbnail};
-
-use crate::{BaseRoomMember, Client, Result};
+use crate::{
+    media::{MediaFormat, MediaRequest, MediaType},
+    BaseRoomMember, Client, Result,
+};
 
 /// The high-level `RoomMember` representation
 #[derive(Debug, Clone)]
@@ -26,14 +27,13 @@ impl RoomMember {
 
     /// Gets the avatar of this member, if set.
     ///
-    /// Returns the avatar. No guarantee on the size of the image is given.
-    /// If no size is given the full-sized avatar will be returned.
+    /// Returns the avatar.
+    /// If a thumbnail is requested no guarantee on the size of the image is
+    /// given.
     ///
     /// # Arguments
     ///
-    /// * `width` - The desired width of the avatar.
-    ///
-    /// * `height` - The desired height of the avatar.
+    /// * `format` - The desired format of the avatar.
     ///
     /// # Example
     /// ```no_run
@@ -41,6 +41,7 @@ impl RoomMember {
     /// # use matrix_sdk::Client;
     /// # use matrix_sdk::identifiers::room_id;
     /// # use matrix_sdk::RoomMember;
+    /// # use matrix_sdk::media::MediaFormat;
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
     /// # block_on(async {
@@ -53,24 +54,15 @@ impl RoomMember {
     ///     .unwrap();
     /// let members = room.members().await.unwrap();
     /// let member = members.first().unwrap();
-    /// if let Some(avatar) = member.avatar(Some(96), Some(96)).await.unwrap() {
+    /// if let Some(avatar) = member.avatar(MediaFormat::File).await.unwrap() {
     ///     std::fs::write("avatar.png", avatar);
     /// }
     /// # })
     /// ```
-    pub async fn avatar(&self, width: Option<u32>, height: Option<u32>) -> Result<Option<Vec<u8>>> {
-        // TODO: try to offer the avatar from cache, requires avatar cache
+    pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
         if let Some(url) = self.avatar_url() {
-            if let (Some(width), Some(height)) = (width, height) {
-                let request =
-                    get_content_thumbnail::Request::from_url(url, width.into(), height.into())?;
-                let response = self.client.send(request, None).await?;
-                Ok(Some(response.file))
-            } else {
-                let request = get_content::Request::from_url(url)?;
-                let response = self.client.send(request, None).await?;
-                Ok(Some(response.file))
-            }
+            let request = MediaRequest { media_type: MediaType::Uri(url.clone()), format };
+            Ok(Some(self.client.get_media_content(&request, true).await?))
         } else {
             Ok(None)
         }


### PR DESCRIPTION
fixes: https://github.com/matrix-org/matrix-rust-sdk/issues/150