### PR TITLE
Build Crypto iOS framework

### DIFF
--- a/bindings/apple/MatrixSDKCrypto.podspec
+++ b/bindings/apple/MatrixSDKCrypto.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+
+    s.name                  = "MatrixSDKCrypto"
+    s.version               = "0.1.0"
+    s.summary               = "Uniffi based bindings for the Rust SDK crypto crate."
+    s.homepage              = "https://github.com/matrix-org/matrix-rust-sdk"
+    s.license               = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
+    s.author                = { "matrix.org" => "support@matrix.org" }
+
+    s.ios.deployment_target = "11.0"
+    s.swift_versions = ['5.0']
+
+    s.source                = { :http => "https://github.com/matrix-org/matrix-rust-sdk/releases/download/matrix-sdk-crypto-ffi-#{s.version}/MatrixSDKCryptoFFI.zip" }
+    s.vendored_frameworks   = "MatrixSDKCryptoFFI.xcframework"
+    s.source_files          = "Sources/**/*.{swift}"
+  
+end

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -1,29 +1,42 @@
 # Apple platforms support
 
-This project and build script demonstrate how to create an XCFramework that can be imported into an Xcode project and run on Apple platforms.
+This project and build script demonstrate how to create an XCFramework that can be imported into an Xcode project and run on Apple platforms. It can compile and bundle an [entire SDK](#Building-the-SDK), or only a smaller [Crypto module](#Building-only-the-Crypto-SDK) that provides end-to-end encryption for clients that already depend on an SDK (e.g. [Matrix iOS SDK](https://github.com/matrix-org/matrix-ios-sdk))
 
-## Building the universal framework
+## Prerequisites for building universal frameworks
+
+* the Rust toolchain
+* UniFFI - `cargo install uniffi_bindgen`
+* Apple targets (e.g. `rustup target add aarch64-apple-ios`)
+* `xcodebuild` command line tool from [Apple](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
+* `lipo` for creating the fat static libs
+
+## Building the SDK
 
 ```
 sh build_xcframework.sh
 ```
 
-**Prerequisites**
-
-* the Rust toolchain
-* UniFFI - `cargo install uniffi_bindge`
-* Apple targets (e.g. `rustup target add aarch64-apple-ios`)
-* `xcodebuild` command line tool from [Apple](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
-* `lipo` for creating the fat static libs
-
-
 The `build_xcframework.sh` script will go through all the steps required to generate a fully usable `.xcframework`:
 
 1. compile `matrix-sdk-ffi` libraries for iOS, the iOS simulator, MacOS, and Mac Catalyst under `/target`. Some targets are not part of the standard library and they will be built using the nightly toolchain. 
-* `lipo` together the libraries for the same platform under `/generated`
-* run `uniffi` and generate the C header, module map and swift files
-* `xcodebuild` an `xcframework` from the fat static libs and the original iOS one, and add the header and module map to it under `generated/MatrixSDKFFI.xcframework`
-* cleanup and delete the generated files except the .xcframework and the swift sources (that aren't part of the framework)
+2. `lipo` together the libraries for the same platform under `/generated`
+3. run `uniffi` and generate the C header, module map and swift files
+4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS one, and add the header and module map to it under `generated/MatrixSDKFFI.xcframework`
+5. cleanup and delete the generated files except the .xcframework and the swift sources (that aren't part of the framework)
+
+## Building only the Crypto SDK
+
+```
+sh build_crypto_xcframework.sh
+```
+
+The `build_crypto_xcframework.sh` script will go through all the steps required to generate a fully usable `.xcframework`:
+
+1. compile `matrix-sdk-crypto-ffi` libraries for iOS and the iOS simulator under `/target`
+2. `lipo` together the libraries for the same platform under `/generated`
+3. run `uniffi` and generate the C header, module map and swift files
+4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS one, and add the header and module map to it under `generated/MatrixSDKCryptoFFI.xcframework`
+5. cleanup and delete the generated files except the .xcframework and the swift sources (that aren't part of the framework)
 
 ## Running the Xcode project
 
@@ -36,4 +49,5 @@ It makes the compiled code available to swift by importing the C header through 
 Once all the generated components are available running it should be as easy as choosing a platform and clicking run.
 
 ## Distribution
-The generated framework and Swift code can be distributed and integrated directly but in order to make things simpler we bundle them together as a Swift package available [TBD](here)
+
+The generated framework and Swift code can be distributed and integrated directly but in order to make things simpler we bundle them together as a Swift package available [TBD](here) in the case of SDK, and as CocoaPods podspec in the case of Crypto SDK.

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -eEu
+
+cd "$(dirname "$0")"
+
+# Path to the repo root
+SRC_ROOT=../..
+
+TARGET_DIR="${SRC_ROOT}/target"
+
+GENERATED_DIR="${SRC_ROOT}/generated"
+if [ -d "${GENERATED_DIR}" ]; then rm -rf "${GENERATED_DIR}"; fi
+mkdir -p ${GENERATED_DIR}
+
+REL_FLAG="--release"
+REL_TYPE_DIR="release"
+
+TARGET_CRATE=matrix-sdk-crypto-ffi
+
+# Build static libs for all the different architectures
+
+# iOS
+cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios"
+
+# iOS Simulator
+cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios-sim"
+cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "x86_64-apple-ios"
+
+# Lipo together the libraries for the same platform
+
+# iOS Simulator
+lipo -create \
+  "${TARGET_DIR}/x86_64-apple-ios/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
+  "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
+  -output "${GENERATED_DIR}/libmatrix_crypto_ffi.a"
+
+# Generate uniffi files
+uniffi-bindgen generate "${SRC_ROOT}/crates/${TARGET_CRATE}/src/olm.udl" --language swift --config-path "${SRC_ROOT}/crates/${TARGET_CRATE}/uniffi.toml" --out-dir ${GENERATED_DIR}
+
+# Move headers to the right place
+HEADERS_DIR=${GENERATED_DIR}/headers
+mkdir -p ${HEADERS_DIR}
+mv ${GENERATED_DIR}/*.h ${HEADERS_DIR}
+
+# Rename and move modulemap to the right place
+mv ${GENERATED_DIR}/*.modulemap ${HEADERS_DIR}/module.modulemap
+
+# Move source files to the right place
+SWIFT_DIR="${GENERATED_DIR}/Sources"
+mkdir -p ${SWIFT_DIR}
+mv ${GENERATED_DIR}/*.swift ${SWIFT_DIR}
+
+# Build the xcframework
+
+if [ -d "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework" ]; then rm -rf "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"; fi
+
+xcodebuild -create-xcframework \
+  -library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
+  -headers ${HEADERS_DIR} \
+  -library "${GENERATED_DIR}/libmatrix_crypto_ffi.a" \
+  -headers ${HEADERS_DIR} \
+  -output "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"
+
+# Cleanup
+
+if [ -f "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" ]; then rm -rf "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a"; fi
+if [ -f "${GENERATED_DIR}/libmatrix_crypto_ffi.a" ]; then rm -rf "${GENERATED_DIR}/libmatrix_crypto_ffi.a"; fi
+if [ -d ${HEADERS_DIR} ]; then rm -rf ${HEADERS_DIR}; fi
+
+# Zip up framework, sources and LICENSE, ready to be uploaded to GitHub Releases and used by MatrixSDKCrypto.podspec
+cp ${SRC_ROOT}/LICENSE $GENERATED_DIR
+cd $GENERATED_DIR
+zip -r MatrixSDKCryptoFFI.zip MatrixSDKCryptoFFI.xcframework Sources LICENSE

--- a/crates/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/crates/matrix-sdk-crypto-ffi/src/olm.udl
@@ -15,7 +15,7 @@ interface MigrationError {
 };
 
 callback interface Logger {
-    void log(string log_line);
+    void log(string logLine);
 };
 
 callback interface ProgressListener {

--- a/crates/matrix-sdk-crypto-ffi/uniffi.toml
+++ b/crates/matrix-sdk-crypto-ffi/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.swift]
+module_name = "MatrixSDKCrypto"


### PR DESCRIPTION
Provide scripts and tooling to compile and package matrix-sdk-crypto-ffi project, to be used with existing [Matrix iOS SDK](https://github.com/matrix-org/matrix-ios-sdk). Changes in this PR are only the first step to get a precompiled library up and running and do not yet include further automation of publishing these artifacts in [GitHub releases](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.1.0).

This PR contains the following changes:

1. Duplicate and tweak an existing `build_xcframework.sh` script, which chooses `matrix-sdk-crypto-ffi` crate to compile, only compiles for iOS targets, and produces a zip file ready to be uploaded to GitHub releases
2. Define `MatrixSDKCrypto.podspec` which can be pushed directly to public CocoaPods repo, see https://cocoapods.org/pods/MatrixSDKCrypto
3. Define uniffi.toml for better name of the output binaries

For an example integration of the final output see [related PR](https://github.com/matrix-org/matrix-ios-sdk/pull/1501)