### PR TITLE
fix(base): Make max_power_level reflect the current maximum only

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -1,7 +1,7 @@
 mod members;
 mod normal;
 
-use std::{cmp::max, collections::HashSet, fmt};
+use std::{collections::HashSet, fmt};
 
 pub use members::RoomMember;
 pub use normal::{Room, RoomInfo, RoomType};
@@ -143,11 +143,7 @@ impl BaseRoomInfo {
                 self.tombstone = Some(t.into());
             }
             AnySyncStateEvent::RoomPowerLevels(p) => {
-                self.max_power_level = p
-                    .power_levels()
-                    .users
-                    .values()
-                    .fold(self.max_power_level, |acc, &p| max(acc, p.into()));
+                self.max_power_level = p.power_levels().max().into();
             }
             _ => return false,
         }
@@ -192,11 +188,7 @@ impl BaseRoomInfo {
                 self.tombstone = Some(t.into());
             }
             AnyStrippedStateEvent::RoomPowerLevels(p) => {
-                self.max_power_level = p
-                    .content
-                    .users
-                    .values()
-                    .fold(self.max_power_level, |acc, &p| max(acc, p.into()));
+                self.max_power_level = p.power_levels().max().into();
             }
             _ => return false,
         }


### PR DESCRIPTION
… instead of taking into account an older maximum as well.

I'm pretty sure this is the desired behavior for normalized power levels. For example, if a room uses standard power levels of 0, 50 and 100 for most users but one person has 200, it makes sense for only them to show up as an admin. However, if they downgrade themselves to 100, all users with that power level should then be shown as admins rather than none of them.