### PR TITLE
feat(sdk): Generate thumbnails for image attachments

### DIFF
--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -147,7 +147,7 @@ impl<'a, R: Read + 'a> AttachmentDecryptor<'a, R> {
 }
 
 /// A wrapper that transparently encrypts anything that implements `Read`.
-pub struct AttachmentEncryptor<'a, R: Read + 'a> {
+pub struct AttachmentEncryptor<'a, R: Read + ?Sized + 'a> {
     finished: bool,
     inner: &'a mut R,
     web_key: JsonWebKey,
@@ -157,7 +157,7 @@ pub struct AttachmentEncryptor<'a, R: Read + 'a> {
     sha: Sha256,
 }
 
-impl<'a, R: 'a + Read + std::fmt::Debug> std::fmt::Debug for AttachmentEncryptor<'a, R> {
+impl<'a, R: 'a + Read + std::fmt::Debug + ?Sized> std::fmt::Debug for AttachmentEncryptor<'a, R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AttachmentEncryptor")
             .field("inner", &self.inner)
@@ -166,7 +166,7 @@ impl<'a, R: 'a + Read + std::fmt::Debug> std::fmt::Debug for AttachmentEncryptor
     }
 }
 
-impl<'a, R: Read + 'a> Read for AttachmentEncryptor<'a, R> {
+impl<'a, R: Read + ?Sized + 'a> Read for AttachmentEncryptor<'a, R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let read_bytes = self.inner.read(buf)?;
 
@@ -185,7 +185,7 @@ impl<'a, R: Read + 'a> Read for AttachmentEncryptor<'a, R> {
     }
 }
 
-impl<'a, R: Read + 'a> AttachmentEncryptor<'a, R> {
+impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
     /// Wrap the given reader encrypting all the data we read from it.
     ///
     /// After all the reads are done, and all the data is encrypted that we wish

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -36,13 +36,16 @@ rustls-tls = ["reqwest/rustls-tls"]
 socks = ["reqwest/socks"]
 sso_login = ["warp", "rand", "tokio-stream"]
 appservice = ["ruma/appservice-api-s", "ruma/appservice-api-helper"]
+image_proc = ["image"]
+image_rayon = ["image/jpeg_rayon"]
 
 docsrs = [
     "encryption",
     "sled_cryptostore",
     "sled_state_store",
     "sso_login",
-    "qrcode"
+    "qrcode",
+    "image_proc",
 ]
 
 [dependencies]
@@ -65,6 +68,26 @@ tracing = "0.1.26"
 url = "2.2.2"
 zeroize = "1.3.0"
 async-stream = "0.3.2"
+
+[dependencies.image]
+version = "0.23.14"
+default-features = false
+features = [
+    "gif",
+    "jpeg",
+    "ico",
+    "png",
+    "pnm",
+    "tga",
+    "tiff",
+    "webp",
+    "bmp",
+    "hdr",
+    "dxt",
+    "dds",
+    "farbfeld",
+]
+optional = true
 
 [dependencies.matrix-sdk-base]
 version = "0.4.0"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -70,7 +70,7 @@ zeroize = "1.3.0"
 async-stream = "0.3.2"
 
 [dependencies.image]
