### PR TITLE
appservice: Sync room state

### DIFF
--- a/matrix_sdk/Cargo.toml
+++ b/matrix_sdk/Cargo.toml
@@ -26,7 +26,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 socks = ["reqwest/socks"]
 sso_login = ["warp", "rand", "tokio-stream"]
 require_auth_for_profile_requests = []
-appservice = ["ruma/appservice-api-s", "ruma/appservice-api-helper", "ruma/rand"]
+appservice = ["ruma/appservice-api-s", "ruma/rand"]
 
 docs = ["encryption", "sled_cryptostore", "sled_state_store", "sso_login"]
 

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -650,24 +650,19 @@ impl Client {
         .await
     }
 
-    /// Process a [transaction] received from the homeserver
+    /// Process a `sync_response`
+    ///
+    /// This is low-level functionality, only use if you know what you're doing
+    /// as it might corrupt your state or crypto store.
     ///
     /// # Arguments
     ///
-    /// * `incoming_transaction` - The incoming transaction received from the
-    ///   homeserver.
-    ///
-    /// [transaction]: https://matrix.org/docs/spec/application_service/r0.1.2#put-matrix-app-v1-transactions-txnid
+    /// * `sync_response` - The sync response received from the homeserver.
     #[cfg(feature = "appservice")]
     #[cfg_attr(feature = "docs", doc(cfg(appservice)))]
