### PR TITLE
WIP: State Event Getters

### DIFF
--- a/matrix_sdk/src/room/common.rs
+++ b/matrix_sdk/src/room/common.rs
@@ -8,6 +8,8 @@ use ruma::{
         membership::{get_member_events, join_room_by_id, leave_room},
         message::get_message_events,
     },
+    events::{AnySyncStateEvent, EventType},
+    serde::Raw,
     UserId,
 };
 
@@ -323,5 +325,26 @@ impl Common {
             .into_iter()
             .map(|member| RoomMember::new(self.client.clone(), member))
             .collect())
+    }
+
+    /// Get all state events of a given type in this room.
+    pub async fn get_state_events(
+        &self,
+        event_type: EventType,
+    ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
+        self.client.store().get_state_events(self.room_id(), event_type).await.map_err(Into::into)
+    }
+
+    /// Get a specific state event in this room.
+    pub async fn get_state_event(
+        &self,
+        event_type: EventType,
+        state_key: &str,
+    ) -> Result<Option<Raw<AnySyncStateEvent>>> {
+        self.client
+            .store()
+            .get_state_event(self.room_id(), event_type, state_key)
+            .await
+            .map_err(Into::into)
     }
 }

--- a/matrix_sdk_base/src/store/memory_store.rs
+++ b/matrix_sdk_base/src/store/memory_store.rs
@@ -293,19 +293,7 @@ impl MemoryStore {
         }))
     }
 
