### PR TITLE
Cancel the verification flow if we have multiple verifications

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -236,6 +236,14 @@ impl Verification {
             Verification::QrV1(v) => v.is_self_verification(),
         }
     }
+
+    fn cancel(&self) -> Option<OutgoingVerificationRequest> {
+        match self {
+            Verification::SasV1(v) => v.cancel(),
+            #[cfg(feature = "qrcode")]
+            Verification::QrV1(v) => v.cancel(),
+        }
+    }
 }
 
 impl From<Sas> for Verification {

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -1107,9 +1107,10 @@ impl RequestState<Ready> {
                         } else {
                             true
                         };
+
                         if start_new {
                             info!("Started a new SAS verification.");
-                            self.verification_cache.insert_sas(s);
+                            self.verification_cache.replace_sas(s);
                         }
                     }
                     Err(c) => {


### PR DESCRIPTION
The spec claims that we should cancel verifications if multiple verifications are attempted at once[[1]]:
> When the same device attempts to initiate multiple verification
    attempts, the recipient should cancel all attempts with that device.

This patch adds support for this.

[1]: https://spec.matrix.org/v1.2/client-server-api/#error-and-exception-handling