### PR TITLE
Specifiy edition in rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2018"
 max_width = 100
 comment_width = 80
 wrap_comments = true


### PR DESCRIPTION
Explicitly specify the rust edition in `rustfmt.toml`. This makes makes the autoformatting in certain editors - like vim - more reliable.