-    pub async fn receive_transaction(
-        &self,
-        incoming_transaction: ruma::api::appservice::event::push_events::v1::IncomingRequest,
-    ) -> Result<()> {
-        let txn_id = incoming_transaction.txn_id.clone();
-        let response = incoming_transaction.try_into_sync_response(txn_id)?;
+    pub async fn receive_sync_response(&self, sync_response: sync_events::Response) -> Result<()> {
         let base_client = self.base_client.clone();
-        let sync_response = base_client.receive_sync_response(response).await?;
+        let sync_response = base_client.receive_sync_response(sync_response).await?;
 
         if let Some(handler) = self.event_handler.read().await.as_ref() {
             handler.handle_sync(&sync_response).await;

--- a/matrix_sdk_appservice/Cargo.toml
+++ b/matrix_sdk_appservice/Cargo.toml
@@ -30,7 +30,7 @@ matrix-sdk = { version = "0.3", path = "../matrix_sdk", default-features = false
 
 [dependencies.ruma]
 version = "0.2.0"
-features = ["client-api-c", "appservice-api-s", "unstable-pre-spec"]
+features = ["client-api-c", "appservice-api-s", "compat", "unstable-pre-spec"]
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/matrix_sdk_appservice/src/error.rs
+++ b/matrix_sdk_appservice/src/error.rs
@@ -34,6 +34,12 @@ pub enum Error {
     #[error("could not convert host:port to socket addr")]
     HostPortToSocketAddrs,
 
+    #[error("uri has empty path")]
+    UriEmptyPath,
+
+    #[error("uri path is unknown")]
+    UriPathUnknown,
+
     #[error(transparent)]
     HttpRequest(#[from] ruma::api::error::FromHttpRequestError),
 

--- a/matrix_sdk_appservice/src/webserver/warp.rs
+++ b/matrix_sdk_appservice/src/webserver/warp.rs
@@ -98,7 +98,7 @@ mod filters {
             .and(filters::valid_access_token(appservice.registration().hs_token.clone()))
             .map(move || appservice.clone())
             .and(http_request().and_then(|request| async move {
-                let request = crate::transform_legacy_route(request).map_err(Error::from)?;
+                let request = crate::transform_request_path(request).map_err(Error::from)?;
                 Ok::<http::Request<Bytes>, Rejection>(request)
             }))
             .boxed()

--- a/matrix_sdk_test/src/test_json/mod.rs
+++ b/matrix_sdk_test/src/test_json/mod.rs
@@ -9,6 +9,7 @@ use serde_json::{json, Value as JsonValue};
 
 pub mod events;
 pub mod members;
+pub mod state;
 pub mod sync;
 
 pub use events::{
@@ -18,6 +19,7 @@ pub use events::{
     REGISTRATION_RESPONSE_ERR, ROOM_ID, ROOM_MESSAGES, TYPING,
 };
 pub use members::MEMBERS;
+pub use state::ROOM_STATE;
 pub use sync::{
     DEFAULT_SYNC_SUMMARY, INVITE_SYNC, LEAVE_SYNC, LEAVE_SYNC_EVENT, MORE_SYNC, SYNC, VOIP_SYNC,
 };

--- a/matrix_sdk_test/src/test_json/state.rs
+++ b/matrix_sdk_test/src/test_json/state.rs
@@ -1,0 +1,87 @@
+use lazy_static::lazy_static;
+use serde_json::{json, Value as JsonValue};
+
+lazy_static! {
+    pub static ref ROOM_STATE: JsonValue = json!([
+        {
+          "content": {
+            "join_rule": "public"
+          },
+          "event_id": "$143273582443PhrSn:example.org",
+          "origin_server_ts": 1432735824653i64,
+          "room_id": "!SVkFJHzfwvuaIEawgC:localhost",
+          "sender": "@example:example.org",
+          "state_key": "",
+          "type": "m.room.join_rules",
+          "unsigned": {
+            "age": 1234
+          }
+        },
+        {
+          "content": {
+            "avatar_url": "mxc://example.org/SEsfnsuifSDFSSEF",
+            "displayname": "Alice Margatroid",
+            "membership": "join"
+          },
+          "event_id": "$143273582443PhrSn:example.org",
+          "origin_server_ts": 1432735824653i64,
+          "room_id": "!SVkFJHzfwvuaIEawgC:localhost",
+          "sender": "@example:example.org",
+          "state_key": "@alice:example.org",
+          "type": "m.room.member",
+          "unsigned": {
+            "age": 1234
+          }
+        },
+        {
+          "content": {
+            "creator": "@example:example.org",
+            "m.federate": true,
+            "predecessor": {
+              "event_id": "$something:example.org",
+              "room_id": "!oldroom:example.org"
+            },
+            "room_version": "1"
+          },
+          "event_id": "$143273582443PhrSn:example.org",
+          "origin_server_ts": 1432735824653i64,
+          "room_id": "!SVkFJHzfwvuaIEawgC:localhost",
+          "sender": "@example:example.org",
+          "state_key": "",
+          "type": "m.room.create",
+          "unsigned": {
+            "age": 1234
+          }
+        },
+        {
+          "content": {
+            "ban": 50,
+            "events": {
+              "m.room.name": 100,
+              "m.room.power_levels": 100
+            },
+            "events_default": 0,
+            "invite": 50,
+            "kick": 50,
+            "notifications": {
+              "room": 20
+            },
+            "redact": 50,
+            "state_default": 50,
+            "users": {
+              "@example:localhost": 100
+            },
+            "users_default": 0
+          },
+          "event_id": "$143273582443PhrSn:example.org",
+          "origin_server_ts": 1432735824653i64,
+          "room_id": "!SVkFJHzfwvuaIEawgC:localhost",
+          "sender": "@example:example.org",
+          "state_key": "",
+          "type": "m.room.power_levels",
+          "unsigned": {
+            "age": 1234
+          }
+        }
+    ]);
+}


### PR DESCRIPTION
Introduces: When an appservice transaction comes in with events for a room that the main user client doesn't know about yet, it'll establish a lock to block processing more events for that room and then calls the homeserver's `/state` endpoint to fetch the current room state. The fetched state is processed by converting it into a sync response, tho that's not yet viable since regular sync response processing requires a batch token. So this probably requires splitting batch token handling from updating the state store?

Todo
- [ ] Split state updating from batch token handling so properly processing a manual state endpoint call is possible
- [ ] Mark members synced after the manual state update since the call to `/state` also includes all members

Refactors
- Rename `get_cached_client` to `get_client`

Superseded #280
Part of #228 