### PR TITLE
crypto: Fix VerificationRequest::generate_qr_code()

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -312,11 +312,12 @@ impl VerificationRequest {
     /// Generate a QR code that can be used by another client to start a QR code
     /// based verification.
     pub async fn generate_qr_code(&self) -> Result<Option<QrVerification>, CryptoStoreError> {
-        self.inner
+        let inner = self.inner
             .lock()
             .unwrap()
-            .generate_qr_code(self.we_started, self.inner.clone().into())
-            .await
+            .clone();
+
+        inner.generate_qr_code(self.we_started, self.inner.clone().into()).await
     }
     ///
     #[cfg(feature = "qrcode")]


### PR DESCRIPTION
We can't keep a lock on the `inner` therefore clone it. It's not pretty
but we do the same in `start_sas()`.