### PR TITLE
Use vodozemac for the E2EE support

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 qrcode = ["matrix-qrcode"]
-backups_v1 = []
+backups_v1 = ["olm-rs", "bs58"]
 docsrs = []
 
 # Testing helpers for implementations based upon this
@@ -29,7 +29,7 @@ aes = { version = "0.7.4", features = ["ctr"] }
 aes-gcm = "0.9.2"
 atomic = "0.5.0"
 base64 = "0.13.0"
-bs58 = "0.4.0"
+bs58 = { version = "0.4.0", optional = true }
 byteorder = "1.4.3"
 dashmap = "5.1.0"
 futures-util = { version = "0.3.15", default-features = false, features = ["alloc"] }
@@ -37,7 +37,7 @@ getrandom = "0.2.3"
 hmac = "0.12.0"
 matrix-qrcode = { version = "0.2.0", path = "../matrix-qrcode", optional = true }
 matrix-sdk-common = { version = "0.4.0", path = "../matrix-sdk-common" }
-olm-rs = { version = "2.1", features = ["serde"] }
+olm-rs = { version = "2.1", features = ["serde"], optional = true }
 pbkdf2 = { version = "0.10.0", default-features = false }
 rand = "0.8.4"
 serde = { version = "1.0.126", features = ["derive", "rc"] }
@@ -51,12 +51,23 @@ anyhow = "1"
 # feature = testing only
 http = { version = "0.2.4", optional = true}
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.vodozemac]
+git = "https://github.com/matrix-org/vodozemac"
+rev = "b6e30ba43742e27f2c996f19f071a6c78e3b30ce"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.vodozemac]
+git = "https://github.com/matrix-org/vodozemac"
+rev = "b6e30ba43742e27f2c996f19f071a6c78e3b30ce"
+features = ["js"]
+
 [dependencies.ruma]
 version = "0.5.0"
 features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"]
 
 [dev-dependencies]
-futures = { version = "0.3.15", default-features = false, features = ["executor"] }
+futures = { version = "0.3.15", default-features = false, features = [
+    "executor",
+] }
 http = "0.2.4"
 indoc = "1.0.3"
 matches = "0.1.8"

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -33,7 +33,6 @@ bs58 = { version = "0.4.0", optional = true }
 byteorder = "1.4.3"
 dashmap = "5.1.0"
 futures-util = { version = "0.3.15", default-features = false, features = ["alloc"] }
-getrandom = "0.2.3"
 hmac = "0.12.0"
 matrix-qrcode = { version = "0.2.0", path = "../matrix-qrcode", optional = true }
 matrix-sdk-common = { version = "0.4.0", path = "../matrix-sdk-common" }

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -22,7 +22,7 @@ use aes::{
     Aes256, Aes256Ctr,
 };
 use base64::DecodeError;
