### PR TITLE
Customized encrypted events

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -57,7 +57,7 @@ features = ["rt-multi-thread"]
 
 [dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "2404f83f7d3a3779c1f518e4d949f7da9677c3dd"
+rev = "18bcbc3359298894415931547ea41abb75af2d4a"
 
 [build-dependencies]
 uniffi_build = { version = "0.18.0", features = ["builtin-bindgen"] }

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -262,6 +262,7 @@ pub fn migrate(
             imported: session.imported,
             backed_up: session.backed_up,
             history_visibility: None,
+            algorithm: ruma::EventEncryptionAlgorithm::MegolmV1AesSha2,
         };
 
         let session = matrix_sdk_crypto::olm::InboundGroupSession::from_pickle(pickle)?;

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -31,10 +31,8 @@ use ruma::{
         },
         IncomingResponse,
     },
-    events::{
-        key::verification::VerificationMethod, room::encrypted::OriginalSyncRoomEncryptedEvent,
-        AnySyncMessageLikeEvent,
-    },
+    events::{key::verification::VerificationMethod, AnySyncMessageLikeEvent},
+    serde::Raw,
     DeviceKeyAlgorithm, EventId, OwnedTransactionId, OwnedUserId, RoomId, UserId,
 };
 use serde::{Deserialize, Serialize};
@@ -601,7 +599,7 @@ impl OlmMachine {
             content: &'a RawValue,
         }
 
-        let event: OriginalSyncRoomEncryptedEvent = serde_json::from_str(event)?;
+        let event: Raw<_> = serde_json::from_str(event)?;
         let room_id = RoomId::parse(room_id)?;
 
         let decrypted = self.runtime.block_on(self.inner.decrypt_room_event(&event, &room_id))?;
@@ -639,7 +637,7 @@ impl OlmMachine {
         event: &str,
         room_id: &str,
     ) -> Result<KeyRequestPair, DecryptionError> {
-        let event: OriginalSyncRoomEncryptedEvent = serde_json::from_str(event)?;
+        let event: Raw<_> = serde_json::from_str(event)?;
         let room_id = RoomId::parse(room_id)?;
 
         let (cancel, request) =

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -31,7 +31,6 @@ tracing = []
 matrix-sdk-common = { version = "0.5.0", path = "../../crates/matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.5.0", path = "../../crates/matrix-sdk-crypto" }
 ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"] }
-vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "2404f83f7d3a3779c1f518e4d949f7da9677c3dd", features = ["js"] }
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"
 js-sys = "0.3.49"
@@ -41,3 +40,8 @@ http = "0.2.6"
 anyhow = "1.0.58"
 tracing = { version = "0.1.35", default-features = false, features = ["attributes"] }
 tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std"] }
+
+[dependencies.vodozemac]
+git = "https://github.com/matrix-org/vodozemac/"
+rev = "18bcbc3359298894415931547ea41abb75af2d4a"
+features = ["js"]

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -3,10 +3,7 @@
 use std::collections::BTreeMap;
 
 use js_sys::{Array, Map, Promise, Set};
-use ruma::{
-    events::room::encrypted::OriginalSyncRoomEncryptedEvent, DeviceKeyAlgorithm,
-    OwnedTransactionId, UInt,
-};
+use ruma::{serde::Raw, DeviceKeyAlgorithm, OwnedTransactionId, UInt};
 use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
 
