### PR TITLE
feat: add .get_alias() method to the client

### DIFF
--- a/crates/matrix-sdk-test/src/test_json/mod.rs
+++ b/crates/matrix-sdk-test/src/test_json/mod.rs
@@ -46,6 +46,17 @@ pub static DEVICES: Lazy<JsonValue> = Lazy::new(|| {
     })
 });
 
+pub static GET_ALIAS: Lazy<JsonValue> = Lazy::new(|| {
+    json!({
+        "room_id": "!lUbmUPdxdXxEQurqOs:example.net",
+        "servers": [
+          "example.org",
+          "example.net",
+          "matrix.org",
+        ]
+    })
+});
+
 pub static WELL_KNOWN: Lazy<JsonValue> = Lazy::new(|| {
     json!({
         "m.homeserver": {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -609,7 +609,7 @@ impl Client {
         self.store().get_room(room_id).and_then(|room| room::Left::new(self.clone(), room))
     }
 
-    /// Resolve a room alias to a room id and a list of servers which knows
+    /// Resolve a room alias to a room id and a list of servers which know
     /// about it.
     ///
     /// # Arguments

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -69,7 +69,7 @@ use ruma::{
     ServerName, UInt, RoomAliasId,
 };
 use serde::de::DeserializeOwned;
-#[cfgnot(target_arch = "wasm32")]
+#[cfg(not(target_arch = "wasm32"))]
 pub use tokio::sync::OnceCell;
 use tracing::{error, info, instrument, warn};
 use url::Url;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2549,7 +2549,7 @@ pub(crate) mod tests {
     async fn get_alias() {
         let client = no_retry_test_client().await;
 
-        let _m = mock("GET", "/_matrix/client/v3/directory/room/%23alias:example.org")
+        let _m = mock("GET", "/_matrix/client/r0/directory/room/%23alias%3Aexample%2Eorg")
             .with_status(200)
             .with_body(test_json::GET_ALIAS.to_string())
             .create();

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -65,8 +65,8 @@ use ruma::{
     assign,
     events::room::MediaSource,
     presence::PresenceState,
-    MxcUri, OwnedDeviceId, OwnedRoomId, OwnedServerName, OwnedUserId, RoomId, RoomOrAliasId,
-    ServerName, UInt, RoomAliasId,
+    MxcUri, OwnedDeviceId, OwnedRoomId, OwnedServerName, OwnedUserId, RoomAliasId, RoomId,
+    RoomOrAliasId, ServerName, UInt,
 };
 use serde::de::DeserializeOwned;
 #[cfg(not(target_arch = "wasm32"))]
@@ -609,7 +609,8 @@ impl Client {
         self.store().get_room(room_id).and_then(|room| room::Left::new(self.clone(), room))
     }
 
-    /// Resolve a room alias to a room id and a list of servers which knows about it.
+    /// Resolve a room alias to a room id and a list of servers which knows
+    /// about it.
     ///
     /// # Arguments
     ///

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2553,7 +2553,7 @@ pub(crate) mod tests {
             .with_body(test_json::GET_ALIAS.to_string())
             .create();
 
-        let alias = room_alias_id!("#alias:example.org");
+        let alias = ruma::room_alias_id!("#alias:example.org");
         assert!(client.get_alias(alias).await.is_ok());
     }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -615,7 +615,10 @@ impl Client {
     /// # Arguments
     ///
     /// `room_alias` - The room alias to be resolved.
-    pub async fn get_alias(&self, room_alias: &RoomAliasId) -> HttpResult<get_alias::v3::Response> {
+    pub async fn resolve_room_alias(
+        &self,
+        room_alias: &RoomAliasId,
+    ) -> HttpResult<get_alias::v3::Response> {
         let request = get_alias::v3::Request::new(room_alias);
         self.send(request, None).await
     }
@@ -2546,7 +2549,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn get_alias() {
+    async fn resolve_room_alias() {
         let client = no_retry_test_client().await;
 
         let _m = mock("GET", "/_matrix/client/r0/directory/room/%23alias%3Aexample%2Eorg")
@@ -2555,7 +2558,7 @@ pub(crate) mod tests {
             .create();
 
         let alias = ruma::room_alias_id!("#alias:example.org");
-        assert!(client.get_alias(alias).await.is_ok());
+        assert!(client.resolve_room_alias(alias).await.is_ok());
     }
 
     #[async_test]


### PR DESCRIPTION
Let me try to fix my own issue https://github.com/matrix-org/matrix-rust-sdk/issues/673.

The method is named after ruma. I don't know if it should be kept the same but if not, I can give it a better name.