-    async fn get_state_events(&self, room_id: &RoomId) -> Result<Vec<Raw<AnySyncStateEvent>>> {
-        #[allow(clippy::map_clone)]
-        Ok(self
-            .room_state
-            .get(room_id)
-            .map(|r| {
-                r.iter().flat_map(|t| t.clone().into_iter().map(|(_, e)| e.clone())).collect()
-                // e.get(event_type.as_ref()).map(|s| s.iter().map(|e| e.clone()).collect::<Vec<_>>())
-            })
-            .unwrap_or_default())
-    }
-
-    async fn get_state_events_by_type(
+    async fn get_state_events(
         &self,
         room_id: &RoomId,
         event_type: EventType,
@@ -485,16 +473,12 @@ impl StateStore for MemoryStore {
         self.get_state_event(room_id, event_type, state_key).await
     }
 
-    async fn get_state_events(&self, room_id: &RoomId) -> Result<Vec<Raw<AnySyncStateEvent>>> {
-        self.get_state_events(room_id).await
-    }
-
-    async fn get_state_events_by_type(
+    async fn get_state_events(
         &self,
         room_id: &RoomId,
         event_type: EventType,
     ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
-        self.get_state_events_by_type(room_id, event_type).await
+        self.get_state_events(room_id, event_type).await
     }
 
     async fn get_profile(

--- a/matrix_sdk_base/src/store/memory_store.rs
+++ b/matrix_sdk_base/src/store/memory_store.rs
@@ -293,6 +293,33 @@ impl MemoryStore {
         }))
     }
 
+    async fn get_state_events(&self, room_id: &RoomId) -> Result<Vec<Raw<AnySyncStateEvent>>> {
+        #[allow(clippy::map_clone)]
+        Ok(self
+            .room_state
+            .get(room_id)
+            .map(|r| {
+                r.iter().flat_map(|t| t.clone().into_iter().map(|(_, e)| e.clone())).collect()
+                // e.get(event_type.as_ref()).map(|s| s.iter().map(|e| e.clone()).collect::<Vec<_>>())
+            })
+            .unwrap_or_default())
+    }
+
+    async fn get_state_events_by_type(
+        &self,
+        room_id: &RoomId,
+        event_type: EventType,
+    ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
+        #[allow(clippy::map_clone)]
+        Ok(self
+            .room_state
+            .get(room_id)
+            .and_then(|e| {
+                e.get(event_type.as_ref()).map(|s| s.iter().map(|e| e.clone()).collect::<Vec<_>>())
+            })
+            .unwrap_or_default())
+    }
+
     async fn get_profile(
         &self,
         room_id: &RoomId,
@@ -456,6 +483,18 @@ impl StateStore for MemoryStore {
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>> {
         self.get_state_event(room_id, event_type, state_key).await
+    }
+
+    async fn get_state_events(&self, room_id: &RoomId) -> Result<Vec<Raw<AnySyncStateEvent>>> {
+        self.get_state_events(room_id).await
+    }
+
+    async fn get_state_events_by_type(
+        &self,
+        room_id: &RoomId,
+        event_type: EventType,
+    ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
+        self.get_state_events_by_type(room_id, event_type).await
     }
 
     async fn get_profile(

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -133,21 +133,14 @@ pub trait StateStore: AsyncTraitDeps {
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>>;
 
-    /// Get all synced state events for a room.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room to get state events for.
-    async fn get_state_events(&self, room_id: &RoomId) -> Result<Vec<Raw<AnySyncStateEvent>>>;
-
-    /// Get a list of state events for a given `EventType`.
+    /// Get a list of state events for a given room and `EventType`.
     ///
     /// # Arguments
     ///
     /// * `room_id` - The id of the room to find events for.
     ///
-    /// * `event_type` - The event type to find.
-    async fn get_state_events_by_type(
+    /// * `event_type` - The event type.
+    async fn get_state_events(
         &self,
         room_id: &RoomId,
         event_type: EventType,

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -133,6 +133,26 @@ pub trait StateStore: AsyncTraitDeps {
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>>;
 
+    /// Get all synced state events for a room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room to get state events for.
+    async fn get_state_events(&self, room_id: &RoomId) -> Result<Vec<Raw<AnySyncStateEvent>>>;
+
+    /// Get a list of state events for a given `EventType`.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room to find events for.
+    ///
+    /// * `event_type` - The event type to find.
+    async fn get_state_events_by_type(
+        &self,
+        room_id: &RoomId,
+        event_type: EventType,
+    ) -> Result<Vec<Raw<AnySyncStateEvent>>>;
+
     /// Get the current profile for the given user in the given room.
     ///
     /// # Arguments

--- a/matrix_sdk_base/src/store/sled_store/mod.rs
+++ b/matrix_sdk_base/src/store/sled_store/mod.rs
@@ -580,15 +580,7 @@ impl SledStore {
             .transpose()?)
     }
 
-    pub async fn get_state_events(&self, room_id: &RoomId) -> Result<Vec<Raw<AnySyncStateEvent>>> {
-        Ok(self
-            .room_state
-            .scan_prefix((room_id.as_str()).encode())
-            .flat_map(|e| e.map(|(_, e)| self.deserialize_event(&e)))
-            .collect::<Result<_, _>>()?)
-    }
-
-    pub async fn get_state_events_by_type(
+    pub async fn get_state_events(
         &self,
         room_id: &RoomId,
         event_type: EventType,
@@ -821,16 +813,12 @@ impl StateStore for SledStore {
         self.get_state_event(room_id, event_type, state_key).await
     }
 
-    async fn get_state_events(&self, room_id: &RoomId) -> Result<Vec<Raw<AnySyncStateEvent>>> {
-        self.get_state_events(room_id).await
-    }
-
-    async fn get_state_events_by_type(
+    async fn get_state_events(
         &self,
         room_id: &RoomId,
         event_type: EventType,
     ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
-        self.get_state_events_by_type(room_id, event_type).await
+        self.get_state_events(room_id, event_type).await
     }
 
     async fn get_profile(


### PR DESCRIPTION
This PR closes #270 and adds getters for state events to `Store` and `room::Common`

Added to store:
- `get_state_events(&room_id, event_type) -> Result<Vec<Raw<AnySyncStateEvent>>>`

Added to `room::Common`:
- `get_state_event(type, state_key) -> Result<Option<Raw<AnySyncStateEvent>>>`
- `get_state_events(event_type) -> Result<Vec<Raw<AnySyncStateEvent>>>`
  
Questions (Answered):
1. These function names feel pretty verbose, suggestions for better ones?
2. Should the getters in `room::Common` return fully deserialized events converted to [AnyStateEvent](https://docs.ruma.io/ruma/events/enum.AnyStateEvent.html) through [into_full_event](https://docs.ruma.io/ruma/events/enum.AnySyncStateEvent.html#method.into_full_event)?
  - I like having the cleaner `AnyStateEvent` output, but letting the user choose when to error could be nice. We could also return a `Result<Vec<Result<AnyStateEvent>>>`. Outer result is store errors, inner result is `Raw` deserialization errors.
