### PR TITLE
Introduce a SignedJsonObject trait

### DIFF
--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -173,7 +173,7 @@ impl BackupMachine {
         signatures: &Signatures,
         auth_data: &str,
     ) -> SignatureState {
-        match self.account.is_signed_by_raw(signatures, auth_data) {
+        match self.account.has_signed_raw(signatures, auth_data) {
             Ok(_) => SignatureState::ValidAndTrusted,
             Err(e) => match e {
                 crate::SignatureError::NoSignatureFound => SignatureState::Missing,
@@ -193,7 +193,7 @@ impl BackupMachine {
         let identity = self.store.get_identity(user_id).await?;
 
         let ret = if let Some(identity) = identity.and_then(|i| i.own()) {
-            match identity.master_key().is_signed_by_raw(signatures, auth_data) {
+            match identity.master_key().has_signed_raw(signatures, auth_data) {
                 Ok(_) => {
                     if identity.is_verified() {
                         SignatureState::ValidAndTrusted
@@ -221,7 +221,7 @@ impl BackupMachine {
         signatures: &Signatures,
         auth_data: &str,
     ) -> SignatureState {
-        if device.is_signed_by_device_raw(signatures, auth_data).is_ok() {
+        if device.has_signed_raw(signatures, auth_data).is_ok() {
             if device.verified() {
                 SignatureState::ValidAndTrusted
             } else {

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -179,6 +179,10 @@ pub enum SignatureError {
     #[error(transparent)]
     InvalidKey(#[from] vodozemac::KeyError),
 
+    /// The signature could not be decoded.
+    #[error("the given signature is not valid and can't be decoded")]
+    InvalidSignature,
+
     /// The signed object couldn't be deserialized.
     #[error(transparent)]
     JsonError(#[from] CanonicalJsonError),

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -572,7 +572,7 @@ impl ReadOnlyDevice {
     /// correctly canonicalized and make sure that the object you are checking
     /// the signature for is allowed to be signed by a device.
     #[cfg(feature = "backups_v1")]
-    pub(crate) fn is_signed_by_device_raw(
+    pub(crate) fn has_signed_raw(
         &self,
         signatures: &Signatures,
         canonical_json: &str,
@@ -584,10 +584,7 @@ impl ReadOnlyDevice {
         key.verify_canonicalized_json(user_id, key_id, signatures, canonical_json)
     }
 
-    fn is_signed_by_device(
-        &self,
-        signed_object: &impl SignedJsonObject,
-    ) -> Result<(), SignatureError> {
+    fn has_signed(&self, signed_object: &impl SignedJsonObject) -> Result<(), SignatureError> {
         let key = self.ed25519_key().ok_or(SignatureError::MissingSigningKey)?;
         let user_id = self.user_id();
         let key_id = &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, self.device_id());
@@ -599,14 +596,14 @@ impl ReadOnlyDevice {
         &self,
         device_keys: &DeviceKeys,
     ) -> Result<(), SignatureError> {
-        self.is_signed_by_device(device_keys)
+        self.has_signed(device_keys)
     }
 
     pub(crate) fn verify_one_time_key(
         &self,
         one_time_key: &SignedKey,
     ) -> Result<(), SignatureError> {
-        self.is_signed_by_device(one_time_key)
+        self.has_signed(one_time_key)
     }
 
     /// Mark the device as deleted.

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -564,9 +564,9 @@ impl ReadOnlyDevice {
 
     /// Check if the given JSON is signed by this device key.
     ///
-    /// This method should only be used if a signature of an object should be
-    /// checked multiple times and the canonicalization step wants to be done
-    /// only a single time.
+    /// This method should only be used if an object's signature needs to be
+    /// checked multiple times, and you'd like to avoid performing the
+    /// canonicalization step each time.
     ///
     /// **Note**: Use this method with caution, the `canonical_json` needs to be
     /// correctly canonicalized and make sure that the object you are checking

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -425,9 +425,9 @@ impl MasterPubkey {
 
     /// Check if the given JSON is signed by this master key.
     ///
-    /// This method should only be used if a signature of an object should be
-    /// checked multiple times and the canonicalization step wants to be done
-    /// only a single time.
+    /// This method should only be used if an object's signature needs to be
+    /// checked multiple times, and you'd like to avoid performing the
+    /// canonicalization step each time.
     ///
     /// **Note**: Use this method with caution, the `canonical_json` needs to be
     /// correctly canonicalized and make sure that the object you are checking

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -433,7 +433,7 @@ impl MasterPubkey {
     /// correctly canonicalized and make sure that the object you are checking
     /// the signature for is allowed to be signed by a master key.
     #[cfg(feature = "backups_v1")]
-    pub(crate) fn is_signed_by_raw(
+    pub(crate) fn has_signed_raw(
         &self,
         signatures: &Signatures,
         canonical_json: &str,

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1524,13 +1524,13 @@ pub(crate) mod tests {
         uint, user_id, DeviceId, DeviceKeyAlgorithm, DeviceKeyId, MilliSecondsSinceUnixEpoch,
         OwnedDeviceKeyId, UserId,
     };
-    use serde_json::json;
     use vodozemac::Ed25519PublicKey;
 
     use super::testing::response_from_file;
     use crate::{
         machine::OlmMachine,
         olm::VerifyJson,
+        types::{DeviceKeys, SignedKey},
         verification::tests::{outgoing_request_to_event, request_to_event},
         EncryptionSettings, ReadOnlyDevice, ToDeviceRequest,
     };
@@ -1678,14 +1678,14 @@ pub(crate) mod tests {
     async fn test_device_key_signing() {
         let machine = OlmMachine::new(user_id(), alice_device_id()).await;
 
-        let mut device_keys = machine.account.device_keys().await;
+        let device_keys = machine.account.device_keys().await;
         let identity_keys = machine.account.identity_keys();
         let ed25519_key = identity_keys.ed25519;
 
         let ret = ed25519_key.verify_json(
             &machine.user_id,
             &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
-            json!(&mut device_keys),
+            &device_keys,
         );
         assert!(ret.is_ok());
     }
@@ -1711,14 +1711,14 @@ pub(crate) mod tests {
     async fn test_invalid_signature() {
         let machine = OlmMachine::new(user_id(), alice_device_id()).await;
 
-        let mut device_keys = machine.account.device_keys().await;
+        let device_keys = machine.account.device_keys().await;
 
         let key = Ed25519PublicKey::from_slice(&[0u8; 32]).unwrap();
 
         let ret = key.verify_json(
             &machine.user_id,
             &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
-            json!(&mut device_keys),
+            &device_keys,
         );
         assert!(ret.is_err());
     }
@@ -1731,14 +1731,18 @@ pub(crate) mod tests {
         let mut one_time_keys = machine.account.signed_one_time_keys().await;
         let ed25519_key = machine.account.identity_keys().ed25519;
 
-        let mut one_time_key =
-            one_time_keys.values_mut().next().expect("One time keys should be generated");
+        let one_time_key: SignedKey = one_time_keys
+            .values_mut()
+            .next()
+            .expect("One time keys should be generated")
+            .deserialize_as()
+            .unwrap();
 
         ed25519_key
             .verify_json(
                 &machine.user_id,
                 &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
-                json!(&mut one_time_key),
+                &one_time_key,
             )
             .expect("One-time key has been signed successfully");
     }
@@ -1753,17 +1757,27 @@ pub(crate) mod tests {
         let mut request =
             machine.keys_for_upload().await.expect("Can't prepare initial key upload");
 
-        let ret = ed25519_key.verify_json(
-            &machine.user_id,
-            &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
-            json!(&mut request.one_time_keys.values_mut().next()),
-        );
-        assert!(ret.is_ok());
+        let one_time_key: SignedKey = request
+            .one_time_keys
+            .values_mut()
+            .next()
+            .expect("One time keys should be generated")
+            .deserialize_as()
+            .unwrap();
 
         let ret = ed25519_key.verify_json(
             &machine.user_id,
             &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
-            json!(&mut request.device_keys.unwrap()),
+            &one_time_key,
+        );
+        assert!(ret.is_ok());
+
+        let device_keys: DeviceKeys = request.device_keys.unwrap().deserialize_as().unwrap();
+
+        let ret = ed25519_key.verify_json(
+            &machine.user_id,
+            &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
+            &device_keys,
         );
         assert!(ret.is_ok());
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -677,9 +677,9 @@ impl ReadOnlyAccount {
 
     /// Check if the given JSON is signed by this Account key.
     ///
-    /// This method should only be used if a signature of an object should be
-    /// checked multiple times and the canonicalization step wants to be done
-    /// only a single time.
+    /// This method should only be used if an object's signature needs to be
+    /// checked multiple times, and you'd like to avoid performing the
+    /// canonicalization step each time.
     ///
     /// **Note**: Use this method with caution, the `canonical_json` needs to be
     /// correctly canonicalized and make sure that the object you are checking

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -685,7 +685,7 @@ impl ReadOnlyAccount {
     /// correctly canonicalized and make sure that the object you are checking
     /// the signature for is allowed to be signed by our own device.
     #[cfg(feature = "backups_v1")]
-    pub fn is_signed_by_raw(
+    pub fn has_signed_raw(
         &self,
         signatures: &crate::types::Signatures,
         canonical_json: &str,

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -675,17 +675,30 @@ impl ReadOnlyAccount {
         self.inner.lock().await.sign(string)
     }
 
-    /// Check that the given json value is signed by this account.
+    /// Check if the given JSON is signed by this Account key.
+    ///
+    /// This method should only be used if a signature of an object should be
+    /// checked multiple times and the canonicalization step wants to be done
+    /// only a single time.
+    ///
+    /// **Note**: Use this method with caution, the `canonical_json` needs to be
+    /// correctly canonicalized and make sure that the object you are checking
+    /// the signature for is allowed to be signed by our own device.
     #[cfg(feature = "backups_v1")]
-    pub fn is_signed(&self, json: Value) -> Result<(), SignatureError> {
+    pub fn is_signed_by_raw(
+        &self,
+        signatures: &crate::types::Signatures,
+        canonical_json: &str,
+    ) -> Result<(), SignatureError> {
         use crate::olm::utility::VerifyJson;
 
         let signing_key = self.identity_keys.ed25519;
 
-        signing_key.verify_json(
+        signing_key.verify_canonicalized_json(
             &self.user_id,
             &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, self.device_id()),
-            json,
+            signatures,
+            canonical_json,
         )
     }
 

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -32,7 +32,7 @@ pub use group_sessions::{
 };
 pub use session::{PickledSession, Session};
 pub use signing::{CrossSigningStatus, PickledCrossSigningIdentity, PrivateCrossSigningIdentity};
-pub(crate) use utility::VerifyJson;
+pub(crate) use utility::{SignedJsonObject, VerifyJson};
 pub use vodozemac::olm::IdentityKeys;
 
 #[cfg(test)]

--- a/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
@@ -312,15 +312,4 @@ impl Signing {
     pub fn sign(&self, message: &str) -> Ed25519Signature {
         self.inner.sign(message.as_bytes())
     }
-
-    #[cfg(test)]
-    pub fn verify_json(
-        &self,
-        user_id: &ruma::UserId,
-        key_id: &DeviceKeyId,
-        message: Value,
-    ) -> Result<(), SignatureError> {
-        use crate::olm::VerifyJson;
-        self.public_key.verify_json(user_id, key_id, message)
-    }
 }

--- a/crates/matrix-sdk-crypto/src/olm/utility.rs
+++ b/crates/matrix-sdk-crypto/src/olm/utility.rs
@@ -63,9 +63,10 @@ pub trait VerifyJson {
     /// * `user_id` - The user that claims to have signed this object.
     ///
     /// * `key_id` - The ID of the key that was used to sign this object.
-    /// **Note**: The key ID must match the ID of the public key that is
-    /// verifying the signature. This is only used to find the correct
-    /// signature.
+    ///
+    ///   **Note**: The key ID must match the ID of the public key that is
+    ///   verifying the signature. This is only used to find the correct
+    ///   signature.
     ///
     /// * `signed_object` - The signed object that we should check for a valid
     /// signature.
@@ -87,17 +88,18 @@ pub trait VerifyJson {
     /// * `user_id` - The user that claims to have signed this object.
     ///
     /// * `key_id` - The ID of the key that was used to sign this object.
-    /// **Note**: The key ID must match the ID of the public key that is
-    /// verifying the signature. This is only used to find the correct
-    /// signature.
+    ///
+    ///   **Note**: The key ID must match the ID of the public key that is
+    ///   verifying the signature. This is only used to find the correct
+    ///   signature.
     ///
     /// * `canonicalized_json` - The canonicalized version of a signed JSON
     /// object.
     ///
-    /// This method should only be used if a signature of an object should be
-    /// checked multiple times and the canonicalization step wants to be done
-    /// only a single time. Prefer the [`VerifyJson::verify_json`] method
-    /// otherwise.
+    /// This method should only be used if an object's signature needs to be
+    /// checked multiple times, and you'd like to avoid performing the
+    /// canonicalization step each time. Otherwise, prefer the
+    /// [`VerifyJson::verify_json`] method
     ///
     /// Returns Ok if the signature was successfully verified, otherwise an
     /// SignatureError.
@@ -159,14 +161,14 @@ fn verify_signature(
 }
 
 /// A trait for Matrix objects that we can canonicalize, sign and verify
-/// signatures for as described by the [spec].
+/// signatures for, as described by the [spec].
 ///
 /// [spec]: https://spec.matrix.org/unstable/appendices/#signing-json
 pub trait SignedJsonObject: Serialize {
-    /// Get the collection of signatures this SignedJsonObject has.
+    /// Get the collection of signatures present on this signed JSON object.
     fn signatures(&self) -> &Signatures;
 
-    /// Convert the SignedJsonObject to a canonicalized signed JSON string.
+    /// Convert this signed JSON object to a canonicalized signed JSON string.
     fn to_canonical_json(&self) -> Result<String, SignatureError> {
         let value = serde_json::to_value(self)?;
         to_signable_json(value)


### PR DESCRIPTION
This should mostly remove the wild west of signature verification. We define a trait that tells us which objects can contain signatures and thus can be passed on to signature verification methods.

It also should be slightly more efficient, since we removed a bunch of duplicate canonicalization steps.

This requires #725 and #724.