### PR TITLE
chore: Replace usage of Store with Arc<dyn StateStore>

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -573,7 +573,7 @@ impl BaseClient {
         };
 
         let mut changes = StateChanges::new(next_batch.clone());
-        let mut ambiguity_cache = AmbiguityCache::new(self.store.clone());
+        let mut ambiguity_cache = AmbiguityCache::new(self.store.inner.clone());
 
         self.handle_account_data(&account_data.events, &mut changes).await;
 
@@ -830,7 +830,7 @@ impl BaseClient {
             })
             .collect();
 
-        let mut ambiguity_cache = AmbiguityCache::new(self.store.clone());
+        let mut ambiguity_cache = AmbiguityCache::new(self.store.inner.clone());
 
         if let Some(room) = self.store.get_room(room_id) {
             let mut room_info = room.clone_info();

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 use matrix_sdk_common::deserialized_responses::{AmbiguityChange, MemberEvent};
 use ruma::{
@@ -22,11 +25,11 @@ use ruma::{
 use tracing::trace;
 
 use super::{Result, StateChanges};
-use crate::Store;
+use crate::StateStore;
 
 #[derive(Debug)]
 pub(crate) struct AmbiguityCache {
-    pub store: Store,
+    pub store: Arc<dyn StateStore>,
     pub cache: BTreeMap<OwnedRoomId, BTreeMap<String, BTreeSet<OwnedUserId>>>,
     pub changes: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, AmbiguityChange>>,
 }
@@ -67,7 +70,7 @@ impl AmbiguityMap {
 }
 
 impl AmbiguityCache {
-    pub fn new(store: Store) -> Self {
+    pub fn new(store: Arc<dyn StateStore>) -> Self {
         Self { store, cache: BTreeMap::new(), changes: BTreeMap::new() }
     }
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -381,7 +381,7 @@ pub trait StateStore: AsyncTraitDeps {
 /// `StateStore` implementation.
 #[derive(Debug, Clone)]
 pub struct Store {
-    inner: Arc<dyn StateStore>,
+    pub(super) inner: Arc<dyn StateStore>,
     session: Arc<OnceCell<Session>>,
     /// The current sync token that should be used for the next sync call.
     pub(super) sync_token: Arc<RwLock<Option<String>>>,


### PR DESCRIPTION
I'm skeptical about the separate `Store` type, but it's not that easy to just remove it, so this is the smallest change I could find to move in that direction. `AmbiguityCache` was using a `Store`, but only ever calling `StateStore` methods on it so I replaced its usage of `Store` with using the underlying `Arc<dyn StateStore>` directly.