### PR TITLE
Replace uses of `Vec::drain(..)` with `into_iter`

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1433,15 +1433,15 @@ impl OlmMachine {
     ) -> StoreResult<Vec<ExportedRoomKey>> {
         let mut exported = Vec::new();
 
-        let mut sessions: Vec<InboundGroupSession> = self
+        let sessions: Vec<InboundGroupSession> = self
             .store
             .get_inbound_group_sessions()
             .await?
-            .drain(..)
+            .into_iter()
             .filter(|s| predicate(s))
             .collect();
 
-        for session in sessions.drain(..) {
+        for session in sessions {
             let export = session.export().await;
             exported.push(export);
         }

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -77,26 +77,26 @@ impl MemoryStore {
         Self::default()
     }
 
-    pub(crate) async fn save_devices(&self, mut devices: Vec<ReadOnlyDevice>) {
-        for device in devices.drain(..) {
+    pub(crate) async fn save_devices(&self, devices: Vec<ReadOnlyDevice>) {
+        for device in devices {
             let _ = self.devices.add(device);
         }
     }
 
-    async fn delete_devices(&self, mut devices: Vec<ReadOnlyDevice>) {
-        for device in devices.drain(..) {
+    async fn delete_devices(&self, devices: Vec<ReadOnlyDevice>) {
+        for device in devices {
             let _ = self.devices.remove(device.user_id(), device.device_id());
         }
     }
 
-    async fn save_sessions(&self, mut sessions: Vec<Session>) {
-        for session in sessions.drain(..) {
+    async fn save_sessions(&self, sessions: Vec<Session>) {
+        for session in sessions {
             let _ = self.sessions.add(session.clone()).await;
         }
     }
 
-    async fn save_inbound_group_sessions(&self, mut sessions: Vec<InboundGroupSession>) {
-        for session in sessions.drain(..) {
+    async fn save_inbound_group_sessions(&self, sessions: Vec<InboundGroupSession>) {
+        for session in sessions {
             self.inbound_group_sessions.add(session);
         }
     }
@@ -117,7 +117,7 @@ impl CryptoStore for MemoryStore {
         Ok(None)
     }
 
-    async fn save_changes(&self, mut changes: Changes) -> Result<()> {
+    async fn save_changes(&self, changes: Changes) -> Result<()> {
         self.save_sessions(changes.sessions).await;
         self.save_inbound_group_sessions(changes.inbound_group_sessions).await;
 
@@ -125,7 +125,7 @@ impl CryptoStore for MemoryStore {
         self.save_devices(changes.devices.changed).await;
         self.delete_devices(changes.devices.deleted).await;
 
-        for identity in changes.identities.new.drain(..).chain(changes.identities.changed) {
+        for identity in changes.identities.new.into_iter().chain(changes.identities.changed) {
             let _ = self.identities.insert(identity.user_id().to_owned(), identity.clone());
         }
 

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -354,10 +354,9 @@ impl Joined {
     #[instrument]
     #[cfg(feature = "encryption")]
     async fn share_group_session(&self) -> Result<()> {
-        let mut requests =
-            self.client.base_client().share_group_session(self.inner.room_id()).await?;
+        let requests = self.client.base_client().share_group_session(self.inner.room_id()).await?;
 
-        for request in requests.drain(..) {
+        for request in requests {
             let response = self.client.send_to_device(&request).await?;
 
             self.client.mark_request_as_sent(&request.txn_id, &response).await?;


### PR DESCRIPTION
`drain` is designed to be used when you want to reuse the `Vec` or only move out a subset range. Using `.into_iter()` is more efficient and idiomatic, and can be dropped entirely when used in `for` loops.