### PR TITLE
Use fine-grained *EventType types

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -54,7 +54,7 @@ use ruma::{
     events::{
         room::member::MembershipState, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
         AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncRoomEvent, AnySyncStateEvent,
-        EventContent, EventType,
+        EventContent, GlobalAccountDataEventType, StateEventType,
     },
     push::{Action, PushConditionRoomCtx, Ruleset},
     serde::Raw,
@@ -1197,13 +1197,13 @@ impl BaseClient {
     pub async fn get_push_rules(&self, changes: &StateChanges) -> Result<Ruleset> {
         if let Some(AnyGlobalAccountDataEvent::PushRules(event)) = changes
             .account_data
-            .get(EventType::PushRules.as_str())
+            .get(GlobalAccountDataEventType::PushRules.as_str())
             .and_then(|e| e.deserialize().ok())
         {
             Ok(event.content.global)
         } else if let Some(AnyGlobalAccountDataEvent::PushRules(event)) = self
             .store
-            .get_account_data_event(EventType::PushRules)
+            .get_account_data_event(GlobalAccountDataEventType::PushRules)
             .await?
             .and_then(|e| e.deserialize().ok())
         {
@@ -1246,14 +1246,14 @@ impl BaseClient {
         let room_power_levels = if let Some(AnySyncStateEvent::RoomPowerLevels(event)) = changes
             .state
             .get(room_id)
-            .and_then(|types| types.get(EventType::RoomPowerLevels.as_str()))
+            .and_then(|types| types.get(StateEventType::RoomPowerLevels.as_str()))
             .and_then(|events| events.get(""))
             .and_then(|e| e.deserialize().ok())
         {
             event.content
         } else if let Some(AnySyncStateEvent::RoomPowerLevels(event)) = self
             .store
-            .get_state_event(room_id, EventType::RoomPowerLevels, "")
+            .get_state_event(room_id, StateEventType::RoomPowerLevels, "")
             .await?
             .and_then(|e| e.deserialize().ok())
         {
@@ -1296,7 +1296,7 @@ impl BaseClient {
         if let Some(AnySyncStateEvent::RoomPowerLevels(event)) = changes
             .state
             .get(&**room_id)
-            .and_then(|types| types.get(EventType::RoomPowerLevels.as_str()))
+            .and_then(|types| types.get(StateEventType::RoomPowerLevels.as_str()))
             .and_then(|events| events.get(""))
             .and_then(|e| e.deserialize().ok())
         {

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -32,7 +32,8 @@ use ruma::{
             tombstone::RoomTombstoneEventContent,
         },
         tag::Tags,
-        AnyRoomAccountDataEvent, AnyStateEventContent, AnySyncStateEvent, EventType,
+        AnyRoomAccountDataEvent, AnyStateEventContent, AnySyncStateEvent, RoomAccountDataEventType,
+        StateEventType,
     },
     receipt::ReceiptType,
     EventId, MxcUri, RoomAliasId, RoomId, UserId,
@@ -415,7 +416,7 @@ impl Room {
 
         let power =
             self.store
-                .get_state_event(self.room_id(), EventType::RoomPowerLevels, "")
+                .get_state_event(self.room_id(), StateEventType::RoomPowerLevels, "")
                 .await?
                 .and_then(|e| e.deserialize().ok())
                 .and_then(|e| {
@@ -451,7 +452,7 @@ impl Room {
     pub async fn tags(&self) -> StoreResult<Option<Tags>> {
         if let Some(AnyRoomAccountDataEvent::Tag(event)) = self
             .store
-            .get_room_account_data_event(self.room_id(), EventType::Tag)
+            .get_room_account_data_event(self.room_id(), RoomAccountDataEventType::Tag)
             .await?
             .and_then(|r| r.deserialize().ok())
         {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -51,9 +51,10 @@ macro_rules! statestore_integration_tests {
                             member::{MembershipState, RoomMemberEventContent},
                             power_levels::RoomPowerLevelsEventContent,
                         },
-                        AnyEphemeralRoomEventContent, AnySyncEphemeralRoomEvent, AnyStrippedStateEvent,
-                        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-                        AnySyncStateEvent, EventType, Unsigned,
+                        AnyEphemeralRoomEventContent, AnySyncEphemeralRoomEvent,
+                        AnyStrippedStateEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
+                        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType,
+                        StateEventType, Unsigned,
                     },
                     mxc_uri,
                     receipt::ReceiptType,
@@ -279,10 +280,10 @@ macro_rules! statestore_integration_tests {
                     assert!(store.get_presence_event(user_id).await?.is_some());
                     assert_eq!(store.get_room_infos().await?.len(), 1);
                     assert_eq!(store.get_stripped_room_infos().await?.len(), 1);
-                    assert!(store.get_account_data_event(EventType::PushRules).await?.is_some());
+                    assert!(store.get_account_data_event(GlobalAccountDataEventType::PushRules).await?.is_some());
 
-                    assert!(store.get_state_event(room_id, EventType::RoomName, "").await?.is_some());
-                    assert_eq!(store.get_state_events(room_id, EventType::RoomTopic).await?.len(), 1);
+                    assert!(store.get_state_event(room_id, StateEventType::RoomName, "").await?.is_some());
+                    assert_eq!(store.get_state_events(room_id, StateEventType::RoomTopic).await?.len(), 1);
                     assert!(store.get_profile(room_id, user_id).await?.is_some());
                     assert!(store.get_member_event(room_id, user_id).await?.is_some());
                     assert_eq!(store.get_user_ids(room_id).await?.len(), 2);
@@ -290,7 +291,7 @@ macro_rules! statestore_integration_tests {
                     assert_eq!(store.get_joined_user_ids(room_id).await?.len(), 1);
                     assert_eq!(store.get_users_with_display_name(room_id, "example").await?.len(), 2);
                     assert!(store
-                        .get_room_account_data_event(room_id, EventType::Tag)
+                        .get_room_account_data_event(room_id, RoomAccountDataEventType::Tag)
                         .await?
                         .is_some());
                     assert!(store
@@ -337,7 +338,7 @@ macro_rules! statestore_integration_tests {
                     let event = raw_event.deserialize().unwrap();
 
                     assert!(store
-                        .get_state_event(room_id, EventType::RoomPowerLevels, "")
+                        .get_state_event(room_id, StateEventType::RoomPowerLevels, "")
                         .await
                         .unwrap()
                         .is_none());
@@ -346,7 +347,7 @@ macro_rules! statestore_integration_tests {
 
                     store.save_changes(&changes).await.unwrap();
                     assert!(store
-                        .get_state_event(room_id, EventType::RoomPowerLevels, "")
+                        .get_state_event(room_id, StateEventType::RoomPowerLevels, "")
                         .await
                         .unwrap()
                         .is_some());
@@ -527,8 +528,8 @@ macro_rules! statestore_integration_tests {
                     assert_eq!(store.get_room_infos().await?.len(), 0);
                     assert_eq!(store.get_stripped_room_infos().await?.len(), 1);
 
-                    assert!(store.get_state_event(room_id, EventType::RoomName, "").await?.is_none());
-                    assert_eq!(store.get_state_events(room_id, EventType::RoomTopic).await?.len(), 0);
+                    assert!(store.get_state_event(room_id, StateEventType::RoomName, "").await?.is_none());
+                    assert_eq!(store.get_state_events(room_id, StateEventType::RoomTopic).await?.len(), 0);
                     assert!(store.get_profile(room_id, user_id).await?.is_none());
                     assert!(store.get_member_event(room_id, user_id).await?.is_none());
                     assert_eq!(store.get_user_ids(room_id).await?.len(), 0);
@@ -536,7 +537,7 @@ macro_rules! statestore_integration_tests {
                     assert_eq!(store.get_joined_user_ids(room_id).await?.len(), 0);
                     assert_eq!(store.get_users_with_display_name(room_id, "example").await?.len(), 0);
                     assert!(store
-                        .get_room_account_data_event(room_id, EventType::Tag)
+                        .get_room_account_data_event(room_id, RoomAccountDataEventType::Tag)
                         .await?
                         .is_none());
                     assert!(store

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -28,7 +28,8 @@ use ruma::{
         receipt::Receipt,
         room::member::{MembershipState, RoomMemberEventContent},
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncMessageEvent, AnySyncRoomEvent, AnySyncStateEvent, EventType,
+        AnySyncMessageEvent, AnySyncRoomEvent, AnySyncStateEvent, GlobalAccountDataEventType,
+        RoomAccountDataEventType, StateEventType,
     },
     receipt::ReceiptType,
     serde::Raw,
@@ -408,7 +409,7 @@ impl MemoryStore {
     async fn get_state_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>> {
         Ok(self.room_state.get(room_id).and_then(|e| {
@@ -419,7 +420,7 @@ impl MemoryStore {
     async fn get_state_events(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
     ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
         Ok(self
             .room_state
@@ -477,7 +478,7 @@ impl MemoryStore {
 
     async fn get_account_data_event(
         &self,
-        event_type: EventType,
+        event_type: GlobalAccountDataEventType,
     ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>> {
         Ok(self.account_data.get(event_type.as_ref()).map(|e| e.clone()))
     }
@@ -485,7 +486,7 @@ impl MemoryStore {
     async fn get_room_account_data_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: RoomAccountDataEventType,
     ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>> {
         Ok(self
             .room_account_data
@@ -631,7 +632,7 @@ impl StateStore for MemoryStore {
     async fn get_state_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>> {
         self.get_state_event(room_id, event_type, state_key).await
@@ -640,7 +641,7 @@ impl StateStore for MemoryStore {
     async fn get_state_events(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
     ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
         self.get_state_events(room_id, event_type).await
     }
@@ -695,7 +696,7 @@ impl StateStore for MemoryStore {
 
     async fn get_account_data_event(
         &self,
-        event_type: EventType,
+        event_type: GlobalAccountDataEventType,
     ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>> {
         self.get_account_data_event(event_type).await
     }
@@ -703,7 +704,7 @@ impl StateStore for MemoryStore {
     async fn get_room_account_data_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: RoomAccountDataEventType,
     ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>> {
         self.get_room_account_data_event(room_id, event_type).await
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -40,7 +40,8 @@ use ruma::{
         receipt::{Receipt, ReceiptEventContent},
         room::member::RoomMemberEventContent,
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, EventContent, EventType,
+        AnySyncStateEvent, EventContent, GlobalAccountDataEventType, RoomAccountDataEventType,
+        StateEventType,
     },
     receipt::ReceiptType,
     serde::Raw,
@@ -145,11 +146,11 @@ pub trait StateStore: AsyncTraitDeps {
     async fn get_state_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>>;
 
-    /// Get a list of state events for a given room and `EventType`.
+    /// Get a list of state events for a given room and `StateEventType`.
     ///
     /// # Arguments
     ///
@@ -159,7 +160,7 @@ pub trait StateStore: AsyncTraitDeps {
     async fn get_state_events(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
     ) -> Result<Vec<Raw<AnySyncStateEvent>>>;
 
     /// Get the current profile for the given user in the given room.
@@ -226,7 +227,7 @@ pub trait StateStore: AsyncTraitDeps {
     /// * `event_type` - The event type of the account data event.
     async fn get_account_data_event(
         &self,
-        event_type: EventType,
+        event_type: GlobalAccountDataEventType,
     ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>>;
 
     /// Get an event out of the room account data store.
@@ -241,7 +242,7 @@ pub trait StateStore: AsyncTraitDeps {
     async fn get_room_account_data_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: RoomAccountDataEventType,
     ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>>;
 
     /// Get an event out of the user room receipt store.

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -30,7 +30,7 @@ use ruma::{
         to_device::send_event_to_device::v3::Response as ToDeviceResponse,
     },
     encryption::CrossSigningKey,
-    events::{AnyMessageEventContent, AnyToDeviceEventContent, EventContent, EventType},
+    events::{AnyMessageEventContent, AnyToDeviceEventContent, EventContent, ToDeviceEventType},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
     DeviceId, RoomId, TransactionId, UserId,
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ToDeviceRequest {
     /// Type of event being sent to each device.
-    pub event_type: EventType,
+    pub event_type: ToDeviceEventType,
 
     /// A request identifier unique to the access token used to send the
     /// request.
@@ -108,7 +108,7 @@ impl ToDeviceRequest {
         content: AnyToDeviceEventContent,
         txn_id: Box<TransactionId>,
     ) -> Self {
-        let event_type = EventType::from(content.event_type());
+        let event_type = ToDeviceEventType::from(content.event_type());
         let raw_content = Raw::new(&content).expect("Failed to serialize to-device event");
 
         let user_messages = iter::once((recipient_device.into(), raw_content)).collect();

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -24,7 +24,7 @@ use matrix_sdk_common::executor::spawn;
 use ruma::{
     events::{
         room::{encrypted::RoomEncryptedEventContent, history_visibility::HistoryVisibility},
-        AnyToDeviceEventContent, EventType,
+        AnyToDeviceEventContent, ToDeviceEventType,
     },
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
@@ -300,7 +300,7 @@ impl GroupSessionManager {
 
         let txn_id = TransactionId::new();
         let request = ToDeviceRequest {
-            event_type: EventType::RoomEncrypted,
+            event_type: ToDeviceEventType::RoomEncrypted,
             txn_id: txn_id.clone(),
             messages,
         };

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -727,7 +727,7 @@ impl TryFrom<ToDeviceRequest> for OutgoingContent {
     type Error = String;
 
     fn try_from(request: ToDeviceRequest) -> Result<Self, Self::Error> {
-        use ruma::events::EventType;
+        use ruma::events::ToDeviceEventType;
         use serde_json::Value;
 
         let json: Value = serde_json::from_str(
@@ -742,30 +742,40 @@ impl TryFrom<ToDeviceRequest> for OutgoingContent {
         .map_err(|e| e.to_string())?;
 
         let content = match request.event_type {
-            EventType::KeyVerificationStart => AnyToDeviceEventContent::KeyVerificationStart(
+            ToDeviceEventType::KeyVerificationStart => {
+                AnyToDeviceEventContent::KeyVerificationStart(
+                    serde_json::from_value(json).map_err(|e| e.to_string())?,
+                )
+            }
+            ToDeviceEventType::KeyVerificationKey => AnyToDeviceEventContent::KeyVerificationKey(
                 serde_json::from_value(json).map_err(|e| e.to_string())?,
             ),
-            EventType::KeyVerificationKey => AnyToDeviceEventContent::KeyVerificationKey(
+            ToDeviceEventType::KeyVerificationAccept => {
+                AnyToDeviceEventContent::KeyVerificationAccept(
+                    serde_json::from_value(json).map_err(|e| e.to_string())?,
+                )
+            }
+            ToDeviceEventType::KeyVerificationMac => AnyToDeviceEventContent::KeyVerificationMac(
                 serde_json::from_value(json).map_err(|e| e.to_string())?,
             ),
-            EventType::KeyVerificationAccept => AnyToDeviceEventContent::KeyVerificationAccept(
+            ToDeviceEventType::KeyVerificationCancel => {
+                AnyToDeviceEventContent::KeyVerificationCancel(
+                    serde_json::from_value(json).map_err(|e| e.to_string())?,
+                )
+            }
+            ToDeviceEventType::KeyVerificationReady => {
+                AnyToDeviceEventContent::KeyVerificationReady(
+                    serde_json::from_value(json).map_err(|e| e.to_string())?,
+                )
+            }
+            ToDeviceEventType::KeyVerificationDone => AnyToDeviceEventContent::KeyVerificationDone(
                 serde_json::from_value(json).map_err(|e| e.to_string())?,
             ),
-            EventType::KeyVerificationMac => AnyToDeviceEventContent::KeyVerificationMac(
-                serde_json::from_value(json).map_err(|e| e.to_string())?,
-            ),
-            EventType::KeyVerificationCancel => AnyToDeviceEventContent::KeyVerificationCancel(
-                serde_json::from_value(json).map_err(|e| e.to_string())?,
-            ),
-            EventType::KeyVerificationReady => AnyToDeviceEventContent::KeyVerificationReady(
-                serde_json::from_value(json).map_err(|e| e.to_string())?,
-            ),
-            EventType::KeyVerificationDone => AnyToDeviceEventContent::KeyVerificationDone(
-                serde_json::from_value(json).map_err(|e| e.to_string())?,
-            ),
-            EventType::KeyVerificationRequest => AnyToDeviceEventContent::KeyVerificationRequest(
-                serde_json::from_value(json).map_err(|e| e.to_string())?,
-            ),
+            ToDeviceEventType::KeyVerificationRequest => {
+                AnyToDeviceEventContent::KeyVerificationRequest(
+                    serde_json::from_value(json).map_err(|e| e.to_string())?,
+                )
+            }
             e => return Err(format!("Unsupported event type {}", e)),
         };
 

--- a/crates/matrix-sdk-indexeddb/src/safe_encode.rs
+++ b/crates/matrix-sdk-indexeddb/src/safe_encode.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
+use matrix_sdk_base::ruma::events::StateEventType;
 use matrix_sdk_common::ruma::{
-    events::EventType, receipt::ReceiptType, DeviceId, EventId, MxcUri, RoomId, TransactionId,
-    UserId,
+    receipt::ReceiptType, DeviceId, EventId, MxcUri, RoomId, TransactionId, UserId,
 };
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
@@ -135,7 +135,7 @@ impl SafeEncode for TransactionId {
     }
 }
 
-impl SafeEncode for EventType {
+impl SafeEncode for StateEventType {
     fn as_encoded_string(&self) -> String {
         self.as_str().as_encoded_string()
     }

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -34,7 +34,8 @@ use matrix_sdk_common::{
             receipt::Receipt,
             room::member::{MembershipState, RoomMemberEventContent},
             AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncMessageEvent,
-            AnySyncRoomEvent, AnySyncStateEvent, EventType,
+            AnySyncRoomEvent, AnySyncStateEvent, GlobalAccountDataEventType,
+            RoomAccountDataEventType, StateEventType,
         },
         receipt::ReceiptType,
         serde::Raw,
@@ -711,7 +712,7 @@ impl IndexeddbStore {
     pub async fn get_state_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>> {
         self.inner
@@ -726,7 +727,7 @@ impl IndexeddbStore {
     pub async fn get_state_events(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
     ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
         let range = (room_id, &event_type).encode_to_range().map_err(StoreError::Codec)?;
         Ok(self
@@ -860,7 +861,7 @@ impl IndexeddbStore {
 
     pub async fn get_account_data_event(
         &self,
-        event_type: EventType,
+        event_type: GlobalAccountDataEventType,
     ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>> {
         self.inner
             .transaction_on_one_with_mode(KEYS::ACCOUNT_DATA, IdbTransactionMode::Readonly)?
@@ -874,7 +875,7 @@ impl IndexeddbStore {
     pub async fn get_room_account_data_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: RoomAccountDataEventType,
     ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>> {
         self.inner
             .transaction_on_one_with_mode(KEYS::ROOM_ACCOUNT_DATA, IdbTransactionMode::Readonly)?
@@ -1122,7 +1123,7 @@ impl StateStore for IndexeddbStore {
     async fn get_state_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
         state_key: &str,
     ) -> StoreResult<Option<Raw<AnySyncStateEvent>>> {
         self.get_state_event(room_id, event_type, state_key).await.map_err(|e| e.into())
@@ -1131,7 +1132,7 @@ impl StateStore for IndexeddbStore {
     async fn get_state_events(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
     ) -> StoreResult<Vec<Raw<AnySyncStateEvent>>> {
         self.get_state_events(room_id, event_type).await.map_err(|e| e.into())
     }
@@ -1182,7 +1183,7 @@ impl StateStore for IndexeddbStore {
 
     async fn get_account_data_event(
         &self,
-        event_type: EventType,
+        event_type: GlobalAccountDataEventType,
     ) -> StoreResult<Option<Raw<AnyGlobalAccountDataEvent>>> {
         self.get_account_data_event(event_type).await.map_err(|e| e.into())
     }
@@ -1190,7 +1191,7 @@ impl StateStore for IndexeddbStore {
     async fn get_room_account_data_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: RoomAccountDataEventType,
     ) -> StoreResult<Option<Raw<AnyRoomAccountDataEvent>>> {
         self.get_room_account_data_event(room_id, event_type).await.map_err(|e| e.into())
     }

--- a/crates/matrix-sdk-sled/bin/state_inspector.rs
+++ b/crates/matrix-sdk-sled/bin/state_inspector.rs
@@ -4,7 +4,7 @@ use atty::Stream;
 use clap::{Arg, ArgMatches, Command as Argparse};
 use futures::executor::block_on;
 use matrix_sdk_base::{RoomInfo, Store};
-use matrix_sdk_common::ruma::{events::EventType, RoomId, UserId};
+use matrix_sdk_common::ruma::{events::StateEventType, RoomId, UserId};
 use matrix_sdk_sled::StateStore;
 use rustyline::{
     completion::{Completer, Pair},
@@ -228,7 +228,8 @@ impl Inspector {
             }
             Some(("get-state", args)) => {
                 let room_id = RoomId::parse(args.value_of("room-id").unwrap()).unwrap();
-                let event_type = EventType::try_from(args.value_of("event-type").unwrap()).unwrap();
+                let event_type =
+                    StateEventType::try_from(args.value_of("event-type").unwrap()).unwrap();
                 self.get_state(room_id, event_type).await;
             }
             _ => unreachable!(),
@@ -263,7 +264,7 @@ impl Inspector {
         }
     }
 
-    async fn get_state(&self, room_id: Box<RoomId>, event_type: EventType) {
+    async fn get_state(&self, room_id: Box<RoomId>, event_type: StateEventType) {
         self.printer.pretty_print_struct(
             &self.store.get_state_event(&room_id, event_type, "").await.unwrap(),
         );
@@ -288,7 +289,9 @@ impl Inspector {
                     RoomId::parse(r).map(|_| ()).map_err(|_| "Invalid room id given".to_owned())
                 }))
                 .arg(Arg::new("event-type").required(true).validator(|e| {
-                    EventType::try_from(e).map(|_| ()).map_err(|_| "Invalid event type".to_owned())
+                    StateEventType::try_from(e)
+                        .map(|_| ())
+                        .map_err(|_| "Invalid event type".to_owned())
                 })),
         ]
     }

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -42,7 +42,8 @@ use matrix_sdk_common::{
             receipt::Receipt,
             room::member::{MembershipState, RoomMemberEventContent},
             AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncMessageEvent,
-            AnySyncRoomEvent, AnySyncStateEvent, EventType,
+            AnySyncRoomEvent, AnySyncStateEvent, GlobalAccountDataEventType,
+            RoomAccountDataEventType, StateEventType,
         },
         receipt::ReceiptType,
         serde::Raw,
@@ -186,11 +187,23 @@ impl EncodeKey for (&str, &str, &str, &str) {
     }
 }
 
-impl EncodeKey for EventType {
+impl EncodeKey for StateEventType {
     fn encode(&self) -> Vec<u8> {
         self.as_str().encode()
     }
 }
+
+impl EncodeKey for GlobalAccountDataEventType {
+    fn encode(&self) -> Vec<u8> {
+        self.as_str().encode()
+    }
+}
+
+/* impl EncodeKey for RoomAccountDataEventType {
+    fn encode(&self) -> Vec<u8> {
+        self.as_str().encode()
+    }
+} */
 
 impl EncodeKey for EventId {
     fn encode(&self) -> Vec<u8> {
@@ -649,7 +662,7 @@ impl SledStore {
     pub async fn get_state_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>> {
         let db = self.clone();
@@ -663,7 +676,7 @@ impl SledStore {
     pub async fn get_state_events(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
     ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
         let db = self.clone();
         let key = (room_id.as_str(), event_type.as_str()).encode();
@@ -809,7 +822,7 @@ impl SledStore {
 
     pub async fn get_account_data_event(
         &self,
-        event_type: EventType,
+        event_type: GlobalAccountDataEventType,
     ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>> {
         let db = self.clone();
         let key = event_type.encode();
@@ -822,7 +835,7 @@ impl SledStore {
     pub async fn get_room_account_data_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: RoomAccountDataEventType,
     ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>> {
         let db = self.clone();
         let key = (room_id.as_str(), event_type.as_str()).encode();
@@ -1300,7 +1313,7 @@ impl StateStore for SledStore {
     async fn get_state_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
         state_key: &str,
     ) -> StoreResult<Option<Raw<AnySyncStateEvent>>> {
         self.get_state_event(room_id, event_type, state_key).await.map_err(Into::into)
@@ -1309,7 +1322,7 @@ impl StateStore for SledStore {
     async fn get_state_events(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: StateEventType,
     ) -> StoreResult<Vec<Raw<AnySyncStateEvent>>> {
         self.get_state_events(room_id, event_type).await.map_err(Into::into)
     }
@@ -1370,7 +1383,7 @@ impl StateStore for SledStore {
 
     async fn get_account_data_event(
         &self,
-        event_type: EventType,
+        event_type: GlobalAccountDataEventType,
     ) -> StoreResult<Option<Raw<AnyGlobalAccountDataEvent>>> {
         self.get_account_data_event(event_type).await.map_err(Into::into)
     }
@@ -1378,7 +1391,7 @@ impl StateStore for SledStore {
     async fn get_room_account_data_event(
         &self,
         room_id: &RoomId,
-        event_type: EventType,
+        event_type: RoomAccountDataEventType,
     ) -> StoreResult<Option<Raw<AnyRoomAccountDataEvent>>> {
         self.get_room_account_data_event(room_id, event_type).await.map_err(Into::into)
     }

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -1449,7 +1449,6 @@ struct TimelineMetadata {
 
 #[cfg(test)]
 mod test {
-
     use matrix_sdk_base::statestore_integration_tests;
 
     use super::{SledStore, StateStore, StoreResult};

--- a/crates/matrix-sdk/src/client.rs
+++ b/crates/matrix-sdk/src/client.rs
@@ -2362,7 +2362,7 @@ pub(crate) mod test {
                 message::{ImageMessageEventContent, RoomMessageEventContent},
                 ImageInfo,
             },
-            AnySyncStateEvent, EventType,
+            AnySyncStateEvent, StateEventType,
         },
         mxc_uri, room_id, thirdparty, uint, user_id, TransactionId, UserId,
     };
@@ -3844,14 +3844,14 @@ pub(crate) mod test {
 
         let room = client.get_joined_room(room_id).unwrap();
 
-        let state_events = room.get_state_events(EventType::RoomEncryption).await.unwrap();
+        let state_events = room.get_state_events(StateEventType::RoomEncryption).await.unwrap();
         assert_eq!(state_events.len(), 1);
 
         let state_events = room.get_state_events("m.custom.note".into()).await.unwrap();
         assert_eq!(state_events.len(), 2);
 
         let encryption_event = room
-            .get_state_event(EventType::RoomEncryption, "")
+            .get_state_event(StateEventType::RoomEncryption, "")
             .await
             .unwrap()
             .unwrap()

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -48,7 +48,7 @@ use ruma::{
         uiaa::AuthData,
     },
     assign,
-    events::{AnyMessageEvent, AnyRoomEvent, AnySyncMessageEvent, EventType},
+    events::{AnyMessageEvent, AnyRoomEvent, AnySyncMessageEvent, GlobalAccountDataEventType},
     serde::Raw,
     DeviceId, TransactionId, UserId,
 };
@@ -666,7 +666,7 @@ impl Client {
         // have with this user.
         let mut content = self
             .store()
-            .get_account_data_event(EventType::Direct)
+            .get_account_data_event(GlobalAccountDataEventType::Direct)
             .await?
             .map(|e| e.deserialize())
             .transpose()?

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -18,7 +18,7 @@ use ruma::{
     events::{
         room::history_visibility::HistoryVisibility,
         tag::{TagInfo, TagName},
-        AnyStateEvent, AnySyncStateEvent, EventType,
+        AnyStateEvent, AnySyncStateEvent, StateEventType,
     },
     serde::Raw,
     uint, EventId, RoomId, UInt, UserId,
@@ -640,7 +640,7 @@ impl Common {
     /// Get all state events of a given type in this room.
     pub async fn get_state_events(
         &self,
-        event_type: EventType,
+        event_type: StateEventType,
     ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
         self.client.store().get_state_events(self.room_id(), event_type).await.map_err(Into::into)
     }
@@ -648,7 +648,7 @@ impl Common {
     /// Get a specific state event in this room.
     pub async fn get_state_event(
         &self,
-        event_type: EventType,
+        event_type: StateEventType,
         state_key: &str,
     ) -> Result<Option<Raw<AnySyncStateEvent>>> {
         self.client


### PR DESCRIPTION
I'd like to remove the `EventType` enum from Ruma in the future, and we've had these more fine-grained types for a while, the right people just weren't aware of them it seems 😄 