### PR TITLE
Splitting Store implementation into separate crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,4 @@
 [workspace]
 members = [
-    "crates/matrix-qrcode",
-    "crates/matrix-sdk",
-    "crates/matrix-sdk-appservice",
-    "crates/matrix-sdk-base",
-    "crates/matrix-sdk-common",
-    "crates/matrix-sdk-crypto",
-    "crates/matrix-sdk-test",
-    "crates/matrix-sdk-test-macros",
+    "crates/*",
 ]

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -37,6 +37,8 @@ state_key = [
     "rand",
     "chacha20poly1305",
 ]
+# helpers for testing features build upon this
+testing = [ ]
 
 [dependencies]
 chacha20poly1305 = { version = "0.9.0", optional = true }
@@ -82,9 +84,6 @@ tokio = { version = "1.7.1", default-features = false, features = [
     "macros",
 ] }
 tempfile = "3.2.0"
-
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.24"
 
 [[example]]
 name = "state_inspector"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -22,16 +22,21 @@ qrcode = ["matrix-sdk-crypto/qrcode"]
 sled_state_store = [
     "sled",
     "tokio",
+    "state_key",
+]
+sled_cryptostore = ["matrix-sdk-crypto/sled_cryptostore"]
+
+indexeddb_state_store = ["state_key"]
+indexeddb_cryptostore = ["matrix-sdk-crypto/indexeddb_cryptostore"]
+
+# State Key is a helper feature for state store implementations
+state_key = [
     "pbkdf2",
     "hmac",
     "sha2",
     "rand",
     "chacha20poly1305",
 ]
-sled_cryptostore = ["matrix-sdk-crypto/sled_cryptostore"]
-
-indexeddb_state_store = ["indexed_db_futures", "wasm-bindgen", "pbkdf2", "hmac", "sha2", "rand", "chacha20poly1305"]
-indexeddb_cryptostore = ["matrix-sdk-crypto/indexeddb_cryptostore"]
 
 [dependencies]
 chacha20poly1305 = { version = "0.9.0", optional = true }
@@ -51,13 +56,10 @@ sled = { version = "0.34.6", optional = true }
 thiserror = "1.0.25"
 tracing = "0.1.26"
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
+anyhow = "1"
 
 ## Feature sled_state_store
 tokio = { version = "1.7.1", optional = true, default-features = false, features = ["sync", "fs"] }
-
-## Feature indexeddb-state-store
-indexed_db_futures = { version = "0.2.0", optional = true }
-wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"], optional = true }
 
 [dependencies.ruma]
 git = "https://github.com/ruma/ruma/"

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -15,9 +15,9 @@
 
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![warn(missing_docs)]
 #![deny(
     missing_debug_implementations,
-    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
@@ -46,7 +46,7 @@ mod error;
 pub mod media;
 mod rooms;
 mod session;
-mod store;
+pub mod store;
 
 pub use client::{BaseClient, BaseClientConfig};
 #[cfg(feature = "encryption")]

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -369,11 +369,13 @@ impl Room {
         Ok(inner.base_info.calculate_room_name(joined, invited, members))
     }
 
