### PR TITLE
Clean up reexports

### DIFF
--- a/matrix_sdk/examples/autojoin.rs
+++ b/matrix_sdk/examples/autojoin.rs
@@ -1,9 +1,9 @@
 use std::{env, process::exit};
 
 use matrix_sdk::{
-    self, async_trait,
-    events::{room::member::MemberEventContent, StrippedStateEvent},
+    async_trait,
     room::Room,
+    ruma::events::{room::member::MemberEventContent, StrippedStateEvent},
     Client, ClientConfig, EventHandler, SyncSettings,
 };
 use tokio::time::{sleep, Duration};

--- a/matrix_sdk/examples/command_bot.rs
+++ b/matrix_sdk/examples/command_bot.rs
@@ -1,12 +1,12 @@
 use std::{env, process::exit};
 
 use matrix_sdk::{
-    self, async_trait,
-    events::{
+    async_trait,
+    room::Room,
+    ruma::events::{
         room::message::{MessageEventContent, MessageType, TextMessageEventContent},
         AnyMessageEventContent, SyncMessageEvent,
     },
-    room::Room,
     Client, ClientConfig, EventHandler, SyncSettings,
 };
 use url::Url;

--- a/matrix_sdk/examples/cross_signing_bootstrap.rs
+++ b/matrix_sdk/examples/cross_signing_bootstrap.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use matrix_sdk::{
-    self, api::r0::uiaa::AuthData, identifiers::UserId, Client, LoopCtrl, SyncSettings,
+    ruma::{api::client::r0::uiaa::AuthData, UserId},
+    Client, LoopCtrl, SyncSettings,
 };
 use serde_json::json;
 use url::Url;

--- a/matrix_sdk/examples/emoji_verification.rs
+++ b/matrix_sdk/examples/emoji_verification.rs
@@ -9,8 +9,12 @@ use std::{
 
 use matrix_sdk::{
     self,
-    events::{room::message::MessageType, AnySyncMessageEvent, AnySyncRoomEvent, AnyToDeviceEvent},
-    identifiers::UserId,
+    ruma::{
+        events::{
+            room::message::MessageType, AnySyncMessageEvent, AnySyncRoomEvent, AnyToDeviceEvent,
+        },
+        UserId,
+    },
     verification::{SasVerification, Verification},
     Client, LoopCtrl, SyncSettings,
 };

--- a/matrix_sdk/examples/get_profiles.rs
+++ b/matrix_sdk/examples/get_profiles.rs
@@ -1,9 +1,7 @@
 use std::{convert::TryFrom, env, process::exit};
 
 use matrix_sdk::{
-    self,
-    api::r0::profile,
-    identifiers::{MxcUri, UserId},
+    ruma::{api::client::r0::profile, MxcUri, UserId},
     Client, Result as MatrixResult,
 };
 use url::Url;

--- a/matrix_sdk/examples/image_bot.rs
+++ b/matrix_sdk/examples/image_bot.rs
@@ -9,11 +9,11 @@ use std::{
 
 use matrix_sdk::{
     self, async_trait,
-    events::{
+    room::Room,
+    ruma::events::{
         room::message::{MessageEventContent, MessageType, TextMessageEventContent},
         SyncMessageEvent,
     },
-    room::Room,
     Client, EventHandler, SyncSettings,
 };
 use tokio::sync::Mutex;

--- a/matrix_sdk/examples/login.rs
+++ b/matrix_sdk/examples/login.rs
@@ -2,11 +2,11 @@ use std::{env, process::exit};
 
 use matrix_sdk::{
     self, async_trait,
-    events::{
+    room::Room,
+    ruma::events::{
         room::message::{MessageEventContent, MessageType, TextMessageEventContent},
         SyncMessageEvent,
     },
-    room::Room,
     Client, EventHandler, SyncSettings,
 };
 use url::Url;

--- a/matrix_sdk/examples/wasm_command_bot/src/lib.rs
+++ b/matrix_sdk/examples/wasm_command_bot/src/lib.rs
@@ -1,10 +1,12 @@
 use matrix_sdk::{
     deserialized_responses::SyncResponse,
-    events::{
-        room::message::{MessageEventContent, MessageType, TextMessageEventContent},
-        AnyMessageEventContent, AnySyncMessageEvent, AnySyncRoomEvent, SyncMessageEvent,
+    ruma::{
+        events::{
+            room::message::{MessageEventContent, MessageType, TextMessageEventContent},
+            AnyMessageEventContent, AnySyncMessageEvent, AnySyncRoomEvent, SyncMessageEvent,
+        },
+        RoomId,
     },
-    identifiers::RoomId,
     Client, LoopCtrl, SyncSettings,
 };
 use url::Url;

--- a/matrix_sdk/examples/wasm_command_bot/src/lib.rs
+++ b/matrix_sdk/examples/wasm_command_bot/src/lib.rs
@@ -60,7 +60,9 @@ impl WasmBot {
 
         for (room_id, room) in response.rooms.join {
             for event in room.timeline.events {
-                if let Ok(AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(ev))) = event.event.deserialize() {
+                if let Ok(AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(ev))) =
+                    event.event.deserialize()
+                {
                     self.on_room_message(&room_id, &ev).await
                 }
             }
@@ -81,19 +83,14 @@ pub async fn run() -> Result<JsValue, JsValue> {
     let homeserver_url = Url::parse(&homeserver_url).unwrap();
     let client = Client::new(homeserver_url).unwrap();
 
-    client
-        .login(username, password, None, Some("rust-sdk-wasm"))
-        .await
-        .unwrap();
+    client.login(username, password, None, Some("rust-sdk-wasm")).await.unwrap();
 
     let bot = WasmBot(client.clone());
 
     client.sync_once(SyncSettings::default()).await.unwrap();
 
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
-    client
-        .sync_with_callback(settings, |response| bot.on_sync_response(response))
-        .await;
+    client.sync_with_callback(settings, |response| bot.on_sync_response(response)).await;
 
     Ok(JsValue::NULL)
 }

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -571,7 +571,7 @@ impl Client {
     /// # Example
     /// ```no_run
     /// # use std::convert::TryFrom;
-    /// # use matrix_sdk::{Client, identifiers::UserId};
+    /// # use matrix_sdk::{Client, ruma::UserId};
     /// # use futures::executor::block_on;
     /// let alice = UserId::try_from("@alice:example.org").unwrap();
     /// # block_on(async {
@@ -792,7 +792,7 @@ impl Client {
     /// ```no_run
     /// # use futures::executor::block_on;
     /// # use matrix_sdk::Client;
-    /// # use matrix_sdk::identifiers::room_id;
+    /// # use matrix_sdk::ruma::room_id;
     /// # use matrix_sdk::media::MediaFormat;
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
@@ -1001,8 +1001,7 @@ impl Client {
     /// ```no_run
     /// # use std::convert::TryFrom;
     /// # use matrix_sdk::Client;
-    /// # use matrix_sdk::identifiers::DeviceId;
-    /// # use matrix_sdk::assign;
+    /// # use matrix_sdk::ruma::{assign, DeviceId};
     /// # use futures::executor::block_on;
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
@@ -1260,8 +1259,7 @@ impl Client {
     /// ```no_run
     /// # use std::convert::TryFrom;
     /// # use matrix_sdk::Client;
-    /// # use matrix_sdk::identifiers::DeviceId;
-    /// # use matrix_sdk::assign;
+    /// # use matrix_sdk::ruma::{assign, DeviceId};
     /// # use futures::executor::block_on;
     /// # use url::Url;
     /// # let homeserver = Url::parse("https://example.com").unwrap();
@@ -1340,10 +1338,13 @@ impl Client {
     /// ```no_run
     /// # use std::convert::TryFrom;
     /// # use matrix_sdk::Client;
-    /// # use matrix_sdk::api::r0::account::register::{Request as RegistrationRequest, RegistrationKind};
-    /// # use matrix_sdk::api::r0::uiaa::AuthData;
-    /// # use matrix_sdk::identifiers::DeviceId;
-    /// # use matrix_sdk::assign;
+    /// # use matrix_sdk::ruma::{
+    /// #     api::client::r0::{
+    /// #         account::register::{Request as RegistrationRequest, RegistrationKind},
+    /// #         uiaa::AuthData,
+    /// #     },
+    /// #     assign, DeviceId,
+    /// # };
     /// # use futures::executor::block_on;
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
@@ -1393,7 +1394,7 @@ impl Client {
     /// ```no_run
     /// # use matrix_sdk::{
     /// #    Client, SyncSettings,
-    /// #    api::r0::{
+    /// #    ruma::api::client::r0::{
     /// #        filter::{
     /// #           FilterDefinition, LazyLoadOptions, RoomEventFilter, RoomFilter,
     /// #        },
@@ -1537,7 +1538,10 @@ impl Client {
     /// # Examples
     /// ```no_run
     /// use matrix_sdk::Client;
-    /// # use matrix_sdk::api::r0::room::{create_room::Request as CreateRoomRequest, Visibility};
+    /// # use matrix_sdk::ruma::api::client::r0::room::{
+    /// #     create_room::Request as CreateRoomRequest,
+    /// #     Visibility,
+    /// # };
     /// # use url::Url;
     ///
     /// # let homeserver = Url::parse("http://example.com").unwrap();
@@ -1570,9 +1574,11 @@ impl Client {
     /// ```no_run
     /// # use std::convert::TryFrom;
     /// # use matrix_sdk::Client;
-    /// # use matrix_sdk::directory::{Filter, RoomNetwork};
-    /// # use matrix_sdk::api::r0::directory::get_public_rooms_filtered::Request as PublicRoomsFilterRequest;
-    /// # use matrix_sdk::assign;
+    /// # use matrix_sdk::ruma::{
+    /// #     api::client::r0::directory::get_public_rooms_filtered::Request as PublicRoomsFilterRequest,
+    /// #     directory::{Filter, RoomNetwork},
+    /// #     assign,
+    /// # };
     /// # use url::Url;
     /// # use futures::executor::block_on;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
@@ -1623,7 +1629,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use std::{path::PathBuf, fs::File, io::Read};
-    /// # use matrix_sdk::{Client, identifiers::room_id};
+    /// # use matrix_sdk::{Client, ruma::room_id};
     /// # use url::Url;
     /// # use futures::executor::block_on;
     /// # use mime;
@@ -1690,9 +1696,9 @@ impl Client {
     /// # use matrix_sdk::{Client, SyncSettings};
     /// # use url::Url;
     /// # use futures::executor::block_on;
-    /// # use matrix_sdk::identifiers::room_id;
+    /// # use matrix_sdk::ruma::room_id;
     /// # use std::convert::TryFrom;
-    /// use matrix_sdk::events::{
+    /// use matrix_sdk::ruma::events::{
     ///     AnyMessageEventContent,
     ///     room::message::{MessageEventContent, TextMessageEventContent},
     /// };
@@ -1752,8 +1758,7 @@ impl Client {
     /// # block_on(async {
     /// # let homeserver = Url::parse("http://localhost:8080").unwrap();
     /// # let mut client = Client::new(homeserver).unwrap();
-    /// use matrix_sdk::api::r0::profile;
-    /// use matrix_sdk::identifiers::user_id;
+    /// use matrix_sdk::ruma::{api::client::r0::profile, user_id};
     ///
     /// // First construct the request you want to make
     /// // See https://docs.rs/ruma-client-api/latest/ruma_client_api/index.html
@@ -1839,8 +1844,11 @@ impl Client {
     ///
     /// ```no_run
     /// # use matrix_sdk::{
-    /// #    api::r0::uiaa::{UiaaResponse, AuthData},
-    /// #    Client, SyncSettings, Error, FromHttpResponseError, ServerError,
+    /// #    ruma::api::{
+    /// #        client::r0::uiaa::{UiaaResponse, AuthData},
+    /// #        error::{FromHttpResponseError, ServerError},
+    /// #    },
+    /// #    Client, Error, SyncSettings,
     /// # };
     /// # use futures::executor::block_on;
     /// # use serde_json::json;
@@ -1959,7 +1967,7 @@ impl Client {
     /// UI thread.
     ///
     /// ```no_run
-    /// # use matrix_sdk::events::{
+    /// # use matrix_sdk::ruma::events::{
     /// #     room::message::{MessageEvent, MessageEventContent, TextMessageEventContent},
     /// # };
     /// # use std::sync::{Arc, RwLock};
@@ -2228,7 +2236,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use std::convert::TryFrom;
-    /// # use matrix_sdk::{Client, identifiers::UserId};
+    /// # use matrix_sdk::{Client, ruma::UserId};
     /// # use url::Url;
     /// # use futures::executor::block_on;
     /// # let alice = UserId::try_from("@alice:example.org").unwrap();
@@ -2270,8 +2278,8 @@ impl Client {
     /// # Examples
     /// ```no_run
     /// # use std::{convert::TryFrom, collections::BTreeMap};
-    /// # use matrix_sdk::{Client, identifiers::UserId};
-    /// # use matrix_sdk::api::r0::uiaa::AuthData;
+    /// # use matrix_sdk::{Client, ruma::UserId};
+    /// # use matrix_sdk::ruma::api::client::r0::uiaa::AuthData;
     /// # use url::Url;
     /// # use futures::executor::block_on;
     /// # use serde_json::json;
@@ -2341,7 +2349,7 @@ impl Client {
     ///
     /// ```no_run
     /// # use std::convert::TryFrom;
-    /// # use matrix_sdk::{Client, identifiers::UserId};
+    /// # use matrix_sdk::{Client, ruma::UserId};
     /// # use url::Url;
     /// # use futures::executor::block_on;
     /// # let alice = UserId::try_from("@alice:example.org").unwrap();
@@ -2395,7 +2403,7 @@ impl Client {
     /// # use std::{path::PathBuf, time::Duration};
     /// # use matrix_sdk::{
     /// #     Client, SyncSettings,
-    /// #     identifiers::room_id,
+    /// #     ruma::room_id,
     /// # };
     /// # use futures::executor::block_on;
     /// # use url::Url;
@@ -2465,7 +2473,7 @@ impl Client {
     /// # use std::{path::PathBuf, time::Duration};
     /// # use matrix_sdk::{
     /// #     Client, SyncSettings,
-    /// #     identifiers::room_id,
+    /// #     ruma::room_id,
     /// # };
     /// # use futures::executor::block_on;
     /// # use url::Url;

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -13,11 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(all(feature = "encryption", not(target_arch = "wasm32")))]
+use std::path::PathBuf;
 #[cfg(feature = "encryption")]
 use std::{
     collections::BTreeMap,
     io::{Cursor, Write},
-    path::PathBuf,
 };
 #[cfg(feature = "sso_login")]
 use std::{
@@ -39,10 +40,12 @@ use futures_timer::Delay as sleep;
 use http::HeaderValue;
 #[cfg(feature = "sso_login")]
 use http::Response;
+#[cfg(all(feature = "encryption", not(target_arch = "wasm32")))]
+use matrix_sdk_base::crypto::{decrypt_key_export, encrypt_key_export, olm::InboundGroupSession};
 #[cfg(feature = "encryption")]
 use matrix_sdk_base::crypto::{
-    decrypt_key_export, encrypt_key_export, olm::InboundGroupSession, store::CryptoStoreError,
-    AttachmentDecryptor, OutgoingRequests, RoomMessageRequest, ToDeviceRequest,
+    store::CryptoStoreError, AttachmentDecryptor, OutgoingRequests, RoomMessageRequest,
+    ToDeviceRequest,
 };
 use matrix_sdk_base::{
     deserialized_responses::SyncResponse,
@@ -64,7 +67,7 @@ use tracing::{error, info, instrument};
 use url::Url;
 #[cfg(feature = "sso_login")]
 use warp::Filter;
-#[cfg(feature = "encryption")]
+#[cfg(all(feature = "encryption", not(target_arch = "wasm32")))]
 use zeroize::Zeroizing;
 
 /// Enum controlling if a loop running callbacks should continue or abort.
@@ -2427,8 +2430,7 @@ impl Client {
     ///     .expect("Can't export keys.");
     /// # });
     /// ```
-    #[cfg(feature = "encryption")]
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(feature = "encryption", not(target_arch = "wasm32")))]
     #[cfg_attr(feature = "docs", doc(cfg(all(encryption, not(target_arch = "wasm32")))))]
     pub async fn export_keys(
         &self,
@@ -2487,8 +2489,7 @@ impl Client {
     ///     .expect("Can't import keys");
     /// # });
     /// ```
-    #[cfg(feature = "encryption")]
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(feature = "encryption", not(target_arch = "wasm32")))]
     #[cfg_attr(feature = "docs", doc(cfg(all(encryption, not(target_arch = "wasm32")))))]
     pub async fn import_keys(&self, path: PathBuf, passphrase: &str) -> Result<(usize, usize)> {
         let olm = self.base_client.olm_machine().await.ok_or(Error::AuthenticationRequired)?;

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -56,7 +56,7 @@ use mime::{self, Mime};
 #[cfg(feature = "sso_login")]
 use rand::{thread_rng, Rng};
 use reqwest::header::InvalidHeaderValue;
-use ruma::{api::SendAccessToken, events::AnyMessageEventContent, identifiers::MxcUri};
+use ruma::{api::SendAccessToken, events::AnyMessageEventContent, MxcUri};
 #[cfg(feature = "sso_login")]
 use tokio::{net::TcpListener, sync::oneshot};
 #[cfg(feature = "sso_login")]

--- a/matrix_sdk/src/device.rs
+++ b/matrix_sdk/src/device.rs
@@ -47,7 +47,7 @@ impl Device {
     ///
     /// ```no_run
     /// # use std::convert::TryFrom;
-    /// # use matrix_sdk::{Client, identifiers::UserId};
+    /// # use matrix_sdk::{Client, ruma::UserId};
     /// # use url::Url;
     /// # use futures::executor::block_on;
     /// # let alice = UserId::try_from("@alice:example.org").unwrap();

--- a/matrix_sdk/src/error.rs
+++ b/matrix_sdk/src/error.rs
@@ -120,11 +120,13 @@ pub enum Error {
 
     /// An error occurred in the crypto store.
     #[cfg(feature = "encryption")]
+    #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
     #[error(transparent)]
     CryptoStoreError(#[from] CryptoStoreError),
 
     /// An error occurred during decryption.
     #[cfg(feature = "encryption")]
+    #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
     #[error(transparent)]
     DecryptorError(#[from] DecryptorError),
 

--- a/matrix_sdk/src/event_handler/mod.rs
+++ b/matrix_sdk/src/event_handler/mod.rs
@@ -375,7 +375,7 @@ pub enum CustomEvent<'c> {
 /// # use matrix_sdk::{
 /// #     async_trait,
 /// #     EventHandler,
-/// #     events::{
+/// #     ruma::events::{
 /// #         room::message::{MessageEventContent, MessageType, TextMessageEventContent},
 /// #         SyncMessageEvent
 /// #     },

--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -18,6 +18,7 @@ use std::{convert::TryFrom, fmt::Debug, sync::Arc};
 
 #[cfg(all(not(target_arch = "wasm32")))]
 use backoff::{future::retry, Error as RetryError, ExponentialBackoff};
+use bytes::{Bytes, BytesMut};
 #[cfg(all(not(target_arch = "wasm32")))]
 use http::StatusCode;
 use http::{HeaderValue, Response as HttpResponse};
@@ -30,7 +31,7 @@ use ruma::api::{
 use tracing::trace;
 use url::Url;
 
-use crate::{error::HttpError, Bytes, BytesMut, ClientConfig, RequestConfig, Session};
+use crate::{error::HttpError, ClientConfig, RequestConfig, Session};
 
 /// Abstraction around the http layer. The allows implementors to use different
 /// http libraries.
@@ -54,7 +55,7 @@ pub trait HttpSend: AsyncTraitDeps {
     ///
     /// ```
     /// use std::convert::TryFrom;
-    /// use matrix_sdk::{HttpSend, async_trait, HttpError, RequestConfig, Bytes};
+    /// use matrix_sdk::{HttpSend, async_trait, HttpError, RequestConfig, bytes::Bytes};
     ///
     /// #[derive(Debug)]
     /// struct Client(reqwest::Client);

--- a/matrix_sdk/src/http_client.rs
+++ b/matrix_sdk/src/http_client.rs
@@ -12,16 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(not(target_arch = "wasm32")))]
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::{convert::TryFrom, fmt::Debug, sync::Arc};
 
-#[cfg(all(not(target_arch = "wasm32")))]
-use backoff::{future::retry, Error as RetryError, ExponentialBackoff};
 use bytes::{Bytes, BytesMut};
-#[cfg(all(not(target_arch = "wasm32")))]
-use http::StatusCode;
-use http::{HeaderValue, Response as HttpResponse};
+use http::Response as HttpResponse;
 use matrix_sdk_common::{async_trait, locks::RwLock, AsyncTraitDeps};
 use reqwest::{Client, Response};
 use ruma::api::{
@@ -236,6 +230,8 @@ pub(crate) fn client_with_config(config: &ClientConfig) -> Result<Client, HttpEr
 
     #[cfg(not(target_arch = "wasm32"))]
     let http_client = {
+        use http::HeaderValue;
+
         let http_client = if config.disable_ssl_verification {
             http_client.danger_accept_invalid_certs(true)
         } else {
@@ -304,6 +300,11 @@ async fn send_request(
     request: http::Request<Bytes>,
     config: RequestConfig,
 ) -> Result<http::Response<Bytes>, HttpError> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use backoff::{future::retry, Error as RetryError, ExponentialBackoff};
+    use http::StatusCode;
+
     let mut backoff = ExponentialBackoff::default();
     let mut request = reqwest::Request::try_from(request)?;
     let retry_limit = config.retry_limit;

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -75,7 +75,7 @@ compile_error!("only one of 'native-tls' or 'rustls-tls' features can be enabled
 #[cfg(all(feature = "sso_login", target_arch = "wasm32"))]
 compile_error!("'sso_login' cannot be enabled on 'wasm32' arch");
 
-pub use bytes::{Bytes, BytesMut};
+pub use bytes;
 #[cfg(feature = "encryption")]
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
 pub use matrix_sdk_base::crypto::{EncryptionInfo, LocalTrust};
@@ -85,23 +85,8 @@ pub use matrix_sdk_base::{
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;
-#[cfg(feature = "appservice")]
-pub use ruma::{
-    api::{appservice as api_appservice, IncomingRequest, OutgoingRequestAppserviceExt},
-    serde::{exports::serde::de::value::Error as SerdeError, urlencoded},
-};
-pub use ruma::{
-    api::{
-        client as api,
-        error::{
-            FromHttpRequestError, FromHttpResponseError, IntoHttpError, MatrixError, ServerError,
-        },
-        AuthScheme, EndpointError, IncomingResponse, OutgoingRequest, SendAccessToken,
-    },
-    assign, directory, encryption, events, identifiers, int, presence, push, receipt,
-    serde::{CanonicalJsonValue, Raw},
-    thirdparty, uint, Int, MilliSecondsSinceUnixEpoch, Outgoing, SecondsSinceUnixEpoch, UInt,
-};
+#[doc(no_inline)]
+pub use ruma;
 
 mod client;
 mod error;

--- a/matrix_sdk/src/lib.rs
+++ b/matrix_sdk/src/lib.rs
@@ -80,8 +80,8 @@ pub use bytes;
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
 pub use matrix_sdk_base::crypto::{EncryptionInfo, LocalTrust};
 pub use matrix_sdk_base::{
-    media, Error as BaseError, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomType,
-    Session, StateChanges, StoreError,
+    media, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomType, Session,
+    StateChanges, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;

--- a/matrix_sdk/src/room/common.rs
+++ b/matrix_sdk/src/room/common.rs
@@ -79,7 +79,7 @@ impl Common {
     /// ```no_run
     /// # use futures::executor::block_on;
     /// # use matrix_sdk::Client;
-    /// # use matrix_sdk::identifiers::room_id;
+    /// # use matrix_sdk::ruma::room_id;
     /// # use matrix_sdk::media::MediaFormat;
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
@@ -118,9 +118,11 @@ impl Common {
     /// ```no_run
     /// # use std::convert::TryFrom;
     /// use matrix_sdk::Client;
-    /// # use matrix_sdk::identifiers::room_id;
-    /// # use matrix_sdk::api::r0::filter::RoomEventFilter;
-    /// # use matrix_sdk::api::r0::message::get_message_events::Request as MessagesRequest;
+    /// # use matrix_sdk::ruma::room_id;
+    /// # use matrix_sdk::ruma::api::client::r0::{
+    /// #     filter::RoomEventFilter,
+    /// #     message::get_message_events::Request as MessagesRequest,
+    /// # };
     /// # use url::Url;
     ///
     /// # let homeserver = Url::parse("http://example.com").unwrap();

--- a/matrix_sdk/src/room/joined.rs
+++ b/matrix_sdk/src/room/joined.rs
@@ -159,10 +159,10 @@ impl Joined {
     ///
     /// ```no_run
     /// use std::time::Duration;
-    /// use matrix_sdk::api::r0::typing::create_typing_event::Typing;
+    /// use matrix_sdk::ruma::api::client::r0::typing::create_typing_event::Typing;
     /// # use matrix_sdk::{
     /// #     Client, SyncSettings,
-    /// #     identifiers::room_id,
+    /// #     ruma::room_id,
     /// # };
     /// # use futures::executor::block_on;
     /// # use url::Url;
@@ -349,9 +349,9 @@ impl Joined {
     /// # use matrix_sdk::{Client, SyncSettings};
     /// # use url::Url;
     /// # use futures::executor::block_on;
-    /// # use matrix_sdk::identifiers::room_id;
+    /// # use matrix_sdk::ruma::room_id;
     /// # use std::convert::TryFrom;
-    /// use matrix_sdk::events::{
+    /// use matrix_sdk::ruma::events::{
     ///     AnyMessageEventContent,
     ///     room::message::{MessageEventContent, TextMessageEventContent},
     /// };
@@ -431,7 +431,7 @@ impl Joined {
     ///
     /// ```no_run
     /// # use std::{path::PathBuf, fs::File, io::Read};
-    /// # use matrix_sdk::{Client, identifiers::room_id};
+    /// # use matrix_sdk::{Client, ruma::room_id};
     /// # use url::Url;
     /// # use mime;
     /// # use futures::executor::block_on;
@@ -532,18 +532,17 @@ impl Joined {
     /// # Example
     ///
     /// ```no_run
-    /// use matrix_sdk::{
+    /// use matrix_sdk::ruma::{
     ///     events::{
     ///         AnyStateEventContent,
     ///         room::member::{MemberEventContent, MembershipState},
     ///     },
-    ///     identifiers::mxc_uri,
-    ///     assign,
+    ///     assign, mxc_uri,
     /// };
     /// # futures::executor::block_on(async {
     /// # let homeserver = url::Url::parse("http://localhost:8080").unwrap();
     /// # let mut client = matrix_sdk::Client::new(homeserver).unwrap();
-    /// # let room_id = matrix_sdk::identifiers::room_id!("!test:localhost");
+    /// # let room_id = matrix_sdk::ruma::room_id!("!test:localhost");
     ///
     /// let avatar_url = mxc_uri!("mxc://example.org/avatar");
     /// let member_event = assign!(MemberEventContent::new(MembershipState::Join), {
@@ -591,11 +590,11 @@ impl Joined {
     /// # futures::executor::block_on(async {
     /// # let homeserver = url::Url::parse("http://localhost:8080").unwrap();
     /// # let mut client = matrix_sdk::Client::new(homeserver).unwrap();
-    /// # let room_id = matrix_sdk::identifiers::room_id!("!test:localhost");
+    /// # let room_id = matrix_sdk::ruma::room_id!("!test:localhost");
     /// # let room = client
     /// #   .get_joined_room(&room_id)
     /// #   .unwrap();
-    /// let event_id = matrix_sdk::identifiers::event_id!("$xxxxxx:example.org");
+    /// let event_id = matrix_sdk::ruma::event_id!("$xxxxxx:example.org");
     /// let reason = Some("Indecent material");
     /// room.redact(&event_id, reason, None).await.unwrap();
     /// # })

--- a/matrix_sdk/src/room/joined.rs
+++ b/matrix_sdk/src/room/joined.rs
@@ -38,8 +38,8 @@ use ruma::{
         },
         AnyMessageEventContent, AnyStateEventContent,
     },
-    identifiers::{EventId, UserId},
     receipt::ReceiptType,
+    EventId, UserId,
 };
 #[cfg(feature = "encryption")]
 use tracing::instrument;

--- a/matrix_sdk/src/room_member.rs
+++ b/matrix_sdk/src/room_member.rs
@@ -39,7 +39,7 @@ impl RoomMember {
     /// ```no_run
     /// # use futures::executor::block_on;
     /// # use matrix_sdk::Client;
-    /// # use matrix_sdk::identifiers::room_id;
+    /// # use matrix_sdk::ruma::room_id;
     /// # use matrix_sdk::RoomMember;
     /// # use matrix_sdk::media::MediaFormat;
     /// # use url::Url;

--- a/matrix_sdk/src/verification/sas.rs
+++ b/matrix_sdk/src/verification/sas.rs
@@ -42,7 +42,7 @@ impl SasVerification {
     /// # use matrix_sdk::Client;
     /// # use futures::executor::block_on;
     /// # use url::Url;
-    /// # use ruma::identifiers::user_id;
+    /// # use ruma::user_id;
     /// use matrix_sdk::verification::SasVerification;
     /// use matrix_sdk_base::crypto::AcceptSettings;
     /// use matrix_sdk::ruma::events::key::verification::ShortAuthenticationString;

--- a/matrix_sdk/src/verification/sas.rs
+++ b/matrix_sdk/src/verification/sas.rs
@@ -45,7 +45,7 @@ impl SasVerification {
     /// # use ruma::identifiers::user_id;
     /// use matrix_sdk::verification::SasVerification;
     /// use matrix_sdk_base::crypto::AcceptSettings;
-    /// use matrix_sdk::events::key::verification::ShortAuthenticationString;
+    /// use matrix_sdk::ruma::events::key::verification::ShortAuthenticationString;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
     /// # let client = Client::new(homeserver).unwrap();
     /// # let flow_id = "someID";

--- a/matrix_sdk_appservice/examples/appservice_autojoin.rs
+++ b/matrix_sdk_appservice/examples/appservice_autojoin.rs
@@ -3,12 +3,14 @@ use std::{convert::TryFrom, env};
 use matrix_sdk_appservice::{
     matrix_sdk::{
         async_trait,
-        events::{
-            room::member::{MemberEventContent, MembershipState},
-            SyncStateEvent,
-        },
-        identifiers::UserId,
         room::Room,
+        ruma::{
+            events::{
+                room::member::{MemberEventContent, MembershipState},
+                SyncStateEvent,
+            },
+            UserId,
+        },
         EventHandler,
     },
     AppService, AppServiceRegistration,

--- a/matrix_sdk_appservice/src/lib.rs
+++ b/matrix_sdk_appservice/src/lib.rs
@@ -89,7 +89,9 @@ use dashmap::DashMap;
 pub use error::Error;
 use http::{uri::PathAndQuery, Uri};
 pub use matrix_sdk;
-use matrix_sdk::{reqwest::Url, Bytes, Client, ClientConfig, EventHandler, HttpError, Session};
+use matrix_sdk::{
+    bytes::Bytes, reqwest::Url, Client, ClientConfig, EventHandler, HttpError, Session,
+};
 use regex::Regex;
 #[doc(inline)]
 pub use ruma::api::{appservice as api, appservice::Registration};

--- a/matrix_sdk_appservice/src/lib.rs
+++ b/matrix_sdk_appservice/src/lib.rs
@@ -89,14 +89,15 @@ use dashmap::DashMap;
 pub use error::Error;
 use http::{uri::PathAndQuery, Uri};
 pub use matrix_sdk;
+#[doc(no_inline)]
+pub use matrix_sdk::ruma;
 use matrix_sdk::{
     bytes::Bytes, reqwest::Url, Client, ClientConfig, EventHandler, HttpError, Session,
 };
 use regex::Regex;
-#[doc(inline)]
-pub use ruma::api::{appservice as api, appservice::Registration};
 use ruma::{
     api::{
+        appservice::Registration,
         client::{
             error::ErrorKind,
             r0::{account::register, uiaa::UiaaResponse},

--- a/matrix_sdk_appservice/src/webserver/warp.rs
+++ b/matrix_sdk_appservice/src/webserver/warp.rs
@@ -15,7 +15,7 @@
 use std::{net::ToSocketAddrs, result::Result as StdResult};
 
 use futures::TryFutureExt;
-use matrix_sdk::Bytes;
+use matrix_sdk::{bytes::Bytes, ruma};
 use serde::Serialize;
 use warp::{filters::BoxedFilter, path::FullPath, Filter, Rejection, Reply};
 
@@ -110,7 +110,7 @@ mod filters {
             .and(warp::query::raw())
             .and_then(|token: String, query: String| async move {
                 let query: Vec<(String, String)> =
-                    matrix_sdk::urlencoded::from_str(&query).map_err(Error::from)?;
+                    ruma::serde::urlencoded::from_str(&query).map_err(Error::from)?;
 
                 if query.into_iter().any(|(key, value)| key == "access_token" && value == token) {
                     Ok::<(), Rejection>(())
@@ -175,8 +175,8 @@ mod handlers {
         appservice: AppService,
         request: http::Request<Bytes>,
     ) -> StdResult<impl warp::Reply, Rejection> {
-        let incoming_transaction: matrix_sdk::api_appservice::event::push_events::v1::IncomingRequest =
-            matrix_sdk::IncomingRequest::try_from_http_request(request).map_err(Error::from)?;
+        let incoming_transaction: ruma::api::appservice::event::push_events::v1::IncomingRequest =
+            ruma::api::IncomingRequest::try_from_http_request(request).map_err(Error::from)?;
 
         let client = appservice.get_cached_client(None)?;
         client.receive_transaction(incoming_transaction).map_err(Error::from).await?;

--- a/matrix_sdk_appservice/tests/tests.rs
+++ b/matrix_sdk_appservice/tests/tests.rs
@@ -3,10 +3,12 @@ use std::sync::{Arc, Mutex};
 #[cfg(feature = "actix")]
 use actix_web::{test as actix_test, App as ActixApp, HttpResponse};
 use matrix_sdk::{
-    api_appservice::Registration,
     async_trait,
-    events::{room::member::MemberEventContent, SyncStateEvent},
     room::Room,
+    ruma::{
+        api::appservice::Registration,
+        events::{room::member::MemberEventContent, SyncStateEvent},
+    },
     ClientConfig, EventHandler, RequestConfig,
 };
 use matrix_sdk_appservice::*;

--- a/matrix_sdk_base/examples/state_inspector.rs
+++ b/matrix_sdk_base/examples/state_inspector.rs
@@ -6,10 +6,7 @@ use atty::Stream;
 use clap::{App as Argparse, AppSettings as ArgParseSettings, Arg, ArgMatches, SubCommand};
 use futures::executor::block_on;
 use matrix_sdk_base::{RoomInfo, Store};
-use ruma::{
-    events::EventType,
-    identifiers::{RoomId, UserId},
-};
+use ruma::{events::EventType, RoomId, UserId};
 #[cfg(not(target_arch = "wasm32"))]
 use rustyline::{
     completion::{Completer, Pair},

--- a/matrix_sdk_base/src/store/memory_store.rs
+++ b/matrix_sdk_base/src/store/memory_store.rs
@@ -28,9 +28,9 @@ use ruma::{
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncStateEvent, EventType,
     },
-    identifiers::{EventId, MxcUri, RoomId, UserId},
     receipt::ReceiptType,
     serde::Raw,
+    EventId, MxcUri, RoomId, UserId,
 };
 use tracing::info;
 
@@ -562,10 +562,8 @@ impl StateStore for MemoryStore {
 mod test {
     use matrix_sdk_test::async_test;
     use ruma::{
-        api::client::r0::media::get_content_thumbnail::Method,
-        identifiers::{event_id, mxc_uri, room_id, user_id, UserId},
-        receipt::ReceiptType,
-        uint,
+        api::client::r0::media::get_content_thumbnail::Method, event_id, mxc_uri,
+        receipt::ReceiptType, room_id, uint, user_id, UserId,
     };
     use serde_json::json;
 

--- a/matrix_sdk_base/src/store/sled_store/mod.rs
+++ b/matrix_sdk_base/src/store/sled_store/mod.rs
@@ -903,6 +903,7 @@ mod test {
     use matrix_sdk_test::async_test;
     use ruma::{
         api::client::r0::media::get_content_thumbnail::Method,
+        event_id,
         events::{
             room::{
                 member::{MemberEventContent, MembershipState},
@@ -910,10 +911,11 @@ mod test {
             },
             AnySyncStateEvent, EventType, Unsigned,
         },
-        identifiers::{event_id, mxc_uri, room_id, user_id, EventId, UserId},
+        mxc_uri,
         receipt::ReceiptType,
+        room_id,
         serde::Raw,
-        uint, MilliSecondsSinceUnixEpoch,
+        uint, user_id, EventId, MilliSecondsSinceUnixEpoch, UserId,
     };
     use serde_json::json;
 

--- a/matrix_sdk_common/src/deserialized_responses.rs
+++ b/matrix_sdk_common/src/deserialized_responses.rs
@@ -12,9 +12,8 @@ use ruma::{
         room::member::MemberEventContent, AnySyncRoomEvent, StateEvent, StrippedStateEvent,
         SyncStateEvent, Unsigned,
     },
-    identifiers::{DeviceKeyAlgorithm, EventId, RoomId, UserId},
     serde::Raw,
-    DeviceIdBox, MilliSecondsSinceUnixEpoch,
+    DeviceIdBox, DeviceKeyAlgorithm, EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/matrix_sdk_crypto/src/identities/device.rs
+++ b/matrix_sdk_crypto/src/identities/device.rs
@@ -30,9 +30,7 @@ use ruma::{
         forwarded_room_key::ForwardedRoomKeyToDeviceEventContent,
         room::encrypted::EncryptedEventContent, AnyToDeviceEventContent,
     },
-    identifiers::{
-        DeviceId, DeviceIdBox, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, UserId,
-    },
+    DeviceId, DeviceIdBox, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, UserId,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};

--- a/matrix_sdk_crypto/src/identities/manager.rs
+++ b/matrix_sdk_crypto/src/identities/manager.rs
@@ -21,9 +21,8 @@ use std::{
 use futures::future::join_all;
 use matrix_sdk_common::executor::spawn;
 use ruma::{
-    api::client::r0::keys::get_keys::Response as KeysQueryResponse,
-    encryption::DeviceKeys,
-    identifiers::{DeviceId, DeviceIdBox, UserId},
+    api::client::r0::keys::get_keys::Response as KeysQueryResponse, encryption::DeviceKeys,
+    DeviceId, DeviceIdBox, UserId,
 };
 use tracing::{trace, warn};
 

--- a/matrix_sdk_crypto/src/key_request.rs
+++ b/matrix_sdk_crypto/src/key_request.rs
@@ -30,8 +30,8 @@ use ruma::{
         room_key_request::{Action, RequestedKeyInfo, RoomKeyRequestToDeviceEventContent},
         AnyToDeviceEvent, AnyToDeviceEventContent, ToDeviceEvent,
     },
-    identifiers::{DeviceId, DeviceIdBox, EventEncryptionAlgorithm, RoomId, UserId},
     to_device::DeviceIdOrAllDevices,
+    DeviceId, DeviceIdBox, EventEncryptionAlgorithm, RoomId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/matrix_sdk_crypto/src/machine.rs
+++ b/matrix_sdk_crypto/src/machine.rs
@@ -1235,6 +1235,7 @@ pub(crate) mod test {
             IncomingResponse,
         },
         encryption::OneTimeKey,
+        event_id,
         events::{
             dummy::DummyToDeviceEventContent,
             room::{
@@ -1244,10 +1245,8 @@ pub(crate) mod test {
             AnyMessageEventContent, AnySyncMessageEvent, AnySyncRoomEvent, AnyToDeviceEvent,
             AnyToDeviceEventContent, SyncMessageEvent, ToDeviceEvent, Unsigned,
         },
-        identifiers::{
-            event_id, room_id, user_id, DeviceId, DeviceKeyAlgorithm, DeviceKeyId, UserId,
-        },
-        uint, MilliSecondsSinceUnixEpoch,
+        room_id, uint, user_id, DeviceId, DeviceKeyAlgorithm, DeviceKeyId,
+        MilliSecondsSinceUnixEpoch, UserId,
     };
     use serde_json::json;
 

--- a/matrix_sdk_crypto/src/olm/account.rs
+++ b/matrix_sdk_crypto/src/olm/account.rs
@@ -37,12 +37,9 @@ use ruma::{
         room::encrypted::{EncryptedEventContent, EncryptedEventScheme},
         AnyToDeviceEvent, ToDeviceEvent,
     },
-    identifiers::{
-        DeviceId, DeviceIdBox, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, RoomId,
-        UserId,
-    },
     serde::{CanonicalJsonValue, Raw},
-    UInt,
+    DeviceId, DeviceIdBox, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, RoomId, UInt,
+    UserId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};

--- a/matrix_sdk_crypto/src/olm/group_sessions/inbound.rs
+++ b/matrix_sdk_crypto/src/olm/group_sessions/inbound.rs
@@ -32,8 +32,8 @@ use ruma::{
         },
         AnySyncRoomEvent, SyncMessageEvent,
     },
-    identifiers::{DeviceKeyAlgorithm, EventEncryptionAlgorithm, RoomId},
     serde::Raw,
+    DeviceKeyAlgorithm, EventEncryptionAlgorithm, RoomId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/matrix_sdk_crypto/src/olm/session.rs
+++ b/matrix_sdk_crypto/src/olm/session.rs
@@ -28,7 +28,7 @@ use ruma::{
         },
         AnyToDeviceEventContent, EventContent,
     },
-    identifiers::{DeviceId, DeviceKeyAlgorithm, UserId},
+    DeviceId, DeviceKeyAlgorithm, UserId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/matrix_sdk_crypto/src/store/mod.rs
+++ b/matrix_sdk_crypto/src/store/mod.rs
@@ -56,11 +56,8 @@ pub use memorystore::MemoryStore;
 use olm_rs::errors::{OlmAccountError, OlmGroupSessionError, OlmSessionError};
 pub use pickle_key::{EncryptedPickleKey, PickleKey};
 use ruma::{
-    events::room_key_request::RequestedKeyInfo,
-    identifiers::{
-        DeviceId, DeviceIdBox, DeviceKeyAlgorithm, Error as IdentifierValidationError, RoomId,
-        UserId,
-    },
+    events::room_key_request::RequestedKeyInfo, identifiers::Error as IdentifierValidationError,
+    DeviceId, DeviceIdBox, DeviceKeyAlgorithm, RoomId, UserId,
 };
 use serde_json::Error as SerdeError;
 use thiserror::Error;

--- a/matrix_sdk_crypto/src/store/sled.rs
+++ b/matrix_sdk_crypto/src/store/sled.rs
@@ -757,9 +757,8 @@ mod test {
     use matrix_sdk_test::async_test;
     use olm_rs::outbound_group_session::OlmOutboundGroupSession;
     use ruma::{
-        encryption::SignedKey,
-        events::room_key_request::RequestedKeyInfo,
-        identifiers::{room_id, user_id, DeviceId, EventEncryptionAlgorithm, UserId},
+        encryption::SignedKey, events::room_key_request::RequestedKeyInfo, room_id, user_id,
+        DeviceId, EventEncryptionAlgorithm, UserId,
     };
     use tempfile::tempdir;
 

--- a/matrix_sdk_crypto/src/verification/event_enums.rs
+++ b/matrix_sdk_crypto/src/verification/event_enums.rs
@@ -33,9 +33,8 @@ use ruma::{
         room::message::{KeyVerificationRequestEventContent, MessageType},
         AnyMessageEvent, AnyMessageEventContent, AnyToDeviceEvent, AnyToDeviceEventContent,
     },
-    identifiers::{DeviceId, RoomId, UserId},
     serde::CanonicalJsonValue,
-    MilliSecondsSinceUnixEpoch,
+    DeviceId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
 };
 
 use super::FlowId;

--- a/matrix_sdk_crypto/src/verification/machine.rs
+++ b/matrix_sdk_crypto/src/verification/machine.rs
@@ -16,7 +16,7 @@ use std::{convert::TryFrom, sync::Arc};
 
 use dashmap::DashMap;
 use matrix_sdk_common::{locks::Mutex, uuid::Uuid};
-use ruma::{uint, DeviceId, MilliSecondsSinceUnixEpoch, UInt, UserId};
+use ruma::{DeviceId, MilliSecondsSinceUnixEpoch, UserId};
 use tracing::{info, trace, warn};
 
 use super::{
@@ -123,6 +123,8 @@ impl VerificationMachine {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn is_timestamp_valid(timestamp: &MilliSecondsSinceUnixEpoch) -> bool {
+        use ruma::{uint, UInt};
+
         // The event should be ignored if the event is older than 10 minutes
         let old_timestamp_threshold: UInt = uint!(600);
         // The event should be ignored if the event is 5 minutes or more into the

--- a/matrix_sdk_crypto/src/verification/qrcode.rs
+++ b/matrix_sdk_crypto/src/verification/qrcode.rs
@@ -33,7 +33,7 @@ use ruma::{
         },
         AnyMessageEventContent, AnyToDeviceEventContent,
     },
-    identifiers::{DeviceIdBox, DeviceKeyAlgorithm, UserId},
+    DeviceIdBox, DeviceKeyAlgorithm, UserId,
 };
 use thiserror::Error;
 
@@ -696,7 +696,7 @@ mod test {
 
     use matrix_qrcode::QrVerificationData;
     use matrix_sdk_test::async_test;
-    use ruma::identifiers::{event_id, room_id, user_id, DeviceIdBox, UserId};
+    use ruma::{event_id, room_id, user_id, DeviceIdBox, UserId};
 
     use crate::{
         olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},

--- a/matrix_sdk_test/src/appservice.rs
+++ b/matrix_sdk_test/src/appservice.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use ruma::{events::AnyRoomEvent, identifiers::room_id};
+use ruma::{events::AnyRoomEvent, room_id};
 use serde_json::Value;
 
 use crate::{test_json, EventsJson};


### PR DESCRIPTION
As discussed on Matrix.

I think this closes #152 (with the largest part of the work already done in #261).

This is what the crate-level documentation looks like after this change (disregard the broken sidebar):

![Screenshot 2021-06-23 at 13-25-40 matrix_sdk - Rust](https://user-images.githubusercontent.com/951129/123088883-921aae80-d426-11eb-83bf-700531ff6839.png)
