### PR TITLE
test: Replace mockito with wiremock

### DIFF
--- a/crates/matrix-sdk-appservice/Cargo.toml
+++ b/crates/matrix-sdk-appservice/Cargo.toml
@@ -46,6 +46,6 @@ warp = { version = "0.3.2", default-features = false }
 
 [dev-dependencies]
 matrix-sdk-test = { version = "0.5.0", path = "../matrix-sdk-test", features = ["appservice"] }
-mockito = "0.31.0"
 tokio = { version = "1.17.0", default-features = false, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = "0.3.11"
+wiremock = "0.5.13"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -142,7 +142,6 @@ dirs = "4.0.0"
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }
 matches = "0.1.9"
 matrix-sdk-test = { version = "0.5.0", path = "../matrix-sdk-test" }
-mockito = "0.31.0"
 once_cell = "1.10.0"
 serde_json = "1.0.79"
 tempfile = "3.3.0"
@@ -154,6 +153,7 @@ wasm-bindgen-test = "0.3.30"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.17.0", default-features = false, features = ["rt-multi-thread", "macros"] }
+wiremock = "0.5.13"
 
 [[example]]
 name = "cross_signing_bootstrap"

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -353,8 +353,8 @@ fn homeserver_from_name(server_name: &ServerName) -> String {
     #[cfg(not(test))]
     return format!("https://{}", server_name);
 
-    // Mockito only knows how to test http endpoints:
-    // https://github.com/lipanski/mockito/issues/127
+    // Wiremock only knows how to test http endpoints:
+    // https://github.com/LukeMathWalker/wiremock-rs/issues/58
     #[cfg(test)]
     return format!("http://{}", server_name);
 }

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -576,7 +576,7 @@ mod tests {
     async fn event_handler() -> crate::Result<()> {
         use std::sync::atomic::{AtomicU8, Ordering::SeqCst};
 
-        let client = crate::client::tests::logged_in_client().await;
+        let client = crate::client::tests::logged_in_client(None).await;
 
         let member_count = Arc::new(AtomicU8::new(0));
         let typing_count = Arc::new(AtomicU8::new(0));

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -8,31 +8,31 @@ use matrix_sdk::{
     config::SyncSettings,
 };
 use matrix_sdk_test::{async_test, test_json};
-use mockito::{mock, Matcher};
 use ruma::{
     api::client::membership::Invite3pidInit, assign, event_id,
     events::room::message::RoomMessageEventContent, mxc_uri, room_id, thirdparty, uint, user_id,
     TransactionId,
 };
 use serde_json::json;
+use wiremock::{
+    matchers::{body_partial_json, header, method, path, path_regex},
+    Mock, ResponseTemplate,
+};
 
-use crate::logged_in_client;
+use crate::{logged_in_client, mock_sync};
 
 #[async_test]
 async fn invite_user_by_id() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/invite".to_owned()))
-        .with_status(200)
-        .with_body(test_json::LOGOUT.to_string())
-        .match_header("authorization", "Bearer 1234")
-        .create();
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/invite$"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGOUT))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -46,20 +46,16 @@ async fn invite_user_by_id() {
 
 #[async_test]
 async fn invite_user_by_3pid() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/invite".to_owned()))
-        .with_status(200)
-        // empty JSON object
-        .with_body(test_json::LOGOUT.to_string())
-        .match_header("authorization", "Bearer 1234")
-        .create();
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/invite$"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGOUT))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -82,20 +78,16 @@ async fn invite_user_by_3pid() {
 
 #[async_test]
 async fn leave_room() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/leave".to_owned()))
-        .with_status(200)
-        // this is an empty JSON object
-        .with_body(test_json::LOGOUT.to_string())
-        .match_header("authorization", "Bearer 1234")
-        .create();
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/leave$"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGOUT))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -108,20 +100,16 @@ async fn leave_room() {
 
 #[async_test]
 async fn ban_user() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/ban".to_owned()))
-        .with_status(200)
-        // this is an empty JSON object
-        .with_body(test_json::LOGOUT.to_string())
-        .match_header("authorization", "Bearer 1234")
-        .create();
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/ban$"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGOUT))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -135,20 +123,16 @@ async fn ban_user() {
 
 #[async_test]
 async fn kick_user() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/kick".to_owned()))
-        .with_status(200)
-        // this is an empty JSON object
-        .with_body(test_json::LOGOUT.to_string())
-        .match_header("authorization", "Bearer 1234")
-        .create();
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/kick$"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGOUT))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -162,20 +146,16 @@ async fn kick_user() {
 
 #[async_test]
 async fn read_receipt() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/receipt".to_owned()))
-        .with_status(200)
-        // this is an empty JSON object
-        .with_body(test_json::LOGOUT.to_string())
-        .match_header("authorization", "Bearer 1234")
-        .create();
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGOUT))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -189,20 +169,16 @@ async fn read_receipt() {
 
 #[async_test]
 async fn read_marker() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/read_markers".to_owned()))
-        .with_status(200)
-        // this is an empty JSON object
-        .with_body(test_json::LOGOUT.to_string())
-        .match_header("authorization", "Bearer 1234")
-        .create();
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/read_markers$"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGOUT))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -216,20 +192,16 @@ async fn read_marker() {
 
 #[async_test]
 async fn typing_notice() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/typing".to_owned()))
-        .with_status(200)
-        // this is an empty JSON object
-        .with_body(test_json::LOGOUT.to_string())
-        .match_header("authorization", "Bearer 1234")
-        .create();
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/typing"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::LOGOUT))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -244,19 +216,16 @@ async fn typing_notice() {
 async fn room_state_event_send() {
     use ruma::events::room::member::{MembershipState, RoomMemberEventContent};
 
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/state/.*".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::EVENT_ID.to_string())
-        .create();
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -276,19 +245,16 @@ async fn room_state_event_send() {
 
 #[async_test]
 async fn room_message_send() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::EVENT_ID.to_string())
-        .create();
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -305,35 +271,31 @@ async fn room_message_send() {
 
 #[async_test]
 async fn room_attachment_send() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .match_body(Matcher::PartialJson(json!({
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_partial_json(json!({
             "info": {
-                "mimetype": "image/jpeg"
+                "mimetype": "image/jpeg",
             }
         })))
-        .with_body(test_json::EVENT_ID.to_string())
-        .create();
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/media/r0/upload".to_owned()))
-        .with_status(200)
-        .match_header("content-type", "image/jpeg")
-        .with_body(
-            json!({
-              "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
-            })
-            .to_string(),
-        )
-        .create();
+    Mock::given(method("POST"))
+        .and(path("/_matrix/media/r0/upload"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(header("content-type", "image/jpeg"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
+        })))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -353,37 +315,33 @@ async fn room_attachment_send() {
 
 #[async_test]
 async fn room_attachment_send_info() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .match_body(Matcher::PartialJson(json!({
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_partial_json(json!({
             "info": {
                 "mimetype": "image/jpeg",
                 "h": 600,
                 "w": 800,
             }
         })))
-        .with_body(test_json::EVENT_ID.to_string())
-        .create();
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
 
-    let upload_mock = mock("POST", Matcher::Regex(r"^/_matrix/media/r0/upload".to_owned()))
-        .with_status(200)
-        .match_header("content-type", "image/jpeg")
-        .with_body(
-            json!({
-              "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
-            })
-            .to_string(),
-        )
-        .create();
+    Mock::given(method("POST"))
+        .and(path("/_matrix/media/r0/upload"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(header("content-type", "image/jpeg"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
+        })))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -403,43 +361,38 @@ async fn room_attachment_send_info() {
     let response =
         room.send_attachment("image", &mime::IMAGE_JPEG, &mut media, config).await.unwrap();
 
-    upload_mock.assert();
     assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
 }
 
 #[async_test]
 async fn room_attachment_send_wrong_info() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .match_body(Matcher::PartialJson(json!({
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_partial_json(json!({
             "info": {
                 "mimetype": "image/jpeg",
                 "h": 600,
                 "w": 800,
             }
         })))
-        .with_body(test_json::EVENT_ID.to_string())
-        .create();
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
 
-    let _m = mock("POST", Matcher::Regex(r"^/_matrix/media/r0/upload".to_owned()))
-        .with_status(200)
-        .match_header("content-type", "image/jpeg")
-        .with_body(
-            json!({
-              "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
-            })
-            .to_string(),
-        )
-        .create();
+    Mock::given(method("POST"))
+        .and(path("/_matrix/media/r0/upload"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(header("content-type", "image/jpeg"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
+        })))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -464,12 +417,12 @@ async fn room_attachment_send_wrong_info() {
 
 #[async_test]
 async fn room_attachment_send_info_thumbnail() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/send/".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .match_body(Matcher::PartialJson(json!({
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_partial_json(json!({
             "info": {
                 "mimetype": "image/jpeg",
                 "h": 600,
@@ -483,26 +436,22 @@ async fn room_attachment_send_info_thumbnail() {
                 "thumbnail_url": "mxc://example.com/AQwafuaFswefuhsfAFAgsw",
             }
         })))
-        .with_body(test_json::EVENT_ID.to_string())
-        .create();
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
 
-    let upload_mock = mock("POST", Matcher::Regex(r"^/_matrix/media/r0/upload".to_owned()))
-        .with_status(200)
-        .match_header("content-type", "image/jpeg")
-        .with_body(
-            json!({
-              "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
-            })
-            .to_string(),
-        )
+    Mock::given(method("POST"))
+        .and(path("/_matrix/media/r0/upload"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(header("content-type", "image/jpeg"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+          "content_uri": "mxc://example.com/AQwafuaFswefuhsfAFAgsw"
+        })))
         .expect(2)
-        .create();
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -533,25 +482,21 @@ async fn room_attachment_send_info_thumbnail() {
     let response =
         room.send_attachment("image", &mime::IMAGE_JPEG, &mut media, config).await.unwrap();
 
-    upload_mock.assert();
     assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
 }
 
 #[async_test]
 async fn room_redact() {
-    let client = logged_in_client().await;
+    let (client, server) = logged_in_client().await;
 
-    let _m = mock("PUT", Matcher::Regex(r"^/_matrix/client/r0/rooms/.*/redact/.*?/.*?".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::EVENT_ID.to_string())
-        .create();
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/redact/.*?/.*?"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
 
-    let _m = mock("GET", Matcher::Regex(r"^/_matrix/client/r0/sync\?.*$".to_owned()))
-        .with_status(200)
-        .match_header("authorization", "Bearer 1234")
-        .with_body(test_json::SYNC.to_string())
-        .create();
+    mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 


### PR DESCRIPTION
The issue with mockito is that it uses only one server so all the tests must be run sequentially. Wiremock uses a pool of servers so the tests can be run in parallel.

On my machine, the matrix-sdk integration tests took ~3.3s with mockito. With wiremock they now take ~1s, which is almost 70% quicker and the difference should grow with the number of tests.

It also avoids an issue I encountered at some point where all the tests hang if a single test hangs. It's then easier to find out which test is the culprit.