### PR TITLE
fix(crypto-ffi): generate static crypto-ffi library for iOS clients

### DIFF
--- a/crates/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/crates/matrix-sdk-crypto-ffi/Cargo.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "lib"]
-name = "matrix_crypto"
+crate-type = ["cdylib", "staticlib"]
+name = "matrix_crypto_ffi"
 
 [dependencies]
 anyhow = "1.0.57"


### PR DESCRIPTION
Updates `crypto-ffi` to output a static library to wrap in a Swift Package, which is the same approach being taken with`matrix-sdk-ffi` and [`matrix-rust-components-swift`](https://github.com/matrix-org/matrix-rust-components-swift).