### PR TITLE
feat(bindings/crypto-nodejs): Implement an `Attachment` API.

### DIFF
--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -30,8 +30,8 @@ matrix-sdk-common = { version = "0.5.0", path = "../../crates/matrix-sdk-common"
 matrix-sdk-sled = { version = "0.1.0", path = "../../crates/matrix-sdk-sled", default-features = false, features = ["crypto-store"] }
 ruma = { git = "https://github.com/ruma/ruma", rev = "96155915f", features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"] }
 vodozemac = {  git = "https://github.com/matrix-org/vodozemac/", rev = "d0e744287a14319c2a9148fef3747548c740fc36" }
-napi = { git = "https://github.com/Hywan/napi-rs", branch = "feat-either-n-up-to-26", default-features = false, features = ["napi6", "tokio_rt"] }
-napi-derive = { git = "https://github.com/Hywan/napi-rs", branch = "feat-either-n-up-to-26" }
+napi = { version = "2.6.1", default-features = false, features = ["napi6", "tokio_rt"] }
+napi-derive = "2.6.0"
 serde_json = "1.0.79"
 http = "0.2.6"
 zeroize = "1.3.0"

--- a/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
@@ -80,6 +80,9 @@ impl EncryptedAttachment {
     ///
     /// The media encryption information aren't stored as a string:
     /// they are parsed, validated and fully deserialized.
+    ///
+    /// See [the specification to learn
+    /// more](https://spec.matrix.org/unstable/client-server-api/#extensions-to-mroommessage-msgtypes).
     #[napi(constructor)]
     pub fn new(encrypted_data: Uint8Array, media_encryption_info: String) -> napi::Result<Self> {
         Ok(Self {

--- a/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
@@ -64,7 +64,9 @@ impl Attachment {
 #[napi]
 pub struct EncryptedAttachment {
     media_encryption_info: matrix_sdk_crypto::MediaEncryptionInfo,
-    encrypted_data: Uint8Array,
+
+    /// The actual encrypted data.
+    pub encrypted_data: Uint8Array,
 }
 
 #[napi]
@@ -92,15 +94,5 @@ impl EncryptedAttachment {
     #[napi(getter)]
     pub fn media_encryption_info(&self) -> String {
         serde_json::to_string(&self.media_encryption_info).unwrap()
-    }
-
-    /// Return a **copy** of the encrypted data in a new `Uint8Array`.
-    ///
-    /// We are aware this is not ideal to copy the value, but the
-    /// current available Node.js API does seem be limited in that
-    /// regard.
-    #[napi(getter)]
-    pub fn encrypted_data(&self) -> Uint8Array {
-        Uint8Array::new(self.encrypted_data.deref().to_owned())
     }
 }

--- a/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
@@ -1,0 +1,106 @@
+use std::{
+    io::{Cursor, Read},
+    ops::Deref,
+};
+
+use napi::bindgen_prelude::Uint8Array;
+use napi_derive::*;
+
+use crate::into_err;
+
+/// A type to encrypt and to decrypt anything that can fit in an
+/// `Uint8Array`, usually big buffer.
+#[napi]
+pub struct Attachment;
+
+#[napi]
+impl Attachment {
+    /// Encrypt the content of the `Uint8Array`.
+    ///
+    /// It produces an `EncryptedAttachment`, we can be used to
+    /// retrieve the media encryption information, or the encrypted
+    /// data.
+    #[napi]
+    pub fn encrypt(array: Uint8Array) -> napi::Result<EncryptedAttachment> {
+        let buffer: &[u8] = array.deref();
+
+        let mut cursor = Cursor::new(buffer);
+        let mut encryptor = matrix_sdk_crypto::AttachmentEncryptor::new(&mut cursor);
+
+        let mut encrypted_data = Vec::new();
+        encryptor.read_to_end(&mut encrypted_data).map_err(into_err)?;
+
+        let media_encryption_info = encryptor.finish();
+
+        Ok(EncryptedAttachment {
+            encrypted_data: Uint8Array::new(encrypted_data),
+            media_encryption_info,
+        })
+    }
+
+    /// Decrypt an `EncryptedAttachment`.
+    ///
+    /// The encrypted attachment can be created manually, or from the
+    /// `encrypt` method.
+    #[napi]
+    pub fn decrypt(attachment: &EncryptedAttachment) -> napi::Result<Uint8Array> {
+        let encrypted_data: &[u8] = attachment.encrypted_data.deref();
+
+        let mut cursor = Cursor::new(encrypted_data);
+        let mut decryptor = matrix_sdk_crypto::AttachmentDecryptor::new(
+            &mut cursor,
+            attachment.media_encryption_info.clone(),
+        )
+        .map_err(into_err)?;
+
+        let mut decrypted_data = Vec::new();
+        decryptor.read_to_end(&mut decrypted_data).map_err(into_err)?;
+
+        Ok(Uint8Array::new(decrypted_data))
+    }
+}
+
+/// An encrypted attachment, usually created from `Attachment.encrypt`.
+#[napi]
+pub struct EncryptedAttachment {
+    media_encryption_info: matrix_sdk_crypto::MediaEncryptionInfo,
+    encrypted_data: Uint8Array,
+}
+
+#[napi]
+impl EncryptedAttachment {
+    /// Create a new encrypted attachment manually.
+    ///
+    /// It needs encrypted data, stored in an `Uint8Array`, and a
+    /// [media encryption
+    /// information](https://docs.rs/matrix-sdk-crypto/latest/matrix_sdk_crypto/struct.MediaEncryptionInfo.html),
+    /// as a JSON-encoded string.
+    ///
+    /// The media encryption information aren't stored as a string:
+    /// they are parsed, validated and fully deserialized.
+    #[napi(constructor)]
+    pub fn new(encrypted_data: Uint8Array, media_encryption_info: String) -> napi::Result<Self> {
+        Ok(Self {
+            encrypted_data,
+            media_encryption_info: serde_json::from_str(media_encryption_info.as_str())
+                .map_err(into_err)?,
+        })
+    }
+
+    /// Return the media encryption info as a JSON-encoded string. The
+    /// structure is fully valid.
+    #[napi(getter)]
+    pub fn media_encryption_info(&self) -> String {
+        serde_json::to_string(&self.media_encryption_info).unwrap()
+    }
+
+    /// Return a **copy** of the encrypted data in a new `Uint8Array`.
+    ///
+    /// We are aware this is not ideal to copy the value, but the
+    /// current available Node.js API does seem be limited in that
+    /// regard.
+    #[napi(getter)]
+    pub fn encrypted_data(&self) -> napi::Result<Uint8Array> {
+        Ok(Uint8Array::new(self.encrypted_data.deref().to_owned()))
+    }
+}

--- a/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
@@ -100,7 +100,7 @@ impl EncryptedAttachment {
     /// current available Node.js API does seem be limited in that
     /// regard.
     #[napi(getter)]
-    pub fn encrypted_data(&self) -> napi::Result<Uint8Array> {
-        Ok(Uint8Array::new(self.encrypted_data.deref().to_owned()))
+    pub fn encrypted_data(&self) -> Uint8Array {
+        Uint8Array::new(self.encrypted_data.deref().to_owned())
     }
 }

--- a/bindings/matrix-sdk-crypto-nodejs/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/lib.rs
@@ -16,6 +16,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //#![warn(missing_docs, missing_debug_implementations)]
 
+pub mod attachment;
 pub mod encryption;
 mod errors;
 pub mod events;

--- a/bindings/matrix-sdk-crypto-nodejs/tests/attachment.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/attachment.test.js
@@ -14,7 +14,7 @@ describe(Attachment.name, () => {
 
         expect(mediaEncryptionInfo).toMatchObject({
             v: 'v2',
-            web_key: {
+            key: {
                 kty: expect.any(String),
                 key_ops: expect.arrayContaining(['encrypt', 'decrypt']),
                 alg: expect.any(String),
@@ -47,7 +47,7 @@ describe(EncryptedAttachment.name, () => {
             new Uint8Array([24, 150, 67, 37, 144]),
             JSON.stringify({
                 v: 'v2',
-                web_key: {
+                key: {
                     kty: 'oct',
                     key_ops: [ 'encrypt', 'decrypt' ],
                     alg: 'A256CTR',

--- a/bindings/matrix-sdk-crypto-nodejs/tests/attachment.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/attachment.test.js
@@ -32,9 +32,18 @@ describe(Attachment.name, () => {
     });
 
     test('can decrypt data', () => {
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(false);
+
         const decryptedAttachment = Attachment.decrypt(encryptedAttachment);
 
         expect(textDecoder.decode(decryptedAttachment)).toStrictEqual(originalData);
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(true);
+    });
+
+    test('can only decrypt once', () => {
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(true);
+
+        expect(() => { textDecoder.decode(decryptedAttachment) }).toThrow()
     });
 });
 
@@ -61,6 +70,8 @@ describe(EncryptedAttachment.name, () => {
             })
         );
 
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(false);
         expect(textDecoder.decode(Attachment.decrypt(encryptedAttachment))).toStrictEqual(originalData);
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(true);
     });
 });

--- a/bindings/matrix-sdk-crypto-nodejs/tests/attachment.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/attachment.test.js
@@ -1,0 +1,66 @@
+const { Attachment, EncryptedAttachment } = require('../');
+
+describe(Attachment.name, () => {
+    const originalData = 'hello';
+    const textEncoder = new TextEncoder();
+    const textDecoder = new TextDecoder();
+
+    let encryptedAttachment;
+    
+    test('can encrypt data', () => {
+        encryptedAttachment = Attachment.encrypt(textEncoder.encode(originalData));
+
+        const mediaEncryptionInfo = JSON.parse(encryptedAttachment.mediaEncryptionInfo);
+
+        expect(mediaEncryptionInfo).toMatchObject({
+            v: 'v2',
+            web_key: {
+                kty: expect.any(String),
+                key_ops: expect.arrayContaining(['encrypt', 'decrypt']),
+                alg: expect.any(String),
+                k: expect.any(String),
+                ext: expect.any(Boolean),
+            },
+            iv: expect.stringMatching(/^[A-Za-z0-9\+/]+$/),
+            hashes: {
+                sha256: expect.stringMatching(/^[A-Za-z0-9\+/]+$/)
+            }
+        });
+
+        const encryptedData = encryptedAttachment.encryptedData;
+        expect(encryptedData.every((i) => { i != 0 })).toStrictEqual(false);
+    });
+
+    test('can decrypt data', () => {
+        const decryptedAttachment = Attachment.decrypt(encryptedAttachment);
+
+        expect(textDecoder.decode(decryptedAttachment)).toStrictEqual(originalData);
+    });
+});
+
+describe(EncryptedAttachment.name, () => {
+    const originalData = 'hello';
+    const textDecoder = new TextDecoder();
+
+    test('can be created manually', () => {
+        const encryptedAttachment = new EncryptedAttachment(
+            new Uint8Array([24, 150, 67, 37, 144]),
+            JSON.stringify({
+                v: 'v2',
+                web_key: {
+                    kty: 'oct',
+                    key_ops: [ 'encrypt', 'decrypt' ],
+                    alg: 'A256CTR',
+                    k: 'QbNXUjuukFyEJ8cQZjJuzN6mMokg0HJIjx0wVMLf5BM',
+                    ext: true
+                },
+                iv: 'xk2AcWkomiYAAAAAAAAAAA',
+                hashes: {
+                    sha256: 'JsRbDXgOja4xvDiF3DwBuLHdxUzIrVYIuj7W/t3aEok'
+                }
+            })
+        );
+
+        expect(textDecoder.decode(Attachment.decrypt(encryptedAttachment))).toStrictEqual(originalData);
+    });
+});

--- a/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -381,7 +381,7 @@ describe(OlmMachine.name, () => {
 
             base64 = signature['ed25519:foobar'].signature.toBase64();
 
-            expect(base64).toMatch(/^[A-Za-z0-9+/]+$/);
+            expect(base64).toMatch(/^[A-Za-z0-9\+/]+$/);
             expect(signature['ed25519:foobar'].signature.ed25519.toBase64()).toStrictEqual(base64);
         }
 

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -277,7 +277,7 @@ impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
 
 /// Struct holding all the information that is needed to decrypt an encrypted
 /// file.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MediaEncryptionInfo {
     #[serde(rename = "v")]
     /// The version of the encryption scheme.

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -277,7 +277,7 @@ impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
 
 /// Struct holding all the information that is needed to decrypt an encrypted
 /// file.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MediaEncryptionInfo {
     /// The version of the encryption scheme.
     #[serde(rename = "v")]

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -313,7 +313,7 @@ mod tests {
     fn example_key() -> MediaEncryptionInfo {
         let info = json!({
             "v": "v2",
-            "web_key": {
+            "key": {
                 "kty": "oct",
                 "alg": "A256CTR",
                 "ext": true,

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -136,7 +136,7 @@ impl<'a, R: Read + 'a> AttachmentDecryptor<'a, R> {
 
         let hash =
             info.hashes.get("sha256").ok_or(DecryptorError::MissingHash)?.as_bytes().to_owned();
-        let mut key = info.web_key.k.into_inner();
+        let mut key = info.key.k.into_inner();
         let iv = info.iv.into_inner();
 
         if key.len() != KEY_SIZE {
@@ -270,7 +270,7 @@ impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
             version: VERSION.to_owned(),
             hashes: self.hashes,
             iv: self.iv,
-            web_key: self.web_key,
+            key: self.web_key,
         }
     }
 }
@@ -283,8 +283,7 @@ pub struct MediaEncryptionInfo {
     #[serde(rename = "v")]
     pub version: String,
     /// The web key that was used to encrypt the file.
-    #[serde(rename = "key")]
-    pub web_key: JsonWebKey,
+    pub key: JsonWebKey,
     /// The initialization vector that was used to encrypt the file.
     pub iv: Base64,
     /// The hashes that can be used to check the validity of the file.
@@ -293,7 +292,7 @@ pub struct MediaEncryptionInfo {
 
 impl From<EncryptedFile> for MediaEncryptionInfo {
     fn from(file: EncryptedFile) -> Self {
-        Self { version: file.v, web_key: file.key, iv: file.iv, hashes: file.hashes }
+        Self { version: file.v, key: file.key, iv: file.iv, hashes: file.hashes }
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -279,10 +279,11 @@ impl<'a, R: Read + ?Sized + 'a> AttachmentEncryptor<'a, R> {
 /// file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MediaEncryptionInfo {
-    #[serde(rename = "v")]
     /// The version of the encryption scheme.
+    #[serde(rename = "v")]
     pub version: String,
     /// The web key that was used to encrypt the file.
+    #[serde(rename = "key")]
     pub web_key: JsonWebKey,
     /// The initialization vector that was used to encrypt the file.
     pub iv: Base64,

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -126,7 +126,7 @@ impl Client {
                 let keys = reader.finish();
                 ruma::events::room::EncryptedFileInit {
                     url: response.content_uri,
-                    key: keys.web_key,
+                    key: keys.key,
                     iv: keys.iv,
                     hashes: keys.hashes,
                     v: keys.version,
@@ -155,7 +155,7 @@ impl Client {
             let keys = reader.finish();
             ruma::events::room::EncryptedFileInit {
                 url: response.content_uri,
-                key: keys.web_key,
+                key: keys.key,
                 iv: keys.iv,
                 hashes: keys.hashes,
                 v: keys.version,


### PR DESCRIPTION
This patch fixes https://github.com/matrix-org/matrix-rust-sdk/issues/796.

This patch provides a new API to encrypt and decrypt attachment, i.e. big buffer of type `Uint8Array`.

This patch also fixes a bug in `matrix_sdk_crypto::MediaEncryptedInfo` where its `web_key` field should serialize to and deserialize from `key` to respect [the specification](https://spec.matrix.org/v1.2/client-server-api/#extensions-to-mroommessage-msgtypes).

It's based on `matrix_sdk_crypto::AttachmentEncryptor` and `AttachmentDecryptor`.

~~Note: I'm really not happy with the fact `EncryptedAttachment.encryptedData` returns a **copy**. But we cannot return a `&T` with `napi-rs`. I tried to create a new buffer that references data from elsewhere, like with [`Uint8Array::with_external_data`](https://docs.rs/napi/latest/napi/bindgen_prelude/struct.Uint8Array.html#method.with_external_data), but the data are collected by the GC (which notifies us before dropping the data); that's not what we want. I then tried with [`Reference`](https://docs.rs/napi/latest/napi/bindgen_prelude/struct.Reference.html) or [`Ref`](https://docs.rs/napi/latest/napi/struct.Ref.html), but `napi-rs` doesn't allow to return them from a function, so it's useless. I'll investigate that. In the meantime, as mentionned in #796, right now, [there is a copy](https://github.com/matrix-org/matrix-rust-sdk-bindings/blob/main/crates/matrix-sdk-crypto-nodejs/src/attachments.rs) in the previous `matrix-sdk-crypto-nodejs` API. This patch is actually better as it doesn't need to serialize and deserialize the entire data, it just computes a new `Uint8Array`, which is an improvement.~~ This is now fixed. Data are no longer copied!