### PR TITLE
feat(sdk): Make get_supported_versions public

### DIFF
--- a/crates/matrix-sdk/src/client.rs
+++ b/crates/matrix-sdk/src/client.rs
@@ -317,7 +317,26 @@ impl Client {
         *homeserver = homeserver_url;
     }
 
-    async fn get_supported_versions(&self) -> HttpResult<get_supported_versions::Response> {
+    /// Get the versions supported by the homeserver.
+    ///
+    /// This method should be used to check that a server is a valid Matrix
+    /// homeserver.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use futures::executor::block_on;
+    /// # block_on(async {
+    /// use matrix_sdk::{Client};
+    /// use url::Url;
+    ///
+    /// let homeserver = Url::parse("http://example.com")?;
+    /// let client = Client::new(homeserver)?;
+    ///
+    /// // Check that it is a valid homeserver.
+    /// client.get_supported_versions().await?;
+    /// # Result::<_, anyhow::Error>::Ok(()) });
+    /// ```
+    pub async fn get_supported_versions(&self) -> HttpResult<get_supported_versions::Response> {
         self.send(
             get_supported_versions::Request::new(),
             Some(RequestConfig::new().disable_retry()),


### PR DESCRIPTION
Since it's the recommended endpoint to call to validate that a URL matches a Matrix homeserver, it makes sense to make it public for users when they don't use auto-discovery with the `Client::new_from_user_id` methods.

Alternatively, we could have a `validate_homeserver` method that returns a `HttpResult<()>`.