### PR TITLE
Nightly ffi crate debug builds

### DIFF
--- a/.github/workflows/ffi.yml
+++ b/.github/workflows/ffi.yml
@@ -27,14 +27,14 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           profile: minimal
           override: true
 
       - name: Install targets
         run: |
-          rustup target add aarch64-apple-ios-sim
-          rustup target add x86_64-apple-ios
+          rustup target add aarch64-apple-ios-sim --toolchain nightly
+          rustup target add x86_64-apple-ios --toolchain nightly
 
       - name: Load cache
         uses: Swatinem/rust-cache@v1

--- a/bindings/apple/debug_build_xcframework.sh
+++ b/bindings/apple/debug_build_xcframework.sh
@@ -20,13 +20,12 @@ TARGET_DIR="${SRC_ROOT}/target"
 GENERATED_DIR="${SRC_ROOT}/generated"
 mkdir -p ${GENERATED_DIR}
 
-# Release for now. Debug builds cause crashes deep inside the Tokio runtime.
-REL_FLAG="--release"
-REL_TYPE_DIR="release"
+REL_FLAG=""
+REL_TYPE_DIR="debug"
 
 # iOS Simulator
-cargo build -p matrix-sdk-ffi ${REL_FLAG} --target "aarch64-apple-ios-sim"
-cargo build -p matrix-sdk-ffi ${REL_FLAG} --target "x86_64-apple-ios"
+cargo +nightly build -p matrix-sdk-ffi ${REL_FLAG} --target "aarch64-apple-ios-sim"
+cargo +nightly build -p matrix-sdk-ffi ${REL_FLAG} --target "x86_64-apple-ios"
 
 lipo -create \
   "${TARGET_DIR}/x86_64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_ffi.a" \


### PR DESCRIPTION
Use the nightly toolchain together with the newly introduced `target-applies-to-host` on the sdk-ffi crate debug builds to avoid cache corruption issues. This happens because the `rustflags` aren't being respected when using a cargo --target.
Also switch back to debug mode as the internal tokio crashes went away.