### PR TITLE
Add restore_with_access_token to the FFI auth service.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -180,7 +180,7 @@ interface AuthenticationService {
     Client login(string username, string password);
     
     [Throws=AuthenticationError]
-    Client login_access_token(string token);
+    Client restore_with_access_token(string token, string device_id);
 };
 
 interface SessionVerificationEmoji {

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -178,6 +178,9 @@ interface AuthenticationService {
     
     [Throws=AuthenticationError]
     Client login(string username, string password);
+    
+    [Throws=AuthenticationError]
+    Client login_access_token(string token);
 };
 
 interface SessionVerificationEmoji {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -51,6 +51,7 @@ impl Client {
         }
     }
 
+    /// Login using a username and password.
     pub fn login(&self, username: String, password: String) -> anyhow::Result<()> {
         RUNTIME.block_on(async move {
             self.client.login_username(&username, &password).send().await?;


### PR DESCRIPTION
This PR is likely a temporary addition until #859 is implemented to allow for https://github.com/vector-im/element-x-ios/issues/137 to be completed with the proof of concept implementation.

The new method first creates an in-memory client to perform a `/whoami` and get the user ID and device ID. Then it creates a second client with a store path set and sets this one up for real.

Forked from #860 so would need to wait for that to be merged first.