### PR TITLE
appservice: Add join_room_by_id(_or_alias)

### DIFF
--- a/matrix_sdk_appservice/Cargo.toml
+++ b/matrix_sdk_appservice/Cargo.toml
@@ -40,6 +40,7 @@ env_logger = "0.8"
 mockito = "0.30"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = "0.2"
+urlencoding = "1"
 
 matrix-sdk-test = { version = "0.3", path = "../matrix_sdk_test", features = ["appservice"] }
 

--- a/matrix_sdk_appservice/Cargo.toml
+++ b/matrix_sdk_appservice/Cargo.toml
@@ -33,7 +33,7 @@ matrix-sdk = { version = "0.3", path = "../matrix_sdk", default-features = false
 
 [dependencies.ruma]
 version = "0.2.0"
-features = ["client-api-c", "appservice-api-s", "unstable-pre-spec"]
+features = ["client-api-c", "appservice-api-s", "compat", "unstable-pre-spec"]
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/matrix_sdk_appservice/src/lib.rs
+++ b/matrix_sdk_appservice/src/lib.rs
@@ -93,6 +93,7 @@ use matrix_sdk::{
     bytes::Bytes, reqwest::Url, Client, ClientConfig, EventHandler, HttpError, Session,
 };
 use regex::Regex;
+pub use ruma;
 use ruma::{
     api::{
         appservice::Registration,

--- a/matrix_sdk_appservice/src/webserver/warp.rs
+++ b/matrix_sdk_appservice/src/webserver/warp.rs
@@ -152,6 +152,8 @@ mod filters {
 }
 
 mod handlers {
+    use tracing::trace;
+
     use super::*;
 
     pub async fn user(
@@ -177,6 +179,8 @@ mod handlers {
     ) -> StdResult<impl warp::Reply, Rejection> {
         let incoming_transaction: ruma::api::appservice::event::push_events::v1::IncomingRequest =
             ruma::api::IncomingRequest::try_from_http_request(request).map_err(Error::from)?;
+
+        trace!("incoming_transaction: {:?}", &incoming_transaction);
 
         let client = appservice.get_cached_client(None)?;
         client.receive_transaction(incoming_transaction).map_err(Error::from).await?;

--- a/matrix_sdk_test/src/test_json/mod.rs
+++ b/matrix_sdk_test/src/test_json/mod.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value as JsonValue};
 
 pub mod events;
 pub mod members;
+pub mod state;
 pub mod sync;
 
 pub use events::{
@@ -18,6 +19,7 @@ pub use events::{
     REGISTRATION_RESPONSE_ERR, ROOM_ID, ROOM_MESSAGES, TYPING,
 };
 pub use members::MEMBERS;
+pub use state::ROOM_STATE;
 pub use sync::{
     DEFAULT_SYNC_SUMMARY, INVITE_SYNC, LEAVE_SYNC, LEAVE_SYNC_EVENT, MORE_SYNC, SYNC, VOIP_SYNC,
 };

--- a/matrix_sdk_test/src/test_json/state.rs
+++ b/matrix_sdk_test/src/test_json/state.rs
@@ -1,0 +1,87 @@
+use lazy_static::lazy_static;
+use serde_json::{json, Value as JsonValue};
+
+lazy_static! {
+    pub static ref ROOM_STATE: JsonValue = json!([
+        {
+          "content": {
+            "join_rule": "public"
+          },
+          "event_id": "$143273582443PhrSn:example.org",
+          "origin_server_ts": 1432735824653i64,
+          "room_id": "!SVkFJHzfwvuaIEawgC:localhost",
+          "sender": "@example:example.org",
+          "state_key": "",
+          "type": "m.room.join_rules",
+          "unsigned": {
+            "age": 1234
+          }
+        },
+        {
+          "content": {
+            "avatar_url": "mxc://example.org/SEsfnsuifSDFSSEF",
+            "displayname": "Alice Margatroid",
+            "membership": "join"
+          },
+          "event_id": "$143273582443PhrSn:example.org",
+          "origin_server_ts": 1432735824653i64,
+          "room_id": "!SVkFJHzfwvuaIEawgC:localhost",
+          "sender": "@example:example.org",
+          "state_key": "@alice:example.org",
+          "type": "m.room.member",
+          "unsigned": {
+            "age": 1234
+          }
+        },
+        {
+          "content": {
+            "creator": "@example:example.org",
+            "m.federate": true,
+            "predecessor": {
+              "event_id": "$something:example.org",
+              "room_id": "!oldroom:example.org"
+            },
+            "room_version": "1"
+          },
+          "event_id": "$143273582443PhrSn:example.org",
+          "origin_server_ts": 1432735824653i64,
+          "room_id": "!SVkFJHzfwvuaIEawgC:localhost",
+          "sender": "@example:example.org",
+          "state_key": "",
+          "type": "m.room.create",
+          "unsigned": {
+            "age": 1234
+          }
+        },
+        {
+          "content": {
+            "ban": 50,
+            "events": {
+              "m.room.name": 100,
+              "m.room.power_levels": 100
+            },
+            "events_default": 0,
+            "invite": 50,
+            "kick": 50,
+            "notifications": {
+              "room": 20
+            },
+            "redact": 50,
+            "state_default": 50,
+            "users": {
+              "@example:localhost": 100
+            },
+            "users_default": 0
+          },
+          "event_id": "$143273582443PhrSn:example.org",
+          "origin_server_ts": 1432735824653i64,
+          "room_id": "!SVkFJHzfwvuaIEawgC:localhost",
+          "sender": "@example:example.org",
+          "state_key": "",
+          "type": "m.room.power_levels",
+          "unsigned": {
+            "age": 1234
+          }
+        }
+    ]);
+}


### PR DESCRIPTION
Adds an appservice-specific way of joining rooms that makes sure room state is synced once (via the room `/state` C2S API) before the method returns so that we have a valid state before proceeding.

This still feels a bit brittle, it might actually make more sense to have a low-level functionality that checks for proper room state, that could also cover the case of syncing state for rooms that are already joined but state store was not persisted, which the regular `Client` does cover through `sync`* methods when there was no sync before the first one. But it should be OK for a first iteration and having the tests for it makes sense anyway.

Part of #228