### PR TITLE
feat(crypto-nodejs): Add `store_path` and `store_passphrase` to the `OlmMachine` constructor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [12.17, 14.0, 15.0, 16.0]
+        node-version: [14.0, 15.0, 16.0]
         include:
           - node-version: 16.0
             build-doc: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [14.0, 15.0, 16.0]
+        node-version: [14.0, 16.0, 18.0]
         include:
-          - node-version: 16.0
+          - node-version: 18.0
             build-doc: true
 
     steps:

--- a/crates/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/crates/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -27,12 +27,14 @@ tracing = ["tracing-subscriber"]
 [dependencies]
 matrix-sdk-crypto = { version = "0.5.0", path = "../matrix-sdk-crypto" }
 matrix-sdk-common = { version = "0.5.0", path = "../matrix-sdk-common" }
+matrix-sdk-sled = { version = "0.1.0", path = "../matrix-sdk-sled", default-features = false, features = ["crypto-store"] }
 ruma = { version = "0.6.2", features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"] }
 vodozemac = {  git = "https://github.com/matrix-org/vodozemac/", rev = "d0e744287a14319c2a9148fef3747548c740fc36" }
 napi = { git = "https://github.com/Hywan/napi-rs", branch = "feat-either-n-up-to-26", default-features = false, features = ["napi6", "tokio_rt"] }
 napi-derive = { git = "https://github.com/Hywan/napi-rs", branch = "feat-either-n-up-to-26" }
 serde_json = "1.0.79"
 http = "0.2.6"
+zeroize = "1.3.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["tracing-log", "time", "smallvec", "fmt", "env-filter"], optional = true }
 
 [build-dependencies]

--- a/crates/matrix-sdk-crypto-nodejs/README.md
+++ b/crates/matrix-sdk-crypto-nodejs/README.md
@@ -19,10 +19,10 @@ Node.js and npm
 Page](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
 The binding is using NAPI 6 (Node API version 6), which means that is
-compatible with Node.js versions 12.17.0, 14.0.0, 15.0.0 and 16.0.0
-(see [the full Node API version
+compatible with Node.js versions 14.0.0, 15.0.0 and 16.0.0 (see [the
+full Node API version
 matrix](https://nodejs.org/api/n-api.html#node-api-version-matrix))
-(we do not support the version 10.20).
+(we do not support the versions 10.20 and 12.17.0).
 
 Once the Rust compiler, Node.js and npm are installed, you can run the
 following commands:

--- a/crates/matrix-sdk-crypto-nodejs/README.md
+++ b/crates/matrix-sdk-crypto-nodejs/README.md
@@ -18,11 +18,14 @@ pretty classical by using [npm], see [the Downloading and installing
 Node.js and npm
 Page](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
-The binding is using NAPI 6 (Node API version 6), which means that is
-compatible with Node.js versions 14.0.0, 15.0.0 and 16.0.0 (see [the
-full Node API version
-matrix](https://nodejs.org/api/n-api.html#node-api-version-matrix))
-(we do not support the versions 10.20 and 12.17.0).
+The binding is compatible with, and tested against, the Node.js
+versions that are in “current”, “active” or “maintenance” states,
+according to [the Node.js Releases
+Page](https://nodejs.org/en/about/releases/), _and_ which are
+compatible with [NAPI v6 (Node.js
+API)](https://nodejs.org/api/n-api.html#node-api-version-matrix). It
+means that this binding will work with the following versions: 14.0.0,
+16.0.0 and 18.0.0.
 
 Once the Rust compiler, Node.js and npm are installed, you can run the
 following commands:

--- a/crates/matrix-sdk-crypto-nodejs/package.json
+++ b/crates/matrix-sdk-crypto-nodejs/package.json
@@ -18,7 +18,7 @@
         "typedoc": "^0.22.17"
     },
     "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
     },
     "scripts": {
         "build": "napi build --platform --release --strip",

--- a/crates/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/crates/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -1,4 +1,7 @@
 const { OlmMachine, UserId, DeviceId, RoomId, DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest, KeysClaimRequest, EncryptionSettings, DecryptedRoomEvent, VerificationState } = require('../');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs/promises');
 
 describe(OlmMachine.name, () => {
     test('cannot be instantiated with the constructor', () => {
@@ -9,6 +12,20 @@ describe(OlmMachine.name, () => {
         expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'))).toBeInstanceOf(OlmMachine);
     });
 
+    describe('can be instantiated with a store', () => {
+        test('with no passphrase', async () => {
+            const temp_directory = await fs.mkdtemp(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
+
+            expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), temp_directory)).toBeInstanceOf(OlmMachine);
+        });
+
+        test('with a passphrase', async () => {
+            const temp_directory = await fs.mkdtemp(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
+
+            expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), temp_directory, 'hello')).toBeInstanceOf(OlmMachine);
+        });
+    });
+    
     const user = new UserId('@alice:example.org');
     const device = new DeviceId('foobar');
     const room = new RoomId('!baz:matrix.org');

--- a/crates/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/crates/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -1,7 +1,7 @@
 const { OlmMachine, UserId, DeviceId, RoomId, DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest, KeysClaimRequest, EncryptionSettings, DecryptedRoomEvent, VerificationState } = require('../');
 const path = require('path');
 const os = require('os');
-const fs = require('fs');
+const fs = require('fs/promises');
 
 describe(OlmMachine.name, () => {
     test('cannot be instantiated with the constructor', () => {
@@ -14,13 +14,13 @@ describe(OlmMachine.name, () => {
 
     describe('can be instantiated with a store', () => {
         test('with no passphrase', async () => {
-            const temp_directory = fs.mkdtempSync(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
+            const temp_directory = await fs.mkdtemp(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
 
             expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), temp_directory)).toBeInstanceOf(OlmMachine);
         });
 
         test('with a passphrase', async () => {
-            const temp_directory = fs.mkdtempSync(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
+            const temp_directory = await fs.mkdtemp(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
 
             expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), temp_directory, 'hello')).toBeInstanceOf(OlmMachine);
         });

--- a/crates/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/crates/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -1,7 +1,7 @@
 const { OlmMachine, UserId, DeviceId, RoomId, DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest, KeysClaimRequest, EncryptionSettings, DecryptedRoomEvent, VerificationState } = require('../');
-const path = require('node:path');
-const os = require('node:os');
-const fs = require('node:fs/promises');
+const path = require('path');
+const os = require('os');
+const fs = require('fs');
 
 describe(OlmMachine.name, () => {
     test('cannot be instantiated with the constructor', () => {
@@ -14,13 +14,13 @@ describe(OlmMachine.name, () => {
 
     describe('can be instantiated with a store', () => {
         test('with no passphrase', async () => {
-            const temp_directory = await fs.mkdtemp(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
+            const temp_directory = fs.mkdtempSync(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
 
             expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), temp_directory)).toBeInstanceOf(OlmMachine);
         });
 
         test('with a passphrase', async () => {
-            const temp_directory = await fs.mkdtemp(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
+            const temp_directory = fs.mkdtempSync(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
 
             expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), temp_directory, 'hello')).toBeInstanceOf(OlmMachine);
         });


### PR DESCRIPTION
This patch fixes https://github.com/matrix-org/matrix-rust-sdk/issues/755.

This patch adds the `store_path` and the `store_passphrase` arguments to the `OlmMachine` constructor to use a `CryptoStore` instead of having an in-memory Olm machine.