### PR TITLE
fix(sled): Fix the compilation if only the cryptostore is enabled

### DIFF
--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -10,7 +10,7 @@ default = ["state-store"]
 state-store = ["matrix-sdk-base"]
 crypto-store = [
     "matrix-sdk-crypto",
-    "matrix-sdk-base?/e2e-encryption",
+    "matrix-sdk-base/e2e-encryption",
 ]
 
 [dependencies]

--- a/crates/matrix-sdk-sled/src/lib.rs
+++ b/crates/matrix-sdk-sled/src/lib.rs
@@ -1,5 +1,7 @@
+#[cfg(any(feature = "state-store", feature = "crypto-store"))]
+use matrix_sdk_base::store::StoreConfig;
 #[cfg(feature = "state-store")]
-use matrix_sdk_base::store::{StoreConfig, StoreError};
+use matrix_sdk_base::store::StoreError;
 #[cfg(feature = "crypto-store")]
 use matrix_sdk_crypto::store::CryptoStoreError;
 use sled::Error as SledError;

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -185,6 +185,7 @@ fn run_crypto_tests() -> Result<()> {
     )
     .run()?;
     cmd!("rustup run stable cargo test -p matrix-sdk-crypto --features=backups_v1").run()?;
+    cmd!("rustup run stable cargo test -p matrix-crypto-ffi").run()?;
 
     Ok(())
 }


### PR DESCRIPTION
`make_store_config()` is enabled for both of the features we have in the sled crate, but `StoreConfig` was only imported if the `state-store` feature was enabled.

We're also building the `crypto-ffi` crate separately in the`xtask ci` target, which uses the sled store with the `crypto-store` feature, which makes sure we don't regress. Not sure if we want to add a separate `sled` target to `xtask`.