### PR TITLE
Use OnceCell to store server versions

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -118,6 +118,7 @@ optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-timer = "0.2.5"
+async-once-cell = "0.3.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -117,8 +117,8 @@ default-features = false
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-timer = "0.2.5"
 async-once-cell = "0.3.0"
+wasm-timer = "0.2.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -327,7 +327,7 @@ impl ClientBuilder {
         let server_versions = {
             let cell = async_once_cell::OnceCell::new();
             if let Some(server_versions) = self.server_versions {
-                cell.get_or_init(async move { server_versions.into() }).await;
+                cell.get_or_init(async move { server_versions }).await;
             }
             cell
         };

--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -114,7 +114,7 @@ impl HttpClient {
         &self,
         request: Request,
         config: Option<RequestConfig>,
-        server_versions: &[MatrixVersion],
+        server_versions: Arc<[MatrixVersion]>,
     ) -> Result<Request::IncomingResponse, HttpError>
     where
         Request: OutgoingRequest + Debug,
@@ -154,7 +154,7 @@ impl HttpClient {
             request.try_into_http_request::<BytesMut>(
                 &self.homeserver.read().await.to_string(),
                 send_access_token,
-                server_versions,
+                &server_versions,
             )?
         } else {
             let (send_access_token, user_id) = {
@@ -169,7 +169,7 @@ impl HttpClient {
                 &self.homeserver.read().await.to_string(),
                 send_access_token,
                 &user_id,
-                server_versions,
+                &server_versions,
             )?
         };
 

--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -114,7 +114,7 @@ impl HttpClient {
         &self,
         request: Request,
         config: Option<RequestConfig>,
-        server_versions: Arc<[MatrixVersion]>,
+        server_versions: &[MatrixVersion],
     ) -> Result<Request::IncomingResponse, HttpError>
     where
         Request: OutgoingRequest + Debug,
@@ -154,7 +154,7 @@ impl HttpClient {
             request.try_into_http_request::<BytesMut>(
                 &self.homeserver.read().await.to_string(),
                 send_access_token,
-                &server_versions,
+                server_versions,
             )?
         } else {
             let (send_access_token, user_id) = {
@@ -169,7 +169,7 @@ impl HttpClient {
                 &self.homeserver.read().await.to_string(),
                 send_access_token,
                 &user_id,
-                &server_versions,
+                server_versions,
             )?
         };
 


### PR DESCRIPTION
Since the server versions isn't modified we can use a OnceCell and
get rid of the Mutex.