### PR TITLE
Use base64 to encode the ciphertext and nonce

### DIFF
--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.60"
 js = ["getrandom/js"]
 
 [dependencies]
+base64 = "0.13.0"
 blake3 = "1.3.1"
 chacha20poly1305 = { version = "0.9.0", features = ["std"] }
 displaydoc = "0.2.3"

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -363,7 +363,7 @@ impl StoreCipher {
         Ok(EncryptedValue { version: VERSION, ciphertext, nonce })
     }
 
-    /// Decrypt a value after it was fetchetd from the key/value store.
+    /// Decrypt a value after it was fetched from the key/value store.
     ///
     /// A value can be encrypted using the [`StoreCipher::encrypt_value()`]
     /// method.
@@ -398,7 +398,7 @@ impl StoreCipher {
         self.decrypt_value_typed(value)
     }
 
-    /// Decrypt a value after it was fetchetd from the key/value store.
+    /// Decrypt a value after it was fetched from the key/value store.
     ///
     /// A value can be encrypted using the
     /// [`StoreCipher::encrypt_value_typed()`] method. Lower level method to
@@ -439,7 +439,7 @@ impl StoreCipher {
         Ok(ret?)
     }
 
-    /// Decrypt a value after it was fetchetd from the key/value store.
+    /// Decrypt a value after it was fetched from the key/value store.
     ///
     /// A value can be encrypted using the [`StoreCipher::encrypt_value_data()`]
     /// method. Lower level method to [`StoreCipher::decrypt_value()`].

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -630,9 +630,9 @@ struct EncryptedStoreCipher {
 }
 
 mod base64_array {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
     use super::XNONCE_SIZE;
-    use serde::{Deserialize, Serialize};
-    use serde::{Deserializer, Serializer};
 
     pub fn serialize<S: Serializer>(v: &[u8; XNONCE_SIZE], s: S) -> Result<S::Ok, S::Error> {
         let base64 = base64::encode(v);
@@ -648,8 +648,7 @@ mod base64_array {
 }
 
 mod base64 {
-    use serde::{Deserialize, Serialize};
-    use serde::{Deserializer, Serializer};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
         let base64 = base64::encode(v);


### PR DESCRIPTION
This mitigates the inneficent way that JSON uses to encode a list of bytes. We bump the version so people that use the highest level `encrypt_value()` methods don't have a breaking change.

This will now encode {"some": "data"} into 116 bytes instead of 236 bytes.

So this is not a breaking change for the sled store, it is for the indexeddb based store since it uses `decrypt_value_typed()`. Though I think that's fine considering that we don't have users of the indexeddb as of now.