### PR TITLE
Fix confusion between initial / stripped state events

### DIFF
--- a/matrix_sdk/src/client.rs
+++ b/matrix_sdk/src/client.rs
@@ -2191,8 +2191,12 @@ impl Client {
             }
 
             // FIXME: Destructure room_info
-            self.handle_sync_events(EventKind::InitialState, &room, &room_info.invite_state.events)
-                .await?;
+            self.handle_sync_events(
+                EventKind::StrippedState,
+                &room,
+                &room_info.invite_state.events,
+            )
+            .await?;
         }
 
         for handler in &*self.notification_handlers.read().await {

--- a/matrix_sdk/src/event_handler.rs
+++ b/matrix_sdk/src/event_handler.rs
@@ -47,7 +47,7 @@ pub enum EventKind {
     EphemeralRoomData,
     Message { redacted: bool },
     State { redacted: bool },
-    StrippedState { redacted: bool },
+    StrippedState,
     InitialState,
     ToDevice,
     Presence,
@@ -398,8 +398,7 @@ mod static_events {
     where
         C: StaticEventContent + events::StateEventContent,
     {
-        const ID: (EventKind, &'static str) =
-            (EventKind::StrippedState { redacted: false }, C::TYPE);
+        const ID: (EventKind, &'static str) = (EventKind::StrippedState, C::TYPE);
     }
 
     impl<C> SyncEvent for events::InitialStateEvent<C>
@@ -432,13 +431,5 @@ mod static_events {
         C: StaticEventContent + events::RedactedStateEventContent,
     {
         const ID: (EventKind, &'static str) = (EventKind::State { redacted: true }, C::TYPE);
-    }
-
-    impl<C> SyncEvent for events::RedactedStrippedStateEvent<C>
-    where
-        C: StaticEventContent + events::RedactedStateEventContent,
-    {
-        const ID: (EventKind, &'static str) =
-            (EventKind::StrippedState { redacted: true }, C::TYPE);
     }
 }


### PR DESCRIPTION
InviteState contains stripped state events, and initial state events are not used anywhere in the sync response.

More complete (and simpler) fix for the autojoin bot being broken, supersedes #332.