-use getrandom::getrandom;
+use rand::{thread_rng, RngCore};
 use ruma::{
     events::room::{EncryptedFile, JsonWebKey, JsonWebKeyInit},
     serde::Base64,
@@ -218,10 +218,12 @@ impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
         let mut key = Zeroizing::new([0u8; KEY_SIZE]);
         let mut iv = Zeroizing::new([0u8; IV_SIZE]);
 
-        getrandom(&mut *key).expect("Can't generate randomness");
+        let mut rng = thread_rng();
+
+        rng.fill_bytes(&mut *key);
         // Only populate the first 8 bytes with randomness, the rest is 0
         // initialized for the counter.
-        getrandom(&mut iv[0..8]).expect("Can't generate randomness");
+        rng.fill_bytes(&mut iv[0..8]);
 
         let web_key = JsonWebKey::from(JsonWebKeyInit {
             kty: "oct".to_owned(),

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -19,9 +19,9 @@ use aes::{
     Aes256, Aes256Ctr,
 };
 use byteorder::{BigEndian, ReadBytesExt};
-use getrandom::getrandom;
 use hmac::{Hmac, Mac};
 use pbkdf2::pbkdf2;
+use rand::{thread_rng, RngCore};
 use serde_json::Error as SerdeError;
 use sha2::{Sha256, Sha512};
 use thiserror::Error;
@@ -152,8 +152,10 @@ fn encrypt_helper(plaintext: &mut [u8], passphrase: &str, rounds: u32) -> String
     let mut iv = [0u8; IV_SIZE];
     let mut derived_keys = [0u8; KEY_SIZE * 2];
 
-    getrandom(&mut salt).expect("Can't generate randomness");
-    getrandom(&mut iv).expect("Can't generate randomness");
+    let mut rng = thread_rng();
+
+    rng.fill_bytes(&mut salt);
+    rng.fill_bytes(&mut iv);
 
     let mut iv = u128::from_be_bytes(iv);
     iv &= !(1 << 63);

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -319,7 +319,10 @@ mod test {
         let encrypted = encrypt_key_export(&export, "1234", 1).unwrap();
         let decrypted = decrypt_key_export(Cursor::new(encrypted), "1234").unwrap();
 
-        assert_eq!(export, decrypted);
+        for (exported, decrypted) in export.iter().zip(decrypted.iter()) {
+            assert_eq!(exported.session_key.as_str(), decrypted.session_key.as_str());
+        }
+
         assert_eq!(
             machine.import_keys(decrypted, false, |_, _| {}).await.unwrap(),
             RoomKeyImportResult::new(0, 1, BTreeMap::new())
@@ -346,7 +349,9 @@ mod test {
             )]),
         );
 
-        assert_eq!(machine.import_keys(export.clone(), false, |_, _| {}).await?, keys,);
+        assert_eq!(machine.import_keys(export, false, |_, _| {}).await?, keys,);
+
+        let export = vec![session.export_at_index(10).await];
         assert_eq!(
             machine.import_keys(export, false, |_, _| {}).await?,
             RoomKeyImportResult::new(0, 1, BTreeMap::new())

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -934,7 +934,7 @@ impl GossipMachine {
 
 #[cfg(test)]
 mod test {
-    use std::{convert::TryInto, sync::Arc};
+    use std::sync::Arc;
 
     use dashmap::DashMap;
     use matches::assert_matches;
@@ -1056,8 +1056,7 @@ mod test {
         let machine = get_machine().await;
         let account = account();
 
-        let (_, session) =
-            account.create_group_session_pair_with_defaults(room_id()).await.unwrap();
+        let (_, session) = account.create_group_session_pair_with_defaults(room_id()).await;
 
         assert!(machine.outgoing_to_device_requests().await.unwrap().is_empty());
         let (cancel, request) = machine
@@ -1088,8 +1087,7 @@ mod test {
         alice_device.set_trust_state(LocalTrust::Verified);
         machine.store.save_devices(&[alice_device]).await.unwrap();
 
-        let (_, session) =
-            account.create_group_session_pair_with_defaults(room_id()).await.unwrap();
+        let (_, session) = account.create_group_session_pair_with_defaults(room_id()).await;
 
         assert!(machine.outgoing_to_device_requests().await.unwrap().is_empty());
         machine
@@ -1133,8 +1131,7 @@ mod test {
         alice_device.set_trust_state(LocalTrust::Verified);
         machine.store.save_devices(&[alice_device]).await.unwrap();
 
-        let (_, session) =
-            account.create_group_session_pair_with_defaults(room_id()).await.unwrap();
+        let (_, session) = account.create_group_session_pair_with_defaults(room_id()).await;
         machine
             .create_outgoing_key_request(
                 session.room_id(),
@@ -1228,8 +1225,7 @@ mod test {
         let own_device =
             machine.store.get_device(alice_id(), alice2_device_id()).await.unwrap().unwrap();
 
-        let (outbound, inbound) =
-            account.create_group_session_pair_with_defaults(room_id()).await.unwrap();
+        let (outbound, inbound) = account.create_group_session_pair_with_defaults(room_id()).await;
 
         // We don't share keys with untrusted devices.
         assert_matches!(
@@ -1287,7 +1283,7 @@ mod test {
         assert!(machine.should_share_key(&bob_device, &inbound).await.is_ok());
 
         let (other_outbound, other_inbound) =
-            account.create_group_session_pair_with_defaults(room_id()).await.unwrap();
+            account.create_group_session_pair_with_defaults(room_id()).await;
 
         // But we don't share some other session that doesn't match our outbound
         // session.
@@ -1365,7 +1361,7 @@ mod test {
         bob_machine.store.save_devices(&[alice_device.clone()]).await.unwrap();
 
         let (group_session, inbound_group_session) =
-            bob_account.create_group_session_pair_with_defaults(room_id()).await.unwrap();
+            bob_account.create_group_session_pair_with_defaults(room_id()).await;
 
         bob_machine.store.save_inbound_group_sessions(&[inbound_group_session]).await.unwrap();
 
@@ -1373,7 +1369,7 @@ mod test {
         alice_machine
             .create_outgoing_key_request(
                 room_id(),
-                bob_account.identity_keys.curve25519(),
+                &bob_account.identity_keys.curve25519.to_base64(),
                 group_session.session_id(),
             )
             .await
@@ -1442,7 +1438,7 @@ mod test {
             .store
             .get_inbound_group_session(
                 room_id(),
-                bob_account.identity_keys().curve25519(),
+                &bob_account.identity_keys().curve25519.to_base64(),
                 group_session.session_id()
             )
             .await
@@ -1569,7 +1565,7 @@ mod test {
         bob_machine.store.save_devices(&[alice_device.clone()]).await.unwrap();
 
         let (group_session, inbound_group_session) =
-            bob_account.create_group_session_pair_with_defaults(room_id()).await.unwrap();
+            bob_account.create_group_session_pair_with_defaults(room_id()).await;
 
         bob_machine.store.save_inbound_group_sessions(&[inbound_group_session]).await.unwrap();
 
@@ -1577,7 +1573,7 @@ mod test {
         alice_machine
             .create_outgoing_key_request(
                 room_id(),
-                bob_account.identity_keys.curve25519(),
+                &bob_account.identity_keys.curve25519.to_base64(),
                 group_session.session_id(),
             )
             .await
@@ -1666,7 +1662,7 @@ mod test {
             .store
             .get_inbound_group_session(
                 room_id(),
-                bob_account.identity_keys().curve25519(),
+                &bob_account.identity_keys().curve25519.to_base64(),
                 group_session.session_id()
             )
             .await

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -288,17 +288,17 @@ impl Account {
 
         let mut decrypted: Option<(Session, String)> = None;
 
+        // Try to decrypt the message using each Session we share with the
+        // given curve25519 sender key.
         for session in &mut *sessions.lock().await {
-            let ret = session.decrypt(message).await;
-
-            match ret {
-                Ok(p) => {
-                    decrypted = Some((session.clone(), p));
-                    break;
-                }
-                Err(_) => {
-                    continue;
-                }
+            if let Ok(p) = session.decrypt(message).await {
+                decrypted = Some((session.clone(), p));
+                break;
+            } else {
+                // An error here is completely normal, after all we don't know
+                // which session was used to encrypt a message. We will log a
+                // warning if no session was able to decrypt the message.
+                continue;
             }
         }
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -25,13 +25,6 @@ use std::{
 
 use dashmap::DashMap;
 use matrix_sdk_common::{instant::Instant, locks::Mutex};
-pub use olm_rs::{
-    account::IdentityKeys,
-    outbound_group_session::OlmOutboundGroupSession,
-    session::{OlmMessage, PreKeyMessage},
-    utility::OlmUtility,
-};
-use olm_rs::{errors::OlmGroupSessionError, PicklingMode};
 use ruma::{
     events::{
         room::{
@@ -49,11 +42,13 @@ use ruma::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::{debug, error, info};
-
-use super::{
-    super::{deserialize_instant, serialize_instant},
-    GroupSessionKey,
+pub use vodozemac::{
+    megolm::{GroupSession, GroupSessionPickle, MegolmMessage, SessionKey},
+    olm::IdentityKeys,
+    PickleError,
 };
+
+use super::super::{deserialize_instant, serialize_instant};
 use crate::{Device, ToDeviceRequest};
 
 const ROTATION_PERIOD: Duration = Duration::from_millis(604800000);
@@ -117,7 +112,7 @@ impl EncryptionSettings {
 /// messages.
 #[derive(Clone)]
 pub struct OutboundGroupSession {
-    inner: Arc<Mutex<OlmOutboundGroupSession>>,
+    inner: Arc<Mutex<GroupSession>>,
     device_id: Arc<DeviceId>,
     account_identity_keys: Arc<IdentityKeys>,
     session_id: Arc<str>,
@@ -170,8 +165,8 @@ impl OutboundGroupSession {
         room_id: &RoomId,
         settings: EncryptionSettings,
     ) -> Self {
-        let session = OlmOutboundGroupSession::new();
-        let session_id = session.session_id();
+        let session = GroupSession::new();
+        let session_id = session.session_id().to_owned();
 
         OutboundGroupSession {
             inner: Arc::new(Mutex::new(session)),
@@ -256,8 +251,8 @@ impl OutboundGroupSession {
     /// # Arguments
     ///
     /// * `plaintext` - The plaintext that should be encrypted.
-    pub(crate) async fn encrypt_helper(&self, plaintext: String) -> String {
-        let session = self.inner.lock().await;
+    pub(crate) async fn encrypt_helper(&self, plaintext: String) -> MegolmMessage {
+        let mut session = self.inner.lock().await;
         self.message_count.fetch_add(1, Ordering::SeqCst);
         session.encrypt(&plaintext)
     }
@@ -296,8 +291,8 @@ impl OutboundGroupSession {
         let ciphertext = self.encrypt_helper(plaintext).await;
 
         let encrypted_content = MegolmV1AesSha2ContentInit {
-            ciphertext,
-            sender_key: self.account_identity_keys.curve25519().to_owned(),
+            ciphertext: ciphertext.to_base64(),
+            sender_key: self.account_identity_keys.curve25519.to_base64(),
             session_id: self.session_id().to_owned(),
             device_id: (*self.device_id).to_owned(),
         }
@@ -345,9 +340,9 @@ impl OutboundGroupSession {
     /// Get the session key of this session.
     ///
     /// A session key can be used to to create an `InboundGroupSession`.
-    pub async fn session_key(&self) -> GroupSessionKey {
+    pub async fn session_key(&self) -> SessionKey {
         let session = self.inner.lock().await;
-        GroupSessionKey(session.session_key())
+        session.session_key()
     }
 
     /// Get the room id of the room this session belongs to.
@@ -366,7 +361,7 @@ impl OutboundGroupSession {
     /// message index that will be used for the next encrypted message.
     pub async fn message_index(&self) -> u32 {
         let session = self.inner.lock().await;
-        session.session_message_index()
+        session.message_index()
     }
 
     pub(crate) async fn as_content(&self) -> AnyToDeviceEventContent {
@@ -481,10 +476,9 @@ impl OutboundGroupSession {
         device_id: Arc<DeviceId>,
         identity_keys: Arc<IdentityKeys>,
         pickle: PickledOutboundGroupSession,
-        pickling_mode: PicklingMode,
-    ) -> Result<Self, OlmGroupSessionError> {
-        let inner = OlmOutboundGroupSession::unpickle(pickle.pickle.0, pickling_mode)?;
-        let session_id = inner.session_id();
+    ) -> Result<Self, PickleError> {
+        let inner: GroupSession = pickle.pickle.into();
+        let session_id = inner.session_id().to_owned();
 
         Ok(Self {
             inner: Arc::new(Mutex::new(inner)),
@@ -516,9 +510,8 @@ impl OutboundGroupSession {
     /// * `pickle_mode` - The mode that should be used to pickle the group
     ///   session,
     /// either an unencrypted mode or an encrypted using passphrase.
-    pub async fn pickle(&self, pickling_mode: PicklingMode) -> PickledOutboundGroupSession {
-        let pickle: OutboundGroupSessionPickle =
-            self.inner.lock().await.pickle(pickling_mode).into();
+    pub async fn pickle(&self) -> PickledOutboundGroupSession {
+        let pickle = self.inner.lock().await.pickle();
 
         PickledOutboundGroupSession {
             pickle,
@@ -572,10 +565,11 @@ impl std::fmt::Debug for OutboundGroupSession {
 ///
 /// Holds all the information that needs to be stored in a database to restore
 /// an InboundGroupSession.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
+#[allow(missing_debug_implementations)]
 pub struct PickledOutboundGroupSession {
     /// The pickle string holding the OutboundGroupSession.
-    pub pickle: OutboundGroupSessionPickle,
+    pub pickle: GroupSessionPickle,
     /// The settings this session adheres to.
     pub settings: Arc<EncryptionSettings>,
     /// The room id this session is used for.

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -15,11 +15,6 @@
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use matrix_sdk_common::{instant::Instant, locks::Mutex};
-use olm_rs::{errors::OlmSessionError, session::OlmSession, PicklingMode};
-pub use olm_rs::{
-    session::{OlmMessage, PreKeyMessage},
-    utility::OlmUtility,
-};
 use ruma::{
     events::{
         room::encrypted::{
@@ -32,10 +27,11 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use vodozemac::olm::{DecryptionError, OlmMessage, Session as InnerSession, SessionPickle};
 
 use super::{deserialize_instant, serialize_instant, IdentityKeys};
 use crate::{
-    error::{EventError, OlmResult, SessionUnpicklingError},
+    error::{EventError, OlmResult},
     ReadOnlyDevice,
 };
 
@@ -50,7 +46,7 @@ pub struct Session {
     /// The `IdentityKeys` associated with this session
     pub our_identity_keys: Arc<IdentityKeys>,
     /// The OlmSession
-    pub inner: Arc<Mutex<OlmSession>>,
+    pub inner: Arc<Mutex<InnerSession>>,
     /// Our sessionId
     pub session_id: Arc<str>,
     /// The Key of the sender
@@ -76,13 +72,13 @@ impl fmt::Debug for Session {
 impl Session {
     /// Decrypt the given Olm message.
     ///
-    /// Returns the decrypted plaintext or an `OlmSessionError` if decryption
+    /// Returns the decrypted plaintext or an `DecrypitonError` if decryption
     /// failed.
     ///
     /// # Arguments
     ///
     /// * `message` - The Olm message that should be decrypted.
-    pub async fn decrypt(&mut self, message: OlmMessage) -> Result<String, OlmSessionError> {
+    pub async fn decrypt(&mut self, message: &OlmMessage) -> Result<String, DecryptionError> {
         let plaintext = self.inner.lock().await.decrypt(message)?;
         self.last_use_time = Arc::new(Instant::now());
         Ok(plaintext)
@@ -131,7 +127,7 @@ impl Session {
             "sender": self.user_id.as_str(),
             "sender_device": self.device_id.as_ref(),
             "keys": {
-                "ed25519": self.our_identity_keys.ed25519(),
+                "ed25519": self.our_identity_keys.ed25519.to_base64(),
             },
             "recipient": recipient_device.user_id(),
             "recipient_keys": {
@@ -142,7 +138,7 @@ impl Session {
         });
 
         let plaintext = serde_json::to_string(&payload)?;
-        let ciphertext = self.encrypt_helper(&plaintext).await.to_tuple();
+        let ciphertext = self.encrypt_helper(&plaintext).await.to_parts();
 
         let message_type = ciphertext.0;
         let ciphertext = CiphertextInfo::new(ciphertext.1, (message_type as u32).into());
@@ -152,28 +148,9 @@ impl Session {
 
         Ok(EncryptedEventScheme::OlmV1Curve25519AesSha2(OlmV1Curve25519AesSha2Content::new(
             content,
-            self.our_identity_keys.curve25519().to_owned(),
+            self.our_identity_keys.curve25519.to_base64(),
         ))
         .into())
-    }
-
-    /// Check if a pre-key Olm message was encrypted for this session.
-    ///
-    /// Returns true if it matches, false if not and a OlmSessionError if there
-    /// was an error checking if it matches.
-    ///
-    /// # Arguments
-    ///
-    /// * `their_identity_key` - The identity/curve25519 key of the account
-    /// that encrypted this Olm message.
-    ///
-    /// * `message` - The pre-key Olm message that should be checked.
-    pub async fn matches(
-        &self,
-        their_identity_key: &str,
-        message: PreKeyMessage,
-    ) -> Result<bool, OlmSessionError> {
-        self.inner.lock().await.matches_inbound_session_from(their_identity_key, message)
     }
 
     /// Returns the unique identifier for this session.
@@ -187,11 +164,11 @@ impl Session {
     ///
     /// * `pickle_mode` - The mode that was used to pickle the session, either
     /// an unencrypted mode or an encrypted using passphrase.
-    pub async fn pickle(&self, pickle_mode: PicklingMode) -> PickledSession {
-        let pickle = self.inner.lock().await.pickle(pickle_mode);
+    pub async fn pickle(&self) -> PickledSession {
+        let pickle = self.inner.lock().await.pickle();
 
         PickledSession {
-            pickle: SessionPickle::from(pickle),
+            pickle,
             sender_key: self.sender_key.to_string(),
             created_using_fallback_key: self.created_using_fallback_key,
             creation_time: *self.creation_time,
@@ -221,12 +198,11 @@ impl Session {
         device_id: Arc<DeviceId>,
         our_identity_keys: Arc<IdentityKeys>,
         pickle: PickledSession,
-        pickle_mode: PicklingMode,
-    ) -> Result<Self, SessionUnpicklingError> {
-        let session = OlmSession::unpickle(pickle.pickle.0, pickle_mode)?;
+    ) -> Self {
+        let session: vodozemac::olm::Session = pickle.pickle.into();
         let session_id = session.session_id();
 
-        Ok(Session {
+        Session {
             user_id,
             device_id,
             our_identity_keys,
@@ -236,7 +212,7 @@ impl Session {
             sender_key: pickle.sender_key.into(),
             creation_time: Arc::new(pickle.creation_time),
             last_use_time: Arc::new(pickle.last_use_time),
-        })
+        }
     }
 }
 
@@ -250,7 +226,8 @@ impl PartialEq for Session {
 ///
 /// Holds all the information that needs to be stored in a database to restore
 /// a Session.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
+#[allow(missing_debug_implementations)]
 pub struct PickledSession {
     /// The pickle string holding the Olm Session.
     pub pickle: SessionPickle,
@@ -265,22 +242,4 @@ pub struct PickledSession {
     /// The relative time elapsed since the session was last used.
     #[serde(deserialize_with = "deserialize_instant", serialize_with = "serialize_instant")]
     pub last_use_time: Instant,
-}
-
-/// The typed representation of a base64 encoded string of the Olm Session
-/// pickle.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SessionPickle(String);
-
-impl From<String> for SessionPickle {
-    fn from(pickle_string: String) -> Self {
-        SessionPickle(pickle_string)
-    }
-}
-
-impl SessionPickle {
-    /// Get the string representation of the pickle.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
 }

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -233,7 +233,7 @@ mod test {
         let (account, _) = get_account_and_session().await;
         let room_id = room_id!("!test:localhost");
 
-        let (outbound, _) = account.create_group_session_pair_with_defaults(room_id).await.unwrap();
+        let (outbound, _) = account.create_group_session_pair_with_defaults(room_id).await;
 
         assert_eq!(0, outbound.message_index().await);
         assert!(!outbound.shared());

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -340,7 +340,7 @@ mod test {
         let (account, _) = get_account_and_session().await;
         let room_id = room_id!("!test:localhost");
 
-        let (outbound, _) = account.create_group_session_pair_with_defaults(room_id).await.unwrap();
+        let (outbound, _) = account.create_group_session_pair_with_defaults(room_id).await;
         let inbound = InboundGroupSession::new(
             "test_key",
             "test_key",

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -54,12 +54,8 @@ use std::{
     sync::Arc,
 };
 
-use base64::DecodeError;
 use matrix_sdk_common::{async_trait, locks::Mutex, AsyncTraitDeps};
 pub use memorystore::MemoryStore;
-use olm_rs::errors::{OlmAccountError, OlmGroupSessionError, OlmSessionError};
-#[allow(unused_imports)]
-pub use olm_rs::{account::IdentityKeys, PicklingMode};
 pub use pickle_key::{EncryptedPickleKey, PickleKey};
 use ruma::{
     events::secret::request::SecretName, identifiers::Error as IdentifierValidationError, DeviceId,
@@ -72,7 +68,6 @@ use tracing::{info, warn};
 use zeroize::Zeroize;
 
 use crate::{
-    error::SessionUnpicklingError,
     identities::{
         user::{OwnUserIdentity, UserIdentities, UserIdentity},
         Device, ReadOnlyDevice, ReadOnlyUserIdentities, UserDevices,
@@ -157,7 +152,7 @@ pub struct DeviceChanges {
 }
 
 /// The private part of a backup key.
-#[derive(Zeroize)]
+#[derive(Zeroize, Deserialize, Serialize)]
 #[zeroize(drop)]
 pub struct RecoveryKey {
     pub(crate) inner: [u8; RecoveryKey::KEY_SIZE],
@@ -183,68 +178,6 @@ struct InnerPickle {
 impl RecoveryKey {
     /// The number of bytes the recovery key will hold.
     pub const KEY_SIZE: usize = 32;
-    const NONCE_SIZE: usize = 12;
-
-    /// Export this [`RecoveryKey`] as an encrypted pickle that can be safely
-    /// stored.
-    pub fn pickle(&self, pickle_key: &[u8]) -> PickledRecoveryKey {
-        use aes::cipher::generic_array::GenericArray;
-        use aes_gcm::aead::{Aead, NewAead};
-        use rand::Fill;
-
-        let key = GenericArray::from_slice(pickle_key);
-        let cipher = aes_gcm::Aes256Gcm::new(key);
-
-        let mut nonce = vec![0u8; Self::NONCE_SIZE];
-        let mut rng = rand::thread_rng();
-
-        nonce.try_fill(&mut rng).expect("Can't generate random nocne to pickle the recovery key");
-        let nonce = GenericArray::from_slice(nonce.as_slice());
-
-        let ciphertext =
-            cipher.encrypt(nonce, self.inner.as_ref()).expect("Can't encrypt recovery key");
-
-        let ciphertext = crate::utilities::encode_url_safe(ciphertext);
-
-        let pickle = InnerPickle {
-            version: 1,
-            nonce: crate::utilities::encode_url_safe(nonce.as_slice()),
-            ciphertext,
-        };
-
-        PickledRecoveryKey(serde_json::to_string(&pickle).expect("Can't encode pickled signing"))
-    }
-
-    /// Try to import a `RecoveryKey` from a previously exported pickle.
-    pub fn from_pickle(
-        pickle: PickledRecoveryKey,
-        pickle_key: &[u8],
-    ) -> Result<Self, CryptoStoreError> {
-        use aes::cipher::generic_array::GenericArray;
-        use aes_gcm::aead::{Aead, NewAead};
-
-        let pickled: InnerPickle = serde_json::from_str(pickle.as_ref())?;
-
-        let key = GenericArray::from_slice(pickle_key);
-        let cipher = aes_gcm::Aes256Gcm::new(key);
-
-        let nonce = crate::utilities::decode_url_safe(pickled.nonce).unwrap();
-        let nonce = GenericArray::from_slice(&nonce);
-        let ciphertext = &crate::utilities::decode_url_safe(pickled.ciphertext).unwrap();
-
-        let decrypted = cipher
-            .decrypt(nonce, ciphertext.as_slice())
-            .map_err(|_| CryptoStoreError::UnpicklingError)?;
-
-        if decrypted.len() != Self::KEY_SIZE {
-            Err(CryptoStoreError::UnpicklingError)
-        } else {
-            let mut key = [0u8; Self::KEY_SIZE];
-            key.copy_from_slice(&decrypted);
-
-            Ok(Self { inner: key })
-        }
-    }
 }
 
 impl Debug for RecoveryKey {
@@ -311,9 +244,9 @@ impl Debug for CrossSigningKeyExport {
 /// or the key backup key.
 #[derive(Debug, Error)]
 pub enum SecretImportError {
-    /// The seed for the private key wasn't valid base64.
+    /// The key that we tried to import was invalid.
     #[error(transparent)]
-    Base64(#[from] DecodeError),
+    Key(#[from] vodozemac::KeyError),
     /// The public key of the imported private key doesn't match to the public
     /// key that was uploaded to the server.
     #[error(
@@ -633,8 +566,8 @@ impl Deref for Store {
     }
 }
 
-#[derive(Debug, Error)]
 /// The crypto store's error type.
+#[derive(Debug, Error)]
 pub enum CryptoStoreError {
     /// The account that owns the sessions, group sessions, and devices wasn't
     /// found.
@@ -645,25 +578,17 @@ pub enum CryptoStoreError {
     #[error(transparent)]
     Io(#[from] IoError),
 
-    /// The underlying Olm Account operation returned an error.
-    #[error(transparent)]
-    OlmAccount(#[from] OlmAccountError),
-
-    /// The underlying Olm session operation returned an error.
-    #[error(transparent)]
-    OlmSession(#[from] OlmSessionError),
-
-    /// The underlying Olm group session operation returned an error.
-    #[error(transparent)]
-    OlmGroupSession(#[from] OlmGroupSessionError),
-
-    /// A session time-stamp couldn't be loaded.
-    #[error(transparent)]
-    SessionUnpickling(#[from] SessionUnpicklingError),
-
     /// Failed to decrypt an pickled object.
     #[error("An object failed to be decrypted while unpickling")]
     UnpicklingError,
+
+    /// Failed to decrypt an pickled object.
+    #[error(transparent)]
+    Pickle(#[from] vodozemac::PickleError),
+
+    /// The received room key couldn't be converted into a valid Megolm session.
+    #[error(transparent)]
+    SessionCreation(#[from] vodozemac::megolm::SessionCreationError),
 
     /// A Matrix identifier failed to be validated.
     #[error(transparent)]

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -597,6 +597,14 @@ pub enum CryptoStoreError {
     /// The store failed to (de)serialize a data type.
     #[error(transparent)]
     Serialization(#[from] SerdeError),
+
+    /// The database format has changed in a backwards incompatible way.
+    #[error(
+        "The database format changed in an incompatible way, current \
+        version: {0}, latest version: {1}"
+    )]
+    UnsupportedDatabaseVersion(usize, usize),
+
     /// A problem with the underlying database backend
     #[error(transparent)]
     Backend(#[from] anyhow::Error),

--- a/crates/matrix-sdk-crypto/src/store/pickle_key.rs
+++ b/crates/matrix-sdk-crypto/src/store/pickle_key.rs
@@ -20,7 +20,6 @@ use aes_gcm::{
 };
 use getrandom::getrandom;
 use hmac::Hmac;
-use olm_rs::PicklingMode;
 use pbkdf2::pbkdf2;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -109,11 +108,6 @@ impl PickleKey {
         let mut key = Zeroizing::from(vec![0u8; KEY_SIZE]);
         pbkdf2::<Hmac<Sha256>>(passphrase.as_bytes(), salt, rounds, &mut *key);
         key
-    }
-
-    /// Get a `PicklingMode` version of this pickle key.
-    pub fn pickle_mode(&self) -> PicklingMode {
-        PicklingMode::Encrypted { key: self.aes256_key.clone() }
     }
 
     /// Get the raw AES256 key.

--- a/crates/matrix-sdk-crypto/src/store/pickle_key.rs
+++ b/crates/matrix-sdk-crypto/src/store/pickle_key.rs
@@ -18,9 +18,9 @@ use aes_gcm::{
     aead::{generic_array::GenericArray, Aead, NewAead},
     Aes256Gcm, Error as DecryptionError,
 };
-use getrandom::getrandom;
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
+use rand::{thread_rng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use zeroize::{Zeroize, Zeroizing};
@@ -81,7 +81,8 @@ pub struct PickleKey {
 impl Default for PickleKey {
     fn default() -> Self {
         let mut key = vec![0u8; KEY_SIZE];
-        getrandom(&mut key).expect("Can't generate new pickle key");
+        let mut rng = thread_rng();
+        rng.fill_bytes(&mut key);
 
         Self { aes256_key: key }
     }
@@ -122,15 +123,17 @@ impl PickleKey {
     /// * `passphrase` - The passphrase that should be used to encrypt the
     /// pickle key.
     pub fn encrypt(&self, passphrase: &str) -> EncryptedPickleKey {
+        let mut rng = thread_rng();
         let mut salt = vec![0u8; KDF_SALT_SIZE];
-        getrandom(&mut salt).expect("Can't generate new random pickle key");
+
+        rng.fill_bytes(&mut salt);
 
         let key = PickleKey::expand_key(passphrase, &salt, KDF_ROUNDS);
         let key = GenericArray::from_slice(key.as_ref());
         let cipher = Aes256Gcm::new(key);
 
         let mut nonce = vec![0u8; NONCE_SIZE];
-        getrandom(&mut nonce).expect("Can't generate new random nonce for the pickle key");
+        rng.fill_bytes(&mut nonce);
 
         let ciphertext = cipher
             .encrypt(GenericArray::from_slice(nonce.as_ref()), self.aes256_key.as_slice())

--- a/crates/matrix-sdk-crypto/src/utilities.rs
+++ b/crates/matrix-sdk-crypto/src/utilities.rs
@@ -13,24 +13,14 @@
 // limitations under the License.
 
 pub use base64::DecodeError;
-use base64::{decode_config, encode_config, STANDARD_NO_PAD, URL_SAFE_NO_PAD};
+use base64::{decode_config, encode_config, STANDARD_NO_PAD};
 
 /// Decode the input as base64 with no padding.
 pub fn decode(input: impl AsRef<[u8]>) -> Result<Vec<u8>, DecodeError> {
     decode_config(input, STANDARD_NO_PAD)
 }
 
-/// Decode the input as URL safe base64 with no padding.
-pub fn decode_url_safe(input: impl AsRef<[u8]>) -> Result<Vec<u8>, DecodeError> {
-    decode_config(input, URL_SAFE_NO_PAD)
-}
-
 /// Encode the input as base64 with no padding.
 pub fn encode(input: impl AsRef<[u8]>) -> String {
     encode_config(input, STANDARD_NO_PAD)
-}
-
-/// Encode the input as URL safe base64 with no padding.
-pub fn encode_url_safe(input: impl AsRef<[u8]>) -> String {
-    encode_config(input, URL_SAFE_NO_PAD)
 }

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -239,14 +239,15 @@ impl From<QrVerification> for Verification {
 ///
 /// We can now mark the device in our verified devices list as verified and sign
 /// the master keys in the verified devices list.
+#[cfg(feature = "qrcode")]
 #[derive(Clone, Debug)]
 pub struct Done {
     verified_devices: Arc<[ReadOnlyDevice]>,
     verified_master_keys: Arc<[ReadOnlyUserIdentities]>,
 }
 
+#[cfg(feature = "qrcode")]
 impl Done {
-    #[cfg(feature = "qrcode")]
     pub fn as_content(&self, flow_id: &FlowId) -> OutgoingContent {
         match flow_id {
             FlowId::ToDevice(t) => AnyToDeviceEventContent::KeyVerificationDone(

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -18,6 +18,7 @@ use matrix_qrcode::{
     qrcode::QrCode, EncodingError, QrVerificationData, SelfVerificationData,
     SelfVerificationNoMasterKey, VerificationData,
 };
+use rand::{thread_rng, RngCore};
 use ruma::{
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
     events::{
@@ -431,10 +432,11 @@ impl QrVerification {
     }
 
     fn generate_secret() -> Base64 {
-        let mut shared_secret = [0u8; SECRET_SIZE];
-        getrandom::getrandom(&mut shared_secret)
-            .expect("Can't generate randomness for the shared secret");
-        Base64::new(shared_secret.to_vec())
+        let mut shared_secret = vec![0u8; SECRET_SIZE];
+        let mut rng = thread_rng();
+        rng.fill_bytes(&mut shared_secret);
+
+        Base64::new(shared_secret)
     }
 
     pub(crate) fn new_self(

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -470,7 +470,7 @@ impl QrVerification {
 
         let inner: QrVerificationData = SelfVerificationNoMasterKey::new(
             flow_id.as_str().to_owned(),
-            store.account.identity_keys().ed25519().to_owned(),
+            store.account.identity_keys().ed25519.to_base64(),
             own_master_key,
             secret,
         )
@@ -556,9 +556,9 @@ impl QrVerification {
             }
             QrVerificationData::SelfVerification(_) => {
                 check_master_key(qr_code.first_key(), &other_identity)?;
-                if qr_code.second_key() != store.account.identity_keys().ed25519() {
+                if qr_code.second_key() != store.account.identity_keys().ed25519.to_base64() {
                     return Err(ScanError::KeyMismatch {
-                        expected: store.account.identity_keys().ed25519().to_owned(),
+                        expected: store.account.identity_keys().ed25519.to_base64(),
                         found: qr_code.second_key().to_owned(),
                     });
                 }
@@ -832,7 +832,7 @@ mod test {
         let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
         let flow_id = FlowId::ToDevice("test_transaction".into());
 
-        let device_key = account.identity_keys().ed25519().to_owned();
+        let device_key = account.identity_keys.ed25519.to_base64();
         let master_key = private_identity.master_public_key().await.unwrap();
         let master_key = master_key.get_first_key().unwrap().to_owned();
 

--- a/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
@@ -23,8 +23,8 @@ use ruma::{
 
 use super::{
     sas_state::{
-        Accepted, Confirmed, Created, KeyReceived, MacReceived, SasState, Started, WaitingForDone,
-        WeAccepted,
+        Accepted, Confirmed, Created, Done, KeyReceived, MacReceived, SasState, Started,
+        WaitingForDone, WeAccepted,
     },
     FlowId,
 };
@@ -32,7 +32,7 @@ use crate::{
     identities::{ReadOnlyDevice, ReadOnlyUserIdentities},
     verification::{
         event_enums::{AnyVerificationContent, OutgoingContent, OwnedAcceptContent, StartContent},
-        Cancelled, Done,
+        Cancelled,
     },
     Emoji, ReadOnlyAccount, ReadOnlyOwnUserIdentity,
 };

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -14,6 +14,7 @@ default-target = "wasm32-unknown-unknown"
 matrix-sdk-base = { path = "../matrix-sdk-base", features = ["store_key"] }
 matrix-sdk-crypto = { path = "../matrix-sdk-crypto", optional = true }
 matrix-sdk-common = { path = "../matrix-sdk-common" }
+matrix-sdk-store-encryption = { path = "../matrix-sdk-store-encryption" }
 thiserror = "1.0.25"
 anyhow = "1"
 

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -27,6 +27,7 @@ futures-util = { version = "0.3.15", default-features = false }
 matrix-sdk-base = { path = "../matrix-sdk-base", features = ["store_key"] }
 matrix-sdk-common = { path = "../matrix-sdk-common" }
 matrix-sdk-crypto = { path = "../matrix-sdk-crypto", optional = true }
+matrix-sdk-store-encryption = { path = "../matrix-sdk-store-encryption" }
 async-stream = "0.3.2"
 serde = "1"
 serde_json = "1.0.64"

--- a/crates/matrix-sdk-sled/src/cryptostore.rs
+++ b/crates/matrix-sdk-sled/src/cryptostore.rs
@@ -41,6 +41,7 @@ use matrix_sdk_crypto::{
     },
     GossipRequest, LocalTrust, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyUserIdentities, SecretInfo,
 };
+use matrix_sdk_store_encryption::StoreCipher;
 use serde::{Deserialize, Serialize};
 pub use sled::Error;
 use sled::{
@@ -51,11 +52,18 @@ use tracing::debug;
 
 use super::OpenStoreError;
 
-/// This needs to be 32 bytes long since AES-GCM requires it, otherwise we will
-/// panic once we try to pickle a Signing object.
-#[cfg(feature = "backups_v1")]
-const DEFAULT_PICKLE: &str = "DEFAULT_PICKLE_PASSPHRASE_123456";
 const DATABASE_VERSION: u8 = 3;
+
+// Table names that are used to derive a separate key for each tree. This ensure
+// that user ids encoded for different trees won't end up as the same byte
+// sequence. This prevents corelation attacks on our tree metadata.
+const DEVICE_TABLE_NAME: &str = "crypto-store-devices";
+const IDENTITIES_TABLE_NAME: &str = "crypto-store-identities";
+const SESSIONS_TABLE_NAME: &str = "crypto-store-sessions";
+const INBOUND_GROUP_TABLE_NAME: &str = "crypto-store-inbound-group-sessions";
+const OUTBOUND_GROUP_TABLE_NAME: &str = "crypto-store-outbound-group-sessions";
+const SECRET_REQUEST_BY_INFO_TABLE: &str = "crypto-store-secret-request-by-info";
+const TRACKED_USERS_TABLE: &str = "crypto-store-secret-tracked-users";
 
 trait EncodeKey {
     const SEPARATOR: u8 = 0xff;
@@ -123,6 +131,133 @@ impl EncodeKey for ReadOnlyDevice {
     }
 }
 
+impl EncodeSecureKey for (&UserId, &DeviceId) {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        let user_id = store_cipher.hash_key(table_name, self.0.as_bytes());
+        let device_id = store_cipher.hash_key(table_name, self.1.as_bytes());
+
+        (user_id, device_id).encode()
+    }
+}
+
+impl EncodeSecureKey for SecretInfo {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        match self {
+            SecretInfo::KeyRequest(k) => k.encode_secure(table_name, store_cipher),
+            SecretInfo::SecretRequest(s) => s.encode_secure(table_name, store_cipher),
+        }
+    }
+}
+
+impl EncodeSecureKey for SecretName {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        let name = store_cipher.hash_key(table_name, self.as_ref().as_bytes());
+
+        [name.as_slice(), &[Self::SEPARATOR]].concat()
+    }
+}
+
+impl EncodeSecureKey for RequestedKeyInfo {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        let room_id = store_cipher.hash_key(table_name, self.room_id.as_bytes());
+        let sender_key = store_cipher.hash_key(table_name, self.sender_key.as_bytes());
+        let algorithm = store_cipher.hash_key(table_name, self.algorithm.as_ref().as_bytes());
+        let session_id = store_cipher.hash_key(table_name, self.session_id.as_bytes());
+
+        [
+            room_id.as_slice(),
+            &[Self::SEPARATOR],
+            sender_key.as_slice(),
+            &[Self::SEPARATOR],
+            algorithm.as_slice(),
+            &[Self::SEPARATOR],
+            session_id.as_slice(),
+            &[Self::SEPARATOR],
+        ]
+        .concat()
+    }
+}
+
+impl EncodeSecureKey for UserId {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        let user_id = store_cipher.hash_key(table_name, self.as_bytes());
+
+        [user_id.as_slice(), &[0xff]].concat()
+    }
+}
+
+impl EncodeSecureKey for ReadOnlyDevice {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        (self.user_id(), self.device_id()).encode_secure(table_name, store_cipher)
+    }
+}
+
+impl EncodeKey for Session {
+    fn encode(&self) -> Vec<u8> {
+        let sender_key = self.sender_key();
+        let session_id = self.session_id();
+
+        [sender_key.as_bytes(), &[Self::SEPARATOR], session_id.as_bytes(), &[Self::SEPARATOR]]
+            .concat()
+    }
+}
+
+impl EncodeSecureKey for str {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        let key = store_cipher.hash_key(table_name, self.as_bytes());
+        [key.as_slice(), &[Self::SEPARATOR]].concat()
+    }
+}
+
+impl EncodeSecureKey for OutboundGroupSession {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        self.room_id().encode_secure(table_name, store_cipher)
+    }
+}
+
+impl EncodeSecureKey for RoomId {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        let room_id = store_cipher.hash_key(table_name, self.as_bytes());
+
+        [room_id.as_slice(), &[Self::SEPARATOR]].concat()
+    }
+}
+
+impl EncodeSecureKey for InboundGroupSession {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        (self.room_id(), self.sender_key(), self.session_id())
+            .encode_secure(table_name, store_cipher)
+    }
+}
+
+impl EncodeSecureKey for (&RoomId, &str, &str) {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        let first = store_cipher.hash_key(table_name, self.0.as_bytes());
+        let second = store_cipher.hash_key(table_name, self.1.as_bytes());
+        let third = store_cipher.hash_key(table_name, self.2.as_bytes());
+
+        [
+            first.as_slice(),
+            &[Self::SEPARATOR],
+            second.as_slice(),
+            &[Self::SEPARATOR],
+            third.as_slice(),
+            &[Self::SEPARATOR],
+        ]
+        .concat()
+    }
+}
+
+impl EncodeSecureKey for Session {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        let sender_key = store_cipher.hash_key(table_name, self.sender_key().as_bytes());
+        let session_id = store_cipher.hash_key(table_name, self.session_id().as_bytes());
+
+        [sender_key.as_slice(), &[Self::SEPARATOR], session_id.as_slice(), &[Self::SEPARATOR]]
+            .concat()
+    }
+}
+
 impl EncodeKey for RoomId {
     fn encode(&self) -> Vec<u8> {
         self.as_str().encode()
@@ -141,13 +276,37 @@ impl EncodeKey for str {
     }
 }
 
+impl<const N: usize> EncodeKey for ([u8; N], [u8; N]) {
+    fn encode(&self) -> Vec<u8> {
+        [self.0.as_slice(), &[Self::SEPARATOR], self.1.as_slice(), &[Self::SEPARATOR]].concat()
+    }
+}
+
 impl EncodeKey for (&str, &str) {
     fn encode(&self) -> Vec<u8> {
         [self.0.as_bytes(), &[Self::SEPARATOR], self.1.as_bytes(), &[Self::SEPARATOR]].concat()
     }
 }
 
-impl EncodeKey for (&str, &str, &str) {
+impl EncodeKey for (&UserId, &DeviceId) {
+    fn encode(&self) -> Vec<u8> {
+        (self.0.as_str(), self.1.as_str()).encode()
+    }
+}
+
+impl EncodeKey for InboundGroupSession {
+    fn encode(&self) -> Vec<u8> {
+        (self.room_id(), self.sender_key(), self.session_id()).encode()
+    }
+}
+
+impl EncodeKey for OutboundGroupSession {
+    fn encode(&self) -> Vec<u8> {
+        self.room_id().encode()
+    }
+}
+
+impl EncodeKey for (&RoomId, &str, &str) {
     fn encode(&self) -> Vec<u8> {
         [
             self.0.as_bytes(),
@@ -161,11 +320,21 @@ impl EncodeKey for (&str, &str, &str) {
     }
 }
 
+trait EncodeSecureKey {
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8>;
+}
+
 #[derive(Clone, Debug)]
 pub struct AccountInfo {
     user_id: Arc<UserId>,
     device_id: Arc<DeviceId>,
     identity_keys: Arc<IdentityKeys>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TrackedUser {
+    user_id: Box<UserId>,
+    dirty: bool,
 }
 
 /// A [sled] based cryptostore.
@@ -174,6 +343,7 @@ pub struct AccountInfo {
 #[derive(Clone)]
 pub struct SledStore {
     account_info: Arc<RwLock<Option<AccountInfo>>>,
+    store_cipher: Arc<Option<StoreCipher>>,
     path: Option<PathBuf>,
     inner: Db,
 
@@ -236,16 +406,44 @@ impl SledStore {
         self.account_info.read().unwrap().clone()
     }
 
+    fn serialize_value(&self, event: &impl Serialize) -> Result<Vec<u8>, CryptoStoreError> {
+        if let Some(key) = &*self.store_cipher {
+            key.encrypt_value(event).map_err(|e| CryptoStoreError::Backend(anyhow!(e)))
+        } else {
+            Ok(serde_json::to_vec(event)?)
+        }
+    }
+
+    fn deserialize_value<T: for<'b> Deserialize<'b>>(
+        &self,
+        event: &[u8],
+    ) -> Result<T, CryptoStoreError> {
+        if let Some(key) = &*self.store_cipher {
+            key.decrypt_value(event).map_err(|e| CryptoStoreError::Backend(anyhow!(e)))
+        } else {
+            Ok(serde_json::from_slice(event)?)
+        }
+    }
+
+    fn encode_key<T: EncodeSecureKey + EncodeKey + ?Sized>(
+        &self,
+        table_name: &str,
+        key: &T,
+    ) -> Vec<u8> {
+        if let Some(store_cipher) = &*self.store_cipher {
+            key.encode_secure(table_name, store_cipher).to_vec()
+        } else {
+            key.encode()
+        }
+    }
+
     async fn reset_backup_state(&self) -> Result<()> {
         let mut pickles: Vec<(IVec, PickledInboundGroupSession)> = self
             .inbound_group_sessions
             .iter()
             .map(|p| {
                 let item = p.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
-                Ok((
-                    item.0,
-                    serde_json::from_slice(&item.1).map_err(CryptoStoreError::Serialization)?,
-                ))
+                Ok((item.0, self.deserialize_value(&item.1)?))
             })
             .collect::<Result<_>>()?;
 
@@ -253,12 +451,13 @@ impl SledStore {
             pickle.backed_up = false;
         }
 
-        let ret: Result<(), TransactionError<serde_json::Error>> =
+        let ret: Result<(), TransactionError<CryptoStoreError>> =
             self.inbound_group_sessions.transaction(|inbound_sessions| {
                 for (key, pickle) in &pickles {
                     inbound_sessions.insert(
                         key,
-                        serde_json::to_vec(&pickle).map_err(ConflictableTransactionError::Abort)?,
+                        self.serialize_value(pickle)
+                            .map_err(ConflictableTransactionError::Abort)?,
                     )?;
                 }
 
@@ -381,10 +580,29 @@ impl SledStore {
         Ok(())
     }
 
+    fn get_or_create_store_cipher(passphrase: &str, database: &Db) -> Result<StoreCipher> {
+        let key = if let Some(key) = database
+            .get("store_cipher".encode())
+            .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
+        {
+            StoreCipher::import(passphrase, &key).map_err(|_| CryptoStoreError::UnpicklingError)?
+        } else {
+            let key = StoreCipher::new().map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
+            let encrypted =
+                key.export(passphrase).map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
+            database
+                .insert("store_cipher".encode(), encrypted)
+                .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
+            key
+        };
+
+        Ok(key)
+    }
+
     fn open_helper(
         db: Db,
         path: Option<PathBuf>,
-        _passphrase: Option<&str>,
+        passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
         let account = db.open_tree("account")?;
         let private_identity = db.open_tree("private_identity")?;
@@ -406,10 +624,18 @@ impl SledStore {
 
         let session_cache = SessionStore::new();
 
+        let store_cipher = if let Some(passphrase) = passphrase {
+            Some(Self::get_or_create_store_cipher(passphrase, &db)?)
+        } else {
+            None
+        }
+        .into();
+
         let database = Self {
             account_info: RwLock::new(None).into(),
             path,
             inner: db,
+            store_cipher,
             account,
             private_identity,
             sessions,
@@ -434,14 +660,13 @@ impl SledStore {
 
     async fn load_tracked_users(&self) -> Result<()> {
         for value in &self.tracked_users {
-            let (user, dirty) = value.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
-            let user = UserId::parse(String::from_utf8_lossy(&user).to_string())?;
-            let dirty = dirty.get(0).map(|d| *d == 1).unwrap_or(true);
+            let (_, user) = value.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
+            let user: TrackedUser = self.deserialize_value(&user)?;
 
-            self.tracked_users_cache.insert(user.to_owned());
+            self.tracked_users_cache.insert(user.user_id.to_owned());
 
-            if dirty {
-                self.users_for_key_query_cache.insert(user);
+            if user.dirty {
+                self.users_for_key_query_cache.insert(user.user_id);
             }
         }
 
@@ -455,9 +680,9 @@ impl SledStore {
         let account_info = self.get_account_info().ok_or(CryptoStoreError::AccountUnset)?;
 
         self.outbound_group_sessions
-            .get(room_id.encode())
+            .get(self.encode_key(OUTBOUND_GROUP_TABLE_NAME, room_id))
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
-            .map(|p| serde_json::from_slice(&p).map_err(CryptoStoreError::Serialization))
+            .map(|p| self.deserialize_value(&p))
             .transpose()?
             .map(|p| {
                 Ok(OutboundGroupSession::from_pickle(
@@ -482,11 +707,8 @@ impl SledStore {
         let mut session_changes = HashMap::new();
 
         for session in changes.sessions {
-            let sender_key = session.sender_key();
-            let session_id = session.session_id();
-
             let pickle = session.pickle().await;
-            let key = (sender_key, session_id).encode();
+            let key = self.encode_key(SESSIONS_TABLE_NAME, &session);
 
             self.session_cache.add(session).await;
             session_changes.insert(key, pickle);
@@ -495,10 +717,7 @@ impl SledStore {
         let mut inbound_session_changes = HashMap::new();
 
         for session in changes.inbound_group_sessions {
-            let room_id = session.room_id();
-            let sender_key = session.sender_key();
-            let session_id = session.session_id();
-            let key = (room_id.as_str(), sender_key, session_id).encode();
+            let key = self.encode_key(INBOUND_GROUP_TABLE_NAME, &session);
             let pickle = session.pickle().await;
 
             inbound_session_changes.insert(key, pickle);
@@ -507,10 +726,10 @@ impl SledStore {
         let mut outbound_session_changes = HashMap::new();
 
         for session in changes.outbound_group_sessions {
-            let room_id = session.room_id();
+            let key = self.encode_key(OUTBOUND_GROUP_TABLE_NAME, &session);
             let pickle = session.pickle().await;
 
-            outbound_session_changes.insert(room_id.to_owned(), pickle);
+            outbound_session_changes.insert(key, pickle);
         }
 
         let identity_changes = changes.identities;
@@ -518,7 +737,7 @@ impl SledStore {
         let key_requests = changes.key_requests;
         let backup_version = changes.backup_version;
 
-        let ret: Result<(), TransactionError<serde_json::Error>> = (
+        let ret: Result<(), TransactionError<CryptoStoreError>> = (
             &self.account,
             &self.private_identity,
             &self.devices,
@@ -548,47 +767,49 @@ impl SledStore {
                     if let Some(a) = &account_pickle {
                         account.insert(
                             "account".encode(),
-                            serde_json::to_vec(a).map_err(ConflictableTransactionError::Abort)?,
+                            self.serialize_value(a).map_err(ConflictableTransactionError::Abort)?,
                         )?;
                     }
 
                     if let Some(i) = &private_identity_pickle {
                         private_identity.insert(
                             "identity".encode(),
-                            serde_json::to_vec(&i).map_err(ConflictableTransactionError::Abort)?,
+                            self.serialize_value(&i)
+                                .map_err(ConflictableTransactionError::Abort)?,
                         )?;
                     }
 
                     if let Some(r) = &recovery_key_pickle {
                         account.insert(
                             "recovery_key_v1".encode(),
-                            serde_json::to_vec(r).map_err(ConflictableTransactionError::Abort)?,
+                            self.serialize_value(r).map_err(ConflictableTransactionError::Abort)?,
                         )?;
                     }
 
                     if let Some(b) = &backup_version {
                         account.insert(
                             "backup_version_v1".encode(),
-                            serde_json::to_vec(b).map_err(ConflictableTransactionError::Abort)?,
+                            self.serialize_value(b).map_err(ConflictableTransactionError::Abort)?,
                         )?;
                     }
 
                     for device in device_changes.new.iter().chain(&device_changes.changed) {
-                        let key = device.encode();
-                        let device = serde_json::to_vec(&device)
+                        let key = self.encode_key(DEVICE_TABLE_NAME, device);
+                        let device = self
+                            .serialize_value(&device)
                             .map_err(ConflictableTransactionError::Abort)?;
                         devices.insert(key, device)?;
                     }
 
                     for device in &device_changes.deleted {
-                        let key = device.encode();
+                        let key = self.encode_key(DEVICE_TABLE_NAME, device);
                         devices.remove(key)?;
                     }
 
                     for identity in identity_changes.changed.iter().chain(&identity_changes.new) {
                         identities.insert(
-                            identity.user_id().encode(),
-                            serde_json::to_vec(&identity)
+                            self.encode_key(IDENTITIES_TABLE_NAME, identity.user_id()),
+                            self.serialize_value(&identity)
                                 .map_err(ConflictableTransactionError::Abort)?,
                         )?;
                     }
@@ -596,7 +817,7 @@ impl SledStore {
                     for (key, session) in &session_changes {
                         sessions.insert(
                             key.as_slice(),
-                            serde_json::to_vec(&session)
+                            self.serialize_value(&session)
                                 .map_err(ConflictableTransactionError::Abort)?,
                         )?;
                     }
@@ -604,30 +825,33 @@ impl SledStore {
                     for (key, session) in &inbound_session_changes {
                         inbound_sessions.insert(
                             key.as_slice(),
-                            serde_json::to_vec(&session)
+                            self.serialize_value(&session)
                                 .map_err(ConflictableTransactionError::Abort)?,
                         )?;
                     }
 
                     for (key, session) in &outbound_session_changes {
                         outbound_sessions.insert(
-                            key.encode(),
-                            serde_json::to_vec(&session)
+                            key.as_slice(),
+                            self.serialize_value(&session)
                                 .map_err(ConflictableTransactionError::Abort)?,
                         )?;
                     }
 
                     for hash in &olm_hashes {
                         hashes.insert(
-                            serde_json::to_vec(&hash)
+                            serde_json::to_vec(hash)
+                                .map_err(CryptoStoreError::Serialization)
                                 .map_err(ConflictableTransactionError::Abort)?,
                             &[0],
                         )?;
                     }
 
                     for key_request in &key_requests {
-                        secret_requests_by_info
-                            .insert(key_request.info.encode(), key_request.request_id.encode())?;
+                        secret_requests_by_info.insert(
+                            self.encode_key(SECRET_REQUEST_BY_INFO_TABLE, &key_request.info),
+                            key_request.request_id.encode(),
+                        )?;
 
                         let key_request_id = key_request.request_id.encode();
 
@@ -635,14 +859,14 @@ impl SledStore {
                             unsent_secret_requests.remove(key_request_id.clone())?;
                             outgoing_secret_requests.insert(
                                 key_request_id,
-                                serde_json::to_vec(&key_request)
+                                self.serialize_value(&key_request)
                                     .map_err(ConflictableTransactionError::Abort)?,
                             )?;
                         } else {
                             outgoing_secret_requests.remove(key_request_id.clone())?;
                             unsent_secret_requests.insert(
                                 key_request_id,
-                                serde_json::to_vec(&key_request)
+                                self.serialize_value(&key_request)
                                     .map_err(ConflictableTransactionError::Abort)?,
                             )?;
                         }
@@ -653,7 +877,7 @@ impl SledStore {
             );
 
         ret.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
-        self.inner.flush_async().await.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
+        self.inner.flush().map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
 
         Ok(())
     }
@@ -663,14 +887,14 @@ impl SledStore {
             .outgoing_secret_requests
             .get(id)
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
-            .map(|r| serde_json::from_slice(&r))
+            .map(|r| self.deserialize_value(&r))
             .transpose()?;
 
         let request = if request.is_none() {
             self.unsent_secret_requests
                 .get(id)
                 .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
-                .map(|r| serde_json::from_slice(&r))
+                .map(|r| self.deserialize_value(&r))
                 .transpose()?
         } else {
             request
@@ -688,7 +912,7 @@ impl CryptoStore for SledStore {
             .get("account".encode())
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
         {
-            let pickle = serde_json::from_slice(&pickle)?;
+            let pickle = self.deserialize_value(&pickle)?;
 
             self.load_tracked_users().await?;
             let account = ReadOnlyAccount::from_pickle(pickle)?;
@@ -727,7 +951,7 @@ impl CryptoStore for SledStore {
             .get("identity".encode())
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
         {
-            let pickle = serde_json::from_slice(&i)?;
+            let pickle = self.deserialize_value(&i)?;
             Ok(Some(
                 PrivateCrossSigningIdentity::from_pickle(pickle)
                     .await
@@ -748,10 +972,9 @@ impl CryptoStore for SledStore {
         if self.session_cache.get(sender_key).is_none() {
             let sessions: Result<Vec<Session>> = self
                 .sessions
-                .scan_prefix(sender_key.encode())
+                .scan_prefix(self.encode_key(SESSIONS_TABLE_NAME, sender_key))
                 .map(|s| {
-                    serde_json::from_slice(&s.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?.1)
-                        .map_err(CryptoStoreError::Serialization)
+                    self.deserialize_value(&s.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?.1)
                 })
                 .map(|p| {
                     Ok(Session::from_pickle(
@@ -775,12 +998,12 @@ impl CryptoStore for SledStore {
         sender_key: &str,
         session_id: &str,
     ) -> Result<Option<InboundGroupSession>> {
-        let key = (room_id.as_str(), sender_key, session_id).encode();
+        let key = self.encode_key(INBOUND_GROUP_TABLE_NAME, &(room_id, sender_key, session_id));
         let pickle = self
             .inbound_group_sessions
             .get(&key)
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
-            .map(|p| serde_json::from_slice(&p));
+            .map(|p| self.deserialize_value(&p));
 
         if let Some(pickle) = pickle {
             Ok(Some(InboundGroupSession::from_pickle(pickle?)?))
@@ -794,8 +1017,7 @@ impl CryptoStore for SledStore {
             .inbound_group_sessions
             .iter()
             .map(|p| {
-                serde_json::from_slice(&p.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?.1)
-                    .map_err(CryptoStoreError::Serialization)
+                self.deserialize_value(&p.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?.1)
             })
             .collect();
 
@@ -808,7 +1030,7 @@ impl CryptoStore for SledStore {
             .iter()
             .map(|p| {
                 let item = p.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
-                serde_json::from_slice(&item.1).map_err(CryptoStoreError::Serialization)
+                self.deserialize_value(&item.1)
             })
             .collect::<Result<_>>()?;
 
@@ -827,7 +1049,7 @@ impl CryptoStore for SledStore {
             .iter()
             .map(|p| {
                 let item = p.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
-                serde_json::from_slice(&item.1).map_err(CryptoStoreError::from)
+                self.deserialize_value(&item.1)
             })
             .filter_map(|p: Result<PickledInboundGroupSession, CryptoStoreError>| match p {
                 Ok(p) => {
@@ -882,8 +1104,13 @@ impl CryptoStore for SledStore {
             self.users_for_key_query_cache.remove(user);
         }
 
+        let user = TrackedUser { user_id: user.to_owned(), dirty };
+
         self.tracked_users
-            .insert(user.as_str(), &[dirty as u8])
+            .insert(
+                self.encode_key(TRACKED_USERS_TABLE, user.user_id.as_str()),
+                self.serialize_value(&user)?,
+            )
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
 
         Ok(already_added)
@@ -894,12 +1121,13 @@ impl CryptoStore for SledStore {
         user_id: &UserId,
         device_id: &DeviceId,
     ) -> Result<Option<ReadOnlyDevice>> {
-        let key = (user_id.as_str(), device_id.as_str()).encode();
+        let key = self.encode_key(DEVICE_TABLE_NAME, &(user_id, device_id));
+
         Ok(self
             .devices
             .get(key)
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
-            .map(|d| serde_json::from_slice(&d))
+            .map(|d| self.deserialize_value(&d))
             .transpose()?)
     }
 
@@ -907,11 +1135,11 @@ impl CryptoStore for SledStore {
         &self,
         user_id: &UserId,
     ) -> Result<HashMap<Box<DeviceId>, ReadOnlyDevice>> {
+        let key = self.encode_key(DEVICE_TABLE_NAME, user_id);
         self.devices
-            .scan_prefix(user_id.encode())
+            .scan_prefix(key)
             .map(|d| {
-                serde_json::from_slice(&d.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?.1)
-                    .map_err(CryptoStoreError::Serialization)
+                self.deserialize_value(&d.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?.1)
             })
             .map(|d| {
                 let d: ReadOnlyDevice = d?;
@@ -921,11 +1149,13 @@ impl CryptoStore for SledStore {
     }
 
     async fn get_user_identity(&self, user_id: &UserId) -> Result<Option<ReadOnlyUserIdentities>> {
+        let key = self.encode_key(IDENTITIES_TABLE_NAME, user_id);
+
         Ok(self
             .identities
-            .get(user_id.encode())
+            .get(key)
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
-            .map(|i| serde_json::from_slice(&i))
+            .map(|i| self.deserialize_value(&i))
             .transpose()?)
     }
 
@@ -954,7 +1184,7 @@ impl CryptoStore for SledStore {
     ) -> Result<Option<GossipRequest>> {
         let id = self
             .secret_requests_by_info
-            .get(key_info.encode())
+            .get(self.encode_key(SECRET_REQUEST_BY_INFO_TABLE, key_info))
             .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?;
 
         if let Some(id) = id {
@@ -969,8 +1199,7 @@ impl CryptoStore for SledStore {
             .unsent_secret_requests
             .iter()
             .map(|i| {
-                serde_json::from_slice(&i.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?.1)
-                    .map_err(CryptoStoreError::from)
+                self.deserialize_value(&i.map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?.1)
             })
             .collect();
 
@@ -978,7 +1207,7 @@ impl CryptoStore for SledStore {
     }
 
     async fn delete_outgoing_secret_requests(&self, request_id: &TransactionId) -> Result<()> {
-        let ret: Result<(), TransactionError<serde_json::Error>> = (
+        let ret: Result<(), TransactionError<CryptoStoreError>> = (
             &self.outgoing_secret_requests,
             &self.unsent_secret_requests,
             &self.secret_requests_by_info,
@@ -987,22 +1216,24 @@ impl CryptoStore for SledStore {
                 |(outgoing_key_requests, unsent_key_requests, key_requests_by_info)| {
                     let sent_request: Option<GossipRequest> = outgoing_key_requests
                         .remove(request_id.encode())?
-                        .map(|r| serde_json::from_slice(&r))
+                        .map(|r| self.deserialize_value(&r))
                         .transpose()
                         .map_err(ConflictableTransactionError::Abort)?;
 
                     let unsent_request: Option<GossipRequest> = unsent_key_requests
                         .remove(request_id.encode())?
-                        .map(|r| serde_json::from_slice(&r))
+                        .map(|r| self.deserialize_value(&r))
                         .transpose()
                         .map_err(ConflictableTransactionError::Abort)?;
 
                     if let Some(request) = sent_request {
-                        key_requests_by_info.remove(request.info.encode())?;
+                        key_requests_by_info
+                            .remove(self.encode_key(SECRET_REQUEST_BY_INFO_TABLE, &request.info))?;
                     }
 
                     if let Some(request) = unsent_request {
-                        key_requests_by_info.remove(request.info.encode())?;
+                        key_requests_by_info
+                            .remove(self.encode_key(SECRET_REQUEST_BY_INFO_TABLE, &request.info))?;
                     }
 
                     Ok(())
@@ -1021,14 +1252,14 @@ impl CryptoStore for SledStore {
                 .account
                 .get("backup_version_v1".encode())
                 .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
-                .map(|v| serde_json::from_slice(&v))
+                .map(|v| self.deserialize_value(&v))
                 .transpose()?;
 
             let recovery_key = {
                 self.account
                     .get("recovery_key_v1".encode())
                     .map_err(|e| CryptoStoreError::Backend(anyhow!(e)))?
-                    .map(|p| serde_json::from_slice(&p))
+                    .map(|p| self.deserialize_value(&p))
                     .transpose()?
             };
 

--- a/crates/matrix-sdk-sled/src/cryptostore.rs
+++ b/crates/matrix-sdk-sled/src/cryptostore.rs
@@ -486,11 +486,10 @@ impl SledStore {
         }
 
         if version <= 3 {
-            return Err(anyhow!(
-                "Unsupported database version, the database \
-                 format changed in a backwards incompatible way"
-            )
-            .into());
+            return Err(CryptoStoreError::UnsupportedDatabaseVersion(
+                version.into(),
+                DATABASE_VERSION.into(),
+            ));
         }
 
         self.inner

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -508,7 +508,7 @@ impl Encryption {
     /// Get the public ed25519 key of our own device. This is usually what is
     /// called the fingerprint of the device.
     pub async fn ed25519_key(&self) -> Option<String> {
-        self.client.olm_machine().await.map(|o| o.identity_keys().ed25519().to_owned())
+        self.client.olm_machine().await.map(|o| o.identity_keys().ed25519.to_base64())
     }
 
     /// Get the status of the private cross signing keys.


### PR DESCRIPTION
This PR intends to replaces olm-rs with vodozemac. It's still in a messy state, but can already be tested. I have been using this for a couple of days in a custom weechat-matrix-rs build.

The missing things here are:
1. A new way to encrypt keys/values in  our store.
2. Migrations for the sled store.

One notable exception here is the backup support. Backup support requires support for `PkEncrypt` and `PkDecrypt` structs from libolm, the whole asymmetric encryption scheme is deemed to be insecure and has been abandoned in favor of [MSC3270].

In conclusion, if backup support is needed, libolm will still be used.

[MSC3270]: https://github.com/matrix-org/matrix-doc/pull/3270