### PR TITLE
Add support for eyre in the Store Error

### DIFF
--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = []
+default = ["anyhow"]
 e2e-encryption = ["matrix-sdk-crypto"]
 qrcode = ["matrix-sdk-crypto/qrcode"]
 
@@ -24,11 +24,12 @@ qrcode = ["matrix-sdk-crypto/qrcode"]
 testing = ["http"]
 
 [dependencies]
-anyhow = "1.0.57"
+anyhow = { version = "1.0.57", optional = true }
 async-stream = "0.3.3"
 async-trait = "0.1.53"
 chacha20poly1305 = { version = "0.9.0", optional = true }
 dashmap = "5.2.0"
+eyre = { version = "0.6.8", optional = true }
 futures-channel = "0.3.21"
 futures-core = "0.3.21"
 futures-util = { version = "0.3.21", default-features = false }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -71,9 +71,14 @@ pub use self::memory_store::MemoryStore;
 /// State store specific error type.
 #[derive(Debug, thiserror::Error)]
 pub enum StoreError {
+    #[cfg(feature = "anyhow")]
     #[error(transparent)]
     /// An error happened in the underlying database backend.
     Backend(#[from] anyhow::Error),
+    #[cfg(feature = "eyre")]
+    #[error(transparent)]
+    /// An error happened in the underlying database backend.
+    BackendEyre(#[from] eyre::Error),
     /// An error happened while serializing or deserializing some data.
     #[error(transparent)]
     Json(#[from] serde_json::Error),

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1.53"
 dashmap = "5.2.0"
 futures-core = "0.3.21"
 futures-util = { version = "0.3.21", default-features = false }
-matrix-sdk-base = { path = "../matrix-sdk-base", optional = true }
+matrix-sdk-base = { path = "../matrix-sdk-base", optional = true, features = ["anyhow"] }
 matrix-sdk-common = { path = "../matrix-sdk-common" }
 matrix-sdk-crypto = { path = "../matrix-sdk-crypto", optional = true }
 matrix-sdk-store-encryption = { path = "../matrix-sdk-store-encryption" }


### PR DESCRIPTION
Downstream applications may wish to implement their own StateStore/CryptoStore and may not use anyhow.

This PR adds optional support for eyre in the StoreError enum.
Additionally, it makes anyhow optional. It remains enabled by default to avoid a breaking change.