### PR TITLE
Remove rooms from store on forget() call

### DIFF
--- a/matrix_sdk/src/room/left.rs
+++ b/matrix_sdk/src/room/left.rs
@@ -42,6 +42,7 @@ impl Left {
     pub async fn forget(&self) -> Result<()> {
         let request = forget_room::Request::new(self.inner.room_id());
         let _response = self.client.send(request, None).await?;
+        self.client.store().remove_room(self.inner.room_id()).await?;
 
         Ok(())
     }

--- a/matrix_sdk_base/src/store/memory_store.rs
+++ b/matrix_sdk_base/src/store/memory_store.rs
@@ -439,6 +439,24 @@ impl MemoryStore {
 
         Ok(())
     }
+
+    async fn remove_room(&self, room_id: &RoomId) -> Result<()> {
+        self.members.remove(room_id);
+        self.profiles.remove(room_id);
+        self.display_names.remove(room_id);
+        self.joined_user_ids.remove(room_id);
+        self.invited_user_ids.remove(room_id);
+        self.room_info.remove(room_id);
+        self.room_state.remove(room_id);
+        self.room_account_data.remove(room_id);
+        self.stripped_room_info.remove(room_id);
+        self.stripped_room_state.remove(room_id);
+        self.stripped_members.remove(room_id);
+        self.room_user_receipts.remove(room_id);
+        self.room_event_receipts.remove(room_id);
+
+        Ok(())
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -577,6 +595,10 @@ impl StateStore for MemoryStore {
 
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
         self.remove_media_content_for_uri(uri).await
+    }
+
+    async fn remove_room(&self, room_id: &RoomId) -> Result<()> {
+        self.remove_room(room_id).await
     }
 }
 

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -293,6 +293,13 @@ pub trait StateStore: AsyncTraitDeps {
     ///
     /// * `uri` - The `MxcUri` of the media files.
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()>;
+
+    /// Removes all references to a room from the state store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The `RoomId` of the room to delete.
+    async fn remove_room(&self, room_id: &RoomId) -> Result<()>;
 }
 
 /// A state store wrapper for the SDK.

--- a/matrix_sdk_base/src/store/sled_store/mod.rs
+++ b/matrix_sdk_base/src/store/sled_store/mod.rs
@@ -781,6 +781,24 @@ impl SledStore {
 
         Ok(self.media.apply_batch(batch)?)
     }
+
+    async fn remove_room(&self, room_id: &RoomId) -> Result<()> {
+        self.members.remove(&room_id.as_bytes())?;
+        self.profiles.remove(&room_id.as_bytes())?;
+        self.display_names.remove(&room_id.as_bytes())?;
+        self.joined_user_ids.remove(&room_id.as_bytes())?;
+        self.invited_user_ids.remove(&room_id.as_bytes())?;
+        self.room_info.remove(&room_id.as_bytes())?;
+        self.room_state.remove(&room_id.as_bytes())?;
+        self.room_account_data.remove(&room_id.as_bytes())?;
+        self.stripped_room_info.remove(&room_id.as_bytes())?;
+        self.stripped_room_state.remove(&room_id.as_bytes())?;
+        self.stripped_members.remove(&room_id.as_bytes())?;
+        self.room_user_receipts.remove(&room_id.as_bytes())?;
+        self.room_event_receipts.remove(&room_id.as_bytes())?;
+
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -913,6 +931,10 @@ impl StateStore for SledStore {
 
     async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()> {
         self.remove_media_content_for_uri(uri).await
+    }
+
+    async fn remove_room(&self, room_id: &RoomId) -> Result<()> {
+        self.remove_room(room_id).await
     }
 }
 


### PR DESCRIPTION
Fixes #205.

Adds a method to the `StateStore` trait for removing rooms from the store, and implements it for `MemoryStore` and `SledStore`. Uses said method to remove rooms from store on `Left::forget()` call.

`remove_room()` implementation is a bit hacky, because you have to remember to remove the key from every relevant tree, so if a new one gets added you have to manually ensure that the key gets removed from the new one as well. If there's a better and more generic way to do this, please let me know.