### PR TITLE
test: Optimize sha2 even in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ lto = true
 # Optimize quote even in debug mode. Speeds up proc-macros enough to account
 # for the extra time of optimizing it for a clean build of matrix-sdk-ffi.
 quote = { opt-level = 2 }
+sha2 = { opt-level = 2 }


### PR DESCRIPTION
This makes the tests finish on my machine twice as fast. This works mainly because some tests utilize pbkdf2 to derive a key from a passphrase.