### PR TITLE
Various code structure improvements

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -156,8 +156,7 @@ impl BaseClient {
     /// # Arguments
     ///
     /// * `response` - A successful login response that contains our access
-    ///   token
-    /// and device id.
+    ///   token and device id.
     pub async fn receive_login_response(
         &self,
         response: &api::session::login::v3::Response,
@@ -174,8 +173,8 @@ impl BaseClient {
     ///
     /// # Arguments
     ///
-    /// * `session` - An session that the user already has from a
-    /// previous login call.
+    /// * `session` - An session that the user already has from a previous login
+    ///   call.
     pub async fn restore_login(&self, session: Session) -> Result<()> {
         self.store.restore_session(session.clone()).await?;
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -176,6 +176,7 @@ impl BaseClient {
     /// * `session` - An session that the user already has from a previous login
     ///   call.
     pub async fn restore_login(&self, session: Session) -> Result<()> {
+        debug!(user_id = %session.user_id, device_id = %session.device_id, "Restoring login");
         self.store.restore_session(session.clone()).await?;
 
         #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -37,6 +37,7 @@ use matrix_sdk_crypto::{
     store::{CryptoStore, MemoryStore as MemoryCryptoStore},
     EncryptionSettings, MegolmError, OlmError, OlmMachine, ToDeviceRequest,
 };
+#[cfg(feature = "e2e-encryption")]
 use once_cell::sync::OnceCell;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::{
@@ -137,7 +138,7 @@ impl BaseClient {
     ///
     /// Returns a session object if the client is logged in. Otherwise returns
     /// `None`.
-    pub fn session(&self) -> Arc<OnceCell<Session>> {
+    pub fn session(&self) -> Option<&Session> {
         self.store.session()
     }
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -149,7 +149,7 @@ impl BaseClient {
 
     /// Is the client logged in.
     pub fn logged_in(&self) -> bool {
-        self.store.session.get().is_some()
+        self.store.session().is_some()
     }
 
     /// Receive a login response and update the session of the client.
@@ -1003,7 +1003,7 @@ impl BaseClient {
             .transpose()?
         {
             Ok(event.content.global)
-        } else if let Some(session) = self.store.session.get() {
+        } else if let Some(session) = self.store.session() {
             Ok(Ruleset::server_default(&session.user_id))
         } else {
             Ok(Ruleset::new())

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -24,14 +24,14 @@ use tracing::trace;
 use super::{Result, StateChanges};
 use crate::Store;
 
-#[derive(Clone, Debug)]
-pub struct AmbiguityCache {
+#[derive(Debug)]
+pub(crate) struct AmbiguityCache {
     pub store: Store,
     pub cache: BTreeMap<OwnedRoomId, BTreeMap<String, BTreeSet<OwnedUserId>>>,
     pub changes: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, AmbiguityChange>>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct AmbiguityMap {
     display_name: String,
     users: BTreeSet<OwnedUserId>,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -432,8 +432,8 @@ impl Store {
 
     /// The current [`Session`] containing our user id, device id and access
     /// token.
-    pub fn session(&self) -> Arc<OnceCell<Session>> {
-        self.session.clone()
+    pub fn session(&self) -> Option<&Session> {
+        self.session.get()
     }
 
     /// Get all the rooms this store knows about.

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -382,7 +382,7 @@ pub trait StateStore: AsyncTraitDeps {
 #[derive(Debug, Clone)]
 pub struct Store {
     inner: Arc<dyn StateStore>,
-    pub(crate) session: Arc<OnceCell<Session>>,
+    session: Arc<OnceCell<Session>>,
     pub(crate) sync_token: Arc<RwLock<Option<String>>>,
     rooms: Arc<DashMap<OwnedRoomId, Room>>,
     stripped_rooms: Arc<DashMap<OwnedRoomId, Room>>,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -383,7 +383,8 @@ pub trait StateStore: AsyncTraitDeps {
 pub struct Store {
     inner: Arc<dyn StateStore>,
     session: Arc<OnceCell<Session>>,
-    pub(crate) sync_token: Arc<RwLock<Option<String>>>,
+    /// The current sync token that should be used for the next sync call.
+    pub(super) sync_token: Arc<RwLock<Option<String>>>,
     rooms: Arc<DashMap<OwnedRoomId, Room>>,
     stripped_rooms: Arc<DashMap<OwnedRoomId, Room>>,
 }

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -66,7 +66,7 @@ pub struct ClientBuilder {
     request_config: RequestConfig,
     respect_login_well_known: bool,
     appservice_mode: bool,
-    server_versions: Option<Arc<[MatrixVersion]>>,
+    server_versions: Option<Box<[MatrixVersion]>>,
 }
 
 impl ClientBuilder {
@@ -305,7 +305,7 @@ impl ClientBuilder {
                         None,
                         homeserver,
                         None,
-                        [MatrixVersion::V1_0].into_iter().collect(),
+                        &[MatrixVersion::V1_0],
                     )
                     .await
                     .map_err(|e| match e {

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -293,15 +293,9 @@ impl ClientBuilder {
         };
 
         let base_client = BaseClient::with_store_config(self.store_config);
-        let session_cell = base_client.session();
 
         let mk_http_client = |homeserver| {
-            HttpClient::new(
-                inner_http_client.clone(),
-                homeserver,
-                session_cell.clone(),
-                self.request_config,
-            )
+            HttpClient::new(inner_http_client.clone(), homeserver, self.request_config)
         };
 
         let homeserver = match homeserver_cfg {
@@ -312,6 +306,7 @@ impl ClientBuilder {
                 let well_known = http_client
                     .send(
                         discover_homeserver::Request::new(),
+                        None,
                         None,
                         [MatrixVersion::V1_0].into_iter().collect(),
                     )

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1110,11 +1110,10 @@ impl Client {
     /// # Arguments
     ///
     /// * `registration` - The easiest way to create this request is using the
-    ///   [`register::v3::Request`]
-    /// itself.
-    ///
+    ///   [`register::v3::Request`] itself.
     ///
     /// # Examples
+    ///
     /// ```no_run
     /// # use std::convert::TryFrom;
     /// # use matrix_sdk::Client;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -128,7 +128,7 @@ pub struct Client {
 
 pub(crate) struct ClientInner {
     /// The URL of the homeserver to connect to.
-    homeserver: Arc<RwLock<Url>>,
+    homeserver: RwLock<Url>,
     /// The underlying HTTP client.
     http_client: HttpClient,
     /// User session data.
@@ -1438,7 +1438,13 @@ impl Client {
         Ok(self
             .inner
             .http_client
-            .send(request, Some(request_config), self.session(), self.server_versions().await?)
+            .send(
+                request,
+                Some(request_config),
+                self.homeserver().await.to_string(),
+                self.session(),
+                self.server_versions().await?,
+            )
             .await?)
     }
 
@@ -1493,7 +1499,13 @@ impl Client {
     {
         self.inner
             .http_client
-            .send(request, config, self.session(), self.server_versions().await?)
+            .send(
+                request,
+                config,
+                self.homeserver().await.to_string(),
+                self.session(),
+                self.server_versions().await?,
+            )
             .await
     }
 
@@ -1504,6 +1516,7 @@ impl Client {
             .send(
                 get_supported_versions::Request::new(),
                 None,
+                self.homeserver().await.to_string(),
                 None,
                 [MatrixVersion::V1_0].into_iter().collect(),
             )

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -71,7 +71,7 @@ use ruma::{
 use serde::de::DeserializeOwned;
 #[cfg(not(target_arch = "wasm32"))]
 pub use tokio::sync::OnceCell;
-use tracing::{error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, warn};
 use url::Url;
 
 #[cfg(feature = "e2e-encryption")]
@@ -1204,14 +1204,17 @@ impl Client {
     ///
     /// let response = client.sync_once(sync_settings).await.unwrap();
     /// # });
+    #[instrument(skip(self, definition))]
     pub async fn get_or_upload_filter(
         &self,
         filter_name: &str,
         definition: FilterDefinition<'_>,
     ) -> Result<String> {
         if let Some(filter) = self.inner.base_client.get_filter(filter_name).await? {
+            debug!("Found filter locally");
             Ok(filter)
         } else {
+            debug!("Didn't find filter locally");
             let user_id = self.user_id().ok_or(Error::AuthenticationRequired)?;
             let request = FilterUploadRequest::new(user_id, definition);
             let response = self.send(request, None).await?;

--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -131,6 +131,7 @@ impl HttpClient {
             return Err(HttpError::NotClientRequest);
         }
 
+        trace!("Serializing request");
         let request = if !self.request_config.assert_identity {
             let send_access_token = if auth_scheme == AuthScheme::None && !config.force_auth {
                 // Small optimization: Don't take the session lock if we know the auth token
@@ -166,12 +167,13 @@ impl HttpClient {
         };
 
         let request = request.map(|body| body.freeze());
+
+        trace!("Sending request");
         let response = self.inner.send_request(request, config).await?;
 
         trace!("Got response: {:?}", response);
 
         let response = Request::IncomingResponse::try_from_http_response(response)?;
-
         Ok(response)
     }
 

--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -108,7 +108,7 @@ impl HttpClient {
         config: Option<RequestConfig>,
         homeserver: String,
         session: Option<&Session>,
-        server_versions: Arc<[MatrixVersion]>,
+        server_versions: &[MatrixVersion],
     ) -> Result<Request::IncomingResponse, HttpError>
     where
         Request: OutgoingRequest + Debug,
@@ -146,14 +146,14 @@ impl HttpClient {
             request.try_into_http_request::<BytesMut>(
                 &homeserver,
                 send_access_token,
-                &server_versions,
+                server_versions,
             )?
         } else {
             request.try_into_http_request_with_user_id::<BytesMut>(
                 &homeserver,
                 SendAccessToken::Always(&session.ok_or(HttpError::UserIdRequired)?.access_token),
                 &session.ok_or(HttpError::UserIdRequired)?.user_id,
-                &server_versions,
+                server_versions,
             )?
         };
 

--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -92,7 +92,7 @@ pub trait HttpSend: AsyncTraitDeps {
     ) -> Result<http::Response<Bytes>, HttpError>;
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct HttpClient {
     pub(crate) inner: Arc<dyn HttpSend>,
     pub(crate) homeserver: Arc<RwLock<Url>>,


### PR DESCRIPTION
Reduces unnecessary sharing of interor-mutable types, simplifies an `Arc` to `Box` and adds a little bit more logging (from #743).

Fixes #746.