### PR TITLE
sdk: Move tag methods to room::Common and use TagName

### DIFF
--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -33,6 +33,7 @@ use ruma::{
         },
         error::{FromHttpResponseError, IntoHttpError, MatrixError as RumaApiError, ServerError},
     },
+    events::tag::InvalidUserTagName,
     identifiers::Error as IdentifierError,
 };
 use serde_json::Error as JsonError;
@@ -157,6 +158,10 @@ pub enum Error {
     #[cfg(feature = "qrcode")]
     #[error(transparent)]
     QrCodeScanError(#[from] ScanError),
+
+    /// An error encountered when trying to parse a user tag name.
+    #[error(transparent)]
+    UserTagName(#[from] InvalidUserTagName),
 }
 
 /// Error for the room key importing functionality.

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -21,14 +21,10 @@ use ruma::{
         receipt::create_receipt,
         redact::redact_event,
         state::send_state_event,
-        tag::{create_tag, delete_tag},
         typing::create_typing_event::{Request as TypingRequest, Typing},
     },
     assign,
-    events::{
-        room::message::RoomMessageEventContent, tag::TagInfo, MessageEventContent,
-        StateEventContent,
-    },
+    events::{room::message::RoomMessageEventContent, MessageEventContent, StateEventContent},
     receipt::ReceiptType,
     serde::Raw,
     EventId, UserId,
@@ -38,7 +34,7 @@ use tracing::debug;
 #[cfg(feature = "encryption")]
 use tracing::instrument;
 
-use crate::{error::HttpResult, room::Common, BaseRoom, Client, HttpError, Result, RoomType};
+use crate::{error::HttpResult, room::Common, BaseRoom, Client, Result, RoomType};
 
 const TYPING_NOTICE_TIMEOUT: Duration = Duration::from_secs(4);
 const TYPING_NOTICE_RESEND_TIMEOUT: Duration = Duration::from_secs(3);
@@ -809,52 +805,6 @@ impl Joined {
                 reason
             });
 
-        self.client.send(request, None).await
-    }
-
-    /// Adds a tag to the room, or updates it if it already exists.
-    ///
-    /// Returns the [`create_tag::Response`] from the server.
-    ///
-    /// # Arguments
-    /// * `tag` - The tag to add or update.
-    ///
-    /// * `tag_info` - Information about the tag, generally containing the
-    ///   `order` parameter.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use ruma::events::tag::TagInfo;
-    /// # futures::executor::block_on(async {
-    /// # let homeserver = url::Url::parse("http://localhost:8080")?;
-    /// # let mut client = matrix_sdk::Client::new(homeserver)?;
-    /// # let room_id = matrix_sdk::ruma::room_id!("!test:localhost");
-    /// use matrix_sdk::ruma::events::tag::TagInfo;
-    ///
-    /// if let Some(room) = client.get_joined_room(&room_id) {
-    ///     let mut tag_info = TagInfo::new();
-    ///     tag_info.order = Some(0.9);
-    ///
-    ///     room.set_tag("u.work", tag_info ).await?;
-    /// }
-    /// # Result::<_, matrix_sdk::Error>::Ok(()) });
-    /// ```
-    pub async fn set_tag(&self, tag: &str, tag_info: TagInfo) -> HttpResult<create_tag::Response> {
-        let user_id = self.client.user_id().await.ok_or(HttpError::AuthenticationRequired)?;
-        let request = create_tag::Request::new(&user_id, self.inner.room_id(), tag, tag_info);
-        self.client.send(request, None).await
-    }
-
-    /// Removes a tag from the room.
-    ///
-    /// Returns the [`delete_tag::Response`] from the server.
-    ///
-    /// # Arguments
-    /// * `tag` - The tag to remove.
-    pub async fn remove_tag(&self, tag: &str) -> HttpResult<delete_tag::Response> {
-        let user_id = self.client.user_id().await.ok_or(HttpError::AuthenticationRequired)?;
-        let request = delete_tag::Request::new(&user_id, self.inner.room_id(), tag);
         self.client.send(request, None).await
     }
 }


### PR DESCRIPTION
**1. Move set/remove tag methods to room::Common**

In the spec, it doesn't say that a room has to be joined before setting or removing room tags. In the SDK, the corresponding methods are only implemented on `Joined rooms.

In practice, it works on matrix.org in the three states we have: invite, joined, left.

My use case is that the user can join an invite and put it in favorites at the same time with drag and drop. Changing the tag before joining the room will make it have the proper tag right away.

**2. Use TagName in set/remove tag methods**

This provides the default values and string validity check for user-defined tags. It's always possible to use `TagName::_Custom` for custom strings.