### PR TITLE
feat(appservice): Improve autojoin example

### DIFF
--- a/crates/matrix-sdk-appservice/examples/appservice_autojoin.rs
+++ b/crates/matrix-sdk-appservice/examples/appservice_autojoin.rs
@@ -8,8 +8,13 @@ use matrix_sdk_appservice::{
             events::room::member::{MembershipState, OriginalSyncRoomMemberEvent},
             UserId,
         },
+        HttpError,
     },
     AppService, AppServiceRegistration, Result,
+};
+use ruma::api::{
+    client::{error::ErrorKind, uiaa::UiaaResponse},
+    error::{FromHttpResponseError, ServerError},
 };
 use tracing::trace;
 
@@ -22,13 +27,26 @@ pub async fn handle_room_member(
         trace!("not an appservice user: {}", event.state_key);
     } else if let MembershipState::Invite = event.content.membership {
         let user_id = UserId::parse(event.state_key.as_str())?;
-        appservice.register_virtual_user(user_id.localpart()).await?;
+        if let Err(error) = appservice.register_virtual_user(user_id.localpart()).await {
+            error_if_user_not_in_use(error)?;
+        }
 
         let client = appservice.virtual_user_client(user_id.localpart()).await?;
         client.join_room_by_id(room.room_id()).await?;
     }
 
     Ok(())
+}
+
+pub fn error_if_user_not_in_use(error: matrix_sdk_appservice::Error) -> Result<()> {
+    match error {
+        // If user is already in use that's OK.
+        matrix_sdk_appservice::Error::Matrix(matrix_sdk::Error::Http(HttpError::UiaaError(
+            FromHttpResponseError::Server(ServerError::Known(UiaaResponse::MatrixError(error))),
+        ))) if matches!(error.kind, ErrorKind::UserInUse) => Ok(()),
+        // In all other cases return with an error.
+        error => Err(error),
+    }
 }
 
 #[tokio::main]
@@ -41,6 +59,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let registration = AppServiceRegistration::try_from_yaml_file("./tests/registration.yaml")?;
 
     let appservice = AppService::new(homeserver_url, server_name, registration).await?;
+    appservice.register_user_query(Box::new(|_, _| Box::pin(async { true }))).await;
     appservice
         .register_event_handler_context(appservice.clone())?
         .register_event_handler(


### PR DESCRIPTION
The already registered user check could probably also happen inside `register_virtual_user` - but not sure if there are scenarios where consumers might want to know that the error happened.

Context: https://matrix.to/#/!iYnZafYUoXkeVPOSQh:matrix.org/$8QgFf_IBjMBGojAri_aZeGBLuC1rU-O0Ni7Fy3s3G1c?via=matrix.org&via=famedly.de&via=gnome.org