### PR TITLE
Ensure all data state stores save is encrypted 

### DIFF
--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -359,6 +359,16 @@ macro_rules! statestore_integration_tests {
                 }
 
                 #[async_test]
+                async fn test_filter_saving() {
+                    let store = get_store().await.unwrap();
+                    let test_name = "filter_name";
+                    let filter_id = "filter_id_1234";
+                    assert_eq!(store.get_filter(test_name).await.unwrap(), None);
+                    assert_eq!(store.save_filter(test_name, filter_id).await.unwrap(), ());
+                    assert_eq!(store.get_filter(test_name).await.unwrap(), Some(filter_id.to_owned()));
+                }
+
+                #[async_test]
                 async fn test_stripped_member_saving() {
                     let store = get_store().await.unwrap();
                     let room_id = room_id!("!test_stripped_member_saving:localhost");

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -364,20 +364,19 @@ macro_rules! statestore_integration_tests {
                     let test_name = "filter_name";
                     let filter_id = "filter_id_1234";
                     assert_eq!(store.get_filter(test_name).await.unwrap(), None);
-                    assert_eq!(store.save_filter(test_name, filter_id).await.unwrap(), ());
+                    store.save_filter(test_name, filter_id).await.unwrap();
                     assert_eq!(store.get_filter(test_name).await.unwrap(), Some(filter_id.to_owned()));
                 }
 
                 #[async_test]
                 async fn test_sync_token_saving() {
-
                     let mut changes = StateChanges::default();
                     let store = get_store().await.unwrap();
                     let sync_token = "t392-516_47314_0_7_1".to_owned();
 
                     changes.sync_token = Some(sync_token.clone());
                     assert_eq!(store.get_sync_token().await.unwrap(), None);
-                    assert_eq!(store.save_changes(&changes).await.unwrap(), ());
+                    store.save_changes(&changes).await.unwrap();
                     assert_eq!(store.get_sync_token().await.unwrap(), Some(sync_token));
                 }
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -369,6 +369,19 @@ macro_rules! statestore_integration_tests {
                 }
 
                 #[async_test]
+                async fn test_sync_token_saving() {
+
+                    let mut changes = StateChanges::default();
+                    let store = get_store().await.unwrap();
+                    let sync_token = "t392-516_47314_0_7_1".to_owned();
+
+                    changes.sync_token = Some(sync_token.clone());
+                    assert_eq!(store.get_sync_token().await.unwrap(), None);
+                    assert_eq!(store.save_changes(&changes).await.unwrap(), ());
+                    assert_eq!(store.get_sync_token().await.unwrap(), Some(sync_token));
+                }
+
+                #[async_test]
                 async fn test_stripped_member_saving() {
                     let store = get_store().await.unwrap();
                     let room_id = room_id!("!test_stripped_member_saving:localhost");

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -647,7 +647,7 @@ macro_rules! statestore_integration_tests {
 
                     // Add sync response
                     let sync = SyncResponse::try_from_http_response(
-                        Response::builder().body(serde_json::to_vec(&*test_json::MORE_SYNC).unwrap()).unwrap(),
+                        Response::builder().body(serde_json::to_vec(&*test_json::MORE_SYNC).expect("Parsing MORE_SYNC failed")).unwrap(),
                         )
                         .unwrap();
 
@@ -665,7 +665,7 @@ macro_rules! statestore_integration_tests {
                         );
                     let mut changes = StateChanges::new(sync.next_batch.clone());
                     changes.add_timeline(room_id, timeline_slice);
-                    store.save_changes(&changes).await.unwrap();
+                    store.save_changes(&changes).await.expect("Saving room timeline failed");
 
                     check_timeline_events(room_id, &store, &stored_events, timeline.prev_batch.as_deref())
                         .await;
@@ -673,7 +673,7 @@ macro_rules! statestore_integration_tests {
                     // Add message response
                     let messages = MessageResponse::try_from_http_response(
                         Response::builder()
-                        .body(serde_json::to_vec(&*test_json::SYNC_ROOM_MESSAGES_BATCH_1).unwrap())
+                        .body(serde_json::to_vec(&*test_json::SYNC_ROOM_MESSAGES_BATCH_1).expect("Parsing SYNC_ROOM_MESSAGES_BATCH_1 failed"))
                         .unwrap(),
                         )
                         .unwrap();
@@ -691,14 +691,14 @@ macro_rules! statestore_integration_tests {
                         TimelineSlice::new(events, messages.start.clone(), messages.end.clone(), false, false);
                     let mut changes = StateChanges::default();
                     changes.add_timeline(room_id, timeline_slice);
-                    store.save_changes(&changes).await.unwrap();
+                    store.save_changes(&changes).await.expect("Saving room update timeline failed");
 
                     check_timeline_events(room_id, &store, &stored_events, messages.end.as_deref()).await;
 
                     // Add second message response
                     let messages = MessageResponse::try_from_http_response(
                         Response::builder()
-                        .body(serde_json::to_vec(&*test_json::SYNC_ROOM_MESSAGES_BATCH_2).unwrap())
+                        .body(serde_json::to_vec(&*test_json::SYNC_ROOM_MESSAGES_BATCH_2).expect("Parsing SYNC_ROOM_MESSAGES_BATCH_2 failed"))
                         .unwrap(),
                         )
                         .unwrap();
@@ -716,7 +716,7 @@ macro_rules! statestore_integration_tests {
                         TimelineSlice::new(events, messages.start.clone(), messages.end.clone(), false, false);
                     let mut changes = StateChanges::default();
                     changes.add_timeline(room_id, timeline_slice);
-                    store.save_changes(&changes).await.unwrap();
+                    store.save_changes(&changes).await.expect("Saving room update timeline 2 failed");
 
                     check_timeline_events(room_id, &store, &stored_events, messages.end.as_deref()).await;
 
@@ -744,7 +744,7 @@ macro_rules! statestore_integration_tests {
                         );
                     let mut changes = StateChanges::new(sync.next_batch.clone());
                     changes.add_timeline(room_id, timeline_slice);
-                    store.save_changes(&changes).await.unwrap();
+                    store.save_changes(&changes).await.expect("Saving room update timeline 3 failed");
 
                     check_timeline_events(room_id, &store, &stored_events, messages.end.as_deref()).await;
 
@@ -759,7 +759,7 @@ macro_rules! statestore_integration_tests {
                         );
                     let mut changes = StateChanges::default();
                     changes.add_timeline(room_id, timeline_slice);
-                    store.save_changes(&changes).await.unwrap();
+                    store.save_changes(&changes).await.expect("Saving room update timeline 4 failed");
 
                     check_timeline_events(room_id, &store, &Vec::new(), end_token.as_deref()).await;
                 }

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -1474,11 +1474,14 @@ mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use matrix_sdk_base::statestore_integration_tests;
+    use uuid::Uuid;
 
     use super::{IndexeddbStore, Result};
 
     async fn get_store() -> Result<IndexeddbStore> {
-        Ok(IndexeddbStore::open().await?)
+        let db_name =
+            format!("test-state-plain-{}", Uuid::new_v4().as_hyphenated().to_string());
+        Ok(IndexeddbStore::open_helper(db_name, None).await?)
     }
 
     statestore_integration_tests! { integration }

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -1479,8 +1479,7 @@ mod tests {
     use super::{IndexeddbStore, Result};
 
     async fn get_store() -> Result<IndexeddbStore> {
-        let db_name =
-            format!("test-state-plain-{}", Uuid::new_v4().as_hyphenated().to_string());
+        let db_name = format!("test-state-plain-{}", Uuid::new_v4().as_hyphenated().to_string());
         Ok(IndexeddbStore::open_helper(db_name, None).await?)
     }
 

--- a/crates/matrix-sdk-sled/src/encode_key.rs
+++ b/crates/matrix-sdk-sled/src/encode_key.rs
@@ -11,6 +11,23 @@ use ruma::{
     RoomId, TransactionId, UserId,
 };
 
+/// Hold any data to be used as an encoding key
+/// without checking for the existence of `ENCODE_SEPARATOR` within
+pub struct EncodeUnchecked<'a>(&'a [u8]);
+
+impl<'a> EncodeUnchecked<'a> {
+    /// Wrap any `[u8]`
+    pub fn from(bytes: &'a [u8]) -> Self {
+        EncodeUnchecked(bytes)
+    }
+}
+
+impl<'a> EncodeKey for EncodeUnchecked<'a> {
+    fn encode_as_bytes(&self) -> Cow<'a, [u8]> {
+        (self.0).into()
+    }
+}
+
 pub const ENCODE_SEPARATOR: u8 = 0xff;
 
 pub trait EncodeKey {
@@ -36,12 +53,6 @@ impl<T: EncodeKey + ?Sized> EncodeKey for &T {
     }
     fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
         T::encode_secure(self, table_name, store_cipher)
-    }
-}
-
-impl EncodeKey for &[u8] {
-    fn encode_as_bytes(&self) -> Cow<'_, [u8]> {
-        (*self).into()
     }
 }
 

--- a/crates/matrix-sdk-sled/src/encode_key.rs
+++ b/crates/matrix-sdk-sled/src/encode_key.rs
@@ -39,6 +39,12 @@ impl<T: EncodeKey + ?Sized> EncodeKey for &T {
     }
 }
 
+impl EncodeKey for &[u8] {
+    fn encode_as_bytes(&self) -> Cow<'_, [u8]> {
+        (*self).into()
+    }
+}
+
 impl EncodeKey for str {
     fn encode_as_bytes(&self) -> Cow<'_, [u8]> {
         self.as_bytes().into()

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -62,9 +62,9 @@ use tokio::task::spawn_blocking;
 
 #[cfg(feature = "crypto-store")]
 use super::OpenStoreError;
-use crate::encode_key::EncodeKey;
 #[cfg(feature = "experimental-timeline")]
 use crate::encode_key::ENCODE_SEPARATOR;
+use crate::encode_key::{EncodeKey, EncodeUnchecked};
 #[cfg(feature = "crypto-store")]
 pub use crate::CryptoStore;
 
@@ -971,13 +971,13 @@ impl SledStore {
     async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         let custom = self.custom.clone();
         let me = self.clone();
-        let key = self.encode_key(CUSTOM, key);
+        let key = self.encode_key(CUSTOM, EncodeUnchecked::from(key));
         spawn_blocking(move || custom.get(key)?.map(move |v| me.deserialize_value(&v)).transpose())
             .await?
     }
 
     async fn set_custom_value(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
-        let key = self.encode_key(CUSTOM, key);
+        let key = self.encode_key(CUSTOM, EncodeUnchecked::from(key));
         let me = self.clone();
         let ret = self
             .custom

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -1152,7 +1152,7 @@ impl SledStore {
         let metadata: Option<TimelineMetadata> = db
             .room_timeline_metadata
             .get(key.as_slice())?
-            .map(|v| serde_json::from_slice(&v).map_err(StoreError::Json))
+            .map(|v| self.deserialize_value(&v))
             .transpose()?;
         let metadata = match metadata {
             Some(m) => m,
@@ -1371,7 +1371,7 @@ impl SledStore {
 
             timeline_metadata_batch.insert(
                 self.encode_key(TIMELINE_METADATA, &room_id),
-                serde_json::to_vec(&metadata)?,
+                self.serialize_value(&metadata)?,
             );
         }
 

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -398,15 +398,16 @@ impl SledStore {
     }
 
     pub async fn save_filter(&self, filter_name: &str, filter_id: &str) -> Result<()> {
-        self.session.insert(self.encode_key(SESSION, ("filter", filter_name)), filter_id)?;
+        self.session.insert(self.encode_key(SESSION, ("filter", filter_name)), self.serialize_value(&filter_id)?)?;
         Ok(())
     }
 
     pub async fn get_filter(&self, filter_name: &str) -> Result<Option<String>> {
-        Ok(self
+        self
             .session
             .get(self.encode_key(SESSION, ("filter", filter_name)))?
-            .map(|f| String::from_utf8_lossy(&f).to_string()))
+            .map(|f| self.deserialize_value(&f))
+            .transpose()
     }
 
     pub async fn get_sync_token(&self) -> Result<Option<String>> {

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -1242,7 +1242,7 @@ impl SledStore {
                 let metadata: Option<TimelineMetadata> = self
                     .room_timeline_metadata
                     .get(self.encode_key(TIMELINE_METADATA, &room_id))?
-                    .map(|v| serde_json::from_slice(&v).map_err(StoreError::Json))
+                    .map(|item| self.deserialize_value(&item))
                     .transpose()?;
                 if let Some(mut metadata) = metadata {
                     if !timeline.sync && Some(&timeline.start) != metadata.end.as_ref() {


### PR DESCRIPTION
... if a cipher is provided.

Effected:

- [x] sled state store
   - [x] filters
   - [x] session
   - [x] media
   - [x] custom
   - [x] [invited|joined]_user_ids
   - [x] room_timeline_metadata 
- [x] indexeddb state store
   - [x] filters
   - [x] room_timeline_metadata 

every other instance of `insert` (in `sled`) and `set_key_val` (in `indexeddb`) has a proper key and value serialization as far as I could see.
 

fixes #609 and brings some more integration tests to cover these functions (though whether they en- & decrypt is black boxed and thus not something we can tests for :( )