-version = "0.23.14"
+version = "0.24.0"
 default-features = false
 features = [
     "gif",

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -37,7 +37,7 @@ socks = ["reqwest/socks"]
 sso_login = ["warp", "rand", "tokio-stream"]
 appservice = ["ruma/appservice-api-s", "ruma/appservice-api-helper"]
 image_proc = ["image"]
-image_rayon = ["image/jpeg_rayon"]
+image_rayon = ["image_proc", "image/jpeg_rayon"]
 
 docsrs = [
     "encryption",

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -101,7 +101,7 @@ default_features = false
 [dependencies.ruma]
 git = "https://github.com/ruma/ruma/"
 rev = "b9f32bc6327542d382d4eb42ec43623495c50e66"
-features = ["client-api-c", "compat", "rand"]
+features = ["client-api-c", "compat", "rand", "unstable-msc2448"]
 
 [dependencies.tokio-stream]
 version = "0.1.6"

--- a/crates/matrix-sdk/README.md
+++ b/crates/matrix-sdk/README.md
@@ -64,6 +64,8 @@ The following crate feature flags are available:
 | `anyhow`           |   No    | Better logging for event handlers that return `anyhow::Result` |
 | `encryption`       |   Yes   | End-to-end encryption support                                  |
 | `eyre`             |   No    | Better logging for event handlers that return `eyre::Result`   |
+| `image_proc`       |   No    | Enables image processing to generate thumbnails                |
+| `image_rayon`      |   No    | Enables faster image processing                                |
 | `markdown`         |   No    | Support to send Markdown-formatted messages                    |
 | `qrcode`           |   Yes   | QR code verification support                                   |
 | `sled_cryptostore` |   Yes   | Persistent storage for E2EE related data                       |

--- a/crates/matrix-sdk/examples/image_bot.rs
+++ b/crates/matrix-sdk/examples/image_bot.rs
@@ -9,6 +9,7 @@ use std::{
 
 use matrix_sdk::{
     self,
+    attachment::Thumbnail,
     config::SyncSettings,
     room::Room,
     ruma::events::room::message::{
@@ -38,8 +39,11 @@ async fn on_room_message(event: SyncRoomMessageEvent, room: Room, image: Arc<Mut
         if msg_body.contains("!image") {
             println!("sending image");
             let mut image = image.lock().await;
+            let none_thumbnail: Option<Thumbnail<&[u8]>> = None;
 
-            room.send_attachment("cat", &mime::IMAGE_JPEG, &mut *image, None).await.unwrap();
+            room.send_attachment("cat", &mime::IMAGE_JPEG, &mut *image, None, none_thumbnail, None)
+                .await
+                .unwrap();
 
             image.seek(SeekFrom::Start(0)).unwrap();
 

--- a/crates/matrix-sdk/examples/image_bot.rs
+++ b/crates/matrix-sdk/examples/image_bot.rs
@@ -9,7 +9,7 @@ use std::{
 
 use matrix_sdk::{
     self,
-    attachment::Thumbnail,
+    attachment::AttachmentConfig,
     config::SyncSettings,
     room::Room,
     ruma::events::room::message::{
@@ -39,9 +39,8 @@ async fn on_room_message(event: SyncRoomMessageEvent, room: Room, image: Arc<Mut
         if msg_body.contains("!image") {
             println!("sending image");
             let mut image = image.lock().await;
-            let none_thumbnail: Option<Thumbnail<&[u8]>> = None;
 
-            room.send_attachment("cat", &mime::IMAGE_JPEG, &mut *image, None, none_thumbnail, None)
+            room.send_attachment("cat", &mime::IMAGE_JPEG, &mut *image, AttachmentConfig::new())
                 .await
                 .unwrap();
 

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -1,5 +1,9 @@
 use std::io::Read;
+#[cfg(feature = "image_proc")]
+use std::io::{BufRead, Seek};
 
+#[cfg(feature = "image_proc")]
+use image::GenericImageView;
 use ruma::{
     assign,
     events::room::{
@@ -8,6 +12,9 @@ use ruma::{
     },
     UInt,
 };
+
+#[cfg(feature = "image_proc")]
+use crate::ImageError;
 
 /// Base metadata about an image.
 #[derive(Debug, Clone)]
@@ -152,3 +159,127 @@ pub struct Thumbnail<'a, R: Read> {
 
 /// Typed `None` for an `<Option<Thumbnail>>`.
 pub const NONE_THUMBNAIL: Option<Thumbnail<&[u8]>> = None;
+
+/// Generate a thumbnail for an image.
+///
+/// This is a convenience method that uses the
+/// [image](https://github.com/image-rs/image) crate.
+///
+/// # Arguments
+/// * `content_type` - The type of the media, this will be used as the
+/// content-type header.
+///
+/// * `reader` - A `Reader` that will be used to fetch the raw bytes of the
+/// media.
+///
+/// * `size` - The size of the thumbnail in pixels as a `(width, height)` tuple.
+/// If set to `None`, defaults to `(800, 600)`.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use std::{path::PathBuf, fs::File, io::{BufReader, Read, Seek}};
+/// # use matrix_sdk::{Client, attachment::{Thumbnail, generate_image_thumbnail}, ruma::room_id};
+/// # use url::Url;
+/// # use mime;
+/// # use futures::executor::block_on;
+/// # block_on(async {
+/// # let homeserver = Url::parse("http://localhost:8080")?;
+/// # let mut client = Client::new(homeserver)?;
+/// # let room_id = room_id!("!test:localhost");
+/// let path = PathBuf::from("/home/example/my-cat.jpg");
+/// let mut image = BufReader::new(File::open(path)?);
+///
+/// let (thumbnail_data, thumbnail_info) = generate_image_thumbnail(
+///     &mime::IMAGE_JPEG,
+///     &mut image,
+///     None
+/// )?;
+/// let thumbnail = Thumbnail {
+///     reader: &mut thumbnail_data.as_slice(),
+///     content_type: &mime::IMAGE_JPEG,
+///     info: Some(thumbnail_info),
+/// };
+///
+/// image.rewind()?;
+///
+/// if let Some(room) = client.get_joined_room(&room_id) {
+///     room.send_attachment(
+///         "My favorite cat",
+///         &mime::IMAGE_JPEG,
+///         &mut image,
+///         None,
+///         Some(thumbnail),
+///         None,
+///     ).await?;
+/// }
+/// # Result::<_, matrix_sdk::Error>::Ok(()) });
+/// ```
+#[cfg(feature = "image_proc")]
+pub fn generate_image_thumbnail<R: BufRead + Seek>(
+    content_type: &mime::Mime,
+    reader: &mut R,
+    size: Option<(u32, u32)>,
+) -> Result<(Vec<u8>, BaseThumbnailInfo), ImageError> {
+    let image_format = image_format_from_mime_type(content_type);
+    if image_format.is_none() {
+        return Err(ImageError::FormatNotSupported);
+    }
+
+    let image_format = image_format.unwrap();
+
+    let image = image::load(reader, image_format)?;
+    let (original_width, original_height) = image.dimensions();
+
+    let (width, height) = size.unwrap_or((800, 600));
+
+    // Don't generate a thumbnail if it would be bigger than or equal to the
+    // original.
+    if height >= original_height && width >= original_width {
+        return Err(ImageError::ThumbnailBiggerThanOriginal);
+    }
+
+    let thumbnail = image.thumbnail(width, height);
+    let (thumbnail_width, thumbnail_height) = thumbnail.dimensions();
+
+    let mut data: Vec<u8> = vec![];
+    thumbnail.write_to(&mut data, image_format)?;
+    let data_size = data.len() as u32;
+
+    Ok((
+        data,
+        BaseThumbnailInfo {
+            width: Some(thumbnail_width.into()),
+            height: Some(thumbnail_height.into()),
+            size: Some(data_size.into()),
+        },
+    ))
+}
+
+// FIXME: Replace this method by ImageFormat::from_mime_type after "image"
+// crate's next release.
+/// Return the image format specified by a MIME type.
+#[cfg(feature = "image_proc")]
+fn image_format_from_mime_type<M>(mime_type: M) -> Option<image::ImageFormat>
+where
+    M: AsRef<str>,
+{
+    match mime_type.as_ref() {
+        "image/avif" => Some(image::ImageFormat::Avif),
+        "image/jpeg" => Some(image::ImageFormat::Jpeg),
+        "image/png" => Some(image::ImageFormat::Png),
+        "image/gif" => Some(image::ImageFormat::Gif),
+        "image/webp" => Some(image::ImageFormat::WebP),
+        "image/tiff" => Some(image::ImageFormat::Tiff),
+        "image/x-targa" | "image/x-tga" => Some(image::ImageFormat::Tga),
+        "image/vnd-ms.dds" => Some(image::ImageFormat::Dds),
+        "image/bmp" => Some(image::ImageFormat::Bmp),
+        "image/x-icon" => Some(image::ImageFormat::Ico),
+        "image/vnd.radiance" => Some(image::ImageFormat::Hdr),
+        "image/x-portable-bitmap"
+        | "image/x-portable-graymap"
+        | "image/x-portable-pixmap"
+        | "image/x-portable-anymap" => Some(image::ImageFormat::Pnm),
+        _ => None,
+    }
+}

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -1,0 +1,154 @@
+use std::io::Read;
+
+use ruma::{
+    assign,
+    events::room::{
+        message::{AudioInfo, FileInfo, VideoInfo},
+        ImageInfo, ThumbnailInfo,
+    },
+    UInt,
+};
+
+/// Base metadata about an image.
+#[derive(Debug, Clone)]
+pub struct BaseImageInfo {
+    /// The height of the image in pixels.
+    pub height: Option<UInt>,
+    /// The width of the image in pixels.
+    pub width: Option<UInt>,
+    /// The file size of the image in bytes.
+    pub size: Option<UInt>,
+    /// The [BlurHash](https://blurha.sh/) for this image.
+    pub blurhash: Option<String>,
+}
+
+/// Base metadata about a video.
+#[derive(Debug, Clone)]
+pub struct BaseVideoInfo {
+    /// The duration of the video in milliseconds.
+    pub duration: Option<UInt>,
+    /// The height of the video in pixels.
+    pub height: Option<UInt>,
+    /// The width of the video in pixels.
+    pub width: Option<UInt>,
+    /// The file size of the video in bytes.
+    pub size: Option<UInt>,
+    /// The [BlurHash](https://blurha.sh/) for this video.
+    pub blurhash: Option<String>,
+}
+
+/// Base metadata about an audio clip.
+#[derive(Debug, Clone)]
+pub struct BaseAudioInfo {
+    /// The duration of the audio clip in milliseconds.
+    pub duration: Option<UInt>,
+    /// The file size of the audio clip in bytes.
+    pub size: Option<UInt>,
+}
+
+/// Base metadata about a file.
+#[derive(Debug, Clone)]
+pub struct BaseFileInfo {
+    /// The size of the file in bytes.
+    pub size: Option<UInt>,
+}
+
+/// Types of metadata for an attachment.
+#[derive(Debug)]
+pub enum AttachmentInfo {
+    /// The metadata of an image.
+    Image(BaseImageInfo),
+    /// The metadata of a video.
+    Video(BaseVideoInfo),
+    /// The metadata of an audio clip.
+    Audio(BaseAudioInfo),
+    /// The metadata of a file.
+    File(BaseFileInfo),
+}
+
+impl From<AttachmentInfo> for ImageInfo {
+    fn from(info: AttachmentInfo) -> Self {
+        match info {
+            AttachmentInfo::Image(info) => assign!(ImageInfo::new(), {
+                height: info.height,
+                width: info.width,
+                size: info.size,
+                blurhash: info.blurhash,
+            }),
+            _ => ImageInfo::new(),
+        }
+    }
+}
+
+impl From<AttachmentInfo> for VideoInfo {
+    fn from(info: AttachmentInfo) -> Self {
+        match info {
+            AttachmentInfo::Video(info) => assign!(VideoInfo::new(), {
+                duration: info.duration,
+                height: info.height,
+                width: info.width,
+                size: info.size,
+                blurhash: info.blurhash,
+            }),
+            _ => VideoInfo::new(),
+        }
+    }
+}
+
+impl From<AttachmentInfo> for AudioInfo {
+    fn from(info: AttachmentInfo) -> Self {
+        match info {
+            AttachmentInfo::Audio(info) => assign!(AudioInfo::new(), {
+                duration: info.duration,
+                size: info.size,
+            }),
+            _ => AudioInfo::new(),
+        }
+    }
+}
+
+impl From<AttachmentInfo> for FileInfo {
+    fn from(info: AttachmentInfo) -> Self {
+        match info {
+            AttachmentInfo::File(info) => assign!(FileInfo::new(), {
+                size: info.size,
+            }),
+            _ => FileInfo::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// Base metadata about a thumbnail.
+pub struct BaseThumbnailInfo {
+    /// The height of the thumbnail in pixels.
+    pub height: Option<UInt>,
+    /// The width of the thumbnail in pixels.
+    pub width: Option<UInt>,
+    /// The file size of the thumbnail in bytes.
+    pub size: Option<UInt>,
+}
+
+impl From<BaseThumbnailInfo> for ThumbnailInfo {
+    fn from(info: BaseThumbnailInfo) -> Self {
+        assign!(ThumbnailInfo::new(), {
+            height: info.height,
+            width: info.width,
+            size: info.size,
+        })
+    }
+}
+
+/// A thumbnail to upload and send for an attachment.
+#[derive(Debug)]
+pub struct Thumbnail<'a, R: Read> {
+    /// A `Reader` that will be used to fetch the raw bytes of the thumbnail.
+    pub reader: &'a mut R,
+    /// The type of the thumbnail, this will be used as the content-type header.
+    pub content_type: &'a mime::Mime,
+    /// The metadata of the thumbnail.
+    pub info: Option<BaseThumbnailInfo>,
+}
+
+/// Typed `None` for an `<Option<Thumbnail>>`.
+pub const NONE_THUMBNAIL: Option<Thumbnail<&[u8]>> = None;

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -177,7 +177,7 @@ pub struct AttachmentConfig<'a, R: Read> {
 impl AttachmentConfig<'static, &'static [u8]> {
     /// Create a new default `AttachmentConfig` without providing a thumbnail.
     ///
-    /// To provide a thumbnail use [`with_thumbnail()`].
+    /// To provide a thumbnail use [`AttachmentConfig::with_thumbnail()`].
     pub fn new() -> Self {
         Self {
             txn_id: Default::default(),
@@ -192,7 +192,7 @@ impl AttachmentConfig<'static, &'static [u8]> {
 
     /// Generate the thumbnail to send for this media.
     ///
-    /// Uses [`attachment::generate_image_thumbnail()`].
+    /// Uses [`generate_image_thumbnail()`].
     ///
     /// Thumbnails can only be generated for supported image attachments. For
     /// more information, see the [image](https://github.com/image-rs/image)
@@ -218,7 +218,7 @@ impl Default for AttachmentConfig<'static, &'static [u8]> {
 }
 
 impl<'a, R: Read> AttachmentConfig<'a, R> {
-    /// Create a new default `AttachmentConfig` with `thumbnail`.
+    /// Create a new default `AttachmentConfig` with a `thumbnail`.
     ///
     /// # Arguments
     ///
@@ -226,8 +226,8 @@ impl<'a, R: Read> AttachmentConfig<'a, R> {
     /// not support it (eg audio clips), it is ignored.
     ///
     /// To generate automatically a thumbnail from an image, use
-    /// [`new()`] and
-    /// [`generate_thumbnail()`].
+    /// [`AttachmentConfig::new()`] and
+    /// [`AttachmentConfig::generate_thumbnail()`].
     pub fn with_thumbnail(thumbnail: Thumbnail<'a, R>) -> Self {
         Self {
             txn_id: Default::default(),

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Kévin Commaille
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io::Read;
 #[cfg(feature = "image_proc")]
 use std::io::{BufRead, Cursor, Seek};

--- a/crates/matrix-sdk/src/client.rs
+++ b/crates/matrix-sdk/src/client.rs
@@ -2353,7 +2353,6 @@ impl Client {
         use ruma::events::room::{self, message};
         Ok(match content_type.type_() {
             mime::IMAGE => {
-                // TODO create a thumbnail using the image crate?.
                 let info = assign!(
                     info.map(room::ImageInfo::from).unwrap_or_default(),
                     {

--- a/crates/matrix-sdk/src/client.rs
+++ b/crates/matrix-sdk/src/client.rs
@@ -69,6 +69,7 @@ use tracing::{error, info, instrument, warn};
 use url::Url;
 
 use crate::{
+    attachment::{AttachmentInfo, Thumbnail},
     config::{ClientConfig, RequestConfig},
     error::{HttpError, HttpResult},
     event_handler::{EventHandler, EventHandlerData, EventHandlerResult, EventKind, SyncEvent},
@@ -2321,42 +2322,95 @@ impl Client {
     }
 
     /// Upload the file to be read from `reader` and construct an attachment
-    /// message with `body` and the specified `content_type`.
-    pub(crate) async fn prepare_attachment_message<R: Read>(
+    /// message with `body`, `content_type`, `info` and `thumbnail`.
+    pub(crate) async fn prepare_attachment_message<R: Read, T: Read>(
         &self,
         body: &str,
         content_type: &Mime,
         reader: &mut R,
+        info: Option<AttachmentInfo>,
+        thumbnail: Option<Thumbnail<'_, T>>,
     ) -> Result<ruma::events::room::message::MessageType> {
+        let (thumbnail_url, thumbnail_info) = if let Some(thumbnail) = thumbnail {
+            let response = self.upload(thumbnail.content_type, thumbnail.reader).await?;
+            let url = response.content_uri;
+
+            use ruma::events::room::ThumbnailInfo;
+            let thumbnail_info = assign!(
+                thumbnail.info.as_ref().map(|info| ThumbnailInfo::from(info.clone())).unwrap_or_default(),
+                { mimetype: Some(thumbnail.content_type.as_ref().to_owned()) }
+            );
+
+            (Some(url), Some(Box::new(thumbnail_info)))
+        } else {
+            (None, None)
+        };
+
         let response = self.upload(content_type, reader).await?;
 
         let url = response.content_uri;
 
-        use ruma::events::room::message;
+        use ruma::events::room::{self, message};
         Ok(match content_type.type_() {
             mime::IMAGE => {
                 // TODO create a thumbnail using the image crate?.
+                let info = assign!(
+                    info.map(room::ImageInfo::from).unwrap_or_default(),
+                    {
+                        mimetype: Some(content_type.as_ref().to_owned()),
+                        thumbnail_url,
+                        thumbnail_info
+                    }
+                );
                 message::MessageType::Image(message::ImageMessageEventContent::plain(
                     body.to_owned(),
                     url,
-                    None,
+                    Some(Box::new(info)),
                 ))
             }
-            mime::AUDIO => message::MessageType::Audio(message::AudioMessageEventContent::plain(
-                body.to_owned(),
-                url,
-                None,
-            )),
-            mime::VIDEO => message::MessageType::Video(message::VideoMessageEventContent::plain(
-                body.to_owned(),
-                url,
-                None,
-            )),
-            _ => message::MessageType::File(message::FileMessageEventContent::plain(
-                body.to_owned(),
-                url,
-                None,
-            )),
+            mime::AUDIO => {
+                let info = assign!(
+                    info.map(message::AudioInfo::from).unwrap_or_default(),
+                    {
+                        mimetype: Some(content_type.as_ref().to_owned()),
+                    }
+                );
+                message::MessageType::Audio(message::AudioMessageEventContent::plain(
+                    body.to_owned(),
+                    url,
+                    Some(Box::new(info)),
+                ))
+            }
+            mime::VIDEO => {
+                let info = assign!(
+                    info.map(message::VideoInfo::from).unwrap_or_default(),
+                    {
+                        mimetype: Some(content_type.as_ref().to_owned()),
+                        thumbnail_url,
+                        thumbnail_info
+                    }
+                );
+                message::MessageType::Video(message::VideoMessageEventContent::plain(
+                    body.to_owned(),
+                    url,
+                    Some(Box::new(info)),
+                ))
+            }
+            _ => {
+                let info = assign!(
+                    info.map(message::FileInfo::from).unwrap_or_default(),
+                    {
+                        mimetype: Some(content_type.as_ref().to_owned()),
+                        thumbnail_url,
+                        thumbnail_info
+                    }
+                );
+                message::MessageType::File(message::FileMessageEventContent::plain(
+                    body.to_owned(),
+                    url,
+                    Some(Box::new(info)),
+                ))
+            }
         })
     }
 }
@@ -2406,6 +2460,10 @@ pub(crate) mod test {
 
     use super::{Client, Session, Url};
     use crate::{
+        attachment::{
+            AttachmentInfo, BaseImageInfo, BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
+            NONE_THUMBNAIL,
+        },
         config::{ClientConfig, RequestConfig, SyncSettings},
         HttpError, RoomMember,
     };
@@ -3188,6 +3246,11 @@ pub(crate) mod test {
         let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_string()))
             .with_status(200)
             .match_header("authorization", "Bearer 1234")
+            .match_body(Matcher::PartialJson(json!({
+                "info": {
+                    "mimetype": "image/jpeg"
+                }
+            })))
             .with_body(test_json::EVENT_ID.to_string())
             .create();
 
@@ -3216,9 +3279,224 @@ pub(crate) mod test {
 
         let mut media = Cursor::new("Hello world");
 
-        let response =
-            room.send_attachment("image", &mime::IMAGE_JPEG, &mut media, None).await.unwrap();
+        let response = room
+            .send_attachment("image", &mime::IMAGE_JPEG, &mut media, None, NONE_THUMBNAIL, None)
+            .await
+            .unwrap();
 
+        assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
+    }
+
+    #[async_test]
+    async fn room_attachment_send_info() {
+        let client = logged_in_client().await;
+
+        let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_string()))
+            .with_status(200)
+            .match_header("authorization", "Bearer 1234")
+            .match_body(Matcher::PartialJson(json!({
+                "info": {
+                    "mimetype": "image/jpeg",
+                    "h": 600,
+                    "w": 800,
+                }
+            })))
+            .with_body(test_json::EVENT_ID.to_string())
+            .create();
+
+        let upload_mock = mock("POST", Matcher::Regex(r"^/_matrix/media/r0/upload".to_string()))
+            .with_status(200)
+            .match_header("content-type", "image/jpeg")
+            .with_body(
+                json!({
+                  "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
+                })
+                .to_string(),
+            )
+            .create();
+
+        let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_string()))
+            .with_status(200)
+            .match_header("authorization", "Bearer 1234")
+            .with_body(test_json::SYNC.to_string())
+            .create();
+
+        let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+        let _response = client.sync_once(sync_settings).await.unwrap();
+
+        let room = client.get_joined_room(room_id!("!SVkFJHzfwvuaIEawgC:localhost")).unwrap();
+
+        let mut media = Cursor::new("Hello world");
+
+        let info = AttachmentInfo::Image(BaseImageInfo {
+            height: Some(uint!(600)),
+            width: Some(uint!(800)),
+            size: None,
+            blurhash: None,
+        });
+
+        let response = room
+            .send_attachment(
+                "image",
+                &mime::IMAGE_JPEG,
+                &mut media,
+                Some(info),
+                NONE_THUMBNAIL,
+                None,
+            )
+            .await
+            .unwrap();
+
+        upload_mock.assert();
+        assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
+    }
+
+    #[async_test]
+    async fn room_attachment_send_wrong_info() {
+        let client = logged_in_client().await;
+
+        let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_string()))
+            .with_status(200)
+            .match_header("authorization", "Bearer 1234")
+            .match_body(Matcher::PartialJson(json!({
+                "info": {
+                    "mimetype": "image/jpeg",
+                    "h": 600,
+                    "w": 800,
+                }
+            })))
+            .with_body(test_json::EVENT_ID.to_string())
+            .create();
+
+        let _m = mock("POST", Matcher::Regex(r"^/_matrix/media/r0/upload".to_string()))
+            .with_status(200)
+            .match_header("content-type", "image/jpeg")
+            .with_body(
+                json!({
+                  "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
+                })
+                .to_string(),
+            )
+            .create();
+
+        let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_string()))
+            .with_status(200)
+            .match_header("authorization", "Bearer 1234")
+            .with_body(test_json::SYNC.to_string())
+            .create();
+
+        let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+        let _response = client.sync_once(sync_settings).await.unwrap();
+
+        let room = client.get_joined_room(room_id!("!SVkFJHzfwvuaIEawgC:localhost")).unwrap();
+
+        let mut media = Cursor::new("Hello world");
+
+        let info = AttachmentInfo::Video(BaseVideoInfo {
+            height: Some(uint!(600)),
+            width: Some(uint!(800)),
+            duration: Some(uint!(3600)),
+            size: None,
+            blurhash: None,
+        });
+
+        let response = room
+            .send_attachment(
+                "image",
+                &mime::IMAGE_JPEG,
+                &mut media,
+                Some(info),
+                NONE_THUMBNAIL,
+                None,
+            )
+            .await;
+
+        assert!(response.is_err())
+    }
+
+    #[async_test]
+    async fn room_attachment_send_info_thumbnail() {
+        let client = logged_in_client().await;
+
+        let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_string()))
+            .with_status(200)
+            .match_header("authorization", "Bearer 1234")
+            .match_body(Matcher::PartialJson(json!({
+                "info": {
+                    "mimetype": "image/jpeg",
+                    "h": 600,
+                    "w": 800,
+                    "thumbnail_info": {
+                        "h": 360,
+                        "w": 480,
+                        "mimetype":"image/jpeg",
+                        "size": 3600,
+                    },
+                    "thumbnail_url": "mxc://example.com/AQwafuaFswefuhsfAFAgsw",
+                }
+            })))
+            .with_body(test_json::EVENT_ID.to_string())
+            .create();
+
+        let upload_mock = mock("POST", Matcher::Regex(r"^/_matrix/media/r0/upload".to_string()))
+            .with_status(200)
+            .match_header("content-type", "image/jpeg")
+            .with_body(
+                json!({
+                  "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
+                })
+                .to_string(),
+            )
+            .expect(2)
+            .create();
+
+        let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_string()))
+            .with_status(200)
+            .match_header("authorization", "Bearer 1234")
+            .with_body(test_json::SYNC.to_string())
+            .create();
+
+        let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+        let _response = client.sync_once(sync_settings).await.unwrap();
+
+        let room = client.get_joined_room(room_id!("!SVkFJHzfwvuaIEawgC:localhost")).unwrap();
+
+        let mut media = Cursor::new("Hello world");
+
+        let info = AttachmentInfo::Image(BaseImageInfo {
+            height: Some(uint!(600)),
+            width: Some(uint!(800)),
+            size: None,
+            blurhash: None,
+        });
+
+        let mut thumbnail_reader = Cursor::new("Thumbnail");
+        let thumbnail = Thumbnail {
+            reader: &mut thumbnail_reader,
+            content_type: &mime::IMAGE_JPEG,
+            info: Some(BaseThumbnailInfo {
+                height: Some(uint!(360)),
+                width: Some(uint!(480)),
+                size: Some(uint!(3600)),
+            }),
+        };
+
+        let response = room
+            .send_attachment(
+                "image",
+                &mime::IMAGE_JPEG,
+                &mut media,
+                Some(info),
+                Some(thumbnail),
+                None,
+            )
+            .await
+            .unwrap();
+
+        upload_mock.assert();
         assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
     }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -157,6 +157,11 @@ pub enum Error {
     /// An error encountered when trying to parse a user tag name.
     #[error(transparent)]
     UserTagName(#[from] InvalidUserTagName),
+
+    /// An error while processing images.
+    #[cfg(feature = "image_proc")]
+    #[error(transparent)]
+    ImageError(#[from] ImageError),
 }
 
 /// Error for the room key importing functionality.
@@ -256,4 +261,21 @@ impl From<ReqwestError> for Error {
     fn from(e: ReqwestError) -> Self {
         Error::Http(HttpError::Reqwest(e))
     }
+}
+
+/// All possible errors that can happen during image processing.
+#[cfg(feature = "image_proc")]
+#[derive(Error, Debug)]
+pub enum ImageError {
+    /// Error processing the image data.
+    #[error(transparent)]
+    Proc(#[from] image::ImageError),
+
+    /// The image format is not supported.
+    #[error("the image format is not supported")]
+    FormatNotSupported,
+
+    /// The thumbnail size is bigger than the original image.
+    #[error("the thumbnail size is bigger than the original image size")]
+    ThumbnailBiggerThanOriginal,
 }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -46,6 +46,8 @@ pub use reqwest;
 #[doc(no_inline)]
 pub use ruma;
 
+/// Types and traits for attachments.
+pub mod attachment;
 mod client;
 pub mod config;
 mod error;

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -39,9 +39,6 @@ compile_error!("'sso_login' cannot be enabled on 'wasm32' arch");
 #[cfg(all(feature = "image_rayon", target_arch = "wasm32"))]
 compile_error!("'image_rayon' cannot be enabled on 'wasm32' arch");
 
-#[cfg(all(feature = "image_rayon", not(feature = "image_proc")))]
-compile_error!("'image_rayon' only works with 'image_proc' feature");
-
 pub use bytes;
 pub use matrix_sdk_base::{
     media, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomType, Session,

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -36,6 +36,12 @@ compile_error!("only one of 'native-tls' or 'rustls-tls' features can be enabled
 #[cfg(all(feature = "sso_login", target_arch = "wasm32"))]
 compile_error!("'sso_login' cannot be enabled on 'wasm32' arch");
 
+#[cfg(all(feature = "image_rayon", target_arch = "wasm32"))]
+compile_error!("'image_rayon' cannot be enabled on 'wasm32' arch");
+
+#[cfg(all(feature = "image_rayon", not(feature = "image_proc")))]
+compile_error!("'image_rayon' only works with 'image_proc' feature");
+
 pub use bytes;
 pub use matrix_sdk_base::{
     media, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomType, Session,
@@ -62,6 +68,8 @@ mod sync;
 pub mod encryption;
 
 pub use client::{Client, LoopCtrl};
+#[cfg(feature = "image_proc")]
+pub use error::ImageError;
 pub use error::{Error, HttpError, HttpResult, Result};
 pub use http_client::HttpSend;
 pub use room_member::RoomMember;

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -667,13 +667,9 @@ impl Joined {
                             info: Some(thumbnail_info),
                         })
                     }
-                    Err(error)
-                        if matches!(
-                            error,
-                            ImageError::ThumbnailBiggerThanOriginal
-                                | ImageError::FormatNotSupported
-                        ) =>
-                    {
+                    Err(
+                        ImageError::ThumbnailBiggerThanOriginal | ImageError::FormatNotSupported,
+                    ) => {
                         reader.rewind()?;
                         None
                     }

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -742,7 +742,7 @@ impl Joined {
         reader: &mut R,
         info: Option<AttachmentInfo>,
         thumbnail_size: Option<(u32, u32)>,
-        txn_id: Option<Uuid>,
+        txn_id: Option<&TransactionId>,
     ) -> Result<send_message_event::Response> {
         let mut reader = BufReader::new(reader);
 

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -636,12 +636,12 @@ impl Joined {
     /// }
     /// # Result::<_, matrix_sdk::Error>::Ok(()) });
     /// ```
-    pub async fn send_attachment<'a, R: Read + Seek, T: Read>(
+    pub async fn send_attachment<R: Read + Seek, T: Read>(
         &self,
         body: &str,
         content_type: &Mime,
         reader: &mut R,
-        config: AttachmentConfig<'a, T>,
+        config: AttachmentConfig<'_, T>,
     ) -> Result<send_message_event::Response> {
         let reader = &mut BufReader::new(reader);
 
@@ -715,12 +715,12 @@ impl Joined {
     /// media.
     ///
     /// * `config` - Metadata and configuration for the attachment.
-    async fn prepare_and_send_attachment<'a, R: Read, T: Read>(
+    async fn prepare_and_send_attachment<R: Read, T: Read>(
         &self,
         body: &str,
         content_type: &Mime,
         reader: &mut R,
-        config: AttachmentConfig<'a, T>,
+        config: AttachmentConfig<'_, T>,
     ) -> Result<send_message_event::Response> {
         #[cfg(feature = "encryption")]
         let content = if self.is_encrypted() {


### PR DESCRIPTION
- Allow to send info and thumbnail for attachments
- Method to generate thumbnails behind `image_proc` feature flag. It seems like the only thing preventing to use `image` in wasm is the rayon dependency so I also added the `image_rayon` feature.
- Method to send attachment with generated thumbnail

I tested it locally with a modified `image_bot` example and it works fine both in encrypted and normal rooms. I'm not sure how to add tests for the image generation feature.