### PR TITLE
fix(common): wasm_bindgen dependency feature

### DIFF
--- a/matrix_sdk_common/Cargo.toml
+++ b/matrix_sdk_common/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.4.0"
 
 [dependencies]
 async-trait = "0.1.50"
-instant = { version = "0.1.9", features = ["wasm-bindgen", "now"] }
 ruma = { version = "0.4.0", features = ["client-api-c"] }
 serde = "1.0.126"
 
@@ -23,6 +22,14 @@ uuid = { version = "0.8.2", default-features = false, features = ["v4", "serde"]
 version = "1.7.1"
 default-features = false
 features = ["rt", "sync"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.instant]
+version = "0.1.9"
+features = ["wasm-bindgen", "now"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.instant]
+version = "0.1.9"
+features = ["now"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures = "0.3.15"


### PR DESCRIPTION
instant doesn't need wasm_bindgen on non wasm targets, avoids building some stuff I suppose