### PR TITLE
chore(crypto): Bump vodozemac

### DIFF
--- a/crates/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/crates/matrix-sdk-crypto-ffi/Cargo.toml
@@ -55,7 +55,8 @@ default_features = false
 features = ["rt-multi-thread"]
 
 [dependencies.vodozemac]
-version = "0.2.0"
+git = "https://github.com/matrix-org/vodozemac/"
+rev = "d0e744287a14319c2a9148fef3747548c740fc36"
 
 [build-dependencies]
 uniffi_build = { version = "0.17.0", features = ["builtin-bindgen"] }

--- a/crates/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/crates/matrix-sdk-crypto-ffi/src/lib.rs
@@ -48,7 +48,7 @@ pub struct MigrationData {
     /// The list of Megolm inbound group sessions.
     inbound_group_sessions: Vec<PickledInboundGroupSession>,
     /// The Olm pickle key that was used to pickle all the Olm objects.
-    pickle_key: String,
+    pickle_key: Vec<u8>,
     /// The backup version that is currently active.
     backup_version: Option<String>,
     // The backup recovery key, as a base58 encoded string.
@@ -521,7 +521,9 @@ mod test {
                   "backed_up":true
                }
             ],
-            "pickle_key":"\u{0011}$xJ_N8$>{\u{0005}iJoF03eBVt\u{000e}rUU\\,GYc7J",
+            "pickle_key": [17, 36, 120, 74, 95, 78, 56, 36, 62, 123, 5, 105, 74,
+                           111, 70, 48, 51, 101, 66, 86, 116, 14, 114, 85, 85,
+                           92, 44, 71, 89, 99, 55, 74],
             "backup_version":"3",
             "backup_recovery_key":"EsTHScmRV5oT1WBhe2mj2Gn3odeYantZ4NEk7L51p6L8hrmB",
             "cross_signing":{

--- a/crates/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/crates/matrix-sdk-crypto-ffi/src/olm.udl
@@ -451,7 +451,7 @@ dictionary MigrationData {
     sequence<PickledInboundGroupSession> inbound_group_sessions;
     string? backup_version;
     string? backup_recovery_key;
-    string pickle_key;
+    sequence<u8> pickle_key;
     CrossSigningKeyExport cross_signing;
     sequence<string> tracked_users;
 };

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -53,7 +53,8 @@ version = "0.6.1"
 features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.vodozemac]
-version = "0.2.0"
+git = "https://github.com/matrix-org/vodozemac/"
+rev = "d0e744287a14319c2a9148fef3747548c740fc36"
 features = ["js"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.ruma]
@@ -61,7 +62,8 @@ version = "0.6.1"
 features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.vodozemac]
-version = "0.2.0"
+git = "https://github.com/matrix-org/vodozemac/"
+rev = "d0e744287a14319c2a9148fef3747548c740fc36"
 
 [dev-dependencies]
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1012,8 +1012,7 @@ impl ReadOnlyAccount {
         message: &PreKeyMessage,
     ) -> Result<InboundCreationResult, SessionCreationError> {
         let their_identity_key = Curve25519PublicKey::from_base64(their_identity_key)?;
-        let result =
-            self.inner.lock().await.create_inbound_session(&their_identity_key, message)?;
+        let result = self.inner.lock().await.create_inbound_session(their_identity_key, message)?;
 
         let now = SecondsSinceUnixEpoch::now();
         let session_id = result.session.session_id();

--- a/crates/matrix-sdk-crypto/src/types/cross_signing_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing_key.rs
@@ -77,7 +77,7 @@ impl CrossSigningKey {
 /// Currently cross signing keys support an ed25519 keypair. The keys transport
 /// format is a base64 encoded string, any unknown key type will be left as such
 /// a string.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SigningKey {
     /// The ed25519 cross-signing key.
     Ed25519(Ed25519PublicKey),

--- a/crates/matrix-sdk-crypto/src/types/device_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/device_keys.rs
@@ -115,7 +115,7 @@ impl UnsignedDeviceInfo {
 /// Currently devices have a curve25519 and ed25519 keypair. The keys transport
 /// format is a base64 encoded string, any unknown key type will be left as such
 /// a string.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DeviceKey {
     /// The curve25519 device key.
     Curve25519(Curve25519PublicKey),

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -29,4 +29,5 @@ ruma-common = "0.9.0"
 thiserror = "1.0.30"
 
 [dependencies.vodozemac]
-version = "0.2.0"
+git = "https://github.com/matrix-org/vodozemac/"
+rev = "d0e744287a14319c2a9148fef3747548c740fc36"

--- a/crates/matrix-sdk-qrcode/src/types.rs
+++ b/crates/matrix-sdk-qrcode/src/types.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 /// An enum representing the different modes a QR verification can be in.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum QrVerificationData {
     /// The QR verification is verifying another user
     Verification(VerificationData),
@@ -375,7 +375,7 @@ impl QrVerificationData {
 ///
 /// This mode is used for verification between two users using their master
 /// cross signing keys.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VerificationData {
     event_id: OwnedEventId,
     first_master_key: Ed25519PublicKey,
@@ -474,7 +474,7 @@ impl From<VerificationData> for QrVerificationData {
 /// This mode is used for verification between two devices of the same user
 /// where this device, that is creating this QR code, is trusting or owning
 /// the cross signing master key.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SelfVerificationData {
     transaction_id: String,
     master_key: Ed25519PublicKey,
@@ -577,7 +577,7 @@ impl From<SelfVerificationData> for QrVerificationData {
 /// This mode is used for verification between two devices of the same user
 /// where this device, that is creating this QR code, is not trusting the
 /// cross signing master key.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SelfVerificationNoMasterKey {
     transaction_id: String,
     device_key: Ed25519PublicKey,


### PR DESCRIPTION
This is mainly so we switch from the `&str` libolm pickle key to a `&[u8]` one in the `matrix-sdk-crypto-ffi` crate.