### PR TITLE
fix SyncMessageEvent import

### DIFF
--- a/crates/matrix-sdk/examples/login.rs
+++ b/crates/matrix-sdk/examples/login.rs
@@ -5,10 +5,8 @@ use matrix_sdk::{
     config::SyncSettings,
     room::Room,
     ruma::events::{
+        room::message::{MessageEventContent, MessageType, TextMessageEventContent},
         SyncMessageEvent,
-        room::message::{
-            MessageEventContent, MessageType, TextMessageEventContent,
-        },
     },
     Client,
 };


### PR DESCRIPTION
I found these changes to be necessary for this example to build (using the `main` branch of `matrix-sdk`).