### PR TITLE
[fix] Persist stripped rooms in the right bucket

### DIFF
--- a/crates/matrix-sdk-base/src/store/indexeddb_store.rs
+++ b/crates/matrix-sdk-base/src/store/indexeddb_store.rs
@@ -283,7 +283,7 @@ impl IndexeddbStore {
             (!changes.receipts.is_empty(), KEYS::ROOM_EVENT_RECEIPTS),
             (!changes.stripped_state.is_empty(), KEYS::STRIPPED_ROOM_STATE),
             (!changes.stripped_members.is_empty(), KEYS::STRIPPED_MEMBERS),
-            (!changes.invited_room_info.is_empty(), KEYS::STRIPPED_ROOM_INFO),
+            (!changes.stripped_room_info.is_empty(), KEYS::STRIPPED_ROOM_INFO),
         ]
         .iter()
         .filter_map(|(id, key)| if *id { Some(*key) } else { None })
@@ -369,9 +369,9 @@ impl IndexeddbStore {
             }
         }
 
-        if !changes.invited_room_info.is_empty() {
+        if !changes.stripped_room_info.is_empty() {
             let store = tx.object_store(KEYS::STRIPPED_ROOM_INFO)?;
-            for (room_id, info) in &changes.invited_room_info {
+            for (room_id, info) in &changes.stripped_room_info {
                 store.put_key_val(&room_id.encode(), &self.serialize_event(&info)?)?;
             }
         }

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -184,7 +184,7 @@ macro_rules! statestore_integration_tests {
                             )]),
                         )]),
                     );
-                    changes.invited_room_info.insert(stripped_room_id.to_owned(), stripped_room.clone());
+
                     changes.add_stripped_room(stripped_room);
 
                     let stripped_member_json: &JsonValue = &test_json::MEMBER_STRIPPED;
@@ -423,6 +423,19 @@ macro_rules! statestore_integration_tests {
                 }
 
                 #[async_test]
+                async fn test_persist_invited_room() -> Result<()> {
+                    let stripped_room_id = stripped_room_id();
+                    let inner_store = get_store().await?;
+                    let store = populated_store(Box::new(inner_store)).await?;
+
+                    assert_eq!(store.get_stripped_room_infos().await?.len(), 1);
+                    assert!(store.get_stripped_room(stripped_room_id).is_some());
+
+                    // populate rooom
+                    Ok(())
+                }
+
+                #[async_test]
                 async fn test_room_removal() -> Result<()>  {
                     let room_id = room_id();
                     let user_id = user_id();
@@ -431,11 +444,9 @@ macro_rules! statestore_integration_tests {
 
                     let store = populated_store(Box::new(inner_store)).await?;
 
-                    // We assume the store was correctly populated like the test above.
-
                     store.remove_room(room_id).await?;
 
-                    assert_eq!(store.get_room_infos().await?.len(), 1);
+                    assert_eq!(store.get_room_infos().await?.len(), 0);
                     assert_eq!(store.get_stripped_room_infos().await?.len(), 1);
 
                     assert!(store.get_state_event(room_id, EventType::RoomName, "").await?.is_none());

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -211,7 +211,7 @@ impl MemoryStore {
             self.presence.insert(sender.clone(), event.clone());
         }
 
-        for (room_id, info) in &changes.invited_room_info {
+        for (room_id, info) in &changes.stripped_room_info {
             self.stripped_room_info.insert(room_id.clone(), info.clone());
         }
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -543,8 +543,8 @@ pub struct StateChanges {
         BTreeMap<Box<RoomId>, BTreeMap<String, BTreeMap<String, Raw<AnyStrippedStateEvent>>>>,
     /// A mapping of `RoomId` to a map of users and their `StrippedMemberEvent`.
     pub stripped_members: BTreeMap<Box<RoomId>, BTreeMap<Box<UserId>, StrippedMemberEvent>>,
-    /// A map of `RoomId` to `RoomInfo`.
-    pub invited_room_info: BTreeMap<Box<RoomId>, RoomInfo>,
+    /// A map of `RoomId` to `RoomInfo` for stripped rooms (e.g. for invites or while knocking)
+    pub stripped_room_info: BTreeMap<Box<RoomId>, RoomInfo>,
 
     /// A map from room id to a map of a display name and a set of user ids that
     /// share that display name in the given room.
@@ -571,7 +571,7 @@ impl StateChanges {
 
     /// Update the `StateChanges` struct with the given `RoomInfo`.
     pub fn add_stripped_room(&mut self, room: RoomInfo) {
-        self.invited_room_info.insert(room.room_id.as_ref().to_owned(), room);
+        self.stripped_room_info.insert(room.room_id.as_ref().to_owned(), room);
     }
 
     /// Update the `StateChanges` struct with the given `AnyBasicEvent`.

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -571,7 +571,7 @@ impl StateChanges {
 
     /// Update the `StateChanges` struct with the given `RoomInfo`.
     pub fn add_stripped_room(&mut self, room: RoomInfo) {
-        self.room_infos.insert(room.room_id.as_ref().to_owned(), room);
+        self.invited_room_info.insert(room.room_id.as_ref().to_owned(), room);
     }
 
     /// Update the `StateChanges` struct with the given `AnyBasicEvent`.

--- a/crates/matrix-sdk-base/src/store/sled_store.rs
+++ b/crates/matrix-sdk-base/src/store/sled_store.rs
@@ -486,7 +486,7 @@ impl SledStore {
                         )?;
                     }
 
-                    for (room_id, info) in &changes.invited_room_info {
+                    for (room_id, info) in &changes.stripped_room_info {
                         striped_rooms.insert(
                             room_id.encode(),
                             self.serialize_event(&info)


### PR DESCRIPTION
A bug in #248 made us store the stripped room info (we get for invited rooms or when knocking) in the wrong bucket of the database. After a restart the correct room info was still returned, but not if you were asking specifically for the stripped info - if would come back empty. This PR fixes this issue and adapts the publicly exposed name `invited_room_infos` in the `StateChange` to the proper generic name of `stripped_room_infos` (as this isn't only used for invites).
 
fixes #467