### PR TITLE
docs(sdk): document features needed for store_path

### DIFF
--- a/crates/matrix-sdk/src/config/client.rs
+++ b/crates/matrix-sdk/src/config/client.rs
@@ -127,10 +127,11 @@ impl ClientConfig {
     /// * `path` - The path where the stores should save data in. It is the
     /// callers responsibility to make sure that the path exists.
     ///
-    /// In the default configuration the client will open default
-    /// implementations for the crypto store and the state store. It will use
-    /// the given path to open the stores. If no path is provided no store will
-    /// be opened
+    /// In the default configuration, and if the corresponding features
+    /// (`sled_state_store` and `sled_cryptostore`) are enabled, the client will
+    /// open default implementations for the crypto store and the state store.
+    /// It will use the given path to open the stores. If no path is provided no
+    /// store will be opened
     #[must_use]
     pub fn store_path(mut self, path: impl AsRef<Path>) -> Self {
         self.base_config = self.base_config.store_path(path);


### PR DESCRIPTION
If default features `sled_state_store` and `sled_cryptostore` aren't enabled, then passing a store path to the Client does nothing.

This change follows a discussion in the matrix-rust-sdk room on Matrix, where I was confused about my program's behaviour because it never saved anything to the `store_path` I passed it. It turned out that I had disabled default features, including `sled_state_store`.

Now other users should be warned, *if* they read the documentation.