@@ -274,7 +271,7 @@ impl OlmMachine {
         event: &str,
         room_id: &identifiers::RoomId,
     ) -> Result<Promise, JsError> {
-        let event: OriginalSyncRoomEncryptedEvent = serde_json::from_str(event)?;
+        let event: Raw<_> = serde_json::from_str(event)?;
         let room_id = room_id.inner.clone();
         let me = self.inner.clone();
 

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -29,13 +29,17 @@ matrix-sdk-crypto = { version = "0.5.0", path = "../../crates/matrix-sdk-crypto"
 matrix-sdk-common = { version = "0.5.0", path = "../../crates/matrix-sdk-common" }
 matrix-sdk-sled = { version = "0.1.0", path = "../../crates/matrix-sdk-sled", default-features = false, features = ["crypto-store"] }
 ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"] }
-vodozemac = {  git = "https://github.com/matrix-org/vodozemac/", rev = "2404f83f7d3a3779c1f518e4d949f7da9677c3dd" }
 napi = { git = "https://github.com/Hywan/napi-rs", branch = "fix-napi-strict-on-t-and-ref-t", default-features = false, features = ["napi6", "tokio_rt"] }
 napi-derive = { git = "https://github.com/Hywan/napi-rs", branch = "fix-napi-strict-on-t-and-ref-t" }
 serde_json = "1.0.79"
 http = "0.2.6"
 zeroize = "1.3.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["tracing-log", "time", "smallvec", "fmt", "env-filter"], optional = true }
+
+[dependencies.vodozemac]
+git = "https://github.com/matrix-org/vodozemac/"
+rev = "18bcbc3359298894415931547ea41abb75af2d4a"
+features = ["js"]
 
 [build-dependencies]
 napi-build = "2.0.0"

--- a/bindings/matrix-sdk-crypto-nodejs/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/machine.rs
@@ -7,11 +7,8 @@ use std::{
 
 use napi::bindgen_prelude::Either7;
 use napi_derive::*;
-use ruma::{
-    events::room::encrypted::OriginalSyncRoomEncryptedEvent, DeviceKeyAlgorithm,
-    OwnedTransactionId, UInt,
-};
-use serde_json::Value as JsonValue;
+use ruma::{serde::Raw, DeviceKeyAlgorithm, OwnedTransactionId, UInt};
+use serde_json::{value::RawValue, Value as JsonValue};
 use zeroize::Zeroize;
 
 use crate::{
@@ -389,8 +386,7 @@ impl OlmMachine {
         event: String,
         room_id: &identifiers::RoomId,
     ) -> napi::Result<responses::DecryptedRoomEvent> {
-        let event: OriginalSyncRoomEncryptedEvent =
-            serde_json::from_str(event.as_str()).map_err(into_err)?;
+        let event = Raw::from_json(RawValue::from_string(event).map_err(into_err)?);
         let room_id = room_id.inner.clone();
 
         let room_event = self.inner.decrypt_room_event(&event, &room_id).await.map_err(into_err)?;

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -305,11 +305,12 @@ impl BaseClient {
                         #[cfg(feature = "e2e-encryption")]
                         AnySyncRoomEvent::MessageLike(e) => match e {
                             AnySyncMessageLikeEvent::RoomEncrypted(
-                                SyncMessageLikeEvent::Original(encrypted),
+                                SyncMessageLikeEvent::Original(_),
                             ) => {
                                 if let Some(olm) = self.olm_machine() {
-                                    if let Ok(decrypted) =
-                                        olm.decrypt_room_event(encrypted, room_id).await
+                                    if let Ok(decrypted) = olm
+                                        .decrypt_room_event(event.event.cast_ref(), room_id)
+                                        .await
                                     {
                                         event = decrypted.into();
                                     }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -51,12 +51,25 @@ zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.18", default-features = false, features = ["time"] }
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "rand", "canonical-json", "unstable-msc2676", "unstable-msc2677"] }
-vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "2404f83f7d3a3779c1f518e4d949f7da9677c3dd" }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "js", "rand", "canonical-json", "unstable-msc2676", "unstable-msc2677"] }
-vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "2404f83f7d3a3779c1f518e4d949f7da9677c3dd", features = ["js"] }
+[target.'cfg(target_arch = "wasm32")'.dependencies.ruma]
+git = "https://github.com/ruma/ruma"
+rev = "ca8c66c885241a7ba3805399604eda4a38979f6b"
+features = ["client-api-c", "js", "rand", "canonical-json", "unstable-msc2676", "unstable-msc2677"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.ruma]
+git = "https://github.com/ruma/ruma"
+rev = "ca8c66c885241a7ba3805399604eda4a38979f6b"
+features = ["client-api-c", "rand", "canonical-json", "unstable-msc2676", "unstable-msc2677"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.vodozemac]
+git = "https://github.com/matrix-org/vodozemac/"
+rev = "18bcbc3359298894415931547ea41abb75af2d4a"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.vodozemac]
+git = "https://github.com/matrix-org/vodozemac/"
+rev = "18bcbc3359298894415931547ea41abb75af2d4a"
+features = ["js"]
 
 [dev-dependencies]
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -39,7 +39,7 @@ pub enum OlmError {
 
     /// The received room key couldn't be converted into a valid Megolm session.
     #[error(transparent)]
-    SessionCreation(#[from] vodozemac::megolm::SessionKeyDecodeError),
+    SessionCreation(#[from] SessionCreationError),
 
     /// The storage layer returned an error.
     #[error("failed to read or write to the crypto store {0}")]

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -591,9 +591,10 @@ impl GossipMachine {
         room_id: &RoomId,
         sender_key: &str,
         session_id: &str,
+        algorithm: &EventEncryptionAlgorithm,
     ) -> Result<(Option<OutgoingRequest>, OutgoingRequest), CryptoStoreError> {
         let key_info = RequestedKeyInfo::new(
-            EventEncryptionAlgorithm::MegolmV1AesSha2,
+            algorithm.to_owned(),
             room_id.to_owned(),
             sender_key.to_owned(),
             session_id.to_owned(),
@@ -668,9 +669,10 @@ impl GossipMachine {
         room_id: &RoomId,
         sender_key: &str,
         session_id: &str,
+        algorithm: &EventEncryptionAlgorithm,
     ) -> Result<bool, CryptoStoreError> {
         let key_info = RequestedKeyInfo::new(
-            EventEncryptionAlgorithm::MegolmV1AesSha2,
+            algorithm.to_owned(),
             room_id.to_owned(),
             sender_key.to_owned(),
             session_id.to_owned(),
@@ -1067,7 +1069,12 @@ mod tests {
 
         assert!(machine.outgoing_to_device_requests().await.unwrap().is_empty());
         let (cancel, request) = machine
-            .request_key(session.room_id(), &session.sender_key, session.session_id())
+            .request_key(
+                session.room_id(),
+                &session.sender_key,
+                session.session_id(),
+                session.algorithm(),
+            )
             .await
             .unwrap();
 
@@ -1076,7 +1083,12 @@ mod tests {
         machine.mark_outgoing_request_as_sent(&request.request_id).await.unwrap();
 
         let (cancel, _) = machine
-            .request_key(session.room_id(), &session.sender_key, session.session_id())
+            .request_key(
+                session.room_id(),
+                &session.sender_key,
+                session.session_id(),
+                session.algorithm(),
+            )
             .await
             .unwrap();
 
@@ -1102,6 +1114,7 @@ mod tests {
                 session.room_id(),
                 &session.sender_key,
                 session.session_id(),
+                session.algorithm(),
             )
             .await
             .unwrap();
@@ -1113,6 +1126,7 @@ mod tests {
                 session.room_id(),
                 &session.sender_key,
                 session.session_id(),
+                session.algorithm(),
             )
             .await
             .unwrap();
@@ -1144,6 +1158,7 @@ mod tests {
                 session.room_id(),
                 &session.sender_key,
                 session.session_id(),
+                session.algorithm(),
             )
             .await
             .unwrap();
@@ -1192,6 +1207,7 @@ mod tests {
                 session.room_id(),
                 &session.sender_key,
                 session.session_id(),
+                session.algorithm(),
             )
             .await
             .unwrap();
@@ -1378,6 +1394,7 @@ mod tests {
                 room_id(),
                 &bob_account.identity_keys.curve25519.to_base64(),
                 group_session.session_id(),
+                &group_session.settings().algorithm,
             )
             .await
             .unwrap();
@@ -1582,6 +1599,7 @@ mod tests {
                 room_id(),
                 &bob_account.identity_keys.curve25519.to_base64(),
                 group_session.session_id(),
+                &group_session.settings().algorithm,
             )
             .await
             .unwrap();

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -959,7 +959,6 @@ mod tests {
             AnyToDeviceEvent, ToDeviceEvent as RumaToDeviceEvent,
         },
         room_id,
-        serde::Raw,
         to_device::DeviceIdOrAllDevices,
         user_id, DeviceId, RoomId, UserId,
     };
@@ -971,6 +970,7 @@ mod tests {
         session_manager::GroupSessionCache,
         store::{Changes, CryptoStore, MemoryStore, Store},
         types::events::{room::encrypted::ToDeviceEncryptedEventContent, ToDeviceEvent},
+        utilities::json_convert,
         verification::VerificationMachine,
         OutgoingRequests,
     };
@@ -1457,7 +1457,7 @@ mod tests {
 
         let event =
             ToDeviceEvent { sender: bob_id().to_owned(), content, other: Default::default() };
-        let event = Raw::new(&event).unwrap().deserialize_as().unwrap();
+        let event = json_convert(&event).unwrap();
 
         // Check that alice doesn't have the session.
         assert!(alice_machine
@@ -1682,7 +1682,7 @@ mod tests {
 
         let event =
             ToDeviceEvent { sender: bob_id().to_owned(), content, other: Default::default() };
-        let event = Raw::new(&event).unwrap().deserialize_as().unwrap();
+        let event = json_convert(&event).unwrap();
 
         // Check that alice doesn't have the session.
         assert!(alice_machine

--- a/crates/matrix-sdk-crypto/src/gossiping/mod.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/mod.rs
@@ -180,10 +180,11 @@ impl GossipRequest {
             }
         };
 
-        let request = ToDeviceRequest::new(
+        let request = ToDeviceRequest::with_id(
             &self.request_recipient,
             DeviceIdOrAllDevices::AllDevices,
             content,
+            TransactionId::new(),
         );
 
         OutgoingRequest { request_id: request.txn_id.clone(), request: Arc::new(request.into()) }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1596,7 +1596,6 @@ pub(crate) mod tests {
         uint, user_id, DeviceId, DeviceKeyAlgorithm, DeviceKeyId, MilliSecondsSinceUnixEpoch,
         OwnedDeviceKeyId, UserId,
     };
-    use serde_json::value::to_raw_value;
     use vodozemac::Ed25519PublicKey;
 
     use super::testing::response_from_file;
@@ -1604,12 +1603,10 @@ pub(crate) mod tests {
         machine::OlmMachine,
         olm::VerifyJson,
         types::{
-            events::{
-                room::encrypted::{EncryptedEvent, ToDeviceEncryptedEventContent},
-                ToDeviceEvent,
-            },
+            events::{room::encrypted::ToDeviceEncryptedEventContent, ToDeviceEvent},
             DeviceKeys, SignedKey,
         },
+        utilities::json_convert,
         verification::tests::{outgoing_request_to_event, request_to_event},
         EncryptionSettings, ReadOnlyDevice, ToDeviceRequest,
     };
@@ -1981,7 +1978,7 @@ pub(crate) mod tests {
             content: to_device_requests_to_content(to_device_requests),
             other: Default::default(),
         };
-        let event = Raw::from_json(to_raw_value(&event).unwrap());
+        let event = json_convert(&event).unwrap();
 
         let alice_session =
             alice.group_session_manager.get_outbound_group_session(room_id).unwrap();
@@ -2052,7 +2049,7 @@ pub(crate) mod tests {
             unsigned: MessageLikeUnsigned::default(),
         };
 
-        let event: Raw<EncryptedEvent> = Raw::new(&event).unwrap().cast();
+        let event = json_convert(&event).unwrap();
 
         let decrypted_event =
             bob.decrypt_room_event(&event, room_id).await.unwrap().event.deserialize().unwrap();

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1070,6 +1070,7 @@ impl ReadOnlyAccount {
             &signing_key,
             room_id,
             &outbound.session_key().await,
+            outbound.settings().algorithm.to_owned(),
             Some(visibility),
         );
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -28,12 +28,7 @@ use ruma::{
         upload_keys,
         upload_signatures::v3::{Request as SignatureUploadRequest, SignedKeys},
     },
-    events::{
-        room::encrypted::{
-            EncryptedEventScheme, OlmV1Curve25519AesSha2Content, ToDeviceRoomEncryptedEvent,
-        },
-        AnyToDeviceEvent, OlmV1Keys,
-    },
+    events::{AnyToDeviceEvent, OlmV1Keys},
     serde::Raw,
     DeviceId, DeviceKeyAlgorithm, DeviceKeyId, EventEncryptionAlgorithm, OwnedDeviceId,
     OwnedDeviceKeyId, OwnedUserId, RoomId, SecondsSinceUnixEpoch, UInt, UserId,
@@ -56,7 +51,12 @@ use crate::{
     identities::{MasterPubkey, ReadOnlyDevice},
     requests::UploadSigningKeysRequest,
     store::{Changes, Store},
-    types::{CrossSigningKey, DeviceKeys, OneTimeKey, SignedKey},
+    types::{
+        events::room::encrypted::{
+            EncryptedToDeviceEvent, OlmV1Curve25519AesSha2Content, ToDeviceEncryptedEventContent,
+        },
+        CrossSigningKey, DeviceKeys, OneTimeKey, SignedKey,
+    },
     utilities::encode,
     CryptoStoreError, OlmError, SignatureError,
 };
@@ -117,14 +117,17 @@ pub struct OlmMessageHash {
 }
 
 impl OlmMessageHash {
-    fn new(sender_key: &str, message_type: u8, ciphertext: &str) -> Self {
+    fn new(sender_key: Curve25519PublicKey, ciphertext: &OlmMessage) -> Self {
+        let (message_type, ciphertext) = ciphertext.clone().to_parts();
+        let sender_key = sender_key.to_base64();
+
         let sha = Sha256::new()
-            .chain_update(sender_key)
-            .chain_update(&[message_type])
+            .chain_update(sender_key.as_bytes())
+            .chain_update(&[message_type as u8])
             .chain_update(&ciphertext)
             .finalize();
 
-        Self { sender_key: sender_key.to_owned(), hash: encode(sha.as_slice()) }
+        Self { sender_key, hash: encode(sha.as_slice()) }
     }
 }
 
@@ -137,24 +140,42 @@ impl Deref for Account {
 }
 
 impl Account {
-    fn parse_message(
-        sender_key: &str,
-        message_type: UInt,
-        ciphertext: String,
-    ) -> Result<(OlmMessage, OlmMessageHash), EventError> {
-        let message_type: u8 = message_type
-            .try_into()
-            .map_err(|_| EventError::UnsupportedOlmType(message_type.into()))?;
-
-        let message_hash = OlmMessageHash::new(sender_key, message_type, &ciphertext);
-        let message = OlmMessage::from_parts(message_type.into(), &ciphertext)
-            .map_err(|_| EventError::UnsupportedOlmType(message_type.into()))?;
-
-        Ok((message, message_hash))
-    }
-
     pub async fn save(&self) -> Result<(), CryptoStoreError> {
         self.store.save_account(self.inner.clone()).await
+    }
+
+    async fn decrypt_olm_helper(
+        &self,
+        sender: &UserId,
+        sender_key: Curve25519PublicKey,
+        ciphertext: &OlmMessage,
+    ) -> OlmResult<OlmDecryptionInfo> {
+        let message_hash = OlmMessageHash::new(sender_key, ciphertext);
+
+        match self.decrypt_olm_message(sender, sender_key, ciphertext).await {
+            Ok((session, event, signing_key)) => Ok(OlmDecryptionInfo {
+                sender: sender.to_owned(),
+                session,
+                message_hash,
+                event,
+                signing_key,
+                sender_key: sender_key.to_base64(),
+                inbound_group_session: None,
+            }),
+            Err(OlmError::SessionWedged(user_id, sender_key)) => {
+                if self.store.is_message_known(&message_hash).await? {
+                    info!(
+                        sender = sender.as_str(),
+                        sender_key, "An Olm message got replayed, decryption failed"
+                    );
+
+                    Err(OlmError::ReplayedMessage(user_id, sender_key))
+                } else {
+                    Err(OlmError::SessionWedged(user_id, sender_key))
+                }
+            }
+            Err(e) => Err(e),
+        }
     }
 
     async fn decrypt_olm_v1(
@@ -162,75 +183,43 @@ impl Account {
         sender: &UserId,
         content: &OlmV1Curve25519AesSha2Content,
     ) -> OlmResult<OlmDecryptionInfo> {
-        let identity_keys = self.inner.identity_keys();
-
-        // Try to find a ciphertext that was meant for our device.
-        if let Some(ciphertext) = content.ciphertext.get(&identity_keys.curve25519.to_base64()) {
-            let (message, message_hash) = match Self::parse_message(
-                &content.sender_key,
-                ciphertext.message_type,
-                ciphertext.body.clone(),
-            ) {
-                Ok(m) => m,
-                Err(e) => {
-                    warn!(error = ?e, "Encrypted to-device event isn't valid");
-                    return Err(e.into());
-                }
-            };
-
-            // Decrypt the OlmMessage and get a Ruma event out of it.
-            match self.decrypt_olm_message(sender, &content.sender_key, message).await {
-                Ok((session, event, signing_key)) => Ok(OlmDecryptionInfo {
-                    sender: sender.to_owned(),
-                    session,
-                    message_hash,
-                    event,
-                    signing_key,
-                    sender_key: content.sender_key.clone(),
-                    inbound_group_session: None,
-                }),
-                Err(OlmError::SessionWedged(user_id, sender_key)) => {
-                    if self.store.is_message_known(&message_hash).await? {
-                        info!(
-                            sender = sender.as_str(),
-                            sender_key = content.sender_key.as_str(),
-                            "An Olm message got replayed, decryption failed"
-                        );
-
-                        Err(OlmError::ReplayedMessage(user_id, sender_key))
-                    } else {
-                        Err(OlmError::SessionWedged(user_id, sender_key))
-                    }
-                }
-                Err(e) => Err(e),
-            }
-        } else {
+        if content.recipient_key != self.identity_keys().curve25519 {
             warn!(
                 sender = sender.as_str(),
-                sender_key = content.sender_key.as_str(),
+                sender_key = content.sender_key.to_base64(),
                 "Olm event doesn't contain a ciphertext for our key"
             );
 
             Err(EventError::MissingCiphertext.into())
+        } else {
+            self.decrypt_olm_helper(sender, content.sender_key, &content.ciphertext).await
         }
     }
 
     pub(crate) async fn decrypt_to_device_event(
         &self,
-        event: &ToDeviceRoomEncryptedEvent,
+        event: &EncryptedToDeviceEvent,
     ) -> OlmResult<OlmDecryptionInfo> {
-        trace!(sender = event.sender.as_str(), "Decrypting a to-device event");
+        trace!(
+            sender = event.sender.as_str(),
+            algorithm = %event.content.algorithm(),
+            "Decrypting a to-device event"
+        );
 
-        if let EncryptedEventScheme::OlmV1Curve25519AesSha2(c) = &event.content.scheme {
-            self.decrypt_olm_v1(&event.sender, c).await
-        } else {
-            warn!(
-                sender = event.sender.as_str(),
-                algorithm = ?event.content.scheme,
-                "Error, unsupported encryption algorithm"
-            );
+        match &event.content {
+            ToDeviceEncryptedEventContent::OlmV1Curve25519AesSha2(c) => {
+                self.decrypt_olm_v1(&event.sender, c).await
+            }
+            ToDeviceEncryptedEventContent::Unknown(_) => {
+                warn!(
+                    sender = event.sender.as_str(),
+                    algorithm = %event.content.algorithm(),
+                    "Error decrypting an to-device event, unsupported \
+                    encryption algorithm"
+                );
 
-            Err(EventError::UnsupportedAlgorithm.into())
+                Err(EventError::UnsupportedAlgorithm.into())
+            }
         }
     }
 
@@ -257,10 +246,10 @@ impl Account {
     /// with the given sender.
     async fn decrypt_with_existing_sessions(
         &self,
-        sender_key: &str,
+        sender_key: Curve25519PublicKey,
         message: &OlmMessage,
     ) -> OlmResult<Option<(Session, String)>> {
-        let s = self.store.get_sessions(sender_key).await?;
+        let s = self.store.get_sessions(&sender_key.to_base64()).await?;
 
         // We don't have any existing sessions, return early.
         let sessions = if let Some(s) = s {
@@ -292,12 +281,12 @@ impl Account {
     async fn decrypt_olm_message(
         &self,
         sender: &UserId,
-        sender_key: &str,
-        message: OlmMessage,
+        sender_key: Curve25519PublicKey,
+        message: &OlmMessage,
     ) -> OlmResult<(SessionType, Raw<AnyToDeviceEvent>, String)> {
         // First try to decrypt using an existing session.
         let (session, plaintext) = if let Some(d) =
-            self.decrypt_with_existing_sessions(sender_key, &message).await?
+            self.decrypt_with_existing_sessions(sender_key, message).await?
         {
             // Decryption succeeded, de-structure the session/plaintext out of
             // the Option.
@@ -305,17 +294,17 @@ impl Account {
         } else {
             // Decryption failed with every known session, let's try to create a
             // new session.
-            match &message {
+            match message {
                 // A new session can only be created using a pre-key message,
                 // return with an error if it isn't one.
                 OlmMessage::Normal(_) => {
                     warn!(
                         sender = sender.as_str(),
-                        sender_key = sender_key,
+                        sender_key = sender_key.to_base64(),
                         "Failed to decrypt a non-pre-key message with all \
                         available sessions",
                     );
-                    return Err(OlmError::SessionWedged(sender.to_owned(), sender_key.to_owned()));
+                    return Err(OlmError::SessionWedged(sender.to_owned(), sender_key.to_base64()));
                 }
 
                 OlmMessage::PreKey(m) => {
@@ -325,14 +314,14 @@ impl Account {
                         Err(e) => {
                             warn!(
                                 sender = sender.as_str(),
-                                sender_key = sender_key,
+                                sender_key = sender_key.to_base64(),
                                 error = ?e,
                                 "Failed to create a new Olm session from a \
                                 prekey message",
                             );
                             return Err(OlmError::SessionWedged(
                                 sender.to_owned(),
-                                sender_key.to_owned(),
+                                sender_key.to_base64(),
                             ));
                         }
                     };
@@ -355,7 +344,7 @@ impl Account {
 
         trace!(
             sender = sender.as_str(),
-            sender_key = sender_key,
+            sender_key = sender_key.to_base64(),
             "Successfully decrypted an Olm message"
         );
 
@@ -381,7 +370,7 @@ impl Account {
 
                 warn!(
                     sender = sender.as_str(),
-                    sender_key = sender_key,
+                    sender_key = sender_key.to_base64(),
                     error = ?e,
                     "A to-device message was successfully decrypted but \
                     parsing and checking the event fields failed"
@@ -1015,10 +1004,9 @@ impl ReadOnlyAccount {
     /// account.
     pub async fn create_inbound_session(
         &self,
-        their_identity_key: &str,
+        their_identity_key: Curve25519PublicKey,
         message: &PreKeyMessage,
     ) -> Result<InboundCreationResult, SessionCreationError> {
-        let their_identity_key = Curve25519PublicKey::from_base64(their_identity_key)?;
         let result = self.inner.lock().await.create_inbound_session(their_identity_key, message)?;
 
         let now = SecondsSinceUnixEpoch::now();
@@ -1120,20 +1108,16 @@ impl ReadOnlyAccount {
         let message = our_session
             .encrypt(&device, AnyToDeviceEventContent::Dummy(ToDeviceDummyEventContent::new()))
             .await
+            .unwrap()
+            .deserialize()
             .unwrap();
-        let content = if let EncryptedEventScheme::OlmV1Curve25519AesSha2(c) = message.scheme {
+        let content = if let ToDeviceEncryptedEventContent::OlmV1Curve25519AesSha2(c) = message {
             c
         } else {
-            panic!("Invalid encrypted event algorithm");
+            panic!("Invalid encrypted event algorithm {}", message.algorithm());
         };
 
-        let own_ciphertext =
-            content.ciphertext.get(&other.identity_keys.curve25519.to_base64()).unwrap();
-        let message_type: u8 = own_ciphertext.message_type.try_into().unwrap();
-
-        let message = OlmMessage::from_parts(message_type.into(), &own_ciphertext.body).unwrap();
-
-        let prekey = if let OlmMessage::PreKey(m) = message.clone() {
+        let prekey = if let OlmMessage::PreKey(m) = content.ciphertext {
             m
         } else {
             panic!("Wrong Olm message type");
@@ -1141,7 +1125,7 @@ impl ReadOnlyAccount {
 
         let our_device = ReadOnlyDevice::from_account(self).await;
         let other_session = other
-            .create_inbound_session(&our_device.curve25519_key().unwrap().to_base64(), &prekey)
+            .create_inbound_session(our_device.curve25519_key().unwrap(), &prekey)
             .await
             .unwrap();
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -30,9 +30,21 @@ pub(crate) use outbound::ShareState;
 pub use outbound::{
     EncryptionSettings, GroupSession, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo,
 };
+use thiserror::Error;
 use vodozemac::megolm::SessionKeyDecodeError;
 pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};
 use zeroize::Zeroize;
+
+/// An error type for the creation of group sessions.
+#[derive(Debug, Error)]
+pub enum SessionCreationError {
+    /// The provided algorithm is not supported.
+    #[error("The provided algorithm is not supported: {0}")]
+    Algorithm(EventEncryptionAlgorithm),
+    /// The room key key couldn't be decoded.
+    #[error(transparent)]
+    Decode(#[from] SessionKeyDecodeError),
+}
 
 /// An exported version of an `InboundGroupSession`
 ///

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -136,10 +136,8 @@ pub(crate) mod tests {
         };
 
         let bob_keys = bob.identity_keys();
-        let result = alice
-            .create_inbound_session(&bob_keys.curve25519.to_base64(), &prekey_message)
-            .await
-            .unwrap();
+        let result =
+            alice.create_inbound_session(bob_keys.curve25519, &prekey_message).await.unwrap();
 
         assert_eq!(bob_session.session_id(), result.session.session_id());
 

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -47,14 +47,15 @@ pub(crate) mod tests {
             room::message::{Relation, Replacement, RoomMessageEventContent},
             AnyMessageLikeEvent, AnyRoomEvent, MessageLikeEvent,
         },
-        room_id,
-        serde::Raw,
-        user_id, DeviceId, UserId,
+        room_id, user_id, DeviceId, UserId,
     };
     use serde_json::json;
     use vodozemac::olm::OlmMessage;
 
-    use crate::olm::{ExportedRoomKey, InboundGroupSession, ReadOnlyAccount, Session};
+    use crate::{
+        olm::{ExportedRoomKey, InboundGroupSession, ReadOnlyAccount, Session},
+        utilities::json_convert,
+    };
 
     fn alice_id() -> &'static UserId {
         user_id!("@alice:example.org")
@@ -224,7 +225,7 @@ pub(crate) mod tests {
             "content": encrypted_content,
         });
 
-        let event = Raw::new(&event).unwrap().deserialize_as().unwrap();
+        let event = json_convert(&event).unwrap();
         let decrypted = inbound.decrypt(&event).await.unwrap().0;
 
         if let AnyRoomEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -252,8 +252,7 @@ impl GroupSessionManager {
                         .or_insert_with(BTreeMap::new)
                         .insert(
                             DeviceIdOrAllDevices::DeviceId(device.device_id().into()),
-                            Raw::new(&AnyToDeviceEventContent::RoomEncrypted(encrypted))
-                                .expect("Failed to serialize encrypted event"),
+                            encrypted.cast(),
                         );
                     share_info
                         .entry(device.user_id().to_owned())

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -23,8 +23,7 @@ use futures_util::future::join_all;
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     events::{
-        room::{encrypted::RoomEncryptedEventContent, history_visibility::HistoryVisibility},
-        AnyToDeviceEventContent, ToDeviceEventType,
+        room::history_visibility::HistoryVisibility, AnyToDeviceEventContent, ToDeviceEventType,
     },
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
@@ -38,6 +37,7 @@ use crate::{
     error::{EventError, MegolmResult, OlmResult},
     olm::{Account, InboundGroupSession, OutboundGroupSession, Session, ShareInfo, ShareState},
     store::{Changes, Result as StoreResult, Store},
+    types::events::room::encrypted::RoomEncryptedEventContent,
     Device, EncryptionSettings, OlmError, ToDeviceRequest,
 };
 
@@ -160,7 +160,7 @@ impl GroupSessionManager {
         room_id: &RoomId,
         content: Value,
         event_type: &str,
-    ) -> MegolmResult<RoomEncryptedEventContent> {
+    ) -> MegolmResult<Raw<RoomEncryptedEventContent>> {
         let session = self.sessions.get(room_id).expect("Session wasn't created nor shared");
 
         assert!(!session.expired(), "Session expired");

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -37,6 +37,7 @@ use crate::{
     olm::Account,
     requests::{OutgoingRequest, ToDeviceRequest},
     store::{Changes, Result as StoreResult, Store},
+    types::events::EventType,
     ReadOnlyDevice,
 };
 
@@ -145,7 +146,8 @@ impl SessionManager {
                 let request = ToDeviceRequest::new(
                     device.user_id(),
                     device.device_id().to_owned(),
-                    AnyToDeviceEventContent::RoomEncrypted(content),
+                    content.event_type(),
+                    content.cast(),
                 );
 
                 let request = OutgoingRequest {

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -240,6 +240,7 @@ mod tests {
             "test_key",
             room_id,
             &outbound.session_key().await,
+            outbound.settings().algorithm.to_owned(),
             None,
         );
 

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -288,7 +288,7 @@ macro_rules! cryptostore_integration_tests {
 
                 export.forwarding_curve25519_key_chain = vec!["some_chain".to_owned()];
 
-                let session = InboundGroupSession::from_export(export);
+                let session = InboundGroupSession::from_export(&export).unwrap();
 
                 let changes =
                     Changes { inbound_group_sessions: vec![session.clone()], ..Default::default() };

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -350,6 +350,7 @@ mod tests {
             "test_key",
             room_id,
             &outbound.session_key().await,
+            outbound.settings().algorithm.to_owned(),
             None,
         );
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -75,7 +75,7 @@ use crate::{
     },
     olm::{
         InboundGroupSession, OlmMessageHash, OutboundGroupSession, PrivateCrossSigningIdentity,
-        ReadOnlyAccount, Session,
+        ReadOnlyAccount, Session, SessionCreationError,
     },
     utilities::encode,
     verification::VerificationMachine,
@@ -603,7 +603,7 @@ pub enum CryptoStoreError {
 
     /// The received room key couldn't be converted into a valid Megolm session.
     #[error(transparent)]
-    SessionCreation(#[from] vodozemac::megolm::SessionKeyDecodeError),
+    SessionCreation(#[from] SessionCreationError),
 
     /// A Matrix identifier failed to be validated.
     #[error(transparent)]

--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -22,12 +22,25 @@ pub mod room_key;
 pub mod secret_send;
 mod to_device;
 
+use ruma::serde::Raw;
 pub use to_device::{ToDeviceCustomEvent, ToDeviceEvent, ToDeviceEvents};
 
 /// A trait for event contents to define their event type.
 pub trait EventType {
+    /// The event type of the event content.
+    const EVENT_TYPE: &'static str;
+
     /// Get the event type of the event content.
-    fn event_type(&self) -> &str;
+    ///
+    /// **Note**: This should never be implemented manually, this takes the
+    /// event type from the constant.
+    fn event_type(&self) -> &'static str {
+        Self::EVENT_TYPE
+    }
+}
+
+impl<T: EventType> EventType for Raw<T> {
+    const EVENT_TYPE: &'static str = T::EVENT_TYPE;
 }
 
 fn from_str<'a, T, E>(string: &'a str) -> Result<T, E>

--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -18,6 +18,7 @@
 //! types. Once deserialized they aim to zeroize all the secret material once
 //! the type is dropped.
 
+pub mod room;
 pub mod room_key;
 pub mod secret_send;
 mod to_device;

--- a/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
@@ -1,0 +1,400 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for the `m.room.encrypted` room events.
+
+use std::collections::BTreeMap;
+
+use ruma::{DeviceId, EventEncryptionAlgorithm, OwnedDeviceId};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use vodozemac::{megolm::MegolmMessage, olm::OlmMessage, Curve25519PublicKey};
+
+use super::Event;
+use crate::types::{
+    deserialize_curve_key,
+    events::{EventType, ToDeviceEvent},
+    serialize_curve_key,
+};
+
+/// An m.room.encrypted room event.
+pub type EncryptedEvent = Event<RoomEncryptedEventContent>;
+
+/// An m.room.encrypted to-device event.
+pub type EncryptedToDeviceEvent = ToDeviceEvent<ToDeviceEncryptedEventContent>;
+
+impl EncryptedToDeviceEvent {
+    /// Get the algorithm of the encrypted event content.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        self.content.algorithm()
+    }
+}
+
+/// The content for `m.room.encrypted` to-device events.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(try_from = "Helper")]
+pub enum ToDeviceEncryptedEventContent {
+    /// The event content for events encrypted with the m.megolm.v1.aes-sha2
+    /// algorithm.
+    OlmV1Curve25519AesSha2(Box<OlmV1Curve25519AesSha2Content>),
+    /// An event content that was encrypted with an unknown encryption
+    /// algorithm.
+    Unknown(UnknownEncryptedContent),
+}
+
+impl EventType for ToDeviceEncryptedEventContent {
+    const EVENT_TYPE: &'static str = "m.room.encrypted";
+}
+
+impl ToDeviceEncryptedEventContent {
+    /// Get the algorithm of the event content.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        match self {
+            ToDeviceEncryptedEventContent::OlmV1Curve25519AesSha2(_) => {
+                EventEncryptionAlgorithm::OlmV1Curve25519AesSha2
+            }
+            ToDeviceEncryptedEventContent::Unknown(c) => c.algorithm.to_owned(),
+        }
+    }
+}
+
+/// The event content for events encrypted with the m.olm.v1.curve25519-aes-sha2
+/// algorithm.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(try_from = "OlmHelper")]
+pub struct OlmV1Curve25519AesSha2Content {
+    /// The encrypted content of the event.
+    pub ciphertext: OlmMessage,
+
+    /// The Curve25519 key of the recipient device.
+    pub recipient_key: Curve25519PublicKey,
+
+    /// The Curve25519 key of the sender.
+    pub sender_key: Curve25519PublicKey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+struct OlmHelper {
+    #[serde(deserialize_with = "deserialize_curve_key", serialize_with = "serialize_curve_key")]
+    sender_key: Curve25519PublicKey,
+    ciphertext: BTreeMap<String, OlmMessage>,
+}
+
+impl Serialize for OlmV1Curve25519AesSha2Content {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let ciphertext =
+            BTreeMap::from([(self.recipient_key.to_base64(), self.ciphertext.clone())]);
+
+        OlmHelper { sender_key: self.sender_key, ciphertext }.serialize(serializer)
+    }
+}
+
+impl TryFrom<OlmHelper> for OlmV1Curve25519AesSha2Content {
+    type Error = serde_json::Error;
+
+    fn try_from(value: OlmHelper) -> Result<Self, Self::Error> {
+        let (recipient_key, ciphertext) = value.ciphertext.into_iter().next().ok_or_else(|| {
+            serde::de::Error::custom(
+                "The `m.room.encrypted` event is missing a ciphertext".to_owned(),
+            )
+        })?;
+
+        let recipient_key =
+            Curve25519PublicKey::from_base64(&recipient_key).map_err(serde::de::Error::custom)?;
+
+        Ok(Self { ciphertext, recipient_key, sender_key: value.sender_key })
+    }
+}
+
+/// The content for `m.room.encrypted` room events.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomEncryptedEventContent {
+    /// Algorithm-specific fields.
+    #[serde(flatten)]
+    pub scheme: RoomEventEncryptionScheme,
+
+    /// Information about related events.
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub relates_to: Option<Value>,
+}
+
+impl RoomEncryptedEventContent {
+    /// Get the algorithm of the event content.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        self.scheme.algorithm()
+    }
+}
+
+impl EventType for RoomEncryptedEventContent {
+    const EVENT_TYPE: &'static str = "m.room.encrypted";
+}
+
+/// An enum for per encryption algorithm event contents.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(try_from = "Helper")]
+pub enum RoomEventEncryptionScheme {
+    /// The event content for events encrypted with the m.megolm.v1.aes-sha2
+    /// algorithm.
+    MegolmV1AesSha2(MegolmV1AesSha2Content),
+    /// An event content that was encrypted with an unknown encryption
+    /// algorithm.
+    Unknown(UnknownEncryptedContent),
+}
+
+impl RoomEventEncryptionScheme {
+    /// Get the algorithm of the event content.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        match self {
+            RoomEventEncryptionScheme::MegolmV1AesSha2(_) => {
+                EventEncryptionAlgorithm::MegolmV1AesSha2
+            }
+            RoomEventEncryptionScheme::Unknown(c) => c.algorithm.to_owned(),
+        }
+    }
+}
+
+pub(crate) enum SupportedEventEncryptionSchemes<'a> {
+    MegolmV1AesSha2(&'a MegolmV1AesSha2Content),
+}
+
+impl SupportedEventEncryptionSchemes<'_> {
+    /// The Curve25519 key of the sender.
+    pub fn sender_key(&self) -> Curve25519PublicKey {
+        match self {
+            SupportedEventEncryptionSchemes::MegolmV1AesSha2(c) => c.sender_key,
+        }
+    }
+
+    /// The ID of the session used to encrypt the message.
+    pub fn session_id(&self) -> &str {
+        match self {
+            SupportedEventEncryptionSchemes::MegolmV1AesSha2(c) => &c.session_id,
+        }
+    }
+
+    /// The ID of the sending device.
+    pub fn device_id(&self) -> &DeviceId {
+        match self {
+            SupportedEventEncryptionSchemes::MegolmV1AesSha2(c) => &c.device_id,
+        }
+    }
+
+    /// The algorithm that was used to encrypt the event content.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        match self {
+            SupportedEventEncryptionSchemes::MegolmV1AesSha2(_) => {
+                EventEncryptionAlgorithm::MegolmV1AesSha2
+            }
+        }
+    }
+}
+
+impl<'a> From<&'a MegolmV1AesSha2Content> for SupportedEventEncryptionSchemes<'a> {
+    fn from(c: &'a MegolmV1AesSha2Content) -> Self {
+        Self::MegolmV1AesSha2(c)
+    }
+}
+
+/// The event content for events encrypted with the m.megolm.v1.aes-sha2
+/// algorithm.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MegolmV1AesSha2Content {
+    /// The encrypted content of the event.
+    pub ciphertext: MegolmMessage,
+
+    /// The Curve25519 key of the sender.
+    #[serde(deserialize_with = "deserialize_curve_key", serialize_with = "serialize_curve_key")]
+    pub sender_key: Curve25519PublicKey,
+
+    /// The ID of the sending device.
+    pub device_id: OwnedDeviceId,
+
+    /// The ID of the session used to encrypt the message.
+    pub session_id: String,
+}
+
+/// An unknown and unsupported `m.room.encrypted` event content.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnknownEncryptedContent {
+    /// The algorithm that was used to encrypt the given event content.
+    pub algorithm: EventEncryptionAlgorithm,
+    /// The other data of the unknown encryped content.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Helper {
+    algorithm: EventEncryptionAlgorithm,
+    #[serde(flatten)]
+    other: Value,
+}
+
+macro_rules! scheme_serialization {
+    ($something:ident, $($algorithm:ident => $content:ident),+ $(,)?) => {
+        $(
+            impl From<$content> for $something {
+                fn from(c: $content) -> Self {
+                    Self::$algorithm(c.into())
+                }
+            }
+        )+
+
+        impl TryFrom<Helper> for $something {
+            type Error = serde_json::Error;
+
+            fn try_from(value: Helper) -> Result<Self, Self::Error> {
+                Ok(match value.algorithm {
+                    $(
+                        EventEncryptionAlgorithm::$algorithm => {
+                            let content: $content = serde_json::from_value(value.other)?;
+                            content.into()
+                        }
+                    )+
+                    _ => Self::Unknown(UnknownEncryptedContent {
+                        algorithm: value.algorithm,
+                        other: serde_json::from_value(value.other)?,
+                    }),
+                })
+            }
+        }
+
+        impl Serialize for $something {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let helper = match self {
+                    $(
+                        Self::$algorithm(r) => Helper {
+                            algorithm: self.algorithm(),
+                            other: serde_json::to_value(r).map_err(serde::ser::Error::custom)?,
+                        },
+                    )+
+                    Self::Unknown(r) => Helper {
+                        algorithm: r.algorithm.clone(),
+                        other: serde_json::to_value(r.other.clone()).map_err(serde::ser::Error::custom)?,
+                    },
+                };
+
+                helper.serialize(serializer)
+            }
+        }
+    };
+}
+
+scheme_serialization!(
+    RoomEventEncryptionScheme,
+    MegolmV1AesSha2 => MegolmV1AesSha2Content,
+);
+
+scheme_serialization!(
+    ToDeviceEncryptedEventContent,
+    OlmV1Curve25519AesSha2 => OlmV1Curve25519AesSha2Content,
+);
+
+#[cfg(test)]
+pub(crate) mod test {
+    use matches::assert_matches;
+    use serde_json::{json, Value};
+    use vodozemac::Curve25519PublicKey;
+
+    use super::{
+        EncryptedEvent, EncryptedToDeviceEvent, OlmV1Curve25519AesSha2Content,
+        RoomEventEncryptionScheme, ToDeviceEncryptedEventContent,
+    };
+
+    pub fn json() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "event_id": "$Nhl3rsgHMjk-DjMJANawr9HHAhLg4GcoTYrSiYYGqEE",
+            "content": {
+                "m.custom": "something custom",
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "device_id": "DEWRCMENGS",
+                "session_id": "ZFD6+OmV7fVCsJ7Gap8UnORH8EnmiAkes8FAvQuCw/I",
+                "sender_key": "WJ6Ce7U67a6jqkHYHd8o0+5H4bqdi9hInZdk0+swuXs",
+                "ciphertext": "AwgAEiBQs2LgBD2CcB+RLH2bsgp9VadFUJhBXOtCmcJuttBD\
+                               OeDNjL21d9z0AcVSfQFAh9huh4or7sWuNrHcvu9/sMbweTgc\
+                               0UtdA5xFLheubHouXy4aewze+ShndWAaTbjWJMLsPSQDUMQH\
+                               BA"
+            },
+            "type": "m.room.encrypted",
+            "origin_server_ts": 1632491098485u64,
+            "m.custom.top": "something custom in the top",
+        })
+    }
+
+    pub fn olm_v1_json() -> Value {
+        json!({
+            "algorithm": "m.olm.v1.curve25519-aes-sha2",
+            "ciphertext": {
+                "Nn0L2hkcCMFKqynTjyGsJbth7QrVmX3lbrksMkrGOAw": {
+                    "body": "Awogv7Iysf062hV1gZNfG/SdO5TdLYtkRI12em6LxralPxoSIC\
+                             C/Avnha6NfkaMWSC+5h+khS0wHiUzA2bPmAvVo/iYhGiAfDNh4\
+                             F0eqPvOc4Hw9wMgd+frzedZgmhUNfKT0UzHQZSJPAwogF8fTdT\
+                             cPt1ppJ/KAEivFZ4dIyAlRUjzhlqzYsw9C1HoQACIgb9MK/a9T\
+                             RLtwol9gfy7OeKdpmSe39YhP+5OchhKvX6eO3/aED3X1oA",
+                    "type": 0
+                }
+            },
+            "sender_key": "mjkTX0I0Cp44ZfolOVbFe5WYPRmT6AX3J0ZbnGWnnWs"
+        })
+    }
+
+    pub fn to_device_json() -> Value {
+        json!({
+            "content": olm_v1_json(),
+            "sender": "@example:morpheus.localhost",
+            "type": "m.room.encrypted"
+        })
+    }
+
+    #[test]
+    fn deserialization() -> Result<(), serde_json::Error> {
+        let json = json();
+        let event: EncryptedEvent = serde_json::from_value(json.clone())?;
+
+        assert_matches!(event.content.scheme, RoomEventEncryptionScheme::MegolmV1AesSha2(_));
+        let serialized = serde_json::to_value(event)?;
+        assert_eq!(json, serialized);
+
+        let json = olm_v1_json();
+        let content: OlmV1Curve25519AesSha2Content = serde_json::from_value(json)?;
+
+        assert_eq!(
+            content.sender_key,
+            Curve25519PublicKey::from_base64("mjkTX0I0Cp44ZfolOVbFe5WYPRmT6AX3J0ZbnGWnnWs")
+                .unwrap()
+        );
+
+        assert_eq!(
+            content.recipient_key,
+            Curve25519PublicKey::from_base64("Nn0L2hkcCMFKqynTjyGsJbth7QrVmX3lbrksMkrGOAw")
+                .unwrap()
+        );
+
+        let json = to_device_json();
+        let event: EncryptedToDeviceEvent = serde_json::from_value(json.clone())?;
+
+        assert_matches!(event.content, ToDeviceEncryptedEventContent::OlmV1Curve25519AesSha2(_));
+        let serialized = serde_json::to_value(event)?;
+        assert_eq!(json, serialized);
+
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/events/room/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/mod.rs
@@ -1,0 +1,91 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for room events.
+
+use std::{collections::BTreeMap, fmt::Debug};
+
+use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::EventType;
+
+pub mod encrypted;
+
+/// Generic room event with a known type and content.
+#[derive(Debug, Deserialize)]
+pub struct Event<C>
+where
+    C: EventType + Debug + Sized + Serialize,
+{
+    /// Contains the fully-qualified ID of the user who sent this event.
+    pub sender: OwnedUserId,
+
+    /// The globally unique identifier for this event.
+    pub event_id: OwnedEventId,
+
+    /// The body of this event, as created by the client which sent it.
+    pub content: C,
+
+    /// Timestamp (in milliseconds since the unix epoch) on originating
+    /// homeserver when this event was sent.
+    pub origin_server_ts: MilliSecondsSinceUnixEpoch,
+
+    /// Contains optional extra information about the event.
+    #[serde(default)]
+    pub unsigned: BTreeMap<String, Value>,
+
+    /// Any other unknown data of the room event.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+impl<C> Serialize for Event<C>
+where
+    C: EventType + Debug + Sized + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a, C> {
+            sender: &'a UserId,
+            event_id: &'a EventId,
+            #[serde(rename = "type")]
+            event_type: &'a str,
+            content: &'a C,
+            origin_server_ts: MilliSecondsSinceUnixEpoch,
+            #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+            unsigned: &'a BTreeMap<String, Value>,
+            #[serde(flatten)]
+            other: &'a BTreeMap<String, Value>,
+        }
+
+        let event_type = C::EVENT_TYPE;
+
+        let helper = Helper {
+            sender: &self.sender,
+            content: &self.content,
+            event_type,
+            other: &self.other,
+            event_id: &self.event_id,
+            origin_server_ts: self.origin_server_ts,
+            unsigned: &self.unsigned,
+        };
+
+        helper.serialize(serializer)
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/events/room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key.rs
@@ -26,6 +26,13 @@ use super::{EventType, ToDeviceEvent};
 /// The `m.room_key` to-device event.
 pub type RoomKeyEvent = ToDeviceEvent<RoomKeyContent>;
 
+impl RoomKeyEvent {
+    /// Get the algorithm of the room key.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        self.content.algorithm()
+    }
+}
+
 impl EventType for RoomKeyContent {
     const EVENT_TYPE: &'static str = "m.room_key";
 }
@@ -47,6 +54,14 @@ pub enum RoomKeyContent {
 }
 
 impl RoomKeyContent {
+    /// Get the algorithm of the room key.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        match &self {
+            RoomKeyContent::MegolmV1AesSha2(_) => EventEncryptionAlgorithm::MegolmV1AesSha2,
+            RoomKeyContent::Unknown(c) => c.algorithm.to_owned(),
+        }
+    }
+
     pub(super) fn serialize_zeroized(&self) -> Result<Raw<RoomKeyContent>, serde_json::Error> {
         #[derive(Serialize)]
         struct Helper<'a> {
@@ -67,7 +82,7 @@ impl RoomKeyContent {
                 };
 
                 let helper = RoomKeyHelper {
-                    algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+                    algorithm: self.algorithm(),
                     other: serde_json::to_value(helper)?,
                 };
 

--- a/crates/matrix-sdk-crypto/src/types/events/room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key.rs
@@ -27,9 +27,7 @@ use super::{EventType, ToDeviceEvent};
 pub type RoomKeyEvent = ToDeviceEvent<RoomKeyContent>;
 
 impl EventType for RoomKeyContent {
-    fn event_type(&self) -> &str {
-        "m.room_key"
-    }
+    const EVENT_TYPE: &'static str = "m.room_key";
 }
 
 /// The `m.room_key` event content.

--- a/crates/matrix-sdk-crypto/src/types/events/secret_send.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/secret_send.rs
@@ -69,9 +69,7 @@ impl std::fmt::Debug for SecretSendContent {
 }
 
 impl EventType for SecretSendContent {
-    fn event_type(&self) -> &str {
-        "m.secret.send"
-    }
+    const EVENT_TYPE: &'static str = "m.secret.send";
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-crypto/src/utilities.rs
+++ b/crates/matrix-sdk-crypto/src/utilities.rs
@@ -24,3 +24,13 @@ pub fn decode(input: impl AsRef<[u8]>) -> Result<Vec<u8>, DecodeError> {
 pub fn encode(input: impl AsRef<[u8]>) -> String {
     encode_config(input, STANDARD_NO_PAD)
 }
+
+#[cfg(test)]
+pub(crate) fn json_convert<T, U>(value: &T) -> serde_json::Result<U>
+where
+    T: serde::Serialize,
+    U: serde::de::DeserializeOwned,
+{
+    let json = serde_json::to_string(value)?;
+    serde_json::from_str(&json)
+}

--- a/crates/matrix-sdk-crypto/src/verification/cache.rs
+++ b/crates/matrix-sdk-crypto/src/verification/cache.rs
@@ -169,7 +169,12 @@ impl VerificationCache {
     ) {
         match content {
             OutgoingContent::ToDevice(c) => {
-                let request = ToDeviceRequest::new(recipient, recipient_device.to_owned(), c);
+                let request = ToDeviceRequest::with_id(
+                    recipient,
+                    recipient_device.to_owned(),
+                    c,
+                    TransactionId::new(),
+                );
                 let request_id = request.txn_id.clone();
 
                 let request = OutgoingRequest {

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -132,8 +132,12 @@ impl VerificationMachine {
                 RoomMessageRequest { room_id: r, txn_id: TransactionId::new(), content: c }.into()
             }
             OutgoingContent::ToDevice(c) => {
-                let request =
-                    ToDeviceRequest::new(device.user_id(), device.device_id().to_owned(), c);
+                let request = ToDeviceRequest::with_id(
+                    device.user_id(),
+                    device.device_id().to_owned(),
+                    c,
+                    TransactionId::new(),
+                );
 
                 self.verifications.insert_sas(sas.clone());
 

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -291,10 +291,11 @@ impl QrVerification {
             OutgoingContent::Room(room_id, content) => {
                 RoomMessageRequest { room_id, txn_id: TransactionId::new(), content }.into()
             }
-            OutgoingContent::ToDevice(c) => ToDeviceRequest::new(
+            OutgoingContent::ToDevice(c) => ToDeviceRequest::with_id(
                 self.identities.other_user_id(),
                 self.identities.other_device_id().to_owned(),
                 c,
+                TransactionId::new(),
             )
             .into(),
         }

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -380,9 +380,13 @@ impl VerificationRequest {
         let mut inner = self.inner.lock().unwrap();
 
         inner.accept(methods).map(|c| match c {
-            OutgoingContent::ToDevice(content) => {
-                ToDeviceRequest::new(self.other_user(), inner.other_device_id(), content).into()
-            }
+            OutgoingContent::ToDevice(content) => ToDeviceRequest::with_id(
+                self.other_user(),
+                inner.other_device_id(),
+                content,
+                TransactionId::new(),
+            )
+            .into(),
             OutgoingContent::Room(room_id, content) => {
                 RoomMessageRequest { room_id, txn_id: TransactionId::new(), content }.into()
             }
@@ -435,7 +439,13 @@ impl VerificationRequest {
                     )
                     .into()
                 } else {
-                    ToDeviceRequest::new(self.other_user(), other_device, content).into()
+                    ToDeviceRequest::with_id(
+                        self.other_user(),
+                        other_device,
+                        content,
+                        TransactionId::new(),
+                    )
+                    .into()
                 }
             }
             OutgoingContent::Room(room_id, content) => {
@@ -627,10 +637,11 @@ impl VerificationRequest {
                     self.verification_cache.insert_sas(sas.clone());
 
                     let request = match content {
-                        OutgoingContent::ToDevice(content) => ToDeviceRequest::new(
+                        OutgoingContent::ToDevice(content) => ToDeviceRequest::with_id(
                             self.other_user(),
                             inner.other_device_id(),
                             content,
+                            TransactionId::new(),
                         )
                         .into(),
                         OutgoingContent::Room(room_id, content) => {

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -473,7 +473,12 @@ impl Sas {
     }
 
     pub(crate) fn content_to_request(&self, content: AnyToDeviceEventContent) -> ToDeviceRequest {
-        ToDeviceRequest::new(self.other_user_id(), self.other_device_id().to_owned(), content)
+        ToDeviceRequest::with_id(
+            self.other_user_id(),
+            self.other_device_id().to_owned(),
+            content,
+            TransactionId::new(),
+        )
     }
 }
 

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -30,4 +30,4 @@ thiserror = "1.0.30"
 
 [dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "2404f83f7d3a3779c1f518e4d949f7da9677c3dd"
+rev = "18bcbc3359298894415931547ea41abb75af2d4a"

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -575,11 +575,8 @@ impl Joined {
 
                 let encrypted_content =
                     olm.encrypt_room_event_raw(self.inner.room_id(), content, event_type).await?;
-                let raw_content = Raw::new(&encrypted_content)
-                    .expect("Failed to serialize encrypted event")
-                    .cast();
 
-                (raw_content, "m.room.encrypted")
+                (encrypted_content.cast(), "m.room.encrypted")
             }
         } else {
             debug!(


### PR DESCRIPTION
This is a continuation from #767,  while #767 added customized `m.room_key` events this PR adds customized `m.room.encrypted` events.

The PR might look scary with a lot of changes, but most of them are boring type changes. One interesting aspect here is that we're starting to take `Raw` variants of events when decrypting. This should allow more flexibility in the case the `matrix-sdk-crypto` consumer isn't the Rust SDK itself.