### PR TITLE
matrix-qrcode: Use GenericImage and GenericImageView trait

### DIFF
--- a/crates/matrix-qrcode/Cargo.toml
+++ b/crates/matrix-qrcode/Cargo.toml
@@ -26,6 +26,6 @@ base64 = "0.13.0"
 byteorder = "1.4.3"
 image = { version = "0.23.14", optional = true }
 qrcode = { version = "0.12.0", default-features = false }
-rqrr = { version = "0.3.2", optional = true }
+rqrr = { version = "0.4.0", optional = true }
 ruma-identifiers = { git = "https://github.com/ruma/ruma", rev = "ac6ecc3e5" }
 thiserror = "1.0.25"

--- a/crates/matrix-qrcode/src/utils.rs
+++ b/crates/matrix-qrcode/src/utils.rs
@@ -16,7 +16,7 @@ use std::convert::TryInto;
 
 use base64::{decode_config, encode_config, STANDARD_NO_PAD};
 #[cfg(feature = "decode_image")]
-use image::{ImageBuffer, Luma};
+use image::{GenericImage, GenericImageView, Luma};
 use qrcode::{bits::Bits, EcLevel, QrCode, Version};
 
 #[cfg(feature = "decode_image")]
@@ -91,7 +91,10 @@ pub(crate) fn to_qr_code(
 }
 
 #[cfg(feature = "decode_image")]
-pub(crate) fn decode_qr(image: ImageBuffer<Luma<u8>, Vec<u8>>) -> Result<Vec<u8>, DecodingError> {
+pub(crate) fn decode_qr<I>(image: I) -> Result<Vec<u8>, DecodingError>
+where
+    I: GenericImage<Pixel = Luma<u8>> + GenericImageView<Pixel = Luma<u8>>,
+{
     let mut image = rqrr::PreparedImage::prepare(image);
     let grids = image.detect_grids();
 


### PR DESCRIPTION
This changes `QrVerificationData::from_luma()` to accept any struct that
implements GenericImage and GenericImageView.
This way we don't force a specific container for the ImageBufffer, hence
the developer doesn't necessarily need to copy the image data into a
Vec<u8>.