### PR TITLE
Handle redactions in BaseRoomInfo

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -8,15 +8,15 @@ pub use normal::{Room, RoomInfo, RoomType};
 use ruma::{
     events::{
         room::{
-            avatar::RoomAvatarEventContent, create::RoomCreateEventContent,
-            encryption::RoomEncryptionEventContent, guest_access::GuestAccess,
-            history_visibility::HistoryVisibility, join_rules::JoinRule,
+            avatar::RoomAvatarEventContent, canonical_alias::RoomCanonicalAliasEventContent,
+            create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
+            guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule,
             tombstone::RoomTombstoneEventContent,
         },
         AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
         RedactedEventContent, StateEventContent, StrippedStateEvent, SyncStateEvent,
     },
-    OwnedEventId, OwnedRoomAliasId, OwnedUserId,
+    OwnedEventId, OwnedUserId,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -111,7 +111,7 @@ pub struct BaseRoomInfo {
     /// The avatar URL of this room.
     avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
     /// The canonical alias of this room.
-    pub(crate) canonical_alias: Option<OwnedRoomAliasId>,
+    canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
     /// The `m.room.create` event content of this room.
     pub(crate) create: Option<RoomCreateEventContent>,
     /// A list of user ids this room is considered as direct message, if this
@@ -185,7 +185,7 @@ impl BaseRoomInfo {
                 self.join_rule = c.join_rule().clone();
             }
             AnySyncStateEvent::RoomCanonicalAlias(a) => {
-                self.canonical_alias = a.as_original().and_then(|a| a.content.alias.clone());
+                self.canonical_alias = Some(a.into());
             }
             AnySyncStateEvent::RoomTopic(t) => {
                 self.topic = t.as_original().map(|t| t.content.topic.clone());
@@ -234,7 +234,7 @@ impl BaseRoomInfo {
                 self.join_rule = c.content.join_rule.clone();
             }
             AnyStrippedStateEvent::RoomCanonicalAlias(a) => {
-                self.canonical_alias = a.content.alias.clone();
+                self.canonical_alias = Some(a.into());
             }
             AnyStrippedStateEvent::RoomTopic(t) => {
                 self.topic = Some(t.content.topic.clone());

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -113,7 +113,7 @@ pub struct BaseRoomInfo {
     /// The canonical alias of this room.
     canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
     /// The `m.room.create` event content of this room.
-    pub(crate) create: Option<RoomCreateEventContent>,
+    create: Option<MinimalStateEvent<RoomCreateEventContent>>,
     /// A list of user ids this room is considered as direct message, if this
     /// room is a DM.
     pub(crate) dm_targets: HashSet<OwnedUserId>,
@@ -170,8 +170,8 @@ impl BaseRoomInfo {
                 self.name =
                     n.as_original().and_then(|n| n.content.name.as_ref().map(|n| n.to_string()));
             }
-            AnySyncStateEvent::RoomCreate(SyncStateEvent::Original(c)) if self.create.is_none() => {
-                self.create = Some(c.content.clone());
+            AnySyncStateEvent::RoomCreate(c) if self.create.is_none() => {
+                self.create = Some(c.into());
             }
             AnySyncStateEvent::RoomHistoryVisibility(h) => {
                 self.history_visibility = h.history_visibility().clone();
@@ -222,7 +222,7 @@ impl BaseRoomInfo {
                 self.name = n.content.name.as_ref().map(|n| n.to_string());
             }
             AnyStrippedStateEvent::RoomCreate(c) if self.create.is_none() => {
-                self.create = Some(c.content.clone());
+                self.create = Some(c.into());
             }
             AnyStrippedStateEvent::RoomHistoryVisibility(h) => {
                 self.history_visibility = h.content.history_visibility.clone();

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -11,8 +11,8 @@ use ruma::{
             avatar::RoomAvatarEventContent, canonical_alias::RoomCanonicalAliasEventContent,
             create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
             guest_access::RoomGuestAccessEventContent,
-            history_visibility::RoomHistoryVisibilityEventContent, join_rules::JoinRule,
-            tombstone::RoomTombstoneEventContent,
+            history_visibility::RoomHistoryVisibilityEventContent,
+            join_rules::RoomJoinRulesEventContent, tombstone::RoomTombstoneEventContent,
         },
         AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
         RedactedEventContent, StateEventContent, StrippedStateEvent, SyncStateEvent,
@@ -125,7 +125,7 @@ pub struct BaseRoomInfo {
     /// The history visibility policy of this room.
     history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
     /// The join rule policy of this room.
-    pub(crate) join_rule: JoinRule,
+    join_rules: Option<MinimalStateEvent<RoomJoinRulesEventContent>>,
     /// The maximal power level that can be found in this room.
     pub(crate) max_power_level: i64,
     /// The `m.room.name` of this room.
@@ -181,7 +181,7 @@ impl BaseRoomInfo {
                 self.guest_access = Some(g.into());
             }
             AnySyncStateEvent::RoomJoinRules(c) => {
-                self.join_rule = c.join_rule().clone();
+                self.join_rules = Some(c.into());
             }
             AnySyncStateEvent::RoomCanonicalAlias(a) => {
                 self.canonical_alias = Some(a.into());
@@ -230,7 +230,7 @@ impl BaseRoomInfo {
                 self.guest_access = Some(g.into());
             }
             AnyStrippedStateEvent::RoomJoinRules(c) => {
-                self.join_rule = c.content.join_rule.clone();
+                self.join_rules = Some(c.into());
             }
             AnyStrippedStateEvent::RoomCanonicalAlias(a) => {
                 self.canonical_alias = Some(a.into());
@@ -265,7 +265,7 @@ impl Default for BaseRoomInfo {
             encryption: None,
             guest_access: None,
             history_visibility: None,
-            join_rule: JoinRule::Public,
+            join_rules: None,
             max_power_level: 100,
             name: None,
             tombstone: None,

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -8,15 +8,100 @@ pub use normal::{Room, RoomInfo, RoomType};
 use ruma::{
     events::{
         room::{
-            create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
-            guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule,
+            avatar::RoomAvatarEventContent, create::RoomCreateEventContent,
+            encryption::RoomEncryptionEventContent, guest_access::GuestAccess,
+            history_visibility::HistoryVisibility, join_rules::JoinRule,
             tombstone::RoomTombstoneEventContent,
         },
-        AnyStrippedStateEvent, AnySyncStateEvent, SyncStateEvent,
+        AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
+        RedactedEventContent, StateEventContent, StrippedStateEvent, SyncStateEvent,
     },
-    OwnedMxcUri, OwnedRoomAliasId, OwnedUserId,
+    OwnedEventId, OwnedRoomAliasId, OwnedUserId,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+// #[serde(bound)] instead of DeserializeOwned in type where clause does not
+// work, it can only be a single bound that replaces the default and if a helper
+// trait is used, the compiler still complains about Deserialize not being
+// implemented for C::Redacted.
+//
+// It is unclear why a Serialize bound on C::Redacted is not also required.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+enum MinimalStateEvent<C: StateEventContent<StateKey = EmptyStateKey> + RedactContent>
+where
+    C::Redacted:
+        StateEventContent<StateKey = EmptyStateKey> + RedactedEventContent + DeserializeOwned,
+{
+    Original(OriginalMinimalStateEvent<C>),
+    Redacted(RedactedMinimalStateEvent<C::Redacted>),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct OriginalMinimalStateEvent<C>
+where
+    C: StateEventContent<StateKey = EmptyStateKey>,
+{
+    content: C,
+    event_id: Option<OwnedEventId>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct RedactedMinimalStateEvent<C>
+where
+    C: StateEventContent<StateKey = EmptyStateKey> + RedactedEventContent,
+{
+    content: C,
+    event_id: Option<OwnedEventId>,
+}
+
+impl<C> MinimalStateEvent<C>
+where
+    C: StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+    C::Redacted:
+        StateEventContent<StateKey = EmptyStateKey> + RedactedEventContent + DeserializeOwned,
+{
+    fn as_original(&self) -> Option<&OriginalMinimalStateEvent<C>> {
+        match self {
+            MinimalStateEvent::Original(ev) => Some(ev),
+            MinimalStateEvent::Redacted(_) => None,
+        }
+    }
+}
+
+impl<C> From<&SyncStateEvent<C>> for MinimalStateEvent<C>
+where
+    C: Clone + StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+    C::Redacted: Clone
+        + StateEventContent<StateKey = EmptyStateKey>
+        + RedactedEventContent
+        + DeserializeOwned,
+{
+    fn from(ev: &SyncStateEvent<C>) -> Self {
+        match ev {
+            SyncStateEvent::Original(ev) => Self::Original(OriginalMinimalStateEvent {
+                content: ev.content.clone(),
+                event_id: Some(ev.event_id.clone()),
+            }),
+            SyncStateEvent::Redacted(ev) => Self::Redacted(RedactedMinimalStateEvent {
+                content: ev.content.clone(),
+                event_id: Some(ev.event_id.clone()),
+            }),
+        }
+    }
+}
+
+impl<C> From<&StrippedStateEvent<C>> for MinimalStateEvent<C>
+where
+    C: Clone + StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+    C::Redacted: Clone
+        + StateEventContent<StateKey = EmptyStateKey>
+        + RedactedEventContent
+        + DeserializeOwned,
+{
+    fn from(ev: &StrippedStateEvent<C>) -> Self {
+        Self::Original(OriginalMinimalStateEvent { content: ev.content.clone(), event_id: None })
+    }
+}
 
 /// A base room info struct that is the backbone of normal as well as stripped
 /// rooms. Holds all the state events that are important to present a room to
@@ -24,7 +109,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BaseRoomInfo {
     /// The avatar URL of this room.
-    pub(crate) avatar_url: Option<OwnedMxcUri>,
+    avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
     /// The canonical alias of this room.
     pub(crate) canonical_alias: Option<OwnedRoomAliasId>,
     /// The `m.room.create` event content of this room.
@@ -79,7 +164,7 @@ impl BaseRoomInfo {
                 self.encryption = Some(encryption.content.clone());
             }
             AnySyncStateEvent::RoomAvatar(a) => {
-                self.avatar_url = a.as_original().and_then(|a| a.content.url.clone());
+                self.avatar = Some(a.into());
             }
             AnySyncStateEvent::RoomName(n) => {
                 self.name =
@@ -131,7 +216,7 @@ impl BaseRoomInfo {
                 self.encryption = Some(encryption.content.clone());
             }
             AnyStrippedStateEvent::RoomAvatar(a) => {
-                self.avatar_url = a.content.url.clone();
+                self.avatar = Some(a.into());
             }
             AnyStrippedStateEvent::RoomName(n) => {
                 self.name = n.content.name.as_ref().map(|n| n.to_string());
@@ -174,7 +259,7 @@ impl BaseRoomInfo {
 impl Default for BaseRoomInfo {
     fn default() -> Self {
         Self {
-            avatar_url: None,
+            avatar: None,
             canonical_alias: None,
             create: None,
             dm_targets: Default::default(),

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -12,7 +12,8 @@ use ruma::{
             create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
             guest_access::RoomGuestAccessEventContent,
             history_visibility::RoomHistoryVisibilityEventContent,
-            join_rules::RoomJoinRulesEventContent, tombstone::RoomTombstoneEventContent,
+            join_rules::RoomJoinRulesEventContent, name::RoomNameEventContent,
+            tombstone::RoomTombstoneEventContent,
         },
         AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
         RedactedEventContent, StateEventContent, StrippedStateEvent, SyncStateEvent,
@@ -129,7 +130,7 @@ pub struct BaseRoomInfo {
     /// The maximal power level that can be found in this room.
     pub(crate) max_power_level: i64,
     /// The `m.room.name` of this room.
-    pub(crate) name: Option<String>,
+    name: Option<MinimalStateEvent<RoomNameEventContent>>,
     /// The `m.room.tombstone` event content of this room.
     pub(crate) tombstone: Option<RoomTombstoneEventContent>,
     /// The topic of this room.
@@ -168,8 +169,7 @@ impl BaseRoomInfo {
                 self.avatar = Some(a.into());
             }
             AnySyncStateEvent::RoomName(n) => {
-                self.name =
-                    n.as_original().and_then(|n| n.content.name.as_ref().map(|n| n.to_string()));
+                self.name = Some(n.into());
             }
             AnySyncStateEvent::RoomCreate(c) if self.create.is_none() => {
                 self.create = Some(c.into());
@@ -218,7 +218,7 @@ impl BaseRoomInfo {
                 self.avatar = Some(a.into());
             }
             AnyStrippedStateEvent::RoomName(n) => {
-                self.name = n.content.name.as_ref().map(|n| n.to_string());
+                self.name = Some(n.into());
             }
             AnyStrippedStateEvent::RoomCreate(c) if self.create.is_none() => {
                 self.create = Some(c.into());

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -10,8 +10,9 @@ use ruma::{
         room::{
             avatar::RoomAvatarEventContent, canonical_alias::RoomCanonicalAliasEventContent,
             create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
-            guest_access::RoomGuestAccessEventContent, history_visibility::HistoryVisibility,
-            join_rules::JoinRule, tombstone::RoomTombstoneEventContent,
+            guest_access::RoomGuestAccessEventContent,
+            history_visibility::RoomHistoryVisibilityEventContent, join_rules::JoinRule,
+            tombstone::RoomTombstoneEventContent,
         },
         AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
         RedactedEventContent, StateEventContent, StrippedStateEvent, SyncStateEvent,
@@ -122,7 +123,7 @@ pub struct BaseRoomInfo {
     /// The guest access policy of this room.
     guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
     /// The history visibility policy of this room.
-    pub(crate) history_visibility: HistoryVisibility,
+    history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
     /// The join rule policy of this room.
     pub(crate) join_rule: JoinRule,
     /// The maximal power level that can be found in this room.
@@ -174,7 +175,7 @@ impl BaseRoomInfo {
                 self.create = Some(c.into());
             }
             AnySyncStateEvent::RoomHistoryVisibility(h) => {
-                self.history_visibility = h.history_visibility().clone();
+                self.history_visibility = Some(h.into());
             }
             AnySyncStateEvent::RoomGuestAccess(g) => {
                 self.guest_access = Some(g.into());
@@ -223,7 +224,7 @@ impl BaseRoomInfo {
                 self.create = Some(c.into());
             }
             AnyStrippedStateEvent::RoomHistoryVisibility(h) => {
-                self.history_visibility = h.content.history_visibility.clone();
+                self.history_visibility = Some(h.into());
             }
             AnyStrippedStateEvent::RoomGuestAccess(g) => {
                 self.guest_access = Some(g.into());
@@ -263,7 +264,7 @@ impl Default for BaseRoomInfo {
             dm_targets: Default::default(),
             encryption: None,
             guest_access: None,
-            history_visibility: HistoryVisibility::WorldReadable,
+            history_visibility: None,
             join_rule: JoinRule::Public,
             max_power_level: 100,
             name: None,

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -10,8 +10,8 @@ use ruma::{
         room::{
             avatar::RoomAvatarEventContent, canonical_alias::RoomCanonicalAliasEventContent,
             create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
-            guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule,
-            tombstone::RoomTombstoneEventContent,
+            guest_access::RoomGuestAccessEventContent, history_visibility::HistoryVisibility,
+            join_rules::JoinRule, tombstone::RoomTombstoneEventContent,
         },
         AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
         RedactedEventContent, StateEventContent, StrippedStateEvent, SyncStateEvent,
@@ -120,7 +120,7 @@ pub struct BaseRoomInfo {
     /// The `m.room.encryption` event content that enabled E2EE in this room.
     pub(crate) encryption: Option<RoomEncryptionEventContent>,
     /// The guest access policy of this room.
-    pub(crate) guest_access: GuestAccess,
+    guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
     /// The history visibility policy of this room.
     pub(crate) history_visibility: HistoryVisibility,
     /// The join rule policy of this room.
@@ -177,9 +177,7 @@ impl BaseRoomInfo {
                 self.history_visibility = h.history_visibility().clone();
             }
             AnySyncStateEvent::RoomGuestAccess(g) => {
-                self.guest_access = g
-                    .as_original()
-                    .map_or(GuestAccess::Forbidden, |g| g.content.guest_access.clone());
+                self.guest_access = Some(g.into());
             }
             AnySyncStateEvent::RoomJoinRules(c) => {
                 self.join_rule = c.join_rule().clone();
@@ -228,7 +226,7 @@ impl BaseRoomInfo {
                 self.history_visibility = h.content.history_visibility.clone();
             }
             AnyStrippedStateEvent::RoomGuestAccess(g) => {
-                self.guest_access = g.content.guest_access.clone();
+                self.guest_access = Some(g.into());
             }
             AnyStrippedStateEvent::RoomJoinRules(c) => {
                 self.join_rule = c.content.join_rule.clone();
@@ -264,7 +262,7 @@ impl Default for BaseRoomInfo {
             create: None,
             dm_targets: Default::default(),
             encryption: None,
-            guest_access: GuestAccess::Forbidden,
+            guest_access: None,
             history_visibility: HistoryVisibility::WorldReadable,
             join_rule: JoinRule::Public,
             max_power_level: 100,

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -13,7 +13,7 @@ use ruma::{
             guest_access::RoomGuestAccessEventContent,
             history_visibility::RoomHistoryVisibilityEventContent,
             join_rules::RoomJoinRulesEventContent, name::RoomNameEventContent,
-            tombstone::RoomTombstoneEventContent,
+            tombstone::RoomTombstoneEventContent, topic::RoomTopicEventContent,
         },
         AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
         RedactedEventContent, StateEventContent, StrippedStateEvent, SyncStateEvent,
@@ -134,7 +134,7 @@ pub struct BaseRoomInfo {
     /// The `m.room.tombstone` event content of this room.
     tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
     /// The topic of this room.
-    pub(crate) topic: Option<String>,
+    topic: Option<MinimalStateEvent<RoomTopicEventContent>>,
 }
 
 impl BaseRoomInfo {
@@ -187,7 +187,7 @@ impl BaseRoomInfo {
                 self.canonical_alias = Some(a.into());
             }
             AnySyncStateEvent::RoomTopic(t) => {
-                self.topic = t.as_original().map(|t| t.content.topic.clone());
+                self.topic = Some(t.into());
             }
             AnySyncStateEvent::RoomTombstone(t) => {
                 self.tombstone = Some(t.into());
@@ -236,7 +236,7 @@ impl BaseRoomInfo {
                 self.canonical_alias = Some(a.into());
             }
             AnyStrippedStateEvent::RoomTopic(t) => {
-                self.topic = Some(t.content.topic.clone());
+                self.topic = Some(t.into());
             }
             AnyStrippedStateEvent::RoomTombstone(t) => {
                 self.tombstone = Some(t.into());

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -132,7 +132,7 @@ pub struct BaseRoomInfo {
     /// The `m.room.name` of this room.
     name: Option<MinimalStateEvent<RoomNameEventContent>>,
     /// The `m.room.tombstone` event content of this room.
-    pub(crate) tombstone: Option<RoomTombstoneEventContent>,
+    tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
     /// The topic of this room.
     pub(crate) topic: Option<String>,
 }
@@ -190,7 +190,7 @@ impl BaseRoomInfo {
                 self.topic = t.as_original().map(|t| t.content.topic.clone());
             }
             AnySyncStateEvent::RoomTombstone(t) => {
-                self.tombstone = t.as_original().map(|t| t.content.clone());
+                self.tombstone = Some(t.into());
             }
             AnySyncStateEvent::RoomPowerLevels(p) => {
                 self.max_power_level = p
@@ -239,7 +239,7 @@ impl BaseRoomInfo {
                 self.topic = Some(t.content.topic.clone());
             }
             AnyStrippedStateEvent::RoomTombstone(t) => {
-                self.tombstone = Some(t.content.clone());
+                self.tombstone = Some(t.into());
             }
             AnyStrippedStateEvent::RoomPowerLevels(p) => {
                 self.max_power_level = p

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -13,12 +13,13 @@ use ruma::{
             guest_access::RoomGuestAccessEventContent,
             history_visibility::RoomHistoryVisibilityEventContent,
             join_rules::RoomJoinRulesEventContent, name::RoomNameEventContent,
-            tombstone::RoomTombstoneEventContent, topic::RoomTopicEventContent,
+            redaction::OriginalSyncRoomRedactionEvent, tombstone::RoomTombstoneEventContent,
+            topic::RoomTopicEventContent,
         },
         AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
         RedactedEventContent, StateEventContent, StrippedStateEvent, SyncStateEvent,
     },
-    OwnedEventId, OwnedUserId,
+    EventId, OwnedEventId, OwnedUserId, RoomVersionId,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -58,14 +59,35 @@ where
 
 impl<C> MinimalStateEvent<C>
 where
-    C: StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+    C: Clone + StateEventContent<StateKey = EmptyStateKey> + RedactContent,
     C::Redacted:
         StateEventContent<StateKey = EmptyStateKey> + RedactedEventContent + DeserializeOwned,
 {
+    fn event_id(&self) -> Option<&EventId> {
+        match self {
+            MinimalStateEvent::Original(ev) => ev.event_id.as_deref(),
+            MinimalStateEvent::Redacted(ev) => ev.event_id.as_deref(),
+        }
+    }
+
     fn as_original(&self) -> Option<&OriginalMinimalStateEvent<C>> {
         match self {
             MinimalStateEvent::Original(ev) => Some(ev),
             MinimalStateEvent::Redacted(_) => None,
+        }
+    }
+
+    fn redact(&mut self, room_version: &RoomVersionId) -> bool {
+        match self {
+            MinimalStateEvent::Original(ev) => {
+                *self = MinimalStateEvent::Redacted(RedactedMinimalStateEvent {
+                    content: ev.content.clone().redact(room_version),
+                    event_id: ev.event_id.clone(),
+                });
+
+                true
+            }
+            MinimalStateEvent::Redacted(_) => false,
         }
     }
 }
@@ -252,6 +274,42 @@ impl BaseRoomInfo {
         }
 
         true
+    }
+
+    pub fn handle_redaction(&mut self, event: &OriginalSyncRoomRedactionEvent) -> bool {
+        let room_version = self
+            .create
+            .as_ref()
+            .and_then(|ev| Some(ev.as_original()?.content.room_version.to_owned()))
+            .unwrap_or(RoomVersionId::V1);
+
+        // This sometimes does more event_id comparisons than necessary, but the
+        // alternatives are a lot of verbosity, and a macro
+        redact_if_match(&mut self.avatar, &event.redacts, &room_version)
+            || redact_if_match(&mut self.canonical_alias, &event.redacts, &room_version)
+            || redact_if_match(&mut self.create, &event.redacts, &room_version)
+            || redact_if_match(&mut self.guest_access, &event.redacts, &room_version)
+            || redact_if_match(&mut self.history_visibility, &event.redacts, &room_version)
+            || redact_if_match(&mut self.join_rules, &event.redacts, &room_version)
+            || redact_if_match(&mut self.name, &event.redacts, &room_version)
+            || redact_if_match(&mut self.tombstone, &event.redacts, &room_version)
+            || redact_if_match(&mut self.topic, &event.redacts, &room_version)
+    }
+}
+
+fn redact_if_match<C>(
+    ev: &mut Option<MinimalStateEvent<C>>,
+    event_id: &EventId,
+    room_version: &RoomVersionId,
+) -> bool
+where
+    C: Clone + StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+    C::Redacted:
+        StateEventContent<StateKey = EmptyStateKey> + RedactedEventContent + DeserializeOwned,
+{
+    match ev {
+        Some(ev) if ev.event_id() == Some(event_id) => ev.redact(room_version),
+        _ => false,
     }
 }
 

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -218,7 +218,7 @@ impl Room {
 
     /// Get the history visibility policy of this room.
     pub fn history_visibility(&self) -> HistoryVisibility {
-        self.inner.read().unwrap().base_info.history_visibility.clone()
+        self.inner.read().unwrap().history_visibility().clone()
     }
 
     /// Is the room considered to be public.
@@ -734,6 +734,13 @@ impl RoomInfo {
         match &self.base_info.guest_access {
             Some(MinimalStateEvent::Original(ev)) => &ev.content.guest_access,
             _ => &GuestAccess::Forbidden,
+        }
+    }
+
+    fn history_visibility(&self) -> &HistoryVisibility {
+        match &self.base_info.history_visibility {
+            Some(MinimalStateEvent::Original(ev)) => &ev.content.history_visibility,
+            _ => &HistoryVisibility::WorldReadable,
         }
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -251,7 +251,7 @@ impl Room {
 
     /// Get the `m.room.tombstone` content of this room if there is one.
     pub fn tombstone(&self) -> Option<RoomTombstoneEventContent> {
-        self.inner.read().unwrap().base_info.tombstone.clone()
+        self.inner.read().unwrap().tombstone().cloned()
     }
 
     /// Get the topic of the room.
@@ -753,5 +753,9 @@ impl RoomInfo {
 
     fn name(&self) -> Option<&str> {
         Some(self.base_info.name.as_ref()?.as_original()?.content.name.as_ref()?.as_ref())
+    }
+
+    fn tombstone(&self) -> Option<&RoomTombstoneEventContent> {
+        Some(&self.base_info.tombstone.as_ref()?.as_original()?.content)
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -168,7 +168,7 @@ impl Room {
 
     /// Get the avatar url of this room.
     pub fn avatar_url(&self) -> Option<OwnedMxcUri> {
-        self.inner.read().unwrap().base_info.avatar_url.clone()
+        self.inner.read().unwrap().base_info.avatar.as_ref()?.as_original()?.content.url.clone()
     }
 
     /// Get the canonical alias of this room.

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -228,7 +228,7 @@ impl Room {
 
     /// Get the join rule policy of this room.
     pub fn join_rule(&self) -> JoinRule {
-        self.inner.read().unwrap().base_info.join_rule.clone()
+        self.inner.read().unwrap().join_rule().clone()
     }
 
     /// Get the maximum power level that this room contains.
@@ -741,6 +741,13 @@ impl RoomInfo {
         match &self.base_info.history_visibility {
             Some(MinimalStateEvent::Original(ev)) => &ev.content.history_visibility,
             _ => &HistoryVisibility::WorldReadable,
+        }
+    }
+
+    fn join_rule(&self) -> &JoinRule {
+        match &self.base_info.join_rules {
+            Some(MinimalStateEvent::Original(ev)) => &ev.content.join_rule,
+            _ => &JoinRule::Public,
         }
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -256,7 +256,7 @@ impl Room {
 
     /// Get the topic of the room.
     pub fn topic(&self) -> Option<String> {
-        self.inner.read().unwrap().base_info.topic.clone()
+        self.inner.read().unwrap().topic().map(ToOwned::to_owned)
     }
 
     /// Calculate the canonical display name of the room, taking into account
@@ -757,5 +757,9 @@ impl RoomInfo {
 
     fn tombstone(&self) -> Option<&RoomTombstoneEventContent> {
         Some(&self.base_info.tombstone.as_ref()?.as_original()?.content)
+    }
+
+    fn topic(&self) -> Option<&str> {
+        Some(&self.base_info.topic.as_ref()?.as_original()?.content.topic)
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -213,7 +213,7 @@ impl Room {
 
     /// Get the guest access policy of this room.
     pub fn guest_access(&self) -> GuestAccess {
-        self.inner.read().unwrap().base_info.guest_access.clone()
+        self.inner.read().unwrap().guest_access().clone()
     }
 
     /// Get the history visibility policy of this room.
@@ -728,5 +728,12 @@ impl RoomInfo {
             MinimalStateEvent::Original(ev) => &ev.content.creator,
             MinimalStateEvent::Redacted(ev) => &ev.content.creator,
         })
+    }
+
+    fn guest_access(&self) -> &GuestAccess {
+        match &self.base_info.guest_access {
+            Some(MinimalStateEvent::Original(ev)) => &ev.content.guest_access,
+            _ => &GuestAccess::Forbidden,
+        }
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -43,7 +43,7 @@ use ruma::{
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 
-use super::{BaseRoomInfo, RoomMember};
+use super::{BaseRoomInfo, MinimalStateEvent, RoomMember};
 use crate::{
     deserialized_responses::{SyncRoomEvent, TimelineSlice, UnreadNotificationsCount},
     store::{Result as StoreResult, StateStore},
@@ -139,10 +139,7 @@ impl Room {
 
     /// Whether this room's [`RoomType`](CreateRoomType) is `m.space`.
     pub fn is_space(&self) -> bool {
-        match self.inner.read().unwrap().base_info.create.as_ref() {
-            Some(create) => create.room_type == Some(CreateRoomType::Space),
-            None => false,
-        }
+        self.inner.read().unwrap().room_type().map_or(false, |t| *t == CreateRoomType::Space)
     }
 
     /// Get the unread notification counts.
@@ -181,8 +178,11 @@ impl Room {
     /// This usually isn't optional but some servers might not send an
     /// `m.room.create` event as the first event for a given room, thus this can
     /// be optional.
+    ///
+    /// It can also be redacted in current room versions, leaving only the
+    /// `creator` field.
     pub fn create_content(&self) -> Option<RoomCreateEventContent> {
-        self.inner.read().unwrap().base_info.create.clone()
+        Some(self.inner.read().unwrap().base_info.create.as_ref()?.as_original()?.content.clone())
     }
 
     /// Is this room considered a direct message.
@@ -406,15 +406,8 @@ impl Room {
             self.store.get_presence_event(user_id).await?.and_then(|e| e.deserialize().ok());
         let profile = self.store.get_profile(self.room_id(), user_id).await?;
         let max_power_level = self.max_power_level();
-        let is_room_creator = self
-            .inner
-            .read()
-            .unwrap()
-            .base_info
-            .create
-            .as_ref()
-            .map(|c| c.creator == user_id)
-            .unwrap_or(false);
+        let is_room_creator =
+            self.inner.read().unwrap().creator().map(|c| c == user_id).unwrap_or(false);
 
         let power =
             self.store
@@ -722,6 +715,18 @@ impl RoomInfo {
 
     /// Get the room version of this room.
     pub fn room_version(&self) -> Option<&RoomVersionId> {
-        self.base_info.create.as_ref().map(|c| &c.room_version)
+        Some(&self.base_info.create.as_ref()?.as_original()?.content.room_version)
+    }
+
+    /// Get the room type of this room.
+    pub fn room_type(&self) -> Option<&CreateRoomType> {
+        self.base_info.create.as_ref()?.as_original()?.content.room_type.as_ref()
+    }
+
+    fn creator(&self) -> Option<&UserId> {
+        Some(match self.base_info.create.as_ref()? {
+            MinimalStateEvent::Original(ev) => &ev.content.creator,
+            MinimalStateEvent::Redacted(ev) => &ev.content.creator,
+        })
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -241,7 +241,7 @@ impl Room {
 
     /// Get the `m.room.name` of this room.
     pub fn name(&self) -> Option<String> {
-        self.inner.read().unwrap().base_info.name.clone()
+        self.inner.read().unwrap().name().map(ToOwned::to_owned)
     }
 
     /// Has the room been tombstoned.
@@ -331,7 +331,7 @@ impl Room {
         let summary = {
             let inner = self.inner.read().unwrap();
 
-            if let Some(name) = &inner.base_info.name {
+            if let Some(name) = &inner.name() {
                 let name = name.trim();
                 return Ok(name.to_owned());
             } else if let Some(alias) = inner.canonical_alias() {
@@ -749,5 +749,9 @@ impl RoomInfo {
             Some(MinimalStateEvent::Original(ev)) => &ev.content.join_rule,
             _ => &JoinRule::Public,
         }
+    }
+
+    fn name(&self) -> Option<&str> {
+        Some(self.base_info.name.as_ref()?.as_original()?.content.name.as_ref()?.as_ref())
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -29,7 +29,7 @@ use ruma::{
         room::{
             create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
             guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule,
-            tombstone::RoomTombstoneEventContent,
+            redaction::OriginalSyncRoomRedactionEvent, tombstone::RoomTombstoneEventContent,
         },
         tag::Tags,
         AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnySyncStateEvent,
@@ -663,6 +663,13 @@ impl RoomInfo {
     /// Returns true if the event modified the info, false otherwise.
     pub fn handle_stripped_state_event(&mut self, event: &AnyStrippedStateEvent) -> bool {
         self.base_info.handle_stripped_state_event(event)
+    }
+
+    /// Handle the given redaction.
+    ///
+    /// Returns true if the event modified the info, false otherwise.
+    pub fn handle_redaction(&mut self, event: &OriginalSyncRoomRedactionEvent) -> bool {
+        self.base_info.handle_redaction(event)
     }
 
     /// Update the notifications count

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -354,9 +354,7 @@ impl MemoryStore {
             let make_room_version = || {
                 self.room_info
                     .get(room)
-                    .and_then(|info| {
-                        info.base_info.create.as_ref().map(|event| event.room_version.clone())
-                    })
+                    .and_then(|info| info.room_version().cloned())
                     .unwrap_or_else(|| {
                         warn!("Unable to find the room version for {}, assume version 9", room);
                         RoomVersionId::V9


### PR DESCRIPTION
Redacting a `m.room.create` or `m.room.encryption` event is rather suspicious and a known wart in the spec. I implemented things in what I think might be the most reasonable way:

For create events, ignore redactions of a create event we have previously seen but accept redacted create events if we haven't previously seen an unredacted one (and then don't accept further ones just like in the unredacted case).

For encryption events, ignore both redactions and incoming already-redacted events (the latter because they contain no data, so are useless).