### PR TITLE
docs(sdk-base) Fix a typo in the `README.md`

### DIFF
--- a/crates/matrix-sdk-base/README.md
+++ b/crates/matrix-sdk-base/README.md
@@ -6,5 +6,5 @@ library.
 The following crate feature flags are available:
 
 * `encryption`: Enables end-to-end encryption support in the library.
-* `qrcode`: Enbles QRcode generation and reading code
-* `testing`: provides facilities and functions for tests, in particular for integration testing store implementations. ATTENTION: do not ever use outside of tests, we do not provide any stability warantees on these, these are merely helpers. If you find you _need_ any function provided here outside of tests, please open a Github Issue and inform us about your use case for us to consider.
+* `qrcode`: Enables QRcode generation and reading code.
+* `testing`: Provides facilities and functions for tests, in particular for integration testing store implementations. ATTENTION: do not ever use outside of tests, we do not provide any stability warantees on these, these are merely helpers. If you find you _need_ any function provided here outside of tests, please open a Github Issue and inform us about your use case for us to consider.


### PR DESCRIPTION
I've recently opened https://github.com/matrix-org/matrix-rust-sdk/pull/645. I may update this PR if I find other typos instead of opening a new PR everytime.