### PR TITLE
room: Add event() method to retrieve a room event

### DIFF
--- a/matrix_sdk/src/room/common.rs
+++ b/matrix_sdk/src/room/common.rs
@@ -6,6 +6,7 @@ use ruma::{
     api::client::r0::{
         membership::{get_member_events, join_room_by_id, leave_room},
         message::get_message_events,
+        room::get_room_event,
     },
     events::room::history_visibility::HistoryVisibility,
     UserId,
@@ -142,6 +143,17 @@ impl Common {
         &self,
         request: impl Into<get_message_events::Request<'_>>,
     ) -> Result<get_message_events::Response> {
+        let request = request.into();
+        self.client.send(request, None).await
+    }
+
+    /// Sends a request to `/_matrix/client/r0/rooms/{roomId}/event/{eventId}`
+    /// and returns a `get_room_event::Response` that contains a event
+    /// (`AnyRoomEvent`).
+    pub async fn event(
+        &self,
+        request: impl Into<get_room_event::Request<'_>>,
+    ) -> Result<get_room_event::Response> {
         let request = request.into();
         self.client.send(request, None).await
     }

--- a/matrix_sdk_common/src/deserialized_responses.rs
+++ b/matrix_sdk_common/src/deserialized_responses.rs
@@ -133,6 +133,14 @@ impl SyncResponse {
     }
 }
 
+pub struct RoomEvent {
+    /// The actual event.
+    pub event: Raw<ruma::events::AnyRoomEvent>,
+    /// The encryption info about the event. Will be `None` if the event was not
+    /// encrypted.
+    pub encryption_info: Option<EncryptionInfo>,
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Rooms {
     /// The rooms that the user has left or been banned from.


### PR DESCRIPTION
It seems there's currently no way to retrieve a event by using the event id. 

This PR adds a `event` method to `matrix_sdk::room::Common`, which makes use of `GET /_matrix/client/r0/rooms/{roomId}/event/{eventId}`

https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-rooms-roomid-event-eventid