### PR TITLE
Support for server-side backups of room keys

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,7 @@
 # Or if we're able to ignore certain lines.
 Fo = "Fo"
 BA = "BA"
+UE = "UE"
 
 [files]
 # Our json files contain a bunch of base64 encoded ed25519 keys which aren't

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -16,8 +16,9 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-default = []
+default = ["backups_v1"]
 qrcode = ["matrix-qrcode"]
+backups_v1 = []
 sled_cryptostore = ["sled"]
 docs = ["sled_cryptostore"]
 
@@ -26,6 +27,7 @@ aes = { version = "0.7.4", features = ["ctr"] }
 aes-gcm = "0.9.2"
 atomic = "0.5.0"
 base64 = "0.13.0"
+bs58 = "0.4.0"
 byteorder = "1.4.3"
 dashmap = "4.0.2"
 futures-util = { version = "0.3.15", default-features = false }
@@ -33,9 +35,13 @@ getrandom = "0.2.3"
 hmac = "0.11.0"
 matrix-qrcode = { version = "0.2.0", path = "../matrix-qrcode", optional = true }
 matrix-sdk-common = { version = "0.4.0", path = "../matrix-sdk-common" }
-olm-rs = { version = "2.0.1", features = ["serde"] }
+olm-rs = { version = "2.1", features = ["serde"] }
 pbkdf2 = { version = "0.9.0", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "ac6ecc3e5", features = ["client-api-c", "unstable-pre-spec"] }
+rand = "0.8.4"
+ruma = { git = "https://github.com/ruma/ruma", rev = "ac6ecc3e5", features = [
+    "client-api-c",
+    "unstable-pre-spec",
+] }
 serde = { version = "1.0.126", features = ["derive", "rc"] }
 serde_json = "1.0.64"
 sha2 = "0.9.5"
@@ -45,7 +51,11 @@ tracing = "0.1.26"
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-criterion = { version = "0.3.4", features = ["async", "async_tokio", "html_reports"] }
+criterion = { version = "0.3.4", features = [
+    "async",
+    "async_tokio",
+    "html_reports",
+] }
 futures = { version = "0.3.15", default-features = false }
 http = "0.2.4"
 indoc = "1.0.3"
@@ -54,7 +64,10 @@ matrix-sdk-test = { version = "0.4.0", path = "../matrix-sdk-test" }
 proptest = "1.0.0"
 serde_json = "1.0.64"
 tempfile = "3.2.0"
