### PR TITLE
fix(bindings/cryto-nodejs): Fix memory corruption in async functions

### DIFF
--- a/bindings/matrix-sdk-crypto-nodejs/src/identifiers.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/identifiers.rs
@@ -59,10 +59,6 @@ impl UserId {
     }
 }
 
-pub(crate) fn lower_user_ids_to_ruma(users: Vec<&UserId>) -> impl Iterator<Item = &ruma::UserId> {
-    users.into_iter().map(|user| user.inner.as_ref())
-}
-
 /// A Matrix device ID.
 ///
 /// Device identifiers in Matrix are completely opaque character


### PR DESCRIPTION
In async functions, the Node.js GC may or may not (that's a random
behavior) collect the arguments passed to the function as soon as it
returns. The function may not be executed yet, since it's async. Thus,
it leads to memory corruption: The function tries to read later on the
value inside an argument and… it crashes at best.

To avoid this bug, there is no other choice than cloning the values
before the function returns, in its “sync path” (so before any
transformation of an `.await` point into an “async block”).

The performance impact is not “massive”, I'm not sure it could be
noticeable easily since it is most of the time related to identifiers
(e.g. `UserId`), which are cheap to clone. I have to find the balance
here, and cloning offers the best trade off from my point of view.