### PR TITLE
store-encryption: Use bincode for encoding

### DIFF
--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -9,8 +9,10 @@ rust-version = "1.60"
 
 [features]
 js = ["getrandom/js"]
+bincode = ["dep:bincode"]
 
 [dependencies]
+bincode = { version = "1.3.3", optional = true }
 blake3 = "1.3.1"
 chacha20poly1305 = { version = "0.9.0", features = ["std"] }
 displaydoc = "0.2.3"


### PR DESCRIPTION
This commit changes the default ciphertext serialization format for matrix-sdk-store-encryption to bincode, as the current json serialization is incurring a large space overhead.

Currently, the following plaintext encrypts to ~237 bytes. With this change, it only takes 58 bytes (75% reduction in size):

```
{"test":"test"}
```

Existing ciphertexts are unaffected, and still supported