### PR TITLE
Change store initialization

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -13,15 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[allow(unused_imports)]
-#[cfg(feature = "encryption")]
-use std::ops::Deref;
 use std::{
     collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
     fmt,
     sync::Arc,
 };
+#[allow(unused_imports)]
+#[cfg(feature = "encryption")]
+use std::{ops::Deref, result::Result as StdResult};
 
 #[cfg(feature = "encryption")]
 use matrix_sdk_common::locks::Mutex;
@@ -69,8 +69,7 @@ use crate::{
     rooms::{Room, RoomInfo, RoomType},
     session::Session,
     store::{
-        ambiguity_map::AmbiguityCache, Result as StoreResult, StateChanges, StateStore, Store,
-        StoreConfig,
+        ambiguity_map::AmbiguityCache, Result as StoreResult, StateChanges, Store, StoreConfig,
     },
 };
 
@@ -100,62 +99,6 @@ impl fmt::Debug for BaseClient {
             .field("session", &self.session)
             .field("sync_token", &self.sync_token)
             .finish()
-    }
-}
-
-/// Configuration for the creation of the `BaseClient`.
-///
-/// # Example
-///
-/// ```
-/// # use matrix_sdk_base::BaseClientConfig;
-///
-/// let client_config = BaseClientConfig::new();
-/// ```
-#[derive(Default)]
-pub struct BaseClientConfig {
-    store_config: StoreConfig,
-}
-
-#[cfg(not(tarpaulin_include))]
-impl std::fmt::Debug for BaseClientConfig {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        fmt.debug_struct("BaseClientConfig").finish()
-    }
-}
-
-impl BaseClientConfig {
-    /// Create a new default `BaseClientConfig`.
-    #[must_use]
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    /// Create a new `BaseClientConfig` with the given `StoreConfig`.
-    #[must_use]
-    pub fn with_store_config(store_config: StoreConfig) -> Self {
-        Self { store_config }
-    }
-
-    /// Get the `StoreConfig` used by this `BaseClientConfig`.
-    #[cfg(feature = "encryption")]
-    pub fn get_store_config(&self) -> &StoreConfig {
-        &self.store_config
-    }
-
-    /// Set a custom implementation of a `CryptoStore`.
-    ///
-    /// The crypto store should be opened before being set.
-    #[cfg(feature = "encryption")]
-    pub fn crypto_store(mut self, store: Box<dyn CryptoStore>) -> Self {
-        self.store_config = self.store_config.crypto_store(store);
-        self
-    }
-
-    /// Set a custom implementation of a `StateStore`.
-    pub fn state_store(mut self, store: Box<dyn StateStore>) -> Self {
-        self.store_config = self.store_config.state_store(store);
-        self
     }
 }
 
