### PR TITLE
doc: Re-organize docs and add bindings'

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.0
+          node-version: 18
 
       - name: Load cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,16 @@ jobs:
           toolchain: nightly
           override: true
 
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.0
+
       - name: Load cache
         uses: Swatinem/rust-cache@v1
 
       # Keep in sync with xtask docs
-      - name: Build docs
+      - name: Build crates' docs
         uses: actions-rs/cargo@v1
         env:
           # Work around https://github.com/rust-lang/cargo/issues/10744
@@ -36,10 +41,24 @@ jobs:
           command: doc
           args: --no-deps --workspace --exclude matrix-sdk-crypto-js --exclude matrix-sdk-crypto-nodejs --features docsrs
 
+      - name: Build `matrix-sdk-crypto-nodejs` doc
+        run: cd crates/matrix-sdk-crypto-nodejs && npm install && npm run build && npm run doc
+
+      - name: Prepare the doc hierarchy
+        shell: bash
+        run: |
+          mkdir docs
+          mkdir docs/crates/
+          mkdir docs/bindings/
+          mkdir docs/bindings/matrix-sdk-crypto-nodejs/
+
+          mv target/doc/* docs/crates/
+          mv crates/matrix-sdk-crypto-nodejs/docs/* docs/bindings/matrix-sdk-crypto-nodejs/
+
       - name: Deploy docs
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc/
+          publish_dir: ./docs/
           force_orphan: true


### PR DESCRIPTION
The new `gh-pages` now has the following hierarchy:

* `crates/` for the documentation of the Rust crates,
* `bindings/` for the documentation of the bindings:
  * `matrix-sdk-crypto-nodejs` for the Node.js bindings of the crypto crate.

There is no `index.html` files in directories, so Github will probably
return 404 responses. Not sure it's a problem though.

**Why Draft PR?** Because it is incomplete. I must update all `README.md` to update the links to the documentations, but first, I wanted to validate the new namings with you.