### PR TITLE
Add an authentication service to the FFI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ emsdk-*
 ## User settings
 xcuserdata/
 .vscode/
+
+## OS garbage
+.DS_Store

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -154,20 +154,30 @@ interface MediaSource {
     string url();
 };
 
-interface AuthenticationService {
-    [Throws=ClientError]
-    constructor(string base_path, string server_name);
-    
-    string homeserver();
-    string? authentication_server();
+[Error]
+enum AuthenticationError {
+  "ClientMissing",
+  "ClientBuilderFailed",
+  "GetLoginFlowsFailed",
+  "LoginFailed",
+};
 
-    [Throws=ClientError]
+interface AuthenticationService {
+    constructor(string base_path);
+    
+    [Throws=AuthenticationError]
+    string homeserver();
+    
+    [Throws=AuthenticationError]
+    string? authentication_issuer();
+
+    [Throws=AuthenticationError]
     boolean supports_password_login();
     
-    [Throws=ClientError]
-    void update(string server_name);
+    [Throws=AuthenticationError]
+    void use_server(string server_name);
     
-    [Throws=ClientError]
+    [Throws=AuthenticationError]
     Client login(string username, string password);
 };
 

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -38,6 +38,8 @@ interface Client {
     [Throws=ClientError]
     void restore_login(string restore_token);
 
+    string homeserver();
+
     void start_sync();
 
     [Throws=ClientError]
@@ -150,6 +152,23 @@ interface EmoteMessage {
 
 interface MediaSource {
     string url();
+};
+
+interface AuthenticationService {
+    [Throws=ClientError]
+    constructor(string base_path, string server_name);
+    
+    string homeserver();
+    string? authentication_server();
+
+    [Throws=ClientError]
+    boolean supports_password_login();
+    
+    [Throws=ClientError]
+    void update(string server_name);
+    
+    [Throws=ClientError]
+    Client login(string username, string password);
 };
 
 interface SessionVerificationEmoji {

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -157,9 +157,7 @@ interface MediaSource {
 [Error]
 enum AuthenticationError {
   "ClientMissing",
-  "ClientBuilderFailed",
-  "GetLoginFlowsFailed",
-  "LoginFailed",
+  "Generic",
 };
 
 interface AuthenticationService {

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use super::{client::Client, client_builder::ClientBuilder};
+
+pub struct AuthenticationService {
+    base_path: String,
+    client: Arc<Client>,
+}
+
+impl AuthenticationService {
+    /// Creates a new service to authenticate with the specified server.
+    pub fn new(base_path: String, server_name: String) -> anyhow::Result<Self> {
+        // Construct a username as the builder currently requires one.
+        let username = format!("@auth:{}", server_name);
+        let client =
+            Arc::new(ClientBuilder::new()).base_path(base_path.clone()).username(username).build();
+
+        client.and_then(|client| Ok(AuthenticationService { base_path, client }))
+    }
+
+    /// The currently configured homeserver.
+    pub fn homeserver(&self) -> String {
+        self.client.homeserver()
+    }
+
+    /// The authentication server to complete an OIDC login on the current
+    /// homeserver.
+    pub fn authentication_server(&self) -> Option<String> {
+        self.client.authentication_server()
+    }
+
+    /// Whether the current homeserver supports the password login flow.
+    pub fn supports_password_login(&self) -> anyhow::Result<bool> {
+        self.client.supports_password_login()
+    }
+
+    /// Updates the server to authenticate with the specified homeserver.
+    pub fn update(&self, server_name: String) -> anyhow::Result<()> {
+        // Construct a username as the builder currently requires one.
+        let username = format!("@auth:{}", server_name);
+        let client = Arc::new(ClientBuilder::new())
+            .base_path(self.base_path.clone())
+            .username(username)
+            .build();
+
+        match client {
+            Ok(client) => {
+                self.client = client;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Performs a password login using the current homeserver.
+    pub fn login(&self, username: String, password: String) -> anyhow::Result<Arc<Client>> {
+        let result = self.client.login(username, password);
+
+        match result {
+            Ok(_) => Ok(self.client.clone()),
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -10,43 +10,72 @@ pub struct AuthenticationService {
 }
 
 struct ClientContainer {
-    client: Arc<Client>,
+    client: Option<Arc<Client>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AuthenticationError {
+    #[error("A successfull call to use_server must be made first.")]
+    ClientMissing,
+    #[error("The client could not be built: {message}")]
+    ClientBuilderFailed { message: String },
+    #[error("Unable to get the supported login flows: {message}")]
+    GetLoginFlowsFailed { message: String },
+    #[error("Login was unsuccessful: {message}")]
+    LoginFailed { message: String },
+}
+
+impl From<anyhow::Error> for AuthenticationError {
+    fn from(e: anyhow::Error) -> AuthenticationError {
+        AuthenticationError::LoginFailed { message: e.to_string() }
+    }
 }
 
 impl AuthenticationService {
     /// Creates a new service to authenticate with the specified server.
-    pub fn new(base_path: String, server_name: String) -> anyhow::Result<Self> {
-        // Construct a username as the builder currently requires one.
-        let username = format!("@auth:{}", server_name);
-        let client =
-            Arc::new(ClientBuilder::new()).base_path(base_path.clone()).username(username).build();
-
-        client.and_then(|client| {
-            Ok(AuthenticationService {
-                base_path,
-                client_container: RwLock::new(ClientContainer { client }),
-            })
-        })
+    pub fn new(base_path: String) -> Self {
+        AuthenticationService {
+            base_path,
+            client_container: RwLock::new(ClientContainer { client: None }),
+        }
     }
 
     /// The currently configured homeserver.
-    pub fn homeserver(&self) -> String {
-        self.client_container.read().client.homeserver()
+    pub fn homeserver(&self) -> Result<String, AuthenticationError> {
+        self.client_container
+            .read()
+            .client
+            .as_ref()
+            .ok_or(AuthenticationError::ClientMissing)
+            .and_then(|client| Ok(client.homeserver()))
     }
 
-    /// The authentication server to complete an OIDC login on the current
-    /// homeserver.
-    pub fn authentication_server(&self) -> Option<String> {
-        self.client_container.read().client.authentication_server()
+    /// The OIDC Provider that is trusted by the homeserver.
+    pub fn authentication_issuer(&self) -> Result<Option<String>, AuthenticationError> {
+        self.client_container
+            .read()
+            .client
+            .as_ref()
+            .ok_or(AuthenticationError::ClientMissing)
+            .and_then(|client| Ok(client.authentication_issuer()))
     }
 
     /// Whether the current homeserver supports the password login flow.
-    pub fn supports_password_login(&self) -> anyhow::Result<bool> {
-        self.client_container.read().client.supports_password_login()
+    pub fn supports_password_login(&self) -> Result<bool, AuthenticationError> {
+        self.client_container
+            .read()
+            .client
+            .as_ref()
+            .ok_or(AuthenticationError::ClientMissing)
+            .and_then(|client| {
+                client.supports_password_login().map_err(|error| {
+                    AuthenticationError::GetLoginFlowsFailed { message: error.to_string() }
+                })
+            })
     }
 
     /// Updates the server to authenticate with the specified homeserver.
-    pub fn update(&self, server_name: String) -> anyhow::Result<()> {
+    pub fn use_server(&self, server_name: String) -> Result<(), AuthenticationError> {
         // Construct a username as the builder currently requires one.
         let username = format!("@auth:{}", server_name);
         let client = Arc::new(ClientBuilder::new())
@@ -57,21 +86,27 @@ impl AuthenticationService {
         match client {
             Ok(client) => {
                 let mut client_containter = self.client_container.write();
-                client_containter.client = client;
+                client_containter.client = Some(client);
                 Ok(())
             }
-            Err(e) => Err(e),
+            Err(error) => {
+                Err(AuthenticationError::ClientBuilderFailed { message: error.to_string() })
+            }
         }
     }
 
     /// Performs a password login using the current homeserver.
-    pub fn login(&self, username: String, password: String) -> anyhow::Result<Arc<Client>> {
-        let client = &self.client_container.read().client;
-        let result = client.login(username, password);
-
-        match result {
-            Ok(_) => Ok(client.clone()),
-            Err(e) => Err(e),
+    pub fn login(
+        &self,
+        username: String,
+        password: String,
+    ) -> Result<Arc<Client>, AuthenticationError> {
+        match self.client_container.read().client.as_ref() {
+            Some(client) => client
+                .login(username, password)
+                .and_then(|_| Ok(client.clone()))
+                .map_err(|error| AuthenticationError::from(error)),
+            None => Err(AuthenticationError::ClientMissing),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -1,9 +1,15 @@
 use std::sync::Arc;
 
+use parking_lot::RwLock;
+
 use super::{client::Client, client_builder::ClientBuilder};
 
 pub struct AuthenticationService {
     base_path: String,
+    client_container: RwLock<ClientContainer>,
+}
+
+struct ClientContainer {
     client: Arc<Client>,
 }
 
@@ -15,23 +21,28 @@ impl AuthenticationService {
         let client =
             Arc::new(ClientBuilder::new()).base_path(base_path.clone()).username(username).build();
 
-        client.and_then(|client| Ok(AuthenticationService { base_path, client }))
+        client.and_then(|client| {
+            Ok(AuthenticationService {
+                base_path,
+                client_container: RwLock::new(ClientContainer { client }),
+            })
+        })
     }
 
     /// The currently configured homeserver.
     pub fn homeserver(&self) -> String {
-        self.client.homeserver()
+        self.client_container.read().client.homeserver()
     }
 
     /// The authentication server to complete an OIDC login on the current
     /// homeserver.
     pub fn authentication_server(&self) -> Option<String> {
-        self.client.authentication_server()
+        self.client_container.read().client.authentication_server()
     }
 
     /// Whether the current homeserver supports the password login flow.
     pub fn supports_password_login(&self) -> anyhow::Result<bool> {
-        self.client.supports_password_login()
+        self.client_container.read().client.supports_password_login()
     }
 
     /// Updates the server to authenticate with the specified homeserver.
@@ -45,7 +56,8 @@ impl AuthenticationService {
 
         match client {
             Ok(client) => {
-                self.client = client;
+                let mut client_containter = self.client_container.write();
+                client_containter.client = client;
                 Ok(())
             }
             Err(e) => Err(e),
@@ -54,10 +66,11 @@ impl AuthenticationService {
 
     /// Performs a password login using the current homeserver.
     pub fn login(&self, username: String, password: String) -> anyhow::Result<Arc<Client>> {
-        let result = self.client.login(username, password);
+        let client = &self.client_container.read().client;
+        let result = client.login(username, password);
 
         match result {
-            Ok(_) => Ok(self.client.clone()),
+            Ok(_) => Ok(client.clone()),
             Err(e) => Err(e),
         }
     }

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -15,7 +15,7 @@ struct ClientContainer {
 
 #[derive(Debug, thiserror::Error)]
 pub enum AuthenticationError {
-    #[error("A successfull call to use_server must be made first.")]
+    #[error("A successful call to use_server must be made first.")]
     ClientMissing,
     #[error("An error occurred: {message}")]
     Generic { message: String },
@@ -78,8 +78,8 @@ impl AuthenticationService {
 
         match client {
             Ok(client) => {
-                let mut client_containter = self.client_container.write();
-                client_containter.client = Some(client);
+                let mut client_container = self.client_container.write();
+                client_container.client = Some(client);
                 Ok(())
             }
             Err(error) => Err(AuthenticationError::Generic { message: error.to_string() }),

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -77,11 +77,11 @@ impl Client {
         RUNTIME.block_on(async move { self.client.homeserver().await.to_string() })
     }
 
-    /// The authentication server used by the client's homeserver. `nil` when
+    /// The OIDC Provider that is trusted by the homeserver. `nil` when
     /// not configured.
-    pub fn authentication_server(&self) -> Option<String> {
+    pub fn authentication_issuer(&self) -> Option<String> {
         RUNTIME.block_on(async move {
-            self.client.authentication_server().await.map(|server| server.to_string())
+            self.client.authentication_issuer().await.map(|server| server.to_string())
         })
     }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -89,9 +89,8 @@ impl Client {
     pub fn supports_password_login(&self) -> anyhow::Result<bool> {
         RUNTIME.block_on(async move {
             let login_types = self.client.get_login_types().await?;
-            let supports_password = login_types.flows.iter().any(|login_type| match login_type {
-                get_login_types::v3::LoginType::Password(_) => true,
-                _ => false,
+            let supports_password = login_types.flows.iter().any(|login_type| {
+                matches!(login_type, get_login_types::v3::LoginType::Password(_))
             });
             Ok(supports_password)
         })

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -6,6 +6,7 @@ use matrix_sdk::{
     ruma::{
         api::client::{
             filter::{FilterDefinition, LazyLoadOptions, RoomEventFilter, RoomFilter},
+            session::get_login_types,
             sync::sync_events::v3::Filter,
         },
         events::room::MediaSource,
@@ -69,6 +70,31 @@ impl Client {
 
     pub fn set_delegate(&self, delegate: Option<Box<dyn ClientDelegate>>) {
         *self.delegate.write() = delegate;
+    }
+
+    /// The homeserver this client is configured to use.
+    pub fn homeserver(&self) -> String {
+        RUNTIME.block_on(async move { self.client.homeserver().await.to_string() })
+    }
+
+    /// The authentication server used by the client's homeserver. `nil` when
+    /// not configured.
+    pub fn authentication_server(&self) -> Option<String> {
+        RUNTIME.block_on(async move {
+            self.client.authentication_server().await.map(|server| server.to_string())
+        })
+    }
+
+    /// Whether or not the client's homeserver supports the password login flow.
+    pub fn supports_password_login(&self) -> anyhow::Result<bool> {
+        RUNTIME.block_on(async move {
+            let login_types = self.client.get_login_types().await?;
+            let supports_password = login_types.flows.iter().any(|login_type| match login_type {
+                get_login_types::v3::LoginType::Password(_) => true,
+                _ => false,
+            });
+            Ok(supports_password)
+        })
     }
 
     pub fn start_sync(&self) {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -77,7 +77,7 @@ impl Client {
         RUNTIME.block_on(async move { self.client.homeserver().await.to_string() })
     }
 
-    /// The OIDC Provider that is trusted by the homeserver. `nil` when
+    /// The OIDC Provider that is trusted by the homeserver. `None` when
     /// not configured.
     pub fn authentication_issuer(&self) -> Option<String> {
         RUNTIME.block_on(async move {

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![allow(unused_qualifications)]
 
+pub mod authentication_service;
 pub mod backward_stream;
 pub mod client;
 pub mod client_builder;
@@ -23,7 +24,10 @@ pub static RUNTIME: Lazy<Runtime> =
 
 pub use matrix_sdk::ruma::{api::client::account::register, UserId};
 
-pub use self::{backward_stream::*, client::*, messages::*, room::*, session_verification::*};
+pub use self::{
+    authentication_service::*, backward_stream::*, client::*, messages::*, room::*,
+    session_verification::*,
+};
 
 #[derive(Default, Debug)]
 pub struct ClientState {

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -116,7 +116,7 @@ features = ["client-api-c", "compat", "rand", "unstable-msc2448"]
 [dependencies.ruma-client-api]
 git = "https://github.com/ruma/ruma"
 rev = "96155915f"
-features = ["compat", "unstable-msc2965"]
+features = ["unstable-msc2965"]
 
 [dependencies.tokio-stream]
 version = "0.1.8"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -113,6 +113,11 @@ git = "https://github.com/ruma/ruma"
 rev = "96155915f"
 features = ["client-api-c", "compat", "rand", "unstable-msc2448"]
 
+[dependencies.ruma-client-api]
+git = "https://github.com/ruma/ruma"
+rev = "96155915f"
+features = ["compat", "unstable-msc2965"]
+
 [dependencies.tokio-stream]
 version = "0.1.8"
 features = ["net"]

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -295,6 +295,7 @@ impl ClientBuilder {
         let base_client = BaseClient::with_store_config(self.store_config);
         let http_client = HttpClient::new(inner_http_client.clone(), self.request_config);
 
+        let mut authentication_server: Option<Url> = None;
         let homeserver = match homeserver_cfg {
             HomeserverConfig::Url(url) => url,
             HomeserverConfig::ServerName(server_name) => {
@@ -313,14 +314,20 @@ impl ClientBuilder {
                         err => ClientBuildError::Http(err),
                     })?;
 
+                if let Some(base_url) = well_known.authentication.map(|server| server.issuer) {
+                    authentication_server = Url::parse(&base_url).ok();
+                };
+
                 well_known.homeserver.base_url
             }
         };
 
         let homeserver = RwLock::new(Url::parse(&homeserver)?);
+        let authentication_server = authentication_server.map(|server| RwLock::new(server));
 
         let inner = Arc::new(ClientInner {
             homeserver,
+            authentication_server,
             http_client,
             base_client,
             server_versions: OnceCell::new_with(self.server_versions),

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -323,7 +323,7 @@ impl ClientBuilder {
         };
 
         let homeserver = RwLock::new(Url::parse(&homeserver)?);
-        let authentication_issuer = authentication_issuer.map(|server| RwLock::new(server));
+        let authentication_issuer = authentication_issuer.map(RwLock::new);
 
         let inner = Arc::new(ClientInner {
             homeserver,

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -295,7 +295,7 @@ impl ClientBuilder {
         let base_client = BaseClient::with_store_config(self.store_config);
         let http_client = HttpClient::new(inner_http_client.clone(), self.request_config);
 
-        let mut authentication_server: Option<Url> = None;
+        let mut authentication_issuer: Option<Url> = None;
         let homeserver = match homeserver_cfg {
             HomeserverConfig::Url(url) => url,
             HomeserverConfig::ServerName(server_name) => {
@@ -314,8 +314,8 @@ impl ClientBuilder {
                         err => ClientBuildError::Http(err),
                     })?;
 
-                if let Some(base_url) = well_known.authentication.map(|server| server.issuer) {
-                    authentication_server = Url::parse(&base_url).ok();
+                if let Some(issuer) = well_known.authentication.map(|auth| auth.issuer) {
+                    authentication_issuer = Url::parse(&issuer).ok();
                 };
 
                 well_known.homeserver.base_url
@@ -323,11 +323,11 @@ impl ClientBuilder {
         };
 
         let homeserver = RwLock::new(Url::parse(&homeserver)?);
-        let authentication_server = authentication_server.map(|server| RwLock::new(server));
+        let authentication_issuer = authentication_issuer.map(|server| RwLock::new(server));
 
         let inner = Arc::new(ClientInner {
             homeserver,
-            authentication_server,
+            authentication_issuer,
             http_client,
             base_client,
             server_versions: OnceCell::new_with(self.server_versions),

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -297,9 +297,10 @@ impl Client {
     /// The OIDC Provider that is trusted by the homeserver.
     pub async fn authentication_issuer(&self) -> Option<Url> {
         if let Some(server) = &self.inner.authentication_issuer {
-            return Some(server.read().await.clone());
+            Some(server.read().await.clone())
+        } else {
+            None
         }
-        None
     }
 
     /// Get the user id of the current owner of the client.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -299,7 +299,7 @@ impl Client {
         if let Some(server) = &self.inner.authentication_issuer {
             return Some(server.read().await.clone());
         }
-        return None;
+        None
     }
 
     /// Get the user id of the current owner of the client.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -135,6 +135,8 @@ pub struct Client {
 pub(crate) struct ClientInner {
     /// The URL of the homeserver to connect to.
     homeserver: RwLock<Url>,
+    /// The URL of the authentication server to connect to.
+    authentication_server: Option<RwLock<Url>>,
     /// The underlying HTTP client.
     http_client: HttpClient,
     /// User session data.
@@ -290,6 +292,14 @@ impl Client {
     /// The Homeserver of the client.
     pub async fn homeserver(&self) -> Url {
         self.inner.homeserver.read().await.clone()
+    }
+
+    /// The authentication server of the client.
+    pub async fn authentication_server(&self) -> Option<Url> {
+        if let Some(server) = &self.inner.authentication_server {
+            return Some(server.read().await.clone());
+        }
+        return None;
     }
 
     /// Get the user id of the current owner of the client.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -135,8 +135,8 @@ pub struct Client {
 pub(crate) struct ClientInner {
     /// The URL of the homeserver to connect to.
     homeserver: RwLock<Url>,
-    /// The URL of the authentication server to connect to.
-    authentication_server: Option<RwLock<Url>>,
+    /// The OIDC Provider that is trusted by the homeserver.
+    authentication_issuer: Option<RwLock<Url>>,
     /// The underlying HTTP client.
     http_client: HttpClient,
     /// User session data.
@@ -294,9 +294,9 @@ impl Client {
         self.inner.homeserver.read().await.clone()
     }
 
-    /// The authentication server of the client.
-    pub async fn authentication_server(&self) -> Option<Url> {
-        if let Some(server) = &self.inner.authentication_server {
+    /// The OIDC Provider that is trusted by the homeserver.
+    pub async fn authentication_issuer(&self) -> Option<Url> {
+        if let Some(server) = &self.inner.authentication_issuer {
             return Some(server.read().await.clone());
         }
         return None;


### PR DESCRIPTION
This PR adds a basic authentication service to the FFI that abstracts away the client until a login has been completed successfully. Additionally it adds
- An `authentication_issuer` property to the SDK client for OIDC detection.

Always happy to learn of any changes that would make this into more idiomatic Rust :)