### PR TITLE
Return the list of room keys we imported

### DIFF
--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -40,6 +40,10 @@ pub mod store;
 mod utilities;
 mod verification;
 
+use std::collections::{BTreeMap, BTreeSet};
+
+use ruma::RoomId;
+
 /// Return type for the room key importing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RoomKeyImportResult {
@@ -47,11 +51,20 @@ pub struct RoomKeyImportResult {
     pub imported_count: usize,
     /// The total number of room keys that were found in the export.
     pub total_count: usize,
+    /// The map of keys that were imported.
+    ///
+    /// It's a map from room id to a map of the sender key to a set of session
+    /// ids.
+    pub keys: BTreeMap<RoomId, BTreeMap<String, BTreeSet<String>>>,
 }
 
 impl RoomKeyImportResult {
-    pub(crate) fn new(imported_count: usize, total_count: usize) -> Self {
-        Self { imported_count, total_count }
+    pub(crate) fn new(
+        imported_count: usize,
+        total_count: usize,
+        keys: BTreeMap<RoomId, BTreeMap<String, BTreeSet<String>>>,
+    ) -> Self {
+        Self { imported_count, total_count, keys }
     }
 }
 


### PR DESCRIPTION
Clients might want to retry decryption after they import room keys, for this to be efficient they'll need to know which room keys got imported.

This patch extends the return value of the room key import result to include the map of room keys that got imported.
