### PR TITLE
Return broken messages unchanged from messages() (followup to #448)

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -422,7 +422,7 @@ impl BaseClient {
                                 if let Ok(decrypted) =
                                     olm.decrypt_room_event(encrypted, room_id).await
                                 {
-                                    event = decrypted;
+                                    event = decrypted.into();
                                 }
                             }
                         }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -38,7 +38,7 @@ use ruma::{
             encrypted::{EncryptedEventScheme, SyncRoomEncryptedEvent},
             history_visibility::HistoryVisibility,
         },
-        AnySyncRoomEvent,
+        AnyRoomEvent,
     },
     serde::Raw,
     DeviceKeyAlgorithm, EventEncryptionAlgorithm, RoomId,
@@ -346,7 +346,7 @@ impl InboundGroupSession {
     pub(crate) async fn decrypt(
         &self,
         event: &SyncRoomEncryptedEvent,
-    ) -> MegolmResult<(Raw<AnySyncRoomEvent>, u32)> {
+    ) -> MegolmResult<(Raw<AnyRoomEvent>, u32)> {
         let content = match &event.content.scheme {
             EncryptedEventScheme::MegolmV1AesSha2(c) => c,
             _ => return Err(EventError::UnsupportedAlgorithm.into()),
@@ -389,7 +389,7 @@ impl InboundGroupSession {
             }
         }
 
-        Ok((serde_json::from_value::<Raw<AnySyncRoomEvent>>(decrypted_value)?, message_index))
+        Ok((serde_json::from_value::<Raw<AnyRoomEvent>>(decrypted_value)?, message_index))
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -70,7 +70,7 @@ pub(crate) mod test {
         events::{
             forwarded_room_key::ToDeviceForwardedRoomKeyEventContent,
             room::message::{Relation, Replacement, RoomMessageEventContent},
-            AnySyncMessageEvent, AnySyncRoomEvent,
+            AnyMessageEvent, AnyRoomEvent, AnySyncMessageEvent, AnySyncRoomEvent,
         },
         room_id, user_id, DeviceId, UserId,
     };
@@ -281,9 +281,7 @@ pub(crate) mod test {
 
         let decrypted = inbound.decrypt(&event).await?.0;
 
-        if let AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(e)) =
-            decrypted.deserialize()?
-        {
+        if let AnyRoomEvent::Message(AnyMessageEvent::RoomMessage(e)) = decrypted.deserialize()? {
             assert_matches!(e.content.relates_to, Some(Relation::Replacement(_)));
         } else {
             panic!("Invalid event type")

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -182,7 +182,7 @@ impl Common {
         for event in http_response.chunk {
             #[cfg(feature = "encryption")]
             let event = match event.deserialize() {
-                Ok(event) => self.client.decrypt_room_event(&event).await?,
+                Ok(event) => self.client.decrypt_room_event(&event).await,
                 Err(_) => {
                     // "Broken" messages (i.e., those that cannot be deserialized) are
                     // returned unchanged so that the caller can handle them individually.
@@ -205,7 +205,7 @@ impl Common {
         let event = self.client.send(request, None).await?.event.deserialize()?;
 
         #[cfg(feature = "encryption")]
-        return Ok(self.client.decrypt_room_event(&event).await?);
+        return Ok(self.client.decrypt_room_event(&event).await);
 
         #[cfg(not(feature = "encryption"))]
         return Ok(RoomEvent { event: Raw::new(&event)?, encryption_info: None });


### PR DESCRIPTION
Without this change, a batch with a message that cannot be deserialized
(for whatever reason) means that the batch cannot be processed at all by
the caller. Now, those messages are returned unchanged in the batch so
that the caller can handle them.

