### PR TITLE
fix(bindings/crypto-js): Use `cross-env` to pass envvar on Windows

### DIFF
--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -28,13 +28,14 @@
     "devDependencies": {
         "wasm-pack": "^0.10.2",
         "jest": "^28.1.0",
-        "typedoc": "^0.22.17"
+        "typedoc": "^0.22.17",
+        "cross-env": "^7.0.3"
     },
     "engines": {
         "node": ">= 10"
     },
     "scripts": {
-        "build": "RUSTFLAGS='-C opt-level=z' wasm-pack build --release --target nodejs --out-name matrix_sdk_crypto --out-dir ./pkg",
+        "build": "cross-env RUSTFLAGS='-C opt-level=z' wasm-pack build --release --target nodejs --out-name matrix_sdk_crypto --out-dir ./pkg",
         "test": "jest --verbose",
         "doc": "typedoc --tsconfig ."
     }


### PR DESCRIPTION
Fix #843.

Windows doesn't support `KEY=value` in its shell to define an environment variable. We must use `set KEY=value` but, in this case, it no longer works on Unix-like OS properly inside NPM.

A common solution, sadly, is to use another NPM package, called [`cross-env`](https://www.npmjs.com/package/cross-env). That's what this patch does.

I wonder whether it is sensible to run the CI on Windows for this project. Wasm is portable so we don't really care about that usually; in this case it would only be useful to test the build system. I'm embarassed by the time and the energy (i.e. electricity) it will take “just” to see if `npm run build` runs correctly on Windows. Let's assume for now we will have issues raised by contributors (not by users, they won't have to build the Wasm module) if this happens again. This `scripts` part won't be updated very often, and is usually pretty simple.