### PR TITLE
client: Remove redudant delay after sync error

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1838,8 +1838,6 @@ impl Client {
                 if callback(r).await == LoopCtrl::Break {
                     return;
                 }
-            } else {
-                continue;
             }
 
             Client::delay_sync(&mut last_sync_time).await

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -129,8 +129,6 @@ impl Client {
             }
             Err(e) => {
                 error!("Received an invalid response: {}", e);
-                Self::sleep().await;
-
                 Err(e)
             }
         }


### PR DESCRIPTION
If the last sync was less then a 1s ago we wait for a 1s, it doesn't
make sense to wait an additional second on an error. Also the stream
sync api returns the error after a delay of 1s, which doesn't make
sense.