### PR TITLE
Fix futures-util dependency

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -30,7 +30,7 @@ base64 = "0.13.0"
 bs58 = "0.4.0"
 byteorder = "1.4.3"
 dashmap = "4.0.2"
-futures-util = { version = "0.3.15", default-features = false }
+futures-util = { version = "0.3.15", default-features = false, features = ["alloc"] }
 getrandom = "0.2.3"
 hmac = "0.11.0"
 matrix-qrcode = { version = "0.2.0", path = "../matrix-qrcode", optional = true }


### PR DESCRIPTION
Turn on alloc feature that is required for `future::join_all`.

Fixes #451.