### PR TITLE
Fix Apple binding tests

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -170,4 +170,4 @@ jobs:
             -project bindings/apple/MatrixRustSDK.xcodeproj \
             -scheme MatrixRustSDK \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 13,OS=15.4'
+            -destination 'platform=iOS Simulator,name=iPhone 13'

--- a/bindings/apple/MatrixRustSDK.xcodeproj/project.pbxproj
+++ b/bindings/apple/MatrixRustSDK.xcodeproj/project.pbxproj
@@ -44,7 +44,6 @@
 		181AA19927B52AA60005F102 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		181AA19A27B52AB40005F102 /* MatrixSDKFFI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MatrixSDKFFI.xcframework; path = ../../generated/MatrixSDKFFI.xcframework; sourceTree = "<group>"; };
 		189A89B927B40BBF0048B0A5 /* sdk.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = sdk.swift; path = ../../../generated/swift/sdk.swift; sourceTree = "<group>"; };
-		189A89C327B417CA0048B0A5 /* MatrixRustSDK-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MatrixRustSDK-Bridging-Header.h"; sourceTree = "<group>"; };
 		18CE89D427B2939900CA89E1 /* MatrixRustSDK.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MatrixRustSDK.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		18CE89D727B2939900CA89E1 /* MatrixRustSDKApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatrixRustSDKApp.swift; sourceTree = "<group>"; };
 		18CE89D927B2939900CA89E1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -117,7 +116,6 @@
 				18CE89D927B2939900CA89E1 /* ContentView.swift */,
 				18CE8A0127B293A900CA89E1 /* MatrixRustSDK.entitlements */,
 				18CE89DB27B2939A00CA89E1 /* Assets.xcassets */,
-				189A89C327B417CA0048B0A5 /* MatrixRustSDK-Bridging-Header.h */,
 			);
 			path = MatrixRustSDK;
 			sourceTree = "<group>";
@@ -401,7 +399,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "MatrixRustSDK/MatrixRustSDK-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -435,7 +432,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "MatrixRustSDK/MatrixRustSDK-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/bindings/apple/MatrixRustSDK/MatrixRustSDK-Bridging-Header.h
+++ b/bindings/apple/MatrixRustSDK/MatrixRustSDK-Bridging-Header.h
@@ -1,5 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import "sdkFFI.h"


### PR DESCRIPTION
CI builds are now failing because the biding tests are looking for iOS 15.4 and the runner has been updated to 15.5. 
This PR will allow the tests to run on **any** iPhone 13 simulator no matter the OS version.