### PR TITLE
feat(RequestConfig): expose force_auth setting

### DIFF
--- a/crates/matrix-sdk/src/config/request.rs
+++ b/crates/matrix-sdk/src/config/request.rs
@@ -104,7 +104,7 @@ impl RequestConfig {
 
     /// Force sending authorization even if the endpoint does not require it.
     /// Default is only sending authorization if it is required.
-    pub(crate) fn force_auth(mut self) -> Self {
+    pub fn force_auth(mut self) -> Self {
         self.force_auth = true;
         self
     }


### PR DESCRIPTION
This is needed for some endpoints where authentication is marqued as None in Ruma, but the homeserver might require it.

For example: [GET /_matrix/client/r0/profile/{userId}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-profile-userid) is marked as not authenticated [in Ruma](https://github.com/ruma/ruma/blob/main/crates/ruma-client-api/src/r0/profile/get_profile.rs#L13) but authentication may be required in Synapse if `require_auth_for_profile_requests` is set to `true`.