@@ -210,29 +153,25 @@ impl BaseClient {
     ///
     /// * `config` - An optional session if the user already has one from a
     /// previous login call.
-    pub async fn new_with_config(config: BaseClientConfig) -> Result<Self> {
-        let store = config
-            .store_config
-            .state_store
-            .map(Store::new)
-            .unwrap_or_else(Store::open_memory_store);
+    pub fn new_with_store_config(config: StoreConfig) -> Self {
+        let store = config.state_store.map(Store::new).unwrap_or_else(Store::open_memory_store);
         #[cfg(feature = "encryption")]
-        let holder = config.store_config.crypto_store.map(CryptoHolder::new).unwrap_or_default();
+        let holder = config.crypto_store.map(CryptoHolder::new).unwrap_or_default();
 
-        Ok(BaseClient {
+        BaseClient {
             session: store.session.clone(),
             sync_token: store.sync_token.clone(),
             store,
             #[cfg(feature = "encryption")]
             olm: Mutex::new(holder).into(),
-        })
+        }
     }
 }
 
 impl BaseClient {
     /// Create a new default client.
-    pub async fn new() -> Result<Self> {
-        BaseClient::new_with_config(BaseClientConfig::default()).await
+    pub fn new() -> Self {
+        BaseClient::new_with_store_config(StoreConfig::default())
     }
     /// The current client session containing our user id, device id and access
     /// token.
@@ -1122,7 +1061,7 @@ impl BaseClient {
     /// # use futures::executor::block_on;
     /// # let alice = user_id!("@alice:example.org").to_owned();
     /// # block_on(async {
-    /// # let client = BaseClient::new().await.unwrap();
+    /// # let client = BaseClient::new();
     /// let device = client.get_device(&alice, device_id!("DEVICEID")).await;
     ///
     /// println!("{:?}", device);
@@ -1176,7 +1115,7 @@ impl BaseClient {
     /// # use futures::executor::block_on;
     /// # let alice = user_id!("@alice:example.org");
     /// # block_on(async {
-    /// # let client = BaseClient::new().await.unwrap();
+    /// # let client = BaseClient::new();
     /// let devices = client.get_user_devices(alice).await.unwrap();
     ///
     /// for device in devices.devices() {
@@ -1321,6 +1260,12 @@ impl BaseClient {
             push_rules.default_power_level = room_power_levels.users_default;
             push_rules.notification_power_levels = room_power_levels.notifications;
         }
+    }
+}
+
+impl Default for BaseClient {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -33,7 +33,7 @@ mod session;
 pub mod store;
 mod timeline_stream;
 
-pub use client::{BaseClient, BaseClientConfig};
+pub use client::BaseClient;
 #[cfg(any(test, feature = "testing"))]
 pub use http;
 #[cfg(feature = "encryption")]

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -641,6 +641,24 @@ impl StoreConfig {
         Default::default()
     }
 
+    /// Create a new store config wrapping the given state store
+    pub fn new_with_state_store(state_store: Box<dyn StateStore>) -> Self {
+        StoreConfig {
+            state_store: Some(state_store),
+            #[cfg(feature = "encryption")]
+            crypto_store: Default::default(),
+        }
+    }
+
+    /// Create a new store config wrapping the given state and crypto store
+    #[cfg(feature = "encryption")]
+    pub fn new_with_state_and_crypto_store(
+        state_store: Box<dyn StateStore>,
+        crypto_store: Box<dyn CryptoStore>,
+    ) -> Self {
+        StoreConfig { state_store: Some(state_store), crypto_store: Some(crypto_store) }
+    }
+
     /// Set a custom implementation of a `CryptoStore`.
     ///
     /// The crypto store must be opened before being set.

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -643,7 +643,7 @@ impl StoreConfig {
 
     /// Set a custom implementation of a `CryptoStore`.
     ///
-    /// The crypto store should be opened before being set.
+    /// The crypto store must be opened before being set.
     #[cfg(feature = "encryption")]
     pub fn crypto_store(mut self, store: Box<dyn CryptoStore>) -> Self {
         self.crypto_store = Some(store);

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = ["encryption"]
-encryption = ["matrix-sdk-crypto"]
+encryption = ["matrix-sdk-base/encryption", "matrix-sdk-crypto"]
 
 [package.metadata.docs.rs]
 default-target = "wasm32-unknown-unknown"

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -20,7 +20,7 @@ pub use state_store::IndexeddbStore as StateStore;
 #[cfg(feature = "encryption")]
 /// Create a [`StateStore`] and a [`CryptoStore`] that use the same name and
 /// passphrase.
-pub async fn open_stores_with_name(
+async fn open_stores_with_name(
     name: impl Into<String>,
     passphrase: Option<&str>,
 ) -> Result<(Box<StateStore>, Box<CryptoStore>), anyhow::Error> {
@@ -41,7 +41,7 @@ pub async fn open_stores_with_name(
 /// Create a [`StoreConfig`] with an opened indexeddb [`StateStore`] that uses
 /// the given name and passphrase. If `encryption` is enabled, a [`CryptoStore`]
 /// with the same parameters is also opened.
-pub async fn make_config(
+async fn make_store_config(
     name: impl Into<String>,
     passphrase: Option<&str>,
 ) -> Result<StoreConfig, anyhow::Error> {

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -41,7 +41,7 @@ async fn open_stores_with_name(
 /// Create a [`StoreConfig`] with an opened indexeddb [`StateStore`] that uses
 /// the given name and passphrase. If `encryption` is enabled, a [`CryptoStore`]
 /// with the same parameters is also opened.
-async fn make_store_config(
+pub async fn make_store_config(
     name: impl Into<String>,
     passphrase: Option<&str>,
 ) -> Result<StoreConfig, anyhow::Error> {

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(target_arch = "wasm32")]
+use matrix_sdk_base::store::StoreConfig;
+
 mod safe_encode;
 
 #[cfg(target_arch = "wasm32")]
@@ -12,3 +15,56 @@ mod cryptostore;
 pub use cryptostore::IndexeddbStore as CryptoStore;
 #[cfg(target_arch = "wasm32")]
 pub use state_store::IndexeddbStore as StateStore;
+
+#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "encryption")]
+/// Create a [`StateStore`] and a [`CryptoStore`] that use the same name and
+/// passphrase.
+pub async fn open_stores_with_name(
+    name: impl Into<String>,
+    passphrase: Option<&str>,
+) -> Result<(Box<StateStore>, Box<CryptoStore>), anyhow::Error> {
+    let name = name.into();
+
+    if let Some(passphrase) = passphrase {
+        let state_store = StateStore::open_with_passphrase(name.clone(), passphrase).await?;
+        let crypto_store = CryptoStore::open_with_passphrase(name, passphrase).await?;
+        Ok((Box::new(state_store), Box::new(crypto_store)))
+    } else {
+        let state_store = StateStore::open_with_name(name.clone()).await?;
+        let crypto_store = CryptoStore::open_with_name(name).await?;
+        Ok((Box::new(state_store), Box::new(crypto_store)))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+/// Create a [`StoreConfig`] with an opened indexeddb [`StateStore`] that uses
+/// the given name and passphrase. If `encryption` is enabled, a [`CryptoStore`]
+/// with the same parameters is also opened.
+pub async fn make_config(
+    name: impl Into<String>,
+    passphrase: Option<&str>,
+) -> Result<StoreConfig, anyhow::Error> {
+    let mut config = StoreConfig::new();
+    let name = name.into();
+
+    #[cfg(feature = "encryption")]
+    {
+        let (state_store, crypto_store) = open_stores_with_name(name, passphrase).await?;
+        config = config.state_store(state_store);
+        config = config.crypto_store(crypto_store);
+    }
+
+    #[cfg(not(feature = "encryption"))]
+    {
+        let state_store = if let Some(passphrase) = passphrase {
+            StateStore::open_with_passphrase(name, passphrase).await?
+        } else {
+            StateStore::open_with_name(name).await?
+        };
+
+        config = config.state_store(Box::new(state_store));
+    }
+
+    Ok(config)
+}

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -45,14 +45,12 @@ async fn make_store_config(
     name: impl Into<String>,
     passphrase: Option<&str>,
 ) -> Result<StoreConfig, anyhow::Error> {
-    let mut config = StoreConfig::new();
     let name = name.into();
 
     #[cfg(feature = "encryption")]
     {
         let (state_store, crypto_store) = open_stores_with_name(name, passphrase).await?;
-        config = config.state_store(state_store);
-        config = config.crypto_store(crypto_store);
+        Ok(StoreConfig::new_with_state_and_crypto_store(state_store, crypto_store))
     }
 
     #[cfg(not(feature = "encryption"))]
@@ -63,8 +61,6 @@ async fn make_store_config(
             StateStore::open_with_name(name).await?
         };
 
-        config = config.state_store(Box::new(state_store));
+        Ok(StoreConfig::new_with_state_store(Box::new(state_store)))
     }
-
-    Ok(config)
 }

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -11,7 +11,7 @@ required-features = ["binary-build"]
 [features]
 default = ["encryption"]
 
-encryption = ["matrix-sdk-crypto"]
+encryption = ["matrix-sdk-base/encryption", "matrix-sdk-crypto"]
 binary-build = [
     "atty",
     "clap",

--- a/crates/matrix-sdk-sled/src/lib.rs
+++ b/crates/matrix-sdk-sled/src/lib.rs
@@ -13,7 +13,7 @@ pub use state_store::SledStore as StateStore;
 #[cfg(feature = "encryption")]
 /// Create a [`StateStore`] and a [`CryptoStore`] that use the same database and
 /// passphrase.
-pub fn open_stores_with_path(
+fn open_stores_with_path(
     path: impl AsRef<Path>,
     passphrase: Option<&str>,
 ) -> Result<(Box<StateStore>, Box<CryptoStore>), anyhow::Error> {
@@ -31,7 +31,7 @@ pub fn open_stores_with_path(
 /// Create a [`StoreConfig`] with an opened sled [`StateStore`] that uses the
 /// given path and passphrase. If `encryption` is enabled, a [`CryptoStore`]
 /// with the same parameters is also opened.
-pub fn make_config(
+pub fn make_store_config(
     path: impl AsRef<Path>,
     passphrase: Option<&str>,
 ) -> Result<StoreConfig, anyhow::Error> {

--- a/crates/matrix-sdk-sled/src/lib.rs
+++ b/crates/matrix-sdk-sled/src/lib.rs
@@ -1,7 +1,28 @@
 #[cfg(feature = "encryption")]
+use std::path::Path;
+
+#[cfg(feature = "encryption")]
 mod cryptostore;
 mod state_store;
 
 #[cfg(feature = "encryption")]
 pub use cryptostore::SledStore as CryptoStore;
 pub use state_store::SledStore as StateStore;
+
+#[cfg(feature = "encryption")]
+/// Create a [`StateStore`] and a [`CryptoStore`] that use the same database and
+/// passphrase.
+pub fn open_stores_with_path(
+    path: impl AsRef<Path>,
+    passphrase: Option<&str>,
+) -> Result<(Box<StateStore>, Box<CryptoStore>), anyhow::Error> {
+    if let Some(passphrase) = passphrase {
+        let state_store = StateStore::open_with_passphrase(path, passphrase)?;
+        let crypto_store = state_store.get_crypto_store(Some(passphrase))?;
+        Ok((Box::new(state_store), Box::new(crypto_store)))
+    } else {
+        let state_store = StateStore::open_with_path(path)?;
+        let crypto_store = state_store.get_crypto_store(None)?;
+        Ok((Box::new(state_store), Box::new(crypto_store)))
+    }
+}

--- a/crates/matrix-sdk-sled/src/lib.rs
+++ b/crates/matrix-sdk-sled/src/lib.rs
@@ -35,13 +35,10 @@ pub fn make_store_config(
     path: impl AsRef<Path>,
     passphrase: Option<&str>,
 ) -> Result<StoreConfig, anyhow::Error> {
-    let mut config = StoreConfig::new();
-
     #[cfg(feature = "encryption")]
     {
         let (state_store, crypto_store) = open_stores_with_path(path, passphrase)?;
-        config = config.state_store(state_store);
-        config = config.crypto_store(crypto_store);
+        Ok(StoreConfig::new_with_state_and_crypto_store(state_store, crypto_store))
     }
 
     #[cfg(not(feature = "encryption"))]
@@ -52,8 +49,6 @@ pub fn make_store_config(
             StateStore::open_with_path(path)?
         };
 
-        config = config.state_store(Box::new(state_store));
+        Ok(StoreConfig::new_with_state_store(Box::new(state_store)))
     }
-
-    Ok(config)
 }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -24,12 +24,13 @@ default = [
     "native-tls"
 ]
 
-indexeddb_stores = ["matrix-sdk-indexeddb"]
+indexeddb_state_store = ["matrix-sdk-indexeddb"]
+indexeddb_cryptostore = ["matrix-sdk-indexeddb/encryption", "encryption"]
 encryption = ["matrix-sdk-base/encryption"]
 qrcode = ["encryption", "matrix-sdk-base/qrcode"]
 # TODO merge those two sled features
 sled_state_store = ["matrix-sdk-sled"]
-sled_cryptostore = ["matrix-sdk-sled", "encryption"]
+sled_cryptostore = ["matrix-sdk-sled/encryption", "encryption"]
 markdown = ["ruma/markdown"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
@@ -69,8 +70,8 @@ url = "2.2.2"
 zeroize = "1.3.0"
 async-stream = "0.3.2"
 
-matrix-sdk-sled = { path = "../matrix-sdk-sled", optional = true }
-matrix-sdk-indexeddb = { path = "../matrix-sdk-indexeddb", optional = true }
+matrix-sdk-sled = { path = "../matrix-sdk-sled", default-features = false, optional = true }
+matrix-sdk-indexeddb = { path = "../matrix-sdk-indexeddb", default-features = false, optional = true }
 
 [dependencies.image]
 version = "0.24.0"

--- a/crates/matrix-sdk/examples/autojoin.rs
+++ b/crates/matrix-sdk/examples/autojoin.rs
@@ -45,9 +45,9 @@ async fn login_and_sync(
     username: &str,
     password: &str,
 ) -> Result<(), matrix_sdk::Error> {
-    #[cfg(not(any(feature = "sled_state_store", feature = "indexeddb_stores")))]
+    #[cfg(not(any(feature = "sled_state_store", feature = "indexeddb_state_store")))]
     let client_config = ClientConfig::new();
-    #[cfg(any(feature = "sled_state_store", feature = "indexeddb_stores"))]
+    #[cfg(any(feature = "sled_state_store", feature = "indexeddb_state_store"))]
     let mut client_config = ClientConfig::new();
 
     #[cfg(feature = "sled_state_store")]
@@ -59,7 +59,7 @@ async fn login_and_sync(
         client_config = client_config.state_store(Box::new(state_store));
     }
 
-    #[cfg(feature = "indexeddb_stores")]
+    #[cfg(feature = "indexeddb_state_store")]
     {
         let state_store = matrix_sdk_indexeddb::StateStore::open();
         client_config = client_config.state_store(Box::new(state_store));

--- a/crates/matrix-sdk/examples/autojoin.rs
+++ b/crates/matrix-sdk/examples/autojoin.rs
@@ -45,6 +45,9 @@ async fn login_and_sync(
     username: &str,
     password: &str,
 ) -> Result<(), matrix_sdk::Error> {
+    #[cfg(not(any(feature = "sled_state_store", feature = "indexeddb_stores")))]
+    let client_config = ClientConfig::new();
+    #[cfg(any(feature = "sled_state_store", feature = "indexeddb_stores"))]
     let mut client_config = ClientConfig::new();
 
     #[cfg(feature = "sled_state_store")]

--- a/crates/matrix-sdk/examples/command_bot.rs
+++ b/crates/matrix-sdk/examples/command_bot.rs
@@ -37,9 +37,9 @@ async fn login_and_sync(
     username: String,
     password: String,
 ) -> Result<(), matrix_sdk::Error> {
-    #[cfg(not(any(feature = "sled_state_store", feature = "indexeddb_stores")))]
+    #[cfg(not(any(feature = "sled_state_store", feature = "indexeddb_state_store")))]
     let client_config = ClientConfig::new();
-    #[cfg(any(feature = "sled_state_store", feature = "indexeddb_stores"))]
+    #[cfg(any(feature = "sled_state_store", feature = "indexeddb_state_store"))]
     let mut client_config = ClientConfig::new();
 
     #[cfg(feature = "sled_state_store")]
@@ -51,7 +51,7 @@ async fn login_and_sync(
         client_config = client_config.state_store(Box::new(state_store));
     }
 
-    #[cfg(feature = "indexeddb_stores")]
+    #[cfg(feature = "indexeddb_state_store")]
     {
         let state_store = matrix_sdk_indexeddb::StateStore::open();
         client_config = client_config.state_store(Box::new(state_store));

--- a/crates/matrix-sdk/examples/command_bot.rs
+++ b/crates/matrix-sdk/examples/command_bot.rs
@@ -37,6 +37,9 @@ async fn login_and_sync(
     username: String,
     password: String,
 ) -> Result<(), matrix_sdk::Error> {
+    #[cfg(not(any(feature = "sled_state_store", feature = "indexeddb_stores")))]
+    let client_config = ClientConfig::new();
+    #[cfg(any(feature = "sled_state_store", feature = "indexeddb_stores"))]
     let mut client_config = ClientConfig::new();
 
     #[cfg(feature = "sled_state_store")]

--- a/crates/matrix-sdk/examples/command_bot.rs
+++ b/crates/matrix-sdk/examples/command_bot.rs
@@ -37,13 +37,22 @@ async fn login_and_sync(
     username: String,
     password: String,
 ) -> Result<(), matrix_sdk::Error> {
-    // the location for `JsonStore` to save files to
-    let mut home = dirs::home_dir().expect("no home directory found");
-    home.push("party_bot");
+    let mut client_config = ClientConfig::new();
 
-    let client_config =
-        ClientConfig::with_named_store(home.to_str().expect("home dir path must be utf-8"), None)
-            .await?;
+    #[cfg(feature = "sled_state_store")]
+    {
+        // The location to save files to
+        let mut home = dirs::home_dir().expect("no home directory found");
+        home.push("party_bot");
+        let state_store = matrix_sdk_sled::StateStore::open_with_path(home)?;
+        client_config = client_config.state_store(Box::new(state_store));
+    }
+
+    #[cfg(feature = "indexeddb_stores")]
+    {
+        let state_store = matrix_sdk_indexeddb::StateStore::open();
+        client_config = client_config.state_store(Box::new(state_store));
+    }
 
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     // create a new Client with the given homeserver url and config

--- a/crates/matrix-sdk/examples/wasm_command_bot/Cargo.toml
+++ b/crates/matrix-sdk/examples/wasm_command_bot/Cargo.toml
@@ -25,7 +25,7 @@ getrandom = { version = "0.2.4", features = ["js"] }
 [dependencies.matrix-sdk]
 path = "../.."
 default-features = false
-features = ["native-tls", "encryption", "indexeddb_stores"]
+features = ["native-tls", "encryption", "indexeddb_state_store", "indexeddb_cryptostore"]
 
 [workspace]
 

--- a/crates/matrix-sdk/src/client.rs
+++ b/crates/matrix-sdk/src/client.rs
@@ -162,7 +162,7 @@ impl Client {
     ///
     /// * `homeserver_url` - The homeserver that the client should connect to.
     pub async fn new(homeserver_url: Url) -> Result<Self> {
-        let config = ClientConfig::new().await?;
+        let config = ClientConfig::new();
         Client::new_with_config(homeserver_url, config).await
     }
 
@@ -241,7 +241,7 @@ impl Client {
     ///
     /// [spec]: https://spec.matrix.org/unstable/client-server-api/#well-known-uri
     pub async fn new_from_user_id(user_id: &UserId) -> Result<Self> {
-        let config = ClientConfig::new().await?;
+        let config = ClientConfig::new();
         Client::new_from_user_id_with_config(user_id, config).await
     }
 
@@ -2385,8 +2385,7 @@ pub(crate) mod test {
             device_id: device_id!("DEVICEID").to_owned(),
         };
         let homeserver = url::Url::parse(&mockito::server_url()).unwrap();
-        let config =
-            ClientConfig::new().await.unwrap().request_config(RequestConfig::new().disable_retry());
+        let config = ClientConfig::new().request_config(RequestConfig::new().disable_retry());
         let client = Client::new_with_config(homeserver, config).await.unwrap();
         client.restore_login(session).await.unwrap();
 
@@ -2484,7 +2483,7 @@ pub(crate) mod test {
     #[async_test]
     async fn login_with_discovery() {
         let homeserver = Url::from_str(&mockito::server_url()).unwrap();
-        let config = ClientConfig::new().await.unwrap().use_discovery_response();
+        let config = ClientConfig::new().use_discovery_response();
 
         let client = Client::new_with_config(homeserver, config).await.unwrap();
 
@@ -2504,7 +2503,7 @@ pub(crate) mod test {
     #[async_test]
     async fn login_no_discovery() {
         let homeserver = Url::from_str(&mockito::server_url()).unwrap();
-        let config = ClientConfig::new().await.unwrap().use_discovery_response();
+        let config = ClientConfig::new().use_discovery_response();
 
         let client = Client::new_with_config(homeserver.clone(), config).await.unwrap();
 
@@ -2633,12 +2632,8 @@ pub(crate) mod test {
         let room = client.get_joined_room(room_id);
         assert!(room.is_some());
 
-        // test store reloads with correct room state from the sled store
-        let path = tempfile::tempdir().unwrap();
-        let config = ClientConfig::with_named_store(path.into_path().to_str().unwrap(), None)
-            .await
-            .unwrap()
-            .request_config(RequestConfig::new().disable_retry());
+        // test store reloads with correct room state from the state store
+        let config = ClientConfig::new().request_config(RequestConfig::new().disable_retry());
         let joined_client = Client::new_with_config(homeserver, config).await.unwrap();
         joined_client.restore_login(session).await.unwrap();
 

--- a/crates/matrix-sdk/src/client.rs
+++ b/crates/matrix-sdk/src/client.rs
@@ -183,7 +183,7 @@ impl Client {
             Arc::new(client_with_config(&config)?)
         };
 
-        let base_client = BaseClient::new_with_config(config.base_config).await?;
+        let base_client = BaseClient::new_with_store_config(config.store_config);
         let session = base_client.session().clone();
 
         let http_client =

--- a/crates/matrix-sdk/src/config/client.rs
+++ b/crates/matrix-sdk/src/config/client.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use http::header::InvalidHeaderValue;
-use matrix_sdk_base::{BaseClientConfig, StateStore};
+use matrix_sdk_base::{store::StoreConfig, BaseClientConfig, StateStore};
 
 use crate::{config::RequestConfig, HttpSend, Result};
 
@@ -98,6 +98,14 @@ impl ClientConfig {
     /// Create a new default `ClientConfig`.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create a new `ClientConfig` with the given `StoreConfig`.
+    pub fn with_store_config(store_config: StoreConfig) -> Self {
+        Self {
+            base_config: BaseClientConfig::with_store_config(store_config),
+            ..Default::default()
+        }
     }
 
     /// Set the proxy through which all the HTTP requests should go.

--- a/crates/matrix-sdk/src/config/client.rs
+++ b/crates/matrix-sdk/src/config/client.rs
@@ -121,7 +121,7 @@ impl ClientConfig {
     /// # let custom_state_store = Box::new(MemoryStore::new());
     /// use matrix_sdk::{Client, config::{ClientConfig, StoreConfig}};
     ///
-    /// let store_config = StoreConfig::new().state_store(custom_state_store);
+    /// let store_config = StoreConfig::new_with_state_store(custom_state_store);
     /// let client_config = ClientConfig::with_store_config(store_config)
     ///     .use_discovery_response();
     ///

--- a/crates/matrix-sdk/src/config/client.rs
+++ b/crates/matrix-sdk/src/config/client.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 use http::header::InvalidHeaderValue;
-use matrix_sdk_base::{BaseClientConfig, StateStore};
+use matrix_sdk_base::StateStore;
 
 use crate::{
     config::{RequestConfig, StoreConfig},
@@ -75,7 +75,7 @@ pub struct ClientConfig {
     pub(crate) proxy: Option<reqwest::Proxy>,
     pub(crate) user_agent: Option<String>,
     pub(crate) disable_ssl_verification: bool,
-    pub(crate) base_config: BaseClientConfig,
+    pub(crate) store_config: StoreConfig,
     pub(crate) request_config: RequestConfig,
     pub(crate) client: Option<Arc<dyn HttpSend>>,
     pub(crate) appservice_mode: bool,
@@ -131,10 +131,7 @@ impl ClientConfig {
     /// [`make_config`]: crate::store::make_config
     /// [`store`]: crate::store
     pub fn with_store_config(store_config: StoreConfig) -> Self {
-        Self {
-            base_config: BaseClientConfig::with_store_config(store_config),
-            ..Default::default()
-        }
+        Self { store_config, ..Default::default() }
     }
 
     /// Set the proxy through which all the HTTP requests should go.
@@ -180,7 +177,7 @@ impl ClientConfig {
     ///
     /// The state store should be opened before being set.
     pub fn state_store(mut self, store: Box<dyn StateStore>) -> Self {
-        self.base_config = self.base_config.state_store(store);
+        self.store_config = self.store_config.state_store(store);
         self
     }
 
@@ -226,7 +223,7 @@ impl ClientConfig {
         mut self,
         store: Box<dyn matrix_sdk_base::crypto::store::CryptoStore>,
     ) -> Self {
-        self.base_config = self.base_config.crypto_store(store);
+        self.store_config = self.store_config.crypto_store(store);
         self
     }
 

--- a/crates/matrix-sdk/src/config/client.rs
+++ b/crates/matrix-sdk/src/config/client.rs
@@ -105,9 +105,9 @@ impl ClientConfig {
 
     /// Create a new `ClientConfig` with the given [`StoreConfig`].
     ///
-    /// The easiest way to get a [`StoreConfig`] is to use the [`make_config`]
-    /// method from the [`store`] module or directly from one of the store
-    /// crates.
+    /// The easiest way to get a [`StoreConfig`] is to use the
+    /// [`make_store_config`] method from the [`store`] module or directly from
+    /// one of the store crates.
     ///
     /// # Arguments
     ///
@@ -128,7 +128,7 @@ impl ClientConfig {
     /// # Result::<_, matrix_sdk::Error>::Ok(())
     /// # });
     /// ```
-    /// [`make_config`]: crate::store::make_config
+    /// [`make_store_config`]: crate::store::make_store_config
     /// [`store`]: crate::store
     pub fn with_store_config(store_config: StoreConfig) -> Self {
         Self { store_config, ..Default::default() }

--- a/crates/matrix-sdk/src/config/client.rs
+++ b/crates/matrix-sdk/src/config/client.rs
@@ -103,7 +103,33 @@ impl ClientConfig {
         Self::default()
     }
 
-    /// Create a new `ClientConfig` with the given `StoreConfig`.
+    /// Create a new `ClientConfig` with the given [`StoreConfig`].
+    ///
+    /// The easiest way to get a [`StoreConfig`] is to use the [`make_config`]
+    /// method from the [`store`] module or directly from one of the store
+    /// crates.
+    ///
+    /// # Arguments
+    ///
+    /// * `store_config` - The configuration of the store.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// # use matrix_sdk_base::store::MemoryStore;
+    /// # let custom_state_store = Box::new(MemoryStore::new());
+    /// use matrix_sdk::{Client, config::{ClientConfig, StoreConfig}};
+    ///
+    /// let store_config = StoreConfig::new().state_store(custom_state_store);
+    /// let client_config = ClientConfig::with_store_config(store_config)
+    ///     .use_discovery_response();
+    ///
+    /// # Result::<_, matrix_sdk::Error>::Ok(())
+    /// # });
+    /// ```
+    /// [`make_config`]: crate::store::make_config
+    /// [`store`]: crate::store
     pub fn with_store_config(store_config: StoreConfig) -> Self {
         Self {
             base_config: BaseClientConfig::with_store_config(store_config),

--- a/crates/matrix-sdk/src/config/client.rs
+++ b/crates/matrix-sdk/src/config/client.rs
@@ -20,9 +20,12 @@ use std::{
 };
 
 use http::header::InvalidHeaderValue;
-use matrix_sdk_base::{store::StoreConfig, BaseClientConfig, StateStore};
+use matrix_sdk_base::{BaseClientConfig, StateStore};
 
-use crate::{config::RequestConfig, HttpSend, Result};
+use crate::{
+    config::{RequestConfig, StoreConfig},
+    HttpSend, Result,
+};
 
 /// Configuration for the creation of the `Client`.
 ///

--- a/crates/matrix-sdk/src/config/mod.rs
+++ b/crates/matrix-sdk/src/config/mod.rs
@@ -20,6 +20,6 @@ mod client;
 mod request;
 mod sync;
 
-pub use client::{default_store, default_store_with_name, ClientConfig};
+pub use client::ClientConfig;
 pub use request::RequestConfig;
 pub use sync::SyncSettings;

--- a/crates/matrix-sdk/src/docs/encryption.md
+++ b/crates/matrix-sdk/src/docs/encryption.md
@@ -165,8 +165,10 @@ unverified devices, verifying devices is **not** necessary for encryption
 to work.
 
 1. Make sure the `encryption` feature is enabled.
-2. Ensure you have a persistent storage backend, either by activating the
-   `sled_state_store`-feature or providing one via [`ClientConfig.state_store`]
+2. To persist the encryption keys, you can use one of the provided backend
+constructors as described in the documentation of the [`store`] module or you
+can provide your own backend that implements [`CryptoStore`] in a
+[`StoreConfig`] or via [`ClientConfig::crypto_store()`].
 
 ## Restoring a client
 
@@ -228,3 +230,7 @@ is **not** supported using the default store.
 [Restoring a Client]: #restoring-a-client
 [spec]: https://spec.matrix.org/unstable/client-server-api/#relationship-between-access-tokens-and-devices
 [device keys]: https://spec.matrix.org/unstable/client-server-api/#device-keys
+[`store`]: crate::store
+[`CryptoStore`]: matrix_sdk_base::crypto::store::CryptoStore
+[`StoreConfig`]: crate::config::StoreConfig
+[`ClientConfig::crypto_store()`]: crate::config::ClientConfig::crypto_store()

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -50,6 +50,7 @@ mod http_client;
 /// High-level room API
 pub mod room;
 mod room_member;
+pub mod store;
 mod sync;
 
 #[cfg(feature = "encryption")]

--- a/crates/matrix-sdk/src/store.rs
+++ b/crates/matrix-sdk/src/store.rs
@@ -14,7 +14,20 @@
 //! Functions and types to initialize a store.
 //!
 //! The re-exports present here depend on the store-related features that are
-//! enabled.
+//! enabled:
+//!
+//! 1. `sled_state_store` provides a `StateStore`, while
+//! `sled_cryptostore` provides also a `CryptoStore` for encryption data. This
+//! is the default persistent store implementation for non-WebAssembly.
+//! 2. `indexeddb_store` provides both a `StateStore` and a `CryptoStore` if
+//! `encryption` is also enabled. This is the default persistent store
+//! implementation for WebAssembly.
+//!
+//! Both options provide a `make_config` convenience method to create a
+//! [`StoreConfig`] for [`ClientConfig::with_store_config()`].
+//!
+//! [`StoreConfig`]: crate::config::StoreConfig
+//! [`ClientConfig::with_store_config()`]: crate::config::ClientConfig::with_store_config()
 
 #[cfg(feature = "indexeddb_stores")]
 pub use matrix_sdk_indexeddb::*;

--- a/crates/matrix-sdk/src/store.rs
+++ b/crates/matrix-sdk/src/store.rs
@@ -29,7 +29,7 @@
 //! [`StoreConfig`]: crate::config::StoreConfig
 //! [`ClientConfig::with_store_config()`]: crate::config::ClientConfig::with_store_config()
 
-#[cfg(feature = "indexeddb_stores")]
+#[cfg(any(feature = "indexeddb_state_store", feature = "indexeddb_cryptostore"))]
 pub use matrix_sdk_indexeddb::*;
 #[cfg(any(feature = "sled_state_store", feature = "sled_cryptostore"))]
 pub use matrix_sdk_sled::*;

--- a/crates/matrix-sdk/src/store.rs
+++ b/crates/matrix-sdk/src/store.rs
@@ -23,7 +23,7 @@
 //! `encryption` is also enabled. This is the default persistent store
 //! implementation for WebAssembly.
 //!
-//! Both options provide a `make_config` convenience method to create a
+//! Both options provide a `make_store_config` convenience method to create a
 //! [`StoreConfig`] for [`ClientConfig::with_store_config()`].
 //!
 //! [`StoreConfig`]: crate::config::StoreConfig

--- a/crates/matrix-sdk/src/store.rs
+++ b/crates/matrix-sdk/src/store.rs
@@ -1,5 +1,4 @@
-// Copyright 2021 The Matrix.org Foundation C.I.C.
-//
+// Copyright 2022 Kévin Commaille
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -12,15 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Configuration to change the behaviour of the [`Client`].
+//! Functions and types to initialize a store.
 //!
-//! [`Client`]: #crate.Client
+//! The re-exports present here depend on the store-related features that are
+//! enabled.
 
-mod client;
-mod request;
-mod sync;
-
-pub use client::ClientConfig;
-pub use matrix_sdk_base::store::StoreConfig;
-pub use request::RequestConfig;
-pub use sync::SyncSettings;
+#[cfg(feature = "indexeddb_stores")]
+pub use matrix_sdk_indexeddb::*;
+#[cfg(any(feature = "sled_state_store", feature = "sled_cryptostore"))]
+pub use matrix_sdk_sled::*;

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -187,14 +187,14 @@ fn run_wasm_checks(cmd: Option<WasmFeatureSet>) -> Result<()> {
             WasmFeatureSet::MatrixSdkNoDefault,
             "-p matrix-sdk \
              --no-default-features \
-             --features qrcode,encryption,indexeddb_stores,rustls-tls",
+             --features qrcode,encryption,indexeddb_state_store,indexeddb_cryptostore,rustls-tls",
         ),
         (WasmFeatureSet::MatrixSdkBase, "-p matrix-sdk-base"),
         (WasmFeatureSet::MatrixSdkCommon, "-p matrix-sdk-common"),
         (WasmFeatureSet::MatrixSdkCrypto, "-p matrix-sdk-crypto"),
         (
             WasmFeatureSet::MatrixSdkIndexeddbStores,
-            "-p matrix-sdk --no-default-features --features indexeddb_stores,encryption,rustls-tls",
+            "-p matrix-sdk --no-default-features --features indexeddb_state_store,indexeddb_cryptostore,encryption,rustls-tls",
         ),
     ]);
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -112,9 +112,15 @@ fn check_typos() -> Result<()> {
 fn check_clippy() -> Result<()> {
     cmd!("rustup run nightly cargo clippy --all-targets -- -D warnings").run()?;
     cmd!(
-        "rustup run nightly cargo clippy --all-targets
+        "rustup run nightly cargo clippy --workspace --all-targets
+            --exclude matrix-sdk-crypto --exclude xtask
             --no-default-features --features native-tls,warp
             -- -D warnings"
+    )
+    .run()?;
+    cmd!(
+        "rustup run nightly cargo clippy --all-targets -p matrix-sdk-crypto
+            --no-default-features -- -D warnings"
     )
     .run()?;
     Ok(())


### PR DESCRIPTION
context: https://matrix.to/#/!iYnZafYUoXkeVPOSQh:matrix.org/$yh6vVuOVhR_RWgdtHY6_HiFBgv_R-46TK-E-B3HwQlw?via=matrix.org&via=kde.org&via=one.ems.host

The main goal of this work is to remove the default magic that happens to create the stores and have something more explicit.

I ended up creating a mix of what was discussed as it made more sense to me looking at how the code is organized. By default I could have reused `BaseClientConfig` but it doesn't make sense to expose it in the main crate as the `BaseClient` doesn't mean anything there, so I created `StoreConfig`.

By default a `MemoryStore` is always used now. The stores have to be explicitely opened and provided to the `ClientConfig`. There are two helper functions to do that in the store crates `open_stores_with_*` and `make_config`.