### PR TITLE
feat(bindings/crypto-nodejs): Transform `timeout` into milliseconds

### DIFF
--- a/bindings/matrix-sdk-crypto-nodejs/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/machine.rs
@@ -215,8 +215,7 @@ impl OlmMachine {
             .into_iter()
             .map(requests::OutgoingRequest)
             .map(TryFrom::try_from)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(into_err)
+            .collect()
     }
 
     /// Mark the request with the given request ID as sent.

--- a/bindings/matrix-sdk-crypto-nodejs/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/requests.rs
@@ -14,6 +14,8 @@ use ruma::api::client::keys::{
     upload_signatures::v3::Request as RumaSignatureUploadRequest,
 };
 
+use crate::into_err;
+
 /// Data for a request to the `/keys/upload` API endpoint
 /// ([specification]).
 ///
@@ -224,7 +226,7 @@ impl KeysBackupRequest {
 macro_rules! request {
     ($request:ident from $ruma_request:ident maps fields $( $field:ident $( { $transformation:expr } )? ),+ $(,)? ) => {
         impl TryFrom<(String, &$ruma_request)> for $request {
-            type Error = serde_json::Error;
+            type Error = napi::Error;
 
             fn try_from(
                 (request_id, request): (String, &$ruma_request),
@@ -239,13 +241,13 @@ macro_rules! request {
                             $transformation
                         };
                     )?
-                    map.insert(stringify!($field).to_owned(), serde_json::to_value(field)?);
+                    map.insert(stringify!($field).to_owned(), serde_json::to_value(field).map_err(into_err)?);
                 )+
                 let value = serde_json::Value::Object(map);
 
                 Ok($request {
                     id: request_id,
-                    body: serde_json::to_string(&value)?.into(),
+                    body: serde_json::to_string(&value).map_err(into_err)?.into(),
                 })
             }
         }
@@ -253,8 +255,8 @@ macro_rules! request {
 }
 
 request!(KeysUploadRequest from RumaKeysUploadRequest maps fields device_keys, one_time_keys, fallback_keys);
-request!(KeysQueryRequest from RumaKeysQueryRequest maps fields timeout { timeout.as_ref().map(Duration::as_millis) }, device_keys, token);
-request!(KeysClaimRequest from RumaKeysClaimRequest maps fields timeout { timeout.as_ref().map(Duration::as_millis) }, one_time_keys);
+request!(KeysQueryRequest from RumaKeysQueryRequest maps fields timeout { timeout.as_ref().map(Duration::as_millis).map(u64::try_from).transpose().map_err(into_err)? }, device_keys, token);
+request!(KeysClaimRequest from RumaKeysClaimRequest maps fields timeout { timeout.as_ref().map(Duration::as_millis).map(u64::try_from).transpose().map_err(into_err)? }, one_time_keys);
 request!(ToDeviceRequest from RumaToDeviceRequest maps fields event_type, txn_id, messages);
 request!(SignatureUploadRequest from RumaSignatureUploadRequest maps fields signed_keys);
 request!(RoomMessageRequest from RumaRoomMessageRequest maps fields room_id, txn_id, content);
@@ -273,7 +275,7 @@ pub type OutgoingRequests = Either7<
 pub(crate) struct OutgoingRequest(pub(crate) matrix_sdk_crypto::OutgoingRequest);
 
 impl TryFrom<OutgoingRequest> for OutgoingRequests {
-    type Error = serde_json::Error;
+    type Error = napi::Error;
 
     fn try_from(outgoing_request: OutgoingRequest) -> Result<Self, Self::Error> {
         let request_id = outgoing_request.0.request_id().to_string();

--- a/bindings/matrix-sdk-crypto-nodejs/tests/requests.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/requests.test.js
@@ -26,5 +26,4 @@ for (const request of [
             expect(() => { new (request)() }).toThrow();
         });
     })
-
 }


### PR DESCRIPTION
This patch fixes #801.

Once encoded into JavaScript, this patch transforms `timeout: Option<Duration>` from `"timeout":{"nanos":0,"secs":10}` to `"timeout": 10000` if there is some duration.

Please @turt2live, can you test it with your code before I merge this patch? In the test suites, `KeysClaimRequest` and `KeysQueryRequest` always have `None` for their `timeout: Option<Duration>` field.