### PR TITLE
Use hoist-and-deserialize when deserializing events for the event emitter

### DIFF
--- a/matrix_sdk/src/event_handler/mod.rs
+++ b/matrix_sdk/src/event_handler/mod.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 use std::ops::Deref;
 
+use matrix_sdk_base::{hoist_and_deserialize_state_event, hoist_room_event_prev_content};
 use matrix_sdk_common::async_trait;
 use ruma::{
     api::client::r0::push::get_notifications::Notification,
@@ -91,7 +92,7 @@ impl Handler {
                 }
 
                 for (raw_event, event) in room_info.state.events.iter().filter_map(|e| {
-                    if let Ok(d) = e.deserialize() {
+                    if let Ok(d) = hoist_and_deserialize_state_event(e) {
                         Some((e, d))
                     } else {
                         None
@@ -101,7 +102,7 @@ impl Handler {
                 }
 
                 for (raw_event, event) in room_info.timeline.events.iter().filter_map(|e| {
-                    if let Ok(d) = e.event.deserialize() {
+                    if let Ok(d) = hoist_room_event_prev_content(&e.event) {
                         Some((&e.event, d))
                     } else {
                         None
@@ -121,7 +122,7 @@ impl Handler {
                 }
 
                 for (raw_event, event) in room_info.state.events.iter().filter_map(|e| {
-                    if let Ok(d) = e.deserialize() {
+                    if let Ok(d) = hoist_and_deserialize_state_event(e) {
                         Some((e, d))
                     } else {
                         None
@@ -131,7 +132,7 @@ impl Handler {
                 }
 
                 for (raw_event, event) in room_info.timeline.events.iter().filter_map(|e| {
-                    if let Ok(d) = e.event.deserialize() {
+                    if let Ok(d) = hoist_room_event_prev_content(&e.event) {
                         Some((&e.event, d))
                     } else {
                         None

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -129,7 +129,7 @@ fn hoist_member_event(
     Ok(e)
 }
 
-fn hoist_room_event_prev_content(
+pub fn hoist_room_event_prev_content(
     event: &Raw<AnySyncRoomEvent>,
 ) -> StdResult<AnySyncRoomEvent, serde_json::Error> {
     let prev_content = event

--- a/matrix_sdk_base/src/client.rs
+++ b/matrix_sdk_base/src/client.rs
@@ -89,8 +89,8 @@ pub struct AdditionalUnsignedData {
     pub prev_content: Option<Raw<MemberEventContent>>,
 }
 
-/// Transform state event by hoisting `prev_content` field from `unsigned` to
-/// the top level.
+/// Transform an `AnySyncStateEvent` by hoisting `prev_content` field from
+/// `unsigned` to the top level.
 ///
 /// Due to a [bug in synapse][synapse-bug], `prev_content` often ends up in
 /// `unsigned` contrary to the C2S spec. Some more discussion can be found
@@ -129,6 +129,16 @@ fn hoist_member_event(
     Ok(e)
 }
 
+/// Transform an `AnySyncRoomEvent` by hoisting `prev_content` field from
+/// `unsigned` to the top level.
+///
+/// Due to a [bug in synapse][synapse-bug], `prev_content` often ends up in
+/// `unsigned` contrary to the C2S spec. Some more discussion can be found
+/// [here][discussion]. Until this is fixed in synapse or handled in Ruma, we
+/// use this to hoist up `prev_content` to the top level.
+///
+/// [synapse-bug]: <https://github.com/matrix-org/matrix-doc/issues/684#issuecomment-641182668>
+/// [discussion]: <https://github.com/matrix-org/matrix-doc/issues/684#issuecomment-641182668>
 pub fn hoist_room_event_prev_content(
     event: &Raw<AnySyncRoomEvent>,
 ) -> StdResult<AnySyncRoomEvent, serde_json::Error> {

--- a/matrix_sdk_base/src/lib.rs
+++ b/matrix_sdk_base/src/lib.rs
@@ -50,7 +50,9 @@ mod rooms;
 mod session;
 mod store;
 
-pub use client::{BaseClient, BaseClientConfig};
+pub use client::{
+    hoist_and_deserialize_state_event, hoist_room_event_prev_content, BaseClient, BaseClientConfig,
+};
 #[cfg(feature = "encryption")]
 #[cfg_attr(feature = "docs", doc(cfg(encryption)))]
 pub use matrix_sdk_crypto as crypto;


### PR DESCRIPTION
This is a continuation of #293, it just adds the missing doc that makes CI fail.