### PR TITLE
chore(ci): Fix new clippy warnings

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -135,7 +135,7 @@ pub enum EventError {
 
     #[error(
         "the room id of the room key doesn't match the room id of the \
-        decrypted event: expected {0}, got {:1}"
+        decrypted event: expected {0}, got {1:?}"
     )]
     MismatchedRoom(OwnedRoomId, Option<OwnedRoomId>),
 }

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -374,6 +374,6 @@ mod tests {
         let mut decryptor = AttachmentDecryptor::new(&mut cursor, key).unwrap();
         let mut decrypted_data = Vec::new();
 
-        assert!(decryptor.read_to_end(&mut decrypted_data).is_err())
+        decryptor.read_to_end(&mut decrypted_data).unwrap_err();
     }
 }

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn test_decode() {
         let export = export_without_headers();
-        assert!(decode(export).is_ok());
+        decode(export).unwrap();
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1257,7 +1257,7 @@ mod tests {
         );
         own_device.set_trust_state(LocalTrust::Verified);
         // Now we do want to share the keys.
-        assert!(machine.should_share_key(&own_device, &inbound).await.is_ok());
+        machine.should_share_key(&own_device, &inbound).await.unwrap();
 
         let bob_device = ReadOnlyDevice::from_account(&bob_account()).await;
         machine.store.save_devices(&[bob_device]).await.unwrap();
@@ -1303,7 +1303,7 @@ mod tests {
                 bob_device.curve25519_key().unwrap(),
             )
             .await;
-        assert!(machine.should_share_key(&bob_device, &inbound).await.is_ok());
+        machine.should_share_key(&bob_device, &inbound).await.unwrap();
 
         let (other_outbound, other_inbound) =
             account.create_group_session_pair_with_defaults(room_id()).await;

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -860,7 +860,7 @@ pub(crate) mod tests {
 
         manager.receive_keys_query_response(&other_key_query()).await.unwrap();
 
-        assert!(task.await.unwrap().is_ok());
+        task.await.unwrap().unwrap();
 
         let devices = manager.store.get_user_devices(other_user).await.unwrap();
         assert_eq!(devices.devices().count(), 1);
@@ -874,7 +874,7 @@ pub(crate) mod tests {
         let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
         let identity = identity.other().unwrap();
 
-        assert!(identity.is_device_signed(&device).is_ok())
+        identity.is_device_signed(&device).unwrap();
     }
 
     #[async_test]
@@ -898,7 +898,7 @@ pub(crate) mod tests {
         let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
         let identity = identity.other().unwrap();
 
-        assert!(identity.is_device_signed(&device).is_ok())
+        identity.is_device_signed(&device).unwrap();
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1014,8 +1014,8 @@ pub(crate) mod tests {
         let identity = get_own_identity();
         let (first, second) = device(&response);
 
-        assert!(identity.is_device_signed(&first).is_err());
-        assert!(identity.is_device_signed(&second).is_ok());
+        identity.is_device_signed(&first).unwrap_err();
+        identity.is_device_signed(&second).unwrap();
 
         let private_identity =
             Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(second.user_id())));

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1768,7 +1768,7 @@ pub(crate) mod tests {
             &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
             &device_keys,
         );
-        assert!(ret.is_ok());
+        ret.unwrap();
     }
 
     #[async_test]
@@ -1801,7 +1801,7 @@ pub(crate) mod tests {
             &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
             &device_keys,
         );
-        assert!(ret.is_err());
+        ret.unwrap_err();
     }
 
     #[async_test]
@@ -1851,7 +1851,7 @@ pub(crate) mod tests {
             &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
             &one_time_key,
         );
-        assert!(ret.is_ok());
+        ret.unwrap();
 
         let device_keys: DeviceKeys = request.device_keys.unwrap().deserialize_as().unwrap();
 
@@ -1860,7 +1860,7 @@ pub(crate) mod tests {
             &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, machine.device_id()),
             &device_keys,
         );
-        assert!(ret.is_ok());
+        ret.unwrap();
 
         let mut response = keys_upload_response();
         response.one_time_key_counts.insert(

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -715,15 +715,15 @@ mod tests {
         let master_key = identity.master_key.lock().await;
         let master_key = master_key.as_ref().unwrap();
 
-        assert!(master_key
+        master_key
             .public_key
             .verify_subkey(&identity.self_signing_key.lock().await.as_ref().unwrap().public_key)
-            .is_ok());
+            .unwrap();
 
-        assert!(master_key
+        master_key
             .public_key
             .verify_subkey(&identity.user_signing_key.lock().await.as_ref().unwrap().public_key)
-            .is_ok());
+            .unwrap();
     }
 
     #[async_test]

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -172,7 +172,7 @@ async fn login_with_sso_token() {
     assert!(can_sso);
 
     let sso_url = client.get_sso_login_url("http://127.0.0.1:3030", None).await;
-    assert!(sso_url.is_ok());
+    sso_url.unwrap();
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
@@ -280,7 +280,7 @@ async fn devices() {
         .mount(&server)
         .await;
 
-    assert!(client.devices().await.is_ok());
+    client.devices().await.unwrap();
 }
 
 #[async_test]
@@ -360,7 +360,7 @@ async fn resolve_room_alias() {
         .await;
 
     let alias = ruma::room_alias_id!("#alias:example.org");
-    assert!(client.resolve_room_alias(alias).await.is_ok());
+    client.resolve_room_alias(alias).await.unwrap();
 }
 
 #[async_test]
@@ -520,9 +520,9 @@ async fn get_media_content() {
         .mount(&server)
         .await;
 
-    assert!(client.get_media_content(&request, true).await.is_ok());
-    assert!(client.get_media_content(&request, true).await.is_ok());
-    assert!(client.get_media_content(&request, false).await.is_ok());
+    client.get_media_content(&request, true).await.unwrap();
+    client.get_media_content(&request, true).await.unwrap();
+    client.get_media_content(&request, false).await.unwrap();
 }
 
 #[async_test]
@@ -548,8 +548,8 @@ async fn get_media_file() {
         .mount(&server)
         .await;
 
-    assert!(client.get_file(event_content.clone(), true).await.is_ok());
-    assert!(client.get_file(event_content.clone(), true).await.is_ok());
+    client.get_file(event_content.clone(), true).await.unwrap();
+    client.get_file(event_content.clone(), true).await.unwrap();
 
     Mock::given(method("GET"))
         .and(path("/_matrix/media/r0/thumbnail/example%2Eorg/image"))
@@ -561,14 +561,14 @@ async fn get_media_file() {
         .mount(&server)
         .await;
 
-    assert!(client
+    client
         .get_thumbnail(
             event_content,
             MediaThumbnailSize { method: Method::Scale, width: uint!(100), height: uint!(100) },
-            true
+            true,
         )
         .await
-        .is_ok());
+        .unwrap();
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -412,7 +412,7 @@ async fn room_attachment_send_wrong_info() {
 
     let response = room.send_attachment("image", &mime::IMAGE_JPEG, &mut media, config).await;
 
-    assert!(response.is_err())
+    response.unwrap_err();
 }
 
 #[async_test]


### PR DESCRIPTION
The main new warning was uses of `assert!(x.is_ok())` or `assert!(x.is_err())` while unwrapping gives better error messages.