### PR TITLE
Fix the room key backup support in the crypto crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,32 @@ jobs:
           command: run
           args: -p xtask -- ci test-features ${{ matrix.name }}
 
+  test-crypto-features:
+    name: linux / crypto-crate features
+    needs: [style]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || !github.event.pull_request.draft
+
+    steps:
+    - name: Checkout the repo
+      uses: actions/checkout@v2
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+
+    - name: Load cache
+      uses: Swatinem/rust-cache@v1
+
+    - name: Clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: run
+        args: -p xtask -- ci test-crypto
+
   test:
     name: ${{ matrix.name }}
     if: github.event_name == 'push' || !github.event.pull_request.draft

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -20,6 +20,7 @@ use std::{
 use olm_rs::pk::OlmPkEncryption;
 use ruma::{
     api::client::backup::{KeyBackupData, KeyBackupDataInit, SessionDataInit},
+    serde::Base64,
     DeviceKeyId, UserId,
 };
 use zeroize::Zeroizing;
@@ -127,9 +128,11 @@ impl MegolmV1BackupKey {
         let message = pk.encrypt(&key);
 
         let session_data = SessionDataInit {
-            ephemeral: message.ephemeral_key,
-            ciphertext: message.ciphertext,
-            mac: message.mac,
+            ephemeral: Base64::parse(message.ephemeral_key)
+                .expect("Can't decode the base64 encoded ephemeral backup key"),
+            ciphertext: Base64::parse(message.ciphertext)
+                .expect("Can't decode a base64 encoded libolm ciphertext"),
+            mac: Base64::parse(message.mac).expect("Can't decode a base64 encoded MAC"),
         }
         .into();
 

--- a/crates/matrix-sdk-crypto/src/backups/keys/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/mod.rs
@@ -51,4 +51,4 @@ mod backup;
 mod recovery;
 
 pub use backup::MegolmV1BackupKey;
-pub use recovery::{DecodeError, PickledRecoveryKey, RecoveryKey};
+pub use recovery::DecodeError;

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -39,13 +39,13 @@ use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
     olm::{Account, InboundGroupSession},
-    store::{BackupKeys, Changes, RoomKeyCounts, Store},
+    store::{BackupKeys, Changes, RecoveryKey, RoomKeyCounts, Store},
     CryptoStoreError, KeysBackupRequest, OutgoingRequest,
 };
 
 mod keys;
 
-pub use keys::{DecodeError, MegolmV1BackupKey, PickledRecoveryKey, RecoveryKey};
+pub use keys::{DecodeError, MegolmV1BackupKey};
 pub use olm_rs::errors::OlmPkDecryptionError;
 
 /// A state machine that handles backing up room keys.
@@ -64,7 +64,7 @@ pub struct BackupMachine {
 
 #[derive(Debug, Clone)]
 struct PendingBackup {
-    request_id: &TransactionId,
+    request_id: Box<TransactionId>,
     request: KeysBackupRequest,
     sessions: BTreeMap<Box<RoomId>, BTreeMap<String, BTreeSet<String>>>,
 }
@@ -388,8 +388,7 @@ mod test {
     use matrix_sdk_test::async_test;
     use ruma::{device_id, room_id, user_id, DeviceId, RoomId, UserId};
 
-    use super::RecoveryKey;
-    use crate::{OlmError, OlmMachine};
+    use crate::{store::RecoveryKey, OlmError, OlmMachine};
 
     fn alice_id() -> &'static UserId {
         user_id!("@alice:example.org")
@@ -430,12 +429,12 @@ mod test {
         let request =
             backup_machine.backup().await?.expect("Created a backup request successfully");
         assert_eq!(
-            Some(request.request_id),
-            backup_machine.backup().await?.map(|r| r.request_id),
+            Some(&*request.request_id),
+            backup_machine.backup().await?.as_ref().map(|r| &*r.request_id),
             "Calling backup again without uploading creates the same backup request"
         );
 
-        backup_machine.mark_request_as_sent(request.request_id).await?;
+        backup_machine.mark_request_as_sent(&request.request_id).await?;
 
         let counts = backup_machine.store.inbound_group_session_counts().await?;
         assert_eq!(counts.total, 2);

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -376,7 +376,7 @@ impl OlmMachine {
             }
             IncomingResponse::KeysBackup(_) => {
                 #[cfg(feature = "backups_v1")]
-                self.backup_machine.mark_request_as_sent(*request_id).await?;
+                self.backup_machine.mark_request_as_sent(request_id).await?;
             }
         };
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -696,6 +696,7 @@ impl ReadOnlyAccount {
         self.inner.lock().await.sign(string)
     }
 
+    /// Check that the given json value is signed by this account.
     #[cfg(feature = "backups_v1")]
     pub fn is_signed(&self, json: &mut Value) -> Result<(), SignatureError> {
         let signing_key = self.identity_keys.ed25519();

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -238,8 +238,6 @@ impl InboundGroupSession {
         self.backed_up.store(false, SeqCst)
     }
 
-    #[cfg(any(test, feature = "testing"))]
-    #[allow(dead_code)]
     /// For testing, allow to manually mark this GroupSession to have been
     /// backed up
     pub fn mark_as_backed_up(&self) {
@@ -342,6 +340,8 @@ impl InboundGroupSession {
         self.inner.lock().await.decrypt(message)
     }
 
+    /// Export the inbound group session into a format that can be uploaded to
+    /// the server as a backup.
     #[cfg(feature = "backups_v1")]
     pub async fn to_backup(&self) -> BackedUpRoomKey {
         self.export().await.into()

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -65,6 +65,7 @@ use ruma::{
     events::secret::request::SecretName, identifiers::Error as IdentifierValidationError, DeviceId,
     DeviceKeyAlgorithm, RoomId, TransactionId, UserId,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::Error as SerdeError;
 use thiserror::Error;
 use tracing::{info, warn};
@@ -108,10 +109,8 @@ pub struct Store {
 pub struct Changes {
     pub account: Option<ReadOnlyAccount>,
     pub private_identity: Option<PrivateCrossSigningIdentity>,
-    #[cfg(feature = "backups_v1")]
     pub backup_version: Option<String>,
-    #[cfg(feature = "backups_v1")]
-    pub recovery_key: Option<crate::backups::RecoveryKey>,
+    pub recovery_key: Option<RecoveryKey>,
     pub sessions: Vec<Session>,
     pub message_hashes: Vec<OlmMessageHash>,
     pub inbound_group_sessions: Vec<InboundGroupSession>,
@@ -157,6 +156,103 @@ pub struct DeviceChanges {
     pub deleted: Vec<ReadOnlyDevice>,
 }
 
+/// The private part of a backup key.
+#[derive(Zeroize)]
+#[zeroize(drop)]
+pub struct RecoveryKey {
+    pub(crate) inner: [u8; RecoveryKey::KEY_SIZE],
+}
+
+/// The pickled version of a recovery key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PickledRecoveryKey(String);
+
+impl AsRef<str> for PickledRecoveryKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InnerPickle {
+    version: u8,
+    nonce: String,
+    ciphertext: String,
+}
+
+impl RecoveryKey {
+    /// The number of bytes the recovery key will hold.
+    pub const KEY_SIZE: usize = 32;
+    const NONCE_SIZE: usize = 12;
+
+    /// Export this [`RecoveryKey`] as an encrypted pickle that can be safely
+    /// stored.
+    pub fn pickle(&self, pickle_key: &[u8]) -> PickledRecoveryKey {
+        use aes::cipher::generic_array::GenericArray;
+        use aes_gcm::aead::{Aead, NewAead};
+        use rand::Fill;
+
+        let key = GenericArray::from_slice(pickle_key);
+        let cipher = aes_gcm::Aes256Gcm::new(key);
+
+        let mut nonce = vec![0u8; Self::NONCE_SIZE];
+        let mut rng = rand::thread_rng();
+
+        nonce.try_fill(&mut rng).expect("Can't generate random nocne to pickle the recovery key");
+        let nonce = GenericArray::from_slice(nonce.as_slice());
+
+        let ciphertext =
+            cipher.encrypt(nonce, self.inner.as_ref()).expect("Can't encrypt recovery key");
+
+        let ciphertext = crate::utilities::encode_url_safe(ciphertext);
+
+        let pickle = InnerPickle {
+            version: 1,
+            nonce: crate::utilities::encode_url_safe(nonce.as_slice()),
+            ciphertext,
+        };
+
+        PickledRecoveryKey(serde_json::to_string(&pickle).expect("Can't encode pickled signing"))
+    }
+
+    /// Try to import a `RecoveryKey` from a previously exported pickle.
+    pub fn from_pickle(
+        pickle: PickledRecoveryKey,
+        pickle_key: &[u8],
+    ) -> Result<Self, CryptoStoreError> {
+        use aes::cipher::generic_array::GenericArray;
+        use aes_gcm::aead::{Aead, NewAead};
+
+        let pickled: InnerPickle = serde_json::from_str(pickle.as_ref())?;
+
+        let key = GenericArray::from_slice(pickle_key);
+        let cipher = aes_gcm::Aes256Gcm::new(key);
+
+        let nonce = crate::utilities::decode_url_safe(pickled.nonce).unwrap();
+        let nonce = GenericArray::from_slice(&nonce);
+        let ciphertext = &crate::utilities::decode_url_safe(pickled.ciphertext).unwrap();
+
+        let decrypted = cipher
+            .decrypt(nonce, ciphertext.as_slice())
+            .map_err(|_| CryptoStoreError::UnpicklingError)?;
+
+        if decrypted.len() != Self::KEY_SIZE {
+            Err(CryptoStoreError::UnpicklingError)
+        } else {
+            let mut key = [0u8; Self::KEY_SIZE];
+            key.copy_from_slice(&decrypted);
+
+            Ok(Self { inner: key })
+        }
+    }
+}
+
+impl Debug for RecoveryKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecoveryKey").finish()
+    }
+}
+
 impl DeviceChanges {
     /// Merge the given `DeviceChanges` into this instance of `DeviceChanges`.
     pub fn extend(&mut self, other: DeviceChanges) {
@@ -183,10 +279,8 @@ pub struct RoomKeyCounts {
 #[derive(Default, Debug)]
 pub struct BackupKeys {
     /// The recovery key, the one used to decrypt backed up room keys.
-    #[cfg(feature = "backups_v1")]
-    pub recovery_key: Option<crate::backups::RecoveryKey>,
+    pub recovery_key: Option<RecoveryKey>,
     /// The version that we are using for backups.
-    #[cfg(feature = "backups_v1")]
     pub backup_version: Option<String>,
 }
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -36,6 +36,8 @@ enum CiCommand {
         #[clap(subcommand)]
         cmd: Option<WasmFeatureSet>,
     },
+    /// Run tests for the different crypto crate features
+    TestCrypto,
 }
 
 #[derive(Subcommand, PartialEq, Eq, PartialOrd, Ord)]
@@ -76,6 +78,7 @@ impl CiArgs {
                 CiCommand::TestFeatures { cmd } => run_feature_tests(cmd),
                 CiCommand::TestAppservice => run_appservice_tests(),
                 CiCommand::Wasm { cmd } => run_wasm_checks(cmd),
+                CiCommand::TestCrypto => run_crypto_tests(),
             },
             None => {
                 check_style()?;
@@ -86,6 +89,7 @@ impl CiArgs {
                 run_feature_tests(None)?;
                 run_appservice_tests()?;
                 run_wasm_checks(None)?;
+                run_crypto_tests()?;
 
                 Ok(())
             }
@@ -155,6 +159,16 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
             }
         }
     }
+
+    Ok(())
+}
+
+fn run_crypto_tests() -> Result<()> {
+    cmd!(
+        "rustup run stable cargo clippy -p matrix-sdk-crypto --features=backups_v1 -- -D warnings"
+    )
+    .run()?;
+    cmd!("rustup run stable cargo test -p matrix-sdk-crypto --features=backups_v1").run()?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR fixes backup support in the crypto crate.  It's only used by Element Android and is not exposed through the main crate, so it was skipped by CI and accidentally broken by a couple of innocently looking PRs.

The `RecoverKey` struct is now available without the feature flag, so stores don't have to juggle the feature around.

This also adds a CI job to check that we don't rebreak it, an xtask is also provided for your convenience. 