### PR TITLE
Make sure to also include the uuid crate's serde feature with wasm

### DIFF
--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -36,4 +36,4 @@ features = ["now"]
 async-lock = "2.4.0"
 futures-util = { version = "0.3.15", default-features = false, features = ["channel"] }
 wasm-bindgen-futures = "0.4.24"
-uuid = { version = "0.8.2", default-features = false, features = ["v4", "wasm-bindgen"] }
+uuid = { version = "0.8.2", default-features = false, features = ["v4", "wasm-bindgen", "serde"] }


### PR DESCRIPTION
This fixes a minor thing that did prevent compiling wasm for me. (Note this likely doesnt fix the runtime wasm issues but I just saw that it caused rust to not compile as uuid was missing the serialize and deserialize traits because of this)