### PR TITLE
Use customized device and cross signing key types.

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -26,7 +26,6 @@ use atomic::Atomic;
 use matrix_sdk_common::locks::Mutex;
 use ruma::{
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
-    encryption::DeviceKeys,
     events::{
         forwarded_room_key::ToDeviceForwardedRoomKeyEventContent,
         key::verification::VerificationMethod, room::encrypted::ToDeviceRoomEncryptedEventContent,
@@ -45,7 +44,7 @@ use crate::{
     identities::{ReadOnlyOwnUserIdentity, ReadOnlyUserIdentities},
     olm::{InboundGroupSession, Session, VerifyJson},
     store::{Changes, CryptoStore, DeviceChanges, Result as StoreResult},
-    types::one_time_keys::SignedKey,
+    types::{device_keys::DeviceKeys, one_time_keys::SignedKey},
     verification::VerificationMachine,
     OutgoingVerificationRequest, Sas, ToDeviceRequest, VerificationRequest,
 };
@@ -617,10 +616,9 @@ impl PartialEq for ReadOnlyDevice {
 pub(crate) mod testing {
     //! Testing Facilities for Device Management
     #![allow(dead_code)]
-    use ruma::encryption::DeviceKeys;
     use serde_json::json;
 
-    use crate::identities::ReadOnlyDevice;
+    use crate::{identities::ReadOnlyDevice, types::device_keys::DeviceKeys};
 
     /// Generate default DeviceKeys for tests
     pub fn device_keys() -> DeviceKeys {

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -35,7 +35,7 @@ use crate::{
     olm::PrivateCrossSigningIdentity,
     requests::KeysQueryRequest,
     store::{Changes, DeviceChanges, IdentityChanges, Result as StoreResult, Store},
-    types::device_keys::DeviceKeys,
+    types::{cross_signing_key::CrossSigningKey, device_keys::DeviceKeys},
     LocalTrust,
 };
 
@@ -331,12 +331,14 @@ impl IdentityManager {
         // TODO this is a bit chunky, refactor this into smaller methods.
 
         for (user_id, master_key) in &response.master_keys {
-            match master_key.deserialize() {
+            match master_key.deserialize_as::<CrossSigningKey>() {
                 Ok(master_key) => {
                     let master_key = MasterPubkey::from(master_key);
 
-                    let self_signing = if let Some(s) =
-                        response.self_signing_keys.get(user_id).and_then(|k| k.deserialize().ok())
+                    let self_signing = if let Some(s) = response
+                        .self_signing_keys
+                        .get(user_id)
+                        .and_then(|k| k.deserialize_as::<CrossSigningKey>().ok())
                     {
                         SelfSigningPubkey::from(s)
                     } else {
@@ -354,7 +356,7 @@ impl IdentityManager {
                                 let user_signing = if let Some(s) = response
                                     .user_signing_keys
                                     .get(user_id)
-                                    .and_then(|k| k.deserialize().ok())
+                                    .and_then(|k| k.deserialize_as::<CrossSigningKey>().ok())
                                 {
                                     UserSigningPubkey::from(s)
                                 } else {
@@ -378,7 +380,7 @@ impl IdentityManager {
                         if let Some(s) = response
                             .user_signing_keys
                             .get(user_id)
-                            .and_then(|k| k.deserialize().ok())
+                            .and_then(|k| k.deserialize_as::<CrossSigningKey>().ok())
                         {
                             let user_signing = UserSigningPubkey::from(s);
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -24,7 +24,7 @@ use std::{
 
 use ruma::{
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
-    encryption::{CrossSigningKey, DeviceKeys, KeyUsage},
+    encryption::{CrossSigningKey, KeyUsage},
     events::{
         key::verification::VerificationMethod, room::message::KeyVerificationRequestEventContent,
     },
@@ -40,6 +40,7 @@ use crate::{
     error::SignatureError,
     olm::VerifyJson,
     store::{Changes, IdentityChanges},
+    types::device_keys::DeviceKeys,
     verification::VerificationMachine,
     CryptoStoreError, OutgoingVerificationRequest, ReadOnlyDevice, VerificationRequest,
 };
@@ -950,9 +951,9 @@ pub(crate) mod testing {
     pub fn device(response: &KeyQueryResponse) -> (ReadOnlyDevice, ReadOnlyDevice) {
         let mut devices = response.device_keys.values().next().unwrap().values();
         let first =
-            ReadOnlyDevice::try_from(&devices.next().unwrap().deserialize().unwrap()).unwrap();
+            ReadOnlyDevice::try_from(&devices.next().unwrap().deserialize_as().unwrap()).unwrap();
         let second =
-            ReadOnlyDevice::try_from(&devices.next().unwrap().deserialize().unwrap()).unwrap();
+            ReadOnlyDevice::try_from(&devices.next().unwrap().deserialize_as().unwrap()).unwrap();
         (first, second)
     }
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -43,7 +43,6 @@ use ruma::{
         secret::request::SecretName,
         AnyRoomEvent, AnyToDeviceEvent, MessageEventContent,
     },
-    serde::Raw,
     DeviceId, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, RoomId, TransactionId,
     UInt, UserId,
 };
@@ -534,8 +533,7 @@ impl OlmMachine {
         if device_keys.is_none() && one_time_keys.is_empty() && fallback_keys.is_empty() {
             None
         } else {
-            let device_keys =
-                device_keys.map(|d| Raw::new(&d).expect("Coulnd't serialize device keys"));
+            let device_keys = device_keys.map(|d| d.to_raw());
 
             Some(assign!(upload_keys::v3::Request::new(), {
                 device_keys, one_time_keys, fallback_keys

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -29,7 +29,7 @@ use ruma::{
         upload_keys,
         upload_signatures::v3::{Request as SignatureUploadRequest, SignedKeys},
     },
-    encryption::{CrossSigningKey, DeviceKeys},
+    encryption::CrossSigningKey,
     events::{
         room::encrypted::{
             EncryptedEventScheme, OlmV1Curve25519AesSha2Content, ToDeviceRoomEncryptedEvent,
@@ -57,7 +57,10 @@ use crate::{
     identities::{MasterPubkey, ReadOnlyDevice},
     requests::UploadSigningKeysRequest,
     store::{Changes, Store},
-    types::one_time_keys::{OneTimeKey, SignedKey},
+    types::{
+        device_keys::DeviceKeys,
+        one_time_keys::{OneTimeKey, SignedKey},
+    },
     utilities::encode,
     CryptoStoreError, OlmError, SignatureError,
 };

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -23,7 +23,7 @@ use matrix_sdk_common::locks::Mutex;
 use pk_signing::{MasterSigning, PickledSignings, SelfSigning, Signing, SigningError, UserSigning};
 use ruma::{
     api::client::keys::upload_signatures::v3::{Request as SignatureUploadRequest, SignedKeys},
-    encryption::{DeviceKeys, KeyUsage},
+    encryption::KeyUsage,
     events::secret::request::SecretName,
     serde::Raw,
     UserId,
@@ -37,6 +37,7 @@ use crate::{
     identities::{MasterPubkey, SelfSigningPubkey, UserSigningPubkey},
     requests::UploadSigningKeysRequest,
     store::SecretImportError,
+    types::device_keys::DeviceKeys,
     OwnUserIdentity, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyOwnUserIdentity,
     ReadOnlyUserIdentity,
 };
@@ -444,7 +445,7 @@ impl PrivateCrossSigningIdentity {
             .await?;
 
         let mut user_signed_keys = SignedKeys::new();
-        user_signed_keys.add_device_keys(device_keys.device_id.clone(), Raw::new(device_keys)?);
+        user_signed_keys.add_device_keys(device_keys.device_id.clone(), device_keys.to_raw());
 
         let signed_keys = [((*self.user_id).to_owned(), user_signed_keys)].into();
         Ok(SignatureUploadRequest::new(signed_keys))

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -25,7 +25,6 @@ use ruma::{
     api::client::keys::upload_signatures::v3::{Request as SignatureUploadRequest, SignedKeys},
     encryption::KeyUsage,
     events::secret::request::SecretName,
-    serde::Raw,
     UserId,
 };
 use serde::{Deserialize, Serialize};
@@ -406,7 +405,7 @@ impl PrivateCrossSigningIdentity {
                 .get_first_key()
                 .ok_or(SignatureError::MissingSigningKey)?
                 .into(),
-            Raw::new(&master_key)?,
+            master_key.to_raw(),
         );
 
         let signed_keys = [(user_identity.user_id().to_owned(), user_signed_keys)].into();
@@ -624,13 +623,13 @@ impl PrivateCrossSigningIdentity {
     /// identity.
     pub(crate) async fn as_upload_request(&self) -> UploadSigningKeysRequest {
         let master_key =
-            self.master_key.lock().await.as_ref().map(|k| k.public_key.to_owned().into());
+            self.master_key.lock().await.as_ref().map(|k| k.public_key.as_ref().clone());
 
         let user_signing_key =
-            self.user_signing_key.lock().await.as_ref().map(|k| k.public_key.to_owned().into());
+            self.user_signing_key.lock().await.as_ref().map(|k| k.public_key.as_ref().clone());
 
         let self_signing_key =
-            self.self_signing_key.lock().await.as_ref().map(|k| k.public_key.to_owned().into());
+            self.self_signing_key.lock().await.as_ref().map(|k| k.public_key.as_ref().clone());
 
         UploadSigningKeysRequest { master_key, self_signing_key, user_signing_key }
     }

--- a/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
@@ -15,7 +15,7 @@
 use std::{collections::BTreeMap, convert::TryInto, sync::Arc};
 
 use ruma::{
-    encryption::{CrossSigningKey, CrossSigningKeySignatures, DeviceKeys, KeyUsage},
+    encryption::{CrossSigningKey, CrossSigningKeySignatures, KeyUsage},
     serde::CanonicalJsonValue,
     DeviceId, DeviceKeyAlgorithm, DeviceKeyId, UserId,
 };
@@ -27,6 +27,7 @@ use vodozemac::{Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, KeyError};
 use crate::{
     error::SignatureError,
     identities::{MasterPubkey, SelfSigningPubkey, UserSigningPubkey},
+    types::device_keys::DeviceKeys,
     utilities::{encode, DecodeError},
     ReadOnlyUserIdentity,
 };

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -29,13 +29,14 @@ use ruma::{
         message::send_message_event::v3::Response as RoomMessageResponse,
         to_device::send_event_to_device::v3::Response as ToDeviceResponse,
     },
-    encryption::CrossSigningKey,
     events::{AnyMessageEventContent, AnyToDeviceEventContent, EventContent, ToDeviceEventType},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
     DeviceId, RoomId, TransactionId, UserId,
 };
 use serde::{Deserialize, Serialize};
+
+use crate::types::cross_signing_key::CrossSigningKey;
 
 /// Customized version of
 /// `ruma_client_api::to_device::send_event_to_device::v3::Request`

--- a/crates/matrix-sdk-crypto/src/types/cross_signing_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing_key.rs
@@ -1,0 +1,107 @@
+// Copyright 2021 Devin Ragotzy.
+// Copyright 2021 Timo Kosters.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+use std::collections::BTreeMap;
+
+use ruma::{encryption::KeyUsage, serde::Raw, DeviceKeyId, UserId};
+use serde::{Deserialize, Serialize};
+use serde_json::{value::to_raw_value, Value};
+
+/// Signatures for a `CrossSigningKey` object.
+pub type CrossSigningKeySignatures = BTreeMap<Box<UserId>, BTreeMap<Box<DeviceKeyId>, String>>;
+
+/// A cross signing key.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CrossSigningKey {
+    /// The ID of the user the key belongs to.
+    pub user_id: Box<UserId>,
+
+    /// What the key is used for.
+    pub usage: Vec<KeyUsage>,
+
+    /// The public key.
+    ///
+    /// The object must have exactly one property.
+    pub keys: BTreeMap<Box<DeviceKeyId>, String>,
+
+    /// Signatures of the key.
+    ///
+    /// Only optional for master key.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub signatures: CrossSigningKeySignatures,
+
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+impl CrossSigningKey {
+    /// Creates a new `CrossSigningKey` with the given user ID, usage, keys and
+    /// signatures.
+    pub fn new(
+        user_id: Box<UserId>,
+        usage: Vec<KeyUsage>,
+        keys: BTreeMap<Box<DeviceKeyId>, String>,
+        signatures: CrossSigningKeySignatures,
+    ) -> Self {
+        Self { user_id, usage, keys, signatures, other: BTreeMap::new() }
+    }
+
+    /// Serialize the cross signing key into a Raw version.
+    pub fn to_raw<T>(&self) -> Raw<T> {
+        Raw::from_json(to_raw_value(&self).expect("Coulnd't serialize cross signing keys"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ruma::user_id;
+    use serde_json::json;
+
+    use super::CrossSigningKey;
+
+    #[test]
+    fn serialization() {
+        let json = json!({
+            "user_id": "@example:localhost",
+              "usage": [
+                "master"
+              ],
+              "keys": {
+                "ed25519:rJ2TAGkEOP6dX41Ksll6cl8K3J48l8s/59zaXyvl2p0": "rJ2TAGkEOP6dX41Ksll6cl8K3J48l8s/59zaXyvl2p0"
+              },
+              "signatures": {
+                "@example:localhost": {
+                  "ed25519:WSKKLTJZCL": "ZzJp1wtmRdykXAUEItEjNiFlBrxx8L6/Vaen9am8AuGwlxxJtOkuY4m+4MPLvDPOgavKHLsrRuNLAfCeakMlCQ"
+                }
+              },
+              "other_data": "other"
+        });
+
+        let key: CrossSigningKey =
+            serde_json::from_value(json.clone()).expect("Can't deserialize cross signing key");
+
+        assert_eq!(key.user_id, user_id!("@example:localhost"));
+
+        let serialized = serde_json::to_value(key).expect("Can't reserialize cross signing key");
+
+        assert_eq!(json, serialized);
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/cross_signing_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing_key.rs
@@ -1,5 +1,5 @@
 // Copyright 2021 Devin Ragotzy.
-// Copyright 2021 Timo Kosters.
+// Copyright 2021 Timo Kösters.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod device_keys;
 pub mod one_time_keys;

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod cross_signing_key;
 pub mod device_keys;
 pub mod one_time_keys;

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -742,13 +742,11 @@ impl Encryption {
 
         let (request, signature_request) = olm.bootstrap_cross_signing(false).await?;
 
-        let to_raw = |k| Raw::new(&k).expect("Can't serialize newly created cross signing keys");
-
         let request = assign!(UploadSigningKeysRequest::new(), {
             auth: auth_data,
-            master_key: request.master_key.map(to_raw),
-            self_signing_key: request.self_signing_key.map(to_raw),
-            user_signing_key: request.user_signing_key.map(to_raw),
+            master_key: request.master_key.map(|c| c.to_raw()),
+            self_signing_key: request.self_signing_key.map(|c| c.to_raw()),
+            user_signing_key: request.user_signing_key.map(|c| c.to_raw()),
         });
 
         self.client.send(request, None).await?;


### PR DESCRIPTION
This is a continuation from https://github.com/matrix-org/matrix-rust-sdk/commit/f4010b597f289e10481f4333a4ed9003833f0fc9. We're still not using vodozemac types in these types, this is a bit of a far reaching change and will come in a separate PR.