### PR TITLE
feat(crypto): Customized event types

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -32,12 +32,9 @@ use ruma::{
             request::{
                 RequestAction, SecretName, ToDeviceSecretRequestEvent as SecretRequestEvent,
             },
-            send::{
-                ToDeviceSecretSendEvent as SecretSendEvent,
-                ToDeviceSecretSendEventContent as SecretSendEventContent,
-            },
+            send::ToDeviceSecretSendEventContent as SecretSendEventContent,
         },
-        AnyToDeviceEvent, AnyToDeviceEventContent,
+        AnyToDeviceEventContent,
     },
     DeviceId, DeviceKeyAlgorithm, EventEncryptionAlgorithm, OwnedDeviceId, OwnedTransactionId,
     OwnedUserId, RoomId, TransactionId, UserId,
@@ -51,6 +48,7 @@ use crate::{
     requests::{OutgoingRequest, ToDeviceRequest},
     session_manager::GroupSessionCache,
     store::{Changes, CryptoStoreError, SecretImportError, Store},
+    types::events::secret_send::SecretSendEvent,
     Device,
 };
 
@@ -764,7 +762,7 @@ impl GossipMachine {
         &self,
         sender_key: &str,
         event: &mut SecretSendEvent,
-    ) -> Result<Option<AnyToDeviceEvent>, CryptoStoreError> {
+    ) -> Result<(), CryptoStoreError> {
         debug!(
             sender = event.sender.as_str(),
             request_id = event.content.request_id.as_str(),
@@ -772,8 +770,6 @@ impl GossipMachine {
         );
 
         let request_id = <&TransactionId>::from(event.content.request_id.as_str());
-
-        let secret = std::mem::take(&mut event.content.secret);
 
         if let Some(request) = self.store.get_outgoing_secret_requests(request_id).await? {
             match &request.info {
@@ -785,6 +781,10 @@ impl GossipMachine {
                     );
                 }
                 SecretInfo::SecretRequest(secret_name) => {
+                    // Set the secret name so other consumers of the event know
+                    // what this event is about.
+                    event.content.secret_name = Some(secret_name.to_owned());
+
                     debug!(
                         sender = event.sender.as_str(),
                         request_id = event.content.request_id.as_str(),
@@ -797,7 +797,11 @@ impl GossipMachine {
                     {
                         if device.verified() {
                             if secret_name != &SecretName::RecoveryKey {
-                                match self.store.import_secret(secret_name, secret).await {
+                                match self
+                                    .store
+                                    .import_secret(secret_name, &event.content.secret)
+                                    .await
+                                {
                                     Ok(_) => self.mark_as_done(request).await?,
                                     Err(e) => {
                                         // If this is a store error propagate it up
@@ -818,10 +822,10 @@ impl GossipMachine {
                             } else {
                                 // Skip importing the recovery key here since
                                 // we'll want to check if the public key matches
-                                // to the latest version on the server. We
+                                // to the latest version on the server. The key
+                                // will not be zeroized and
                                 // instead leave the key in the event and let
                                 // the user import it later.
-                                event.content.secret = secret;
                             }
                         } else {
                             warn!(
@@ -844,19 +848,19 @@ impl GossipMachine {
             }
         }
 
-        Ok(Some(AnyToDeviceEvent::SecretSend(event.clone())))
+        Ok(())
     }
 
     /// Receive a forwarded room key event.
     pub async fn receive_forwarded_room_key(
         &self,
         sender_key: &str,
-        event: &mut ToDeviceForwardedRoomKeyEvent,
-    ) -> Result<(Option<AnyToDeviceEvent>, Option<InboundGroupSession>), CryptoStoreError> {
+        event: &ToDeviceForwardedRoomKeyEvent,
+    ) -> Result<Option<InboundGroupSession>, CryptoStoreError> {
         let key_info = self.get_key_info(&event.content).await?;
 
         if let Some(info) = key_info {
-            match InboundGroupSession::from_forwarded_key(sender_key, &mut event.content) {
+            match InboundGroupSession::from_forwarded_key(sender_key, &event.content) {
                 Ok(session) => {
                     let old_session = self
                         .store
@@ -907,7 +911,7 @@ impl GossipMachine {
                         );
                     }
 
-                    Ok((Some(AnyToDeviceEvent::ForwardedRoomKey(event.clone())), session))
+                    Ok(session)
                 }
                 Err(e) => {
                     warn!(
@@ -929,7 +933,7 @@ impl GossipMachine {
                 claimed_sender_key = event.content.sender_key.as_str(),
                 "Received a forwarded room key that we didn't request",
             );
-            Ok((None, None))
+            Ok(None)
         }
     }
 }
@@ -1151,7 +1155,7 @@ mod tests {
 
         let content: ToDeviceForwardedRoomKeyEventContent = export.try_into().unwrap();
 
-        let mut event = ToDeviceEvent { sender: alice_id().to_owned(), content };
+        let event = ToDeviceEvent { sender: alice_id().to_owned(), content };
 
         assert!(
             machine
@@ -1166,8 +1170,8 @@ mod tests {
                 .is_none()
         );
 
-        let (_, first_session) =
-            machine.receive_forwarded_room_key(&session.sender_key, &mut event).await.unwrap();
+        let first_session =
+            machine.receive_forwarded_room_key(&session.sender_key, &event).await.unwrap();
         let first_session = first_session.unwrap();
 
         assert_eq!(first_session.first_known_index(), 10);
@@ -1198,10 +1202,10 @@ mod tests {
 
         let content: ToDeviceForwardedRoomKeyEventContent = export.try_into().unwrap();
 
-        let mut event = ToDeviceEvent { sender: alice_id().to_owned(), content };
+        let event = ToDeviceEvent { sender: alice_id().to_owned(), content };
 
-        let (_, second_session) =
-            machine.receive_forwarded_room_key(&session.sender_key, &mut event).await.unwrap();
+        let second_session =
+            machine.receive_forwarded_room_key(&session.sender_key, &event).await.unwrap();
 
         assert!(second_session.is_none());
 
@@ -1209,10 +1213,10 @@ mod tests {
 
         let content: ToDeviceForwardedRoomKeyEventContent = export.try_into().unwrap();
 
-        let mut event = ToDeviceEvent { sender: alice_id().to_owned(), content };
+        let event = ToDeviceEvent { sender: alice_id().to_owned(), content };
 
-        let (_, second_session) =
-            machine.receive_forwarded_room_key(&session.sender_key, &mut event).await.unwrap();
+        let second_session =
+            machine.receive_forwarded_room_key(&session.sender_key, &event).await.unwrap();
 
         assert_eq!(second_session.unwrap().first_known_index(), 0);
     }
@@ -1447,11 +1451,9 @@ mod tests {
 
         let decrypted = alice_account.decrypt_to_device_event(&event).await.unwrap();
 
-        if let AnyToDeviceEvent::ForwardedRoomKey(mut e) = decrypted.event.deserialize().unwrap() {
-            let (_, session) = alice_machine
-                .receive_forwarded_room_key(&decrypted.sender_key, &mut e)
-                .await
-                .unwrap();
+        if let AnyToDeviceEvent::ForwardedRoomKey(e) = decrypted.event.deserialize().unwrap() {
+            let session =
+                alice_machine.receive_forwarded_room_key(&decrypted.sender_key, &e).await.unwrap();
             alice_machine.store.save_inbound_group_sessions(&[session.unwrap()]).await.unwrap();
         } else {
             panic!("Invalid decrypted event type");
@@ -1671,11 +1673,9 @@ mod tests {
 
         let decrypted = alice_account.decrypt_to_device_event(&event).await.unwrap();
 
-        if let AnyToDeviceEvent::ForwardedRoomKey(mut e) = decrypted.event.deserialize().unwrap() {
-            let (_, session) = alice_machine
-                .receive_forwarded_room_key(&decrypted.sender_key, &mut e)
-                .await
-                .unwrap();
+        if let AnyToDeviceEvent::ForwardedRoomKey(e) = decrypted.event.deserialize().unwrap() {
+            let session =
+                alice_machine.receive_forwarded_room_key(&decrypted.sender_key, &e).await.unwrap();
             alice_machine.store.save_inbound_group_sessions(&[session.unwrap()]).await.unwrap();
         } else {
             panic!("Invalid decrypted event type");

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -39,17 +39,16 @@ use ruma::{
             EncryptedEventScheme, MegolmV1AesSha2Content, OriginalSyncRoomEncryptedEvent,
             RoomEncryptedEventContent, ToDeviceRoomEncryptedEvent,
         },
-        room_key::ToDeviceRoomKeyEvent,
         secret::request::SecretName,
-        AnyMessageLikeEvent, AnyRoomEvent, AnyToDeviceEvent, MessageLikeEventContent,
+        AnyMessageLikeEvent, AnyRoomEvent, MessageLikeEventContent,
     },
-    DeviceId, DeviceKeyAlgorithm, EventEncryptionAlgorithm, OwnedDeviceKeyId, OwnedTransactionId,
-    OwnedUserId, RoomId, TransactionId, UInt, UserId,
+    serde::Raw,
+    DeviceId, DeviceKeyAlgorithm, OwnedDeviceKeyId, OwnedTransactionId, OwnedUserId, RoomId,
+    TransactionId, UInt, UserId,
 };
-use serde_json::Value;
+use serde_json::{value::to_raw_value, Value};
 use tracing::{debug, error, info, trace, warn};
 use vodozemac::Ed25519Signature;
-use zeroize::Zeroize;
 
 #[cfg(feature = "backups_v1")]
 use crate::backups::BackupMachine;
@@ -60,7 +59,7 @@ use crate::{
     olm::{
         Account, CrossSigningStatus, EncryptionSettings, ExportedRoomKey, IdentityKeys,
         InboundGroupSession, OlmDecryptionInfo, PrivateCrossSigningIdentity, ReadOnlyAccount,
-        SessionKey, SessionType,
+        SessionType,
     },
     requests::{IncomingResponse, OutgoingRequest, UploadSigningKeysRequest},
     session_manager::{GroupSessionManager, SessionManager},
@@ -68,7 +67,13 @@ use crate::{
         Changes, CryptoStore, DeviceChanges, IdentityChanges, MemoryStore, Result as StoreResult,
         SecretImportError, Store,
     },
-    types::Signatures,
+    types::{
+        events::{
+            room_key::{RoomKeyContent, RoomKeyEvent},
+            ToDeviceEvents,
+        },
+        Signatures,
+    },
     verification::{Verification, VerificationMachine, VerificationRequest},
     CrossSigningKeyExport, ReadOnlyDevice, RoomKeyImportResult, SignatureError, ToDeviceRequest,
 };
@@ -538,17 +543,7 @@ impl OlmMachine {
         let mut decrypted = self.account.decrypt_to_device_event(event).await?;
         // Handle the decrypted event, e.g. fetch out Megolm sessions out of
         // the event.
-        if let (Some(event), group_session) =
-            self.handle_decrypted_to_device_event(&decrypted).await?
-        {
-            // Some events may have sensitive data e.g. private keys, while we
-            // want to notify our users that a private key was received we
-            // don't want them to be able to do silly things with it. Handling
-            // events modifies them and returns a modified one, so replace it
-            // here if we get one.
-            decrypted.deserialized_event = Some(event);
-            decrypted.inbound_group_session = group_session;
-        }
+        self.handle_decrypted_to_device_event(&mut decrypted).await?;
 
         Ok(decrypted)
     }
@@ -558,53 +553,36 @@ impl OlmMachine {
         &self,
         sender_key: &str,
         signing_key: &str,
-        event: &mut ToDeviceRoomKeyEvent,
-    ) -> OlmResult<(Option<AnyToDeviceEvent>, Option<InboundGroupSession>)> {
-        match event.content.algorithm {
-            EventEncryptionAlgorithm::MegolmV1AesSha2 => {
-                match SessionKey::from_base64(&event.content.session_key) {
-                    Ok(session_key) => {
-                        event.content.session_key.zeroize();
-                        let session = InboundGroupSession::new(
-                            sender_key,
-                            signing_key,
-                            &event.content.room_id,
-                            session_key,
-                            None,
-                        );
+        event: &RoomKeyEvent,
+    ) -> OlmResult<Option<InboundGroupSession>> {
+        match &event.content {
+            RoomKeyContent::MegolmV1AesSha2(content) => {
+                let session = InboundGroupSession::new(
+                    sender_key,
+                    signing_key,
+                    &content.room_id,
+                    &content.session_key,
+                    None,
+                );
 
-                        info!(
-                            sender = event.sender.as_str(),
-                            sender_key = sender_key,
-                            room_id = event.content.room_id.as_str(),
-                            session_id = session.session_id(),
-                            "Received a new room key",
-                        );
-
-                        let event = AnyToDeviceEvent::RoomKey(event.clone());
-
-                        Ok((Some(event), Some(session)))
-                    }
-                    Err(e) => {
-                        warn!(
-                            sender = event.sender.as_str(),
-                            sender_key = sender_key,
-                            room_id = event.content.room_id.as_str(),
-                            "Couldn't create a group session from a received room key"
-                        );
-                        Err(e.into())
-                    }
-                }
-            }
-            _ => {
-                warn!(
-                    sender = event.sender.as_str(),
+                info!(
+                    sender = %event.sender,
                     sender_key = sender_key,
-                    room_id = event.content.room_id.as_str(),
-                    algorithm = ?event.content.algorithm,
+                    room_id = %content.room_id,
+                    session_id = session.session_id(),
+                    "Received a new room key",
+                );
+
+                Ok(Some(session))
+            }
+            RoomKeyContent::Unknown(content) => {
+                warn!(
+                    sender = %event.sender,
+                    sender_key = sender_key,
+                    algorithm = ?content.algorithm,
                     "Received room key with unsupported key algorithm",
                 );
-                Ok((None, None))
+                Ok(None)
             }
         }
     }
@@ -739,9 +717,9 @@ impl OlmMachine {
     /// * `decrypted` - The decrypted event and some associated metadata.
     async fn handle_decrypted_to_device_event(
         &self,
-        decrypted: &OlmDecryptionInfo,
-    ) -> OlmResult<(Option<AnyToDeviceEvent>, Option<InboundGroupSession>)> {
-        let event = match decrypted.event.deserialize() {
+        decrypted: &mut OlmDecryptionInfo,
+    ) -> OlmResult<()> {
+        let event: ToDeviceEvents = match decrypted.event.deserialize_as() {
             Ok(e) => e,
             Err(e) => {
                 warn!(
@@ -750,7 +728,8 @@ impl OlmMachine {
                     error = ?e,
                     "Decrypted to-device event failed to be deserialized correctly"
                 );
-                return Ok((None, None));
+
+                return Ok(());
             }
         };
 
@@ -762,25 +741,34 @@ impl OlmMachine {
         );
 
         match event {
-            AnyToDeviceEvent::RoomKey(mut e) => {
-                Ok(self.add_room_key(&decrypted.sender_key, &decrypted.signing_key, &mut e).await?)
+            ToDeviceEvents::RoomKey(e) => {
+                let session =
+                    self.add_room_key(&decrypted.sender_key, &decrypted.signing_key, &e).await?;
+                decrypted.inbound_group_session = session;
             }
-            AnyToDeviceEvent::ForwardedRoomKey(mut e) => Ok(self
-                .key_request_machine
-                .receive_forwarded_room_key(&decrypted.sender_key, &mut e)
-                .await?),
-            AnyToDeviceEvent::SecretSend(mut e) => Ok((
-                self.key_request_machine.receive_secret(&decrypted.sender_key, &mut e).await?,
-                None,
-            )),
+            ToDeviceEvents::ForwardedRoomKey(e) => {
+                let session = self
+                    .key_request_machine
+                    .receive_forwarded_room_key(&decrypted.sender_key, &e)
+                    .await?;
+                decrypted.inbound_group_session = session;
+            }
+            ToDeviceEvents::SecretSend(mut e) => {
+                self.key_request_machine.receive_secret(&decrypted.sender_key, &mut e).await?;
+                decrypted.event = Raw::from_json(to_raw_value(&e)?)
+            }
             _ => {
-                warn!(event_type = ?event.event_type(), "Received an unexpected encrypted to-device event");
-                Ok((Some(event), None))
+                warn!(
+                    event_type = ?event.event_type(),
+                    "Received an unexpected encrypted to-device event"
+                );
             }
         }
+
+        Ok(())
     }
 
-    async fn handle_verification_event(&self, event: &AnyToDeviceEvent) {
+    async fn handle_verification_event(&self, event: &ToDeviceEvents) {
         if let Err(e) = self.verification_machine.receive_any_event(event).await {
             error!("Error handling a verification event: {:?}", e);
         }
@@ -823,28 +811,23 @@ impl OlmMachine {
         self.account.update_key_counts(one_time_key_count, unused_fallback_keys).await;
     }
 
-    async fn handle_to_device_event(&self, event: &AnyToDeviceEvent) {
+    async fn handle_to_device_event(&self, event: &ToDeviceEvents) {
+        use crate::types::events::ToDeviceEvents::*;
+
         match event {
-            AnyToDeviceEvent::RoomKeyRequest(e) => {
-                self.key_request_machine.receive_incoming_key_request(e)
-            }
-            AnyToDeviceEvent::SecretRequest(e) => {
-                self.key_request_machine.receive_incoming_secret_request(e)
-            }
-            AnyToDeviceEvent::KeyVerificationAccept(..)
-            | AnyToDeviceEvent::KeyVerificationCancel(..)
-            | AnyToDeviceEvent::KeyVerificationKey(..)
-            | AnyToDeviceEvent::KeyVerificationMac(..)
-            | AnyToDeviceEvent::KeyVerificationRequest(..)
-            | AnyToDeviceEvent::KeyVerificationReady(..)
-            | AnyToDeviceEvent::KeyVerificationDone(..)
-            | AnyToDeviceEvent::KeyVerificationStart(..) => {
+            RoomKeyRequest(e) => self.key_request_machine.receive_incoming_key_request(e),
+            SecretRequest(e) => self.key_request_machine.receive_incoming_secret_request(e),
+            KeyVerificationAccept(..)
+            | KeyVerificationCancel(..)
+            | KeyVerificationKey(..)
+            | KeyVerificationMac(..)
+            | KeyVerificationRequest(..)
+            | KeyVerificationReady(..)
+            | KeyVerificationDone(..)
+            | KeyVerificationStart(..) => {
                 self.handle_verification_event(event).await;
             }
-            AnyToDeviceEvent::Dummy(_)
-            | AnyToDeviceEvent::RoomKey(_)
-            | AnyToDeviceEvent::ForwardedRoomKey(_)
-            | AnyToDeviceEvent::RoomEncrypted(_) => {}
+            Dummy(_) | RoomKey(_) | ForwardedRoomKey(_) | RoomEncrypted(_) => {}
             _ => {}
         }
     }
@@ -892,7 +875,7 @@ impl OlmMachine {
         }
 
         for mut raw_event in to_device_events.events {
-            let event = match raw_event.deserialize() {
+            let event: ToDeviceEvents = match raw_event.deserialize_as() {
                 Ok(e) => e,
                 Err(e) => {
                     // Skip invalid events.
@@ -900,6 +883,7 @@ impl OlmMachine {
                         error = ?e,
                         "Received an invalid to-device event"
                     );
+                    events.push(raw_event);
                     continue;
                 }
             };
@@ -911,7 +895,7 @@ impl OlmMachine {
             );
 
             match event {
-                AnyToDeviceEvent::RoomEncrypted(e) => {
+                ToDeviceEvents::RoomEncrypted(e) => {
                     let decrypted = match self.decrypt_to_device_event(&e).await {
                         Ok(e) => e,
                         Err(err) => {
@@ -950,11 +934,23 @@ impl OlmMachine {
                         changes.inbound_group_sessions.push(group_session);
                     }
 
-                    if let Some(event) = decrypted.deserialized_event {
-                        self.handle_to_device_event(&event).await;
-                    }
+                    match decrypted.event.deserialize_as() {
+                        Ok(event) => {
+                            self.handle_to_device_event(&event).await;
 
-                    raw_event = decrypted.event;
+                            raw_event = event
+                                .serialize_zeroized()
+                                .expect("Zeroizing and reserializing our events should always work")
+                                .cast();
+                        }
+                        Err(e) => {
+                            warn!(
+                                error = ?e,
+                                "Received an invalid encrypted to-device event"
+                            );
+                            raw_event = decrypted.event;
+                        }
+                    }
                 }
                 e => self.handle_to_device_event(&e).await,
             }
@@ -1563,7 +1559,10 @@ pub(crate) mod tests {
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{
         api::{
-            client::keys::{claim_keys, get_keys, upload_keys},
+            client::{
+                keys::{claim_keys, get_keys, upload_keys},
+                sync::sync_events::v3::ToDevice,
+            },
             IncomingResponse,
         },
         device_id,
@@ -1585,6 +1584,7 @@ pub(crate) mod tests {
         uint, user_id, DeviceId, DeviceKeyAlgorithm, DeviceKeyId, MilliSecondsSinceUnixEpoch,
         OwnedDeviceKeyId, UserId,
     };
+    use serde_json::value::to_raw_value;
     use vodozemac::Ed25519PublicKey;
 
     use super::testing::response_from_file;
@@ -1955,18 +1955,20 @@ pub(crate) mod tests {
             sender: alice.user_id().to_owned(),
             content: to_device_requests_to_content(to_device_requests),
         };
+        let event = Raw::from_json(to_raw_value(&event).unwrap());
 
         let alice_session =
             alice.group_session_manager.get_outbound_group_session(room_id).unwrap();
 
-        let decrypted = bob.decrypt_to_device_event(&event).await.unwrap();
+        let mut to_device = ToDevice::new();
+        to_device.events.push(event);
 
-        bob.store.save_sessions(&[decrypted.session.session()]).await.unwrap();
-        bob.store
-            .save_inbound_group_sessions(&[decrypted.inbound_group_session.unwrap()])
+        let decrypted = bob
+            .receive_sync_changes(to_device, &Default::default(), &Default::default(), None)
             .await
             .unwrap();
-        let event = decrypted.deserialized_event.unwrap();
+
+        let event = decrypted.events[0].deserialize().unwrap();
 
         if let AnyToDeviceEvent::RoomKey(event) = event {
             assert_eq!(&event.sender, alice.user_id());

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -100,7 +100,6 @@ pub(crate) struct OlmDecryptionInfo {
     pub sender: OwnedUserId,
     pub session: SessionType,
     pub message_hash: OlmMessageHash,
-    pub deserialized_event: Option<AnyToDeviceEvent>,
     pub event: Raw<AnyToDeviceEvent>,
     pub signing_key: String,
     pub sender_key: String,
@@ -189,7 +188,6 @@ impl Account {
                     event,
                     signing_key,
                     sender_key: content.sender_key.clone(),
-                    deserialized_event: None,
                     inbound_group_session: None,
                 }),
                 Err(OlmError::SessionWedged(user_id, sender_key)) => {
@@ -1085,7 +1083,7 @@ impl ReadOnlyAccount {
             &sender_key,
             &signing_key,
             room_id,
-            outbound.session_key().await,
+            &outbound.session_key().await,
             Some(visibility),
         );
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -45,7 +45,6 @@ use vodozemac::{
     },
     PickleError,
 };
-use zeroize::Zeroize;
 
 use super::{BackedUpRoomKey, ExportedRoomKey, SessionKey};
 use crate::error::{EventError, MegolmResult};
@@ -97,10 +96,10 @@ impl InboundGroupSession {
         sender_key: &str,
         signing_key: &str,
         room_id: &RoomId,
-        session_key: SessionKey,
+        session_key: &SessionKey,
         history_visibility: Option<HistoryVisibility>,
     ) -> Self {
-        let session = InnerSession::new(&session_key);
+        let session = InnerSession::new(session_key);
         let session_id = session.session_id();
         let first_known_index = session.first_known_index();
 
@@ -159,10 +158,9 @@ impl InboundGroupSession {
     /// to create the `InboundGroupSession`.
     pub fn from_forwarded_key(
         sender_key: &str,
-        content: &mut ToDeviceForwardedRoomKeyEventContent,
+        content: &ToDeviceForwardedRoomKeyEventContent,
     ) -> Result<Self, SessionKeyDecodeError> {
         let key = ExportedSessionKey::from_base64(&content.session_key)?;
-        content.session_key.zeroize();
 
         let session = InnerSession::import(&key);
         let first_known_index = session.first_known_index();

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -162,7 +162,7 @@ pub(crate) mod tests {
             "test_key",
             "test_key",
             room_id,
-            outbound.session_key().await,
+            &outbound.session_key().await,
             None,
         );
 
@@ -202,7 +202,7 @@ pub(crate) mod tests {
             "test_key",
             "test_key",
             room_id,
-            outbound.session_key().await,
+            &outbound.session_key().await,
             None,
         );
 

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -239,7 +239,7 @@ mod tests {
             "test_key",
             "test_key",
             room_id,
-            outbound.session_key().await,
+            &outbound.session_key().await,
             None,
         );
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -349,7 +349,7 @@ mod tests {
             "test_key",
             "test_key",
             room_id,
-            outbound.session_key().await,
+            &outbound.session_key().await,
             None,
         );
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -535,10 +535,8 @@ impl Store {
     pub async fn import_secret(
         &self,
         secret_name: &SecretName,
-        secret: String,
+        secret: &str,
     ) -> Result<(), SecretImportError> {
-        let secret = zeroize::Zeroizing::new(secret);
-
         match secret_name {
             SecretName::CrossSigningMasterKey
             | SecretName::CrossSigningUserSigningKey
@@ -548,7 +546,7 @@ impl Store {
                 {
                     let identity = self.identity.lock().await;
 
-                    identity.import_secret(public_identity, secret_name, &secret).await?;
+                    identity.import_secret(public_identity, secret_name, secret).await?;
                     info!(
                         secret_name = secret_name.as_ref(),
                         "Successfully imported a private cross signing key"

--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -1,0 +1,39 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types modeling end-to-end encryption related Matrix events
+//!
+//! These types aim to provide a more strict variant of the equivalent Ruma
+//! types. Once deserialized they aim to zeroize all the secret material once
+//! the type is dropped.
+
+pub mod room_key;
+pub mod secret_send;
+mod to_device;
+
+pub use to_device::{ToDeviceCustomEvent, ToDeviceEvent, ToDeviceEvents};
+
+/// A trait for event contents to define their event type.
+pub trait EventType {
+    /// Get the event type of the event content.
+    fn event_type(&self) -> &str;
+}
+
+fn from_str<'a, T, E>(string: &'a str) -> Result<T, E>
+where
+    T: serde::Deserialize<'a>,
+    E: serde::de::Error,
+{
+    serde_json::from_str(string).map_err(serde::de::Error::custom)
+}

--- a/crates/matrix-sdk-crypto/src/types/events/room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key.rs
@@ -1,0 +1,203 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for `m.room_key` to-device events.
+
+use std::collections::BTreeMap;
+
+use ruma::{serde::Raw, EventEncryptionAlgorithm, OwnedRoomId, RoomId};
+use serde::{Deserialize, Serialize};
+use serde_json::{value::to_raw_value, Value};
+use vodozemac::megolm::SessionKey;
+
+use super::{EventType, ToDeviceEvent};
+
+/// The `m.room_key` to-device event.
+pub type RoomKeyEvent = ToDeviceEvent<RoomKeyContent>;
+
+impl EventType for RoomKeyContent {
+    fn event_type(&self) -> &str {
+        "m.room_key"
+    }
+}
+
+/// The `m.room_key` event content.
+///
+/// This is an enum over the different room key algorithms we support.
+///
+/// This event type is used to exchange keys for end-to-end encryption.
+/// Typically it is encrypted as an m.room.encrypted event, then sent as a
+/// to-device event.
+#[derive(Debug, Deserialize)]
+#[serde(try_from = "RoomKeyHelper")]
+pub enum RoomKeyContent {
+    /// The `m.megolm.v1.aes-sha2` variant of the `m.room_key` content.
+    MegolmV1AesSha2(Box<MegolmV1AesSha2Content>),
+    /// An unknown and unsupported variant of the `m.room_key` content.
+    Unknown(UnknownRoomKey),
+}
+
+impl RoomKeyContent {
+    pub(super) fn serialize_zeroized(&self) -> Result<Raw<RoomKeyContent>, serde_json::Error> {
+        #[derive(Serialize)]
+        struct Helper<'a> {
+            pub room_id: &'a RoomId,
+            pub session_id: &'a str,
+            pub session_key: &'a str,
+            #[serde(flatten)]
+            other: &'a BTreeMap<String, Value>,
+        }
+
+        match self {
+            RoomKeyContent::MegolmV1AesSha2(c) => {
+                let helper = Helper {
+                    room_id: &c.room_id,
+                    session_id: &c.session_id,
+                    session_key: "",
+                    other: &c.other,
+                };
+
+                let helper = RoomKeyHelper {
+                    algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+                    other: serde_json::to_value(helper)?,
+                };
+
+                Ok(Raw::from_json(to_raw_value(&helper)?))
+            }
+            RoomKeyContent::Unknown(c) => Ok(Raw::from_json(to_raw_value(&c)?)),
+        }
+    }
+}
+
+/// The `m.megolm.v1.aes-sha2` variant of the `m.room_key` content.
+#[derive(Deserialize, Serialize)]
+pub struct MegolmV1AesSha2Content {
+    /// The room where the key is used.
+    pub room_id: OwnedRoomId,
+    /// The ID of the session that the key is for.
+    pub session_id: String,
+    /// The key to be exchanged. Can be used to create a [`InboundGroupSession`]
+    /// that can be used to decrypt room events.
+    ///
+    /// [`InboundGroupSession`]: vodozemac::megolm::InboundGroupSession
+    pub session_key: SessionKey,
+    /// Any other, custom and non-specced fields of the content.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+impl std::fmt::Debug for MegolmV1AesSha2Content {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MegolmV1AesSha2Content")
+            .field("room_id", &self.room_id)
+            .field("session_id", &self.session_id)
+            .finish_non_exhaustive()
+    }
+}
+
+/// An unknown and unsupported `m.room_key` algorithm.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UnknownRoomKey {
+    /// The algorithm of the unknown room key.
+    pub algorithm: EventEncryptionAlgorithm,
+    /// The other data of the unknown room key.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct RoomKeyHelper {
+    algorithm: EventEncryptionAlgorithm,
+    #[serde(flatten)]
+    other: Value,
+}
+
+impl TryFrom<RoomKeyHelper> for RoomKeyContent {
+    type Error = serde_json::Error;
+
+    fn try_from(value: RoomKeyHelper) -> Result<Self, Self::Error> {
+        Ok(match value.algorithm {
+            EventEncryptionAlgorithm::MegolmV1AesSha2 => {
+                let content: MegolmV1AesSha2Content = serde_json::from_value(value.other)?;
+                Self::MegolmV1AesSha2(content.into())
+            }
+            _ => Self::Unknown(UnknownRoomKey {
+                algorithm: value.algorithm,
+                other: serde_json::from_value(value.other)?,
+            }),
+        })
+    }
+}
+
+impl Serialize for RoomKeyContent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let helper = match self {
+            Self::MegolmV1AesSha2(r) => RoomKeyHelper {
+                algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+                other: serde_json::to_value(r).map_err(serde::ser::Error::custom)?,
+            },
+            Self::Unknown(r) => RoomKeyHelper {
+                algorithm: r.algorithm.clone(),
+                other: serde_json::to_value(r.other.clone()).map_err(serde::ser::Error::custom)?,
+            },
+        };
+
+        helper.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+pub(super) mod test {
+    use matches::assert_matches;
+    use serde_json::{json, Value};
+
+    use super::RoomKeyEvent;
+    use crate::types::events::room_key::RoomKeyContent;
+
+    pub fn json() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "m.custom": "something custom",
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "room_id": "!Cuyf34gef24t:localhost",
+                "session_id": "ZFD6+OmV7fVCsJ7Gap8UnORH8EnmiAkes8FAvQuCw/I",
+                "session_key": "AgAAAADNp1EbxXYOGmJtyX4AkD1bvJvAUyPkbIaKxtnGKjv\
+                                SQ3E/4mnuqdM4vsmNzpO1EeWzz1rDkUpYhYE9kP7sJhgLXi\
+                                jVv80fMPHfGc49hPdu8A+xnwD4SQiYdFmSWJOIqsxeo/fiH\
+                                tino//CDQENtcKuEt0I9s0+Kk4YSH310Szse2RQ+vjple31\
+                                QrCexmqfFJzkR/BJ5ogJHrPBQL0LgsPyglIbMTLg7qygIaY\
+                                U5Fe2QdKMH7nTZPNIRHh1RaMfHVETAUJBax88EWZBoifk80\
+                                gdHUwHSgMk77vCc2a5KHKLDA"
+            },
+            "type": "m.room_key",
+            "m.custom.top": "something custom in the top",
+        })
+    }
+
+    #[test]
+    fn deserialization() -> Result<(), serde_json::Error> {
+        let json = json();
+        let event: RoomKeyEvent = serde_json::from_value(json.clone())?;
+
+        assert_matches!(event.content, RoomKeyContent::MegolmV1AesSha2(_));
+        let serialized = serde_json::to_value(event)?;
+        assert_eq!(json, serialized);
+
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/events/secret_send.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/secret_send.rs
@@ -1,0 +1,106 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for `m.secret.send` to-device events.
+
+use std::collections::BTreeMap;
+
+use ruma::events::secret::request::SecretName;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use zeroize::Zeroize;
+
+use super::{EventType, ToDeviceEvent};
+
+/// The `m.secret.send` to-device event.
+pub type SecretSendEvent = ToDeviceEvent<SecretSendContent>;
+
+/// The `m.secret.send` event content.
+///
+/// Sent by a client to share a secret with another device, in response to an
+/// `m.secret.request` event. It must be encrypted as an `m.room.encrypted`
+/// event, then sent as a to-device event.
+#[derive(Serialize, Deserialize)]
+pub struct SecretSendContent {
+    /// The ID of the request that this a response to.
+    pub request_id: String,
+    /// The contents of the secret.
+    pub secret: String,
+    /// The name of the secret, typically not part of the event but can be
+    /// inserted when processing `m.secret.send` events so other event consumers
+    /// know which secret this event contains.
+    #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
+    pub secret_name: Option<SecretName>,
+    /// Any other, custom and non-specced fields of the content.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+impl Zeroize for SecretSendContent {
+    fn zeroize(&mut self) {
+        self.secret.zeroize();
+    }
+}
+
+impl Drop for SecretSendContent {
+    fn drop(&mut self) {
+        self.zeroize()
+    }
+}
+
+impl std::fmt::Debug for SecretSendContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SecretSendContent")
+            .field("request_id", &self.request_id)
+            .field("secret_name", &self.secret_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EventType for SecretSendContent {
+    fn event_type(&self) -> &str {
+        "m.secret.send"
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use serde_json::{json, Value};
+
+    use super::SecretSendEvent;
+
+    pub(crate) fn json() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "request_id": "randomly_generated_id_9573",
+                "secret": "ThisIsASecretDon'tTellAnyone"
+            },
+            "type": "m.secret.send",
+        })
+    }
+
+    #[test]
+    fn deserialization() -> Result<(), serde_json::Error> {
+        let json = json();
+        let event: SecretSendEvent = serde_json::from_value(json.clone())?;
+
+        assert_eq!(&event.content.secret, "ThisIsASecretDon'tTellAnyone");
+
+        let serialized = serde_json::to_value(event)?;
+        assert_eq!(json, serialized);
+
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/events/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/to_device.rs
@@ -1,0 +1,498 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeMap, fmt::Debug};
+
+use ruma::{
+    events::{
+        dummy::ToDeviceDummyEvent,
+        forwarded_room_key::ToDeviceForwardedRoomKeyEvent,
+        key::verification::{
+            accept::ToDeviceKeyVerificationAcceptEvent, cancel::ToDeviceKeyVerificationCancelEvent,
+            done::ToDeviceKeyVerificationDoneEvent, key::ToDeviceKeyVerificationKeyEvent,
+            mac::ToDeviceKeyVerificationMacEvent, ready::ToDeviceKeyVerificationReadyEvent,
+            request::ToDeviceKeyVerificationRequestEvent, start::ToDeviceKeyVerificationStartEvent,
+        },
+        room::encrypted::ToDeviceRoomEncryptedEvent,
+        room_key_request::ToDeviceRoomKeyRequestEvent,
+        secret::request::{SecretName, ToDeviceSecretRequestEvent},
+        EventContent, ToDeviceEventType,
+    },
+    serde::Raw,
+    OwnedUserId, UserId,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{
+    value::{to_raw_value, RawValue},
+    Value,
+};
+use zeroize::Zeroize;
+
+use super::{room_key::RoomKeyEvent, secret_send::SecretSendEvent, EventType};
+use crate::types::events::from_str;
+
+/// An enum over the various to-device events we support.
+#[derive(Debug)]
+pub enum ToDeviceEvents {
+    /// A to-device event of an unknown or custom type.
+    Custom(ToDeviceCustomEvent),
+    /// The `m.dummy` to-device event.
+    Dummy(ToDeviceDummyEvent),
+
+    /// The `m.key.verification.accept` to-device event.
+    KeyVerificationAccept(ToDeviceKeyVerificationAcceptEvent),
+    /// The `m.key.verification.cancel` to-device event.
+    KeyVerificationCancel(ToDeviceKeyVerificationCancelEvent),
+    /// The `m.key.verification.key` to-device event.
+    KeyVerificationKey(ToDeviceKeyVerificationKeyEvent),
+    /// The `m.key.verification.mac` to-device event.
+    KeyVerificationMac(ToDeviceKeyVerificationMacEvent),
+    /// The `m.key.verification.done` to-device event.
+    KeyVerificationDone(ToDeviceKeyVerificationDoneEvent),
+    /// The `m.key.verification.start` to-device event.
+    KeyVerificationStart(ToDeviceKeyVerificationStartEvent),
+    /// The `m.key.verification.ready` to-device event.
+    KeyVerificationReady(ToDeviceKeyVerificationReadyEvent),
+    /// The `m.key.verification.request` to-device event.
+    KeyVerificationRequest(ToDeviceKeyVerificationRequestEvent),
+
+    /// The `m.room.encrypted` to-device event.
+    RoomEncrypted(ToDeviceRoomEncryptedEvent),
+    /// The `m.room_key` to-device event.
+    RoomKey(RoomKeyEvent),
+    /// The `m.room_key_request` to-device event.
+    RoomKeyRequest(ToDeviceRoomKeyRequestEvent),
+    /// The `m.forwarded_room_key` to-device event.
+    ForwardedRoomKey(ToDeviceForwardedRoomKeyEvent),
+    /// The `m.secret.send` to-device event.
+    SecretSend(SecretSendEvent),
+    /// The `m.secret.request` to-device event.
+    SecretRequest(ToDeviceSecretRequestEvent),
+}
+
+impl ToDeviceEvents {
+    /// The sender of the to-device event.
+    pub fn sender(&self) -> &UserId {
+        match self {
+            ToDeviceEvents::Custom(e) => &e.sender,
+            ToDeviceEvents::Dummy(e) => &e.sender,
+
+            ToDeviceEvents::KeyVerificationAccept(e) => &e.sender,
+            ToDeviceEvents::KeyVerificationCancel(e) => &e.sender,
+            ToDeviceEvents::KeyVerificationKey(e) => &e.sender,
+            ToDeviceEvents::KeyVerificationMac(e) => &e.sender,
+            ToDeviceEvents::KeyVerificationDone(e) => &e.sender,
+            ToDeviceEvents::KeyVerificationStart(e) => &e.sender,
+            ToDeviceEvents::KeyVerificationReady(e) => &e.sender,
+            ToDeviceEvents::KeyVerificationRequest(e) => &e.sender,
+
+            ToDeviceEvents::RoomEncrypted(e) => &e.sender,
+            ToDeviceEvents::RoomKey(e) => &e.sender,
+            ToDeviceEvents::RoomKeyRequest(e) => &e.sender,
+            ToDeviceEvents::ForwardedRoomKey(e) => &e.sender,
+
+            ToDeviceEvents::SecretSend(e) => &e.sender,
+            ToDeviceEvents::SecretRequest(e) => &e.sender,
+        }
+    }
+
+    /// The event type of the to-device event.
+    pub fn event_type(&self) -> ToDeviceEventType {
+        match self {
+            ToDeviceEvents::Custom(e) => ToDeviceEventType::from(e.event_type.to_owned()),
+            ToDeviceEvents::Dummy(e) => e.content.event_type(),
+
+            ToDeviceEvents::KeyVerificationAccept(e) => e.content.event_type(),
+            ToDeviceEvents::KeyVerificationCancel(e) => e.content.event_type(),
+            ToDeviceEvents::KeyVerificationKey(e) => e.content.event_type(),
+            ToDeviceEvents::KeyVerificationMac(e) => e.content.event_type(),
+            ToDeviceEvents::KeyVerificationDone(e) => e.content.event_type(),
+            ToDeviceEvents::KeyVerificationStart(e) => e.content.event_type(),
+            ToDeviceEvents::KeyVerificationReady(e) => e.content.event_type(),
+            ToDeviceEvents::KeyVerificationRequest(e) => e.content.event_type(),
+
+            ToDeviceEvents::RoomEncrypted(e) => e.content.event_type(),
+            ToDeviceEvents::RoomKey(_) => ToDeviceEventType::RoomKey,
+            ToDeviceEvents::RoomKeyRequest(e) => e.content.event_type(),
+            ToDeviceEvents::ForwardedRoomKey(e) => e.content.event_type(),
+
+            ToDeviceEvents::SecretSend(_) => ToDeviceEventType::SecretSend,
+            ToDeviceEvents::SecretRequest(e) => e.content.event_type(),
+        }
+    }
+
+    /// Serialize this event into a Raw variant while zeroizing any secrets it
+    /// might contain.
+    ///
+    /// Secrets in Matrix are usually base64 encoded strings, zeroizing in this
+    /// context means that the secret will be converted into an empty string.
+    ///
+    /// The following secrets will be zeroized by this method:
+    ///
+    /// * `m.room_key` - The `session_key` field.
+    /// * `m.forwarded_room_key` - The `session_key` field.
+    /// * `m.secret.send` - The `secret` field will be zeroized, unless the
+    /// secret name of the matching `m.secret.request` event was
+    /// `m.megolm_backup.v1`.
+    ///
+    /// **Warning**: Some events won't be able to be deserialized into the
+    /// `ToDeviceEvents` type again since they might expect a valid `SessionKey`
+    /// for `m.room.key` events or valid base64 for some other secrets.
+    ///
+    /// You can do a couple of things to avoid this problem:
+    ///
+    /// 1. Call `Raw::cast()` to convert the event to another, less strict type.
+    /// [`AnyToDeviceEvent`] from Ruma will work.
+    ///
+    /// 2. Call `Raw::deserialize_as()` to deserialize into a less strict type.
+    ///
+    /// 3. Pass the event over FFI, losing the exact type information, this will
+    /// mostl likely end up using a less strict type naturally.
+    ///
+    /// [`AnyToDeviceEvent`]: ruma::events::AnyToDeviceEvent
+    pub(crate) fn serialize_zeroized(self) -> Result<Raw<ToDeviceEvents>, serde_json::Error> {
+        let serialized = match self {
+            ToDeviceEvents::Custom(_)
+            | ToDeviceEvents::Dummy(_)
+            | ToDeviceEvents::KeyVerificationAccept(_)
+            | ToDeviceEvents::KeyVerificationCancel(_)
+            | ToDeviceEvents::KeyVerificationKey(_)
+            | ToDeviceEvents::KeyVerificationMac(_)
+            | ToDeviceEvents::KeyVerificationDone(_)
+            | ToDeviceEvents::KeyVerificationStart(_)
+            | ToDeviceEvents::KeyVerificationReady(_)
+            | ToDeviceEvents::KeyVerificationRequest(_)
+            | ToDeviceEvents::RoomEncrypted(_)
+            | ToDeviceEvents::RoomKeyRequest(_)
+            | ToDeviceEvents::SecretRequest(_) => Raw::from_json(to_raw_value(&self)?),
+            ToDeviceEvents::RoomKey(e) => {
+                let event_type = e.content.event_type();
+                let content = e.content.serialize_zeroized()?;
+
+                #[derive(Serialize)]
+                struct Helper<'a, C> {
+                    sender: &'a UserId,
+                    content: &'a Raw<C>,
+                    #[serde(rename = "type")]
+                    event_type: &'a str,
+                }
+
+                let helper = Helper { sender: &e.sender, content: &content, event_type };
+
+                let raw_value = to_raw_value(&helper)?;
+
+                Raw::from_json(raw_value)
+            }
+            ToDeviceEvents::ForwardedRoomKey(mut e) => {
+                e.content.session_key.zeroize();
+                Raw::from_json(to_raw_value(&e)?)
+            }
+            ToDeviceEvents::SecretSend(mut e) => {
+                if let Some(SecretName::RecoveryKey) = e.content.secret_name {
+                    // We don't zeroize the recovery key since it requires
+                    // additional requests and possibly user-interaction to be
+                    // verified. We let the user deal with this.
+                } else {
+                    e.content.secret.zeroize();
+                }
+                Raw::from_json(to_raw_value(&e)?)
+            }
+        };
+
+        Ok(serialized)
+    }
+}
+
+/// A to-device event with an unknown type and content.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ToDeviceCustomEvent {
+    /// The sender of the to-device event.
+    pub sender: OwnedUserId,
+    /// The content of the to-device event.
+    pub content: BTreeMap<String, Value>,
+    /// The type of the to-device event.
+    #[serde(rename = "type")]
+    pub event_type: String,
+    /// Any other unknown data of the to-device event.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+/// Generic to-device event with a known type and content.
+#[derive(Debug, Deserialize)]
+pub struct ToDeviceEvent<C>
+where
+    C: EventType + Debug + Sized + Serialize,
+{
+    /// The sender of the to-device event.
+    pub sender: OwnedUserId,
+    /// The content of the to-device event.
+    pub content: C,
+    /// Any other unknown data of the to-device event.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+impl<C> Serialize for ToDeviceEvent<C>
+where
+    C: EventType + Debug + Sized + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a, C> {
+            sender: &'a UserId,
+            content: &'a C,
+            #[serde(rename = "type")]
+            event_type: &'a str,
+            #[serde(flatten)]
+            other: &'a BTreeMap<String, Value>,
+        }
+
+        let event_type = self.content.event_type();
+
+        let helper =
+            Helper { sender: &self.sender, content: &self.content, event_type, other: &self.other };
+
+        helper.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ToDeviceEvents {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Debug, Deserialize)]
+        struct Helper<'a> {
+            #[serde(rename = "type")]
+            event_type: &'a str,
+        }
+
+        let json = Box::<RawValue>::deserialize(deserializer)?;
+        let helper: Helper<'_> =
+            serde_json::from_str(json.get()).map_err(serde::de::Error::custom)?;
+
+        let json = json.get();
+
+        Ok(match helper.event_type {
+            "m.dummy" => ToDeviceEvents::Dummy(from_str(json)?),
+
+            "m.key.verification.accept" => ToDeviceEvents::KeyVerificationAccept(from_str(json)?),
+            "m.key.verification.cancel" => ToDeviceEvents::KeyVerificationCancel(from_str(json)?),
+            "m.key.verification.done" => ToDeviceEvents::KeyVerificationDone(from_str(json)?),
+            "m.key.verification.key" => ToDeviceEvents::KeyVerificationKey(from_str(json)?),
+            "m.key.verification.mac" => ToDeviceEvents::KeyVerificationMac(from_str(json)?),
+            "m.key.verification.start" => ToDeviceEvents::KeyVerificationStart(from_str(json)?),
+            "m.key.verification.ready" => ToDeviceEvents::KeyVerificationReady(from_str(json)?),
+            "m.key.verification.request" => ToDeviceEvents::KeyVerificationRequest(from_str(json)?),
+
+            "m.room.encrypted" => ToDeviceEvents::RoomEncrypted(from_str(json)?),
+            "m.room_key" => ToDeviceEvents::RoomKey(from_str(json)?),
+            "m.forwarded_room_key" => ToDeviceEvents::ForwardedRoomKey(from_str(json)?),
+            "m.room_key_request" => ToDeviceEvents::RoomKeyRequest(from_str(json)?),
+
+            "m.secret.send" => ToDeviceEvents::SecretSend(from_str(json)?),
+            "m.secret.request" => ToDeviceEvents::SecretRequest(from_str(json)?),
+
+            _ => ToDeviceEvents::Custom(from_str(json)?),
+        })
+    }
+}
+
+impl Serialize for ToDeviceEvents {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            ToDeviceEvents::Custom(e) => e.serialize(serializer),
+            ToDeviceEvents::Dummy(e) => e.serialize(serializer),
+
+            ToDeviceEvents::KeyVerificationAccept(e) => e.serialize(serializer),
+            ToDeviceEvents::KeyVerificationCancel(e) => e.serialize(serializer),
+            ToDeviceEvents::KeyVerificationKey(e) => e.serialize(serializer),
+            ToDeviceEvents::KeyVerificationMac(e) => e.serialize(serializer),
+            ToDeviceEvents::KeyVerificationDone(e) => e.serialize(serializer),
+            ToDeviceEvents::KeyVerificationStart(e) => e.serialize(serializer),
+            ToDeviceEvents::KeyVerificationReady(e) => e.serialize(serializer),
+            ToDeviceEvents::KeyVerificationRequest(e) => e.serialize(serializer),
+
+            ToDeviceEvents::RoomEncrypted(e) => e.serialize(serializer),
+            ToDeviceEvents::RoomKey(e) => e.serialize(serializer),
+            ToDeviceEvents::RoomKeyRequest(e) => e.serialize(serializer),
+            ToDeviceEvents::ForwardedRoomKey(e) => e.serialize(serializer),
+
+            ToDeviceEvents::SecretSend(e) => e.serialize(serializer),
+            ToDeviceEvents::SecretRequest(e) => e.serialize(serializer),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use matches::assert_matches;
+    use serde_json::{json, Value};
+
+    use super::ToDeviceEvents;
+
+    fn custom_event() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "custom_key": "custom_value",
+            },
+            "m.custom.top": "something custom in the top",
+            "type": "m.custom.event",
+        })
+    }
+
+    fn key_verification_event() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "from_device": "AliceDevice2",
+                "methods": [
+                  "m.sas.v1"
+                ],
+                "timestamp": 1559598944869u64,
+                "transaction_id": "S0meUniqueAndOpaqueString"
+            },
+            "type": "m.key.verification.request"
+        })
+    }
+
+    fn dummy_event() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {},
+            "type": "m.dummy"
+        })
+    }
+
+    fn secret_request_event() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "name": "org.example.some.secret",
+                "action": "request",
+                "requesting_device_id": "ABCDEFG",
+                "request_id": "randomly_generated_id_9573"
+            },
+            "type": "m.secret.request"
+        })
+    }
+
+    fn room_encrypted_event() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "algorithm": "m.olm.v1.curve25519-aes-sha2",
+                "sender_key": "<sender_curve25519_key>",
+                "ciphertext": {
+                    "<device_curve25519_key>": {
+                    "type": 0,
+                    "body": "<encrypted_payload_base_64>"
+                    }
+                }
+            },
+            "type": "m.room.encrypted",
+        })
+    }
+
+    fn forwarded_room_key_event() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "forwarding_curve25519_key_chain": [
+                "hPQNcabIABgGnx3/ACv/jmMmiQHoeFfuLB17tzWp6Hw"
+            ],
+            "room_id": "!Cuyf34gef24t:localhost",
+            "sender_claimed_ed25519_key": "aj40p+aw64yPIdsxoog8jhPu9i7l7NcFRecuOQblE3Y",
+            "sender_key": "RF3s+E7RkTQTGF2d8Deol0FkQvgII2aJDf3/Jp5mxVU",
+            "session_id": "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ",
+            "session_key": "AgAAAADxKHa9uFxcXzwYoNueL5Xqi69IkD4sni8Llf..."
+            },
+            "type": "m.forwarded_room_key"
+        })
+    }
+
+    fn room_key_request_event() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "action": "request",
+                "body": {
+                  "algorithm": "m.megolm.v1.aes-sha2",
+                  "room_id": "!Cuyf34gef24t:localhost",
+                  "sender_key": "RF3s+E7RkTQTGF2d8Deol0FkQvgII2aJDf3/Jp5mxVU",
+                  "session_id": "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ"
+                },
+                "request_id": "1495474790150.19",
+                "requesting_device_id": "RJYKSTBOIE"
+            },
+            "type": "m.room_key_request"
+        })
+    }
+
+    #[test]
+    fn deserialization() -> Result<(), serde_json::Error> {
+        macro_rules! assert_serialization_roundtrip {
+            ( $( $json:path => $to_device_events:ident ),* $(,)? ) => {
+                $(
+                    let json = $json();
+                    let event: ToDeviceEvents = serde_json::from_value(json.clone())?;
+
+                    assert_matches!(event, ToDeviceEvents::$to_device_events(_));
+                    let serialized = serde_json::to_value(event)?;
+                    assert_eq!(json, serialized);
+                )*
+            }
+        }
+
+        assert_serialization_roundtrip!(
+            // `m.room_key
+            crate::types::events::room_key::test::json => RoomKey,
+
+            // `m.forwarded_room_key`
+            forwarded_room_key_event => ForwardedRoomKey,
+
+            // `m.room_key_request`
+            room_key_request_event => RoomKeyRequest,
+
+            // `m.secret.send`
+            crate::types::events::secret_send::test::json => SecretSend,
+
+            // `m.secret.request`
+            secret_request_event => SecretRequest,
+
+            // Unknown event
+            custom_event => Custom,
+
+            // `m.key.verification.request`
+            key_verification_event => KeyVerificationRequest,
+
+            // `m.dummy`
+            dummy_event => Dummy,
+
+            // `m.room.encrypted`
+            room_encrypted_event => RoomEncrypted,
+        );
+
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Module containing customized types modeling Matrix keys.
+//! Module containing customized types modeling Matrix keys and events.
 //!
 //! These types were mostly taken from the Ruma project. The types differ in two
 //! important ways to the Ruma types of the same name:
 //!
 //! 1. They are using vodozemac types so we directly deserialize into a
-//!    vodozemac curve25519 or ed25519 key.
+//!    vodozemac Curve25519 or Ed25519 key.
 //! 2. They support lossless serialization cycles in a canonical JSON supported
 //!    way, meaning the white-space and field order won't be preserved but the
 //!    data will.
@@ -26,6 +26,7 @@
 mod backup;
 mod cross_signing_key;
 mod device_keys;
+pub mod events;
 mod one_time_keys;
 
 use std::collections::BTreeMap;

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -710,20 +710,21 @@ pub(crate) mod tests {
     use std::convert::TryInto;
 
     use ruma::{
-        events::{AnyToDeviceEvent, AnyToDeviceEventContent, ToDeviceEvent},
+        events::{AnyToDeviceEventContent, ToDeviceEvent},
         UserId,
     };
 
     use super::event_enums::OutgoingContent;
     use crate::{
         requests::{OutgoingRequest, OutgoingRequests},
+        types::events::ToDeviceEvents,
         OutgoingVerificationRequest,
     };
 
     pub(crate) fn request_to_event(
         sender: &UserId,
         request: &OutgoingVerificationRequest,
-    ) -> AnyToDeviceEvent {
+    ) -> ToDeviceEvents {
         let content =
             request.to_owned().try_into().expect("Can't fetch content out of the request");
         wrap_any_to_device_content(sender, content)
@@ -732,7 +733,7 @@ pub(crate) mod tests {
     pub(crate) fn outgoing_request_to_event(
         sender: &UserId,
         request: &OutgoingRequest,
-    ) -> AnyToDeviceEvent {
+    ) -> ToDeviceEvents {
         match request.request() {
             OutgoingRequests::ToDeviceRequest(r) => request_to_event(sender, &r.clone().into()),
             _ => panic!("Unsupported outgoing request"),
@@ -742,31 +743,31 @@ pub(crate) mod tests {
     pub(crate) fn wrap_any_to_device_content(
         sender: &UserId,
         content: OutgoingContent,
-    ) -> AnyToDeviceEvent {
+    ) -> ToDeviceEvents {
         let content = if let OutgoingContent::ToDevice(c) = content { c } else { unreachable!() };
         let sender = sender.to_owned();
 
         match content {
             AnyToDeviceEventContent::KeyVerificationRequest(c) => {
-                AnyToDeviceEvent::KeyVerificationRequest(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationRequest(ToDeviceEvent { sender, content: c })
             }
             AnyToDeviceEventContent::KeyVerificationReady(c) => {
-                AnyToDeviceEvent::KeyVerificationReady(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationReady(ToDeviceEvent { sender, content: c })
             }
             AnyToDeviceEventContent::KeyVerificationKey(c) => {
-                AnyToDeviceEvent::KeyVerificationKey(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationKey(ToDeviceEvent { sender, content: c })
             }
             AnyToDeviceEventContent::KeyVerificationStart(c) => {
-                AnyToDeviceEvent::KeyVerificationStart(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationStart(ToDeviceEvent { sender, content: c })
             }
             AnyToDeviceEventContent::KeyVerificationAccept(c) => {
-                AnyToDeviceEvent::KeyVerificationAccept(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationAccept(ToDeviceEvent { sender, content: c })
             }
             AnyToDeviceEventContent::KeyVerificationMac(c) => {
-                AnyToDeviceEvent::KeyVerificationMac(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationMac(ToDeviceEvent { sender, content: c })
             }
             AnyToDeviceEventContent::KeyVerificationDone(c) => {
-                AnyToDeviceEvent::KeyVerificationDone(ToDeviceEvent { sender, content: c })
+                ToDeviceEvents::KeyVerificationDone(ToDeviceEvent { sender, content: c })
             }
 
             _ => unreachable!(),


### PR DESCRIPTION
This patch adds customized event types, currently only for the m.room_key and m.secret.send to-device events.

This allows us to:
    a) Deserialize the session_key field into a vodozemac type
    b) Control when we zeroize secrets better