### PR TITLE
fix(sdk): Use the local config variable to decide identity assertion

### DIFF
--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -125,7 +125,7 @@ impl HttpClient {
         }
 
         trace!("Serializing request");
-        let request = if !self.request_config.assert_identity {
+        let request = if !config.assert_identity {
             let send_access_token = if auth_scheme == AuthScheme::None && !config.force_auth {
                 // Small optimization: Don't take the session lock if we know the auth token
                 // isn't going to be used anyways.


### PR DESCRIPTION
Without this fix a potentially provided per-request config gets ignored.