### PR TITLE
Improve CI coverage reporting

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -7,17 +7,29 @@ coverage:
         target: auto
         threshold: 1%
         paths:
-          - "crates"
+          - "crates/matrix-sdk/"
+          - "crates/matrix-sdk-appservice/"
+          - "crates/matrix-sdk-base/"
+          - "crates/matrix-sdk-common/"
+          - "crates/matrix-sdk-crypto/"
+          - "crates/matrix-sdk-qrcode/"
+          - "crates/matrix-sdk-sled/"
+          - "crates/matrix-sdk-store-encryption/"
+          # Coverage of wasm tests isn't supported at the moment,
+          # see rustwasm/wasm-bindgen#2276
+          # - "crates/matrix-sdk-indexeddb"
       bindings:
         # Coverage of binding tests is recorded but for informational
         # purposes only
         informational: true
         paths:
-          - "bindings"
+          - "bindings/"
+          - "crates/matrix-sdk-crypto-ffi/"
+          - "crates/matrix-sdk-ffi/"
       labs:
         # Coverage of lab tests is recorded but for informational
         # purposes only
         informational: true
         paths:
-          - "labs"
+          - "labs/"
     patch: off

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -20,11 +20,4 @@ coverage:
         informational: true
         paths:
           - "labs"
-    patch:
-      default:
-        # Be tolerant on slight code coverage diff on PRs to limit
-        # noisy red coverage status on github PRs.
-        # Note: The coverage stats are still uploaded
-        # to codecov so that PR reviewers can see uncovered lines
-        target: auto
-        threshold: 1%
+    patch: off

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -2,10 +2,24 @@ coverage:
   status:
     project:
       default:
-        # Commits pushed to master should not make the overall
-        # project coverage decrease by more than 1%:
+        # by default, we only care about test coverage of the main
+        # rust crates
         target: auto
         threshold: 1%
+        paths:
+          - "crates"
+      bindings:
+        # Coverage of binding tests is recorded but for informational
+        # purposes only
+        informational: true
+        paths:
+          - "bindings"
+      labs:
+        # Coverage of lab tests is recorded but for informational
+        # purposes only
+        informational: true
+        paths:
+          - "labs"
     patch:
       default:
         # Be tolerant on slight code coverage diff on PRs to limit


### PR DESCRIPTION
 - [x] split coverage in multiple sections: default for crates, bindings and labs as informational (not mandataory)
 - [x] disable patch-level analytics - we don't care that n% of lines _in that PR_ were hit, only project wide statistics