### PR TITLE
refactor(appservice)!: Improve API and cleanup docs

### DIFF
--- a/crates/matrix-sdk-appservice/examples/appservice_autojoin.rs
+++ b/crates/matrix-sdk-appservice/examples/appservice_autojoin.rs
@@ -31,7 +31,7 @@ pub async fn handle_room_member(
             error_if_user_not_in_use(error)?;
         }
 
-        let client = appservice.virtual_user_client(user_id.localpart()).await?;
+        let client = appservice.virtual_user(Some(user_id.localpart())).await?;
         client.join_room_by_id(room.room_id()).await?;
     }
 
@@ -61,7 +61,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let appservice = AppService::new(homeserver_url, server_name, registration).await?;
     appservice.register_user_query(Box::new(|_, _| Box::pin(async { true }))).await;
     appservice
-        .register_event_handler_context(appservice.clone())?
+        .virtual_user(None)
+        .await?
+        .register_event_handler_context(appservice.clone())
         .register_event_handler(
             move |event: OriginalSyncRoomMemberEvent,
                   room: Room,
@@ -69,7 +71,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 handle_room_member(appservice, room, event)
             },
         )
-        .await?;
+        .await;
 
     let (host, port) = appservice.registration().get_host_and_port()?;
     appservice.run(host, port).await?;

--- a/crates/matrix-sdk-appservice/src/event_handler.rs
+++ b/crates/matrix-sdk-appservice/src/event_handler.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Famedly GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use matrix_sdk::locks::Mutex;

