### PR TITLE
style(crypto): use matches for legibility

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -1098,12 +1098,10 @@ impl RequestState<Ready> {
                             // before the other side tried to do the same; ignore it if we did and
                             // we're the lexicographically smaller user ID (or device ID if equal).
                             use std::cmp::Ordering;
-                            match (sender.cmp(own_user_id), device.device_id().cmp(own_device_id)) {
-                                (Ordering::Greater, _) | (Ordering::Equal, Ordering::Greater) => {
-                                    false
-                                }
-                                _ => true,
-                            }
+                            !matches!(
+                                (sender.cmp(own_user_id), device.device_id().cmp(own_device_id)),
+                                (Ordering::Greater, _) | (Ordering::Equal, Ordering::Greater)
+                            )
                         } else {
                             true
                         };


### PR DESCRIPTION
Fixing a [new clippy-lint that appeared on our CI after merging to main](https://github.com/matrix-org/matrix-rust-sdk/runs/7406421293?check_suite_focus=true#step:5:711)