### PR TITLE
Hunting the nodejs segfault bug, long-term

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -61,13 +61,28 @@ jobs:
         working-directory: ${{ env.MATRIX_SDK_CRYPTO_NODEJS_PATH }}
         run: npm install
 
+      # Building in dev-mode and copy lib for potential failure case
       - name: Build the Node.js binding
         working-directory: ${{ env.MATRIX_SDK_CRYPTO_NODEJS_PATH }}
-        run: npm run build
+        run: |
+          npm run build
+          cp *.node non-release-mode-lib.node
+
+      - name: Build the Node.js binding
+        working-directory: ${{ env.MATRIX_SDK_CRYPTO_NODEJS_PATH }}
+        run: npm run release-build
 
       - name: Test the Node.js binding
         working-directory: ${{ env.MATRIX_SDK_CRYPTO_NODEJS_PATH }}
         run: npm run test
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Failure Files
+          path: |
+            bindings/matrix-sdk-crypto-nodejs/*.node
+            /var/crash/*.crash
 
       - if: ${{ matrix.build-doc }}
         name: Build the documentation

--- a/bindings/matrix-sdk-crypto-nodejs/package.json
+++ b/bindings/matrix-sdk-crypto-nodejs/package.json
@@ -21,7 +21,8 @@
         "node": ">= 14"
     },
     "scripts": {
-        "build": "napi build --platform --release --strip",
+        "release-build": "napi build --platform --release --strip",
+        "build": "napi build --platform",
         "test": "jest --verbose --testTimeout 10000",
         "doc": "typedoc --tsconfig ."
     }


### PR DESCRIPTION
This extends the CI job to:
1. build a non-release non-stripped version of the lib, we keep around
2. upon failure in the test, we bundle the lib, the non-stripped lib and the crash up as an artifact for us to investigate with.

