### PR TITLE
feat(base): Allow shared Stores in StoreConfig

### DIFF
--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -676,14 +676,35 @@ impl StoreConfig {
     ///
     /// The crypto store must be opened before being set.
     #[cfg(feature = "e2e-encryption")]
-    pub fn crypto_store(mut self, store: impl CryptoStore + 'static) -> Self {
-        self.crypto_store = Some(Arc::new(store));
+    pub fn crypto_store(self, store: impl CryptoStore + 'static) -> Self {
+        self.crypto_store_shared(Arc::new(store))
+    }
+
+    /// Set a custom implementation of a shared `CryptoStore`.
+    ///
+    /// This allows a single connection to the cryptostore to be shared between
+    /// multiple Clients for the same user. It also allows you to manually use
+    /// an `OlmMachine` for lower-level control over the way messages are
+    /// encrypted.
+    ///
+    /// The crypto store must be opened before being set.
+    #[cfg(feature = "e2e-encryption")]
+    pub fn crypto_store_shared(mut self, store: Arc<dyn CryptoStore>) -> Self {
+        self.crypto_store = Some(store);
         self
     }
 
     /// Set a custom implementation of a `StateStore`.
-    pub fn state_store(mut self, store: impl StateStore + 'static) -> Self {
-        self.state_store = Some(Arc::new(store));
+    pub fn state_store(self, store: impl StateStore + 'static) -> Self {
+        self.state_store_shared(Arc::new(store))
+    }
+
+    /// Set a custom implementation of a shared `StateStore`.
+    ///
+    /// This allows a single connection to the statestore to be shared between
+    /// multiple Clients for the same user.
+    pub fn state_store_shared(mut self, store: Arc<dyn StateStore>) -> Self {
+        self.state_store = Some(store);
         self
     }
 }


### PR DESCRIPTION
With 4971802e7506dd56f78be6d24e373282133b31cd, the client uses shared references to both the `StateStore` and the `CryptoStore`.
The `StoreConfig` builder however currently only accepts taking ownership of the store types.

This PR adds `crypto_store_shared` and `state_store_shared` methods that set the `Arc<dyn *Store>` directly.

This feature can be used by `matrix-sdk-sql` to have 1 instance of the store type, as the cryptostore and the statestore share some code and currently it needs to open two seperate store instances.
It can also be used for using `OlmMachine` manually, which allows for finer-grained control over end-to-end encryption, especially in an appservice environment.
