### PR TITLE
test(base): Remove invalid sync event from test json

### DIFF
--- a/crates/matrix-sdk-test/src/test_json/sync.rs
+++ b/crates/matrix-sdk-test/src/test_json/sync.rs
@@ -210,30 +210,6 @@ pub static SYNC: Lazy<JsonValue> = Lazy::new(|| {
                                     "replaces_state": "$152034819067QWJxM:localhost"
                                 }
                             },
-                            {
-                                "content": {
-                                "membership": "leave",
-                                "reason": "offline",
-                                "avatar_url": "mxc://avatar.com/d0dV9jLpe",
-                                "displayname": "example"
-                                },
-                                "event_id": "$1585345508297748AIUBh:matrix.org",
-                                "origin_server_ts": 158534550,
-                                "sender": "@example:localhost",
-                                "state_key": "@example:localhost",
-                                "type": "m.room.member",
-                                "unsigned": {
-                                "replaces_state": "$1585345354296486IGZfp:localhost",
-                                "prev_content": {
-                                    "avatar_url": "mxc://avatar.com/d0dV9jLpe",
-                                    "displayname": "example",
-                                    "membership": "join"
-                                },
-                                "prev_sender": "@example2:localhost",
-                                "age": 6992
-                                },
-                                "room_id": "!roomid:room.com"
-                            }
                         ]
                     },
                     "timeline": {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -3362,7 +3362,7 @@ pub(crate) mod tests {
         let room = client.get_joined_room(room_id!("!SVkFJHzfwvuaIEawgC:localhost")).unwrap();
         let members: Vec<RoomMember> = room.active_members().await.unwrap();
 
-        assert_eq!(1, members.len());
+        assert_eq!(2, members.len());
         // assert!(room.power_levels.is_some())
     }
 


### PR DESCRIPTION
The test json used for mocking a sync response contained an ill-formed
event with a room_id key present in the event. Since the deserialization
ignores the room_id key, this resulted in the client's membership state
evaluating to left going by the contents of the state events, despite
the room being in the "joined" section of the sync response. This is a
violation of the spec.

I chose to remove the event rather than correct it and move it to the "left" section of the responses, as the one test that failed after I removed the event assumed the event applied to `!SVkFJHzfwvuaIEawgC:localhost` rather than `!roomid:room.com` specified in the event itself.

See also #507.

