### PR TITLE
feat(crypto-js): Implement key verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,6 +2303,7 @@ dependencies = [
  "matrix-sdk-common",
  "matrix-sdk-crypto",
  "matrix-sdk-indexeddb",
+ "matrix-sdk-qrcode",
  "ruma",
  "serde_json",
  "tracing",

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -22,7 +22,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["tracing", "qrcode"]
-qrcode = ["matrix-sdk-crypto/qrcode", "matrix-sdk-qrcode"]
+qrcode = ["matrix-sdk-crypto/qrcode", "dep:matrix-sdk-qrcode"]
 tracing = []
 
 [dependencies]

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -31,6 +31,7 @@ matrix-sdk-crypto = { version = "0.5.0", path = "../../crates/matrix-sdk-crypto"
 matrix-sdk-indexeddb = { version = "0.1.0", path = "../../crates/matrix-sdk-indexeddb" }
 matrix-sdk-qrcode = { version = "0.3.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
 ruma = { version = "0.7.0", features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"] }
+vodozemac = { version = "0.3.0", features = ["js"] }
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"
 js-sys = "0.3.49"
@@ -41,7 +42,3 @@ anyhow = "1.0.58"
 tracing = { version = "0.1.35", default-features = false, features = ["attributes"] }
 tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std"] }
 zeroize = "1.3.0"
-
-[dependencies.vodozemac]
-version = "0.3.0"
-features = ["js"]

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -21,7 +21,7 @@ wasm-opt = ['-Oz']
 crate-type = ["cdylib"]
 
 [features]
-default = ["tracing"]
+default = ["tracing", "qrcode"]
 qrcode = ["matrix-sdk-crypto/qrcode", "matrix-sdk-qrcode"]
 tracing = []
 

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -22,13 +22,14 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["tracing"]
-qrcode = ["matrix-sdk-crypto/qrcode"]
+qrcode = ["matrix-sdk-crypto/qrcode", "matrix-sdk-qrcode"]
 tracing = []
 
 [dependencies]
 matrix-sdk-common = { version = "0.5.0", path = "../../crates/matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.5.0", path = "../../crates/matrix-sdk-crypto" }
 matrix-sdk-indexeddb = { version = "0.1.0", path = "../../crates/matrix-sdk-indexeddb" }
+matrix-sdk-qrcode = { version = "0.3.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
 ruma = { version = "0.7.0", features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"] }
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"

--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -26,7 +26,6 @@
         "pkg/matrix_sdk_crypto.d.ts"
     ],
     "devDependencies": {
-        "canvas": "^2.10.1",
         "cross-env": "^7.0.3",
         "fake-indexeddb": "^4.0",
         "jest": "^28.1.0",

--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -26,12 +26,13 @@
         "pkg/matrix_sdk_crypto.d.ts"
     ],
     "devDependencies": {
-        "wasm-pack": "^0.10.2",
+        "canvas": "^2.10.1",
+        "cross-env": "^7.0.3",
+        "fake-indexeddb": "^4.0",
         "jest": "^28.1.0",
         "typedoc": "^0.22.17",
-        "cross-env": "^7.0.3",
-        "yargs-parser": "~21.0.1",
-        "fake-indexeddb": "^4.0"
+        "wasm-pack": "^0.10.2",
+        "yargs-parser": "~21.0.1"
     },
     "engines": {
         "node": ">= 10"

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -63,7 +63,7 @@ impl Device {
     /// method returns `true`.
     #[wasm_bindgen(js_name = "isVerified")]
     pub fn is_verified(&self) -> bool {
-        self.inner.verified()
+        self.inner.is_verified()
     }
 
     /// Is this device considered to be verified using cross signing.

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -9,6 +9,7 @@ use crate::{
     types, verification, vodozemac,
 };
 
+/// A device represents a E2EE capable client of an user.
 #[wasm_bindgen]
 #[derive(Debug)]
 pub struct Device {

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -191,7 +191,7 @@ pub enum LocalTrust {
     /// The trust state of the device is being ignored.
     Ignored,
 
-    /// The trust stte is unset.
+    /// The trust state is unset.
     Unset,
 }
 

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -1,0 +1,229 @@
+//! Types for a `Device`.
+
+use js_sys::{Array, Map, Promise};
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    future::future_to_promise,
+    identifiers::{self, DeviceId, UserId},
+    types, vodozemac,
+};
+
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct Device {
+    pub(crate) inner: matrix_sdk_crypto::Device,
+}
+
+impl From<matrix_sdk_crypto::Device> for Device {
+    fn from(inner: matrix_sdk_crypto::Device) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl Device {
+    /// Is this device considered to be verified.
+    ///
+    /// This method returns true if either the `is_locally_trusted`
+    /// method returns `true` or if the `is_cross_signing_trusted`
+    /// method returns `true`.
+    #[wasm_bindgen(js_name = "isVerified")]
+    pub fn is_verified(&self) -> bool {
+        self.inner.verified()
+    }
+
+    /// Is this device considered to be verified using cross signing.
+    #[wasm_bindgen(js_name = "isCrossSigningTrusted")]
+    pub fn is_cross_signing_trusted(&self) -> bool {
+        self.inner.is_cross_signing_trusted()
+    }
+
+    /// Set the local trust state of the device to the given state.
+    ///
+    /// This won’t affect any cross signing trust state, this only
+    /// sets a flag marking to have the given trust state.
+    ///
+    /// `trust_state` represents the new trust state that should be
+    /// set for the device.
+    #[wasm_bindgen(js_name = "setLocalTrust")]
+    pub fn set_local_trust(&self, local_state: LocalTrust) -> Promise {
+        let me = self.inner.clone();
+
+        future_to_promise(async move {
+            me.set_local_trust(local_state.into()).await?;
+
+            Ok(JsValue::NULL)
+        })
+    }
+
+    /// The user ID of the device owner.
+    #[wasm_bindgen(getter, js_name = "userId")]
+    pub fn user_id(&self) -> UserId {
+        self.inner.user_id().to_owned().into()
+    }
+
+    /// The unique ID of the device.
+    #[wasm_bindgen(getter, js_name = "deviceId")]
+    pub fn device_id(&self) -> DeviceId {
+        self.inner.device_id().to_owned().into()
+    }
+
+    /// Get the human readable name of the device.
+    #[wasm_bindgen(getter, js_name = "displayName")]
+    pub fn display_name(&self) -> Option<String> {
+        self.inner.display_name().map(ToOwned::to_owned)
+    }
+
+    /// Get the key of the given key algorithm belonging to this device.
+    #[wasm_bindgen(js_name = "getKey")]
+    pub fn get_key(
+        &self,
+        algorithm: identifiers::DeviceKeyAlgorithmName,
+    ) -> Result<Option<vodozemac::DeviceKey>, JsError> {
+        Ok(self.inner.get_key(algorithm.try_into()?).cloned().map(Into::into))
+    }
+
+    /// Get the Curve25519 key of the given device.
+    #[wasm_bindgen(getter, js_name = "curve25519Key")]
+    pub fn curve25519_key(&self) -> Option<vodozemac::Curve25519PublicKey> {
+        self.inner.curve25519_key().map(Into::into)
+    }
+
+    /// Get the Ed25519 key of the given device.
+    #[wasm_bindgen(getter, js_name = "ed25519Key")]
+    pub fn ed25519_key(&self) -> Option<vodozemac::Ed25519PublicKey> {
+        self.inner.ed25519_key().map(Into::into)
+    }
+
+    /// Get a map containing all the device keys.
+    #[wasm_bindgen(getter)]
+    pub fn keys(&self) -> Map {
+        let map = Map::new();
+
+        for (device_key_id, device_key) in self.inner.keys() {
+            map.set(
+                &identifiers::DeviceKeyId::from(device_key_id.clone()).into(),
+                &vodozemac::DeviceKey::from(device_key.clone()).into(),
+            );
+        }
+
+        map
+    }
+
+    /// Get a map containing all the device signatures.
+    #[wasm_bindgen(getter)]
+    pub fn signatures(&self) -> types::Signatures {
+        self.inner.signatures().clone().into()
+    }
+
+    /// Get the trust state of the device.
+    #[wasm_bindgen(getter, js_name = "localTrustState")]
+    pub fn local_trust_state(&self) -> LocalTrust {
+        self.inner.local_trust_state().into()
+    }
+
+    /// Is the device locally marked as trusted?
+    #[wasm_bindgen(js_name = "isLocallyTrusted")]
+    pub fn is_locally_trusted(&self) -> bool {
+        self.inner.is_locally_trusted()
+    }
+
+    /// Is the device locally marked as blacklisted?
+    ///
+    /// Blacklisted devices won’t receive any group sessions.
+    #[wasm_bindgen(js_name = "isBlacklisted")]
+    pub fn is_blacklisted(&self) -> bool {
+        self.inner.is_blacklisted()
+    }
+
+    /// Is the device deleted?
+    #[wasm_bindgen(js_name = "isDeleted")]
+    pub fn is_deleted(&self) -> bool {
+        self.inner.deleted()
+    }
+}
+
+/// The local trust state of a device.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub enum LocalTrust {
+    /// The device has been verified and is trusted.
+    Verified,
+
+    /// The device been blacklisted from communicating.
+    BlackListed,
+
+    /// The trust state of the device is being ignored.
+    Ignored,
+
+    /// The trust stte is unset.
+    Unset,
+}
+
+impl From<matrix_sdk_crypto::LocalTrust> for LocalTrust {
+    fn from(value: matrix_sdk_crypto::LocalTrust) -> Self {
+        use matrix_sdk_crypto::LocalTrust::*;
+
+        match value {
+            Verified => Self::Verified,
+            BlackListed => Self::BlackListed,
+            Ignored => Self::Ignored,
+            Unset => Self::Unset,
+        }
+    }
+}
+
+impl From<LocalTrust> for matrix_sdk_crypto::LocalTrust {
+    fn from(value: LocalTrust) -> Self {
+        use LocalTrust::*;
+
+        match value {
+            Verified => Self::Verified,
+            BlackListed => Self::BlackListed,
+            Ignored => Self::Ignored,
+            Unset => Self::Unset,
+        }
+    }
+}
+
+/// A read only view over all devices belonging to a user.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct UserDevices {
+    pub(crate) inner: matrix_sdk_crypto::UserDevices,
+}
+
+impl From<matrix_sdk_crypto::UserDevices> for UserDevices {
+    fn from(inner: matrix_sdk_crypto::UserDevices) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl UserDevices {
+    /// Get the specific device with the given device ID.
+    pub fn get(&self, device_id: &DeviceId) -> Option<Device> {
+        self.inner.get(&device_id.inner).map(Into::into)
+    }
+
+    /// Returns true if there is at least one devices of this user
+    /// that is considered to be verified, false otherwise.
+    ///
+    /// This won't consider your own device as verified, as your own
+    /// device is always implicitly verified.
+    #[wasm_bindgen(js_name = "isAnyVerified")]
+    pub fn is_any_verified(&self) -> bool {
+        self.inner.is_any_verified()
+    }
+
+    /// Array over all the device IDs of the user devices.
+    pub fn keys(&self) -> Array {
+        self.inner.keys().map(ToOwned::to_owned).map(DeviceId::from).map(JsValue::from).collect()
+    }
+
+    /// Iterator over all the devices of the user devices.
+    pub fn devices(&self) -> Array {
+        self.inner.devices().map(Device::from).map(JsValue::from).collect()
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -173,7 +173,7 @@ impl Device {
     /// Is the device deleted?
     #[wasm_bindgen(js_name = "isDeleted")]
     pub fn is_deleted(&self) -> bool {
-        self.inner.deleted()
+        self.inner.is_deleted()
     }
 }
 

--- a/bindings/matrix-sdk-crypto-js/src/identifiers.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identifiers.rs
@@ -135,7 +135,7 @@ impl DeviceKeyId {
 #[wasm_bindgen]
 #[derive(Debug)]
 pub struct DeviceKeyAlgorithm {
-    inner: ruma::DeviceKeyAlgorithm,
+    pub(crate) inner: ruma::DeviceKeyAlgorithm,
 }
 
 impl From<ruma::DeviceKeyAlgorithm> for DeviceKeyAlgorithm {
@@ -178,6 +178,25 @@ pub enum DeviceKeyAlgorithmName {
 
     /// An unknown device key algorithm.
     Unknown,
+}
+
+impl TryFrom<DeviceKeyAlgorithmName> for ruma::DeviceKeyAlgorithm {
+    type Error = JsError;
+
+    fn try_from(value: DeviceKeyAlgorithmName) -> Result<Self, Self::Error> {
+        use DeviceKeyAlgorithmName::*;
+
+        Ok(match value {
+            Ed25519 => Self::Ed25519,
+            Curve25519 => Self::Curve25519,
+            SignedCurve25519 => Self::SignedCurve25519,
+            Unknown => {
+                return Err(JsError::new(
+                    "The `DeviceKeyAlgorithmName.Unknown` variant cannot be converted",
+                ))
+            }
+        })
+    }
 }
 
 impl From<ruma::DeviceKeyAlgorithm> for DeviceKeyAlgorithmName {

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -30,6 +30,7 @@ pub mod sync_events;
 mod tracing;
 pub mod types;
 pub mod vodozemac;
+pub mod verification;
 
 use js_sys::{Object, Reflect};
 use wasm_bindgen::{convert::RefFromWasmAbi, prelude::*};

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -27,6 +27,7 @@ pub mod machine;
 pub mod olm;
 pub mod requests;
 pub mod responses;
+pub mod store;
 pub mod sync_events;
 mod tracing;
 pub mod types;

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -18,6 +18,7 @@
 #![allow(clippy::drop_non_drop)] // triggered by wasm_bindgen code
 
 pub mod attachment;
+pub mod device;
 pub mod encryption;
 pub mod events;
 mod future;
@@ -29,8 +30,8 @@ pub mod responses;
 pub mod sync_events;
 mod tracing;
 pub mod types;
-pub mod vodozemac;
 pub mod verification;
+pub mod vodozemac;
 
 use js_sys::{Object, Reflect};
 use wasm_bindgen::{convert::RefFromWasmAbi, prelude::*};

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -8,7 +8,7 @@ use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    downcast, encryption,
+    device, downcast, encryption,
     future::future_to_promise,
     identifiers, olm, requests,
     requests::OutgoingRequest,
@@ -453,6 +453,44 @@ impl OlmMachine {
             }
         }))
     }
+
+    /// Get a map holding all the devices of a user.
+    ///
+    /// `user_id` represents the unique ID of the user that the
+    /// devices belong to.
+    #[wasm_bindgen(js_name = "getUserDevices")]
+    pub fn get_user_devices(&self, user_id: &identifiers::UserId) -> Promise {
+        let user_id = user_id.inner.clone();
+
+        let me = self.inner.clone();
+
+        future_to_promise::<_, device::UserDevices>(async move {
+            Ok(me.get_user_devices(&user_id, None).await.map(Into::into)?)
+        })
+    }
+
+    /// Get a specific device of a user if one is found and the crypto store
+    /// didn't throw an error.
+    ///
+    /// `user_id` represents the unique ID of the user that the
+    /// identity belongs to. `device_id` represents the unique ID of
+    /// the device.
+    #[wasm_bindgen(js_name = "getDevice")]
+    pub fn get_device(
+        &self,
+        user_id: &identifiers::UserId,
+        device_id: &identifiers::DeviceId,
+    ) -> Promise {
+        let user_id = user_id.inner.clone();
+        let device_id = device_id.inner.clone();
+
+        let me = self.inner.clone();
+
+        future_to_promise::<_, Option<device::Device>>(async move {
+            Ok(me.get_device(&user_id, &device_id, None).await?.map(Into::into))
+        })
+    }
+
     /// Get a verification object for the given user ID with the given
     /// flow ID (a to-device request ID if the verification has been
     /// requested by a to-device request, or a room event ID if the

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -496,7 +496,8 @@ impl OlmMachine {
     /// requested by a to-device request, or a room event ID if the
     /// verification has been requested by a room event).
     ///
-    /// It returns a `Verification` object.
+    /// It returns a “`Verification` object”, which is either a `Sas`
+    /// or `Qr` object.
     #[wasm_bindgen(js_name = "getVerification")]
     pub fn get_verification(
         &self,

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -383,6 +383,36 @@ impl OlmMachine {
         })
     }
 
+    /// Create a new cross signing identity and get the upload request
+    /// to push the new public keys to the server.
+    ///
+    /// Warning: This will delete any existing cross signing keys that
+    /// might exist on the server and thus will reset the trust
+    /// between all the devices.
+    ///
+    /// Uploading these keys will require user interactive auth.
+    #[wasm_bindgen(js_name = "bootstrapCrossSigning")]
+    pub fn bootstrap_cross_signing(&self, reset: bool) -> Promise {
+        let me = self.inner.clone();
+
+        future_to_promise(async move {
+            let (upload_signing_keys_request, upload_signatures_request) =
+                me.bootstrap_cross_signing(reset).await?;
+
+            let tuple = Array::new();
+            tuple.set(
+                0,
+                requests::SigningKeysUploadRequest::try_from(&upload_signing_keys_request)?.into(),
+            );
+            tuple.set(
+                1,
+                requests::SignatureUploadRequest::try_from(&upload_signatures_request)?.into(),
+            );
+
+            Ok(tuple)
+        })
+    }
+
     /// Sign the given message using our device key and if available
     /// cross-signing master key.
     pub fn sign(&self, message: String) -> Promise {

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -267,6 +267,7 @@ pub struct KeysBackupRequest {
 ///
 /// This uploads the public cross signing key triplet.
 #[wasm_bindgen(getter_with_clone)]
+#[derive(Debug)]
 pub struct SigningKeysUploadRequest {
     /// The request ID.
     #[wasm_bindgen(readonly)]

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -276,7 +276,7 @@ pub struct SigningKeysUploadRequest {
     /// A JSON-encoded object of form:
     ///
     /// ```json
-    /// {"master_key", …, "self_signing_key": …, "user_signing_key": …}
+    /// {"master_key": …, "self_signing_key": …, "user_signing_key": …}
     /// ```
     #[wasm_bindgen(readonly)]
     pub body: JsString,

--- a/bindings/matrix-sdk-crypto-js/src/store.rs
+++ b/bindings/matrix-sdk-crypto-js/src/store.rs
@@ -1,0 +1,38 @@
+//! Store types.
+
+use wasm_bindgen::prelude::*;
+
+/// A struct containing private cross signing keys that can be backed
+/// up or uploaded to the secret store.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct CrossSigningKeyExport {
+    pub(crate) inner: matrix_sdk_crypto::store::CrossSigningKeyExport,
+}
+
+impl From<matrix_sdk_crypto::store::CrossSigningKeyExport> for CrossSigningKeyExport {
+    fn from(inner: matrix_sdk_crypto::store::CrossSigningKeyExport) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl CrossSigningKeyExport {
+    /// The seed of the master key encoded as unpadded base64.
+    #[wasm_bindgen(getter, js_name = "masterKey")]
+    pub fn master_key(&self) -> Option<String> {
+        self.inner.master_key.clone()
+    }
+
+    /// The seed of the self signing key encoded as unpadded base64.
+    #[wasm_bindgen(getter, js_name = "self_signing_key")]
+    pub fn self_signing_key(&self) -> Option<String> {
+        self.inner.self_signing_key.clone()
+    }
+
+    /// The seed of the user signing key encoded as unpadded base64.
+    #[wasm_bindgen(getter, js_name = "userSigningKey")]
+    pub fn user_signing_key(&self) -> Option<String> {
+        self.inner.user_signing_key.clone()
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/types.rs
+++ b/bindings/matrix-sdk-crypto-js/src/types.rs
@@ -77,7 +77,7 @@ impl Signatures {
 
     /// Do we hold any signatures or is our collection completely
     /// empty.
-    #[wasm_bindgen(getter, js_name = "isEmpty")]
+    #[wasm_bindgen(js_name = "isEmpty")]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
@@ -138,13 +138,13 @@ impl From<MaybeSignatureInner> for MaybeSignature {
 #[wasm_bindgen]
 impl MaybeSignature {
     /// Check whether the signature has been successfully decoded.
-    #[wasm_bindgen(getter, js_name = "isValid")]
+    #[wasm_bindgen(js_name = "isValid")]
     pub fn is_valid(&self) -> bool {
         self.inner.is_ok()
     }
 
     /// Check whether the signature could not be successfully decoded.
-    #[wasm_bindgen(getter, js_name = "isInvalid")]
+    #[wasm_bindgen(js_name = "isInvalid")]
     pub fn is_invalid(&self) -> bool {
         self.inner.is_err()
     }

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -274,18 +274,30 @@ impl Sas {
         })
     }
 
-    /*
-    pub fn cancel(&self) {
-        todo!()
+    /// Cancel the verification.
+    pub fn cancel(&self) -> Result<JsValue, JsError> {
+        self.inner
+            .cancel()
+            .map(OutgoingVerificationRequest::from)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
     }
-    */
 
-    /*
+    /// Cancel the verification.
+    ///
+    /// This cancels the verification with given code.
     #[wasm_bindgen(js_name = "cancelWithCode")]
-    pub fn cancel_with_code(&self) {
-        todo!()
+    pub fn cancel_with_code(&self, code: CancelCode) -> Result<JsValue, JsError> {
+        self.inner
+            .cancel_with_code(code.try_into()?)
+            .map(OutgoingVerificationRequest::from)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
     }
-    */
 
     /// Has the SAS verification flow timed out.
     #[wasm_bindgen(js_name = "timedOut")]
@@ -509,11 +521,30 @@ impl Qr {
             .map_err(Into::into)
     }
 
-    /*
     /// Cancel the verification flow.
-    pub fn cancel(&self) -> … {}
-    pub fn cancel_with_code(&self, code: …) -> … {}
-    */
+    pub fn cancel(&self) -> Result<JsValue, JsError> {
+        self.inner
+            .cancel()
+            .map(OutgoingVerificationRequest::from)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
+    }
+
+    /// Cancel the verification.
+    ///
+    /// This cancels the verification with given code.
+    #[wasm_bindgen(js_name = "cancelWithCode")]
+    pub fn cancel_with_code(&self, code: CancelCode) -> Result<JsValue, JsError> {
+        self.inner
+            .cancel_with_code(code.try_into()?)
+            .map(OutgoingVerificationRequest::from)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
+    }
 }
 
 /// Information about the cancellation of a verification request or
@@ -624,6 +655,29 @@ impl From<&RumaCancelCode> for CancelCode {
             MismatchedSas => Self::MismatchedSas,
             _ => Self::Other,
         }
+    }
+}
+
+impl TryFrom<CancelCode> for RumaCancelCode {
+    type Error = JsError;
+
+    fn try_from(code: CancelCode) -> Result<Self, Self::Error> {
+        use CancelCode::*;
+
+        Ok(match code {
+            User => Self::User,
+            Timeout => Self::Timeout,
+            UnknownTransaction => Self::UnknownTransaction,
+            UnknownMethod => Self::UnknownMethod,
+            UnexpectedMessage => Self::UnexpectedMessage,
+            KeyMismatch => Self::KeyMismatch,
+            UserMismatch => Self::UserMismatch,
+            InvalidMessage => Self::InvalidMessage,
+            Accepted => Self::Accepted,
+            MismatchedCommitment => Self::MismatchedCommitment,
+            MismatchedSas => Self::MismatchedSas,
+            Other => return Err(JsError::new("`Other` variant is invalid at this place")),
+        })
     }
 }
 

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -1,4 +1,4 @@
-///! Different verification types.
+//! Different verification types.
 
 #[cfg(feature = "qrcode")]
 use std::fmt;

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -235,7 +235,7 @@ impl Sas {
     pub fn accept(&self) -> Result<JsValue, JsError> {
         self.inner
             .accept()
-            .map(OutgoingVerificationRequest)
+            .map(OutgoingVerificationRequest::from)
             .map(JsValue::try_from)
             .transpose()
             .map(JsValue::from)
@@ -256,7 +256,7 @@ impl Sas {
             let (outgoing_verification_requests, signature_upload_request) = me.confirm().await?;
             let outgoing_verification_requests = outgoing_verification_requests
                 .into_iter()
-                .map(OutgoingVerificationRequest)
+                .map(OutgoingVerificationRequest::from)
                 .map(JsValue::try_from)
                 .collect::<Result<Array, _>>()?;
 
@@ -482,12 +482,37 @@ impl Qr {
         Ok(self.inner.to_bytes()?.into_iter().map(JsValue::from).collect())
     }
 
+    /// Notify the other side that we have successfully scanned the QR
+    /// code and that the QR verification flow can start.
+    ///
+    /// This will return some OutgoingContent if the object is in the
+    /// correct state to start the verification flow, otherwise None.
+    pub fn reciprocate(&self) -> Result<JsValue, JsError> {
+        self.inner
+            .reciprocate()
+            .map(OutgoingVerificationRequest::from)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
+    }
+
+    /// Confirm that the other side has scanned our QR code.
+    #[wasm_bindgen(js_name = "confirmScanning")]
+    pub fn confirm_scanning(&self) -> Result<JsValue, JsError> {
+        self.inner
+            .confirm_scanning()
+            .map(OutgoingVerificationRequest::from)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
+    }
+
     /*
     /// Cancel the verification flow.
     pub fn cancel(&self) -> … {}
     pub fn cancel_with_code(&self, code: …) -> … {}
-    pub fn reciprocate(&self) -> … {}
-    pub fn confirm_scanning(&self) -> … {}
     */
 }
 
@@ -891,7 +916,7 @@ impl VerificationRequest {
 
         self.inner
             .accept_with_methods(methods)
-            .map(OutgoingVerificationRequest)
+            .map(OutgoingVerificationRequest::from)
             .map(JsValue::try_from)
             .transpose()
             .map(JsValue::from)
@@ -915,7 +940,7 @@ impl VerificationRequest {
     pub fn accept(&self) -> Result<JsValue, JsError> {
         self.inner
             .accept()
-            .map(OutgoingVerificationRequest)
+            .map(OutgoingVerificationRequest::from)
             .map(JsValue::try_from)
             .transpose()
             .map(JsValue::from)
@@ -929,7 +954,7 @@ impl VerificationRequest {
     pub fn cancel(&self) -> Result<JsValue, JsError> {
         self.inner
             .cancel()
-            .map(OutgoingVerificationRequest)
+            .map(OutgoingVerificationRequest::from)
             .map(JsValue::try_from)
             .transpose()
             .map(JsValue::from)

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -663,6 +663,7 @@ impl From<matrix_sdk_qrcode::qrcode::QrCode> for QrCode {
 impl QrCode {
     /// Render the QR code into a `Uint8Array` where 1 represents a
     /// dark pixel and 0 a white pixel.
+    #[wasm_bindgen(js_name = "renderIntoBuffer")]
     pub fn render_into_buffer(&self) -> Result<Uint8Array, JsError> {
         let colors: Vec<u8> =
             self.inner.to_colors().into_iter().map(|color| color.select(1u8, 0u8)).collect();

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -1,5 +1,4 @@
-//! Different verification types.
-
+///! Different verification types.
 use js_sys::{Array, JsString, Promise};
 use ruma::events::key::verification::{
     cancel::CancelCode as RumaCancelCode, VerificationMethod as RumaVerificationMethod,
@@ -230,11 +229,20 @@ impl Sas {
         self.inner.we_started()
     }
 
-    /*
-    pub fn accept(&self) {
-        todo!()
+    /// Accept the SAS verification.
+    ///
+    /// This does nothing if the verification was already accepted,
+    /// otherwise it returns an `AcceptEventContent` that needs to be
+    /// sent out.
+    pub fn accept(&self) -> Result<JsValue, JsError> {
+        self.inner
+            .accept()
+            .map(OutgoingVerificationRequest)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
     }
-    */
 
     /*
     #[wasm_bindgen(js_name = "acceptWithSettings")]
@@ -308,7 +316,7 @@ impl Sas {
     /// inclusive which can be converted to an emoji using [the
     /// relevant specification
     /// entry](https://spec.matrix.org/unstable/client-server-api/#sas-method-emoji).
-    #[wasm_bindgen(js_name = "emoji_index")]
+    #[wasm_bindgen(js_name = "emojiIndex")]
     pub fn emoji_index(&self) -> Option<Array> {
         Some(self.inner.emoji_index()?.into_iter().map(JsValue::from).collect())
     }

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -259,7 +259,7 @@ impl Sas {
             tuple.set(
                 1,
                 signature_upload_request
-                    .map(|request| requests::SignatureUploadRequest::to_json(&request))
+                    .map(|request| requests::SignatureUploadRequest::try_from(&request))
                     .transpose()?
                     .into(),
             );

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -661,6 +661,10 @@ impl From<matrix_sdk_crypto::VerificationRequest> for VerificationRequest {
 
 #[wasm_bindgen]
 impl VerificationRequest {
+    /// Create an event content that can be sent as a room event to
+    /// request verification from the other side. This should be used
+    /// only for verifications of other users and it should be sent to
+    /// a room we consider to be a DM with the other user.
     #[wasm_bindgen]
     pub fn request(
         own_user_id: &UserId,
@@ -686,35 +690,35 @@ impl VerificationRequest {
     }
 
     /// Our own user id.
-    #[wasm_bindgen(js_name = "ownUserId")]
+    #[wasm_bindgen(getter, js_name = "ownUserId")]
     pub fn own_user_id(&self) -> UserId {
         self.inner.own_user_id().to_owned().into()
     }
 
     /// The ID of the other user that is participating in this
     /// verification request.
-    #[wasm_bindgen(js_name = "otherUserId")]
+    #[wasm_bindgen(getter, js_name = "otherUserId")]
     pub fn other_user_id(&self) -> UserId {
         self.inner.other_user().to_owned().into()
     }
 
     /// The ID of the other device that is participating in this
     /// verification.
-    #[wasm_bindgen(js_name = "otherDeviceId")]
+    #[wasm_bindgen(getter, js_name = "otherDeviceId")]
     pub fn other_device_id(&self) -> Option<DeviceId> {
         self.inner.other_device_id().map(Into::into)
     }
 
     /// Get the room ID if the verification is happening inside a
     /// room.
-    #[wasm_bindgen(js_name = "roomId")]
+    #[wasm_bindgen(getter, js_name = "roomId")]
     pub fn room_id(&self) -> Option<RoomId> {
         self.inner.room_id().map(ToOwned::to_owned).map(Into::into)
     }
 
     /// Get info about the cancellation if the verification request
     /// has been cancelled.
-    #[wasm_bindgen(js_name = "cancelInfo")]
+    #[wasm_bindgen(getter, js_name = "cancelInfo")]
     pub fn cancel_info(&self) -> Option<CancelInfo> {
         self.inner.cancel_info().map(Into::into)
     }
@@ -743,7 +747,7 @@ impl VerificationRequest {
     /// verification or if we’re in the ready state.
     ///
     /// It return a `Option<Vec<VerificationMethod>>`.
-    #[wasm_bindgen(js_name = "theirSupportedMethods")]
+    #[wasm_bindgen(getter, js_name = "theirSupportedMethods")]
     pub fn their_supported_methods(&self) -> Result<Option<Array>, JsError> {
         self.inner
             .their_supported_methods()
@@ -760,7 +764,7 @@ impl VerificationRequest {
     ///
     /// Will be present only we requested the verification or if we’re
     /// in the ready state.
-    #[wasm_bindgen(js_name = "ourSupportedMethods")]
+    #[wasm_bindgen(getter, js_name = "ourSupportedMethods")]
     pub fn our_supported_methods(&self) -> Result<Option<Array>, JsError> {
         self.inner
             .our_supported_methods()
@@ -774,7 +778,7 @@ impl VerificationRequest {
     }
 
     /// Get the unique ID of this verification request
-    #[wasm_bindgen(js_name = "flowId")]
+    #[wasm_bindgen(getter, js_name = "flowId")]
     pub fn flow_id(&self) -> String {
         self.inner.flow_id().as_str().to_owned()
     }

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -1,0 +1,899 @@
+//! Different verification types.
+
+use js_sys::{Array, JsString};
+use ruma::events::key::verification::{
+    cancel::CancelCode as RumaCancelCode, VerificationMethod as RumaVerificationMethod,
+};
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    identifiers::{DeviceId, RoomId, UserId},
+    requests,
+};
+
+/// List of available verification methods.
+#[wasm_bindgen]
+#[derive(Debug, Clone)]
+pub enum VerificationMethod {
+    /// The `m.sas.v1` verification method.
+    ///
+    /// SAS means Short Authentication String.
+    SasV1 = 0,
+
+    /// The `m.qr_code.scan.v1` verification method.
+    QrCodeScanV1 = 1,
+
+    /// The `m.qr_code.show.v1` verification method.
+    QrCodeShowV1 = 2,
+
+    /// The `m.reciprocate.v1` verification method.
+    ReciprocateV1 = 3,
+}
+
+impl From<VerificationMethod> for JsValue {
+    fn from(value: VerificationMethod) -> Self {
+        use VerificationMethod::*;
+
+        match value {
+            SasV1 => JsValue::from(0),
+            QrCodeScanV1 => JsValue::from(1),
+            QrCodeShowV1 => JsValue::from(2),
+            ReciprocateV1 => JsValue::from(3),
+        }
+    }
+}
+
+impl TryFrom<JsValue> for VerificationMethod {
+    type Error = JsError;
+
+    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+        let value = value.as_f64().ok_or_else(|| {
+            JsError::new(&format!("Expect a `number`, received a `{:?}`", value.js_typeof()))
+        })? as u32;
+
+        Ok(match value {
+            0 => Self::SasV1,
+            1 => Self::QrCodeScanV1,
+            2 => Self::QrCodeShowV1,
+            3 => Self::ReciprocateV1,
+            _ => {
+                return Err(JsError::new(&format!(
+                    "Unknown verification method (received `{:?}`)",
+                    value
+                )))
+            }
+        })
+    }
+}
+
+impl From<VerificationMethod> for RumaVerificationMethod {
+    fn from(value: VerificationMethod) -> Self {
+        use VerificationMethod::*;
+
+        match value {
+            SasV1 => Self::SasV1,
+            QrCodeScanV1 => Self::QrCodeScanV1,
+            QrCodeShowV1 => Self::QrCodeShowV1,
+            ReciprocateV1 => Self::ReciprocateV1,
+        }
+    }
+}
+
+impl TryFrom<RumaVerificationMethod> for VerificationMethod {
+    type Error = JsError;
+
+    fn try_from(value: RumaVerificationMethod) -> Result<Self, Self::Error> {
+        use RumaVerificationMethod::*;
+
+        Ok(match value {
+            SasV1 => Self::SasV1,
+            QrCodeScanV1 => Self::QrCodeScanV1,
+            QrCodeShowV1 => Self::QrCodeShowV1,
+            ReciprocateV1 => Self::ReciprocateV1,
+            _ => {
+                return Err(JsError::new(&format!(
+                    "Unknown verification method (received `{:?}`)",
+                    value
+                )))
+            }
+        })
+    }
+}
+
+pub(crate) struct Verification(pub(crate) matrix_sdk_crypto::Verification);
+
+impl TryFrom<Verification> for JsValue {
+    type Error = JsError;
+
+    fn try_from(verification: Verification) -> Result<Self, Self::Error> {
+        use matrix_sdk_crypto::Verification::*;
+
+        Ok(match verification.0 {
+            SasV1(sas) => JsValue::from(Sas { inner: sas }),
+
+            #[cfg(feature = "qrcode")]
+            QrV1(qr) => JsValue::from(Qr { inner: qr }),
+
+            _ => {
+                return Err(JsError::new(
+                    "Unknown verification type, expect `m.sas.v1` only for now",
+                ))
+            }
+        })
+    }
+}
+
+/// Short Authentication String (SAS) verification.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct Sas {
+    inner: matrix_sdk_crypto::Sas,
+}
+
+#[wasm_bindgen]
+impl Sas {
+    /// Get our own user ID.
+    #[wasm_bindgen(getter, js_name = "userId")]
+    pub fn user_id(&self) -> UserId {
+        self.inner.user_id().to_owned().into()
+    }
+
+    /// Get our own device ID.
+    #[wasm_bindgen(getter, js_name = "deviceId")]
+    pub fn device_id(&self) -> DeviceId {
+        self.inner.device_id().to_owned().into()
+    }
+
+    /// Get the user id of the other side.
+    #[wasm_bindgen(getter, js_name = "otherUserId")]
+    pub fn other_user_id(&self) -> UserId {
+        self.inner.other_user_id().to_owned().into()
+    }
+
+    /// Get the device ID of the other side.
+    #[wasm_bindgen(getter, js_name = "otherDeviceId")]
+    pub fn other_device_id(&self) -> DeviceId {
+        self.inner.other_device_id().to_owned().into()
+    }
+
+    /*
+    /// Get the device of the other user.
+    #[wasm_bindgen(js_name = "otherDevice")]
+    pub fn other_device(&self) {
+        todo!()
+    }
+    */
+
+    /// Get the unique ID that identifies this SAS verification flow,
+    /// be either a to-device request ID or a room event ID.
+    #[wasm_bindgen(getter, js_name = "flowId")]
+    pub fn flow_id(&self) -> String {
+        self.inner.flow_id().as_str().to_owned()
+    }
+
+    /// Get the room ID if the verification is happening inside a
+    /// room.
+    #[wasm_bindgen(getter, js_name = "roomId")]
+    pub fn room_id(&self) -> Option<RoomId> {
+        self.inner.room_id().map(ToOwned::to_owned).map(Into::into)
+    }
+
+    /// Does this verification flow support displaying emoji for the
+    /// short authentication string.
+    #[wasm_bindgen(js_name = "supportsEmoji")]
+    pub fn supports_emoji(&self) -> bool {
+        self.inner.supports_emoji()
+    }
+
+    /// Did this verification flow start from a verification request.
+    #[wasm_bindgen(js_name = "startedFromRequest")]
+    pub fn started_from_request(&self) -> bool {
+        self.inner.started_from_request()
+    }
+
+    /// Is this a verification that is veryfying one of our own
+    /// devices.
+    #[wasm_bindgen(js_name = "isSelfVerification")]
+    pub fn is_self_verification(&self) -> bool {
+        self.inner.is_self_verification()
+    }
+
+    /// Have we confirmed that the short auth string matches.
+    #[wasm_bindgen(js_name = "haveWeConfirmed")]
+    pub fn have_we_confirmed(&self) -> bool {
+        self.inner.have_we_confirmed()
+    }
+
+    /// Has the verification been accepted by both parties.
+    #[wasm_bindgen(js_name = "hasBeenAccepted")]
+    pub fn has_been_accepted(&self) -> bool {
+        self.inner.has_been_accepted()
+    }
+
+    /// Get info about the cancellation if the verification flow has
+    /// been cancelled.
+    #[wasm_bindgen(js_name = "cancelInfo")]
+    pub fn cancel_info(&self) -> Option<CancelInfo> {
+        self.inner.cancel_info().map(Into::into)
+    }
+
+    /// Did we initiate the verification flow.
+    #[wasm_bindgen(js_name = "weStarted")]
+    pub fn we_started(&self) -> bool {
+        self.inner.we_started()
+    }
+
+    /*
+    pub fn accept(&self) {
+        todo!()
+    }
+    */
+
+    /*
+    #[wasm_bindgen(js_name = "acceptWithSettings")]
+    pub fn accept_with_settings(&self) {
+        todo!()
+    }
+    */
+
+    /*
+    pub fn confirm(&self) {
+        todo!()
+    }
+    */
+
+    /*
+    pub fn cancel(&self) {
+        todo!()
+    }
+    */
+
+    /*
+    #[wasm_bindgen(js_name = "cancelWithCode")]
+    pub fn cancel_with_code(&self) {
+        todo!()
+    }
+    */
+
+    /// Has the SAS verification flow timed out.
+    #[wasm_bindgen(js_name = "timedOut")]
+    pub fn timed_out(&self) -> bool {
+        self.inner.timed_out()
+    }
+
+    /// Are we in a state where we can show the short auth string.
+    #[wasm_bindgen(js_name = "canBePresented")]
+    pub fn can_be_presented(&self) -> bool {
+        self.inner.can_be_presented()
+    }
+
+    /// Is the SAS flow done.
+    #[wasm_bindgen(js_name = "isDone")]
+    pub fn is_done(&self) -> bool {
+        self.inner.is_done()
+    }
+
+    /// Is the SAS flow canceled.
+    #[wasm_bindgen(js_name = "isCancelled")]
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Get the emoji version of the short auth string.
+    ///
+    /// Returns `undefined` if we can't yet present the short auth string,
+    /// otherwise seven tuples containing the emoji and description.
+    pub fn emoji(&self) -> Option<Array> {
+        Some(
+            self.inner
+                .emoji()?
+                .iter()
+                .map(|emoji| Emoji::from(emoji.to_owned()))
+                .map(JsValue::from)
+                .collect(),
+        )
+    }
+
+    /// Get the index of the emoji representing the short auth string
+    ///
+    /// Returns `undefined` if we can’t yet present the short auth
+    /// string, otherwise seven `u8` numbers in the range from 0 to 63
+    /// inclusive which can be converted to an emoji using [the
+    /// relevant specification
+    /// entry](https://spec.matrix.org/unstable/client-server-api/#sas-method-emoji).
+    #[wasm_bindgen(js_name = "emoji_index")]
+    pub fn emoji_index(&self) -> Option<Array> {
+        Some(self.inner.emoji_index()?.into_iter().map(JsValue::from).collect())
+    }
+
+    /// Get the decimal version of the short auth string.
+    ///
+    /// Returns None if we can’t yet present the short auth string,
+    /// otherwise a tuple containing three 4-digit integers that
+    /// represent the short auth string.
+    pub fn decimals(&self) -> Option<Array> {
+        let decimals = self.inner.decimals()?;
+
+        let out = Array::new_with_length(3);
+        out.set(0, JsValue::from(decimals.0));
+        out.set(1, JsValue::from(decimals.1));
+        out.set(2, JsValue::from(decimals.2));
+
+        Some(out)
+    }
+}
+
+/// QR code based verification.
+#[cfg(feature = "qrcode")]
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct Qr {
+    inner: matrix_sdk_crypto::QrVerification,
+}
+
+#[cfg(feature = "qrcode")]
+#[wasm_bindgen]
+impl Qr {
+    /// Has the QR verification been scanned by the other side.
+    ///
+    /// When the verification object is in this state it’s required
+    /// that the user confirms that the other side has scanned the QR
+    /// code.
+    #[wasm_bindgen(js_name = "hasBeenScanned")]
+    pub fn has_been_scanned(&self) -> bool {
+        self.inner.has_been_scanned()
+    }
+
+    /// Has the scanning of the QR code been confirmed by us.
+    #[wasm_bindgen(js_name = "hasBeenConfirmed")]
+    pub fn has_been_confirmed(&self) -> bool {
+        self.inner.has_been_confirmed()
+    }
+
+    /// Get our own user ID.
+    #[wasm_bindgen(getter, js_name = "userId")]
+    pub fn user_id(&self) -> UserId {
+        self.inner.user_id().to_owned().into()
+    }
+
+    /// Get the user id of the other user that is participating in
+    /// this verification flow.
+    #[wasm_bindgen(getter, js_name = "otherUserId")]
+    pub fn other_user_id(&self) -> UserId {
+        self.inner.other_user_id().to_owned().into()
+    }
+
+    /// Get the device ID of the other side.
+    #[wasm_bindgen(getter, js_name = "otherDeviceId")]
+    pub fn other_device_id(&self) -> DeviceId {
+        self.inner.other_device_id().to_owned().into()
+    }
+
+    /*
+    #[wasm_bindgen(getter, js_name = "otherDevice")]
+    pub fn other_device(&self) -> ReadOnlyDevice {}
+    */
+
+    /// Did we initiate the verification request.
+    #[wasm_bindgen(js_name = "weStarted")]
+    pub fn we_started(&self) -> bool {
+        self.inner.we_started()
+    }
+
+    /// Get info about the cancellation if the verification flow has
+    /// been cancelled.
+    #[wasm_bindgen(js_name = "cancelInfo")]
+    pub fn cancel_info(&self) -> Option<CancelInfo> {
+        self.inner.cancel_info().map(Into::into)
+    }
+
+    /// Has the verification flow completed.
+    #[wasm_bindgen(js_name = "isDone")]
+    pub fn is_done(&self) -> bool {
+        self.inner.is_done()
+    }
+
+    /// Has the verification flow been cancelled.
+    #[wasm_bindgen(js_name = "isCancelled")]
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Is this a verification that is veryfying one of our own devices.
+    #[wasm_bindgen(js_name = "isSelfVerification")]
+    pub fn is_self_verification(&self) -> bool {
+        self.inner.is_self_verification()
+    }
+
+    /// Have we successfully scanned the QR code and are able to send
+    /// a reciprocation event.
+    pub fn reciprocated(&self) -> bool {
+        self.inner.reciprocated()
+    }
+
+    /// Get the unique ID that identifies this QR verification flow,
+    /// be either a to-device request ID or a room event ID.
+    #[wasm_bindgen(getter, js_name = "flowId")]
+    pub fn flow_id(&self) -> String {
+        self.inner.flow_id().as_str().to_owned()
+    }
+
+    /// Get the room id if the verification is happening inside a
+    /// room.
+    #[wasm_bindgen(getter, js_name = "roomId")]
+    pub fn room_id(&self) -> Option<RoomId> {
+        self.inner.room_id().map(ToOwned::to_owned).map(Into::into)
+    }
+
+    /// Generate a QR code object that is representing this
+    /// verification flow.
+    ///
+    /// The QrCode can then be rendered as an image or as an unicode
+    /// string.
+    ///
+    /// The `to_bytes` method can be used to instead output the raw
+    /// bytes that should be encoded as a QR code.
+    #[wasm_bindgen(js_name = "toQrCode")]
+    pub fn to_qr_code(&self) -> Result<QrCode, JsError> {
+        Ok(self.inner.to_qr_code().map(Into::into)?)
+    }
+
+    /// Generate a the raw bytes that should be encoded as a QR code
+    /// is representing this verification flow.
+    ///
+    /// The `to_qr_code` method can be used to instead output a QrCode
+    /// object that can be rendered.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Result<Array, JsError> {
+        Ok(self.inner.to_bytes()?.into_iter().map(JsValue::from).collect())
+    }
+
+    /*
+    /// Cancel the verification flow.
+    pub fn cancel(&self) -> … {}
+    pub fn cancel_with_code(&self, code: …) -> … {}
+    pub fn reciprocate(&self) -> … {}
+    pub fn confirm_scanning(&self) -> … {}
+    */
+}
+
+/// Information about the cancellation of a verification request or
+/// verification flow.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct CancelInfo {
+    inner: matrix_sdk_crypto::CancelInfo,
+}
+
+impl From<matrix_sdk_crypto::CancelInfo> for CancelInfo {
+    fn from(inner: matrix_sdk_crypto::CancelInfo) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl CancelInfo {
+    /// Get the human readable reason of the cancellation.
+    pub fn reason(&self) -> JsString {
+        self.inner.reason().into()
+    }
+
+    /// Get the `CancelCode` that cancelled this verification.
+    #[wasm_bindgen(js_name = "cancelCode")]
+    pub fn cancel_code(&self) -> CancelCode {
+        self.inner.cancel_code().into()
+    }
+
+    /// Was the verification cancelled by us?
+    #[wasm_bindgen(js_name = "cancelledbyUs")]
+    pub fn cancelled_by_us(&self) -> bool {
+        self.inner.cancelled_by_us()
+    }
+}
+
+/// An error code for why the process/request was cancelled by the
+/// user.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub enum CancelCode {
+    /// Unknown cancel code.
+    Other,
+
+    /// The user cancelled the verification.
+    User,
+
+    /// The verification process timed out.
+    ///
+    /// Verification processes can define their own timeout
+    /// parameters.
+    Timeout,
+
+    /// The device does not know about the given transaction ID.
+    UnknownTransaction,
+
+    /// The device does not know how to handle the requested method.
+    ///
+    /// Should be sent for `m.key.verification.start` messages and
+    /// messages defined by individual verification processes.
+    UnknownMethod,
+
+    /// The device received an unexpected message.
+    ///
+    /// Typically raised when one of the parties is handling the
+    /// verification out of order.
+    UnexpectedMessage,
+
+    /// The key was not verified.
+    KeyMismatch,
+
+    /// The expected user did not match the user verified.
+    UserMismatch,
+
+    /// The message received was invalid.
+    InvalidMessage,
+
+    /// An `m.key.verification.request` was accepted by a different
+    /// device.
+    ///
+    /// The device receiving this error can ignore the verification
+    /// request.
+    Accepted,
+
+    /// The device receiving this error can ignore the verification
+    /// request.
+    MismatchedCommitment,
+
+    /// The SAS did not match.
+    MismatchedSas,
+}
+
+impl From<&RumaCancelCode> for CancelCode {
+    fn from(code: &RumaCancelCode) -> Self {
+        use RumaCancelCode::*;
+
+        match code {
+            User => Self::User,
+            Timeout => Self::Timeout,
+            UnknownTransaction => Self::UnknownTransaction,
+            UnknownMethod => Self::UnknownMethod,
+            UnexpectedMessage => Self::UnexpectedMessage,
+            KeyMismatch => Self::KeyMismatch,
+            UserMismatch => Self::UserMismatch,
+            InvalidMessage => Self::InvalidMessage,
+            Accepted => Self::Accepted,
+            MismatchedCommitment => Self::MismatchedCommitment,
+            MismatchedSas => Self::MismatchedSas,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// An emoji that is used for interactive verification using a short
+/// auth string.
+///
+/// This will contain a single emoji and description from the list of
+/// emojis from [the specification].
+///
+/// [the specification]: https://spec.matrix.org/unstable/client-server-api/#sas-method-emoji
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct Emoji {
+    inner: matrix_sdk_crypto::Emoji,
+}
+
+impl From<matrix_sdk_crypto::Emoji> for Emoji {
+    fn from(inner: matrix_sdk_crypto::Emoji) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl Emoji {
+    /// The emoji symbol that represents a part of the short auth
+    /// string, for example: 🐶
+    #[wasm_bindgen(getter)]
+    pub fn symbol(&self) -> JsString {
+        self.inner.symbol.into()
+    }
+
+    /// The description of the emoji, for example ‘Dog’.
+    #[wasm_bindgen(getter)]
+    pub fn description(&self) -> JsString {
+        self.inner.description.into()
+    }
+}
+
+/// A QR code.
+#[cfg(feature = "qrcode")]
+#[wasm_bindgen]
+pub struct QrCode {
+    inner: matrix_sdk_qrcode::qrcode::QrCode,
+}
+
+#[cfg(feature = "qrcode")]
+impl fmt::Debug for QrCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct(stringify!(QrCode)).finish()
+    }
+}
+
+#[cfg(feature = "qrcode")]
+impl From<matrix_sdk_qrcode::qrcode::QrCode> for QrCode {
+    fn from(inner: matrix_sdk_qrcode::qrcode::QrCode) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "qrcode")]
+#[wasm_bindgen]
+impl QrCode {
+    /// Render the QR code into a `Uint8Array` where 1 represents a
+    /// dark pixel and 0 a white pixel.
+    pub fn render_into_buffer(&self) -> Result<Uint8Array, JsError> {
+        let colors: Vec<u8> =
+            self.inner.to_colors().into_iter().map(|color| color.select(1u8, 0u8)).collect();
+        let buffer = Uint8Array::new_with_length(colors.len().try_into()?);
+        buffer.copy_from(colors.as_slice());
+
+        Ok(buffer)
+    }
+}
+
+/// An object controlling key verification requests.
+///
+/// Interactive verification flows usually start with a verification
+/// request, this object lets you send and reply to such a
+/// verification request.
+///
+/// After the initial handshake the verification flow transitions into
+/// one of the verification methods.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct VerificationRequest {
+    inner: matrix_sdk_crypto::VerificationRequest,
+}
+
+impl From<matrix_sdk_crypto::VerificationRequest> for VerificationRequest {
+    fn from(inner: matrix_sdk_crypto::VerificationRequest) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl VerificationRequest {
+    #[wasm_bindgen]
+    pub fn request(
+        own_user_id: &UserId,
+        own_device_id: &DeviceId,
+        other_user_id: &UserId,
+        methods: Option<Array>,
+    ) -> Result<String, JsError> {
+        let methods: Option<Vec<RumaVerificationMethod>> = methods
+            .map(|array| {
+                array
+                    .iter()
+                    .map(|method| VerificationMethod::try_from(method).map(Into::into))
+                    .collect::<Result<_, _>>()
+            })
+            .transpose()?;
+
+        Ok(serde_json::to_string(&matrix_sdk_crypto::VerificationRequest::request(
+            &own_user_id.inner,
+            &own_device_id.inner,
+            &other_user_id.inner,
+            methods,
+        ))?)
+    }
+
+    /// Our own user id.
+    #[wasm_bindgen(js_name = "ownUserId")]
+    pub fn own_user_id(&self) -> UserId {
+        self.inner.own_user_id().to_owned().into()
+    }
+
+    /// The ID of the other user that is participating in this
+    /// verification request.
+    #[wasm_bindgen(js_name = "otherUserId")]
+    pub fn other_user_id(&self) -> UserId {
+        self.inner.other_user().to_owned().into()
+    }
+
+    /// The ID of the other device that is participating in this
+    /// verification.
+    #[wasm_bindgen(js_name = "otherDeviceId")]
+    pub fn other_device_id(&self) -> Option<DeviceId> {
+        self.inner.other_device_id().map(Into::into)
+    }
+
+    /// Get the room ID if the verification is happening inside a
+    /// room.
+    #[wasm_bindgen(js_name = "roomId")]
+    pub fn room_id(&self) -> Option<RoomId> {
+        self.inner.room_id().map(ToOwned::to_owned).map(Into::into)
+    }
+
+    /// Get info about the cancellation if the verification request
+    /// has been cancelled.
+    #[wasm_bindgen(js_name = "cancelInfo")]
+    pub fn cancel_info(&self) -> Option<CancelInfo> {
+        self.inner.cancel_info().map(Into::into)
+    }
+
+    /// Has the verification request been answered by another device.
+    #[wasm_bindgen(js_name = "isPassive")]
+    pub fn is_passive(&self) -> bool {
+        self.inner.is_passive()
+    }
+
+    /// Is the verification request ready to start a verification flow.
+    #[wasm_bindgen(js_name = "isReady")]
+    pub fn is_ready(&self) -> bool {
+        self.inner.is_ready()
+    }
+
+    /// Has the verification flow timed out.
+    #[wasm_bindgen(js_name = "timedOut")]
+    pub fn timed_out(&self) -> bool {
+        self.inner.timed_out()
+    }
+
+    /// Get the supported verification methods of the other side.
+    ///
+    /// Will be present only if the other side requested the
+    /// verification or if we’re in the ready state.
+    ///
+    /// It return a `Option<Vec<VerificationMethod>>`.
+    #[wasm_bindgen(js_name = "theirSupportedMethods")]
+    pub fn their_supported_methods(&self) -> Result<Option<Array>, JsError> {
+        self.inner
+            .their_supported_methods()
+            .map(|methods| {
+                methods
+                    .into_iter()
+                    .map(|method| VerificationMethod::try_from(method).map(JsValue::from))
+                    .collect::<Result<Array, _>>()
+            })
+            .transpose()
+    }
+
+    /// Get our own supported verification methods that we advertised.
+    ///
+    /// Will be present only we requested the verification or if we’re
+    /// in the ready state.
+    #[wasm_bindgen(js_name = "ourSupportedMethods")]
+    pub fn our_supported_methods(&self) -> Result<Option<Array>, JsError> {
+        self.inner
+            .our_supported_methods()
+            .map(|methods| {
+                methods
+                    .into_iter()
+                    .map(|method| VerificationMethod::try_from(method).map(JsValue::from))
+                    .collect::<Result<Array, _>>()
+            })
+            .transpose()
+    }
+
+    /// Get the unique ID of this verification request
+    #[wasm_bindgen(js_name = "flowId")]
+    pub fn flow_id(&self) -> String {
+        self.inner.flow_id().as_str().to_owned()
+    }
+
+    /// Is this a verification that is veryfying one of our own
+    /// devices.
+    #[wasm_bindgen(js_name = "isSelfVerification")]
+    pub fn is_self_verification(&self) -> bool {
+        self.inner.is_self_verification()
+    }
+
+    /// Did we initiate the verification request.
+    #[wasm_bindgen(js_name = "weStarted")]
+    pub fn we_started(&self) -> bool {
+        self.inner.we_started()
+    }
+
+    /// Has the verification flow that was started with this request
+    /// finished.
+    #[wasm_bindgen(js_name = "isDone")]
+    pub fn is_done(&self) -> bool {
+        self.inner.is_done()
+    }
+
+    /// Has the verification flow that was started with this request
+    /// been cancelled.
+    #[wasm_bindgen(js_name = "isCancelled")]
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Accept the verification request signaling that our client
+    /// supports the given verification methods.
+    ///
+    /// `methods` represents the methods that we should advertise as
+    /// supported by us.
+    ///
+    /// It returns either a `ToDeviceRequest`, a `RoomMessageRequest`
+    /// or `undefined`.
+    #[wasm_bindgen(js_name = "acceptWithMethods")]
+    pub fn accept_with_methods(&self, methods: Array) -> Result<JsValue, JsError> {
+        let methods: Vec<RumaVerificationMethod> = methods
+            .iter()
+            .map(|method| VerificationMethod::try_from(method).map(Into::into))
+            .collect::<Result<_, _>>()?;
+
+        self.inner
+            .accept_with_methods(methods)
+            .map(OutgoingVerificationRequest)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
+    }
+
+    /// Accept the verification request.
+    ///
+    /// This method will accept the request and signal that it
+    /// supports the `m.sas.v1`, the `m.qr_code.show.v1`, and
+    /// `m.reciprocate.v1` method.
+    ///
+    /// `m.qr_code.show.v1` will only be signaled if the `qrcode`
+    /// feature is enabled. This feature is disabled by default. If
+    /// it's enabled and QR code scanning should be supported or QR
+    /// code showing shouldn't be supported the `accept_with_methods`
+    /// method should be used instead.
+    ///
+    /// It returns either a `ToDeviceRequest`, a `RoomMessageRequest`
+    /// or `undefined`.
+    pub fn accept(&self) -> Result<JsValue, JsError> {
+        self.inner
+            .accept()
+            .map(OutgoingVerificationRequest)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
+    }
+
+    /// Cancel the verification request.
+    ///
+    /// It returns either a `ToDeviceRequest`, a `RoomMessageRequest`
+    /// or `undefined`.
+    pub fn cancel(&self) -> Result<JsValue, JsError> {
+        self.inner
+            .cancel()
+            .map(OutgoingVerificationRequest)
+            .map(JsValue::try_from)
+            .transpose()
+            .map(JsValue::from)
+            .map_err(Into::into)
+    }
+
+    // start_sas
+    // generate_qr_code if `qrcode`
+    // scan_qr_code if `qrcode`
+}
+
+// JavaScript has no complex enums like Rust. To return structs of
+// different types, we have no choice that hiding everything behind a
+// `JsValue`.
+struct OutgoingVerificationRequest(pub(crate) matrix_sdk_crypto::OutgoingVerificationRequest);
+
+impl TryFrom<OutgoingVerificationRequest> for JsValue {
+    type Error = serde_json::Error;
+
+    fn try_from(outgoing_request: OutgoingVerificationRequest) -> Result<Self, Self::Error> {
+        use matrix_sdk_crypto::OutgoingVerificationRequest::*;
+
+        let request_id = outgoing_request.0.request_id().to_string();
+
+        Ok(match outgoing_request.0 {
+            ToDevice(request) => {
+                JsValue::from(requests::ToDeviceRequest::try_from((request_id, &request))?)
+            }
+
+            InRoom(request) => {
+                JsValue::from(requests::RoomMessageRequest::try_from((request_id, &request))?)
+            }
+        })
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -756,6 +756,7 @@ impl QrCode {
 /// A scanned QR code.
 #[cfg(feature = "qrcode")]
 #[wasm_bindgen]
+#[derive(Debug)]
 pub struct QrCodeScan {
     inner: matrix_sdk_qrcode::QrVerificationData,
 }

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -876,7 +876,15 @@ impl VerificationRequest {
 // JavaScript has no complex enums like Rust. To return structs of
 // different types, we have no choice that hiding everything behind a
 // `JsValue`.
-struct OutgoingVerificationRequest(pub(crate) matrix_sdk_crypto::OutgoingVerificationRequest);
+pub(crate) struct OutgoingVerificationRequest(
+    pub(crate) matrix_sdk_crypto::OutgoingVerificationRequest,
+);
+
+impl From<matrix_sdk_crypto::OutgoingVerificationRequest> for OutgoingVerificationRequest {
+    fn from(inner: matrix_sdk_crypto::OutgoingVerificationRequest) -> Self {
+        Self(inner)
+    }
+}
 
 impl TryFrom<OutgoingVerificationRequest> for JsValue {
     type Error = serde_json::Error;

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -4,7 +4,7 @@
 use std::fmt;
 
 #[cfg(feature = "qrcode")]
-use js_sys::Uint8Array;
+use js_sys::Uint8ClampedArray;
 use js_sys::{Array, JsString, Promise};
 use ruma::events::key::verification::{
     cancel::CancelCode as RumaCancelCode, VerificationMethod as RumaVerificationMethod,
@@ -661,13 +661,13 @@ impl From<matrix_sdk_qrcode::qrcode::QrCode> for QrCode {
 #[cfg(feature = "qrcode")]
 #[wasm_bindgen]
 impl QrCode {
-    /// Render the QR code into a `Uint8Array` where 1 represents a
+    /// Render the QR code into a `Uint8ClampedArray` where 1 represents a
     /// dark pixel and 0 a white pixel.
     #[wasm_bindgen(js_name = "renderIntoBuffer")]
-    pub fn render_into_buffer(&self) -> Result<Uint8Array, JsError> {
+    pub fn render_into_buffer(&self) -> Result<Uint8ClampedArray, JsError> {
         let colors: Vec<u8> =
             self.inner.to_colors().into_iter().map(|color| color.select(1u8, 0u8)).collect();
-        let buffer = Uint8Array::new_with_length(colors.len().try_into()?);
+        let buffer = Uint8ClampedArray::new_with_length(colors.len().try_into()?);
         buffer.copy_from(colors.as_slice());
 
         Ok(buffer)

--- a/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
+++ b/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
@@ -142,7 +142,7 @@ impl DeviceKey {
         use matrix_sdk_crypto::types::DeviceKey::*;
 
         match &self.inner {
-            Curve25519(key) => Some(key.clone().into()),
+            Curve25519(key) => Some((*key).into()),
             _ => None,
         }
     }
@@ -153,7 +153,7 @@ impl DeviceKey {
         use matrix_sdk_crypto::types::DeviceKey::*;
 
         match &self.inner {
-            Ed25519(key) => Some(key.clone().into()),
+            Ed25519(key) => Some((*key).into()),
             _ => None,
         }
     }

--- a/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
+++ b/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
@@ -25,6 +25,12 @@ impl Ed25519PublicKey {
     }
 }
 
+impl From<vodozemac::Ed25519PublicKey> for Ed25519PublicKey {
+    fn from(inner: vodozemac::Ed25519PublicKey) -> Self {
+        Self { inner }
+    }
+}
+
 /// An Ed25519 digital signature, can be used to verify the
 /// authenticity of a message.
 #[wasm_bindgen]
@@ -79,6 +85,12 @@ impl Curve25519PublicKey {
     }
 }
 
+impl From<vodozemac::Curve25519PublicKey> for Curve25519PublicKey {
+    fn from(inner: vodozemac::Curve25519PublicKey) -> Self {
+        Self { inner }
+    }
+}
+
 /// Struct holding the two public identity keys of an account.
 #[wasm_bindgen(getter_with_clone)]
 #[derive(Debug)]
@@ -97,4 +109,99 @@ impl From<matrix_sdk_crypto::olm::IdentityKeys> for IdentityKeys {
             curve25519: Curve25519PublicKey { inner: value.curve25519 },
         }
     }
+}
+
+/// An enum over the different key types a device can have.
+///
+/// Currently devices have a curve25519 and ed25519 keypair. The keys
+/// transport format is a base64 encoded string, any unknown key type
+/// will be left as such a string.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct DeviceKey {
+    inner: matrix_sdk_crypto::types::DeviceKey,
+}
+
+impl From<matrix_sdk_crypto::types::DeviceKey> for DeviceKey {
+    fn from(inner: matrix_sdk_crypto::types::DeviceKey) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl DeviceKey {
+    /// Get the name of the device key.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> DeviceKeyName {
+        (&self.inner).into()
+    }
+
+    /// Get the value associated to the `Curve25519` device key name.
+    #[wasm_bindgen(getter)]
+    pub fn curve25519(&self) -> Option<Curve25519PublicKey> {
+        use matrix_sdk_crypto::types::DeviceKey::*;
+
+        match &self.inner {
+            Curve25519(key) => Some(key.clone().into()),
+            _ => None,
+        }
+    }
+
+    /// Get the value associated to the `Ed25519` device key name.
+    #[wasm_bindgen(getter)]
+    pub fn ed25519(&self) -> Option<Ed25519PublicKey> {
+        use matrix_sdk_crypto::types::DeviceKey::*;
+
+        match &self.inner {
+            Ed25519(key) => Some(key.clone().into()),
+            _ => None,
+        }
+    }
+
+    /// Get the value associated to the `Unknown` device key name.
+    #[wasm_bindgen(getter)]
+    pub fn unknown(&self) -> Option<String> {
+        use matrix_sdk_crypto::types::DeviceKey::*;
+
+        match &self.inner {
+            Unknown(key) => Some(key.clone()),
+            _ => None,
+        }
+    }
+
+    /// Convert the `DeviceKey` into a base64 encoded string.
+    #[wasm_bindgen(js_name = "toBase64")]
+    pub fn to_base64(&self) -> String {
+        self.inner.to_base64()
+    }
+}
+
+impl From<&matrix_sdk_crypto::types::DeviceKey> for DeviceKeyName {
+    fn from(device_key: &matrix_sdk_crypto::types::DeviceKey) -> Self {
+        use matrix_sdk_crypto::types::DeviceKey::*;
+
+        match device_key {
+            Curve25519(_) => Self::Curve25519,
+            Ed25519(_) => Self::Ed25519,
+            Unknown(_) => Self::Unknown,
+        }
+    }
+}
+
+/// An enum over the different key types a device can have.
+///
+/// Currently devices have a curve25519 and ed25519 keypair. The keys
+/// transport format is a base64 encoded string, any unknown key type
+/// will be left as such a string.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub enum DeviceKeyName {
+    /// The curve25519 device key.
+    Curve25519,
+
+    /// The ed25519 device key.
+    Ed25519,
+
+    /// An unknown device key.
+    Unknown,
 }

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -1,0 +1,79 @@
+const { OlmMachine, UserId, DeviceId, DeviceKeyId, RoomId, DeviceKeyAlgorithName, Device, LocalTrust, UserDevices, DeviceKey, DeviceKeyName, DeviceKeyAlgorithmName, Ed25519PublicKey, Curve25519PublicKey, Signatures } = require('../pkg/matrix_sdk_crypto_js');
+
+describe('LocalTrust', () => {
+    test('has the correct variant values', () => {
+        expect(LocalTrust.Verified).toStrictEqual(0);
+        expect(LocalTrust.BlackListed).toStrictEqual(1);
+        expect(LocalTrust.Ignored).toStrictEqual(2);
+        expect(LocalTrust.Unset).toStrictEqual(3);
+    });
+});
+
+describe('DeviceKeyName', () => {
+    test('has the correct variant values', () => {
+        expect(DeviceKeyName.Curve25519).toStrictEqual(0);
+        expect(DeviceKeyName.Ed25519).toStrictEqual(1);
+        expect(DeviceKeyName.Unknown).toStrictEqual(2);
+    });
+});
+
+describe(OlmMachine.name, () => {
+    const user = new UserId('@alice:example.org');
+    const device = new DeviceId('foobar');
+    const room = new RoomId('!baz:matrix.org');
+
+    function machine(new_user, new_device) {
+        return new OlmMachine(new_user || user, new_device || device);
+    }
+
+    test('can read user devices', async () => {
+        const m = await machine();
+        const userDevices = await m.getUserDevices(user);
+
+        expect(userDevices).toBeInstanceOf(UserDevices);
+        expect(userDevices.get(device)).toBeInstanceOf(Device);
+        expect(userDevices.isAnyVerified()).toStrictEqual(false);
+        expect(userDevices.keys().map(device_id => device_id.toString())).toStrictEqual([device.toString()]);
+        expect(userDevices.devices().map(device => device.deviceId.toString())).toStrictEqual([device.toString()]);
+    });
+
+    test('can read a user device', async () => {
+        const m = await machine();
+        const dev = await m.getDevice(user, device);
+
+        expect(dev).toBeInstanceOf(Device);
+        expect(dev.isVerified()).toStrictEqual(false);
+        expect(dev.isCrossSigningTrusted()).toStrictEqual(false);
+
+        expect(dev.localTrustState).toStrictEqual(LocalTrust.Unset);
+        expect(dev.isLocallyTrusted()).toStrictEqual(false);
+        expect(await dev.setLocalTrust(LocalTrust.Verified)).toBeNull();
+        expect(dev.localTrustState).toStrictEqual(LocalTrust.Verified);
+        expect(dev.isLocallyTrusted()).toStrictEqual(true);
+
+        expect(dev.userId.toString()).toStrictEqual(user.toString());
+        expect(dev.deviceId.toString()).toStrictEqual(device.toString());
+        expect(dev.deviceName).toBeUndefined();
+
+        const deviceKey = dev.getKey(DeviceKeyAlgorithmName.Ed25519);
+
+        expect(deviceKey).toBeInstanceOf(DeviceKey);
+        expect(deviceKey.name).toStrictEqual(DeviceKeyName.Ed25519);
+        expect(deviceKey.curve25519).toBeUndefined();
+        expect(deviceKey.ed25519).toBeInstanceOf(Ed25519PublicKey);
+        expect(deviceKey.unknown).toBeUndefined();
+        expect(deviceKey.toBase64()).toMatch(/^[A-Za-z0-9\+/]+$/);
+
+        expect(dev.curve25519Key).toBeInstanceOf(Curve25519PublicKey);
+        expect(dev.ed25519Key).toBeInstanceOf(Ed25519PublicKey);
+
+        for (const [deviceKeyId, deviceKey] of dev.keys) {
+            expect(deviceKeyId).toBeInstanceOf(DeviceKeyId);
+            expect(deviceKey).toBeInstanceOf(DeviceKey);
+        }
+
+        expect(dev.signatures).toBeInstanceOf(Signatures);
+        expect(dev.isBlacklisted()).toStrictEqual(false);
+        expect(dev.isDeleted()).toStrictEqual(false);
+    });
+});

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -1,4 +1,4 @@
-const { OlmMachine, UserId, DeviceId, DeviceKeyId, RoomId, DeviceKeyAlgorithName, Device, LocalTrust, UserDevices, DeviceKey, DeviceKeyName, DeviceKeyAlgorithmName, Ed25519PublicKey, Curve25519PublicKey, Signatures } = require('../pkg/matrix_sdk_crypto_js');
+const { OlmMachine, UserId, DeviceId, DeviceKeyId, RoomId, DeviceKeyAlgorithName, Device, LocalTrust, UserDevices, DeviceKey, DeviceKeyName, DeviceKeyAlgorithmName, Ed25519PublicKey, Curve25519PublicKey, Signatures, VerificationRequest, ToDeviceRequest } = require('../pkg/matrix_sdk_crypto_js');
 
 describe('LocalTrust', () => {
     test('has the correct variant values', () => {
@@ -75,5 +75,25 @@ describe(OlmMachine.name, () => {
         expect(dev.signatures).toBeInstanceOf(Signatures);
         expect(dev.isBlacklisted()).toStrictEqual(false);
         expect(dev.isDeleted()).toStrictEqual(false);
+    });
+});
+
+describe(Device.name, () => {
+    const user = new UserId('@alice:example.org');
+    const device = new DeviceId('foobar');
+    const room = new RoomId('!baz:matrix.org');
+
+    function machine(new_user, new_device) {
+        return new OlmMachine(new_user || user, new_device || device);
+    }
+
+    test('can request verification', async () => {
+        const m = await machine();
+        const dev = await m.getDevice(user, device);
+
+        const [verificationRequest, outgoingVerificationRequest] = await dev.requestVerification();
+
+        expect(verificationRequest).toBeInstanceOf(VerificationRequest);
+        expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
     });
 });

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -79,7 +79,7 @@ describe(OlmMachine.name, () => {
     });
 });
 
-describe(Device.name, () => {
+describe('Key Verification', () => {
     const userId1 = new UserId('@alice:example.org');
     const deviceId1 = new DeviceId('alice_device');
 
@@ -90,12 +90,24 @@ describe(Device.name, () => {
         return new OlmMachine(new_user || userId1, new_device || deviceId1);
     }
 
-    test('can request verification', async () => {
-        // First Olm machine.
-        const m1 = await machine(userId1, deviceId1);
-        // Second Olm machine.
-        const m2 = await machine(userId2, deviceId2);
+    // First Olm machine.
+    let m1;
 
+    // Second Olm machine.
+    let m2;
+
+    beforeAll(async () => {
+        m1 = await machine(userId1, deviceId1);
+        m2 = await machine(userId2, deviceId2);
+    });
+
+    // Verification request for `m1`.
+    let verificationRequest1;
+
+    // Temporary variable.
+    let outgoingVerificationRequest;
+
+    test('can request verification (`m.key.verification.request`)', async () => {
         // Make `m1` and `m2` be aware of each other.
         {
             await addMachineToMachine(m2, m1);
@@ -108,318 +120,311 @@ describe(Device.name, () => {
         expect(device2).toBeInstanceOf(Device);
 
         // Request a verification from `m1` to `device2`.
-        let [verificationRequest1, outgoingVerificationRequest] = await device2.requestVerification();
+        [verificationRequest1, outgoingVerificationRequest] = await device2.requestVerification();
 
-        {
-            expect(verificationRequest1).toBeInstanceOf(VerificationRequest);
+        expect(verificationRequest1).toBeInstanceOf(VerificationRequest);
 
-            expect(verificationRequest1.ownUserId.toString()).toStrictEqual(userId1.toString());
-            expect(verificationRequest1.otherUserId.toString()).toStrictEqual(userId2.toString());
-            expect(verificationRequest1.otherDeviceId).toBeUndefined();
-            expect(verificationRequest1.roomId).toBeUndefined();
-            expect(verificationRequest1.cancelInfo).toBeUndefined();
-            expect(verificationRequest1.isPassive()).toStrictEqual(false);
-            expect(verificationRequest1.isReady()).toStrictEqual(false);
-            expect(verificationRequest1.timedOut()).toStrictEqual(false);
-            expect(verificationRequest1.theirSupportedMethods).toBeUndefined();
-            expect(verificationRequest1.ourSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
-            expect(verificationRequest1.flowId).toMatch(/^[a-f0-9]+$/);
-            expect(verificationRequest1.isSelfVerification()).toStrictEqual(false);
-            expect(verificationRequest1.weStarted()).toStrictEqual(true);
-            expect(verificationRequest1.isDone()).toStrictEqual(false);
-            expect(verificationRequest1.isCancelled()).toStrictEqual(false);
+        expect(verificationRequest1.ownUserId.toString()).toStrictEqual(userId1.toString());
+        expect(verificationRequest1.otherUserId.toString()).toStrictEqual(userId2.toString());
+        expect(verificationRequest1.otherDeviceId).toBeUndefined();
+        expect(verificationRequest1.roomId).toBeUndefined();
+        expect(verificationRequest1.cancelInfo).toBeUndefined();
+        expect(verificationRequest1.isPassive()).toStrictEqual(false);
+        expect(verificationRequest1.isReady()).toStrictEqual(false);
+        expect(verificationRequest1.timedOut()).toStrictEqual(false);
+        expect(verificationRequest1.theirSupportedMethods).toBeUndefined();
+        expect(verificationRequest1.ourSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
+        expect(verificationRequest1.flowId).toMatch(/^[a-f0-9]+$/);
+        expect(verificationRequest1.isSelfVerification()).toStrictEqual(false);
+        expect(verificationRequest1.weStarted()).toStrictEqual(true);
+        expect(verificationRequest1.isDone()).toStrictEqual(false);
+        expect(verificationRequest1.isCancelled()).toStrictEqual(false);
 
-            expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
+        expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
 
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
-            expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.request');
-        }
+        outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
+        expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.request');
+    });
 
-        let flowId;
+    // Verification request for `m2`.
+    let verificationRequest2;
 
-        // Fetch the verification from `m2`.
-        let verificationRequest2;
+    // The flow ID.
+    let flowId;
 
-        {
-            const outgoingContent = outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()];
+    test('can fetch received request verification', async () => {
+        const outgoingContent = outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()];
 
-            const toDeviceEvents = {
-                events: [{
-                    sender: userId1.toString(),
-                    type: outgoingVerificationRequest.event_type,
-                    content: outgoingContent,
-                }]
-            };
+        const toDeviceEvents = {
+            events: [{
+                sender: userId1.toString(),
+                type: outgoingVerificationRequest.event_type,
+                content: outgoingContent,
+            }]
+        };
 
-            // Let's send the verification request to `m2`.
-            await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
+        // Let's send the verification request to `m2`.
+        await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
 
-            // Oh, a new verification request.
-            flowId = outgoingContent.transaction_id;
-            verificationRequest2 = m2.getVerificationRequest(userId1, flowId);
+        // Oh, a new verification request.
+        verificationRequest2 = m2.getVerificationRequest(userId1, outgoingContent.transaction_id);
 
-            expect(verificationRequest2).toBeInstanceOf(VerificationRequest);
+        expect(verificationRequest2).toBeInstanceOf(VerificationRequest);
 
-            expect(verificationRequest2.ownUserId.toString()).toStrictEqual(userId2.toString());
-            expect(verificationRequest2.otherUserId.toString()).toStrictEqual(userId1.toString());
-            expect(verificationRequest2.otherDeviceId.toString()).toStrictEqual(deviceId1.toString());
-            expect(verificationRequest2.roomId).toBeUndefined();
-            expect(verificationRequest2.cancelInfo).toBeUndefined();
-            expect(verificationRequest2.isPassive()).toStrictEqual(false);
-            expect(verificationRequest2.isReady()).toStrictEqual(false);
-            expect(verificationRequest2.timedOut()).toStrictEqual(false);
-            expect(verificationRequest2.theirSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
-            expect(verificationRequest2.ourSupportedMethods).toBeUndefined();
-            expect(verificationRequest2.flowId).toMatch(/^[a-f0-9]+$/);
-            expect(verificationRequest2.isSelfVerification()).toStrictEqual(false);
-            expect(verificationRequest2.weStarted()).toStrictEqual(false);
-            expect(verificationRequest2.isDone()).toStrictEqual(false);
-            expect(verificationRequest2.isCancelled()).toStrictEqual(false);
+        expect(verificationRequest2.ownUserId.toString()).toStrictEqual(userId2.toString());
+        expect(verificationRequest2.otherUserId.toString()).toStrictEqual(userId1.toString());
+        expect(verificationRequest2.otherDeviceId.toString()).toStrictEqual(deviceId1.toString());
+        expect(verificationRequest2.roomId).toBeUndefined();
+        expect(verificationRequest2.cancelInfo).toBeUndefined();
+        expect(verificationRequest2.isPassive()).toStrictEqual(false);
+        expect(verificationRequest2.isReady()).toStrictEqual(false);
+        expect(verificationRequest2.timedOut()).toStrictEqual(false);
+        expect(verificationRequest2.theirSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
+        expect(verificationRequest2.ourSupportedMethods).toBeUndefined();
+        expect(verificationRequest2.flowId).toMatch(/^[a-f0-9]+$/);
+        expect(verificationRequest2.isSelfVerification()).toStrictEqual(false);
+        expect(verificationRequest2.weStarted()).toStrictEqual(false);
+        expect(verificationRequest2.isDone()).toStrictEqual(false);
+        expect(verificationRequest2.isCancelled()).toStrictEqual(false);
 
-            const verificationRequests = m2.getVerificationRequests(userId1);
-            expect(verificationRequests).toHaveLength(1);
-            expect(verificationRequests[0].flowId).toStrictEqual(verificationRequest2.flowId); // there are the same
-        }
+        const verificationRequests = m2.getVerificationRequests(userId1);
+        expect(verificationRequests).toHaveLength(1);
+        expect(verificationRequests[0].flowId).toStrictEqual(verificationRequest2.flowId); // there are the same
+
+        flowId = verificationRequest2.flowId;
+    });
+
+    test('can accept a verification request (`m.key.verification.ready`)', async () => {
+        // Accept the verification request.
+        let outgoingVerificationRequest = verificationRequest2.accept();
+
+        expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
 
         // The request verification is ready.
-        {
-            let outgoingVerificationRequest = verificationRequest2.accept();
+        outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
+        expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.ready');
 
-            expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
+        const toDeviceEvents = {
+            events: [{
+                sender: userId2.toString(),
+                type: outgoingVerificationRequest.event_type,
+                content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
+            }],
+        };
 
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
-            expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.ready');
+        // Let's send the verification ready to `m1`.
+        await m1.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
+    });
 
-            const toDeviceEvents = {
-                events: [{
-                    sender: userId2.toString(),
-                    type: outgoingVerificationRequest.event_type,
-                    content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
-                }],
-            };
+    test('verification requests are synchronized and automatically updated', async () => {
+        expect(verificationRequest1.isReady()).toStrictEqual(true);
+        expect(verificationRequest2.isReady()).toStrictEqual(true);
 
-            // Let's send the verification ready to `m1`.
-            await m1.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
-        }
+        expect(verificationRequest1.theirSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
+        expect(verificationRequest1.ourSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
 
-        // Verification is ready on both side.
-        {
-            expect(verificationRequest1.isReady()).toStrictEqual(true);
-            expect(verificationRequest2.isReady()).toStrictEqual(true);
+        expect(verificationRequest2.theirSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
+        expect(verificationRequest2.ourSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
+    });
 
-            expect(verificationRequest1.theirSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
-            expect(verificationRequest1.ourSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
+    // SAS verification for the second machine.
+    let sas2;
 
-            expect(verificationRequest2.theirSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
-            expect(verificationRequest2.ourSupportedMethods).toStrictEqual([VerificationMethod.SasV1, VerificationMethod.ReciprocateV1]);
-        }
-
+    test('can start a SAS verification (`m.key.verification.start`)', async () => {
         // Let's start a SAS verification, from `m2` for example.
-        let sas2;
+        [sas2, outgoingVerificationRequest] = await verificationRequest2.startSas();
+        expect(sas2).toBeInstanceOf(Sas);
 
-        {
-            let [sas, outgoingVerificationRequest] = await verificationRequest2.startSas();
-            sas2 = sas;
-            expect(sas2).toBeInstanceOf(Sas);
+        expect(sas2.userId.toString()).toStrictEqual(userId2.toString());
+        expect(sas2.deviceId.toString()).toStrictEqual(deviceId2.toString());
+        expect(sas2.otherUserId.toString()).toStrictEqual(userId1.toString());
+        expect(sas2.otherDeviceId.toString()).toStrictEqual(deviceId1.toString());
+        expect(sas2.flowId).toStrictEqual(flowId);
+        expect(sas2.roomId).toBeUndefined();
+        expect(sas2.supportsEmoji()).toStrictEqual(false);
+        expect(sas2.startedFromRequest()).toStrictEqual(true);
+        expect(sas2.isSelfVerification()).toStrictEqual(false);
+        expect(sas2.haveWeConfirmed()).toStrictEqual(false);
+        expect(sas2.hasBeenAccepted()).toStrictEqual(false);
+        expect(sas2.cancelInfo()).toBeUndefined();
+        expect(sas2.weStarted()).toStrictEqual(false);
+        expect(sas2.timedOut()).toStrictEqual(false);
+        expect(sas2.canBePresented()).toStrictEqual(false);
+        expect(sas2.isDone()).toStrictEqual(false);
+        expect(sas2.isCancelled()).toStrictEqual(false);
+        expect(sas2.emoji()).toBeUndefined();
+        expect(sas2.emojiIndex()).toBeUndefined();
+        expect(sas2.decimals()).toBeUndefined();
 
-            expect(sas2.userId.toString()).toStrictEqual(userId2.toString());
-            expect(sas2.deviceId.toString()).toStrictEqual(deviceId2.toString());
-            expect(sas2.otherUserId.toString()).toStrictEqual(userId1.toString());
-            expect(sas2.otherDeviceId.toString()).toStrictEqual(deviceId1.toString());
-            expect(sas2.flowId).toStrictEqual(flowId);
-            expect(sas2.roomId).toBeUndefined();
-            expect(sas2.supportsEmoji()).toStrictEqual(false);
-            expect(sas2.startedFromRequest()).toStrictEqual(true);
-            expect(sas2.isSelfVerification()).toStrictEqual(false);
-            expect(sas2.haveWeConfirmed()).toStrictEqual(false);
-            expect(sas2.hasBeenAccepted()).toStrictEqual(false);
-            expect(sas2.cancelInfo()).toBeUndefined();
-            expect(sas2.weStarted()).toStrictEqual(false);
-            expect(sas2.timedOut()).toStrictEqual(false);
-            expect(sas2.canBePresented()).toStrictEqual(false);
-            expect(sas2.isDone()).toStrictEqual(false);
-            expect(sas2.isCancelled()).toStrictEqual(false);
-            expect(sas2.emoji()).toBeUndefined();
-            expect(sas2.emojiIndex()).toBeUndefined();
-            expect(sas2.decimals()).toBeUndefined();
+        expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
 
-            expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
+        outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
+        expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.start');
 
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
-            expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.start');
+        const toDeviceEvents = {
+            events: [{
+                sender: userId2.toString(),
+                type: outgoingVerificationRequest.event_type,
+                content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
+            }],
+        };
 
-            const toDeviceEvents = {
-                events: [{
-                    sender: userId2.toString(),
-                    type: outgoingVerificationRequest.event_type,
-                    content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
-                }],
-            };
+        // Let's send the SAS start to `m1`.
+        await m1.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
+    });
 
-            // Let's send the SAS start to `m1`.
-            await m1.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
+    // SAS verification for the second machine.
+    let sas1;
+
+    test('can fetch and accept an ongoing SAS verification (`m.key.verification.accept`)', async () => {
+        // Let's fetch the ongoing SAS verification.
+        sas1 = await m1.getVerification(userId2, flowId);
+
+        expect(sas1).toBeInstanceOf(Sas);
+
+        expect(sas1.userId.toString()).toStrictEqual(userId1.toString());
+        expect(sas1.deviceId.toString()).toStrictEqual(deviceId1.toString());
+        expect(sas1.otherUserId.toString()).toStrictEqual(userId2.toString());
+        expect(sas1.otherDeviceId.toString()).toStrictEqual(deviceId2.toString());
+        expect(sas1.flowId).toStrictEqual(flowId);
+        expect(sas1.roomId).toBeUndefined();
+        expect(sas1.startedFromRequest()).toStrictEqual(true);
+        expect(sas1.isSelfVerification()).toStrictEqual(false);
+        expect(sas1.haveWeConfirmed()).toStrictEqual(false);
+        expect(sas1.hasBeenAccepted()).toStrictEqual(false);
+        expect(sas1.cancelInfo()).toBeUndefined();
+        expect(sas1.weStarted()).toStrictEqual(true);
+        expect(sas1.timedOut()).toStrictEqual(false);
+        expect(sas1.canBePresented()).toStrictEqual(false);
+        expect(sas1.isDone()).toStrictEqual(false);
+        expect(sas1.isCancelled()).toStrictEqual(false);
+        expect(sas1.emoji()).toBeUndefined();
+        expect(sas1.emojiIndex()).toBeUndefined();
+        expect(sas1.decimals()).toBeUndefined();
+
+        // Let's accept thet SAS start request.
+        let outgoingVerificationRequest = sas1.accept();
+        expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
+
+        outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
+        expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.accept');
+
+        const toDeviceEvents = {
+            events: [{
+                sender: userId1.toString(),
+                type: outgoingVerificationRequest.event_type,
+                content: outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()],
+            }],
+        };
+
+        // Let's send the SAS accept to `m2`.
+        await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
+    });
+
+    test('emojis are supported by both sides', async () => {
+        expect(sas1.supportsEmoji()).toStrictEqual(true);
+        expect(sas2.supportsEmoji()).toStrictEqual(true);
+    });
+
+    test('one side sends verification key (`m.key.verification.key`)', async () => {
+        // Let's send the verification keys from `m2` to `m1`.
+        const outgoingRequests = await m2.outgoingRequests();
+        let toDeviceRequest = outgoingRequests.find((request) => request.type == RequestType.ToDevice);
+
+        expect(toDeviceRequest).toBeInstanceOf(ToDeviceRequest);
+        const toDeviceRequestId = toDeviceRequest.id;
+        const toDeviceRequestType = toDeviceRequest.type;
+
+        toDeviceRequest = JSON.parse(toDeviceRequest.body);
+        expect(toDeviceRequest.event_type).toStrictEqual('m.key.verification.key');
+
+        const toDeviceEvents = {
+            events: [{
+                sender: userId2.toString(),
+                type: toDeviceRequest.event_type,
+                content: toDeviceRequest.messages[userId1.toString()][deviceId1.toString()],
+            }],
+        };
+
+        // Let's send te SAS key to `m1`.
+        await m1.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
+
+        m2.markRequestAsSent(toDeviceRequestId, toDeviceRequestType, '{}');
+    });
+
+    test('other side sends back verification key (`m.key.verification.key`)', async () => {
+        // Let's send the verification keys from `m1` to `m2`.
+        const outgoingRequests = await m1.outgoingRequests();
+        let toDeviceRequest = outgoingRequests.find((request) => request.type == RequestType.ToDevice);
+
+        expect(toDeviceRequest).toBeInstanceOf(ToDeviceRequest);
+        const toDeviceRequestId = toDeviceRequest.id;
+        const toDeviceRequestType = toDeviceRequest.type;
+
+        toDeviceRequest = JSON.parse(toDeviceRequest.body);
+        expect(toDeviceRequest.event_type).toStrictEqual('m.key.verification.key');
+
+        const toDeviceEvents = {
+            events: [{
+                sender: userId1.toString(),
+                type: toDeviceRequest.event_type,
+                content: toDeviceRequest.messages[userId2.toString()][deviceId2.toString()],
+            }],
+        };
+
+        // Let's send te SAS key to `m2`.
+        await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
+
+        m1.markRequestAsSent(toDeviceRequestId, toDeviceRequestType, '{}');
+    });
+
+    test('emojis match from both sides', async () => {
+        const emojis1 = sas1.emoji();
+        const emojiIndexes1 = sas1.emojiIndex();
+        const emojis2 = sas2.emoji();
+        const emojiIndexes2 = sas2.emojiIndex();
+
+        expect(emojis1).toHaveLength(7);
+        expect(emojiIndexes1).toHaveLength(emojis1.length);
+        expect(emojis2).toHaveLength(emojis1.length);
+        expect(emojiIndexes2).toHaveLength(emojis1.length);
+
+        const isEmoji = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/;
+
+        for (const [emoji1, emojiIndex1, emoji2, emojiIndex2] of zip(emojis1, emojiIndexes1, emojis2, emojiIndexes2)) {
+            expect(emoji1).toBeInstanceOf(Emoji);
+            expect(emoji1.symbol).toMatch(isEmoji);
+            expect(emoji1.description).toBeTruthy();
+
+            expect(emojiIndex1).toBeGreaterThanOrEqual(0);
+            expect(emojiIndex1).toBeLessThanOrEqual(63);
+
+            expect(emoji2).toBeInstanceOf(Emoji);
+            expect(emoji2.symbol).toStrictEqual(emoji1.symbol);
+            expect(emoji2.description).toStrictEqual(emoji1.description);
+
+            expect(emojiIndex2).toStrictEqual(emojiIndex1);
         }
+    });
 
-        // Let's accept the SAS start request.
-        let sas1;
+    test('decimals match from both sides', async () => {
+        const decimals1 = sas1.decimals();
+        const decimals2 = sas2.decimals();
 
-        {
-            const sas = await m1.getVerification(userId2, flowId);
-            sas1 = sas;
+        expect(decimals1).toHaveLength(3);
+        expect(decimals2).toHaveLength(decimals1.length);
 
-            expect(sas1).toBeInstanceOf(Sas);
+        const isDecimal = /^[0-9]{4}$/;
 
-            expect(sas1.userId.toString()).toStrictEqual(userId1.toString());
-            expect(sas1.deviceId.toString()).toStrictEqual(deviceId1.toString());
-            expect(sas1.otherUserId.toString()).toStrictEqual(userId2.toString());
-            expect(sas1.otherDeviceId.toString()).toStrictEqual(deviceId2.toString());
-            expect(sas1.flowId).toStrictEqual(flowId);
-            expect(sas1.roomId).toBeUndefined();
-            expect(sas1.startedFromRequest()).toStrictEqual(true);
-            expect(sas1.isSelfVerification()).toStrictEqual(false);
-            expect(sas1.haveWeConfirmed()).toStrictEqual(false);
-            expect(sas1.hasBeenAccepted()).toStrictEqual(false);
-            expect(sas1.cancelInfo()).toBeUndefined();
-            expect(sas1.weStarted()).toStrictEqual(true);
-            expect(sas1.timedOut()).toStrictEqual(false);
-            expect(sas1.canBePresented()).toStrictEqual(false);
-            expect(sas1.isDone()).toStrictEqual(false);
-            expect(sas1.isCancelled()).toStrictEqual(false);
-            expect(sas1.emoji()).toBeUndefined();
-            expect(sas1.emojiIndex()).toBeUndefined();
-            expect(sas1.decimals()).toBeUndefined();
+        for (const [decimal1, decimal2] of zip(decimals1, decimals2)) {
+            expect(decimal1.toString()).toMatch(isDecimal);
 
-
-            let outgoingVerificationRequest = sas1.accept();
-            expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
-            expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.accept');
-
-            const toDeviceEvents = {
-                events: [{
-                    sender: userId1.toString(),
-                    type: outgoingVerificationRequest.event_type,
-                    content: outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()],
-                }],
-            };
-
-            // Let's send the SAS accept to `m2`.
-            await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
+            expect(decimal2).toStrictEqual(decimal1);
         }
+    });
 
-        // Let's see if SAS's state on both side.
-        {
-            expect(sas1.supportsEmoji()).toStrictEqual(true);
-            expect(sas2.supportsEmoji()).toStrictEqual(true);
-        }
-
-        // Let's send the verification keys.
-        {
-            // From `m2` to `m1`.
-            {
-                const outgoingRequests = await m2.outgoingRequests();
-                let toDeviceRequest = outgoingRequests.find((request) => request.type == RequestType.ToDevice);
-
-                expect(toDeviceRequest).toBeInstanceOf(ToDeviceRequest);
-                const toDeviceRequestId = toDeviceRequest.id;
-                const toDeviceRequestType = toDeviceRequest.type;
-
-                toDeviceRequest = JSON.parse(toDeviceRequest.body);
-                expect(toDeviceRequest.event_type).toStrictEqual('m.key.verification.key');
-
-                const toDeviceEvents = {
-                    events: [{
-                        sender: userId2.toString(),
-                        type: toDeviceRequest.event_type,
-                        content: toDeviceRequest.messages[userId1.toString()][deviceId1.toString()],
-                    }],
-                };
-
-                // Let's send te SAS key to `m1`.
-                await m1.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
-
-                m2.markRequestAsSent(toDeviceRequestId, toDeviceRequestType, '{}');
-            }
-
-            // From `m1` to `m2`.
-            {
-                const outgoingRequests = await m1.outgoingRequests();
-                let toDeviceRequest = outgoingRequests.find((request) => request.type == RequestType.ToDevice);
-
-                expect(toDeviceRequest).toBeInstanceOf(ToDeviceRequest);
-                const toDeviceRequestId = toDeviceRequest.id;
-                const toDeviceRequestType = toDeviceRequest.type;
-
-                toDeviceRequest = JSON.parse(toDeviceRequest.body);
-                expect(toDeviceRequest.event_type).toStrictEqual('m.key.verification.key');
-
-                const toDeviceEvents = {
-                    events: [{
-                        sender: userId1.toString(),
-                        type: toDeviceRequest.event_type,
-                        content: toDeviceRequest.messages[userId2.toString()][deviceId2.toString()],
-                    }],
-                };
-
-                // Let's send te SAS key to `m2`.
-                await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
-
-                m1.markRequestAsSent(toDeviceRequestId, toDeviceRequestType, '{}');
-            }
-        }
-
-        // Let's see the emojis :-].
-        {
-            const emojis1 = sas1.emoji();
-            const emojiIndexes1 = sas1.emojiIndex();
-            const emojis2 = sas2.emoji();
-            const emojiIndexes2 = sas2.emojiIndex();
-
-            expect(emojis1).toHaveLength(7);
-            expect(emojiIndexes1).toHaveLength(emojis1.length);
-            expect(emojis2).toHaveLength(emojis1.length);
-            expect(emojiIndexes2).toHaveLength(emojis1.length);
-
-            const isEmoji = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/;
-
-            for (const [emoji1, emojiIndex1, emoji2, emojiIndex2] of zip(emojis1, emojiIndexes1, emojis2, emojiIndexes2)) {
-                expect(emoji1).toBeInstanceOf(Emoji);
-                expect(emoji1.symbol).toMatch(isEmoji);
-                expect(emoji1.description).toBeTruthy();
-
-                expect(emojiIndex1).toBeGreaterThanOrEqual(0);
-                expect(emojiIndex1).toBeLessThanOrEqual(63);
-
-                expect(emoji2).toBeInstanceOf(Emoji);
-                expect(emoji2.symbol).toStrictEqual(emoji1.symbol);
-                expect(emoji2.description).toStrictEqual(emoji1.description);
-
-                expect(emojiIndex2).toStrictEqual(emojiIndex1);
-            }
-        }
-
-        // Let's see the decimals.
-        {
-            const decimals1 = sas1.decimals();
-            const decimals2 = sas2.decimals();
-
-            expect(decimals1).toHaveLength(3);
-            expect(decimals2).toHaveLength(decimals1.length);
-
-            const isDecimal = /^[0-9]{4}$/;
-
-            for (const [decimal1, decimal2] of zip(decimals1, decimals2)) {
-                expect(decimal1.toString()).toMatch(isDecimal);
-
-                expect(decimal2).toStrictEqual(decimal1);
-            }
-        }
-
-        // Let's confirm the verification: We have a match!
-        {
-
-        }
+    test('can confirm keys match', async () => {
+        // We have a match!
     });
 });
 

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -707,10 +707,13 @@ describe('Key Verification', () => {
         });
 
         test('can read QR code\'s bytes', async () => {
+            const qrCodeHeader = 'MATRIX';
+            const qrCodeVersion = '\x02';
+
             const bytes = qr2.toBytes();
 
             expect(bytes).toHaveLength(122);
-            expect(bytes.slice(0, 10)).toStrictEqual([77, 65, 84, 82, 73, 88, 2, 0, 0, 32]);
+            expect(bytes.slice(0, 7)).toStrictEqual([...qrCodeHeader, ...qrCodeVersion].map(char => char.charCodeAt(0)));
         });
     });
 });

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -721,11 +721,9 @@ describe('Key Verification', () => {
 
             const buffer = qrCode.renderIntoBuffer();
 
-            expect(buffer).toBeInstanceOf(Uint8Array);
-
+            expect(buffer).toBeInstanceOf(Uint8ClampedArray);
             // 45px ⨉ 45px
             expect(buffer).toHaveLength(45 * 45);
-
             // 0 for a white pixel, 1 for a black pixel.
             expect(buffer.every(p => p == 0 || p == 1)).toStrictEqual(true);
         });

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -710,6 +710,7 @@ describe('Key Verification', () => {
             const bytes = qr2.toBytes();
 
             expect(bytes).toHaveLength(122);
+            expect(bytes.slice(0, 10)).toStrictEqual([77, 65, 84, 82, 73, 88, 2, 0, 0, 32]);
         });
     });
 });

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -702,8 +702,6 @@ describe('Key Verification', () => {
             expect(qr2.reciprocated()).toStrictEqual(false);
             expect(qr2.flowId).toMatch(/^[a-f0-9]+$/);
             expect(qr2.roomId).toBeUndefined();
-            expect(qr2.toQrCode()).toBeInstanceOf(QrCode);
-            expect(qr2.toBytes()).toBeInstanceOf(Array);
         });
 
         test('can read QR code\'s bytes', async () => {
@@ -714,6 +712,22 @@ describe('Key Verification', () => {
 
             expect(bytes).toHaveLength(122);
             expect(bytes.slice(0, 7)).toStrictEqual([...qrCodeHeader, ...qrCodeVersion].map(char => char.charCodeAt(0)));
+        });
+
+        test('can render QR code', async () => {
+            const qrCode = qr2.toQrCode();
+
+            expect(qrCode).toBeInstanceOf(QrCode);
+
+            const buffer = qrCode.renderIntoBuffer();
+
+            expect(buffer).toBeInstanceOf(Uint8Array);
+
+            // 45px ⨉ 45px
+            expect(buffer).toHaveLength(45 * 45);
+
+            // 0 for a white pixel, 1 for a black pixel.
+            expect(buffer.every(p => p == 0 || p == 1)).toStrictEqual(true);
         });
     });
 });

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -4,7 +4,6 @@ const {
     DeviceId,
     DeviceKeyId,
     RoomId,
-    DeviceKeyAlgorithName,
     Device,
     LocalTrust,
     UserDevices,
@@ -882,7 +881,7 @@ describe('Key Verification', () => {
             await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
         });
 
-        test('can confirm QR code has beeen confirmed', () => {
+        test('can confirm QR code has been confirmed', () => {
             expect(qr2.hasBeenConfirmed()).toStrictEqual(true);
         });
     });

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -749,7 +749,9 @@ describe('Key Verification', () => {
 
             expect(qrCode).toBeInstanceOf(QrCode);
 
-            let canvasBuffer;
+            // Want to get `canvasBuffer` to render the QR code? Install `npm install canvas` and uncomment the following blocks.
+
+            //let canvasBuffer;
 
             {
                 const buffer = qrCode.renderIntoBuffer();
@@ -760,6 +762,7 @@ describe('Key Verification', () => {
                 // 0 for a white pixel, 1 for a black pixel.
                 expect(buffer.every(p => p == 0 || p == 1)).toStrictEqual(true);
 
+                /*
                 const { Canvas } = require('canvas');
                 const canvas = new Canvas(55, 55);
 
@@ -792,6 +795,7 @@ describe('Key Verification', () => {
 
                 context.putImageData(imageData, 5, 5);
                 canvasBuffer = canvas.toBuffer('image/png');
+                */
             }
 
             // Want to see the QR code? Uncomment the following block.

--- a/bindings/matrix-sdk-crypto-js/tests/helper.js
+++ b/bindings/matrix-sdk-crypto-js/tests/helper.js
@@ -1,5 +1,13 @@
 const { DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest } = require('../pkg/matrix_sdk_crypto_js');
 
+function* zip(...arrays) {
+    const len = Math.min(...arrays.map((array) => array.length));
+
+    for (let nth = 0; nth < len; ++nth) {
+        yield [...arrays.map((array) => array.at(nth))]
+    }
+}
+
 // Add a machine to another machine, i.e. be sure a machine knows
 // another exists.
 async function addMachineToMachine(machineToAdd, machine) {
@@ -55,4 +63,7 @@ async function addMachineToMachine(machineToAdd, machine) {
     }
 }
 
-module.exports = { addMachineToMachine };
+module.exports = {
+    zip,
+    addMachineToMachine,
+};

--- a/bindings/matrix-sdk-crypto-js/tests/helper.js
+++ b/bindings/matrix-sdk-crypto-js/tests/helper.js
@@ -51,12 +51,23 @@ async function addMachineToMachine(machineToAdd, machine) {
     {
         expect(outgoingRequests[1]).toBeInstanceOf(KeysQueryRequest);
 
+        let [signingKeysUploadRequest, _] = await machineToAdd.bootstrapCrossSigning(true);
+        signingKeysUploadRequest = JSON.parse(signingKeysUploadRequest.body);
+
         // Let's forge a `KeysQuery`'s response.
-        let keyQueryResponse = {'device_keys': {}};
+        let keyQueryResponse = {
+            device_keys: {},
+            master_keys: {},
+            self_signing_keys: {},
+            user_signing_keys: {},
+        };
         const userId = machineToAdd.userId.toString();
         const deviceId = machineToAdd.deviceId.toString();
-        keyQueryResponse['device_keys'][userId] = {};
-        keyQueryResponse['device_keys'][userId][deviceId] = keysUploadRequest.device_keys;
+        keyQueryResponse.device_keys[userId] = {};
+        keyQueryResponse.device_keys[userId][deviceId] = keysUploadRequest.device_keys;
+        keyQueryResponse.master_keys[userId] = signingKeysUploadRequest.master_key;
+        keyQueryResponse.self_signing_keys[userId] = signingKeysUploadRequest.self_signing_key;
+        keyQueryResponse.user_signing_keys[userId] = signingKeysUploadRequest.user_signing_key;
 
         const marked = await machine.markRequestAsSent(outgoingRequests[1].id, outgoingRequests[1].type, JSON.stringify(keyQueryResponse));
         expect(marked).toStrictEqual(true);

--- a/bindings/matrix-sdk-crypto-js/tests/helper.js
+++ b/bindings/matrix-sdk-crypto-js/tests/helper.js
@@ -1,0 +1,48 @@
+const { DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest } = require('../pkg/matrix_sdk_crypto_js');
+
+// Add a machine to another machine, i.e. be sure a machine knows
+// another exists.
+async function addMachineToMachine(machineToAdd, machine) {
+    const toDeviceEvents = JSON.stringify({});
+    const changedDevices = new DeviceLists();
+    const oneTimeKeyCounts = new Map();
+    const unusedFallbackKeys = new Set();
+
+    const receiveSyncChanges = JSON.parse(await machineToAdd.receiveSyncChanges(toDeviceEvents, changedDevices, oneTimeKeyCounts, unusedFallbackKeys));
+
+    expect(receiveSyncChanges).toEqual({});
+
+    const outgoingRequests = await machineToAdd.outgoingRequests();
+
+    expect(outgoingRequests).toHaveLength(2);
+
+    let keysUploadRequest;
+    // Read the `KeysUploadRequest`.
+    {
+        expect(outgoingRequests[0]).toBeInstanceOf(KeysUploadRequest);
+        expect(outgoingRequests[0].id).toBeDefined();
+        expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
+
+        const body = JSON.parse(outgoingRequests[0].body);
+        expect(body.device_keys).toBeDefined();
+        expect(body.one_time_keys).toBeDefined();
+
+        keysUploadRequest = body;
+    }
+
+    {
+        // Just to be sure… not important.
+        expect(outgoingRequests[1]).toBeInstanceOf(KeysQueryRequest);
+    }
+
+    // Let's forge a `KeysQuery`'s response.
+    let keyQueryResponse = {'device_keys': {}};
+    const userId = machineToAdd.userId.toString();
+    const deviceId = machineToAdd.deviceId.toString();
+    keyQueryResponse['device_keys'][userId] = {};
+    keyQueryResponse['device_keys'][userId][deviceId] = keysUploadRequest.device_keys;
+
+    await machine.markRequestAsSent('anID', RequestType.KeysQuery, JSON.stringify(keyQueryResponse));
+}
+
+module.exports = { addMachineToMachine };

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -414,7 +414,7 @@ describe(OlmMachine.name, () => {
         const m = await machine();
         const signatures = await m.sign('foo');
 
-        expect(signatures.isEmpty).toStrictEqual(false);
+        expect(signatures.isEmpty()).toStrictEqual(false);
         expect(signatures.count).toStrictEqual(1);
 
         let base64;
@@ -429,8 +429,8 @@ describe(OlmMachine.name, () => {
 
             expect(s).toBeInstanceOf(MaybeSignature);
 
-            expect(s.isValid).toStrictEqual(true);
-            expect(s.isInvalid).toStrictEqual(false);
+            expect(s.isValid()).toStrictEqual(true);
+            expect(s.isInvalid()).toStrictEqual(false);
             expect(s.invalidSignatureSource).toBeUndefined();
 
             base64 = s.signature.toBase64();

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -417,44 +417,52 @@ impl Cancelled {
     }
 }
 
+/// A key verification can be requested and started by a to-device
+/// request or a room event. `FlowId` helps to represent both
+/// usecases.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd)]
 pub enum FlowId {
+    /// The flow ID comes from a to-device request.
     ToDevice(OwnedTransactionId),
+
+    /// The flow ID comes from a room event.
     InRoom(OwnedRoomId, OwnedEventId),
 }
 
 impl FlowId {
+    /// Get the room ID if the flow ID comes from a room event.
     pub fn room_id(&self) -> Option<&RoomId> {
-        if let FlowId::InRoom(room_id, _) = &self {
+        if let Self::InRoom(room_id, _) = &self {
             Some(room_id)
         } else {
             None
         }
     }
 
+    /// Get the ID a string.
     pub fn as_str(&self) -> &str {
         match self {
-            FlowId::InRoom(_, event_id) => event_id.as_str(),
-            FlowId::ToDevice(transaction_id) => transaction_id.as_str(),
+            Self::InRoom(_, event_id) => event_id.as_str(),
+            Self::ToDevice(transaction_id) => transaction_id.as_str(),
         }
     }
 }
 
 impl From<OwnedTransactionId> for FlowId {
     fn from(transaction_id: OwnedTransactionId) -> Self {
-        FlowId::ToDevice(transaction_id)
+        Self::ToDevice(transaction_id)
     }
 }
 
 impl From<(OwnedRoomId, OwnedEventId)> for FlowId {
     fn from(ids: (OwnedRoomId, OwnedEventId)) -> Self {
-        FlowId::InRoom(ids.0, ids.1)
+        Self::InRoom(ids.0, ids.1)
     }
 }
 
 impl From<(&RoomId, &EventId)> for FlowId {
     fn from(ids: (&RoomId, &EventId)) -> Self {
-        FlowId::InRoom(ids.0.to_owned(), ids.1.to_owned())
+        Self::InRoom(ids.0.to_owned(), ids.1.to_owned())
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/matrix-org/matrix-rust-sdk/issues/1016.

This PR is quite important. It brings the Key Verification API to `crypto-js`, aka SAS, Emoji, QR Code and bootstraping cross stuff.

## Progression

* [x] Support `OlmMachine.get_user_devices` (imply supporting a `UserDevices` type),
* [x] Support `OlmMachine.get_device` (imply supporting a `Device` type),
* [x] Support `OlmMachine.get_verification` (imply supporting a `Verificaftion` type),
* [x] Support `OlmMachine.get_verification_request` and `.get_verification_requests` (imply supporting a `VerificationRequest` type),
* [x] Support `OlmMachine.receive_unencrypted_verification_event`,
* [x] Implement `Verification`,
* [x] Implement `VerificationRequest`,
* [x] Implement `Sas`,
* [x] Implement `Emoji`
* [x] Implement `Qr`,
* [x] Implement `QrCode`,
* [x] Implement `CancelInfo`,
* [x] Implement `CancelCode`,
* [x] Implement `DeviceKey`,
* [x] Implement `Device`,
* [x] Implement `LocalTrust`,
* [x] Implement `UserDevices`.