### PR TITLE
chore(test): Remove `labs` from the projects + exclude `matrix-sdk-indexeddb` from code coverage report

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -32,6 +32,7 @@ ignore:
   - "crates/matrix-sdk-crypto-js"
   - "crates/matrix-sdk-crypto-nodejs"
   - "crates/matrix-sdk-ffi"
+  - "crates/matrix-sdk-indexeddb"
   - "crates/matrix-sdk-test"
   - "crates/matrix-sdk-test-macros"
   - "labs"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -26,12 +26,6 @@ coverage:
           - "bindings/"
           - "crates/matrix-sdk-crypto-ffi/"
           - "crates/matrix-sdk-ffi/"
-      labs:
-        # Coverage of lab tests is recorded but for informational
-        # purposes only
-        informational: true
-        paths:
-          - "labs/"
     patch: off
 ignore:
   - "crates/matrix-sdk-crypto-ffi"


### PR DESCRIPTION
First patch remove `labs` from the projects list. It's already part of the `ignore` section.
Second patch exclude `matrix-sdk-indexeddb` from the code coverage report. It's already excluded from Tarpaulin, but not for codecov.io.

It's a sequel of #748.