### PR TITLE
Add basic support for login detection to the FFI.

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,7 +24,6 @@ futures-util = { version = "0.3.17", default-features = false }
 matrix-sdk = { path = "../../crates/matrix-sdk", features = ["experimental-timeline", "markdown"] }
 once_cell = "1.10.0"
 parking_lot = "0.12.0"
-ruma = "0.6.1"
 sanitize-filename-reader-friendly = "2.2.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,6 +24,7 @@ futures-util = { version = "0.3.17", default-features = false }
 matrix-sdk = { path = "../../crates/matrix-sdk", features = ["experimental-timeline", "markdown"] }
 once_cell = "1.10.0"
 parking_lot = "0.12.0"
+ruma = "0.6.1"
 sanitize-filename-reader-friendly = "2.2.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
@@ -34,3 +35,4 @@ tracing = "0.1.32"
 # keep in sync with uniffi dependency in matrix-sdk-crypto-ffi, and uniffi_bindgen in ffi CI job
 uniffi = "0.18.0"
 uniffi_macros = "0.18.0"
+url = "2.2.2"

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -35,6 +35,8 @@ interface Client {
     boolean supports_password_login();
     
     string homeserver();
+    
+    string? authentication_server();
 
     void start_sync();
 

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -1,6 +1,9 @@
 namespace sdk {
     [Throws=ClientError]
-    Client login_new_client(string base_path, string username, string password);
+    Client new_client(string homeserver);
+
+    [Throws=ClientError]
+    Client discover_client(string domain);
 
     [Throws=ClientError]
     Client guest_client(string base_path, string homeserver);
@@ -8,6 +11,9 @@ namespace sdk {
     [Throws=ClientError]
     Client login_with_token(string base_path, string restore_token);
 
+    [Throws=ClientError]
+    Client login_new_client(string base_path, string username, string password);
+    
     MediaSource media_source_from_url(string url);
     MessageEventContent message_event_content_from_markdown(string md);
     string gen_transaction_id();
@@ -24,6 +30,11 @@ callback interface ClientDelegate {
 
 interface Client {
     void set_delegate(ClientDelegate? delegate);
+    
+    [Throws=ClientError]
+    boolean supports_password_login();
+    
+    string homeserver();
 
     void start_sync();
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -6,6 +6,7 @@ use matrix_sdk::{
     ruma::{
         api::client::{
             filter::{FilterDefinition, LazyLoadOptions, RoomEventFilter, RoomFilter},
+            session::get_login_types,
             sync::sync_events::v3::Filter,
         },
         events::room::MediaSource,
@@ -14,7 +15,6 @@ use matrix_sdk::{
     Client as MatrixClient, LoopCtrl,
 };
 use parking_lot::RwLock;
-use ruma::api::client::session::get_login_types;
 
 use super::{room::Room, ClientState, RestoreToken, RUNTIME};
 
@@ -63,6 +63,12 @@ impl Client {
     /// The homeserver address of this client.
     pub fn homeserver(&self) -> String {
         RUNTIME.block_on(async move { self.client.homeserver().await.to_string() })
+    }
+
+    pub fn authentication_server(&self) -> Option<String> {
+        RUNTIME.block_on(async move {
+            self.client.authentication_server().await.map(|server| server.to_string())
+        })
     }
 
     pub fn start_sync(&self) {

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -11,9 +11,10 @@ mod uniffi_api;
 use std::{fs, path, sync::Arc};
 
 use client::Client;
-use matrix_sdk::{store::make_store_config, Client as MatrixClient, ClientBuilder, Session};
+use matrix_sdk::{
+    ruma::ServerName, store::make_store_config, Client as MatrixClient, ClientBuilder, Session,
+};
 use once_cell::sync::Lazy;
-use ruma::ServerName;
 use sanitize_filename_reader_friendly::sanitize;
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Runtime;

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -295,6 +295,7 @@ impl ClientBuilder {
         let base_client = BaseClient::with_store_config(self.store_config);
         let http_client = HttpClient::new(inner_http_client.clone(), self.request_config);
 
+        let mut authentication_server: Option<Url> = None;
         let homeserver = match homeserver_cfg {
             HomeserverConfig::Url(url) => url,
             HomeserverConfig::ServerName(server_name) => {
@@ -313,14 +314,20 @@ impl ClientBuilder {
                         err => ClientBuildError::Http(err),
                     })?;
 
+                if let Some(base_url) = well_known.identity_server.map(|server| server.base_url) {
+                    authentication_server = Url::parse(&base_url).ok();
+                };
+
                 well_known.homeserver.base_url
             }
         };
 
         let homeserver = RwLock::new(Url::parse(&homeserver)?);
+        let authentication_server = authentication_server.map(|server| RwLock::new(server));
 
         let inner = Arc::new(ClientInner {
             homeserver,
+            authentication_server,
             http_client,
             base_client,
             server_versions: OnceCell::new_with(self.server_versions),

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -192,6 +192,20 @@ impl Client {
             .map_err(ClientBuildError::assert_valid_builder_args)
     }
 
+    /// Create a new [`Client`] that will discover a homeserver from the given
+    /// server name.
+    ///
+    /// # Arguments
+    ///
+    /// * `server_name` - The server name the client should use for discovery.
+    pub async fn discover(server_name: &ServerName) -> Result<Self, HttpError> {
+        Self::builder()
+            .server_name(server_name)
+            .build()
+            .await
+            .map_err(ClientBuildError::assert_valid_builder_args)
+    }
+
     /// Create a new [`ClientBuilder`].
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new()

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -135,6 +135,8 @@ pub struct Client {
 pub(crate) struct ClientInner {
     /// The URL of the homeserver to connect to.
     homeserver: RwLock<Url>,
+    /// The URL of the authentication server to connect to.
+    authentication_server: Option<RwLock<Url>>,
     /// The underlying HTTP client.
     http_client: HttpClient,
     /// User session data.
@@ -284,6 +286,14 @@ impl Client {
     /// The Homeserver of the client.
     pub async fn homeserver(&self) -> Url {
         self.inner.homeserver.read().await.clone()
+    }
+
+    /// The authentication server of the client.
+    pub async fn authentication_server(&self) -> Option<Url> {
+        if let Some(server) = &self.inner.authentication_server {
+            return Some(server.read().await.clone());
+        }
+        return None;
     }
 
     /// Get the user id of the current owner of the client.


### PR DESCRIPTION
Draft for now as it will need the next version of Ruma with https://github.com/ruma/ruma/pull/1193 included. The PR does the following:
- Add a `discover_client` SDK function that creates a new client for a domain string.
- Add a `new_client` SDK function that creates a new client for a homeserver URL (as a string through the FFI).
- Add `authentication_server()` and `supports_password_login()` client methods to discover login options available to the client.

For now the authentication server method is using the identity server until Ruma is updated.