### PR TITLE
feat(sdk): Implement remove_event_handler

### DIFF
--- a/crates/matrix-sdk-appservice/examples/appservice_autojoin.rs
+++ b/crates/matrix-sdk-appservice/examples/appservice_autojoin.rs
@@ -60,10 +60,11 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let appservice = AppService::new(homeserver_url, server_name, registration).await?;
     appservice.register_user_query(Box::new(|_, _| Box::pin(async { true }))).await;
-    appservice
-        .virtual_user(None)
-        .await?
-        .register_event_handler_context(appservice.clone())
+
+    let virtual_user = appservice.virtual_user(None).await?;
+
+    virtual_user.register_event_handler_context(appservice.clone());
+    virtual_user
         .register_event_handler(
             move |event: OriginalSyncRoomMemberEvent,
                   room: Room,

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = [
     "e2e-encryption",
     "sled",
-    "native-tls"
+    "native-tls", 
 ]
 
 e2e-encryption = [
@@ -117,6 +117,14 @@ features = ["client-api-c", "compat", "rand", "unstable-msc2448", "unstable-msc2
 version = "0.1.8"
 features = ["net"]
 optional = true
+
+[dependencies.uuid]
+version = "1.1.2"
+features = [
+    "v4",                
+    "fast-rng",          
+    "macro-diagnostics", 
+]
 
 [dependencies.warp]
 version = "0.3.2"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = [
     "e2e-encryption",
     "sled",
-    "native-tls"
+    "native-tls",
 ]
 
 e2e-encryption = [
@@ -117,14 +117,6 @@ features = ["client-api-c", "compat", "rand", "unstable-msc2448", "unstable-msc2
 version = "0.1.8"
 features = ["net"]
 optional = true
-
-[dependencies.uuid]
-version = "1.1.2"
-features = [
-    "v4",                
-    "fast-rng",          
-    "macro-diagnostics", 
-]
 
 [dependencies.warp]
 version = "0.3.2"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = [
     "e2e-encryption",
     "sled",
-    "native-tls", 
+    "native-tls"
 ]
 
 e2e-encryption = [

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -342,6 +342,7 @@ impl ClientBuilder {
             typing_notice_times: Default::default(),
             event_handlers: Default::default(),
             event_handler_data: Default::default(),
+            event_handler_counter: Default::default(),
             notification_handlers: Default::default(),
             appservice_mode: self.appservice_mode,
             respect_login_well_known: self.respect_login_well_known,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -391,23 +391,22 @@ impl Client {
     /// #     .build()
     /// #     .await
     /// #     .unwrap();
-    /// client
-    ///     .register_event_handler(
+    /// client.register_event_handler(
     ///         |ev: SyncRoomMessageEvent, room: Room, client: Client| async move {
     ///             // Common usage: Room event plus room and client.
     ///         },
     ///     )
-    ///     .await
-    ///     .register_event_handler(
-    ///         |ev: SyncRoomMessageEvent, room: Room, encryption_info: Option<EncryptionInfo>| {
+    ///     .await;
+    /// client.register_event_handler(
+    ///          |ev: SyncRoomMessageEvent, room: Room, encryption_info: Option<EncryptionInfo>| {
     ///             async move {
     ///                 // An `Option<EncryptionInfo>` parameter lets you distinguish between
     ///                 // unencrypted events and events that were decrypted by the SDK.
     ///             }
     ///         },
     ///     )
-    ///     .await
-    ///     .register_event_handler(|ev: SyncRoomTopicEvent| async move {
+    ///     .await;
+    /// client.register_event_handler(|ev: SyncRoomTopicEvent| async move {
     ///         // You can omit any or all arguments after the first.
     ///     })
     ///     .await;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 Damir Jelić
 // Copyright 2020 The Matrix.org Foundation C.I.C.
+// Copyright 2022 Famedly GmbH
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -393,13 +394,16 @@ impl Client {
     /// #     .build()
     /// #     .await
     /// #     .unwrap();
-    /// client.register_event_handler(
+    ///
+    /// client
+    ///     .register_event_handler(
     ///         |ev: SyncRoomMessageEvent, room: Room, client: Client| async move {
     ///             // Common usage: Room event plus room and client.
     ///         },
     ///     )
     ///     .await;
-    /// client.register_event_handler(
+    /// client
+    ///     .register_event_handler(
     ///          |ev: SyncRoomMessageEvent, room: Room, encryption_info: Option<EncryptionInfo>| {
     ///             async move {
     ///                 // An `Option<EncryptionInfo>` parameter lets you distinguish between
@@ -408,7 +412,8 @@ impl Client {
     ///         },
     ///     )
     ///     .await;
-    /// client.register_event_handler(|ev: SyncRoomTopicEvent| async move {
+    /// client
+    ///     .register_event_handler(|ev: SyncRoomTopicEvent| async move {
     ///         // You can omit any or all arguments after the first.
     ///     })
     ///     .await;
@@ -510,9 +515,6 @@ impl Client {
     /// # use futures::executor::block_on;
     /// # use url::Url;
     /// # use tokio::sync::mpsc;
-    /// # use matrix_sdk_test::{
-    /// #   EphemeralTestEvent, EventBuilder, StateTestEvent, TimelineTestEvent, JoinedRoomBuilder
-    /// # };
     ///
     /// # let homeserver = Url::parse("http://localhost:8080").unwrap();
     ///
@@ -529,8 +531,6 @@ impl Client {
     /// #     .await
     /// #     .unwrap();
     ///
-    ///
-    ///
     /// client.register_event_handler(
     ///         |ev: SyncRoomMemberEvent, client: Client, handle: EventHandlerHandle| async move {
     ///             // Common usage: Check arriving Event is the expected one
@@ -539,8 +539,6 @@ impl Client {
     ///         },
     ///     )
     ///     .await;
-    ///
-    ///
     /// # });
     /// ```
     pub async fn remove_event_handler(&self, handle: EventHandlerHandle) {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -550,7 +550,7 @@ impl Client {
         let mut event_handlers = self.inner.event_handlers.write().await;
 
         if let Some(v) = event_handlers.get_mut(&handle.ev_id) {
-            v.retain(|e| -> bool { e.handle.handler_id.ne(&handle.handler_id) });
+            v.retain(|e| e.handle.handler_id != handle.handler_id);
 
             if v.is_empty() {
                 event_handlers.remove(&handle.ev_id);

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -494,7 +494,7 @@ impl Client {
             .await
             .entry(key)
             .or_default()
-            .push(EventHandlerWrapper { handler_fn, handle: handle.clone() });
+            .push(EventHandlerWrapper { handler_fn, handle });
 
         handle
     }

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -102,7 +102,7 @@ pub struct EventHandlerHandle {
 
 impl EventHandlerContext for EventHandlerHandle {
     fn from_data(data: &EventHandlerData<'_>) -> Option<Self> {
-        Some(data.handle.clone())
+        Some(data.handle)
     }
 }
 
@@ -408,7 +408,7 @@ impl Client {
                         room: room.clone(),
                         raw: raw_event.json(),
                         encryption_info,
-                        handle: handler_wrapper.handle.clone(),
+                        handle: handler_wrapper.handle,
                     };
                     (handler_wrapper.handler_fn)(data)
                 })

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -733,7 +733,8 @@ mod tests {
             .register_event_handler({
                 move |_ev: OriginalSyncRoomMemberEvent| {
                     panic!("handler should have been removed");
-                    return future::ready(());
+                    #[allow(unreachable_code)]
+                    future::ready(())
                 }
             })
             .await;

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -93,10 +93,11 @@ pub(crate) struct EventHandlerWrapper {
 }
 
 #[derive(Debug, Clone)]
-/// Handle to remove a registered event handler.
+/// Handle to remove a registered event handler by passing it to
+/// [`Client::remove_event_handler`].
 pub struct EventHandlerHandle {
     pub(crate) id: (EventKind, &'static str),
-    pub(crate) addr: usize,
+    pub(crate) addr: u64,
 }
 
 impl EventHandlerContext for EventHandlerHandle {

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -94,7 +94,7 @@ pub(crate) struct EventHandlerWrapper {
 
 /// Handle to remove a registered event handler by passing it to
 /// [`Client::remove_event_handler`].
-#[derive(Debug, Clone)]
+#[derive(Clone, Copy, Debug)]
 pub struct EventHandlerHandle {
     pub(crate) ev_id: (EventKind, &'static str),
     pub(crate) handler_id: u64,

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -88,16 +88,16 @@ pub trait SyncEvent {
 }
 
 pub(crate) struct EventHandlerWrapper {
-    pub handler_function: Box<EventHandlerFn>,
+    pub handler_fn: Box<EventHandlerFn>,
     pub handle: EventHandlerHandle,
 }
 
-#[derive(Debug, Clone)]
 /// Handle to remove a registered event handler by passing it to
 /// [`Client::remove_event_handler`].
+#[derive(Debug, Clone)]
 pub struct EventHandlerHandle {
-    pub(crate) id: (EventKind, &'static str),
-    pub(crate) addr: u64,
+    pub(crate) ev_id: (EventKind, &'static str),
+    pub(crate) handler_id: u64,
 }
 
 impl EventHandlerContext for EventHandlerHandle {
@@ -410,7 +410,7 @@ impl Client {
                         encryption_info,
                         handle: handler_wrapper.handle.clone(),
                     };
-                    (handler_wrapper.handler_function)(data)
+                    (handler_wrapper.handler_fn)(data)
                 })
                 .collect();
 

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -39,11 +39,7 @@ use matrix_sdk_base::deserialized_responses::{EncryptionInfo, SyncRoomEvent};
 use ruma::{events::AnySyncStateEvent, serde::Raw};
 use serde::Deserialize;
 use serde_json::value::RawValue as RawJsonValue;
-<<<<<<< HEAD
 use tracing::error;
-=======
-use uuid::Uuid;
->>>>>>> 24deb588 (feat(sdk): Implement remove_event_handler)
 
 use crate::{client::EventHandlerFn, room, Client};
 
@@ -92,20 +88,15 @@ pub trait SyncEvent {
 }
 
 pub(crate) struct EventHandlerWrapper {
-    pub handler_function: EventHandlerFn,
+    pub handler_function: Box<EventHandlerFn>,
     pub handle: EventHandlerHandle,
 }
 
 #[derive(Debug, Clone)]
 /// Handle to remove a registered event handler.
-pub struct EventHandlerHandle(pub(crate) Uuid, pub(crate) (EventKind, &'static str));
-
-impl EventHandlerHandle {
-    #[must_use]
-    /// Returns a new [`EventHandlerHandle`].
-    pub(crate) fn new(event_id: (EventKind, &'static str)) -> Self {
-        EventHandlerHandle(Uuid::new_v4(), event_id)
-    }
+pub struct EventHandlerHandle {
+    pub(crate) id: (EventKind, &'static str),
+    pub(crate) addr: usize,
 }
 
 /// Interface for event handlers.


### PR DESCRIPTION
This PR implements the ability to remove a previously registered event handler.

To remove the event handler, the struct `EventHandlerWrapper` containing the actual handler and an `EventHandlerHandle` is saved in the HashMap for all event handlers instead of event handlers directly. Client.register_event_handler was amended to return an instance of `EventHandlerHandle` associated with the registered handler, which can later be used to remove the event handler with `Client.remove_event_handler`. The Handle contains a uniquely generated ID and the event ID which the event handler is interested in, so the event handler can be removed only with the handle.

This is a breaking change since it removes the method chaining functionality of `Client.register_event_handler`, which is a conscious decision made after consulting with @jplatte. 