### PR TITLE
[Breaking Change] Use boxed errors in StoreError

### DIFF
--- a/crates/matrix-crypto-ffi/src/machine.rs
+++ b/crates/matrix-crypto-ffi/src/machine.rs
@@ -5,7 +5,6 @@ use std::{
     ops::Deref,
 };
 
-use anyhow::anyhow;
 use base64::{decode_config, encode, STANDARD_NO_PAD};
 use js_int::UInt;
 use matrix_sdk_common::deserialized_responses::AlgorithmInfo;
@@ -102,9 +101,9 @@ impl OlmMachine {
                         // variant for the state store. Not sure what to do about
                         // this.
                         matrix_sdk_sled::OpenStoreError::Crypto(r) => r.into(),
-                        matrix_sdk_sled::OpenStoreError::Sled(s) => {
-                            CryptoStoreError::CryptoStore(anyhow!(s).into())
-                        }
+                        matrix_sdk_sled::OpenStoreError::Sled(s) => CryptoStoreError::CryptoStore(
+                            matrix_sdk_crypto::store::CryptoStoreError::Backend(Box::new(s)),
+                        ),
                         _ => unreachable!(),
                     }
                 })?,

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -25,7 +25,6 @@ experimental-timeline = []
 testing = ["http"]
 
 [dependencies]
-anyhow = "1.0.57"
 async-stream = "0.3.3"
 async-trait = "0.1.53"
 chacha20poly1305 = { version = "0.9.0", optional = true }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -75,7 +75,7 @@ pub use self::memory_store::MemoryStore;
 pub enum StoreError {
     #[error(transparent)]
     /// An error happened in the underlying database backend.
-    Backend(#[from] anyhow::Error),
+    Backend(#[from] Box<dyn std::error::Error + Send + Sync>),
     /// An error happened while serializing or deserializing some data.
     #[error(transparent)]
     Json(#[from] serde_json::Error),

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -27,7 +27,6 @@ testing = ["http"]
 [dependencies]
 aes = "0.8.1"
 aes-gcm = "0.9.4"
-anyhow = "1.0.57"
 atomic = "0.5.1"
 async-trait = "0.1.53"
 base64 = "0.13.0"

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -625,7 +625,7 @@ pub enum CryptoStoreError {
 
     /// A problem with the underlying database backend
     #[error(transparent)]
-    Backend(#[from] anyhow::Error),
+    Backend(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Trait abstracting a store that the `OlmMachine` uses to store cryptographic

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -95,7 +95,7 @@ impl From<SerializationError> for StoreError {
                     expected, found
                 )),
             },
-            _ => StoreError::Backend(anyhow!(e)),
+            _ => StoreError::Backend(Box::new(e)),
         }
     }
 }
@@ -307,7 +307,7 @@ impl IndexeddbStore {
             Some(ref cipher) => key.encode_to_range_secure(table_name, cipher),
             None => key.encode_to_range(),
         }
-        .map_err(|e| SerializationError::StoreError(StoreError::Backend(anyhow!(e))))
+        .map_err(|e| SerializationError::StoreError(StoreError::Backend(anyhow!(e).into())))
     }
 
     #[cfg(feature = "experimental-timeline")]

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -15,7 +15,6 @@ crypto-store = [
 experimental-timeline = ["matrix-sdk-base/experimental-timeline"]
 
 [dependencies]
-anyhow = "1.0.57"
 async-stream = "0.3.3"
 async-trait = "0.1.53"
 dashmap = "5.2.0"


### PR DESCRIPTION
Downstream applications may wish to implement their own StateStore/CryptoStore and may not use anyhow.

This commit switches the Database backend error from `anyhow::Error` to `Box<Error>`, which is more compatible with other rust error libraries.

### Migration Guide
If you are using anyhow or eyre, you need to map the error like this:

```rust
expr.map_err(|e| StoreError::Backend(e.into())
```

If your error types implement std::error::Error, you need to map the error like this:

```rust
expr.map_err(|e| StoreError::Backend(Box::new(e)))
```

Special thanks to @jplatte for the idea.

Replaces/Closes #643