--- a/crates/matrix-sdk-appservice/src/registration.rs
+++ b/crates/matrix-sdk-appservice/src/registration.rs
@@ -1,0 +1,124 @@
+// Copyright 2022 Famedly GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! AppService Registration.
+
+use std::{convert::TryFrom, fs::File, ops::Deref, path::PathBuf};
+
+use http::Uri;
+use regex::Regex;
+use ruma::api::appservice::Registration;
+
+use crate::{Error, Result};
+
+pub type Host = String;
+pub type Port = u16;
+
+/// AppService Registration
+///
+/// Wrapper around [`Registration`]. See also <https://matrix.org/docs/spec/application_service/r0.1.2#registration>.
+#[derive(Debug, Clone)]
+pub struct AppServiceRegistration {
+    inner: Registration,
+}
+
+impl AppServiceRegistration {
+    /// Try to load registration from yaml string
+    ///
+    /// See the fields of [`Registration`] for the required format
+    pub fn try_from_yaml_str(value: impl AsRef<str>) -> Result<Self> {
+        Ok(Self { inner: serde_yaml::from_str(value.as_ref())? })
+    }
+
+    /// Try to load registration from yaml file
+    ///
+    /// See the fields of [`Registration`] for the required format
+    pub fn try_from_yaml_file(path: impl Into<PathBuf>) -> Result<Self> {
+        let file = File::open(path.into())?;
+
+        Ok(Self { inner: serde_yaml::from_reader(file)? })
+    }
+
+    /// Get the host and port from the registration URL
+    ///
+    /// If no port is found it falls back to scheme defaults: 80 for http and
+    /// 443 for https
+    pub fn get_host_and_port(&self) -> Result<(Host, Port)> {
+        let uri = Uri::try_from(&self.inner.url)?;
+
+        let host = uri.host().ok_or(Error::MissingRegistrationHost)?.to_owned();
+        let port = match uri.port() {
+            Some(port) => Ok(port.as_u16()),
+            None => match uri.scheme_str() {
+                Some("http") => Ok(80),
+                Some("https") => Ok(443),
+                _ => Err(Error::MissingRegistrationPort),
+            },
+        }?;
+
+        Ok((host, port))
+    }
+}
+
+impl From<Registration> for AppServiceRegistration {
+    fn from(value: Registration) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl Deref for AppServiceRegistration {
+    type Target = Registration;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Cache data for the registration namespaces.
+#[derive(Debug, Clone)]
+pub struct NamespaceCache {
+    /// List of user regexes in our namespace
+    pub(crate) users: Vec<Regex>,
+    /// List of alias regexes in our namespace
+    #[allow(dead_code)]
+    aliases: Vec<Regex>,
+    /// List of room id regexes in our namespace
+    #[allow(dead_code)]
+    rooms: Vec<Regex>,
+}
+
+impl NamespaceCache {
+    /// Creates a new registration cache from a [`Registration`] value
+    pub fn from_registration(registration: &Registration) -> Result<Self> {
+        let users = registration
+            .namespaces
+            .users
+            .iter()
+            .map(|user| Regex::new(&user.regex))
+            .collect::<Result<Vec<_>, _>>()?;
+        let aliases = registration
+            .namespaces
+            .aliases
+            .iter()
+            .map(|user| Regex::new(&user.regex))
+            .collect::<Result<Vec<_>, _>>()?;
+        let rooms = registration
+            .namespaces
+            .rooms
+            .iter()
+            .map(|user| Regex::new(&user.regex))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(NamespaceCache { users, aliases, rooms })
+    }
+}

--- a/crates/matrix-sdk-appservice/src/virtual_user.rs
+++ b/crates/matrix-sdk-appservice/src/virtual_user.rs
@@ -1,0 +1,149 @@
+// Copyright 2022 Famedly GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Virtual users.
+
+use matrix_sdk::{config::RequestConfig, Client, ClientBuildError, ClientBuilder, Session};
+use ruma::{
+    api::client::{session::login, uiaa::UserIdentifier},
+    assign, DeviceId, OwnedDeviceId, UserId,
+};
+use tracing::warn;
+
+use crate::{AppService, Result};
+
+/// Builder for a virtual user
+#[derive(Debug)]
+pub struct VirtualUserBuilder<'a> {
+    appservice: &'a AppService,
+    localpart: &'a str,
+    device_id: Option<OwnedDeviceId>,
+    client_builder: ClientBuilder,
+    log_in: bool,
+    restored_session: Option<Session>,
+}
+
+impl<'a> VirtualUserBuilder<'a> {
+    /// Create a new virtual user builder
+    /// # Arguments
+    ///
+    /// * `localpart` - The localpart of the virtual user
+    pub fn new(appservice: &'a AppService, localpart: &'a str) -> Self {
+        Self {
+            appservice,
+            localpart,
+            device_id: None,
+            client_builder: Client::builder(),
+            log_in: false,
+            restored_session: None,
+        }
+    }
+
+    /// Set the device ID of the virtual user
+    pub fn device_id(mut self, device_id: Option<OwnedDeviceId>) -> Self {
+        self.device_id = device_id;
+        self
+    }
+
+    /// Sets the client builder to use for the virtual user
+    pub fn client_builder(mut self, client_builder: ClientBuilder) -> Self {
+        self.client_builder = client_builder;
+        self
+    }
+
+    /// Log in as the virtual user
+    ///
+    /// In some cases it is necessary to log in as the virtual user, such as to
+    /// upload device keys
+    pub fn login(mut self) -> Self {
+        self.log_in = true;
+        self
+    }
+
+    /// Restore a persisted session
+    ///
+    /// This is primarily useful if you enable
+    /// [`VirtualUserBuilder::login()`] and want to restore a session
+    /// from a previous run.
+    pub fn restored_session(mut self, session: Session) -> Self {
+        self.restored_session = Some(session);
+        self
+    }
+
+    /// Build the virtual user
+    ///
+    /// # Errors
+    /// This function returns an error if an invalid localpart is provided.
+    pub async fn build(self) -> Result<Client> {
+        if let Some(client) = self.appservice.clients.get(self.localpart) {
+            return Ok(client.clone());
+        }
+
+        let user_id = UserId::parse_with_server_name(self.localpart, &self.appservice.server_name)?;
+        if !(self.appservice.user_id_is_in_namespace(&user_id)
+            || self.localpart == self.appservice.registration.sender_localpart)
+        {
+            warn!("Virtual client id '{user_id}' is not in the namespace")
+        }
+
+        let mut builder = self.client_builder;
+
+        if !self.log_in && self.localpart != self.appservice.registration.sender_localpart {
+            builder = builder.assert_identity();
+        }
+
+        let client = builder
+            .homeserver_url(self.appservice.homeserver_url.clone())
+            .appservice_mode()
+            .build()
+            .await
+            .map_err(ClientBuildError::assert_valid_builder_args)?;
+
+        let session = if let Some(session) = self.restored_session {
+            session
+        } else if self.log_in && self.localpart != self.appservice.registration.sender_localpart {
+            let login_info =
+                login::v3::LoginInfo::ApplicationService(login::v3::ApplicationService::new(
+                    UserIdentifier::UserIdOrLocalpart(self.localpart),
+                ));
+
+            let request = assign!(login::v3::Request::new(login_info), {
+                device_id: self.device_id.as_ref().map(|v| v.as_ref()),
+                initial_device_display_name: None,
+            });
+
+            let response =
+                client.send(request, Some(RequestConfig::short_retry().force_auth())).await?;
+
+            Session {
+                access_token: response.access_token,
+                user_id: response.user_id,
+                device_id: response.device_id,
+            }
+        } else {
+            // Don’t log in
+            Session {
+                access_token: self.appservice.registration.as_token.clone(),
+                user_id: user_id.clone(),
+                device_id: self.device_id.unwrap_or_else(DeviceId::new),
+            }
+        };
+
+        client.restore_login(session).await?;
+
+        self.appservice.clients.insert(self.localpart.to_owned(), client.clone());
+
+        Ok(client)
+    }
+}

--- a/crates/matrix-sdk-appservice/tests/tests.rs
+++ b/crates/matrix-sdk-appservice/tests/tests.rs
@@ -125,6 +125,8 @@ async fn test_put_transaction_with_repeating_txn_id() -> Result<()> {
     #[allow(clippy::mutex_atomic)]
     let on_state_member = Arc::new(Mutex::new(false));
     appservice
+        .virtual_user(None)
+        .await?
         .register_event_handler({
             let on_state_member = on_state_member.clone();
             move |_ev: OriginalSyncRoomMemberEvent| {
@@ -132,7 +134,7 @@ async fn test_put_transaction_with_repeating_txn_id() -> Result<()> {
                 future::ready(())
             }
         })
-        .await?;
+        .await;
 
     let status = warp::test::request()
         .method("PUT")
@@ -279,6 +281,8 @@ async fn test_event_handler() -> Result<()> {
     #[allow(clippy::mutex_atomic)]
     let on_state_member = Arc::new(Mutex::new(false));
     appservice
+        .virtual_user(None)
+        .await?
         .register_event_handler({
             let on_state_member = on_state_member.clone();
             move |_ev: OriginalSyncRoomMemberEvent| {
@@ -286,7 +290,7 @@ async fn test_event_handler() -> Result<()> {
                 future::ready(())
             }
         })
-        .await?;
+        .await;
 
     let uri = "/_matrix/app/v1/transactions/1?access_token=hs_token";
 
@@ -365,7 +369,8 @@ async fn test_appservice_on_sub_path() -> Result<()> {
     };
 
     let members = appservice
-        .get_cached_client(None)?
+        .virtual_user(None)
+        .await?
         .get_room(room_id)
         .expect("Expected room to be available")
         .members_no_sync()
@@ -455,8 +460,8 @@ async fn test_receive_transaction() -> Result<()> {
     ];
     let appservice = appservice(None, None).await?;
 
-    let alice = appservice.virtual_user_client("_appservice_alice").await?;
-    let bob = appservice.virtual_user_client("_appservice_bob").await?;
+    let alice = appservice.virtual_user(Some("_appservice_alice")).await?;
+    let bob = appservice.virtual_user(Some("_appservice_bob")).await?;
     appservice
         .receive_transaction(push_events::v1::IncomingRequest::new("dontcare".into(), json))
         .await?;


### PR DESCRIPTION
Since the `lib.rs` was slowly growing a bit too large and covering multiple contexts it was about time to refactor a bit. Also clarified the implicit behavior which special-cases the ` sender_localpart` user.

- Clarify why we create a virtual user for the `sender_localpart` on `AppService` construction
- Drop the methods `register_event_handler` and `register_event_handler_context`, so the consumer has to be explicit
- Drop the method `get_cached_client` as it's already covered by the method `virtual_user`
- Move `create_session` into the `VirtualUserBuilder`, as it's only used there
- Rename `virtual_user_client*` to `virtual_user*` to make it more concise 
- Make `NamespaceCache` private since there's no reason to expose it
- Split out `AppServiceRegistration` and `VirtualUserBuilder` into their own files to make the code easier to navigate
- Clean up docs