-    pub(crate) fn clone_info(&self) -> RoomInfo {
+    #[cfg(any(cfg, feature = "testing"))]
+    pub fn clone_info(&self) -> RoomInfo {
         (*self.inner.read().unwrap()).clone()
     }
 
-    pub(crate) fn update_summary(&self, summary: RoomInfo) {
+    #[cfg(any(cfg, feature = "testing"))]
+    pub fn update_summary(&self, summary: RoomInfo) {
         let mut inner = self.inner.write().unwrap();
         *inner = summary;
     }
@@ -495,23 +497,23 @@ pub struct RoomInfo {
 }
 
 impl RoomInfo {
-    pub(crate) fn mark_as_joined(&mut self) {
+    pub fn mark_as_joined(&mut self) {
         self.room_type = RoomType::Joined;
     }
 
-    pub(crate) fn mark_as_left(&mut self) {
+    pub fn mark_as_left(&mut self) {
         self.room_type = RoomType::Left;
     }
 
-    pub(crate) fn mark_members_synced(&mut self) {
+    pub fn mark_members_synced(&mut self) {
         self.members_synced = true;
     }
 
-    pub(crate) fn mark_members_missing(&mut self) {
+    pub fn mark_members_missing(&mut self) {
         self.members_synced = false;
     }
 
-    pub(crate) fn set_prev_batch(&mut self, prev_batch: Option<&str>) -> bool {
+    pub fn set_prev_batch(&mut self, prev_batch: Option<&str>) -> bool {
         if self.last_prev_batch.as_deref() != prev_batch {
             self.last_prev_batch = prev_batch.map(|p| p.to_string());
             true
@@ -520,22 +522,22 @@ impl RoomInfo {
         }
     }
 
-    pub(crate) fn is_encrypted(&self) -> bool {
+    pub fn is_encrypted(&self) -> bool {
         self.base_info.encryption.is_some()
     }
 
-    pub(crate) fn handle_state_event(&mut self, event: &AnyStateEventContent) -> bool {
+    pub fn handle_state_event(&mut self, event: &AnyStateEventContent) -> bool {
         self.base_info.handle_state_event(event)
     }
 
-    pub(crate) fn update_notification_count(
+    pub fn update_notification_count(
         &mut self,
         notification_counts: UnreadNotificationsCount,
     ) {
         self.notification_counts = notification_counts;
     }
 
-    pub(crate) fn update_summary(&mut self, summary: &RumaSummary) -> bool {
+    pub fn update_summary(&mut self, summary: &RumaSummary) -> bool {
         let mut changed = false;
 
         if !summary.is_empty() {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1,11 +1,12 @@
-#[allow(unused_macros)]
+#[allow(unused_macros, unused_extern_crates)]
 
+#[macro_export]
 macro_rules! statestore_integration_tests {
     ($($name:ident)*) => {
         $(
             mod $name {
                 use matrix_sdk_test::{async_test, test_json};
-                use ruma::{
+                use matrix_sdk_common::ruma::{
                     api::client::r0::media::get_content_thumbnail::Method,
                     device_id, event_id,
                     events::{
@@ -28,7 +29,7 @@ macro_rules! statestore_integration_tests {
 
                 use std::collections::{BTreeMap, BTreeSet};
 
-                use crate::{
+                use $crate::{
                     RoomType, Session,
                     deserialized_responses::{MemberEvent, StrippedMemberEvent},
                     media::{MediaFormat, MediaRequest, MediaThumbnailSize, MediaType},

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub use async_trait::async_trait;
 pub use instant;
+pub use ruma;
 
 pub mod deserialized_responses;
 pub mod executor;

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -21,7 +21,10 @@ qrcode = ["matrix-qrcode"]
 backups_v1 = []
 sled_cryptostore = ["sled"]
 docsrs = ["sled_cryptostore"]
-indexeddb_cryptostore = ["indexed_db_futures", "wasm-bindgen"]
+indexeddb_cryptostore = []
+
+# Testing helpers for implementations based upon this
+testing = ["http"]
 
 [dependencies]
 aes = { version = "0.7.4", features = ["ctr"] }
@@ -46,10 +49,13 @@ sled = { version = "0.34.6", optional = true }
 thiserror = "1.0.25"
 tracing = "0.1.26"
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
+anyhow = "1"
 
-## Feature indexeddb-state-store
-indexed_db_futures = { version = "0.2.0", optional = true }
-wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"], optional = true }
+
+# feature = testing only
+http = { version = "0.2.4", optional = true}
+
+
 [dependencies.ruma]
 git = "https://github.com/ruma/ruma/"
 rev = "37095f88553b311e7a70adaaabe39976fb8ff71c"
@@ -79,8 +85,6 @@ lazy_static = "1.4"
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof = { version = "0.6.2", features = ["flamegraph", "criterion"] }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.24"
 
 [[bench]]
 name = "crypto_bench"

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -188,7 +188,7 @@ pub enum SignatureError {
 }
 
 #[derive(Error, Debug)]
-pub(crate) enum SessionCreationError {
+pub enum SessionCreationError {
     #[error(
         "Failed to create a new Olm session for {0} {1}, the requested \
         one-time key isn't a signed curve key"

--- a/crates/matrix-sdk-crypto/src/gossiping/mod.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/mod.rs
@@ -85,10 +85,9 @@ pub enum SecretInfo {
 }
 
 impl SecretInfo {
-    #[allow(dead_code)]
     /// Serialize `SecretInfo` into `String` for usage as database keys and
     /// comparison
-    pub(crate) fn as_key(&self) -> String {
+    pub fn as_key(&self) -> String {
         match &self {
             SecretInfo::KeyRequest(ref info) => format!(
                 "keyRequest:{:}:{:}:{:}:{:}",

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -935,23 +935,16 @@ impl ReadOnlyOwnUserIdentity {
     }
 }
 
-#[cfg(test)]
-pub(crate) mod test {
-    use std::{convert::TryFrom, sync::Arc};
-
-    use matrix_sdk_common::locks::Mutex;
-    use matrix_sdk_test::async_test;
+#[cfg(any(test, feature = "testing"))]
+pub(crate) mod testing {
+    #![allow(dead_code)]
     use ruma::{api::client::r0::keys::get_keys::Response as KeyQueryResponse, user_id};
 
-    use super::{ReadOnlyOwnUserIdentity, ReadOnlyUserIdentities, ReadOnlyUserIdentity};
+    use super::{ReadOnlyOwnUserIdentity, ReadOnlyUserIdentity};
     use crate::{
         identities::{
-            manager::test::{other_key_query, own_key_query},
-            Device, ReadOnlyDevice,
+            manager::testing::{other_key_query, own_key_query}, ReadOnlyDevice,
         },
-        olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
-        store::MemoryStore,
-        verification::VerificationMachine,
     };
 
     fn device(response: &KeyQueryResponse) -> (ReadOnlyDevice, ReadOnlyDevice) {
@@ -974,11 +967,11 @@ pub(crate) mod test {
             .unwrap()
     }
 
-    pub(crate) fn get_own_identity() -> ReadOnlyOwnUserIdentity {
+    pub fn get_own_identity() -> ReadOnlyOwnUserIdentity {
         own_identity(&own_key_query())
     }
 
-    pub(crate) fn get_other_identity() -> ReadOnlyUserIdentity {
+    pub fn get_other_identity() -> ReadOnlyUserIdentity {
         let user_id = user_id!("@example2:localhost");
         let response = other_key_query();
 
@@ -987,6 +980,28 @@ pub(crate) mod test {
 
         ReadOnlyUserIdentity::new(master_key.into(), self_signing.into()).unwrap()
     }
+}
+
+
+#[cfg(test)]
+pub(crate) mod test {
+    use std::{convert::TryFrom, sync::Arc};
+
+    use matrix_sdk_common::locks::Mutex;
+    use matrix_sdk_test::async_test;
+    use ruma::{api::client::r0::keys::get_keys::Response as KeyQueryResponse, user_id};
+
+    use super::{ReadOnlyOwnUserIdentity, ReadOnlyUserIdentities, ReadOnlyUserIdentity};
+    use crate::{
+        identities::{
+            manager::test::{other_key_query, own_key_query},
+            Device, ReadOnlyDevice,
+        },
+        olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
+        store::MemoryStore,
+        verification::VerificationMachine,
+    };
+    use super::testing::{get_other_identity, get_own_identity};
 
     #[test]
     fn own_identity_create() {

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -14,10 +14,10 @@
 
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![warn(missing_docs)]
 #![deny(
     missing_debug_implementations,
     dead_code,
-    missing_docs,
     trivial_casts,
     trivial_numeric_casts,
     unused_extern_crates,
@@ -41,6 +41,15 @@ mod session_manager;
 pub mod store;
 mod utilities;
 mod verification;
+
+#[cfg(feature = "testing")]
+pub mod testing {
+/// Testing facilities and helpers for crypto tests
+    pub use crate::identities::{
+        device::testing::get_device,
+        user::testing::{get_other_identity, get_own_identity},
+    };
+}
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -82,13 +91,14 @@ pub use identities::{
 pub use machine::OlmMachine;
 #[cfg(feature = "qrcode")]
 pub use matrix_qrcode;
-pub(crate) use olm::ReadOnlyAccount;
+pub use olm::ReadOnlyAccount;
 pub use olm::{CrossSigningStatus, EncryptionSettings};
+pub use gossiping::GossipRequest;
 pub use requests::{
     IncomingResponse, KeysBackupRequest, KeysQueryRequest, OutgoingRequest, OutgoingRequests,
     OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest, UploadSigningKeysRequest,
 };
-pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretImportError};
+pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretInfo, SecretImportError};
 pub use verification::{AcceptSettings, CancelInfo, Emoji, Sas, Verification, VerificationRequest};
 #[cfg(feature = "qrcode")]
 pub use verification::{QrVerification, ScanError};

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -464,13 +464,15 @@ impl OlmMachine {
     /// }
     /// # });
     /// ```
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
     async fn should_upload_keys(&self) -> bool {
         self.account.should_upload_keys().await
     }
 
     /// Get the underlying Olm account of the machine.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
     pub(crate) fn account(&self) -> &ReadOnlyAccount {
         &self.account
     }
@@ -1548,13 +1550,24 @@ impl OlmMachine {
         &self.backup_machine
     }
 }
+#[cfg(any(feature = "testing", test))]
+pub(crate) mod testing {
+    #![allow(dead_code)]
+    use http::Response;
+    use serde_json;
+
+    pub fn response_from_file(json: &serde_json::Value) -> Response<Vec<u8>> {
+        Response::builder().status(200).body(json.to_string().as_bytes().to_vec()).unwrap()
+    }
+
+
+}
 
 #[cfg(test)]
 pub(crate) mod test {
 
     use std::{collections::BTreeMap, convert::TryInto, iter, sync::Arc};
 
-    use http::Response;
     use matrix_sdk_common::util::milli_seconds_since_unix_epoch;
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{
@@ -1580,6 +1593,7 @@ pub(crate) mod test {
         uint, user_id, DeviceId, DeviceKeyAlgorithm, DeviceKeyId, UserId,
     };
     use serde_json::json;
+    use super::testing::response_from_file;
 
     use crate::{
         machine::OlmMachine,
@@ -1601,10 +1615,6 @@ pub(crate) mod test {
 
     fn user_id() -> &'static UserId {
         user_id!("@bob:example.com")
-    }
-
-    pub fn response_from_file(json: &serde_json::Value) -> Response<Vec<u8>> {
-        Response::builder().status(200).body(json.to_string().as_bytes().to_vec()).unwrap()
     }
 
     fn keys_upload_response() -> upload_keys::Response {

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -66,8 +66,8 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct Account {
-    pub(crate) inner: ReadOnlyAccount,
-    pub(crate) store: Store,
+    pub inner: ReadOnlyAccount,
+    pub store: Store,
 }
 
 #[derive(Debug, Clone)]
@@ -146,7 +146,7 @@ impl Account {
         Ok((message, message_hash))
     }
 
-    pub(crate) async fn save(&self) -> Result<(), CryptoStoreError> {
+    pub async fn save(&self) -> Result<(), CryptoStoreError> {
         self.store.save_account(self.inner.clone()).await
     }
 
@@ -479,10 +479,13 @@ impl Account {
 /// devices.
 #[derive(Clone)]
 pub struct ReadOnlyAccount {
-    pub(crate) user_id: Arc<UserId>,
-    pub(crate) device_id: Arc<DeviceId>,
+    /// The user_id this account belongs to
+    pub user_id: Arc<UserId>,
+    /// The device_id of this entry 
+    pub device_id: Arc<DeviceId>,
     inner: Arc<Mutex<OlmAccount>>,
-    pub(crate) identity_keys: Arc<IdentityKeys>,
+    /// The associated identity keys
+    pub identity_keys: Arc<IdentityKeys>,
     shared: Arc<AtomicBool>,
     /// The number of signed one-time keys we have uploaded to the server. If
     /// this is None, no action will be taken. After a sync request the client
@@ -579,7 +582,7 @@ impl ReadOnlyAccount {
     /// # Arguments
     ///
     /// * `new_count` - The new count that was reported by the server.
-    pub(crate) fn update_uploaded_key_count(&self, new_count: u64) {
+    pub fn update_uploaded_key_count(&self, new_count: u64) {
         self.uploaded_signed_key_count.store(new_count, Ordering::SeqCst);
     }
 
@@ -597,31 +600,31 @@ impl ReadOnlyAccount {
     ///
     /// Messages shouldn't be encrypted with the session before it has been
     /// shared.
-    pub(crate) fn mark_as_shared(&self) {
+    pub fn mark_as_shared(&self) {
         self.shared.store(true, Ordering::SeqCst);
     }
 
     /// Get the one-time keys of the account.
     ///
     /// This can be empty, keys need to be generated first.
-    pub(crate) async fn one_time_keys(&self) -> OneTimeKeys {
+    pub async fn one_time_keys(&self) -> OneTimeKeys {
         self.inner.lock().await.parsed_one_time_keys()
     }
 
     /// Generate count number of one-time keys.
-    pub(crate) async fn generate_one_time_keys_helper(&self, count: usize) {
+    pub async fn generate_one_time_keys_helper(&self, count: usize) {
         self.inner.lock().await.generate_one_time_keys(count);
     }
 
     /// Get the maximum number of one-time keys the account can hold.
-    pub(crate) async fn max_one_time_keys(&self) -> usize {
+    pub async fn max_one_time_keys(&self) -> usize {
         self.inner.lock().await.max_number_of_one_time_keys()
     }
 
     /// Get a tuple of device and one-time keys that need to be uploaded.
     ///
     /// Returns an empty error if no keys need to be uploaded.
-    pub(crate) async fn generate_one_time_keys(&self) -> Result<u64, ()> {
+    pub async fn generate_one_time_keys(&self) -> Result<u64, ()> {
         // Only generate one-time keys if there aren't any, otherwise the caller
         // might have failed to upload them the last time this method was
         // called.
@@ -645,7 +648,7 @@ impl ReadOnlyAccount {
     }
 
     /// Should account or one-time keys be uploaded to the server.
-    pub(crate) async fn should_upload_keys(&self) -> bool {
+    pub async fn should_upload_keys(&self) -> bool {
         if !self.shared() {
             return true;
         }
@@ -668,7 +671,7 @@ impl ReadOnlyAccount {
     /// Get a tuple of device and one-time keys that need to be uploaded.
     ///
     /// Returns None if no keys need to be uploaded.
-    pub(crate) async fn keys_for_upload(
+    pub async fn keys_for_upload(
         &self,
     ) -> Option<(Option<DeviceKeys>, BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>)> {
         if !self.should_upload_keys().await {
@@ -683,7 +686,7 @@ impl ReadOnlyAccount {
     }
 
     /// Mark the current set of one-time keys as being published.
-    pub(crate) async fn mark_keys_as_published(&self) {
+    pub async fn mark_keys_as_published(&self) {
         self.inner.lock().await.mark_keys_as_published();
     }
 
@@ -695,7 +698,7 @@ impl ReadOnlyAccount {
     }
 
     #[cfg(feature = "backups_v1")]
-    pub(crate) fn is_signed(&self, json: &mut Value) -> Result<(), SignatureError> {
+    pub fn is_signed(&self, json: &mut Value) -> Result<(), SignatureError> {
         let signing_key = self.identity_keys.ed25519();
         let utility = crate::olm::Utility::new();
 
@@ -752,7 +755,7 @@ impl ReadOnlyAccount {
         })
     }
 
-    pub(crate) fn unsigned_device_keys(&self) -> DeviceKeys {
+    pub fn unsigned_device_keys(&self) -> DeviceKeys {
         let identity_keys = self.identity_keys();
         let keys = BTreeMap::from([
             (
@@ -776,7 +779,7 @@ impl ReadOnlyAccount {
 
     /// Sign the device keys of the account and return them so they can be
     /// uploaded.
-    pub(crate) async fn device_keys(&self) -> DeviceKeys {
+    pub async fn device_keys(&self) -> DeviceKeys {
         let mut device_keys = self.unsigned_device_keys();
 
         // Create a copy of the device keys containing only fields that will
@@ -800,13 +803,13 @@ impl ReadOnlyAccount {
         device_keys
     }
 
-    pub(crate) async fn bootstrap_cross_signing(
+    pub async fn bootstrap_cross_signing(
         &self,
     ) -> (PrivateCrossSigningIdentity, UploadSigningKeysRequest, SignatureUploadRequest) {
         PrivateCrossSigningIdentity::new_with_account(self).await
     }
 
-    pub(crate) async fn sign_cross_signing_key(
+    pub async fn sign_cross_signing_key(
         &self,
         cross_signing_key: &mut CrossSigningKey,
     ) -> Result<(), SignatureError> {
@@ -824,7 +827,7 @@ impl ReadOnlyAccount {
         Ok(())
     }
 
-    pub(crate) async fn sign_master_key(
+    pub async fn sign_master_key(
         &self,
         master_key: MasterPubkey,
     ) -> Result<SignatureUploadRequest, SignatureError> {
@@ -865,7 +868,7 @@ impl ReadOnlyAccount {
         self.sign(&canonical_json.to_string()).await
     }
 
-    pub(crate) async fn signed_one_time_keys_helper(
+    pub async fn signed_one_time_keys_helper(
         &self,
     ) -> BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>> {
         let one_time_keys = self.one_time_keys().await;
@@ -911,7 +914,7 @@ impl ReadOnlyAccount {
     /// Generate, sign and prepare one-time keys to be uploaded.
     ///
     /// If no one-time keys need to be uploaded returns an empty error.
-    pub(crate) async fn signed_one_time_keys(
+    pub async fn signed_one_time_keys(
         &self,
     ) -> Result<BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>, ()> {
         let _ = self.generate_one_time_keys().await?;
@@ -928,7 +931,7 @@ impl ReadOnlyAccount {
     ///
     /// * `their_one_time_key` - A signed one-time key that the other account
     /// created and shared with us.
-    pub(crate) async fn create_outbound_session_helper(
+    pub async fn create_outbound_session_helper(
         &self,
         their_identity_key: &str,
         their_one_time_key: &SignedKey,
@@ -966,7 +969,7 @@ impl ReadOnlyAccount {
     ///
     /// * `key_map` - A map from the algorithm and device id to the one-time key
     ///   that the other account created and shared with us.
-    pub(crate) async fn create_outbound_session(
+    pub async fn create_outbound_session(
         &self,
         device: ReadOnlyDevice,
         key_map: &BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>,
@@ -1029,7 +1032,7 @@ impl ReadOnlyAccount {
     ///
     /// * `message` - A pre-key Olm message that was sent to us by the other
     /// account.
-    pub(crate) async fn create_inbound_session(
+    pub async fn create_inbound_session(
         &self,
         their_identity_key: &str,
         message: PreKeyMessage,
@@ -1071,7 +1074,7 @@ impl ReadOnlyAccount {
     ///
     /// * `settings` - Settings determining the algorithm and rotation period of
     /// the outbound group session.
-    pub(crate) async fn create_group_session_pair(
+    pub async fn create_group_session_pair(
         &self,
         room_id: &RoomId,
         settings: EncryptionSettings,
@@ -1105,16 +1108,18 @@ impl ReadOnlyAccount {
         Ok((outbound, inbound))
     }
 
-    #[cfg(test)]
-    pub(crate) async fn create_group_session_pair_with_defaults(
+    #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
+    pub async fn create_group_session_pair_with_defaults(
         &self,
         room_id: &RoomId,
     ) -> Result<(OutboundGroupSession, InboundGroupSession), ()> {
         self.create_group_session_pair(room_id, EncryptionSettings::default()).await
     }
 
-    #[cfg(test)]
-    pub(crate) async fn create_session_for(&self, other: &ReadOnlyAccount) -> (Session, Session) {
+    #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
+    pub async fn create_session_for(&self, other: &ReadOnlyAccount) -> (Session, Session) {
         use ruma::events::{dummy::ToDeviceDummyEventContent, AnyToDeviceEventContent};
 
         other.generate_one_time_keys_helper(1).await;

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![warn(missing_docs)]
+
 use std::{
     collections::BTreeMap,
     convert::TryFrom,
@@ -62,11 +64,11 @@ use crate::error::{EventError, MegolmResult};
 pub struct InboundGroupSession {
     inner: Arc<Mutex<OlmInboundGroupSession>>,
     history_visibility: Arc<Option<HistoryVisibility>>,
-    pub(crate) session_id: Arc<str>,
+    pub session_id: Arc<str>,
     first_known_index: u32,
-    pub(crate) sender_key: Arc<str>,
-    pub(crate) signing_keys: Arc<BTreeMap<DeviceKeyAlgorithm, String>>,
-    pub(crate) room_id: Arc<RoomId>,
+    pub sender_key: Arc<str>,
+    pub signing_keys: Arc<BTreeMap<DeviceKeyAlgorithm, String>>,
+    pub room_id: Arc<RoomId>,
     forwarding_chains: Arc<Vec<String>>,
     imported: bool,
     backed_up: Arc<AtomicBool>,
@@ -89,7 +91,7 @@ impl InboundGroupSession {
     ///
     /// * `session_key` - The private session key that is used to decrypt
     /// messages.
-    pub(crate) fn new(
+    pub fn new(
         sender_key: &str,
         signing_key: &str,
         room_id: &RoomId,
@@ -159,7 +161,7 @@ impl InboundGroupSession {
     ///
     /// * `content` - A forwarded room key content that contains the session key
     /// to create the `InboundGroupSession`.
-    pub(crate) fn from_forwarded_key(
+    pub fn from_forwarded_key(
         sender_key: &str,
         content: &mut ToDeviceForwardedRoomKeyEventContent,
     ) -> Result<Self, OlmGroupSessionError> {
@@ -228,13 +230,13 @@ impl InboundGroupSession {
     }
 
     /// Reset the backup state of the inbound group session.
-    pub(crate) fn reset_backup_state(&self) {
+    pub fn reset_backup_state(&self) {
         self.backed_up.store(false, SeqCst)
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
-    pub(crate) fn mark_as_backed_up(&self) {
+    pub fn mark_as_backed_up(&self) {
         self.backed_up.store(true, SeqCst)
     }
 
@@ -327,7 +329,7 @@ impl InboundGroupSession {
     /// # Arguments
     ///
     /// * `message` - The message that should be decrypted.
-    pub(crate) async fn decrypt_helper(
+    pub async fn decrypt_helper(
         &self,
         message: String,
     ) -> Result<(String, u32), OlmGroupSessionError> {
@@ -335,7 +337,7 @@ impl InboundGroupSession {
     }
 
     #[cfg(feature = "backups_v1")]
-    pub(crate) async fn to_backup(&self) -> BackedUpRoomKey {
+    pub async fn to_backup(&self) -> BackedUpRoomKey {
         self.export().await.into()
     }
 
@@ -344,7 +346,7 @@ impl InboundGroupSession {
     /// # Arguments
     ///
     /// * `event` - The event that should be decrypted.
-    pub(crate) async fn decrypt(
+    pub async fn decrypt(
         &self,
         event: &SyncRoomEncryptedEvent,
     ) -> MegolmResult<(Raw<AnyRoomEvent>, u32)> {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -28,7 +28,7 @@ mod outbound;
 
 pub use inbound::{InboundGroupSession, InboundGroupSessionPickle, PickledInboundGroupSession};
 pub use outbound::{
-    EncryptionSettings, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo, ShareState,
+    OlmOutboundGroupSession, EncryptionSettings, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo, ShareState,
 };
 
 /// The private session key of a group session.

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -28,10 +28,11 @@ use matrix_sdk_common::{instant::Instant, locks::Mutex};
 pub use olm_rs::{
     account::IdentityKeys,
     session::{OlmMessage, PreKeyMessage},
+    outbound_group_session::OlmOutboundGroupSession,
     utility::OlmUtility,
 };
 use olm_rs::{
-    errors::OlmGroupSessionError, outbound_group_session::OlmOutboundGroupSession, PicklingMode,
+    errors::OlmGroupSessionError, PicklingMode,
 };
 use ruma::{
     events::{

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -27,9 +27,9 @@ pub(crate) use account::{Account, OlmDecryptionInfo, SessionType};
 pub use account::{AccountPickle, OlmMessageHash, PickledAccount, ReadOnlyAccount};
 pub use group_sessions::{
     EncryptionSettings, ExportedRoomKey, InboundGroupSession, InboundGroupSessionPickle,
-    OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession, ShareInfo,
+    OlmOutboundGroupSession, OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession, ShareInfo,
 };
-pub(crate) use group_sessions::{GroupSessionKey, ShareState};
+pub use group_sessions::{GroupSessionKey, ShareState};
 use matrix_sdk_common::instant::{Duration, Instant};
 pub use olm_rs::{account::IdentityKeys, PicklingMode};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -43,15 +43,15 @@ use crate::{
 /// `Account`s
 #[derive(Clone)]
 pub struct Session {
-    pub(crate) user_id: Arc<UserId>,
-    pub(crate) device_id: Arc<DeviceId>,
-    pub(crate) our_identity_keys: Arc<IdentityKeys>,
-    pub(crate) inner: Arc<Mutex<OlmSession>>,
-    pub(crate) session_id: Arc<str>,
-    pub(crate) sender_key: Arc<str>,
-    pub(crate) created_using_fallback_key: bool,
-    pub(crate) creation_time: Arc<Instant>,
-    pub(crate) last_use_time: Arc<Instant>,
+    pub user_id: Arc<UserId>,
+    pub device_id: Arc<DeviceId>,
+    pub our_identity_keys: Arc<IdentityKeys>,
+    pub inner: Arc<Mutex<OlmSession>>,
+    pub session_id: Arc<str>,
+    pub sender_key: Arc<str>,
+    pub created_using_fallback_key: bool,
+    pub creation_time: Arc<Instant>,
+    pub last_use_time: Arc<Instant>,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -531,8 +531,9 @@ impl PrivateCrossSigningIdentity {
 
     /// Create a new cross signing identity without signing the device that
     /// created it.
-    #[cfg(test)]
-    pub(crate) async fn new(user_id: Box<UserId>) -> Self {
+    #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
+    pub async fn new(user_id: Box<UserId>) -> Self {
         let master = Signing::new();
 
         let public_key = master.cross_signing_key(user_id.clone(), KeyUsage::Master);
@@ -541,8 +542,9 @@ impl PrivateCrossSigningIdentity {
         Self::new_helper(&user_id, master).await
     }
 
-    #[cfg(test)]
-    pub(crate) async fn reset(&mut self) {
+    #[cfg(any(test, feature = "testing"))]
+    #[allow(dead_code)]
+    pub async fn reset(&mut self) {
         let new = Self::new(self.user_id().to_owned()).await;
         *self = new
     }

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -1,5 +1,5 @@
 #[allow(unused_macros)]
-
+#[macro_export]
 macro_rules! cryptostore_integration_tests {
     ($($name:ident)*) => {
     $(
@@ -8,20 +8,17 @@ macro_rules! cryptostore_integration_tests {
             use std::collections::BTreeMap;
 
             use matrix_sdk_test::async_test;
-            use olm_rs::outbound_group_session::OlmOutboundGroupSession;
-            use ruma::{
+            use matrix_sdk_common::ruma::{
                 encryption::SignedKey, events::room_key_request::RequestedKeyInfo,
                 serde::Base64, user_id, TransactionId, DeviceId, EventEncryptionAlgorithm, UserId,
                 room_id, device_id,
             };
 
-            use crate::{
-                gossiping::SecretInfo,
-                identities::{
-                    device::test::get_device,
-                    user::test::{get_other_identity, get_own_identity},
-                },
+            use $crate::{
+                SecretInfo,
+                testing::{get_device, get_other_identity, get_own_identity},
                 olm::{
+                    OlmOutboundGroupSession,
                     GroupSessionKey, InboundGroupSession, OlmMessageHash, PrivateCrossSigningIdentity,
                     ReadOnlyAccount, Session,
                 },

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 matrix-sdk-base = { path = "../matrix-sdk-base", features = ["state_key"] }
+matrix-sdk-crypto = { path = "../matrix-sdk-crypto" }
 matrix-sdk-common = { path = "../matrix-sdk-common" }
 thiserror = "1.0.25"
 anyhow = "1"
@@ -15,8 +16,10 @@ indexed_db_futures = { version = "0.2.0" }
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"] }
 serde = { version = "1.0.126" }
 serde_json = "1.0.64"
+dashmap = "4.0.2"
 
 [dev-dependencies]
 matrix-sdk-base = {  path = "../matrix-sdk-base", features = ["testing"] }
+matrix-sdk-crypto = { path = "../matrix-sdk-crypto", features = ["testing"] }
 matrix-sdk-test = { path = "../matrix-sdk-test" }
 wasm-bindgen-test = "0.3.24"

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "matrix-sdk-indexeddb"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+matrix-sdk-base = { path = "../matrix-sdk-base", features = ["state_key"] }
+matrix-sdk-common = { path = "../matrix-sdk-common" }
+thiserror = "1.0.25"
+anyhow = "1"
+
+indexed_db_futures = { version = "0.2.0" }
+wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"] }
+serde = { version = "1.0.126" }
+serde_json = "1.0.64"

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -15,3 +15,8 @@ indexed_db_futures = { version = "0.2.0" }
 wasm-bindgen = { version = "0.2.74", features = ["serde-serialize"] }
 serde = { version = "1.0.126" }
 serde_json = "1.0.64"
+
+[dev-dependencies]
+matrix-sdk-base = {  path = "../matrix-sdk-base", features = ["testing"] }
+matrix-sdk-test = { path = "../matrix-sdk-test" }
+wasm-bindgen-test = "0.3.24"

--- a/crates/matrix-sdk-indexeddb/src/cryptostore.rs
+++ b/crates/matrix-sdk-indexeddb/src/cryptostore.rs
@@ -20,31 +20,23 @@ use std::{
 
 use dashmap::DashSet;
 use indexed_db_futures::prelude::*;
-use matrix_sdk_common::{async_trait, locks::Mutex, SafeEncode};
-use olm_rs::{account::IdentityKeys, PicklingMode};
-use ruma::{DeviceId, RoomId, TransactionId, UserId};
+use matrix_sdk_common::{async_trait, locks::Mutex, SafeEncode,
+    ruma::{DeviceId, RoomId, TransactionId, UserId}
+};
 use wasm_bindgen::JsValue;
 
-use super::{
-    caches::SessionStore, BackupKeys, Changes, CryptoStore, CryptoStoreError, EncryptedPickleKey,
-    InboundGroupSession, PickleKey, ReadOnlyAccount, Result, RoomKeyCounts, Session,
+use matrix_sdk_crypto::{
+    store::{
+        caches::SessionStore, BackupKeys, Changes, CryptoStore, CryptoStoreError, EncryptedPickleKey,
+        PickleKey, RoomKeyCounts, PicklingMode, IdentityKeys,
+    },
+    GossipRequest, SecretInfo, ReadOnlyAccount, 
+    ReadOnlyDevice, ReadOnlyUserIdentities,
+    olm::{
+        InboundGroupSession, Session, OutboundGroupSession, PrivateCrossSigningIdentity, OlmMessageHash},
 };
-use crate::{
-    gossiping::{GossipRequest, SecretInfo},
-    identities::{ReadOnlyDevice, ReadOnlyUserIdentities},
-    olm::{OutboundGroupSession, PrivateCrossSigningIdentity},
-};
+use anyhow::anyhow;
 
-/// This needs to be 32 bytes long since AES-GCM requires it, otherwise we will
-/// panic once we try to pickle a Signing object.
-const DEFAULT_PICKLE: &str = "DEFAULT_PICKLE_PASSPHRASE_123456";
-
-#[derive(Clone, Debug)]
-pub struct AccountInfo {
-    user_id: Arc<UserId>,
-    device_id: Arc<DeviceId>,
-    identity_keys: Arc<IdentityKeys>,
-}
 
 #[allow(non_snake_case)]
 mod KEYS {
@@ -89,6 +81,59 @@ impl std::fmt::Debug for IndexeddbStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IndexeddbStore").field("name", &self.name).finish()
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IndexeddbStoreError {
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("DomException {name} ({code}): {message}")]
+    DomException {
+        /// DomException code
+        code: u16,
+        /// Specific name of the DomException
+        name: String,
+        /// Message given to the DomException
+        message: String,
+    },
+    #[error(transparent)]
+    CryptoStoreError(#[from] CryptoStoreError),
+
+}
+
+impl From<indexed_db_futures::web_sys::DomException> for IndexeddbStoreError {
+    fn from(frm: indexed_db_futures::web_sys::DomException) -> IndexeddbStoreError {
+        IndexeddbStoreError::DomException {
+            name: frm.name(),
+            message: frm.message(),
+            code: frm.code(),
+        }
+    }
+}
+
+impl From<IndexeddbStoreError> for CryptoStoreError {
+    fn from(frm: IndexeddbStoreError) -> CryptoStoreError  {
+        match frm {
+            IndexeddbStoreError::Json(e) => CryptoStoreError::Serialization(e),
+            IndexeddbStoreError::CryptoStoreError(e) => e,
+            _ => {
+                CryptoStoreError::Backend(anyhow!(frm))
+            }
+        }
+    }
+}
+
+type Result<A, E = IndexeddbStoreError> = std::result::Result<A, E>;
+
+/// This needs to be 32 bytes long since AES-GCM requires it, otherwise we will
+/// panic once we try to pickle a Signing object.
+const DEFAULT_PICKLE: &str = "DEFAULT_PICKLE_PASSPHRASE_123456";
+
+#[derive(Clone, Debug)]
+pub struct AccountInfo {
+    user_id: Arc<UserId>,
+    device_id: Arc<DeviceId>,
+    identity_keys: Arc<IdentityKeys>,
 }
 
 impl IndexeddbStore {
@@ -451,10 +496,7 @@ impl IndexeddbStore {
             Some(request) => Some(request),
         })
     }
-}
 
-#[async_trait(?Send)]
-impl CryptoStore for IndexeddbStore {
     async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
         if let Some(pickle) = self
             .inner
@@ -466,7 +508,8 @@ impl CryptoStore for IndexeddbStore {
             self.load_tracked_users().await?;
 
             let account =
-                ReadOnlyAccount::from_pickle(pickle.into_serde()?, self.get_pickle_mode())?;
+                ReadOnlyAccount::from_pickle(pickle.into_serde()?, self.get_pickle_mode())
+                .map_err(|e| CryptoStoreError::OlmAccount(e))?;
 
             let account_info = AccountInfo {
                 user_id: account.user_id.clone(),
@@ -517,16 +560,12 @@ impl CryptoStore for IndexeddbStore {
         }
     }
 
-    async fn save_changes(&self, changes: Changes) -> Result<()> {
-        self.save_changes(changes).await
-    }
-
     async fn get_sessions(&self, sender_key: &str) -> Result<Option<Arc<Mutex<Vec<Session>>>>> {
         let account_info = self.get_account_info().ok_or(CryptoStoreError::AccountUnset)?;
 
         if self.session_cache.get(sender_key).is_none() {
             let range =
-                sender_key.encode_to_range().map_err(|e| CryptoStoreError::IndexedDatabase {
+                sender_key.encode_to_range().map_err(|e| IndexeddbStoreError::DomException {
                     code: 0,
                     name: "IdbKeyRangeMakeError".to_owned(),
                     message: e,
@@ -577,7 +616,7 @@ impl CryptoStore for IndexeddbStore {
             Ok(Some(InboundGroupSession::from_pickle(
                 pickle.into_serde()?,
                 self.get_pickle_mode(),
-            )?))
+            ).map_err(|e| CryptoStoreError::OlmGroupSession(e))?))
         } else {
             Ok(None)
         }
@@ -713,7 +752,7 @@ impl CryptoStore for IndexeddbStore {
         &self,
         user_id: &UserId,
     ) -> Result<HashMap<Box<DeviceId>, ReadOnlyDevice>> {
-        let range = user_id.encode_to_range().map_err(|e| CryptoStoreError::IndexedDatabase {
+        let range = user_id.encode_to_range().map_err(|e| IndexeddbStoreError::DomException {
             code: 0,
             name: "IdbKeyRangeMakeError".to_owned(),
             message: e,
@@ -743,7 +782,7 @@ impl CryptoStore for IndexeddbStore {
             .transpose()?)
     }
 
-    async fn is_message_known(&self, hash: &crate::olm::OlmMessageHash) -> Result<bool> {
+    async fn is_message_known(&self, hash: &OlmMessageHash) -> Result<bool> {
         Ok(self
             .inner
             .transaction_on_one_with_mode(KEYS::OLM_HASHES, IdbTransactionMode::Readonly)?
@@ -835,10 +874,152 @@ impl CryptoStore for IndexeddbStore {
     }
 }
 
+
+
+#[async_trait(?Send)]
+impl CryptoStore for IndexeddbStore {
+    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>, CryptoStoreError> {
+        self.load_account().await.map_err(|e| e.into())
+    }
+
+    async fn save_account(&self, account: ReadOnlyAccount) -> Result<(), CryptoStoreError> {
+        let account_info = AccountInfo {
+            user_id: account.user_id.clone(),
+            device_id: account.device_id.clone(),
+            identity_keys: account.identity_keys.clone(),
+        };
+
+        *self.account_info.write().unwrap() = Some(account_info);
+
+        let changes = Changes { account: Some(account), ..Default::default() };
+
+        self.save_changes(changes).await.map_err(|e| e.into())
+    }
+
+    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>, CryptoStoreError> {
+        self.load_identity().await.map_err(|e| e.into())
+
+    }
+
+    async fn save_changes(&self, changes: Changes) -> Result<(), CryptoStoreError> {
+        self.save_changes(changes).await.map_err(|e| e.into())
+    }
+
+    async fn get_sessions(&self, sender_key: &str) -> Result<Option<Arc<Mutex<Vec<Session>>>>, CryptoStoreError> {
+        self.get_sessions(sender_key).await.map_err(|e| e.into())
+    }
+
+    async fn get_inbound_group_session(
+        &self,
+        room_id: &RoomId,
+        sender_key: &str,
+        session_id: &str,
+    ) -> Result<Option<InboundGroupSession>, CryptoStoreError> {
+        self.get_inbound_group_session(room_id, sender_key, session_id).await.map_err(|e| e.into())
+    }
+
+    async fn get_inbound_group_sessions(&self) -> Result<Vec<InboundGroupSession>, CryptoStoreError> {
+        self.get_inbound_group_sessions().await.map_err(|e| e.into())
+    }
+
+    async fn get_outbound_group_sessions(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Option<OutboundGroupSession>, CryptoStoreError> {
+        self.load_outbound_group_session(room_id).await.map_err(|e| e.into())
+    }
+
+    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts, CryptoStoreError> {
+        self.inbound_group_session_counts().await.map_err(|e| e.into())
+    }
+
+    async fn inbound_group_sessions_for_backup(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<InboundGroupSession>, CryptoStoreError> {
+        self.inbound_group_sessions_for_backup(limit).await.map_err(|e| e.into())
+    }
+
+    async fn reset_backup_state(&self) -> Result<(), CryptoStoreError> {
+        self.reset_backup_state().await.map_err(|e| e.into())
+    }
+
+    fn is_user_tracked(&self, user_id: &UserId) -> bool {
+        self.tracked_users_cache.contains(user_id)
+    }
+
+    fn has_users_for_key_query(&self) -> bool {
+        !self.users_for_key_query_cache.is_empty()
+    }
+
+    fn tracked_users(&self) -> HashSet<Box<UserId>> {
+        self.tracked_users()
+    }
+
+    fn users_for_key_query(&self) -> HashSet<Box<UserId>> {
+        self.users_for_key_query()
+    }
+
+    async fn load_backup_keys(&self) -> Result<BackupKeys, CryptoStoreError> {
+        todo!()
+    }
+
+    async fn update_tracked_user(&self, user: &UserId, dirty: bool) -> Result<bool, CryptoStoreError> {
+        self.update_tracked_user(user, dirty).await.map_err(|e| e.into())
+    }
+
+    async fn get_device(
+        &self,
+        user_id: &UserId,
+        device_id: &DeviceId,
+    ) -> Result<Option<ReadOnlyDevice>, CryptoStoreError> {
+        self.get_device(user_id, device_id).await.map_err(|e| e.into())
+    }
+
+    async fn get_user_devices(
+        &self,
+        user_id: &UserId,
+    ) -> Result<HashMap<Box<DeviceId>, ReadOnlyDevice>, CryptoStoreError> {
+        self.get_user_devices(user_id).await.map_err(|e| e.into())
+    }
+
+    async fn get_user_identity(&self, user_id: &UserId) -> Result<Option<ReadOnlyUserIdentities>, CryptoStoreError> {
+        self.get_user_identity(user_id).await.map_err(|e| e.into())
+    }
+
+    async fn is_message_known(&self, hash: &OlmMessageHash) -> Result<bool, CryptoStoreError> {
+        self.is_message_known(hash).await.map_err(|e| e.into())
+    
+    }
+
+    async fn get_outgoing_secret_requests(
+        &self,
+        request_id: &TransactionId,
+    ) -> Result<Option<GossipRequest>, CryptoStoreError> {
+        self.get_outgoing_key_request_helper(&request_id.as_str()).await.map_err(|e| e.into())
+    }
+
+    async fn get_secret_request_by_info(
+        &self,
+        key_info: &SecretInfo,
+    ) -> Result<Option<GossipRequest>, CryptoStoreError> {
+        self.get_secret_request_by_info(key_info).await.map_err(|e| e.into())
+    }
+
+    async fn get_unsent_secret_requests(&self) -> Result<Vec<GossipRequest>, CryptoStoreError> {
+        self.get_unsent_secret_requests().await.map_err(|e| e.into())
+    }
+
+    async fn delete_outgoing_secret_requests(&self, request_id: &TransactionId) -> Result<(), CryptoStoreError> {
+        self.delete_outgoing_secret_requests(request_id).await.map_err(|e| e.into())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::IndexeddbStore;
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+    use matrix_sdk_crypto::cryptostore_integration_tests;
 
     async fn get_store(name: String, passphrase: Option<&str>) -> IndexeddbStore {
         match passphrase {

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -1,5 +1,4 @@
 #[cfg(not(target_arch="wasm32"))]
 compile_error!("indexeddb is only support on wasm32. You may want to add --target wasm32-unknown-unknown");
 
-
 pub mod state_store;

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -1,0 +1,5 @@
+#[cfg(not(target_arch="wasm32"))]
+compile_error!("indexeddb is only support on wasm32. You may want to add --target wasm32-unknown-unknown");
+
+
+pub mod state_store;

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -2,3 +2,4 @@
 compile_error!("indexeddb is only support on wasm32. You may want to add --target wasm32-unknown-unknown");
 
 pub mod state_store;
+pub mod cryptostore;

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -1013,6 +1013,7 @@ mod test {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use super::{IndexeddbStore, Result};
+    use matrix_sdk_base::statestore_integration_tests;
 
     async fn get_store() -> Result<IndexeddbStore> {
         IndexeddbStore::open().await


### PR DESCRIPTION
This change attempts to move the concrete state & crypto-store implementations from the core crates into separate crates to allow for easier plugability. 

This requires:
 - [x] move IndexedDB Stores into separate crate
 - [  ] move Sled Stores into a separate crate
 - [ ] redo client builder infrastructure
 - [ ] document all newly exposed functions
 - [ ] updaet examples
 - [ ] clean up `testing`-infrastructure