-tokio = { version = "1.7.1", default-features = false, features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.7.1", default-features = false, features = [
+    "rt-multi-thread",
+    "macros",
+] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof = { version = "0.5.0", features = ["flamegraph", "criterion"] }

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -1,0 +1,132 @@
+// Copyright 2021 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use olm_rs::pk::OlmPkEncryption;
+use ruma::{
+    api::client::r0::backup::{BackupAlgorithm, KeyBackupData, KeyBackupDataInit, SessionDataInit},
+    DeviceKeyId, UserId,
+};
+use zeroize::Zeroizing;
+
+use super::recovery::DecodeError;
+use crate::olm::InboundGroupSession;
+
+#[derive(Debug)]
+struct InnerBackupKey {
+    key: [u8; MegolmV1BackupKey::KEY_SIZE],
+    signatures: BTreeMap<UserId, BTreeMap<DeviceKeyId, String>>,
+    version: Mutex<Option<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MegolmV1BackupKey {
+    inner: Arc<InnerBackupKey>,
+}
+
+impl MegolmV1BackupKey {
+    const KEY_SIZE: usize = 32;
+
+    pub(super) fn new(public_key: &str, version: Option<String>) -> Self {
+        let key = Self::from_base64(public_key).expect("Invalid backup key");
+
+        if let Some(version) = version {
+            key.set_version(version)
+        }
+
+        key
+    }
+
+    /// TODO
+    pub fn from_base64(public_key: &str) -> Result<Self, DecodeError> {
+        let mut key = [0u8; Self::KEY_SIZE];
+        let decoded_key = crate::utilities::decode(public_key)?;
+
+        if decoded_key.len() != Self::KEY_SIZE {
+            Err(DecodeError::Length(Self::KEY_SIZE, decoded_key.len()))
+        } else {
+            key.copy_from_slice(&decoded_key);
+
+            let inner =
+                InnerBackupKey { key, signatures: Default::default(), version: Mutex::new(None) };
+
+            Ok(MegolmV1BackupKey { inner: inner.into() })
+        }
+    }
+
+    /// TODO
+    pub fn backup_version(&self) -> Option<String> {
+        self.inner.version.lock().unwrap().clone()
+    }
+
+    /// TODO
+    pub fn set_version(&self, version: String) {
+        *self.inner.version.lock().unwrap() = Some(version);
+    }
+
+    pub(crate) async fn encrypt(&self, session: InboundGroupSession) -> KeyBackupData {
+        let pk = OlmPkEncryption::new(&self.encoded_key());
+
+        // It's ok to truncate here, there's a semantic difference only between
+        // 0 and 1+ anyways.
+        let forwarded_count = (session.forwarding_key_chain().len() as u32).into();
+        let first_message_index = session.first_known_index().into();
+
+        // Convert our key to the backup representation.
+        let key = session.to_backup().await;
+
+        // The key gets zeroized in `BackedUpRoomKey` but we're creating a copy
+        // here that won't, so let's wrap it up in a `Zeroizing` struct.
+        let key =
+            Zeroizing::new(serde_json::to_string(&key).expect("Can't serialize exported room key"));
+
+        let message = pk.encrypt(&key);
+
+        let session_data = SessionDataInit {
+            ephemeral: message.ephemeral_key,
+            ciphertext: message.ciphertext,
+            mac: message.mac,
+        }
+        .into();
+
+        KeyBackupDataInit {
+            first_message_index,
+            forwarded_count,
+            // TODO is this actually used anywhere? seems to be completely
+            // useless and requires us to get the Device out of the store?
+            is_verified: false,
+            session_data,
+        }
+        .into()
+    }
+
+    pub fn encoded_key(&self) -> String {
+        crate::utilities::encode(&self.inner.key)
+    }
+
+    pub fn signatures(&self) -> BTreeMap<UserId, BTreeMap<DeviceKeyId, String>> {
+        self.inner.signatures.to_owned()
+    }
+
+    pub fn to_backup_algorithm(&self) -> BackupAlgorithm {
+        BackupAlgorithm::MegolmBackupV1Curve25519AesSha2 {
+            public_key: self.encoded_key(),
+            signatures: self.inner.signatures.to_owned(),
+        }
+    }
+}

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -34,9 +34,19 @@ struct InnerBackupKey {
     version: Mutex<Option<String>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct MegolmV1BackupKey {
     inner: Arc<InnerBackupKey>,
+}
+
+impl std::fmt::Debug for MegolmV1BackupKey {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MegolmV1BackupKey")
+            .field("key", &self.encoded_key())
+            .field("version", &self.backup_version())
+            .finish()
+    }
 }
 
 impl MegolmV1BackupKey {

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -63,6 +63,11 @@ impl MegolmV1BackupKey {
         key
     }
 
+    /// Get the full name of the backup algorithm this backup key supports.
+    pub fn backup_algorithm(&self) -> &str {
+        "m.megolm_backup.v1.curve25519-aes-sha2"
+    }
+
     /// Get all the signatures of this `MegolmV1BackupKey`.
     pub fn signatures(&self) -> BTreeMap<UserId, BTreeMap<DeviceKeyId, String>> {
         self.inner.signatures.to_owned()

--- a/crates/matrix-sdk-crypto/src/backups/keys/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/mod.rs
@@ -1,0 +1,54 @@
+// Copyright 2021 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module for the keys that are used to backup room keys.
+//!
+//! The backup key is split into two parts:
+//!
+//! ```text
+//!                     ┌───────────────────────────┐
+//!                     │  RecoveryKey | BackupKey  │
+//!                     └───────────────────────────┘
+//! ```
+//!
+//! 1. RecoveryKey, a private Curve25519 key that is used to decrypt backed up
+//!    room keys.
+//! 2. BackupKey, the public part of the Curve25519 RecoveryKey, this one is
+//!    used to encrypt room keys that get backed up.
+//!
+//! The `RecoveryKey` can be derived from a passphrase or randomly generated.
+//! To allow other devices access to this key you'll either have to re-enter the
+//! passphrase or the key as a base58 encoded string or received from another
+//! device using the secret sharing mechanism.
+//!
+//! In practice deriving a recovery key from a passphrase isn't done, and is
+//! **not** supported by the spec. Instead the secret storage key that encrypts
+//! secrets and puts them into your global account data gets derived from a
+//! passphrase and presented as a base58 encoded string, confusingly also called
+//! recovery key.
+//!
+//! The `RecoveryKey` can also be uploaded to your account data as an
+//! `m.megolm.v1` event, which gets encrypted by the SSSS key.
+//!
+//! The `MegolmV1BackupKey` is used to encrypt individual room keys so they can
+//! be uploaded to the homeserver.
+//!
+//! The `MegolmV1BackupKey` is a public key and is uploaded to the server using
+//! the `/room_keys/version` API endpoint.
+
+mod backup;
+mod recovery;
+
+pub use backup::MegolmV1BackupKey;
+pub use recovery::{DecodeError, PickledRecoveryKey, RecoveryKey};

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -71,12 +71,6 @@ pub struct RecoveryKey {
     version: Option<String>,
 }
 
-impl RecoveryKey {
-    fn as_bytes(&self) -> &[u8] {
-        &self.key
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PickledRecoveryKey(String);
 

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -224,7 +224,8 @@ impl RecoveryKey {
     }
 
     fn get_pk_decrytpion(&self) -> OlmPkDecryption {
-        OlmPkDecryption::from_private_key(self.key.as_ref()).expect("Hello world")
+        OlmPkDecryption::from_bytes(self.key.as_ref())
+            .expect("Can't generate a libom PkDecryption object from our private key")
     }
 
     /// Extract the public key from this `RecoveryKey`.

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -260,7 +260,6 @@ impl RecoveryKey {
 
     /// Try to import a `RecoveryKey` from a previously exported pickle.
     pub fn from_pickle(
-        &self,
         pickle: PickledRecoveryKey,
         pickle_key: &[u8],
     ) -> Result<Self, UnpicklingError> {

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -143,7 +143,7 @@ impl RecoveryKey {
         Self { key, version: None }
     }
 
-    pub fn from_base64(key: String) -> Result<Self, DecodeError> {
+    pub fn from_base64(key: &str) -> Result<Self, DecodeError> {
         let decoded = Zeroizing::new(crate::utilities::decode(key)?);
 
         if decoded.len() != Self::KEY_SIZE {

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -316,7 +316,7 @@ mod test {
 
         let base64 = key.to_base64();
         let decoded_key = RecoveryKey::from_base64(&base64)?;
-        assert_eq!(key.inner, decoded_key.inner, "The decode key doens't match the original");
+        assert_eq!(key.inner, decoded_key.inner, "The decode key does't match the original");
 
         RecoveryKey::from_base64("i").expect_err("The recovery key is too short");
 
@@ -329,7 +329,7 @@ mod test {
 
         let base64 = key.to_base58();
         let decoded_key = RecoveryKey::from_base58(&base64)?;
-        assert_eq!(key.inner, decoded_key.inner, "The decode key doens't match the original");
+        assert_eq!(key.inner, decoded_key.inner, "The decode key does't match the original");
 
         let test_key =
             RecoveryKey::from_base58("EsTcLW2KPGiFwKEA3As5g5c4BXwkqeeJZJV8Q9fugUMNUE4d")?;

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -1,0 +1,264 @@
+// Copyright 2021 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    convert::TryFrom,
+    io::{Cursor, Read},
+};
+
+use aes::cipher::generic_array::GenericArray;
+use aes_gcm::{
+    aead::{Aead, NewAead},
+    Aes256Gcm,
+};
+use bs58;
+use olm_rs::pk::OlmPkDecryption;
+use rand::{thread_rng, Error as RandomError, Fill};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use zeroize::{Zeroize, Zeroizing};
+
+use super::MegolmV1BackupKey;
+use crate::utilities::{decode_url_safe, encode, encode_url_safe};
+
+const NONCE_SIZE: usize = 12;
+
+#[derive(Debug, Error)]
+pub enum DecodeError {
+    #[error("The decoded recovery key has an invalid prefix: expected {0:?}, got {1:?}")]
+    Prefix([u8; 2], [u8; 2]),
+    #[error("The parity byte of the recovery key doesn't match: expected {0:?}, got {1:?}")]
+    Parity(u8, u8),
+    #[error("The decoded recovery key has a invalid length: expected {0}, got {1}")]
+    Length(usize, usize),
+    #[error(transparent)]
+    Base58(#[from] bs58::decode::Error),
+    #[error(transparent)]
+    Base64(#[from] base64::DecodeError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum UnpicklingError {
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("Couldn't decrypt the pickle: {0}")]
+    Decryption(String),
+    #[error(transparent)]
+    Decode(#[from] DecodeError),
+}
+
+#[derive(Zeroize)]
+#[zeroize(drop)]
+#[allow(missing_debug_implementations)]
+pub struct RecoveryKey {
+    key: [u8; RecoveryKey::KEY_SIZE],
+    version: Option<String>,
+}
+
+impl RecoveryKey {
+    fn as_bytes(&self) -> &[u8] {
+        &self.key
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PickledRecoveryKey(String);
+
+impl AsRef<str> for PickledRecoveryKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InnerPickle {
+    version: u8,
+    backup_version: Option<String>,
+    nonce: String,
+    ciphertext: String,
+}
+
+impl TryFrom<String> for RecoveryKey {
+    type Error = DecodeError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_base58(&value)
+    }
+}
+
+impl std::fmt::Display for RecoveryKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let string = Zeroizing::new(self.to_base58());
+
+        let string = Zeroizing::new(
+            string
+                .chars()
+                .collect::<Vec<char>>()
+                .chunks(Self::DISPLAY_CHUNK_SIZE)
+                .map(|c| c.iter().collect::<String>())
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+
+        write!(f, "{}", string.as_str())
+    }
+}
+
+impl RecoveryKey {
+    const KEY_SIZE: usize = 32;
+    const PREFIX: [u8; 2] = [0x8b, 0x01];
+    const PREFIX_PARITY: u8 = Self::PREFIX[0] ^ Self::PREFIX[1];
+    const DISPLAY_CHUNK_SIZE: usize = 4;
+
+    fn parity_byte(bytes: &[u8]) -> u8 {
+        bytes.iter().fold(Self::PREFIX_PARITY, |acc, x| acc ^ x)
+    }
+
+    pub fn new() -> Result<Self, RandomError> {
+        let mut rng = thread_rng();
+
+        let mut key = [0u8; Self::KEY_SIZE];
+        key.try_fill(&mut rng)?;
+
+        Ok(Self { key, version: None })
+    }
+
+    pub fn from_bytes(key: [u8; Self::KEY_SIZE]) -> Self {
+        Self { key, version: None }
+    }
+
+    pub fn from_base64(key: String) -> Result<Self, DecodeError> {
+        let decoded = Zeroizing::new(crate::utilities::decode(key)?);
+
+        if decoded.len() != Self::KEY_SIZE {
+            Err(DecodeError::Length(decoded.len(), Self::KEY_SIZE))
+        } else {
+            let mut key = [0u8; Self::KEY_SIZE];
+            key.copy_from_slice(&decoded);
+
+            Ok(Self { key, version: None })
+        }
+    }
+
+    pub fn to_base64(&self) -> String {
+        encode(self.key)
+    }
+
+    pub fn from_base58(value: &str) -> Result<Self, DecodeError> {
+        // Remove any whitespace we might have
+        let value: String = value.chars().filter(|c| !c.is_whitespace()).collect();
+
+        let decoded = bs58::decode(value).with_alphabet(bs58::Alphabet::BITCOIN).into_vec()?;
+        let mut decoded = Cursor::new(decoded);
+
+        let mut prefix = [0u8; 2];
+        let mut key = [0u8; Self::KEY_SIZE];
+        let mut expected_parity = [0u8; 1];
+
+        decoded.read_exact(&mut prefix)?;
+        decoded.read_exact(&mut key)?;
+        decoded.read_exact(&mut expected_parity)?;
+
+        let expected_parity = expected_parity[0];
+        let parity = Self::parity_byte(key.as_ref());
+
+        let _ = Zeroizing::new(decoded.into_inner());
+
+        if prefix != Self::PREFIX {
+            Err(DecodeError::Prefix(Self::PREFIX, prefix))
+        } else if expected_parity != parity {
+            Err(DecodeError::Parity(expected_parity, parity))
+        } else {
+            Ok(Self { key, version: None })
+        }
+    }
+
+    pub fn set_version(&mut self, version: String) {
+        self.version = Some(version)
+    }
+
+    pub fn public_key(&self) -> MegolmV1BackupKey {
+        let pk = OlmPkDecryption::from_private_key(self.key.as_ref()).unwrap();
+        let public_key = MegolmV1BackupKey::new(pk.public_key(), self.version.clone());
+        public_key
+    }
+
+    pub fn to_base58(&self) -> String {
+        let bytes = Zeroizing::new(
+            [
+                Self::PREFIX.as_ref(),
+                self.key.as_ref(),
+                [Self::parity_byte(self.key.as_ref())].as_ref(),
+            ]
+            .concat(),
+        );
+
+        bs58::encode(bytes.as_slice()).with_alphabet(bs58::Alphabet::BITCOIN).into_string()
+    }
+
+    pub fn pickle(&self, pickle_key: &[u8]) -> PickledRecoveryKey {
+        let key = GenericArray::from_slice(pickle_key);
+        let cipher = Aes256Gcm::new(key);
+
+        let mut nonce = vec![0u8; NONCE_SIZE];
+        let mut rng = thread_rng();
+
+        nonce.try_fill(&mut rng).expect("Can't generate random nocne to pickle the recovery key");
+        let nonce = GenericArray::from_slice(nonce.as_slice());
+
+        let ciphertext =
+            cipher.encrypt(nonce, self.key.as_ref()).expect("Can't encrypt recovery key");
+
+        let ciphertext = encode_url_safe(ciphertext);
+
+        let pickle = InnerPickle {
+            version: 1,
+            nonce: encode_url_safe(nonce.as_slice()),
+            ciphertext,
+            backup_version: self.version.clone(),
+        };
+
+        PickledRecoveryKey(serde_json::to_string(&pickle).expect("Can't encode pickled signing"))
+    }
+
+    pub fn from_pickle(
+        &self,
+        pickle: PickledRecoveryKey,
+        pickle_key: &[u8],
+    ) -> Result<Self, UnpicklingError> {
+        let pickled: InnerPickle = serde_json::from_str(pickle.as_ref())?;
+
+        let key = GenericArray::from_slice(pickle_key);
+        let cipher = Aes256Gcm::new(key);
+
+        let nonce = decode_url_safe(pickled.nonce).map_err(DecodeError::from)?;
+        let nonce = GenericArray::from_slice(&nonce);
+        let ciphertext = &decode_url_safe(pickled.ciphertext).map_err(DecodeError::from)?;
+
+        let decrypted = cipher
+            .decrypt(nonce, ciphertext.as_slice())
+            .map_err(|e| UnpicklingError::Decryption(e.to_string()))?;
+
+        if decrypted.len() != Self::KEY_SIZE {
+            Err(DecodeError::Length(decrypted.len(), Self::KEY_SIZE).into())
+        } else {
+            let mut key = [0u8; Self::KEY_SIZE];
+            key.copy_from_slice(&decrypted);
+
+            Ok(Self { key, version: pickled.backup_version })
+        }
+    }
+}

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -287,7 +287,13 @@ impl RecoveryKey {
     }
 
     /// Try to decrypt the given ciphertext using this `RecoveryKey`.
-    pub fn decrypt(
+    ///
+    /// This will use the [`m.megolm_backup.v1.curve25519-aes-sha2`] algorithm
+    /// to decrypt the given ciphertext.
+    ///
+    /// [`m.megolm_backup.v1.curve25519-aes-sha2`]:
+    /// https://spec.matrix.org/unstable/client-server-api/#backup-algorithm-mmegolm_backupv1curve25519-aes-sha2
+    pub fn decrypt_v1(
         &self,
         mac: String,
         ephemeral_key: String,

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -228,8 +228,8 @@ impl RecoveryKey {
             .expect("Can't generate a libom PkDecryption object from our private key")
     }
 
-    /// Extract the public key from this `RecoveryKey`.
-    pub fn public_key(&self) -> MegolmV1BackupKey {
+    /// Extract the megolm.v1 public key from this `RecoveryKey`.
+    pub fn megolm_v1_public_key(&self) -> MegolmV1BackupKey {
         let pk = self.get_pk_decrytpion();
         let public_key = MegolmV1BackupKey::new(pk.public_key(), None);
         public_key

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -80,6 +80,10 @@ impl BackupMachine {
         }
     }
 
+    pub async fn enabled(&self) -> bool {
+        self.backup_key.read().await.as_ref().map(|b| b.backup_version().is_some()).unwrap_or(false)
+    }
+
     /// TODO
     pub async fn enable_backup(&self, key: MegolmV1BackupKey) -> Result<(), CryptoStoreError> {
         if key.backup_version().is_some() {

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code, missing_docs)]
+#![allow(missing_docs)]
 
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -115,7 +115,7 @@ impl BackupMachine {
     /// serialization cycle.
     ///
     /// [`BackupAlgorithm`]: ruma::api::client::r0::backup::BackupAlgorithm
-    /// [`/room_keys/verson`]: https://spec.matrix.org/unstable/client-server-api/#get_matrixclientv3room_keysversion
+    /// [`/room_keys/version`]: https://spec.matrix.org/unstable/client-server-api/#get_matrixclientv3room_keysversion
     pub async fn verify_backup(
         &self,
         mut serialized_auth_data: Value,

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -36,6 +36,7 @@ use crate::{
 mod keys;
 
 pub use keys::{DecodeError, MegolmV1BackupKey, PickledRecoveryKey, RecoveryKey};
+pub use olm_rs::errors::OlmPkDecryptionError;
 
 /// TODO
 #[derive(Debug, Clone)]

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -104,7 +104,7 @@ impl BackupMachine {
 
         let auth_data: AuthData = serde_json::from_value(serialized_auth_data.clone())?;
 
-        debug!(auth_data =? auth_data, "Verifying backup auth data");
+        debug!(?auth_data, "Verifying backup auth data");
 
         Ok(if let Some(signatures) = auth_data.signatures.get(self.store.user_id()) {
             for (device_key_id, _) in signatures {
@@ -112,7 +112,7 @@ impl BackupMachine {
                     if device_key_id.device_id() == self.account.device_id() {
                         let result = self.account.is_signed(&mut serialized_auth_data);
 
-                        debug!(result =? result, "Checking auth data signature of our own device");
+                        debug!(?result, "Checking auth data signature of our own device");
 
                         if result.is_ok() {
                             return Ok(true);
@@ -282,7 +282,7 @@ impl BackupMachine {
 
                     Ok(Some(request))
                 } else {
-                    debug!(backup_key =? backup_key, "No room keys need to be backed up");
+                    debug!(?backup_key, "No room keys need to be backed up");
                     Ok(None)
                 }
             } else {

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -65,7 +65,7 @@ impl PendingBackup {
 
 impl From<PendingBackup> for OutgoingRequest {
     fn from(b: PendingBackup) -> Self {
-        OutgoingRequest { request_id: b.request_id, request: Arc::new(b.request.into()) }.into()
+        OutgoingRequest { request_id: b.request_id, request: Arc::new(b.request.into()) }
     }
 }
 
@@ -108,7 +108,7 @@ impl BackupMachine {
         debug!(?auth_data, "Verifying backup auth data");
 
         Ok(if let Some(signatures) = auth_data.signatures.get(self.store.user_id()) {
-            for (device_key_id, _) in signatures {
+            for device_key_id in signatures.keys() {
                 if device_key_id.algorithm() == DeviceKeyAlgorithm::Ed25519 {
                     if device_key_id.device_id() == self.account.device_id() {
                         let result = self.account.is_signed(&mut serialized_auth_data);
@@ -184,11 +184,7 @@ impl BackupMachine {
         recovery_key: Option<RecoveryKey>,
         version: Option<String>,
     ) -> Result<(), CryptoStoreError> {
-        let mut changes = Changes::default();
-
-        changes.recovery_key = recovery_key;
-        changes.backup_version = version;
-
+        let changes = Changes { recovery_key, backup_version: version, ..Default::default() };
         self.store.save_changes(changes).await
     }
 

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -232,7 +232,7 @@ impl BackupMachine {
     }
 
     /// Encrypt a batch of room keys and return a request that needs to be sent
-    /// out to backup room keys.
+    /// out to backup the room keys.
     pub async fn backup(&self) -> Result<Option<OutgoingRequest>, CryptoStoreError> {
         let mut request = self.pending_backup.write().await;
 

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -179,7 +179,13 @@ impl BackupMachine {
 
     /// Activate the given backup key to be used to encrypt and backup room
     /// keys.
-    pub async fn enable_backup(&self, key: MegolmV1BackupKey) -> Result<(), CryptoStoreError> {
+    ///
+    /// This will use the [`m.megolm_backup.v1.curve25519-aes-sha2`] algorithm
+    /// to encrypt the room keys.
+    ///
+    /// [`m.megolm_backup.v1.curve25519-aes-sha2`]:
+    /// https://spec.matrix.org/unstable/client-server-api/#backup-algorithm-mmegolm_backupv1curve25519-aes-sha2
+    pub async fn enable_backup_v1(&self, key: MegolmV1BackupKey) -> Result<(), CryptoStoreError> {
         if key.backup_version().is_some() {
             *self.backup_key.write().await = Some(key.clone());
             info!(backup_key =? key, "Activated a backup");
@@ -414,7 +420,7 @@ mod test {
         let backup_key = recovery_key.public_key();
         backup_key.set_version("1".to_owned());
 
-        backup_machine.enable_backup(backup_key).await?;
+        backup_machine.enable_backup_v1(backup_key).await?;
 
         let request =
             backup_machine.backup().await?.expect("Created a backup request successfully");

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -417,7 +417,7 @@ mod test {
         assert_eq!(counts.backed_up, 0, "No room keys have been backed up yet");
 
         let recovery_key = RecoveryKey::new().expect("Can't create new recovery key");
-        let backup_key = recovery_key.public_key();
+        let backup_key = recovery_key.megolm_v1_public_key();
         backup_key.set_version("1".to_owned());
 
         backup_machine.enable_backup_v1(backup_key).await?;

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -1,0 +1,251 @@
+// Copyright 2021 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(dead_code, missing_docs)]
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use matrix_sdk_common::{locks::RwLock, uuid::Uuid};
+use ruma::{api::client::r0::backup::RoomKeyBackup, RoomId};
+use tracing::{debug, info, warn};
+
+use crate::{
+    olm::{Account, InboundGroupSession},
+    store::{BackupKeys, Changes, RoomKeyCounts, Store},
+    CryptoStoreError, KeysBackupRequest, OutgoingRequest,
+};
+
+mod keys;
+
+pub use keys::{DecodeError, MegolmV1BackupKey, PickledRecoveryKey, RecoveryKey};
+
+/// TODO
+#[derive(Debug, Clone)]
+pub struct BackupMachine {
+    account: Account,
+    store: Store,
+    backup_key: Arc<RwLock<Option<MegolmV1BackupKey>>>,
+    pending_backup: Arc<RwLock<Option<PendingBackup>>>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingBackup {
+    request_id: Uuid,
+    request: KeysBackupRequest,
+    sessions: BTreeMap<RoomId, BTreeMap<String, BTreeSet<String>>>,
+}
+
+impl PendingBackup {
+    fn session_was_part_of_the_backup(&self, session: &InboundGroupSession) -> bool {
+        self.sessions
+            .get(session.room_id())
+            .and_then(|r| r.get(session.sender_key()).map(|s| s.contains(session.session_id())))
+            .unwrap_or(false)
+    }
+}
+
+impl From<PendingBackup> for OutgoingRequest {
+    fn from(b: PendingBackup) -> Self {
+        OutgoingRequest { request_id: b.request_id, request: Arc::new(b.request.into()) }.into()
+    }
+}
+
+impl BackupMachine {
+    const BACKUP_BATCH_SIZE: usize = 100;
+
+    pub(crate) fn new(
+        account: Account,
+        store: Store,
+        backup_key: Option<MegolmV1BackupKey>,
+    ) -> Self {
+        Self {
+            account,
+            store,
+            backup_key: RwLock::new(backup_key).into(),
+            pending_backup: RwLock::new(None).into(),
+        }
+    }
+
+    /// TODO
+    pub async fn enable_backup(&self, key: MegolmV1BackupKey) -> Result<(), CryptoStoreError> {
+        if key.backup_version().is_some() {
+            *self.backup_key.write().await = Some(key.clone());
+            info!(backup_key =? key, "Activated a backup");
+        } else {
+            warn!(backup_key =? key, "Tried to activate a backup without having the backup key uploaded");
+        }
+
+        Ok(())
+    }
+
+    /// TODO
+    pub async fn room_key_counts(&self) -> Result<RoomKeyCounts, CryptoStoreError> {
+        self.store.inbound_group_session_counts().await
+    }
+
+    /// TODO
+    pub async fn disable_backup(&self) -> Result<(), CryptoStoreError> {
+        self.backup_key.write().await.take();
+        self.pending_backup.write().await.take();
+
+        self.store.reset_backup_state().await?;
+
+        Ok(())
+    }
+
+    /// TODO
+    pub async fn save_recovery_key(
+        &self,
+        recovery_key: Option<RecoveryKey>,
+        version: Option<String>,
+    ) -> Result<(), CryptoStoreError> {
+        let mut changes = Changes::default();
+
+        changes.recovery_key = recovery_key;
+        changes.backup_version = version;
+
+        self.store.save_changes(changes).await
+    }
+
+    /// TODO
+    pub async fn get_backup_keys(&self) -> Result<BackupKeys, CryptoStoreError> {
+        self.store.load_backup_keys().await
+    }
+
+    /// TODO
+    pub async fn backup(&self) -> Result<Option<OutgoingRequest>, CryptoStoreError> {
+        if let Some(request) = &*self.pending_backup.read().await {
+            Ok(Some(request.clone().into()))
+        } else {
+            let request = self.backup_helper().await?;
+            *self.pending_backup.write().await = request.clone();
+
+            Ok(request.map(|r| r.into()))
+        }
+    }
+
+    pub(crate) async fn mark_request_as_sent(
+        &self,
+        request_id: Uuid,
+    ) -> Result<(), CryptoStoreError> {
+        let mut request = self.pending_backup.write().await;
+
+        if let Some(r) = &*request {
+            if r.request_id == request_id {
+                let sessions: Vec<_> = self
+                    .store
+                    .get_inbound_group_sessions()
+                    .await?
+                    .into_iter()
+                    .filter(|s| r.session_was_part_of_the_backup(s))
+                    .collect();
+
+                for session in &sessions {
+                    session.mark_as_backed_up()
+                }
+
+                debug!(sessions =? r.sessions, "Marking inbound group sessions as backed up",);
+
+                let changes = Changes { inbound_group_sessions: sessions, ..Default::default() };
+                self.store.save_changes(changes).await?;
+
+                *request = None;
+            } else {
+                warn!(
+                    expected = r.request_id.to_string().as_str(),
+                    got = request_id.to_string().as_str(),
+                    "Tried to mark a pending backup as sent but the request id didn't match"
+                )
+            }
+        } else {
+            warn!(
+                request_id = request_id.to_string().as_str(),
+                "Tried to mark a pending backup as sent but there isn't a backup pending"
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn backup_helper(&self) -> Result<Option<PendingBackup>, CryptoStoreError> {
+        if let Some(backup_key) = &*self.backup_key.read().await {
+            if let Some(version) = backup_key.backup_version() {
+                let sessions = self.store.inbound_group_sessions_for_backup().await?;
+
+                if !sessions.is_empty() {
+                    let key_count = sessions.len();
+                    let (backup, session_record) = Self::backup_keys(sessions, backup_key).await;
+
+                    let request = PendingBackup {
+                        request_id: Uuid::new_v4(),
+                        request: KeysBackupRequest { version, rooms: backup },
+                        sessions: session_record,
+                    };
+
+                    info!(key_count = key_count, backup_key =? backup_key, "Backed up room keys");
+
+                    Ok(Some(request))
+                } else {
+                    debug!(backup_key =? backup_key, "No room keys need to be backed up");
+                    Ok(None)
+                }
+            } else {
+                info!("Trying to backup room keys but the backup key wasn't uploaded");
+                Ok(None)
+            }
+        } else {
+            info!("Trying to backup room keys but no backup key was found");
+            Ok(None)
+        }
+    }
+
+    /// Backup all the non-backed up room keys we know about
+    async fn backup_keys(
+        sessions: Vec<InboundGroupSession>,
+        backup_key: &MegolmV1BackupKey,
+    ) -> (BTreeMap<RoomId, RoomKeyBackup>, BTreeMap<RoomId, BTreeMap<String, BTreeSet<String>>>)
+    {
+        let mut backup: BTreeMap<RoomId, RoomKeyBackup> = BTreeMap::new();
+        let mut session_record: BTreeMap<RoomId, BTreeMap<String, BTreeSet<String>>> =
+            BTreeMap::new();
+
+        for session in sessions.into_iter().take(Self::BACKUP_BATCH_SIZE) {
+            let room_id = session.room_id().to_owned();
+            let session_id = session.session_id().to_owned();
+            let sender_key = session.sender_key().to_owned();
+            let session = backup_key.encrypt(session).await;
+
+            session_record
+                .entry(room_id.clone())
+                .or_default()
+                .entry(sender_key)
+                .or_default()
+                .insert(session_id.clone());
+
+            backup
+                .entry(room_id)
+                .or_insert_with(|| RoomKeyBackup::new(BTreeMap::new()))
+                .sessions
+                .insert(session_id, session);
+        }
+
+        (backup, session_record)
+    }
+}
+
+#[cfg(test)]
+mod test {}

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -539,7 +539,7 @@ impl ReadOnlyDevice {
         Ok(())
     }
 
-    fn is_signed_by_device(&self, json: &mut Value) -> Result<(), SignatureError> {
+    pub(crate) fn is_signed_by_device(&self, json: &mut Value) -> Result<(), SignatureError> {
         let signing_key =
             self.get_key(DeviceKeyAlgorithm::Ed25519).ok_or(SignatureError::MissingSigningKey)?;
 

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -25,6 +25,9 @@
     unused_qualifications
 )]
 
+#[cfg(feature = "backups_v1")]
+#[cfg_attr(feature = "docs", doc(cfg(backups_v1)))]
+pub mod backups;
 mod error;
 mod file_encryption;
 mod gossiping;
@@ -67,7 +70,7 @@ pub use matrix_qrcode;
 pub(crate) use olm::ReadOnlyAccount;
 pub use olm::{CrossSigningStatus, EncryptionSettings};
 pub use requests::{
-    IncomingResponse, KeysQueryRequest, OutgoingRequest, OutgoingRequests,
+    IncomingResponse, KeysBackupRequest, KeysQueryRequest, OutgoingRequest, OutgoingRequests,
     OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest, UploadSigningKeysRequest,
 };
 pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretImportError};

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -46,11 +46,14 @@ use ruma::{
         secret::request::SecretName,
         AnyMessageEventContent, AnyRoomEvent, AnyToDeviceEvent, EventContent,
     },
-    DeviceId, DeviceIdBox, DeviceKeyAlgorithm, EventEncryptionAlgorithm, RoomId, UInt, UserId,
+    DeviceId, DeviceIdBox, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, RoomId, UInt,
+    UserId,
 };
 use serde_json::Value;
 use tracing::{debug, error, info, trace, warn};
 
+#[cfg(feature = "backups_v1")]
+use crate::backups::BackupMachine;
 #[cfg(feature = "sled_cryptostore")]
 use crate::store::sled::SledStore;
 use crate::{
@@ -104,6 +107,9 @@ pub struct OlmMachine {
     /// State machine handling public user identities and devices, keeping track
     /// of when a key query needs to be done and handling one.
     identity_manager: IdentityManager,
+    /// A state machine that handles creating room key backups.
+    #[cfg(feature = "backups_v1")]
+    backup_machine: BackupMachine,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -180,6 +186,9 @@ impl OlmMachine {
         let identity_manager =
             IdentityManager::new(user_id.clone(), device_id.clone(), store.clone());
 
+        #[cfg(feature = "backups_v1")]
+        let backup_machine = BackupMachine::new(account.clone(), store.clone(), None);
+
         OlmMachine {
             user_id,
             device_id,
@@ -191,6 +200,8 @@ impl OlmMachine {
             verification_machine,
             key_request_machine,
             identity_manager,
+            #[cfg(feature = "backups_v1")]
+            backup_machine,
         }
     }
 
@@ -370,6 +381,10 @@ impl OlmMachine {
             }
             IncomingResponse::RoomMessage(_) => {
                 self.verification_machine.mark_request_as_sent(request_id);
+            }
+            IncomingResponse::KeysBackup(_) => {
+                #[cfg(feature = "backups_v1")]
+                self.backup_machine.mark_request_as_sent(*request_id).await?;
             }
         };
 
@@ -1452,6 +1467,58 @@ impl OlmMachine {
         export: CrossSigningKeyExport,
     ) -> Result<CrossSigningStatus, SecretImportError> {
         self.store.import_cross_signing_keys(export).await
+    }
+
+    async fn sign_account(
+        &self,
+        message: &str,
+        signatures: &mut BTreeMap<UserId, BTreeMap<DeviceKeyId, String>>,
+    ) {
+        let device_key_id = DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, self.device_id());
+        let signature = self.account.sign(message).await;
+
+        signatures.entry(self.user_id().to_owned()).or_default().insert(device_key_id, signature);
+    }
+
+    async fn sign_master(
+        &self,
+        message: &str,
+        signatures: &mut BTreeMap<UserId, BTreeMap<DeviceKeyId, String>>,
+    ) -> Result<(), crate::SignatureError> {
+        let identity = &*self.user_identity.lock().await;
+
+        let master_key: DeviceIdBox = identity
+            .master_public_key()
+            .await
+            .and_then(|m| m.get_first_key().map(|k| k.to_owned()))
+            .ok_or(crate::SignatureError::MissingSigningKey)?
+            .into();
+
+        let device_key_id = DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, &master_key);
+        let signature = identity.sign(message).await?;
+
+        signatures.entry(self.user_id().to_owned()).or_default().insert(device_key_id, signature);
+
+        Ok(())
+    }
+
+    /// TODO
+    pub async fn sign(&self, message: &str) -> BTreeMap<UserId, BTreeMap<DeviceKeyId, String>> {
+        let mut signatures: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
+
+        self.sign_account(message, &mut signatures).await;
+
+        if let Err(e) = self.sign_master(message, &mut signatures).await {
+            warn!(error =? e, "Couldn't sign the message using the cross signing master key")
+        }
+
+        signatures
+    }
+
+    /// TODO
+    #[cfg(feature = "backups_v1")]
+    pub fn backup_machine(&self) -> &BackupMachine {
+        &self.backup_machine
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1502,7 +1502,8 @@ impl OlmMachine {
         Ok(())
     }
 
-    /// TODO
+    /// Sign the given message using our device key and if available cross
+    /// signing master key.
     pub async fn sign(&self, message: &str) -> BTreeMap<UserId, BTreeMap<DeviceKeyId, String>> {
         let mut signatures: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
 
@@ -1515,7 +1516,10 @@ impl OlmMachine {
         signatures
     }
 
-    /// TODO
+    /// Get a reference to the backup related state machine.
+    ///
+    /// This state machine can be used to incrementally backup all room keys to
+    /// the server.
     #[cfg(feature = "backups_v1")]
     pub fn backup_machine(&self) -> &BackupMachine {
         &self.backup_machine

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -50,7 +50,7 @@ use tracing::{debug, info, trace, warn};
 
 use super::{
     EncryptionSettings, InboundGroupSession, OutboundGroupSession, PrivateCrossSigningIdentity,
-    Session, Utility,
+    Session,
 };
 use crate::{
     error::{EventError, OlmResult, SessionCreationError},
@@ -686,10 +686,10 @@ impl ReadOnlyAccount {
         self.inner.lock().await.sign(string)
     }
 
+    #[cfg(feature = "backups_v1")]
     pub(crate) fn is_signed(&self, json: &mut Value) -> Result<(), SignatureError> {
         let signing_key = self.identity_keys.ed25519();
-
-        let utility = Utility::new();
+        let utility = crate::olm::Utility::new();
 
         utility.verify_json(
             &self.user_id,

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -50,7 +50,7 @@ use tracing::{debug, info, trace, warn};
 
 use super::{
     EncryptionSettings, InboundGroupSession, OutboundGroupSession, PrivateCrossSigningIdentity,
-    Session,
+    Session, Utility,
 };
 use crate::{
     error::{EventError, OlmResult, SessionCreationError},
@@ -684,6 +684,19 @@ impl ReadOnlyAccount {
     /// Returns the signature as a base64 encoded string.
     pub async fn sign(&self, string: &str) -> String {
         self.inner.lock().await.sign(string)
+    }
+
+    pub(crate) fn is_signed(&self, json: &mut Value) -> Result<(), SignatureError> {
+        let signing_key = self.identity_keys.ed25519();
+
+        let utility = Utility::new();
+
+        utility.verify_json(
+            &self.user_id,
+            &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, self.device_id()),
+            signing_key,
+            json,
+        )
     }
 
     /// Store the account as a base64 encoded string.

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -232,6 +232,7 @@ impl InboundGroupSession {
         self.backed_up.store(false, SeqCst)
     }
 
+    #[cfg(feature = "backups_v1")]
     pub(crate) fn mark_as_backed_up(&self) {
         self.backed_up.store(true, SeqCst)
     }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -43,7 +43,7 @@ pub struct GroupSessionKey(pub String);
 #[zeroize(drop)]
 pub struct ExportedGroupSessionKey(pub String);
 
-/// An exported version of a `InboundGroupSession`
+/// An exported version of an `InboundGroupSession`
 ///
 /// This can be used to share the `InboundGroupSession` in an exported file.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -59,6 +59,28 @@ pub struct ExportedRoomKey {
 
     /// The ID of the session that the key is for.
     pub session_id: String,
+
+    /// The key for the session.
+    pub session_key: ExportedGroupSessionKey,
+
+    /// The Ed25519 key of the device which initiated the session originally.
+    pub sender_claimed_keys: BTreeMap<DeviceKeyAlgorithm, String>,
+
+    /// Chain of Curve25519 keys through which this session was forwarded, via
+    /// m.forwarded_room_key events.
+    pub forwarding_curve25519_key_chain: Vec<String>,
+}
+
+/// A backed up version of an `InboundGroupSession`
+///
+/// This can be used to backup the `InboundGroupSession` to the server.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct BackedUpRoomKey {
+    /// The encryption algorithm that the session uses.
+    pub algorithm: EventEncryptionAlgorithm,
+
+    /// The Curve25519 key of the device which initiated the session originally.
+    pub sender_key: String,
 
     /// The key for the session.
     pub session_key: ExportedGroupSessionKey,
@@ -100,6 +122,18 @@ impl TryInto<ToDeviceForwardedRoomKeyEventContent> for ExportedRoomKey {
                 forwarding_curve25519_key_chain: self.forwarding_curve25519_key_chain,
             }
             .into())
+        }
+    }
+}
+
+impl From<ExportedRoomKey> for BackedUpRoomKey {
+    fn from(k: ExportedRoomKey) -> Self {
+        Self {
+            algorithm: k.algorithm,
+            sender_key: k.sender_key,
+            session_key: k.session_key,
+            sender_claimed_keys: k.sender_claimed_keys,
+            forwarding_curve25519_key_chain: k.forwarding_curve25519_key_chain,
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -458,6 +458,17 @@ impl PrivateCrossSigningIdentity {
         Ok(SignatureUploadRequest::new(signed_keys))
     }
 
+    pub(crate) async fn sign(&self, message: &str) -> Result<String, SignatureError> {
+        Ok(self
+            .master_key
+            .lock()
+            .await
+            .as_ref()
+            .ok_or(SignatureError::MissingSigningKey)?
+            .sign(message)
+            .await)
+    }
+
     /// Create a new identity for the given Olm Account.
     ///
     /// Returns the new identity, the upload signing keys request and a

--- a/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
@@ -155,6 +155,10 @@ impl MasterSigning {
         Ok(Self { inner, public_key: pickle.public_key.into() })
     }
 
+    pub async fn sign(&self, message: &str) -> String {
+        self.inner.sign(message).await.0
+    }
+
     pub async fn sign_subkey<'a>(&self, subkey: &mut CrossSigningKey) {
         let subkey_without_signatures = json!({
             "user_id": subkey.user_id.clone(),
@@ -164,7 +168,7 @@ impl MasterSigning {
 
         let message = serde_json::to_string(&subkey_without_signatures)
             .expect("Can't serialize cross signing subkey");
-        let signature = self.inner.sign(&message).await;
+        let signature = self.sign(&message).await;
 
         subkey
             .signatures
@@ -176,7 +180,7 @@ impl MasterSigning {
                     self.inner.public_key().as_str().into(),
                 )
                 .to_string(),
-                signature.0,
+                signature,
             );
     }
 }

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -17,6 +17,7 @@ use std::{collections::BTreeMap, iter, sync::Arc, time::Duration};
 use matrix_sdk_common::uuid::Uuid;
 use ruma::{
     api::client::r0::{
+        backup::{add_backup_keys::Response as KeysBackupResponse, RoomKeyBackup},
         keys::{
             claim_keys::{Request as KeysClaimRequest, Response as KeysClaimResponse},
             get_keys::Response as KeysQueryResponse,
@@ -197,6 +198,8 @@ pub enum OutgoingRequests {
     /// A room message request, usually for sending in-room interactive
     /// verification events.
     RoomMessage(RoomMessageRequest),
+    /// TODO
+    KeysBackup(KeysBackupRequest),
 }
 
 #[cfg(test)]
@@ -212,6 +215,12 @@ impl OutgoingRequests {
 impl From<KeysQueryRequest> for OutgoingRequests {
     fn from(request: KeysQueryRequest) -> Self {
         OutgoingRequests::KeysQuery(request)
+    }
+}
+
+impl From<KeysBackupRequest> for OutgoingRequests {
+    fn from(r: KeysBackupRequest) -> Self {
+        OutgoingRequests::KeysBackup(r)
     }
 }
 
@@ -278,11 +287,19 @@ pub enum IncomingResponse<'a> {
     SignatureUpload(&'a SignatureUploadResponse),
     /// A room message response, usually for interactive verifications.
     RoomMessage(&'a RoomMessageResponse),
+    /// TODO
+    KeysBackup(&'a KeysBackupResponse),
 }
 
 impl<'a> From<&'a KeysUploadResponse> for IncomingResponse<'a> {
     fn from(response: &'a KeysUploadResponse) -> Self {
         IncomingResponse::KeysUpload(response)
+    }
+}
+
+impl<'a> From<&'a KeysBackupResponse> for IncomingResponse<'a> {
+    fn from(response: &'a KeysBackupResponse) -> Self {
+        IncomingResponse::KeysBackup(response)
     }
 }
 
@@ -354,6 +371,15 @@ pub struct RoomMessageRequest {
 
     /// The event content to send.
     pub content: AnyMessageEventContent,
+}
+
+/// TODO
+#[derive(Clone, Debug)]
+pub struct KeysBackupRequest {
+    /// TODO
+    pub version: String,
+    /// TODO
+    pub rooms: BTreeMap<RoomId, RoomKeyBackup>,
 }
 
 /// An enum over the different outgoing verification based requests.

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -198,7 +198,7 @@ pub enum OutgoingRequests {
     /// A room message request, usually for sending in-room interactive
     /// verification events.
     RoomMessage(RoomMessageRequest),
-    /// TODO
+    /// A request that will back up a batch of room keys to the server.
     KeysBackup(KeysBackupRequest),
 }
 
@@ -287,7 +287,7 @@ pub enum IncomingResponse<'a> {
     SignatureUpload(&'a SignatureUploadResponse),
     /// A room message response, usually for interactive verifications.
     RoomMessage(&'a RoomMessageResponse),
-    /// TODO
+    /// Response for the server-side room key backup request.
     KeysBackup(&'a KeysBackupResponse),
 }
 
@@ -373,12 +373,13 @@ pub struct RoomMessageRequest {
     pub content: AnyMessageEventContent,
 }
 
-/// TODO
+/// A request that will back up a batch of room keys to the server.
 #[derive(Clone, Debug)]
 pub struct KeysBackupRequest {
-    /// TODO
+    /// The backup version that these room keys should be part of.
     pub version: String,
-    /// TODO
+    /// The map from room id to a backed up room key that we're going to upload
+    /// to the server.
     pub rooms: BTreeMap<RoomId, RoomKeyBackup>,
 }
 

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -111,6 +111,11 @@ impl GroupSessionStore {
             .collect()
     }
 
+    /// Get the number of `InboundGroupSession`s we have.
+    pub fn count(&self) -> usize {
+        self.entries.iter().map(|d| d.value().values().map(|t| t.len()).sum::<usize>()).sum()
+    }
+
     /// Get a inbound group session from our store.
     ///
     /// # Arguments

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -166,7 +166,7 @@ impl CryptoStore for MemoryStore {
 
     async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
         let backed_up =
-            self.get_inbound_group_sessions().await?.into_iter().filter(|s| !s.backed_up()).count();
+            self.get_inbound_group_sessions().await?.into_iter().filter(|s| s.backed_up()).count();
 
         Ok(RoomKeyCounts { total: self.inbound_group_sessions.count(), backed_up })
     }
@@ -302,7 +302,7 @@ impl CryptoStore for MemoryStore {
     }
 
     async fn load_backup_keys(&self) -> Result<BackupKeys> {
-        todo!()
+        Ok(BackupKeys::default())
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -165,17 +165,22 @@ impl CryptoStore for MemoryStore {
     }
 
     async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
-        let backed_up = self.inbound_group_sessions_for_backup().await?.len();
+        let backed_up =
+            self.get_inbound_group_sessions().await?.into_iter().filter(|s| !s.backed_up()).count();
 
         Ok(RoomKeyCounts { total: self.inbound_group_sessions.count(), backed_up })
     }
 
-    async fn inbound_group_sessions_for_backup(&self) -> Result<Vec<InboundGroupSession>> {
+    async fn inbound_group_sessions_for_backup(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<InboundGroupSession>> {
         Ok(self
             .get_inbound_group_sessions()
             .await?
             .into_iter()
             .filter(|s| !s.backed_up())
+            .take(limit)
             .collect())
     }
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -176,14 +176,13 @@ pub struct RoomKeyCounts {
     pub backed_up: usize,
 }
 
-/// TODO
-#[derive(Default)]
-#[allow(missing_debug_implementations)]
+/// Stored versions of the backup keys.
+#[derive(Default, Debug)]
 pub struct BackupKeys {
-    /// TODO
+    /// The recovery key, the one used to decrypt backed up room keys.
     #[cfg(feature = "backups_v1")]
     pub recovery_key: Option<crate::backups::RecoveryKey>,
-    /// TODO
+    /// The version that we are using for backups.
     #[cfg(feature = "backups_v1")]
     pub backup_version: Option<String>,
 }
@@ -657,7 +656,7 @@ pub trait CryptoStore: AsyncTraitDeps {
     /// Reset the backup state of all the stored inbound group sessions.
     async fn reset_backup_state(&self) -> Result<()>;
 
-    /// TODO
+    /// Get the backup keys we have stored.
     async fn load_backup_keys(&self) -> Result<BackupKeys>;
 
     /// Get the outbound group sessions we have stored that is used for the

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -514,7 +514,12 @@ impl Store {
                     self.save_changes(changes).await?;
                 }
             }
-            SecretName::RecoveryKey => (),
+            SecretName::RecoveryKey => {
+                // We don't import the recovery key here since we'll want to
+                // check if the public key matches to the latest version on the
+                // server. We instead leave the key in the event and let the
+                // user import it later.
+            }
             name => {
                 warn!(secret =? name, "Tried to import an unknown secret");
             }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -633,7 +633,10 @@ pub trait CryptoStore: AsyncTraitDeps {
     async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts>;
 
     /// Get all the inbound group sessions we have not backed up yet.
-    async fn inbound_group_sessions_for_backup(&self) -> Result<Vec<InboundGroupSession>>;
+    async fn inbound_group_sessions_for_backup(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<InboundGroupSession>>;
 
     /// Reset the backup state of all the stored inbound group sessions.
     async fn reset_backup_state(&self) -> Result<()>;

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -100,8 +100,8 @@ pub(crate) struct Store {
     verification_machine: VerificationMachine,
 }
 
-#[derive(Default)]
-#[allow(missing_docs, missing_debug_implementations)]
+#[derive(Default, Debug)]
+#[allow(missing_docs)]
 pub struct Changes {
     pub account: Option<ReadOnlyAccount>,
     pub private_identity: Option<PrivateCrossSigningIdentity>,

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -100,11 +100,15 @@ pub(crate) struct Store {
     verification_machine: VerificationMachine,
 }
 
-#[derive(Clone, Debug, Default)]
-#[allow(missing_docs)]
+#[derive(Default)]
+#[allow(missing_docs, missing_debug_implementations)]
 pub struct Changes {
     pub account: Option<ReadOnlyAccount>,
     pub private_identity: Option<PrivateCrossSigningIdentity>,
+    #[cfg(feature = "backups_v1")]
+    pub backup_version: Option<String>,
+    #[cfg(feature = "backups_v1")]
+    pub recovery_key: Option<crate::backups::RecoveryKey>,
     pub sessions: Vec<Session>,
     pub message_hashes: Vec<OlmMessageHash>,
     pub inbound_group_sessions: Vec<InboundGroupSession>,
@@ -161,6 +165,27 @@ impl DeviceChanges {
     fn is_empty(&self) -> bool {
         self.new.is_empty() && self.changed.is_empty() && self.deleted.is_empty()
     }
+}
+
+/// Struct holding info about how many room keys the store has.
+#[derive(Debug, Clone, Default)]
+pub struct RoomKeyCounts {
+    /// The total number of room keys the store has.
+    pub total: usize,
+    /// The number of backed up room keys the store has.
+    pub backed_up: usize,
+}
+
+/// TODO
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+pub struct BackupKeys {
+    /// TODO
+    #[cfg(feature = "backups_v1")]
+    pub recovery_key: Option<crate::backups::RecoveryKey>,
+    /// TODO
+    #[cfg(feature = "backups_v1")]
+    pub backup_version: Option<String>,
 }
 
 /// A struct containing private cross signing keys that can be backed up or
@@ -602,6 +627,19 @@ pub trait CryptoStore: AsyncTraitDeps {
 
     /// Get all the inbound group sessions we have stored.
     async fn get_inbound_group_sessions(&self) -> Result<Vec<InboundGroupSession>>;
+
+    /// Get the number inbound group sessions we have and how many of them are
+    /// backed up.
+    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts>;
+
+    /// Get all the inbound group sessions we have not backed up yet.
+    async fn inbound_group_sessions_for_backup(&self) -> Result<Vec<InboundGroupSession>>;
+
+    /// Reset the backup state of all the stored inbound group sessions.
+    async fn reset_backup_state(&self) -> Result<()>;
+
+    /// TODO
+    async fn load_backup_keys(&self) -> Result<BackupKeys>;
 
     /// Get the outbound group sessions we have stored that is used for the
     /// given room.

--- a/crates/matrix-sdk-crypto/src/store/sled.rs
+++ b/crates/matrix-sdk-crypto/src/store/sled.rs
@@ -277,6 +277,7 @@ impl SledStore {
         }
 
         self.inner.insert("version", DATABASE_VERSION.to_be_bytes().as_ref())?;
+        self.inner.flush()?;
 
         Ok(())
     }

--- a/crates/matrix-sdk-crypto/src/store/sled.rs
+++ b/crates/matrix-sdk-crypto/src/store/sled.rs
@@ -156,7 +156,6 @@ pub struct SledStore {
 
     account: Tree,
     private_identity: Tree,
-    misc: Tree,
 
     olm_hashes: Tree,
     sessions: Tree,
@@ -300,7 +299,6 @@ impl SledStore {
         let outgoing_secret_requests = db.open_tree("outgoing_secret_requests")?;
         let unsent_secret_requests = db.open_tree("unsent_secret_requests")?;
         let secret_requests_by_info = db.open_tree("secret_requests_by_info")?;
-        let misc = db.open_tree("misc")?;
 
         let session_cache = SessionStore::new();
 
@@ -319,7 +317,6 @@ impl SledStore {
             account,
             private_identity,
             sessions,
-            misc,
             session_cache,
             tracked_users_cache: DashSet::new().into(),
             users_for_key_query_cache: DashSet::new().into(),

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -775,11 +775,12 @@ impl TryFrom<OutgoingRequest> for OutgoingContent {
 
     fn try_from(value: OutgoingRequest) -> Result<Self, Self::Error> {
         match value.request() {
-            crate::OutgoingRequests::KeysUpload(_) => Err("Invalid request type".to_owned()),
-            crate::OutgoingRequests::KeysQuery(_) => Err("Invalid request type".to_owned()),
+            crate::OutgoingRequests::KeysUpload(_)
+            | crate::OutgoingRequests::KeysQuery(_)
+            | crate::OutgoingRequests::KeysBackup(_)
+            | crate::OutgoingRequests::SignatureUpload(_)
+            | crate::OutgoingRequests::KeysClaim(_) => Err("Invalid request type".to_owned()),
             crate::OutgoingRequests::ToDeviceRequest(r) => Self::try_from(r.clone()),
-            crate::OutgoingRequests::SignatureUpload(_) => Err("Invalid request type".to_owned()),
-            crate::OutgoingRequests::KeysClaim(_) => Err("Invalid request type".to_owned()),
             crate::OutgoingRequests::RoomMessage(r) => Ok(Self::from(r.clone())),
         }
     }

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -42,7 +42,6 @@ use ruma::{
             done::{KeyVerificationDoneEventContent, ToDeviceKeyVerificationDoneEventContent},
             Relation,
         },
-        secret::request::SecretName,
         AnyMessageEventContent, AnyToDeviceEventContent,
     },
     DeviceId, DeviceIdBox, DeviceKeyId, EventId, RoomId, UserId,
@@ -549,11 +548,12 @@ impl IdentitiesBeingVerified {
     }
 
     async fn request_missing_secrets(&self) -> Result<Vec<GossipRequest>, CryptoStoreError> {
+        #[allow(unused_mut)]
         let mut secrets = self.private_identity.get_missing_secrets().await;
 
         #[cfg(feature = "backups_v1")]
         if self.store.inner.load_backup_keys().await?.recovery_key.is_none() {
-            secrets.push(SecretName::RecoveryKey);
+            secrets.push(ruma::events::secret::request::SecretName::RecoveryKey);
         }
 
         Ok(GossipMachine::request_missing_secrets(self.user_id(), secrets))


### PR DESCRIPTION
This is mostly just here to get backups working in Element Android, the backup functionality is missing from the top level sdk crate.

The top level crate will first need 4S support and we'll likely only enable backups once [symmetric backups](https://github.com/uhoreg/matrix-doc/blob/symmetric-backups/proposals/3270-symmetric-megolm-backup.md) have been implemented.

I'm not completely happy with the API, but it's what EA expects  and the backups being so heavily tied to making requests to check the current state makes it a bit hard to model nicely.