### PR TITLE
fix(crypto-ffi): Rename the error message field for MigrationError

### DIFF
--- a/crates/matrix-crypto-ffi/src/lib.rs
+++ b/crates/matrix-crypto-ffi/src/lib.rs
@@ -123,16 +123,16 @@ pub struct PickledInboundGroupSession {
 #[derive(thiserror::Error, Debug)]
 pub enum MigrationError {
     /// Generic catch all error variant.
-    #[error("error migrating database: {message}")]
+    #[error("error migrating database: {error_message}")]
     Generic {
         /// The error message
-        message: String,
+        error_message: String,
     },
 }
 
 impl From<anyhow::Error> for MigrationError {
     fn from(e: anyhow::Error) -> MigrationError {
-        MigrationError::Generic { message: e.to_string() }
+        MigrationError::Generic { error_message: e.to_string() }
     }
 }
 

--- a/crates/matrix-crypto-ffi/src/olm.udl
+++ b/crates/matrix-crypto-ffi/src/olm.udl
@@ -11,7 +11,7 @@ namespace olm {
 
 [Error]
 interface MigrationError {
-  Generic(string message);
+  Generic(string error_message);
 };
 
 callback interface Logger {


### PR DESCRIPTION
The field is called message which clashes with the field of the same name in the Kotlin Exception class.