### PR TITLE
Put timeline behind a feature-flag

### DIFF
--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -19,6 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 encryption = ["matrix-sdk-crypto"]
 qrcode = ["matrix-sdk-crypto/qrcode"]
+experimental-timeline = []
 
 # helpers for testing features build upon this
 testing = ["http"]

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -22,12 +22,14 @@ use std::{
 #[cfg(feature = "encryption")]
 use std::{ops::Deref, result::Result as StdResult};
 
+#[cfg(feature = "experimental-timeline")]
+use matrix_sdk_common::deserialized_responses::TimelineSlice;
 #[cfg(feature = "encryption")]
 use matrix_sdk_common::locks::Mutex;
 use matrix_sdk_common::{
     deserialized_responses::{
         AmbiguityChanges, JoinedRoom, LeftRoom, MembersResponse, Rooms, SyncResponse,
-        SyncRoomEvent, Timeline, TimelineSlice,
+        SyncRoomEvent, Timeline,
     },
     instant::Instant,
     locks::RwLock,
@@ -665,6 +667,8 @@ impl BaseClient {
             let notification_count = new_info.unread_notifications.into();
             room_info.update_notification_count(notification_count);
 
+            let mut changes = StateChanges::default();
+            #[cfg(feature = "experimental-timeline")]
             let timeline_slice = TimelineSlice::new(
                 timeline.events.clone(),
                 next_batch.clone(),
@@ -809,10 +813,10 @@ impl BaseClient {
     /// You should pass only slices requested from the store to this function.
     ///
     /// * `timeline` - The `TimelineSlice`
+    #[cfg(feature = "experimental-timeline")]
     pub async fn receive_messages(&self, room_id: &RoomId, timeline: TimelineSlice) -> Result<()> {
         let mut changes = StateChanges::default();
 
-        #[cfg(feature = "experimental-timeline")]
         changes.add_timeline(room_id, timeline);
 
         self.store().save_changes(&changes).await?;

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -667,7 +667,6 @@ impl BaseClient {
             let notification_count = new_info.unread_notifications.into();
             room_info.update_notification_count(notification_count);
 
-            let mut changes = StateChanges::default();
             #[cfg(feature = "experimental-timeline")]
             let timeline_slice = TimelineSlice::new(
                 timeline.events.clone(),

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -673,6 +673,7 @@ impl BaseClient {
                 true,
             );
 
+            #[cfg(feature = "experimental-timeline")]
             changes.add_timeline(&room_id, timeline_slice);
 
             new_rooms.join.insert(
@@ -795,6 +796,7 @@ impl BaseClient {
             }
         }
 
+        #[cfg(feature = "experimental-timeline")]
         for (room_id, timeline_slice) in &changes.timeline {
             if let Some(room) = self.store.get_room(room_id) {
                 room.add_timeline_slice(timeline_slice).await;
@@ -810,6 +812,7 @@ impl BaseClient {
     pub async fn receive_messages(&self, room_id: &RoomId, timeline: TimelineSlice) -> Result<()> {
         let mut changes = StateChanges::default();
 
+        #[cfg(feature = "experimental-timeline")]
         changes.add_timeline(room_id, timeline);
 
         self.store().save_changes(&changes).await?;

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -19,10 +19,11 @@
 
 pub use matrix_sdk_common::*;
 
+#[cfg(feature = "experimental-timeline")]
+pub use crate::timeline_stream::TimelineStreamError;
 pub use crate::{
     error::{Error, Result},
     session::Session,
-    timeline_stream::TimelineStreamError,
 };
 
 mod client;
@@ -31,6 +32,7 @@ pub mod media;
 mod rooms;
 mod session;
 pub mod store;
+#[cfg(feature = "experimental-timeline")]
 mod timeline_stream;
 
 pub use client::BaseClient;

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -58,7 +58,9 @@ pub struct Room {
     own_user_id: Arc<UserId>,
     inner: Arc<SyncRwLock<RoomInfo>>,
     store: Arc<dyn StateStore>,
+    #[cfg(feature = "experimental-timeline")]
     forward_timeline_streams: Arc<Mutex<Vec<mpsc::Sender<TimelineSlice>>>>,
+    #[cfg(feature = "experimental-timeline")]
     backward_timeline_streams: Arc<Mutex<Vec<mpsc::Sender<TimelineSlice>>>>,
 }
 
@@ -117,7 +119,9 @@ impl Room {
             room_id: room_info.room_id.clone(),
             store,
             inner: Arc::new(SyncRwLock::new(room_info)),
+            #[cfg(feature = "experimental-timeline")]
             forward_timeline_streams: Default::default(),
+            #[cfg(feature = "experimental-timeline")]
             backward_timeline_streams: Default::default(),
         }
     }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -484,6 +484,7 @@ impl Room {
 
     /// Get two stream into the timeline.
     /// First one is forward in time and the second one is backward in time.
+    #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(
         &self,
     ) -> StoreResult<(
@@ -522,6 +523,7 @@ impl Room {
     ///
     /// If you need also a backward stream you should use
     /// [`timeline`][`crate::Room::timeline`]
+    #[cfg(feature = "experimental-timeline")]
     pub async fn timeline_forward(&self) -> StoreResult<impl Stream<Item = SyncRoomEvent>> {
         let mut forward_timeline_streams = self.forward_timeline_streams.lock().await;
         let event_ids = Arc::new(DashSet::new());
@@ -537,6 +539,7 @@ impl Room {
     ///
     /// If you need also a forward stream you should use
     /// [`timeline`][`crate::Room::timeline`]
+    #[cfg(feature = "experimental-timeline")]
     pub async fn timeline_backward(
         &self,
     ) -> StoreResult<impl Stream<Item = Result<SyncRoomEvent, TimelineStreamError>>> {
@@ -558,6 +561,7 @@ impl Room {
     }
 
     /// Add a new timeline slice to the timeline streams.
+    #[cfg(feature = "experimental-timeline")]
     pub async fn add_timeline_slice(&self, timeline: &TimelineSlice) {
         if timeline.sync {
             let mut streams = self.forward_timeline_streams.lock().await;

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -33,17 +33,21 @@ macro_rules! statestore_integration_tests {
         $(
             mod $name {
 
+                #[cfg(feature = "experimental-timeline")]
                 use futures_util::StreamExt;
-                use matrix_sdk_test::{async_test, test_json};
+                #[cfg(feature = "experimental-timeline")]
                 use ruma::{
                     api::{
                         client::{
-                            media::get_content_thumbnail::v3::Method,
                             message::get_message_events::v3::Response as MessageResponse,
                             sync::sync_events::v3::Response as SyncResponse,
                         },
                         IncomingResponse,
-                    },
+                    }
+                };
+                use matrix_sdk_test::{async_test, test_json};
+                use ruma::{
+                    api::client::media::get_content_thumbnail::v3::Method,
                     device_id, event_id,
                     events::{
                         presence::PresenceEvent,
@@ -71,10 +75,13 @@ macro_rules! statestore_integration_tests {
 
                 use std::collections::{BTreeMap, BTreeSet};
 
+                #[cfg(feature = "experimental-timeline")]
                 use $crate::{
                     http::Response,
-                    RoomType, Session,
                     deserialized_responses::{ RoomEvent, SyncRoomEvent, TimelineSlice},
+                };
+                use $crate::{
+                    RoomType, Session,
                     media::{MediaFormat, MediaRequest, MediaThumbnailSize},
                     store::{
                         Store,

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -572,6 +572,7 @@ macro_rules! statestore_integration_tests {
                 }
 
                 #[async_test]
+                #[cfg(feature = "experimental-timeline")]
                 async fn test_room_timeline() {
                     let store = get_store().await.unwrap();
                     let mut stored_events = Vec::new();
@@ -699,6 +700,7 @@ macro_rules! statestore_integration_tests {
                     check_timeline_events(room_id, &store, &Vec::new(), end_token.as_deref()).await;
                 }
 
+                #[cfg(feature = "experimental-timeline")]
                 async fn check_timeline_events(
                     room_id: &RoomId,
                     store: &dyn StateStore,

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -85,6 +85,7 @@ pub struct MemoryStore {
     >,
     media: Arc<Mutex<LruCache<String, Vec<u8>>>>,
     custom: Arc<DashMap<Vec<u8>, Vec<u8>>>,
+    #[cfg(feature = "experimental-timeline")]
     room_timeline: Arc<DashMap<OwnedRoomId, TimelineData>>,
 }
 
@@ -118,6 +119,7 @@ impl MemoryStore {
             room_event_receipts: Default::default(),
             media: Arc::new(Mutex::new(LruCache::new(100))),
             custom: DashMap::new().into(),
+            #[cfg(feature = "experimental-timeline")]
             room_timeline: Default::default(),
         }
     }
@@ -300,6 +302,7 @@ impl MemoryStore {
             }
         }
 
+        #[cfg(feature = "experimental-timeline")]
         for (room, timeline) in &changes.timeline {
             if timeline.sync {
                 info!("Save new timeline batch from sync response for {}", room);
@@ -588,11 +591,14 @@ impl MemoryStore {
         self.stripped_members.remove(room_id);
         self.room_user_receipts.remove(room_id);
         self.room_event_receipts.remove(room_id);
+
+        #[cfg(feature = "experimental-timeline")]
         self.room_timeline.remove(room_id);
 
         Ok(())
     }
 
+    #[cfg(feature = "experimental-timeline")]
     async fn room_timeline(
         &self,
         room_id: &RoomId,
@@ -765,6 +771,7 @@ impl StateStore for MemoryStore {
         self.remove_room(room_id).await
     }
 
+    #[cfg(feature = "experimental-timeline")]
     async fn room_timeline(
         &self,
         room_id: &RoomId,

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "experimental-timeline")]
+use std::collections::{BTreeMap, HashMap};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::BTreeSet,
     sync::{Arc, RwLock},
 };
 
+#[cfg(feature = "experimental-timeline")]
 use async_stream::stream;
 use async_trait::async_trait;
 use dashmap::{DashMap, DashSet};
@@ -27,31 +30,30 @@ use ruma::{
     events::{
         presence::PresenceEvent,
         receipt::Receipt,
-        room::{
-            member::{
-                MembershipState, OriginalSyncRoomMemberEvent, RoomMemberEventContent,
-                StrippedRoomMemberEvent,
-            },
-            redaction::SyncRoomRedactionEvent,
+        room::member::{
+            MembershipState, OriginalSyncRoomMemberEvent, RoomMemberEventContent,
+            StrippedRoomMemberEvent,
         },
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncMessageLikeEvent, AnySyncRoomEvent, AnySyncStateEvent, GlobalAccountDataEventType,
-        RoomAccountDataEventType, StateEventType,
+        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
     },
     receipt::ReceiptType,
     serde::Raw,
+    EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
+};
+#[cfg(feature = "experimental-timeline")]
+use ruma::{
+    events::{room::redaction::SyncRoomRedactionEvent, AnySyncMessageLikeEvent, AnySyncRoomEvent},
     signatures::{redact_in_place, CanonicalJsonObject},
-    EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, RoomVersionId, UserId,
+    RoomVersionId,
 };
-#[allow(unused_imports)]
-use tracing::{info, warn};
 
-use super::{BoxStream, Result, RoomInfo, StateChanges, StateStore};
-use crate::{
-    deserialized_responses::SyncRoomEvent,
-    media::{MediaRequest, UniqueKey},
-    StoreError,
-};
+#[cfg(feature = "experimental-timeline")]
+use super::BoxStream;
+use super::{Result, RoomInfo, StateChanges, StateStore};
+use crate::media::{MediaRequest, UniqueKey};
+#[cfg(feature = "experimental-timeline")]
+use crate::{deserialized_responses::SyncRoomEvent, StoreError};
 
 /// In-Memory, non-persistent implementation of the `StateStore`
 ///
@@ -305,21 +307,24 @@ impl MemoryStore {
         #[cfg(feature = "experimental-timeline")]
         for (room, timeline) in &changes.timeline {
             if timeline.sync {
-                info!("Save new timeline batch from sync response for {}", room);
+                tracing::info!("Save new timeline batch from sync response for {}", room);
             } else {
-                info!("Save new timeline batch from messages response for {}", room);
+                tracing::info!("Save new timeline batch from messages response for {}", room);
             }
 
             let mut delete_timeline = false;
             if timeline.limited {
-                info!("Delete stored timeline for {} because the sync response was limited", room);
+                tracing::info!(
+                    "Delete stored timeline for {} because the sync response was limited",
+                    room
+                );
                 delete_timeline = true;
             } else if let Some(mut data) = self.room_timeline.get_mut(room) {
                 if !timeline.sync && Some(&timeline.start) != data.end.as_ref() {
                     // This should only happen when a developer adds a wrong timeline
                     // batch to the `StateChanges` or the server returns a wrong response
                     // to our request.
-                    warn!("Drop unexpected timeline batch for {}", room);
+                    tracing::warn!("Drop unexpected timeline batch for {}", room);
                     return Ok(());
                 }
 
@@ -343,7 +348,7 @@ impl MemoryStore {
             }
 
             if delete_timeline {
-                info!("Delete stored timeline for {} because of duplicated events", room);
+                tracing::info!("Delete stored timeline for {} because of duplicated events", room);
                 self.room_timeline.remove(room);
             }
 
@@ -361,7 +366,10 @@ impl MemoryStore {
                         info.base_info.create.as_ref().map(|event| event.room_version.clone())
                     })
                     .unwrap_or_else(|| {
-                        warn!("Unable to find the room version for {}, assume version 9", room);
+                        tracing::warn!(
+                            "Unable to find the room version for {}, assume version 9",
+                            room
+                        );
                         RoomVersionId::V9
                     })
             };
@@ -412,7 +420,7 @@ impl MemoryStore {
             }
         }
 
-        info!("Saved changes in {:?}", now.elapsed());
+        tracing::info!("Saved changes in {:?}", now.elapsed());
 
         Ok(())
     }
@@ -606,7 +614,7 @@ impl MemoryStore {
         let (events, end_token) = if let Some(data) = self.room_timeline.get(room_id) {
             (data.events.clone(), data.end.clone())
         } else {
-            info!("No timeline for {} was previously stored", room_id);
+            tracing::info!("No timeline for {} was previously stored", room_id);
             return Ok(None);
         };
 
@@ -616,7 +624,11 @@ impl MemoryStore {
             }
         };
 
-        info!("Found previously stored timeline for {}, with end token {:?}", room_id, end_token);
+        tracing::info!(
+            "Found previously stored timeline for {}, with end token {:?}",
+            room_id,
+            end_token
+        );
 
         Ok(Some((Box::pin(stream), end_token)))
     }

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -781,6 +781,7 @@ impl StateStore for MemoryStore {
 }
 
 #[derive(Debug, Default)]
+#[cfg(feature = "experimental-timeline")]
 struct TimelineData {
     pub start: String,
     pub start_position: isize,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -344,6 +344,7 @@ pub trait StateStore: AsyncTraitDeps {
     ///
     /// Returns a stream of events and a token that can be used to request
     /// previous events.
+    #[cfg(feature = "experimental-timeline")]
     async fn room_timeline(
         &self,
         room_id: &RoomId,
@@ -520,6 +521,7 @@ pub struct StateChanges {
     /// A map of `RoomId` to a vector of `Notification`s
     pub notifications: BTreeMap<OwnedRoomId, Vec<Notification>>,
     /// A mapping of `RoomId` to a `TimelineSlice`
+    #[cfg(feature = "experimental-timeline")]
     pub timeline: BTreeMap<OwnedRoomId, TimelineSlice>,
 }
 
@@ -605,6 +607,7 @@ impl StateChanges {
 
     /// Update the `StateChanges` struct with the given room with a new
     /// `TimelineSlice`.
+    #[cfg(feature = "experimental-timeline")]
     pub fn add_timeline(&mut self, room_id: &RoomId, timeline: TimelineSlice) {
         self.timeline.insert(room_id.to_owned(), timeline);
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -56,8 +56,9 @@ use ruma::{
 /// BoxStream of owned Types
 pub type BoxStream<T> = Pin<Box<dyn futures_util::Stream<Item = T> + Send>>;
 
+#[cfg(feature = "experimental-timeline")]
+use crate::deserialized_responses::{SyncRoomEvent, TimelineSlice};
 use crate::{
-    deserialized_responses::{SyncRoomEvent, TimelineSlice},
     media::MediaRequest,
     rooms::{RoomInfo, RoomType},
     Room, Session,

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = ["encryption"]
 encryption = ["matrix-sdk-base/encryption", "matrix-sdk-crypto"]
+experimental-timeline = ["matrix-sdk-base/experimental-timeline"]
 
 [package.metadata.docs.rs]
 default-target = "wasm32-unknown-unknown"

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [features]
 default = ["state-store", "crypto-store"]
+experimental-timeline = ["matrix-sdk-base/experimental-timeline"]
 
 state-store = ["matrix-sdk-base"]
 crypto-store = ["matrix-sdk-crypto"]

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -583,6 +583,7 @@ impl SledStore {
 
         ret?;
 
+        #[cfg(feature = "experimental-timeline")]
         self.save_room_timeline(changes).await?;
 
         self.inner.flush_async().await?;
@@ -970,6 +971,7 @@ impl SledStore {
 
         ret?;
 
+        #[cfg(feature = "experimental-timeline")]
         self.remove_room_timeline(room_id).await?;
 
         self.inner.flush_async().await?;
@@ -977,6 +979,7 @@ impl SledStore {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-timeline")]
     async fn room_timeline(
         &self,
         room_id: &RoomId,
@@ -1012,6 +1015,7 @@ impl SledStore {
         Ok(Some((Box::pin(stream), end_token)))
     }
 
+    #[cfg(feature = "experimental-timeline")]
     async fn remove_room_timeline(&self, room_id: &RoomId) -> Result<()> {
         info!("Remove stored timeline for {}", room_id);
 
@@ -1048,6 +1052,7 @@ impl SledStore {
         Ok(())
     }
 
+    #[cfg(feature = "experimental-timeline")]
     async fn save_room_timeline(&self, changes: &StateChanges) -> Result<()> {
         let mut timeline_batch = sled::Batch::default();
         let mut event_id_to_position_batch = sled::Batch::default();
@@ -1379,6 +1384,7 @@ impl StateStore for SledStore {
         self.remove_room(room_id).await.map_err(Into::into)
     }
 
+    #[cfg(feature = "experimental-timeline")]
     async fn room_timeline(
         &self,
         room_id: &RoomId,
@@ -1388,6 +1394,7 @@ impl StateStore for SledStore {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[cfg(feature = "experimental-timeline")]
 struct TimelineMetadata {
     pub start: String,
     pub start_position: usize,

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -39,6 +39,12 @@ appservice = ["ruma/appservice-api-s", "ruma/appservice-api-helper"]
 image-proc = ["image"]
 image-rayon = ["image-proc", "image/jpeg_rayon"]
 
+experimental-timeline = [
+    "matrix-sdk-base/experimental-timeline",
+    "matrix-sdk-indexeddb?/experimental-timeline",
+    "matrix-sdk-sled?/experimental-timeline",
+]
+
 docsrs = [
     "encryption",
     "sled-crypto-store",
@@ -151,4 +157,4 @@ required-features = ["encryption"]
 
 [[example]]
 name = "timeline"
-required-features = ["sled-state-store"]
+required-features = ["sled-state-store", "experimental-timeline"]

--- a/crates/matrix-sdk/examples/timeline.rs
+++ b/crates/matrix-sdk/examples/timeline.rs
@@ -41,7 +41,7 @@ fn event_content(event: AnySyncRoomEvent) -> Option<String> {
         None
     }
 }
-#[cfg(feature = "experimental-timeline")]
+
 async fn print_timeline(room: Room) {
     let backward_stream = room.timeline_backward().await.unwrap();
 

--- a/crates/matrix-sdk/examples/timeline.rs
+++ b/crates/matrix-sdk/examples/timeline.rs
@@ -41,6 +41,7 @@ fn event_content(event: AnySyncRoomEvent) -> Option<String> {
         None
     }
 }
+#[cfg(feature = "experimental-timeline")]
 async fn print_timeline(room: Room) {
     let backward_stream = room.timeline_backward().await.unwrap();
 

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -423,7 +423,7 @@ pub enum ClientBuildError {
     IndexeddbStore(#[from] matrix_sdk_indexeddb::OpenStoreError),
 
     /// Error opening the sled store.
-    #[cfg(any(feature = "sled-statehstore", feature = "sled-crypto-store"))]
+    #[cfg(any(feature = "sled-state-store", feature = "sled-crypto-store"))]
     #[error(transparent)]
     SledStore(#[from] matrix_sdk_sled::OpenStoreError),
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3775,6 +3775,7 @@ pub(crate) mod tests {
     // inconsistent manners, isn't activated.
     //#[async_test]
     #[allow(dead_code)]
+    #[cfg(feature = "experimental-timeline")]
     async fn room_timeline_with_remove() {
         let client = logged_in_client().await;
         let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -3898,7 +3899,9 @@ pub(crate) mod tests {
         mocked_messages.assert();
         mocked_messages_2.assert();
     }
+
     #[async_test]
+    #[cfg(feature = "experimental-timeline")]
     async fn room_timeline() {
         let client = logged_in_client().await;
         let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2250,6 +2250,7 @@ pub(crate) mod tests {
     use std::{collections::BTreeMap, convert::TryInto, io::Cursor, str::FromStr, time::Duration};
 
     use matrix_sdk_base::media::{MediaFormat, MediaRequest, MediaThumbnailSize};
+    #[cfg(feature = "experimental-timeline")]
     use matrix_sdk_common::deserialized_responses::SyncRoomEvent;
     use matrix_sdk_test::{test_json, EventBuilder, EventsJson};
     use mockito::{mock, Matcher};

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -262,6 +262,7 @@ impl Common {
     /// # Result::<_, matrix_sdk::Error>::Ok(())
     /// # });
     /// ```
+    #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(
         &self,
     ) -> Result<(impl Stream<Item = SyncRoomEvent>, impl Stream<Item = Result<SyncRoomEvent>>)>
@@ -330,7 +331,7 @@ impl Common {
     /// # Result::<_, matrix_sdk::Error>::Ok(())
     /// # });
     /// ```
-
+    #[cfg(feature = "experimental-timeline")]
     pub async fn timeline_forward(&self) -> Result<impl Stream<Item = SyncRoomEvent>> {
         Ok(self.inner.timeline_forward().await?)
     }
@@ -394,6 +395,7 @@ impl Common {
     /// # Result::<_, matrix_sdk::Error>::Ok(())
     /// # });
     /// ```
+    #[cfg(feature = "experimental-timeline")]
     pub async fn timeline_backward(&self) -> Result<impl Stream<Item = Result<SyncRoomEvent>>> {
         let backward_store = self.inner.timeline_backward().await?;
 
@@ -431,6 +433,7 @@ impl Common {
             false,
         );
 
+        #[cfg(feature = "experimental-timeline")]
         self.inner.add_timeline_slice(&timeline).await;
         self.client.base_client().receive_messages(self.room_id(), timeline).await?;
 


### PR DESCRIPTION
Feature-gated with `experimental-timeline` for base, sled, indexeddb and the main SDK-crates.

Note: this has to use weak dependencies in order to allow proper switching it on from the main crate.