### PR TITLE
Convert the `Signatures` type alias into a struct

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -50,7 +50,7 @@ zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.ruma]
 version = "0.6.1"
-features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"]
+features = ["client-api-c", "js", "rand", "signatures", "unstable-msc2676", "unstable-msc2677"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
@@ -59,7 +59,7 @@ features = ["js"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.ruma]
 version = "0.6.1"
-features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"]
+features = ["client-api-c", "rand", "signatures", "unstable-msc2676", "unstable-msc2677"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::{IdParseError, OwnedDeviceId, OwnedRoomId, OwnedUserId};
+use ruma::{signatures::CanonicalJsonError, IdParseError, OwnedDeviceId, OwnedRoomId, OwnedUserId};
 use serde_json::Error as SerdeError;
 use thiserror::Error;
 
@@ -181,7 +181,13 @@ pub enum SignatureError {
 
     /// The signed object couldn't be deserialized.
     #[error(transparent)]
-    JsonError(#[from] SerdeError),
+    JsonError(#[from] CanonicalJsonError),
+}
+
+impl From<SerdeError> for SignatureError {
+    fn from(e: SerdeError) -> Self {
+        CanonicalJsonError::SerDe(e).into()
+    }
 }
 
 #[derive(Error, Debug)]

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -32,7 +32,7 @@ use ruma::{
         AnyToDeviceEventContent,
     },
     DeviceId, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, OwnedDeviceId,
-    OwnedDeviceKeyId, OwnedUserId, UserId,
+    OwnedDeviceKeyId, UserId,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{json, Value};
@@ -47,7 +47,7 @@ use crate::{
     identities::{ReadOnlyOwnUserIdentity, ReadOnlyUserIdentities},
     olm::{InboundGroupSession, Session, VerifyJson},
     store::{Changes, CryptoStore, DeviceChanges, Result as StoreResult},
-    types::{DeviceKey, DeviceKeys, SignedKey},
+    types::{DeviceKey, DeviceKeys, Signatures, SignedKey},
     verification::VerificationMachine,
     OutgoingVerificationRequest, ReadOnlyAccount, Sas, ToDeviceRequest, VerificationRequest,
 };
@@ -433,7 +433,7 @@ impl ReadOnlyDevice {
     }
 
     /// Get a map containing all the device signatures.
-    pub fn signatures(&self) -> &BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>> {
+    pub fn signatures(&self) -> &Signatures {
         &self.inner.signatures
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -28,7 +28,7 @@ use ruma::{
     events::{
         key::verification::VerificationMethod, room::message::KeyVerificationRequestEventContent,
     },
-    DeviceKeyId, EventId, OwnedDeviceId, OwnedDeviceKeyId, OwnedUserId, RoomId, UserId,
+    DeviceKeyId, EventId, OwnedDeviceId, OwnedDeviceKeyId, RoomId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::to_value;
@@ -40,7 +40,7 @@ use crate::{
     error::SignatureError,
     olm::VerifyJson,
     store::{Changes, IdentityChanges},
-    types::{CrossSigningKey, DeviceKeys, SigningKey},
+    types::{CrossSigningKey, DeviceKeys, Signatures, SigningKey},
     verification::VerificationMachine,
     CryptoStoreError, OutgoingVerificationRequest, ReadOnlyDevice, VerificationRequest,
 };
@@ -404,7 +404,7 @@ impl MasterPubkey {
     }
 
     /// Get the signatures map of this cross signing key.
-    pub fn signatures(&self) -> &BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>> {
+    pub fn signatures(&self) -> &Signatures {
         &self.0.signatures
     }
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -739,7 +739,7 @@ impl ReadOnlyAccount {
             (*self.device_id).to_owned(),
             Self::ALGORITHMS.iter().map(|a| (**a).clone()).collect(),
             keys,
-            BTreeMap::new(),
+            Default::default(),
         )
     }
 
@@ -757,9 +757,10 @@ impl ReadOnlyAccount {
             .await
             .expect("Newly created device keys can always be signed");
 
-        device_keys.signatures.entry(self.user_id().to_owned()).or_default().insert(
+        device_keys.signatures.add_signature(
+            self.user_id().to_owned(),
             DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, &self.device_id),
-            signature.to_base64(),
+            signature,
         );
 
         device_keys

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -883,15 +883,11 @@ impl ReadOnlyAccount {
             .await
             .expect("Newly created one-time keys can always be signed");
 
-        let signatures = BTreeMap::from([(
+        key.signatures_mut().add_signature(
             self.user_id().to_owned(),
-            BTreeMap::from([(
-                DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, &self.device_id),
-                signature,
-            )]),
-        )]);
-
-        *key.signatures() = signatures;
+            DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, self.device_id()),
+            signature,
+        );
 
         key
     }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -780,9 +780,10 @@ impl ReadOnlyAccount {
     ) -> Result<(), SignatureError> {
         let signature = self.sign_json(serde_json::to_value(&cross_signing_key)?).await?;
 
-        cross_signing_key.signatures.entry(self.user_id().to_owned()).or_default().insert(
+        cross_signing_key.signatures.add_signature(
+            self.user_id().to_owned(),
             DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, self.device_id()),
-            signature.to_base64(),
+            signature,
         );
 
         Ok(())

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -780,8 +780,11 @@ mod tests {
 
         let master = user_signing.sign_user(&bob_public).unwrap();
 
-        let num_signatures: usize = master.signatures.iter().map(|(_, u)| u.len()).sum();
-        assert_eq!(num_signatures, 1, "We're only uploading our own signature");
+        assert_eq!(
+            master.signatures.signature_count(),
+            1,
+            "We're only uploading our own signature"
+        );
 
         bob_public.master_key = master.into();
 

--- a/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
@@ -224,12 +224,13 @@ impl SelfSigning {
         let serialized = serde_json::to_value(&device_keys)?;
         let signature = self.inner.sign_json(serialized)?;
 
-        device_keys.signatures.entry(self.public_key.user_id().to_owned()).or_default().insert(
+        device_keys.signatures.add_signature(
+            self.public_key.user_id().to_owned(),
             DeviceKeyId::from_parts(
                 DeviceKeyAlgorithm::Ed25519,
                 self.inner.public_key.to_base64().as_str().into(),
             ),
-            signature.to_base64(),
+            signature,
         );
 
         Ok(())

--- a/crates/matrix-sdk-crypto/src/olm/utility.rs
+++ b/crates/matrix-sdk-crypto/src/olm/utility.rs
@@ -28,7 +28,7 @@ pub trait SignJson {
         let _ = json_object.remove("signatures");
         let _ = json_object.remove("unsigned");
 
-        let canonical_json: CanonicalJsonValue = value.try_into().unwrap();
+        let canonical_json: CanonicalJsonValue = value.try_into()?;
         Ok(canonical_json.to_string())
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/cross_signing_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing_key.rs
@@ -26,8 +26,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{value::to_raw_value, Value};
 use vodozemac::Ed25519PublicKey;
 
-/// Signatures for a `CrossSigningKey` object.
-pub type CrossSigningKeySignatures = BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>;
+use super::Signatures;
 
 /// A cross signing key.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -47,8 +46,7 @@ pub struct CrossSigningKey {
     /// Signatures of the key.
     ///
     /// Only optional for master key.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub signatures: CrossSigningKeySignatures,
+    pub signatures: Signatures,
 
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
@@ -61,7 +59,7 @@ impl CrossSigningKey {
         user_id: OwnedUserId,
         usage: Vec<KeyUsage>,
         keys: BTreeMap<OwnedDeviceKeyId, SigningKey>,
-        signatures: CrossSigningKeySignatures,
+        signatures: Signatures,
     ) -> Self {
         Self { user_id, usage, keys, signatures, other: BTreeMap::new() }
     }
@@ -106,8 +104,8 @@ struct CrossSigningKeyHelper {
     pub user_id: OwnedUserId,
     pub usage: Vec<KeyUsage>,
     pub keys: BTreeMap<OwnedDeviceKeyId, String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub signatures: CrossSigningKeySignatures,
+    #[serde(default, skip_serializing_if = "Signatures::is_empty")]
+    pub signatures: Signatures,
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
 }

--- a/crates/matrix-sdk-crypto/src/types/device_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/device_keys.rs
@@ -28,6 +28,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{value::to_raw_value, Value};
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};
 
+use super::Signatures;
+
 /// Identity keys for a device.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(try_from = "DeviceKeyHelper", into = "DeviceKeyHelper")]
@@ -49,7 +51,7 @@ pub struct DeviceKeys {
     pub keys: BTreeMap<OwnedDeviceKeyId, DeviceKey>,
 
     /// Signatures for the device key object.
-    pub signatures: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>,
+    pub signatures: Signatures,
 
     /// Additional data added to the device key information by intermediate
     /// servers, and not covered by the signatures.
@@ -68,7 +70,7 @@ impl DeviceKeys {
         device_id: OwnedDeviceId,
         algorithms: Vec<EventEncryptionAlgorithm>,
         keys: BTreeMap<OwnedDeviceKeyId, DeviceKey>,
-        signatures: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>,
+        signatures: Signatures,
     ) -> Self {
         Self {
             user_id,
@@ -154,7 +156,7 @@ struct DeviceKeyHelper {
     pub device_id: OwnedDeviceId,
     pub algorithms: Vec<EventEncryptionAlgorithm>,
     pub keys: BTreeMap<OwnedDeviceKeyId, String>,
-    pub signatures: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>,
+    pub signatures: Signatures,
     #[serde(default, skip_serializing_if = "UnsignedDeviceInfo::is_empty")]
     pub unsigned: UnsignedDeviceInfo,
     #[serde(flatten)]

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -106,6 +106,16 @@ impl Signatures {
     pub fn clear(&mut self) {
         self.0.clear()
     }
+
+    /// Do we hold any signatures or is our collection completely empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// How many signatures do we currently hold.
+    pub fn signature_count(&self) -> usize {
+        self.0.iter().map(|(_, u)| u.len()).sum()
+    }
 }
 
 impl Default for Signatures {

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -27,6 +27,146 @@ mod cross_signing_key;
 mod device_keys;
 mod one_time_keys;
 
+use std::collections::BTreeMap;
+
 pub use cross_signing_key::*;
 pub use device_keys::*;
 pub use one_time_keys::*;
+use ruma::{DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, UserId};
+use serde::{Deserialize, Serialize, Serializer};
+use vodozemac::Ed25519Signature;
+
+/// An enum over all the signature types.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Signature {
+    /// A Ed25519 digital signature.
+    Ed25519(Ed25519Signature),
+    /// An unknown digital signature as a base64 encoded string.
+    Other(String),
+}
+
+impl Signature {
+    /// Get the Ed25519 signature, if this is one.
+    pub fn ed25519(&self) -> Option<Ed25519Signature> {
+        if let Self::Ed25519(signature) = &self {
+            Some(*signature)
+        } else {
+            None
+        }
+    }
+
+    /// Convert the signature to a base64 encoded string.
+    pub fn to_base64(&self) -> String {
+        match self {
+            Signature::Ed25519(s) => s.to_base64(),
+            Signature::Other(s) => s.to_owned(),
+        }
+    }
+}
+
+impl From<Ed25519Signature> for Signature {
+    fn from(signature: Ed25519Signature) -> Self {
+        Self::Ed25519(signature)
+    }
+}
+
+/// Signatures for a signed object.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Signatures(BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, Signature>>);
+
+impl Signatures {
+    /// Create a new, empty, signatures collection.
+    pub fn new() -> Self {
+        Signatures(Default::default())
+    }
+
+    /// Add the given signature from the given signer and the given key_id to
+    /// the collection.
+    pub fn add_signature(
+        &mut self,
+        signer: OwnedUserId,
+        key_id: OwnedDeviceKeyId,
+        signature: Ed25519Signature,
+    ) -> Option<Signature> {
+        self.0.entry(signer).or_insert_with(Default::default).insert(key_id, signature.into())
+    }
+
+    /// Try to find an Ed25519 signature from the given signer with the given
+    /// key id.
+    pub fn get_signature(&self, signer: &UserId, key_id: &DeviceKeyId) -> Option<Ed25519Signature> {
+        self.get(signer)?.get(key_id)?.ed25519()
+    }
+
+    /// Get the map of signatures that belong to the given user.
+    pub fn get(&self, signer: &UserId) -> Option<&BTreeMap<OwnedDeviceKeyId, Signature>> {
+        self.0.get(signer)
+    }
+}
+
+impl Default for Signatures {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntoIterator for Signatures {
+    type Item = (OwnedUserId, BTreeMap<OwnedDeviceKeyId, Signature>);
+
+    type IntoIter =
+        std::collections::btree_map::IntoIter<OwnedUserId, BTreeMap<OwnedDeviceKeyId, Signature>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'de> Deserialize<'de> for Signatures {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let map: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>> =
+            serde::Deserialize::deserialize(deserializer)?;
+
+        Ok(Signatures(
+            map.into_iter()
+                .map(|(user, signatures)| {
+                    Ok((
+                        user,
+                        signatures
+                            .into_iter()
+                            .map(|(key_id, s)| {
+                                let algorithm = key_id.algorithm();
+                                let signature = match algorithm {
+                                    DeviceKeyAlgorithm::Ed25519 => {
+                                        Ed25519Signature::from_base64(&s)
+                                            .map_err(serde::de::Error::custom)?
+                                            .into()
+                                    }
+                                    _ => Signature::Other(s),
+                                };
+
+                                Ok((key_id, signature))
+                            })
+                            .collect::<Result<BTreeMap<_, _>, _>>()?,
+                    ))
+                })
+                .collect::<Result<_, _>>()?,
+        ))
+    }
+}
+
+impl Serialize for Signatures {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let signatures: BTreeMap<&OwnedUserId, BTreeMap<&OwnedDeviceKeyId, String>> = self
+            .0
+            .iter()
+            .map(|(u, m)| (u, m.iter().map(|(d, s)| (d, s.to_base64())).collect()))
+            .collect();
+
+        serde::Serialize::serialize(&signatures, serializer)
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -101,6 +101,11 @@ impl Signatures {
     pub fn get(&self, signer: &UserId) -> Option<&BTreeMap<OwnedDeviceKeyId, Signature>> {
         self.0.get(signer)
     }
+
+    /// Remove all the signatures we currently hold.
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
 }
 
 impl Default for Signatures {

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -20,10 +20,7 @@ mod qrcode;
 mod requests;
 mod sas;
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use event_enums::OutgoingContent;
 pub use machine::VerificationMachine;
@@ -47,8 +44,8 @@ use ruma::{
         },
         AnyMessageLikeEventContent, AnyToDeviceEventContent,
     },
-    DeviceId, EventId, OwnedDeviceId, OwnedDeviceKeyId, OwnedEventId, OwnedRoomId,
-    OwnedTransactionId, OwnedUserId, RoomId, UserId,
+    DeviceId, EventId, OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId,
+    UserId,
 };
 pub use sas::{AcceptSettings, Sas};
 use tracing::{error, info, trace, warn};
@@ -58,6 +55,7 @@ use crate::{
     gossiping::{GossipMachine, GossipRequest},
     olm::{PrivateCrossSigningIdentity, ReadOnlyAccount, Session},
     store::{Changes, CryptoStore},
+    types::Signatures,
     CryptoStoreError, LocalTrust, ReadOnlyDevice, ReadOnlyOwnUserIdentity, ReadOnlyUserIdentities,
 };
 
@@ -140,10 +138,7 @@ impl VerificationStore {
     }
 
     /// Get the signatures that have signed our own device.
-    pub async fn device_signatures(
-        &self,
-    ) -> Result<Option<BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>>, CryptoStoreError>
-    {
+    pub async fn device_signatures(&self) -> Result<Option<Signatures>, CryptoStoreError> {
         Ok(self
             .inner
             .get_device(self.account.user_id(), self.account.device_id())


### PR DESCRIPTION
The main purpose of this PR is to have stronger typing for our signatures, we directly deserialize into a vodozemac type for the known signature types.

This isn't directly useful right now, but hopefully we'll be able to make our signature checking a bit less reliant on `serde_json::Value`.