### PR TITLE
docs: configure docs.rs build to contain more features

### DIFF
--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2021"
 rust-version = "1.60"
 readme = "README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["e2e-encryption"]
 e2e-encryption = ["matrix-sdk-base/e2e-encryption", "matrix-sdk-crypto"]

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [package.metadata.docs.rs]
 all-features = true
+default-target = "wasm32-unknown-unknown"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -17,8 +18,6 @@ default = ["e2e-encryption"]
 e2e-encryption = ["matrix-sdk-base/e2e-encryption", "matrix-sdk-crypto"]
 experimental-timeline = ["matrix-sdk-base/experimental-timeline"]
 
-[package.metadata.docs.rs]
-default-target = "wasm32-unknown-unknown"
 
 [dependencies]
 anyhow = "1.0.57"

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -9,6 +9,10 @@ license = "Apache-2.0"
 rust-version = "1.60"
 readme = "README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = ["state-store"]
 

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/matrix-org/matrix-rust-sdk"
 license = "Apache-2.0"
 rust-version = "1.60"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 js = ["getrandom/js"]
 


### PR DESCRIPTION
- add `all-features` for docs.rs build on sled and indexeddb-store
- add docsrs feature on store-encryption (but not all features, to not enable the `js` features)
fixes #694