### PR TITLE
Appservice virt member test

### DIFF
--- a/crates/matrix-sdk-appservice/src/lib.rs
+++ b/crates/matrix-sdk-appservice/src/lib.rs
@@ -202,6 +202,11 @@ impl<'a> VirtualUserBuilder<'a> {
         }
 
         let user_id = UserId::parse_with_server_name(self.localpart, &self.appservice.server_name)?;
+        if !(self.appservice.user_id_is_in_namespace(&user_id)?
+            || self.localpart == self.appservice.registration.sender_localpart)
+        {
+            warn!("Virtual client id '{user_id}' is not in the namespace")
+        }
 
         let mut builder = self.client_builder;
 

--- a/crates/matrix-sdk-appservice/src/lib.rs
+++ b/crates/matrix-sdk-appservice/src/lib.rs
@@ -685,11 +685,12 @@ impl AppService {
             let client = client.clone();
             let virt_client = virt_client.clone();
             let transaction = transaction.clone();
+            let appserv_uid = self.registration.sender_localpart.clone();
 
             let task = tokio::spawn(async move {
                 let user_id = match virt_client.user_id() {
                     Some(user_id) => user_id.localpart(),
-                    // Unauthenticated client. (should that be possible?)
+                    // The client is not logged in, skipping
                     None => return Ok(()),
                 };
                 let mut response = sync_events::v3::Response::new(transaction.txn_id.to_string());
@@ -709,25 +710,28 @@ impl AppService {
                     let key = &[USER_MEMBER, room_id.as_bytes(), b".", user_id.as_bytes()].concat();
                     let membership = match client.store().get_custom_value(key).await? {
                         Some(value) => String::from_utf8(value).ok().map(MembershipState::from),
+                        // Assume the appservice is in every known room
+                        None if user_id == appserv_uid => Some(MembershipState::Join),
                         None => None,
                     };
 
-                    match membership.unwrap_or(MembershipState::Join) {
-                        MembershipState::Join => {
+                    match membership {
+                        Some(MembershipState::Join) => {
                             let room = response.rooms.join.entry(room_id).or_default();
                             room.timeline.events.push(raw_event.clone().cast())
                         }
-                        MembershipState::Leave | MembershipState::Ban => {
+                        Some(MembershipState::Leave | MembershipState::Ban) => {
                             let room = response.rooms.leave.entry(room_id).or_default();
                             room.timeline.events.push(raw_event.clone().cast())
                         }
-                        MembershipState::Knock => {
+                        Some(MembershipState::Knock) => {
                             response.rooms.knock.entry(room_id).or_default();
                         }
-                        MembershipState::Invite => {
+                        Some(MembershipState::Invite) => {
                             response.rooms.invite.entry(room_id).or_default();
                         }
-                        _ => debug!("Membership type we don't know how to handle"),
+                        Some(unknown) => debug!("Unknown membership type: {unknown}"),
+                        None => debug!("Assuming {user_id} is not in {room_id}"),
                     }
                 }
                 virt_client.receive_transaction(&transaction.txn_id, response).await?;

--- a/crates/matrix-sdk-appservice/tests/tests.rs
+++ b/crates/matrix-sdk-appservice/tests/tests.rs
@@ -10,7 +10,12 @@ use matrix_sdk::{
 };
 use matrix_sdk_appservice::*;
 use matrix_sdk_test::{appservice::TransactionBuilder, async_test, EventsJson};
-use ruma::{api::MatrixVersion, room_id};
+use ruma::{
+    api::{appservice::event::push_events, MatrixVersion},
+    events::AnyRoomEvent,
+    room_id,
+    serde::Raw,
+};
 use serde_json::json;
 use warp::{Filter, Reply};
 
@@ -296,6 +301,105 @@ async fn test_appservice_on_sub_path() -> Result<()> {
 
     assert_eq!(members[0].display_name().unwrap(), "changed");
 
+    Ok(())
+}
+
+#[async_test]
+async fn test_receive_transaction() -> Result<()> {
+    tracing_subscriber::fmt().try_init().ok();
+    let json = vec![
+        Raw::new(&json!({
+            "content": {
+                "avatar_url": null,
+                "displayname": "Appservice",
+                "membership": "join"
+            },
+            "event_id": "$151800140479rdvjg:localhost",
+            "membership": "join",
+            "origin_server_ts": 151800140,
+            "sender": "@_appservice:localhost",
+            "state_key": "@_appservice:localhost",
+            "type": "m.room.member",
+            "room_id": "!coolplace:localhost",
+            "unsigned": {
+                "age": 2970366
+            }
+        }))?
+        .cast::<AnyRoomEvent>(),
+        Raw::new(&json!({
+            "content": {
+                "avatar_url": null,
+                "displayname": "Appservice",
+                "membership": "join"
+            },
+            "event_id": "$151800140491rfbja:localhost",
+            "membership": "join",
+            "origin_server_ts": 151800140,
+            "sender": "@_appservice:localhost",
+            "state_key": "@_appservice:localhost",
+            "type": "m.room.member",
+            "room_id": "!boringplace:localhost",
+            "unsigned": {
+                "age": 2970366
+            }
+        }))?
+        .cast::<AnyRoomEvent>(),
+        Raw::new(&json!({
+            "content": {
+                "avatar_url": null,
+                "displayname": "Alice",
+                "membership": "join"
+            },
+            "event_id": "$151800140517rfvjc:localhost",
+            "membership": "join",
+            "origin_server_ts": 151800140,
+            "sender": "@_appservice_alice:localhost",
+            "state_key": "@_appservice_alice:localhost",
+            "type": "m.room.member",
+            "room_id": "!coolplace:localhost",
+            "unsigned": {
+                "age": 2970366
+            }
+        }))?
+        .cast::<AnyRoomEvent>(),
+        Raw::new(&json!({
+            "content": {
+                "avatar_url": null,
+                "displayname": "Bob",
+                "membership": "invite"
+            },
+            "event_id": "$151800140594rfvjc:localhost",
+            "membership": "invite",
+            "origin_server_ts": 151800174,
+            "sender": "@_appservice_bob:localhost",
+            "state_key": "@_appservice_bob:localhost",
+            "type": "m.room.member",
+            "room_id": "!boringplace:localhost",
+            "unsigned": {
+                "age": 2970366
+            }
+        }))?
+        .cast::<AnyRoomEvent>(),
+    ];
+    let appservice = appservice(None).await?;
+
+    let alice = appservice.virtual_user_client("_appservice_alice").await?;
+    let bob = appservice.virtual_user_client("_appservice_bob").await?;
+    appservice
+        .receive_transaction(push_events::v1::IncomingRequest::new("dontcare".into(), json))
+        .await?;
+    let coolplace = room_id!("!coolplace:localhost");
+    let boringplace = room_id!("!boringplace:localhost");
+    assert!(
+        alice.get_joined_room(coolplace).is_some(),
+        "Alice's membership in coolplace should be join"
+    );
+    assert!(
+        bob.get_invited_room(boringplace).is_some(),
+        "Bob's membership in boringplace should be invite"
+    );
+    assert!(alice.get_room(boringplace).is_none(), "Alice should not know about boringplace");
+    assert!(bob.get_room(coolplace).is_none(), "Bob should not know about coolplace");
     Ok(())
 }
 


### PR DESCRIPTION
commit 1: Don't assume virtual client membership is join if none is stored, since that leads to a client being told it's joined in rooms it has no membership of. The main appservice client still assumes it's joined every room it receives transaction events about.

commit 2: Test that virtual clients get assigned the correct membership to rooms when processing received transactions.