### PR TITLE
test(crypto-nodejs): Increase timeout

### DIFF
--- a/bindings/matrix-sdk-crypto-nodejs/package.json
+++ b/bindings/matrix-sdk-crypto-nodejs/package.json
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "build": "napi build --platform --release --strip",
-        "test": "jest --verbose",
+        "test": "jest --verbose --testTimeout 10000",
         "doc": "typedoc --tsconfig ."
     }
 }


### PR DESCRIPTION
For some unknown reasons, sometimes, randomly, one test (initializing
an `OlmMachine` with a local store with a passphrase) can take more
than 5s, only on Github Actions. Let's increase the test timeout value
so that the entire test suite doesn't fail.