### PR TITLE
build: Adding .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -58,8 +58,8 @@ jobs:
         run: |
           mkdir -p target/docs/bindings/matrix-sdk-crypto-nodejs/
           mkdir -p target/docs/bindings/matrix-sdk-crypto-js/
-          mv bindings/matrix-sdk-crypto-nodejs/docs/* target/docs/bindings/matrix-sdk-crypto-nodejs/
-          mv bindings/matrix-sdk-crypto-js/docs/* target/docs/bindings/matrix-sdk-crypto-js/
+          mv -f bindings/matrix-sdk-crypto-nodejs/docs/* target/docs/bindings/matrix-sdk-crypto-nodejs/
+          mv -f bindings/matrix-sdk-crypto-js/docs/* target/docs/bindings/matrix-sdk-crypto-js/
 
       - name: Deploy documentation
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Adding an `.editorconfig` in the root to ensure the editors do all the line-endings as we want them to.