### PR TITLE
Update to webpack5

### DIFF
--- a/crates/matrix-sdk/examples/wasm_command_bot/package.json
+++ b/crates/matrix-sdk/examples/wasm_command_bot/package.json
@@ -1,14 +1,15 @@
 {
     "scripts": {
         "build": "webpack",
-        "serve": "webpack-dev-server"
+        "serve": "webpack-dev-server",
+        "test": "cargo test && wasm-pack test --node"
     },
     "devDependencies": {
-        "@wasm-tool/wasm-pack-plugin": "1.0.1",
-        "html-webpack-plugin": "^3.2.0",
+        "@wasm-tool/wasm-pack-plugin": "^1.3.3",
+        "html-webpack-plugin": "^5.3.1",
         "text-encoding": "^0.7.0",
-        "webpack": "^4.29.4",
-        "webpack-cli": "^3.1.1",
-        "webpack-dev-server": "^3.1.0"
+        "webpack": "^5.58.2",
+        "webpack-cli": "^4.9.0",
+        "webpack-dev-server": "^4.3.1"
     }
 }

--- a/crates/matrix-sdk/examples/wasm_command_bot/webpack.config.js
+++ b/crates/matrix-sdk/examples/wasm_command_bot/webpack.config.js
@@ -10,6 +10,10 @@ module.exports = {
         filename: 'index.js',
     },
     devtool: 'source-map',
+    experiments: {
+      asyncWebAssembly: true,
+      syncWebAssembly: true
+    },
     plugins: [
         new HtmlWebpackPlugin(),
         new WasmPackPlugin({


### PR DESCRIPTION
This PR updates the wasm-example to use webpack5, fixing the unexpected-section-bug described in #353 . The env-bug however is coming from libolm 2.3.3, for which a PR has been sent upstream but isn't integrated yet.