### PR TITLE
Add ways to wait for a `/keys/query` request to be done

### DIFF
--- a/crates/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/crates/matrix-sdk-crypto-ffi/src/machine.rs
@@ -140,10 +140,12 @@ impl OlmMachine {
     ///
     /// * `user_id` - The unique id of the user that the identity belongs to
     ///
-    /// * `timeout` - The amount of time we should wait before returning if the
-    /// user's device list has been marked as stale. **Note**, this assumes that
-    /// the requests from [`OlmMachine::outgoing_requests`] are being
-    /// processed and sent out.
+    /// * `timeout` - The time in seconds we should wait before returning if
+    /// the user's device list has been marked as stale. Passing a 0 as the
+    /// timeout means that we won't wait at all. **Note**, this assumes that
+    /// the requests from [`OlmMachine::outgoing_requests`] are being processed
+    /// and sent out. Namely, this waits for a `/keys/query` response to be
+    /// received.
     pub fn get_identity(
         &self,
         user_id: &str,
@@ -217,10 +219,12 @@ impl OlmMachine {
     ///
     /// * `device_id` - The id of the device itself.
     ///
-    /// * `timeout` - The amount of time we should wait before returning if the
-    /// user's device list has been marked as stale. **Note**, this assumes that
-    /// the requests from [`OlmMachine::outgoing_requests`] are being
-    /// processed and sent out.
+    /// * `timeout` - The time in seconds we should wait before returning if
+    /// the user's device list has been marked as stale. Passing a 0 as the
+    /// timeout means that we won't wait at all. **Note**, this assumes that
+    /// the requests from [`OlmMachine::outgoing_requests`] are being processed
+    /// and sent out. Namely, this waits for a `/keys/query` response to be
+    /// received.
     pub fn get_device(
         &self,
         user_id: &str,
@@ -290,10 +294,12 @@ impl OlmMachine {
     ///
     /// * `user_id` - The id of the device owner.
     ///
-    /// * `timeout` - The amount of time we should wait before returning if the
-    /// user's device list has been marked as stale. **Note**, this assumes that
-    /// the requests from [`OlmMachine::outgoing_requests`] are being
-    /// processed and sent out.
+    /// * `timeout` - The time in seconds we should wait before returning if
+    /// the user's device list has been marked as stale. Passing a 0 as the
+    /// timeout means that we won't wait at all. **Note**, this assumes that
+    /// the requests from [`OlmMachine::outgoing_requests`] are being processed
+    /// and sent out. Namely, this waits for a `/keys/query` response to be
+    /// received.
     pub fn get_user_devices(
         &self,
         user_id: &str,

--- a/crates/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/crates/matrix-sdk-crypto-ffi/src/olm.udl
@@ -280,17 +280,17 @@ interface OlmMachine {
     string encrypt([ByRef] string room_id, [ByRef] string event_type, [ByRef] string content);
 
     [Throws=CryptoStoreError]
-    UserIdentity? get_identity([ByRef] string user_id);
+    UserIdentity? get_identity([ByRef] string user_id, u32 timeout);
     [Throws=SignatureError]
     SignatureUploadRequest verify_identity([ByRef] string user_id);
     [Throws=CryptoStoreError]
-    Device? get_device([ByRef] string user_id, [ByRef] string device_id);
+    Device? get_device([ByRef] string user_id, [ByRef] string device_id, u32 timeout);
     [Throws=CryptoStoreError]
     void mark_device_as_trusted([ByRef] string user_id, [ByRef] string device_id);
     [Throws=SignatureError]
     SignatureUploadRequest verify_device([ByRef] string user_id, [ByRef] string device_id);
     [Throws=CryptoStoreError]
-    sequence<Device> get_user_devices([ByRef] string user_id);
+    sequence<Device> get_user_devices([ByRef] string user_id, u32 timeout);
 
     [Throws=CryptoStoreError]
     boolean is_user_tracked([ByRef] string user_id);

--- a/crates/matrix-sdk-crypto-js/src/requests.rs
+++ b/crates/matrix-sdk-crypto-js/src/requests.rs
@@ -52,7 +52,7 @@ pub struct KeysQueryRequest {
 
     /// A JSON-encoded object of form:
     ///
-    /// ```
+    /// ```json
     /// {"timeout": …, "device_keys": …, "token": …}
     /// ```
     #[wasm_bindgen(readonly)]
@@ -75,7 +75,7 @@ pub struct KeysClaimRequest {
 
     /// A JSON-encoded object of form:
     ///
-    /// ```
+    /// ```json
     /// {"timeout": …, "one_time_keys": …}
     /// ```
     #[wasm_bindgen(readonly)]
@@ -97,7 +97,7 @@ pub struct ToDeviceRequest {
 
     /// A JSON-encoded object of form:
     ///
-    /// ```
+    /// ```json
     /// {"event_type": …, "txn_id": …, "messages": …}
     /// ```
     #[wasm_bindgen(readonly)]
@@ -119,7 +119,7 @@ pub struct SignatureUploadRequest {
 
     /// A JSON-encoded object of form:
     ///
-    /// ```
+    /// ```json
     /// {"signed_keys": …, "txn_id": …, "messages": …}
     /// ```
     #[wasm_bindgen(readonly)]
@@ -139,7 +139,7 @@ pub struct RoomMessageRequest {
 
     /// A JSON-encoded object of form:
     ///
-    /// ```
+    /// ```json
     /// {"room_id": …, "txn_id": …, "content": …}
     /// ```
     #[wasm_bindgen(readonly)]
@@ -159,7 +159,7 @@ pub struct KeysBackupRequest {
 
     /// A JSON-encoded object of form:
     ///
-    /// ```
+    /// ```json
     /// {"rooms": …}
     /// ```
     #[wasm_bindgen(readonly)]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -33,6 +33,7 @@ bs58 = { version = "0.4.0", optional = true }
 byteorder = "1.4.3"
 ctr = "0.9.1"
 dashmap = "5.2.0"
+event-listener = "2.5.2"
 futures-util = { version = "0.3.21", default-features = false, features = ["alloc"] }
 hmac = "0.12.1"
 http = { version = "0.2.6", optional = true } # feature = testing only
@@ -49,6 +50,7 @@ tracing = "0.1.34"
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.18", default-features = false, features = ["time"] }
 ruma = { version = "0.6.2", features = ["client-api-c", "rand", "signatures", "unstable-msc2676", "unstable-msc2677"] }
 vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "d0e744287a14319c2a9148fef3747548c740fc36" }
 

--- a/crates/matrix-sdk-crypto/src/identities/mod.rs
+++ b/crates/matrix-sdk-crypto/src/identities/mod.rs
@@ -50,7 +50,7 @@ use std::sync::{
 };
 
 pub use device::{Device, LocalTrust, ReadOnlyDevice, UserDevices};
-pub(crate) use manager::IdentityManager;
+pub(crate) use manager::{IdentityManager, KeysQueryListener, UserKeyQueryResult};
 use serde::{Deserialize, Deserializer, Serializer};
 pub use user::{
     MasterPubkey, OwnUserIdentity, ReadOnlyOwnUserIdentity, ReadOnlyUserIdentities,

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -166,15 +166,18 @@ impl OlmMachine {
             group_session_manager.session_cache(),
             users_for_key_claim.clone(),
         );
+        let identity_manager =
+            IdentityManager::new(user_id.clone(), device_id.clone(), store.clone());
+
+        let event = identity_manager.listen_for_received_queries();
 
         let session_manager = SessionManager::new(
             account.clone(),
             users_for_key_claim,
             key_request_machine.clone(),
             store.clone(),
+            event,
         );
-        let identity_manager =
-            IdentityManager::new(user_id.clone(), device_id.clone(), store.clone());
 
         #[cfg(feature = "backups_v1")]
         let backup_machine = BackupMachine::new(account.clone(), store.clone(), None);

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -594,7 +594,7 @@ impl Encryption {
         device_id: &DeviceId,
     ) -> Result<Option<Device>, CryptoStoreError> {
         if let Some(machine) = self.client.olm_machine() {
-            let device = machine.get_device(user_id, device_id).await?;
+            let device = machine.get_device(user_id, device_id, None).await?;
             Ok(device.map(|d| Device { inner: d, client: self.client.clone() }))
         } else {
             Ok(None)
@@ -633,7 +633,7 @@ impl Encryption {
             .client
             .olm_machine()
             .ok_or(Error::AuthenticationRequired)?
-            .get_user_devices(user_id)
+            .get_user_devices(user_id, None)
             .await?;
 
         Ok(UserDevices { inner: devices, client: self.client.clone() })
@@ -677,7 +677,7 @@ impl Encryption {
         use crate::encryption::identities::UserIdentity;
 
         if let Some(olm) = self.client.olm_machine() {
-            let identity = olm.get_identity(user_id).await?;
+            let identity = olm.get_identity(user_id, None).await?;
 
             Ok(identity.map(|i| match i {
                 matrix_sdk_base::crypto::UserIdentities::Own(i) => {


### PR DESCRIPTION
This PR adds a mechanism to wait for a `/keys/query` response to be received by the `OlmMachine`.

Namely, the sync response will contain only a notification that a user has changed their devices in some way. We need to send out a `/keys/query` request to actually know what devices were added/changed/removed.

The time between the received notification from the sync response and sending/receiving/processing the matching `/keys/query` response is a race where we have an outdated device list. When encrypting a room event we need to know the accurate list of devices a user possesses, so each and one of their devices gets a copy of the room key.

Users might also want to verify a device while this race is going on. Not finding the correct device.

This PR solves the first problem by waiting for a `/keys/query` response if we call `get_missing_sessions()`, we will wait only iff:
1. The user's device list is marked as outdated
2. We don't know about any devices belonging to this user, i.e. it's the first time we're querying the device keys of this user

The second problem is solved by giving users the ability to wait for a `/keys/query` when fetching identities out of the store if they pass in a `timeout` as and argument.