### PR TITLE
Make Store type internal to the base crate

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -65,6 +65,7 @@ use crate::{
     store::{
         ambiguity_map::AmbiguityCache, Result as StoreResult, StateChanges, Store, StoreConfig,
     },
+    StateStore,
 };
 
 /// A no IO Client implementation.
@@ -134,9 +135,19 @@ impl BaseClient {
         self.store.session()
     }
 
+    /// Get all the rooms this client knows about.
+    pub fn get_rooms(&self) -> Vec<Room> {
+        self.store.get_rooms()
+    }
+
+    /// Get all the rooms this client knows about.
+    pub fn get_stripped_rooms(&self) -> Vec<Room> {
+        self.store.get_stripped_rooms()
+    }
+
     /// Get a reference to the store.
-    pub fn store(&self) -> &Store {
-        &self.store
+    pub fn store(&self) -> &dyn StateStore {
+        &*self.store
     }
 
     /// Is the client logged in.

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -43,7 +43,7 @@ pub use http;
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{DisplayName, Room, RoomInfo, RoomMember, RoomType};
-pub use store::{StateChanges, StateStore, Store, StoreError};
+pub use store::{StateChanges, StateStore, StoreError};
 pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,
 };

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -104,16 +104,7 @@ impl Room {
         room_id: &RoomId,
         room_type: RoomType,
     ) -> Self {
-        let room_info = RoomInfo {
-            room_id: room_id.into(),
-            room_type,
-            notification_counts: Default::default(),
-            summary: Default::default(),
-            members_synced: false,
-            last_prev_batch: None,
-            base_info: BaseRoomInfo::new(),
-        };
-
+        let room_info = RoomInfo::new(room_id, room_type);
         Self::restore(own_user_id, store, room_info)
     }
 
