### PR TITLE
Add custom storage

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -828,6 +828,16 @@ impl Client {
         self.base_client.store()
     }
 
+    /// Store a value in the custom tree on the store
+    pub async fn store_save_value(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
+        Ok(self.store().set_custom_value(key, value).await?)
+    }
+
+    /// Get a value in the custom tree in the store
+    pub async fn store_get_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        Ok(self.store().get_custom_value(key).await?)
+    }
+
     /// Sets the mxc avatar url of the client's owner. The avatar gets unset if
     /// `url` is `None`.
     pub async fn set_avatar_url(&self, url: Option<&MxcUri>) -> Result<()> {

--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -828,16 +828,6 @@ impl Client {
         self.base_client.store()
     }
 
-    /// Store a value in the custom tree on the store
-    pub async fn store_save_value(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
-        Ok(self.store().set_custom_value(key, value).await?)
-    }
-
-    /// Get a value in the custom tree in the store
-    pub async fn store_get_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        Ok(self.store().get_custom_value(key).await?)
-    }
-
     /// Sets the mxc avatar url of the client's owner. The avatar gets unset if
     /// `url` is `None`.
     pub async fn set_avatar_url(&self, url: Option<&MxcUri>) -> Result<()> {

--- a/matrix_sdk_base/src/store/mod.rs
+++ b/matrix_sdk_base/src/store/mod.rs
@@ -263,6 +263,22 @@ pub trait StateStore: AsyncTraitDeps {
         event_id: &EventId,
     ) -> Result<Vec<(UserId, Receipt)>>;
 
+    /// Get arbitrary data from the custom store
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to fetch data for
+    async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
+
+    /// Put arbitrary data into the custom store
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert data into
+    ///
+    /// * `value` - The value to insert
+    async fn set_custom_value(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>>;
+
     /// Add a media file's content in the media store.
     ///
     /// # Arguments


### PR DESCRIPTION
Closes #271.

Add an additional tree to the Store where custom api consumer data may
be stored.

I'm not sure exactly what types are the smartest to use for the keys and values here. While it would be nice to be able to use sled-types as suggested by the issue, it would make the custom store implementation dependent. I'm also not sure if the method on `Client` is necessary when the custom store can be interacted with via getting a reference to the `Store`.