### PR TITLE
matrix-sdk: room::Common:messages() don't return decryption error

### DIFF
--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -205,17 +205,21 @@ impl Common {
         #[cfg(feature = "e2e-encryption")]
         if let Some(machine) = self.client.olm_machine().await {
             for event in http_response.chunk {
-                if let Ok(AnySyncRoomEvent::MessageLike(AnySyncMessageLikeEvent::RoomEncrypted(
-                    SyncMessageLikeEvent::Original(encrypted_event),
-                ))) = event.deserialize_as::<AnySyncRoomEvent>()
+                let decrypted_event = if let Ok(AnySyncRoomEvent::MessageLike(
+                    AnySyncMessageLikeEvent::RoomEncrypted(SyncMessageLikeEvent::Original(
+                        encrypted_event,
+                    )),
+                )) = event.deserialize_as::<AnySyncRoomEvent>()
                 {
                     if let Ok(event) = machine.decrypt_room_event(&encrypted_event, room_id).await {
-                        response.chunk.push(event);
-                        continue;
+                        event
+                    } else {
+                        RoomEvent { event, encryption_info: None }
                     }
-                }
+                } else {
+                    RoomEvent { event, encryption_info: None }
+                };
 
-                let decrypted_event = RoomEvent { event, encryption_info: None };
                 response.chunk.push(decrypted_event);
             }
         } else {


### PR DESCRIPTION
If decryption fails we want that the user still has access to
the events.
This was broken in a previous commit.