### PR TITLE
feat(login): add support for email/3pid/phone-based login

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1274,6 +1274,7 @@ impl BaseClient {
         };
 
         Ok(Some(PushConditionRoomCtx {
+            user_id: user_id.to_owned(),
             room_id: room_id.to_owned(),
             member_count: UInt::new(member_count).unwrap_or(UInt::MAX),
             user_display_name,

--- a/crates/matrix-sdk/README.md
+++ b/crates/matrix-sdk/README.md
@@ -37,7 +37,7 @@ async fn main() -> anyhow::Result<()> {
     let client = Client::builder().user_id(alice).build().await?;
 
     // First we need to log in.
-    client.login(alice, "password", None, None).await?;
+    client.login_with_password(alice, "password", None, None).await?;
 
     client
         .register_event_handler(|ev: SyncRoomMessageEvent| async move {
@@ -59,19 +59,19 @@ More examples can be found in the [examples] directory.
 
 The following crate feature flags are available:
 
-| Feature             | Default | Description                                                           |
-| ------------------- | :-----: | --------------------------------------------------------------------- |
-| `anyhow`            |   No    | Better logging for event handlers that return `anyhow::Result`        |
-| `e2e-encryption`    |   Yes   | Enable End-to-end encryption support                                  |
-| `eyre`              |   No    | Better logging for event handlers that return `eyre::Result`          |
-| `image-proc`        |   No    | Enables image processing to generate thumbnails                       |
-| `image-rayon`       |   No    | Enables faster image processing                                       |
-| `markdown`          |   No    | Support to send Markdown-formatted messages                           |
-| `qrcode`            |   Yes   | QR code verification support                                          |
-| `sled`              |   Yes   | Persistent storage of state and E2EE-Data using sled (if `e2e-encryption` is activated)
-| `indexeddb`         |   No    | Persistent storage of state and E2EE-Data for browsers using indexeddb (if `e2e-encryption` is activated)
-| `socks`             |   No    | Enables SOCKS support in the default HTTP client, [`reqwest`]         |
-| `sso-login`         |   No    | Enables SSO login with a local HTTP server                            |
+| Feature          | Default | Description                                                                                               |
+| ---------------- | :-----: | --------------------------------------------------------------------------------------------------------- |
+| `anyhow`         |   No    | Better logging for event handlers that return `anyhow::Result`                                            |
+| `e2e-encryption` |   Yes   | Enable End-to-end encryption support                                                                      |
+| `eyre`           |   No    | Better logging for event handlers that return `eyre::Result`                                              |
+| `image-proc`     |   No    | Enables image processing to generate thumbnails                                                           |
+| `image-rayon`    |   No    | Enables faster image processing                                                                           |
+| `markdown`       |   No    | Support to send Markdown-formatted messages                                                               |
+| `qrcode`         |   Yes   | QR code verification support                                                                              |
+| `sled`           |   Yes   | Persistent storage of state and E2EE-Data using sled (if `e2e-encryption` is activated)                   |
+| `indexeddb`      |   No    | Persistent storage of state and E2EE-Data for browsers using indexeddb (if `e2e-encryption` is activated) |
+| `socks`          |   No    | Enables SOCKS support in the default HTTP client, [`reqwest`]                                             |
+| `sso-login`      |   No    | Enables SSO login with a local HTTP server                                                                |
 
 [`reqwest`]: https://docs.rs/reqwest/0.11.5/reqwest/index.html
 

--- a/crates/matrix-sdk/examples/autojoin.rs
+++ b/crates/matrix-sdk/examples/autojoin.rs
@@ -61,7 +61,7 @@ async fn login_and_sync(
 
     let client = client_builder.build().await?;
 
-    client.login(username, password, None, Some("autojoin bot")).await?;
+    client.login_with_password(username, password, None, Some("autojoin bot")).await?;
 
     println!("logged in as {}", username);
 

--- a/crates/matrix-sdk/examples/command_bot.rs
+++ b/crates/matrix-sdk/examples/command_bot.rs
@@ -55,7 +55,7 @@ async fn login_and_sync(
     }
 
     let client = client_builder.build().await.unwrap();
-    client.login(&username, &password, None, Some("command bot")).await?;
+    client.login_with_password(&username, &password, None, Some("command bot")).await?;
 
     println!("logged in as {}", username);
 

--- a/crates/matrix-sdk/examples/cross_signing_bootstrap.rs
+++ b/crates/matrix-sdk/examples/cross_signing_bootstrap.rs
@@ -45,7 +45,7 @@ async fn login(
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).await.unwrap();
 
-    let response = client.login(username, password, None, Some("rust-sdk")).await?;
+    let response = client.login_with_password(username, password, None, Some("rust-sdk")).await?;
 
     let user_id = &response.user_id;
     let client_ref = &client;

--- a/crates/matrix-sdk/examples/emoji_verification.rs
+++ b/crates/matrix-sdk/examples/emoji_verification.rs
@@ -73,7 +73,7 @@ async fn login(
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).await.unwrap();
 
-    client.login(username, password, None, Some("rust-sdk")).await?;
+    client.login_with_password(username, password, None, Some("rust-sdk")).await?;
 
     let client_ref = &client;
     let initial_sync = Arc::new(AtomicBool::from(true));

--- a/crates/matrix-sdk/examples/get_profiles.rs
+++ b/crates/matrix-sdk/examples/get_profiles.rs
@@ -39,7 +39,7 @@ async fn login(
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).await.unwrap();
 
-    client.login(username, password, None, Some("rust-sdk")).await?;
+    client.login_with_password(username, password, None, Some("rust-sdk")).await?;
 
     Ok(client)
 }

--- a/crates/matrix-sdk/examples/image_bot.rs
+++ b/crates/matrix-sdk/examples/image_bot.rs
@@ -60,7 +60,7 @@ async fn login_and_sync(
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).await.unwrap();
 
-    client.login(&username, &password, None, Some("command bot")).await?;
+    client.login_with_password(&username, &password, None, Some("command bot")).await?;
 
     client.sync_once(SyncSettings::default()).await.unwrap();
 

--- a/crates/matrix-sdk/examples/login.rs
+++ b/crates/matrix-sdk/examples/login.rs
@@ -40,7 +40,7 @@ async fn login(
 
     client.register_event_handler(on_room_message).await;
 
-    client.login(username, password, None, Some("rust-sdk")).await?;
+    client.login_with_password(username, password, None, Some("rust-sdk")).await?;
     client.sync(SyncSettings::new()).await;
 
     Ok(())

--- a/crates/matrix-sdk/examples/timeline.rs
+++ b/crates/matrix-sdk/examples/timeline.rs
@@ -27,7 +27,7 @@ async fn login(homeserver_url: String, username: &str, password: &str) -> Client
         .await
         .unwrap();
 
-    client.login(username, password, None, Some("rust-sdk")).await.unwrap();
+    client.login_with_password(username, password, None, Some("rust-sdk")).await.unwrap();
     client
 }
 

--- a/crates/matrix-sdk/examples/wasm_command_bot/src/lib.rs
+++ b/crates/matrix-sdk/examples/wasm_command_bot/src/lib.rs
@@ -85,7 +85,7 @@ pub async fn run() -> Result<JsValue, JsValue> {
     let homeserver_url = Url::parse(homeserver_url).unwrap();
     let client = Client::new(homeserver_url).await.unwrap();
 
-    client.login(username, password, None, Some("rust-sdk-wasm")).await.unwrap();
+    client.login_with_password(username, password, None, Some("rust-sdk-wasm")).await.unwrap();
 
     let bot = WasmBot(client.clone());
 

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -62,7 +62,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// let user = "example";
     /// let client = Client::new(homeserver).await?;
-    /// client.login(user, "password", None, None).await?;
+    /// client.login_with_password(user, "password", None, None).await?;
     ///
     /// if let Some(name) = client.account().get_display_name().await? {
     ///     println!("Logged in as user '{}' with display name '{}'", user, name);
@@ -87,7 +87,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// let user = "example";
     /// let client = Client::new(homeserver).await?;
-    /// client.login(user, "password", None, None).await?;
+    /// client.login_with_password(user, "password", None, None).await?;
     ///
     /// client.account().set_display_name(Some("Alice")).await?;
     /// # Result::<_, matrix_sdk::Error>::Ok(()) });
@@ -110,7 +110,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// # let user = "example";
     /// let client = Client::new(homeserver).await?;
-    /// client.login(user, "password", None, None).await?;
+    /// client.login_with_password(user, "password", None, None).await?;
     ///
     /// if let Some(url) = client.account().get_avatar_url().await? {
     ///     println!("Your avatar's mxc url is {}", url);
@@ -159,7 +159,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// # let user = "example";
     /// let client = Client::new(homeserver).await?;
-    /// client.login(user, "password", None, None).await?;
+    /// client.login_with_password(user, "password", None, None).await?;
     ///
     /// if let Some(avatar) = client.account().get_avatar(MediaFormat::File).await? {
     ///     std::fs::write("avatar.png", avatar);

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -130,7 +130,7 @@ impl Common {
     /// # block_on(async {
     /// # let user = "example";
     /// let client = Client::new(homeserver).await.unwrap();
-    /// client.login(user, "password", None, None).await.unwrap();
+    /// client.login_with_password(user, "password", None, None).await.unwrap();
     /// let room_id = room_id!("!roomid:example.com");
     /// let room = client
     ///     .get_joined_room(&room_id)

--- a/crates/matrix-sdk/src/room_member.rs
+++ b/crates/matrix-sdk/src/room_member.rs
@@ -49,7 +49,7 @@ impl RoomMember {
     /// # block_on(async {
     /// # let user = "example";
     /// let client = Client::new(homeserver).await.unwrap();
-    /// client.login(user, "password", None, None).await.unwrap();
+    /// client.login_with_password(user, "password", None, None).await.unwrap();
     /// let room_id = room_id!("!roomid:example.com");
     /// let room = client
     ///     .get_joined_room(&room_id)


### PR DESCRIPTION
This adds support for logging in using Third-Party IDs (such as email addresses), as well as phones.

This PR depends on https://github.com/ruma/ruma/pull/1116, which it uses to smooth out the experience of having to pass in `UserIdentifier`, which is otherwise buried pretty deep in `ruma`.