### PR TITLE
chore(ci): limit CI to pull-requests & push main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Running CI on every push means running it twice for any PR as well as commit on branches that aren't PRs. This limits the CI run to pull-requests against main and pushes to main directly, removing unnecessary workload for the CI and making PRs CI faster.