### PR TITLE
Upgrade async-once-cell to 0.3.1

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -123,7 +123,7 @@ default-features = false
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-async-once-cell = "0.3.0"
+async-once-cell = "0.3.1"
 wasm-timer = "0.2.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -1,11 +1,15 @@
 use std::sync::Arc;
 
+#[cfg(target_arch = "wasm32")]
+use async_once_cell::OnceCell;
 use matrix_sdk_base::{locks::RwLock, store::StoreConfig, BaseClient, StateStore};
 use ruma::{
     api::{client::discovery::discover_homeserver, error::FromHttpResponseError, MatrixVersion},
     OwnedServerName, ServerName, UserId,
 };
 use thiserror::Error;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::sync::OnceCell;
 use url::Url;
 
 use super::{Client, ClientInner};
@@ -323,23 +327,11 @@ impl ClientBuilder {
         let homeserver = Arc::new(RwLock::new(Url::parse(&homeserver)?));
         let http_client = mk_http_client(homeserver.clone());
 
-        #[cfg(target_arch = "wasm32")]
-        let server_versions = {
-            let cell = async_once_cell::OnceCell::new();
-            if let Some(server_versions) = self.server_versions {
-                cell.get_or_init(async move { server_versions }).await;
-            }
-            cell
-        };
-
-        #[cfg(not(target_arch = "wasm32"))]
-        let server_versions = tokio::sync::OnceCell::new_with(self.server_versions);
-
         let inner = Arc::new(ClientInner {
             homeserver,
             http_client,
             base_client,
-            server_versions,
+            server_versions: OnceCell::new_with(self.server_versions),
             #[cfg(feature = "e2e-encryption")]
             group_session_locks: Default::default(),
             #[cfg(feature = "e2e-encryption")]


### PR DESCRIPTION
I [asked](https://github.com/danieldg/async-once-cell/issues/1) for a `new_with` so we don't need different initialization of tokio's and async_once_cell's `OnceCell` types, the author wrote it and published it super fast! 🥳 