### PR TITLE
DisplayName fixes

### DIFF
--- a/crates/matrix-sdk-appservice/src/lib.rs
+++ b/crates/matrix-sdk-appservice/src/lib.rs
@@ -593,7 +593,8 @@ pub(crate) fn transform_request_path(
                 };
 
                 if let Some(query) = uri.query() {
-                    path.push_str(&format!("?{}", query));
+                    path.push('?');
+                    path.push_str(query);
                 }
 
                 path

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -18,7 +18,7 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 
-/// The name of the room, either from the metadata or calculaetd
+/// The name of the room, either from the metadata or calculated
 /// according to [matrix specification](https://matrix.org/docs/spec/client_server/latest#calculating-the-display-name-for-a-room)
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum DisplayName {

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -32,8 +32,8 @@ compile_error!("'image-rayon' cannot be enabled on 'wasm32' arch");
 pub use async_trait::async_trait;
 pub use bytes;
 pub use matrix_sdk_base::{
-    media, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomType, Session,
-    StateChanges, StoreError,
+    media, DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomType,
+    Session, StateChanges, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;


### PR DESCRIPTION
- Fix a typo in its docs
- Reexport it from the sdk crate so it can be used.