### PR TITLE
doc: Propose conventional commits scopes & types

### DIFF
--- a/CONVENTIONAL_COMMITS.md
+++ b/CONVENTIONAL_COMMITS.md
@@ -7,6 +7,22 @@ the [Full
 Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
 to learn more.
 
+## Types
+
+Conventional Commits defines _type_ (as in `type(scope):
+message`). This section aims at listing the types used inside this
+project:
+
+| Type | Definition |
+|-|-|
+| `feat` | About a new feature. |
+| `fix` | About a bug fix. |
+| `test` | About a test (suite, case, runner…). |
+| `doc` | About a documentation modification. |
+| `refactor` | About a refactoring. |
+| `ci` | About a Continuous Integration modification. |
+| `chore` | About some cleanup, or regular tasks. |
+
 ## Scopes
 
 Conventional Commits defines _scope_ (as in `type(scope): message`). This


### PR DESCRIPTION
As discussed with @gnunicorn, it happens that, even if we are using conventional commits, the scopes & types are kind of broken since we are using different scopes for the same projects.

This document is an attempt to standardize the scopes & types and to document how we use conventional commits.

[Rendered](https://github.com/Hywan/matrix-rust-sdk/blob/doc-conventional-commits/CONVENTIONAL_COMMITS.md).