### PR TITLE
Revert "Use OnceCell to store matrix_sdk::Session" to get back working login

### DIFF
--- a/crates/matrix-sdk-appservice/src/lib.rs
+++ b/crates/matrix-sdk-appservice/src/lib.rs
@@ -687,8 +687,8 @@ impl AppService {
             let transaction = transaction.clone();
 
             let task = tokio::spawn(async move {
-                let user_id = match virt_client.user_id() {
-                    Some(user_id) => user_id.localpart(),
+                let user_id = match virt_client.user_id().await {
+                    Some(user_id) => user_id.localpart().to_owned(),
                     // Unauthenticated client. (should that be possible?)
                     None => return Ok(()),
                 };

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -157,8 +157,7 @@ impl BaseClient {
     /// # Arguments
     ///
     /// * `response` - A successful login response that contains our access
-    ///   token
-    /// and device id.
+    ///   token and device id.
     pub async fn receive_login_response(
         &self,
         response: &api::session::login::v3::Response,
@@ -175,8 +174,8 @@ impl BaseClient {
     ///
     /// # Arguments
     ///
-    /// * `session` - An session that the user already has from a
-    /// previous login call.
+    /// * `session` - An session that the user already has from a previous login
+    ///   call.
     pub async fn restore_login(&self, session: Session) -> Result<()> {
         self.store.restore_session(session.clone()).await?;
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -177,6 +177,7 @@ impl BaseClient {
     /// * `session` - An session that the user already has from a previous login
     ///   call.
     pub async fn restore_login(&self, session: Session) -> Result<()> {
+        debug!(user_id = %session.user_id, device_id = %session.device_id, "Restoring login");
         self.store.restore_session(session.clone()).await?;
 
         #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -41,7 +41,6 @@ pub use client::BaseClient;
 pub use http;
 #[cfg(feature = "e2e-encryption")]
 pub use matrix_sdk_crypto as crypto;
-pub use once_cell;
 pub use rooms::{DisplayName, Room, RoomInfo, RoomMember, RoomType};
 pub use store::{StateChanges, StateStore, Store, StoreError};
 pub use utils::{

--- a/crates/matrix-sdk-ffi/src/client.rs
+++ b/crates/matrix-sdk-ffi/src/client.rs
@@ -106,7 +106,7 @@ impl Client {
 
     pub fn restore_token(&self) -> anyhow::Result<String> {
         RUNTIME.block_on(async move {
-            let session = self.client.session().expect("Missing session").clone();
+            let session = self.client.session().await.expect("Missing session").clone();
             let homeurl = self.client.homeserver().await.into();
             Ok(serde_json::to_string(&RestoreToken {
                 session,
@@ -121,8 +121,11 @@ impl Client {
     }
 
     pub fn user_id(&self) -> anyhow::Result<String> {
-        let user_id = self.client.user_id().expect("No User ID found");
-        Ok(user_id.to_string())
+        let client = self.client.clone();
+        RUNTIME.block_on(async move {
+            let user_id = client.user_id().await.expect("No User ID found");
+            Ok(user_id.to_string())
+        })
     }
 
     pub fn display_name(&self) -> anyhow::Result<String> {
@@ -142,8 +145,11 @@ impl Client {
     }
 
     pub fn device_id(&self) -> anyhow::Result<String> {
-        let device_id = self.client.device_id().expect("No Device ID found");
-        Ok(device_id.to_string())
+        let client = self.client.clone();
+        RUNTIME.block_on(async move {
+            let device_id = client.device_id().await.expect("No Device ID found");
+            Ok(device_id.to_string())
+        })
     }
 
     pub fn get_media_content(&self, media_source: Arc<MediaSource>) -> anyhow::Result<Vec<u8>> {

--- a/crates/matrix-sdk/examples/autojoin.rs
+++ b/crates/matrix-sdk/examples/autojoin.rs
@@ -10,7 +10,7 @@ async fn on_stripped_state_member(
     client: Client,
     room: Room,
 ) {
-    if room_member.state_key != client.user_id().unwrap() {
+    if room_member.state_key != client.user_id().await.unwrap() {
         return;
     }
 

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -70,8 +70,8 @@ impl Account {
     /// # anyhow::Ok(()) });
     /// ```
     pub async fn get_display_name(&self) -> Result<Option<String>> {
-        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        let request = get_display_name::v3::Request::new(user_id);
+        let user_id = self.client.user_id().await.ok_or(Error::AuthenticationRequired)?;
+        let request = get_display_name::v3::Request::new(&user_id);
         let response = self.client.send(request, None).await?;
         Ok(response.displayname)
     }
@@ -93,8 +93,8 @@ impl Account {
     /// # anyhow::Ok(()) });
     /// ```
     pub async fn set_display_name(&self, name: Option<&str>) -> Result<()> {
-        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        let request = set_display_name::v3::Request::new(user_id, name);
+        let user_id = self.client.user_id().await.ok_or(Error::AuthenticationRequired)?;
+        let request = set_display_name::v3::Request::new(&user_id, name);
         self.client.send(request, None).await?;
         Ok(())
     }
@@ -118,8 +118,8 @@ impl Account {
     /// # anyhow::Ok(()) });
     /// ```
     pub async fn get_avatar_url(&self) -> Result<Option<OwnedMxcUri>> {
-        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        let request = get_avatar_url::v3::Request::new(user_id);
+        let user_id = self.client.user_id().await.ok_or(Error::AuthenticationRequired)?;
+        let request = get_avatar_url::v3::Request::new(&user_id);
 
         let config = Some(RequestConfig::new().force_auth());
 
@@ -131,8 +131,8 @@ impl Account {
     ///
     /// The avatar is unset if `url` is `None`.
     pub async fn set_avatar_url(&self, url: Option<&MxcUri>) -> Result<()> {
-        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        let request = set_avatar_url::v3::Request::new(user_id, url);
+        let user_id = self.client.user_id().await.ok_or(Error::AuthenticationRequired)?;
+        let request = set_avatar_url::v3::Request::new(&user_id, url);
         self.client.send(request, None).await?;
         Ok(())
     }
@@ -233,8 +233,8 @@ impl Account {
     /// # anyhow::Ok(()) });
     /// ```
     pub async fn get_profile(&self) -> Result<get_profile::v3::Response> {
-        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        let request = get_profile::v3::Request::new(user_id);
+        let user_id = self.client.user_id().await.ok_or(Error::AuthenticationRequired)?;
+        let request = get_profile::v3::Request::new(&user_id);
         Ok(self.client.send(request, None).await?)
     }
 

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -295,7 +295,12 @@ impl ClientBuilder {
         let base_client = BaseClient::with_store_config(self.store_config);
 
         let mk_http_client = |homeserver| {
-            HttpClient::new(inner_http_client.clone(), homeserver, self.request_config)
+            HttpClient::new(
+                inner_http_client.clone(),
+                homeserver,
+                base_client.session().clone(),
+                self.request_config,
+            )
         };
 
         let homeserver = match homeserver_cfg {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -71,7 +71,7 @@ use ruma::{
 use serde::de::DeserializeOwned;
 #[cfg(not(target_arch = "wasm32"))]
 pub use tokio::sync::OnceCell;
-use tracing::{error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use url::Url;
 
 #[cfg(feature = "e2e-encryption")]
@@ -1205,14 +1205,17 @@ impl Client {
     ///
     /// let response = client.sync_once(sync_settings).await.unwrap();
     /// # });
+    #[instrument(skip(self, definition))]
     pub async fn get_or_upload_filter(
         &self,
         filter_name: &str,
         definition: FilterDefinition<'_>,
     ) -> Result<String> {
         if let Some(filter) = self.inner.base_client.get_filter(filter_name).await? {
+            debug!("Found filter locally");
             Ok(filter)
         } else {
+            debug!("Didn't find filter locally");
             let user_id = self.user_id().ok_or(Error::AuthenticationRequired)?;
             let request = FilterUploadRequest::new(user_id, definition);
             let response = self.send(request, None).await?;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -65,8 +65,8 @@ use ruma::{
     assign,
     events::room::MediaSource,
     presence::PresenceState,
-    DeviceId, MxcUri, OwnedDeviceId, OwnedRoomId, OwnedServerName, RoomAliasId, RoomId,
-    RoomOrAliasId, ServerName, UInt, UserId,
+    MxcUri, OwnedDeviceId, OwnedRoomId, OwnedServerName, OwnedUserId, RoomAliasId, RoomId,
+    RoomOrAliasId, ServerName, UInt,
 };
 use serde::de::DeserializeOwned;
 #[cfg(not(target_arch = "wasm32"))]
@@ -257,8 +257,8 @@ impl Client {
     }
 
     /// Is the client logged in.
-    pub fn logged_in(&self) -> bool {
-        self.inner.base_client.logged_in()
+    pub async fn logged_in(&self) -> bool {
+        self.inner.base_client.logged_in().await
     }
 
     /// The Homeserver of the client.
@@ -267,13 +267,15 @@ impl Client {
     }
 
     /// Get the user id of the current owner of the client.
-    pub fn user_id(&self) -> Option<&UserId> {
-        self.inner.base_client.session().map(|s| s.user_id.as_ref())
+    pub async fn user_id(&self) -> Option<OwnedUserId> {
+        let session = self.inner.base_client.session().read().await;
+        session.as_ref().cloned().map(|s| s.user_id)
     }
 
     /// Get the device id that identifies the current session.
-    pub fn device_id(&self) -> Option<&DeviceId> {
-        self.inner.base_client.session().map(|s| s.device_id.as_ref())
+    pub async fn device_id(&self) -> Option<OwnedDeviceId> {
+        let session = self.inner.base_client.session().read().await;
+        session.as_ref().map(|s| s.device_id.clone())
     }
 
     /// Get the whole session info of this client.
@@ -282,8 +284,8 @@ impl Client {
     ///
     /// Can be used with [`Client::restore_login`] to restore a previously
     /// logged in session.
-    pub fn session(&self) -> Option<&Session> {
-        self.inner.base_client.session()
+    pub async fn session(&self) -> Option<Session> {
+        self.inner.base_client.session().read().await.clone()
     }
 
     /// Get a reference to the store.
@@ -1102,7 +1104,6 @@ impl Client {
     ///
     /// [`login`]: #method.login
     pub async fn restore_login(&self, session: Session) -> Result<()> {
-        self.inner.http_client.set_session(session.clone());
         Ok(self.inner.base_client.restore_login(session).await?)
     }
 
@@ -1216,8 +1217,8 @@ impl Client {
             Ok(filter)
         } else {
             debug!("Didn't find filter locally");
-            let user_id = self.user_id().ok_or(Error::AuthenticationRequired)?;
-            let request = FilterUploadRequest::new(user_id, definition);
+            let user_id = self.user_id().await.ok_or(Error::AuthenticationRequired)?;
+            let request = FilterUploadRequest::new(&user_id, definition);
             let response = self.send(request, None).await?;
 
             self.inner.base_client.receive_filter_upload(filter_name, &response).await?;
@@ -2397,7 +2398,7 @@ pub(crate) mod tests {
 
         client.login("example", "wordpass", None, None).await.unwrap();
 
-        let logged_in = client.logged_in();
+        let logged_in = client.logged_in().await;
         assert!(logged_in, "Client should be logged in");
 
         assert_eq!(client.homeserver().await, homeserver);
@@ -2414,7 +2415,7 @@ pub(crate) mod tests {
 
         client.login("example", "wordpass", None, None).await.unwrap();
 
-        let logged_in = client.logged_in();
+        let logged_in = client.logged_in().await;
         assert!(logged_in, "Client should be logged in");
 
         assert_eq!(client.homeserver().await.as_str(), "https://example.org/");
@@ -2431,7 +2432,7 @@ pub(crate) mod tests {
 
         client.login("example", "wordpass", None, None).await.unwrap();
 
-        let logged_in = client.logged_in();
+        let logged_in = client.logged_in().await;
         assert!(logged_in, "Client should be logged in");
 
         assert_eq!(client.homeserver().await, Url::parse(&mockito::server_url()).unwrap());
@@ -2475,7 +2476,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let logged_in = client.logged_in();
+        let logged_in = client.logged_in().await;
         assert!(logged_in, "Client should be logged in");
     }
 
@@ -2507,7 +2508,7 @@ pub(crate) mod tests {
 
         client.login_with_token("averysmalltoken", None, None).await.unwrap();
 
-        let logged_in = client.logged_in();
+        let logged_in = client.logged_in().await;
         assert!(logged_in, "Client should be logged in");
     }
 
@@ -2546,7 +2547,7 @@ pub(crate) mod tests {
             .create();
 
         let client = logged_in_client().await;
-        let session = client.session().unwrap().clone();
+        let session = client.session().await.unwrap().clone();
 
         let room = client.get_joined_room(room_id);
         assert!(room.is_none());

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1111,11 +1111,10 @@ impl Client {
     /// # Arguments
     ///
     /// * `registration` - The easiest way to create this request is using the
-    ///   [`register::v3::Request`]
-    /// itself.
-    ///
+    ///   [`register::v3::Request`] itself.
     ///
     /// # Examples
+    ///
     /// ```no_run
     /// # use std::convert::TryFrom;
     /// # use matrix_sdk::Client;

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -223,9 +223,9 @@ impl Client {
         T: GlobalAccountDataEventContent,
     {
         let own_user =
-            self.user_id().ok_or_else(|| Error::from(HttpError::AuthenticationRequired))?;
+            self.user_id().await.ok_or_else(|| Error::from(HttpError::AuthenticationRequired))?;
 
-        let request = set_global_account_data::v3::Request::new(&content, own_user)?;
+        let request = set_global_account_data::v3::Request::new(&content, &own_user)?;
 
         Ok(self.send(request, None).await?)
     }

--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -92,7 +92,7 @@ pub trait HttpSend: AsyncTraitDeps {
     ) -> Result<http::Response<Bytes>, HttpError>;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct HttpClient {
     pub(crate) inner: Arc<dyn HttpSend>,
     pub(crate) homeserver: Arc<RwLock<Url>>,

--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -17,7 +17,6 @@ use std::{any::type_name, convert::TryFrom, fmt::Debug, sync::Arc, time::Duratio
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use http::Response as HttpResponse;
-use matrix_sdk_base::once_cell::sync::OnceCell;
 use matrix_sdk_common::{locks::RwLock, AsyncTraitDeps};
 use reqwest::Response;
 use ruma::api::{
@@ -96,7 +95,7 @@ pub trait HttpSend: AsyncTraitDeps {
 pub(crate) struct HttpClient {
     pub(crate) inner: Arc<dyn HttpSend>,
     pub(crate) homeserver: Arc<RwLock<Url>>,
-    pub(crate) session: OnceCell<Session>,
+    pub(crate) session: Arc<RwLock<Option<Session>>>,
     pub(crate) request_config: RequestConfig,
 }
 
@@ -104,9 +103,10 @@ impl HttpClient {
     pub(crate) fn new(
         inner: Arc<dyn HttpSend>,
         homeserver: Arc<RwLock<Url>>,
+        session: Arc<RwLock<Option<Session>>>,
         request_config: RequestConfig,
     ) -> Self {
-        HttpClient { inner, homeserver, session: Default::default(), request_config }
+        HttpClient { inner, homeserver, session, request_config }
     }
 
     #[tracing::instrument(skip(self, request), fields(request_type = type_name::<Request>()))]
@@ -131,18 +131,21 @@ impl HttpClient {
         }
 
         trace!("Serializing request");
+        let access_token;
+
         let request = if !self.request_config.assert_identity {
             let send_access_token = if auth_scheme == AuthScheme::None && !config.force_auth {
                 // Small optimization: Don't take the session lock if we know the auth token
                 // isn't going to be used anyways.
                 SendAccessToken::None
             } else {
-                match self.session() {
+                match self.session.read().await.as_ref() {
                     Some(session) => {
+                        access_token = session.access_token.clone();
                         if config.force_auth {
-                            SendAccessToken::Always(&session.access_token)
+                            SendAccessToken::Always(&access_token)
                         } else {
-                            SendAccessToken::IfRequired(&session.access_token)
+                            SendAccessToken::IfRequired(&access_token)
                         }
                     }
                     None => SendAccessToken::None,
@@ -155,12 +158,18 @@ impl HttpClient {
                 &server_versions,
             )?
         } else {
+            let (send_access_token, user_id) = {
+                let session = self.session.read().await;
+                let session = session.as_ref().ok_or(HttpError::UserIdRequired)?;
+
+                access_token = session.access_token.clone();
+                (SendAccessToken::Always(&access_token), session.user_id.clone())
+            };
+
             request.try_into_http_request_with_user_id::<BytesMut>(
                 &self.homeserver.read().await.to_string(),
-                SendAccessToken::Always(
-                    &self.session().ok_or(HttpError::UserIdRequired)?.access_token,
-                ),
-                &self.session().ok_or(HttpError::UserIdRequired)?.user_id,
+                send_access_token,
+                &user_id,
                 &server_versions,
             )?
         };
@@ -174,14 +183,6 @@ impl HttpClient {
 
         let response = Request::IncomingResponse::try_from_http_response(response)?;
         Ok(response)
-    }
-
-    pub(crate) fn set_session(&self, session: Session) {
-        self.session.set(session).expect("A session was already set");
-    }
-
-    fn session(&self) -> Option<&Session> {
-        self.session.get()
     }
 }
 

--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -130,6 +130,7 @@ impl HttpClient {
             return Err(HttpError::NotClientRequest);
         }
 
+        trace!("Serializing request");
         let request = if !self.request_config.assert_identity {
             let send_access_token = if auth_scheme == AuthScheme::None && !config.force_auth {
                 // Small optimization: Don't take the session lock if we know the auth token
@@ -165,12 +166,13 @@ impl HttpClient {
         };
 
         let request = request.map(|body| body.freeze());
+
+        trace!("Sending request");
         let response = self.inner.send_request(request, config).await?;
 
         trace!("Got response: {:?}", response);
 
         let response = Request::IncomingResponse::try_from_http_response(response)?;
-
         Ok(response)
     }
 

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -852,9 +852,9 @@ impl Common {
         tag: TagName,
         tag_info: TagInfo,
     ) -> HttpResult<create_tag::v3::Response> {
-        let user_id = self.client.user_id().ok_or(HttpError::AuthenticationRequired)?;
+        let user_id = self.client.user_id().await.ok_or(HttpError::AuthenticationRequired)?;
         let request =
-            create_tag::v3::Request::new(user_id, self.inner.room_id(), tag.as_ref(), tag_info);
+            create_tag::v3::Request::new(&user_id, self.inner.room_id(), tag.as_ref(), tag_info);
         self.client.send(request, None).await
     }
 
@@ -865,8 +865,8 @@ impl Common {
     /// # Arguments
     /// * `tag` - The tag to remove.
     pub async fn remove_tag(&self, tag: TagName) -> HttpResult<delete_tag::v3::Response> {
-        let user_id = self.client.user_id().ok_or(HttpError::AuthenticationRequired)?;
-        let request = delete_tag::v3::Request::new(user_id, self.inner.room_id(), tag.as_ref());
+        let user_id = self.client.user_id().await.ok_or(HttpError::AuthenticationRequired)?;
+        let request = delete_tag::v3::Request::new(&user_id, self.inner.room_id(), tag.as_ref());
         self.client.send(request, None).await
     }
 
@@ -879,8 +879,11 @@ impl Common {
     /// # Arguments
     /// * `is_direct` - Whether to mark this room as direct.
     pub async fn set_is_direct(&self, is_direct: bool) -> Result<()> {
-        let user_id =
-            self.client.user_id().ok_or_else(|| Error::from(HttpError::AuthenticationRequired))?;
+        let user_id = self
+            .client
+            .user_id()
+            .await
+            .ok_or_else(|| Error::from(HttpError::AuthenticationRequired))?;
 
         let mut content = self
             .client
@@ -911,7 +914,7 @@ impl Common {
             content.retain(|_, list| !list.is_empty());
         }
 
-        let request = set_global_account_data::v3::Request::new(&content, user_id)?;
+        let request = set_global_account_data::v3::Request::new(&content, &user_id)?;
 
         self.client.send(request, None).await?;
         Ok(())


### PR DESCRIPTION
I would really like to find a different solution, I think it comes down to calling `http_client.set_session` in the right place but I don't know where that is.