### PR TITLE
store: Make sure that event position in store is contiguous

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -616,7 +616,7 @@ impl IndexeddbStore {
                     TimelineMetadata {
                         start: timeline.start.clone(),
                         end: timeline.end.clone(),
-                        start_position: usize::MAX / 2,
+                        start_position: usize::MAX / 2 + 1,
                         end_position: usize::MAX / 2,
                     }
                 };

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -1211,7 +1211,7 @@ impl SledStore {
                 TimelineMetadata {
                     start: timeline.start.clone(),
                     end: timeline.end.clone(),
-                    start_position: usize::MAX / 2,
+                    start_position: usize::MAX / 2 + 1,
                     end_position: usize::MAX / 2,
                 }
             };


### PR DESCRIPTION
This fixes the breaking gap in the timeline when reading the events from
store.