@@ -651,6 +642,18 @@ pub struct RoomInfo {
 }
 
 impl RoomInfo {
+    pub(crate) fn new(room_id: &RoomId, room_type: RoomType) -> Self {
+        Self {
+            room_id: room_id.into(),
+            room_type,
+            notification_counts: Default::default(),
+            summary: Default::default(),
+            members_synced: false,
+            last_prev_batch: None,
+            base_info: BaseRoomInfo::new(),
+        }
+    }
+
     /// Mark this Room as joined
     pub fn mark_as_joined(&mut self) {
         self.room_type = RoomType::Joined;

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -642,7 +642,8 @@ pub struct RoomInfo {
 }
 
 impl RoomInfo {
-    pub(crate) fn new(room_id: &RoomId, room_type: RoomType) -> Self {
+    #[doc(hidden)] // used by store tests, otherwise it would be pub(crate)
+    pub fn new(room_id: &RoomId, room_type: RoomType) -> Self {
         Self {
             room_id: room_id.into(),
             room_type,

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -52,7 +52,7 @@ macro_rules! statestore_integration_tests {
                 use matrix_sdk_test::{async_test, test_json};
                 use ruma::{
                     api::client::media::get_content_thumbnail::v3::Method,
-                    device_id, event_id,
+                    event_id,
                     events::{
                         presence::PresenceEvent,
                         room::{
@@ -83,14 +83,13 @@ macro_rules! statestore_integration_tests {
                     deserialized_responses::{ RoomEvent, SyncRoomEvent, TimelineSlice},
                 };
                 use $crate::{
-                    RoomType, Session,
                     media::{MediaFormat, MediaRequest, MediaThumbnailSize},
                     store::{
-                        Store,
                         StateStore,
                         Result as StoreResult,
                         StateChanges
-                    }
+                    },
+                    RoomInfo, RoomType,
                 };
 
                 use super::get_store;
@@ -115,22 +114,13 @@ macro_rules! statestore_integration_tests {
                 }
 
                 /// Populate the given `StateStore`.
-                pub(crate) async fn populated_store(inner: Arc<dyn StateStore>) -> StoreResult<Store> {
+                pub async fn populate_store(store: Arc<dyn StateStore>) -> StoreResult<()> {
                     let mut changes = StateChanges::default();
-                    let store = Store::new(inner);
 
                     let user_id = user_id();
                     let invited_user_id = invited_user_id();
                     let room_id = room_id();
                     let stripped_room_id = stripped_room_id();
-                    let device_id = device_id!("device");
-
-                    let session = Session {
-                        access_token: "token".to_owned(),
-                        user_id: user_id.to_owned(),
-                        device_id: device_id.to_owned(),
-                    };
-                    store.restore_session(session).await.unwrap();
 
                     changes.sync_token = Some("t392-516_47314_0_7_1_1_1_11444_1".to_owned());
 
@@ -147,7 +137,7 @@ macro_rules! statestore_integration_tests {
                     let pushrules_event = pushrules_raw.deserialize().unwrap();
                     changes.add_account_data(pushrules_event, pushrules_raw);
 
-                    let mut room = store.get_or_create_room(room_id, RoomType::Joined).await.clone_info();
+                    let mut room = RoomInfo::new(room_id, RoomType::Joined);
                     room.mark_as_left();
 
                     let tag_json: &JsonValue = &test_json::TAG;
@@ -220,8 +210,7 @@ macro_rules! statestore_integration_tests {
                     changes.members.insert(room_id.to_owned(), room_members);
                     changes.add_room(room);
 
-                    let mut stripped_room =
-                        store.get_or_create_stripped_room(stripped_room_id).await.clone_info();
+                    let mut stripped_room = RoomInfo::new(room_id, RoomType::Invited);
 
                     let stripped_name_json: &JsonValue = &test_json::NAME_STRIPPED;
                     let stripped_name_raw =
@@ -249,7 +238,7 @@ macro_rules! statestore_integration_tests {
                     changes.add_stripped_member(stripped_room_id, stripped_member_event);
 
                     store.save_changes(&changes).await?;
-                    Ok(store)
+                    Ok(())
                 }
 
                 fn power_level_event() -> Raw<AnySyncStateEvent> {
@@ -305,7 +294,8 @@ macro_rules! statestore_integration_tests {
                     let user_id = user_id();
                     let inner_store = get_store().await?;
 
-                    let store = populated_store(Arc::new(inner_store)).await?;
+                    let store = Arc::new(inner_store);
+                    populate_store(store.clone()).await?;
 
                     assert!(store.get_sync_token().await?.is_some());
                     assert!(store.get_presence_event(user_id).await?.is_some());
@@ -580,25 +570,24 @@ macro_rules! statestore_integration_tests {
 
                 #[async_test]
                 async fn test_persist_invited_room() -> StoreResult<()> {
-                    let stripped_room_id = stripped_room_id();
                     let inner_store = get_store().await?;
-                    let store = populated_store(Arc::new(inner_store)).await?;
+                    let store = Arc::new(inner_store);
+                    populate_store(store.clone()).await?;
 
                     assert_eq!(store.get_stripped_room_infos().await?.len(), 1);
-                    assert!(store.get_stripped_room(stripped_room_id).is_some());
 
-                    // populate rooom
                     Ok(())
                 }
 
                 #[async_test]
-                async fn test_room_removal() -> StoreResult<()>  {
+                async fn test_room_removal() -> StoreResult<()> {
                     let room_id = room_id();
                     let user_id = user_id();
                     let inner_store = get_store().await?;
                     let stripped_room_id = stripped_room_id();
 
-                    let store = populated_store(Arc::new(inner_store)).await?;
+                    let store = Arc::new(inner_store);
+                    populate_store(store.clone()).await?;
 
                     store.remove_room(room_id).await?;
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -408,7 +408,7 @@ where
 /// This adds additional higher level store functionality on top of a
 /// `StateStore` implementation.
 #[derive(Debug, Clone)]
-pub struct Store {
+pub(crate) struct Store {
     pub(super) inner: Arc<dyn StateStore>,
     session: Arc<OnceCell<Session>>,
     /// The current sync token that should be used for the next sync call.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -30,7 +30,7 @@ use futures_core::stream::Stream;
 use matrix_sdk_base::{
     deserialized_responses::SyncResponse,
     media::{MediaEventContent, MediaFormat, MediaRequest, MediaThumbnailSize},
-    BaseClient, Session, Store,
+    BaseClient, Session, StateStore,
 };
 use matrix_sdk_common::{
     instant::{Duration, Instant},
@@ -289,12 +289,12 @@ impl Client {
     /// Can be used with [`Client::restore_login`] to restore a previously
     /// logged-in session.
     pub fn session(&self) -> Option<&Session> {
-        self.store().session()
+        self.base_client().session()
     }
 
-    /// Get a reference to the store.
-    pub fn store(&self) -> &Store {
-        self.inner.base_client.store()
+    /// Get a reference to the state store.
+    pub fn store(&self) -> &dyn StateStore {
+        self.base_client().store()
     }
 
     /// Get the account of the current owner of the client.
@@ -533,7 +533,7 @@ impl Client {
     ///
     /// This will return the list of joined, invited, and left rooms.
     pub fn rooms(&self) -> Vec<room::Room> {
-        self.store()
+        self.base_client()
             .get_rooms()
             .into_iter()
             .map(|room| room::Common::new(self.clone(), room).into())
@@ -542,7 +542,7 @@ impl Client {
 
     /// Returns the joined rooms this client knows about.
     pub fn joined_rooms(&self) -> Vec<room::Joined> {
-        self.store()
+        self.base_client()
             .get_rooms()
             .into_iter()
             .filter_map(|room| room::Joined::new(self.clone(), room))
@@ -551,7 +551,7 @@ impl Client {
 
     /// Returns the invited rooms this client knows about.
     pub fn invited_rooms(&self) -> Vec<room::Invited> {
-        self.store()
+        self.base_client()
             .get_stripped_rooms()
             .into_iter()
             .filter_map(|room| room::Invited::new(self.clone(), room))
@@ -560,7 +560,7 @@ impl Client {
 
     /// Returns the left rooms this client knows about.
     pub fn left_rooms(&self) -> Vec<room::Left> {
-        self.store()
+        self.base_client()
             .get_rooms()
             .into_iter()
             .filter_map(|room| room::Left::new(self.clone(), room))
@@ -573,7 +573,9 @@ impl Client {
     ///
     /// `room_id` - The unique id of the room that should be fetched.
     pub fn get_room(&self, room_id: &RoomId) -> Option<room::Room> {
-        self.store().get_room(room_id).map(|room| room::Common::new(self.clone(), room).into())
+        self.base_client()
+            .get_room(room_id)
+            .map(|room| room::Common::new(self.clone(), room).into())
     }
 
     /// Get a joined room with the given room id.
@@ -582,7 +584,7 @@ impl Client {
     ///
     /// `room_id` - The unique id of the room that should be fetched.
     pub fn get_joined_room(&self, room_id: &RoomId) -> Option<room::Joined> {
-        self.store().get_room(room_id).and_then(|room| room::Joined::new(self.clone(), room))
+        self.base_client().get_room(room_id).and_then(|room| room::Joined::new(self.clone(), room))
     }
 
     /// Get an invited room with the given room id.
@@ -591,7 +593,7 @@ impl Client {
     ///
     /// `room_id` - The unique id of the room that should be fetched.
     pub fn get_invited_room(&self, room_id: &RoomId) -> Option<room::Invited> {
-        self.store().get_room(room_id).and_then(|room| room::Invited::new(self.clone(), room))
+        self.base_client().get_room(room_id).and_then(|room| room::Invited::new(self.clone(), room))
     }
 
     /// Get a left room with the given room id.
@@ -600,7 +602,7 @@ impl Client {
     ///
     /// `room_id` - The unique id of the room that should be fetched.
     pub fn get_left_room(&self, room_id: &RoomId) -> Option<room::Left> {
-        self.store().get_room(room_id).and_then(|room| room::Left::new(self.clone(), room))
+        self.base_client().get_room(room_id).and_then(|room| room::Left::new(self.clone(), room))
     }
 
     /// Resolve a room alias to a room id and a list of servers which know


### PR DESCRIPTION
I think this is worth two reviews. After this it should be very simple to inline `Store` type into the `BaseClient`, but I didn't want to implement that part before it's clear we actually want to go this direction 🙂 