### PR TITLE
chore(test):  Code Coverage must ignore some `matrix-sdk-crypto-(js|nodejs)`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: tarpaulin
-        args: --workspace --ignore-config --exclude-files "crates/matrix-sdk/examples/*,crates/matrix-sdk-common,crates/matrix-sdk-test" --exclude matrix-sdk-crypto-js --exclude matrix-sdk-crypto-nodejs --out Xml
+        args: --workspace
 
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v3

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -37,5 +37,8 @@ ignore:
   - "crates/matrix-sdk-crypto-ffi"
   - "crates/matrix-sdk-crypto-js"
   - "crates/matrix-sdk-crypto-nodejs"
+  - "crates/matrix-sdk-ffi"
+  - "crates/matrix-sdk-test"
+  - "crates/matrix-sdk-test-macros"
   - "labs"
   - "xtask"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -36,3 +36,5 @@ coverage:
 ignore:
   - "crates/matrix-sdk-crypto-js"
   - "crates/matrix-sdk-crypto-nodejs"
+  - "labs"
+  - "xtask"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -33,3 +33,6 @@ coverage:
         paths:
           - "labs/"
     patch: off
+ignore:
+  - "crates/matrix-sdk-crypto-js"
+  - "crates/matrix-sdk-crypto-nodejs"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -34,6 +34,7 @@ coverage:
           - "labs/"
     patch: off
 ignore:
+  - "crates/matrix-sdk-crypto-ffi"
   - "crates/matrix-sdk-crypto-js"
   - "crates/matrix-sdk-crypto-nodejs"
   - "labs"

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -3,7 +3,6 @@ debug = false
 verbose = false
 exclude-files = ["crates/matrix_sdk/examples/*"]
 exclude = [
-    "matrix-sdk-common",
     "matrix-sdk-test",
     "matrix-sdk-indexeddb",
     "matrix-sdk-crypto-ffi",

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,5 +1,12 @@
 [default-config]
 debug = false
 verbose = false
-exclude-files = ["crates/matrix_sdk/examples/*", "crates/matrix_sdk_common", "crates/matrix_sdk_test"]
-exclude = ["matrix-sdk-crypto-js", "matrix-sdk-crypto-nodejs"]
+exclude-files = ["crates/matrix_sdk/examples/*"]
+exclude = [
+    "matrix-sdk-common",
+    "matrix-sdk-test",
+    "matrix-sdk-indexeddb",
+    "matrix-sdk-crypto-ffi",
+    "matrix-sdk-crypto-js",
+    "matrix-sdk-crypto-nodejs"
+]

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,4 +1,5 @@
 [default-config]
 debug = false
 verbose = false
-exclude-files = ["matrix_sdk/examples/*", "matrix_sdk_common", "matrix_sdk_test"]
+exclude-files = ["crates/matrix_sdk/examples/*", "crates/matrix_sdk_common", "crates/matrix_sdk_test"]
+exclude = ["matrix-sdk-crypto-js", "matrix-sdk-crypto-nodejs"]

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -3,9 +3,11 @@ debug = false
 verbose = false
 exclude-files = ["crates/matrix_sdk/examples/*"]
 exclude = [
-    "matrix-sdk-test",
-    "matrix-sdk-indexeddb",
     "matrix-sdk-crypto-ffi",
     "matrix-sdk-crypto-js",
-    "matrix-sdk-crypto-nodejs"
+    "matrix-sdk-crypto-nodejs",
+    "matrix-sdk-ffi",
+    "matrix-sdk-indexeddb",
+    "matrix-sdk-test",
+    "matrix-sdk-test-macros",
 ]


### PR DESCRIPTION
This patch fixes https://github.com/matrix-org/matrix-rust-sdk/issues/748 and https://github.com/matrix-org/matrix-rust-sdk/issues/749.

The first patch uses [the Ignoring Paths feature](https://docs.codecov.com/docs/ignoring-paths) of codecov.io. I hope it will exclude entirely the `crates/matrix-sdk-crypto-(js|nodejs)/` paths from their UI and code coverage score.

The second patch updates the `tarpaulin` configuration file to:
1. fix the `exclude-files` paths (because they were invalid),
2. `exclude` crates entirely
3. be used in the CI directly, so that we don't have different configurations.