### PR TITLE
Add a `HomeserverLoginDetails` to the FFI's auth service.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -156,24 +156,21 @@ interface MediaSource {
 
 [Error]
 enum AuthenticationError {
-  "ClientMissing",
-  "Generic",
+    "ClientMissing",
+    "Generic",
+};
+
+interface HomeserverLoginDetails {
+    string url();
+    string? authentication_issuer();
+    boolean supports_password_login();
 };
 
 interface AuthenticationService {
     constructor(string base_path);
     
     [Throws=AuthenticationError]
-    string homeserver();
-    
-    [Throws=AuthenticationError]
-    string? authentication_issuer();
-
-    [Throws=AuthenticationError]
-    boolean supports_password_login();
-    
-    [Throws=AuthenticationError]
-    void use_server(string server_name);
+    HomeserverLoginDetails configure_homeserver(string server_name);
     
     [Throws=AuthenticationError]
     Client login(string username, string password);

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -169,8 +169,10 @@ interface HomeserverLoginDetails {
 interface AuthenticationService {
     constructor(string base_path);
     
+    HomeserverLoginDetails? homeserver_details();
+    
     [Throws=AuthenticationError]
-    HomeserverLoginDetails configure_homeserver(string server_name);
+    void configure_homeserver(string server_name);
     
     [Throws=AuthenticationError]
     Client login(string username, string password);

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -74,26 +74,27 @@ impl Client {
 
     /// The homeserver this client is configured to use.
     pub fn homeserver(&self) -> String {
-        RUNTIME.block_on(async move { self.client.homeserver().await.to_string() })
+        RUNTIME.block_on(async move { self.async_homeserver().await })
+    }
+
+    pub async fn async_homeserver(&self) -> String {
+        self.client.homeserver().await.to_string()
     }
 
     /// The OIDC Provider that is trusted by the homeserver. `None` when
     /// not configured.
-    pub fn authentication_issuer(&self) -> Option<String> {
-        RUNTIME.block_on(async move {
-            self.client.authentication_issuer().await.map(|server| server.to_string())
-        })
+    pub async fn authentication_issuer(&self) -> Option<String> {
+        self.client.authentication_issuer().await.map(|server| server.to_string())
     }
 
     /// Whether or not the client's homeserver supports the password login flow.
-    pub fn supports_password_login(&self) -> anyhow::Result<bool> {
-        RUNTIME.block_on(async move {
-            let login_types = self.client.get_login_types().await?;
-            let supports_password = login_types.flows.iter().any(|login_type| {
-                matches!(login_type, get_login_types::v3::LoginType::Password(_))
-            });
-            Ok(supports_password)
-        })
+    pub async fn supports_password_login(&self) -> anyhow::Result<bool> {
+        let login_types = self.client.get_login_types().await?;
+        let supports_password = login_types
+            .flows
+            .iter()
+            .any(|login_type| matches!(login_type, get_login_types::v3::LoginType::Password(_)));
+        Ok(supports_password)
     }
 
     pub fn start_sync(&self) {


### PR DESCRIPTION
This PR removes the separate calls for `homeserver()`, `authentication_issuer()` and `supports_password_login()`, instead wrapping them up in a value that can be requested via `homeserver_details()` with a single call.

`use_server` has also been renamed to `configure_homeserver` for a bit more clarity.