### PR TITLE
Adjust error messages to not have `\`

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -60,8 +60,7 @@ pub enum OlmError {
     /// Encryption failed because the device does not have a valid Olm session
     /// with us.
     #[error(
-        "encryption failed because the device does not \
-            have a valid Olm session with us"
+        "encryption failed because the device does not have a valid Olm session with us"
     )]
     MissingSession,
 }


### PR DESCRIPTION
Else the error would've printed something like;

```
encryption failed because the device does not \            have a valid Olm session with us
```