### PR TITLE
test: Run tests faster with `nextest`

### DIFF
--- a/.github/workflows/appservice.yml
+++ b/.github/workflows/appservice.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Load cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Run checks
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,10 @@ jobs:
     - name: Load cache
       uses: Swatinem/rust-cache@v1
 
-    - name: Clippy
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+
+    - name: Test
       uses: actions-rs/cargo@v1
       with:
         command: run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Load cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Test
         uses: actions-rs/cargo@v1
         with:
@@ -115,10 +118,14 @@ jobs:
       - name: Load cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Test
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: nextest
+          args: run
 
   test-nodejs:
     name: linux / node.js (${{ matrix.node-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,12 @@ jobs:
           command: nextest
           args: run
 
+      - name: Test documentation
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --doc
+
   test-nodejs:
     name: linux / node.js (${{ matrix.node-version }})
     if: github.event_name == 'push' || !github.event.pull_request.draft

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -62,6 +62,9 @@ jobs:
     - name: Load cache
       uses: Swatinem/rust-cache@v1
 
+    - name: Install nextest
+      uses: taiki-e/install-action@nextest
+
     - name: Rust Check
       uses: actions-rs/cargo@v1
       with:

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -184,7 +184,6 @@ fn run_crypto_tests() -> Result<()> {
     cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --features=backups_v1").run()?;
     cmd!("rustup run stable cargo test --doc -p matrix-sdk-crypto --features=backups_v1").run()?;
     cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto-ffi").run()?;
-    cmd!("rustup run stable cargo test --doc -p matrix-sdk-crypto-ffi").run()?;
 
     Ok(())
 }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -156,6 +156,9 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
     let run = |arg_set: &str| {
         cmd!("rustup run stable cargo nextest run -p matrix-sdk")
             .args(arg_set.split_whitespace())
+            .run()?;
+        cmd!("rustup run stable cargo test --doc -p matrix-sdk")
+            .args(arg_set.split_whitespace())
             .run()
     };
 
@@ -179,7 +182,9 @@ fn run_crypto_tests() -> Result<()> {
     )
     .run()?;
     cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --features=backups_v1").run()?;
+    cmd!("rustup run stable cargo test --doc -p matrix-sdk-crypto --features=backups_v1").run()?;
     cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto-ffi").run()?;
+    cmd!("rustup run stable cargo test --doc -p matrix-sdk-crypto-ffi").run()?;
 
     Ok(())
 }
@@ -187,6 +192,7 @@ fn run_crypto_tests() -> Result<()> {
 fn run_appservice_tests() -> Result<()> {
     cmd!("rustup run stable cargo clippy -p matrix-sdk-appservice -- -D warnings").run()?;
     cmd!("rustup run stable cargo nextest run -p matrix-sdk-appservice").run()?;
+    cmd!("rustup run stable cargo test --doc -p matrix-sdk-appservice").run()?;
 
     Ok(())
 }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -164,7 +164,9 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
     ]);
 
     let run = |arg_set: &str| {
-        cmd!("rustup run stable cargo test -p matrix-sdk").args(arg_set.split_whitespace()).run()
+        cmd!("rustup run stable cargo nextest run -p matrix-sdk")
+            .args(arg_set.split_whitespace())
+            .run()
     };
 
     match cmd {
@@ -186,15 +188,15 @@ fn run_crypto_tests() -> Result<()> {
         "rustup run stable cargo clippy -p matrix-sdk-crypto --features=backups_v1 -- -D warnings"
     )
     .run()?;
-    cmd!("rustup run stable cargo test -p matrix-sdk-crypto --features=backups_v1").run()?;
-    cmd!("rustup run stable cargo test -p matrix-sdk-crypto-ffi").run()?;
+    cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --features=backups_v1").run()?;
+    cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto-ffi").run()?;
 
     Ok(())
 }
 
 fn run_appservice_tests() -> Result<()> {
     cmd!("rustup run stable cargo clippy -p matrix-sdk-appservice -- -D warnings").run()?;
-    cmd!("rustup run stable cargo test -p matrix-sdk-appservice").run()?;
+    cmd!("rustup run stable cargo nextest run -p matrix-sdk-appservice").run()?;
 
     Ok(())
 }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -22,8 +22,6 @@ enum CiCommand {
     Clippy,
     /// Check documentation
     Docs,
-    /// Run default tests
-    Test,
     /// Run tests with a specific feature set
     TestFeatures {
         #[clap(subcommand)]
@@ -84,7 +82,6 @@ impl CiArgs {
                 CiCommand::Typos => check_typos(),
                 CiCommand::Clippy => check_clippy(),
                 CiCommand::Docs => check_docs(),
-                CiCommand::Test => run_tests(),
                 CiCommand::TestFeatures { cmd } => run_feature_tests(cmd),
                 CiCommand::TestAppservice => run_appservice_tests(),
                 CiCommand::Wasm { cmd } => run_wasm_checks(cmd),
@@ -96,7 +93,6 @@ impl CiArgs {
                 check_clippy()?;
                 check_typos()?;
                 check_docs()?;
-                run_tests()?;
                 run_feature_tests(None)?;
                 run_appservice_tests()?;
                 run_wasm_checks(None)?;
@@ -139,12 +135,6 @@ fn check_clippy() -> Result<()> {
 
 fn check_docs() -> Result<()> {
     build_docs([], DenyWarnings::Yes)
-}
-
-fn run_tests() -> Result<()> {
-    cmd!("rustup run stable cargo test").run()?;
-    cmd!("rustup run beta cargo test").run()?;
-    Ok(())
 }
 
 fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {


### PR DESCRIPTION
> [`cargo-nextest`](https://nexte.st/index.html) is a next-generation
> test runner for Rust projects.

This patch installs and uses `nextest` to run our own tests.

Comparing `cargo test` and `cargo nextest` with hyperfine provides the
following results:

```
$ hyperfine 'cargo test --workspace' 'cargo nextest run --workspace && cargo test --doc'
Benchmark 1: cargo test --workspace
  Time (mean ± σ):     51.785 s ±  2.066 s    [User: 183.471 s, System: 10.563 s]
  Range (min … max):   49.151 s … 56.641 s    10 runs

Benchmark 2: cargo nextest run --workspace && cargo test --doc
  Time (mean ± σ):     44.556 s ±  0.894 s    [User: 192.213 s, System: 11.441 s]
  Range (min … max):   43.170 s … 45.762 s    10 runs
```

Benchmark 2 is 1.16 times faster than Benchmark 1