### PR TITLE
refactor(sdk): Check permissible feature configuration in build script

### DIFF
--- a/crates/matrix-sdk-sled/build.rs
+++ b/crates/matrix-sdk-sled/build.rs
@@ -1,0 +1,17 @@
+use std::{env, process};
+
+fn main() {
+    let target_arch = env::var_os("CARGO_CFG_TARGET_ARCH");
+    if target_arch.map_or(false, |arch| arch == "wasm32") {
+        let err = "this crate does not support the target arch 'wasm32'";
+        eprintln!(
+            "\n\
+            ┏━━━━━━━━{pad}━┓\n\
+            ┃ error: {err} ┃\n\
+            ┗━━━━━━━━{pad}━┛\n\
+            ",
+            pad = "━".repeat(err.len()),
+        );
+        process::exit(1);
+    }
+}

--- a/crates/matrix-sdk/build.rs
+++ b/crates/matrix-sdk/build.rs
@@ -1,0 +1,44 @@
+use std::{env, process};
+
+fn env_is_set(var_name: &str) -> bool {
+    env::var_os(var_name).is_some()
+}
+
+fn ensure(cond: bool, err: &str) {
+    if !cond {
+        eprintln!(
+            "\n\
+            ┏━━━━━━━━{pad}━┓\n\
+            ┃ error: {err} ┃\n\
+            ┗━━━━━━━━{pad}━┛\n\
+            ",
+            pad = "━".repeat(err.len()),
+        );
+        process::exit(1);
+    }
+}
+
+fn main() {
+    let native_tls_set = env_is_set("CARGO_FEATURE_NATIVE_TLS");
+    let rustls_tls_set = env_is_set("CARGO_FEATURE_RUSTLS_TLS");
+    ensure(
+        native_tls_set || rustls_tls_set,
+        "one of the features 'native-tls' or 'rustls-tls' must be enabled",
+    );
+    ensure(
+        !native_tls_set || !rustls_tls_set,
+        "only one of the features 'native-tls' or 'rustls-tls' can be enabled",
+    );
+
+    let is_wasm = env::var_os("CARGO_CFG_TARGET_ARCH").map_or(false, |arch| arch == "wasm32");
+    if is_wasm {
+        ensure(
+            !env_is_set("CARGO_FEATURE_SSO_LOGIN"),
+            "feature 'sso-login' is not available on target arch 'wasm32'",
+        );
+        ensure(
+            !env_is_set("CARGO_FEATURE_IMAGE_RAYON"),
+            "feature 'image-rayon' is not available on target arch 'wasm32'",
+        );
+    }
+}

--- a/crates/matrix-sdk/src/client/login_builder.rs
+++ b/crates/matrix-sdk/src/client/login_builder.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
 
-#[cfg(all(feature = "sso-login", not(target_arch = "wasm32")))]
+#[cfg(feature = "sso-login")]
 use std::future::Future;
 
 use ruma::{
@@ -149,7 +149,7 @@ impl<'a> LoginBuilder<'a> {
 ///
 /// Created with [`Client::login_sso`].
 /// Finalized with [`.send()`](Self::send).
-#[cfg(all(feature = "sso-login", not(target_arch = "wasm32")))]
+#[cfg(feature = "sso-login")]
 #[allow(missing_debug_implementations)]
 pub struct SsoLoginBuilder<'a, F> {
     client: Client,
@@ -162,7 +162,7 @@ pub struct SsoLoginBuilder<'a, F> {
     request_refresh_token: bool,
 }
 
-#[cfg(all(feature = "sso-login", not(target_arch = "wasm32")))]
+#[cfg(feature = "sso-login")]
 impl<'a, F, Fut> SsoLoginBuilder<'a, F>
 where
     F: FnOnce(String) -> Fut + Send,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -96,7 +96,7 @@ use crate::{
 mod builder;
 mod login_builder;
 
-#[cfg(all(feature = "sso-login", not(target_arch = "wasm32")))]
+#[cfg(feature = "sso-login")]
 pub use self::login_builder::SsoLoginBuilder;
 pub use self::{
     builder::{ClientBuildError, ClientBuilder},
@@ -1157,7 +1157,7 @@ impl Client {
     /// [`get_sso_login_url`]: #method.get_sso_login_url
     /// [`login_token`]: #method.login_token
     /// [`restore_login`]: #method.restore_login
-    #[cfg(all(feature = "sso-login", not(target_arch = "wasm32")))]
+    #[cfg(feature = "sso-login")]
     pub fn login_sso<'a, F, Fut>(&self, use_sso_login_url: F) -> SsoLoginBuilder<'a, F>
     where
         F: FnOnce(String) -> Fut + Send,
@@ -1189,7 +1189,7 @@ impl Client {
 
     /// Login to the server via Single Sign-On.
     #[deprecated = "Replaced by [`Client::login_sso`](#method.login_sso)"]
-    #[cfg(all(feature = "sso-login", not(target_arch = "wasm32")))]
+    #[cfg(feature = "sso-login")]
     #[deny(clippy::future_not_send)]
     pub async fn login_with_sso<C>(
         &self,

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -17,18 +17,6 @@
 #![warn(missing_debug_implementations, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
-compile_error!("one of 'native-tls' or 'rustls-tls' features must be enabled");
-
-#[cfg(all(feature = "native-tls", feature = "rustls-tls"))]
-compile_error!("only one of 'native-tls' or 'rustls-tls' features can be enabled");
-
-#[cfg(all(feature = "sso-login", target_arch = "wasm32"))]
-compile_error!("'sso-login' cannot be enabled on 'wasm32' arch");
-
-#[cfg(all(feature = "image-rayon", target_arch = "wasm32"))]
-compile_error!("'image-rayon' cannot be enabled on 'wasm32' arch");
-
 pub use async_trait::async_trait;
 pub use bytes;
 pub use matrix_sdk_base::{
@@ -58,7 +46,7 @@ mod sync;
 pub mod encryption;
 
 pub use account::Account;
-#[cfg(all(feature = "sso-login", not(target_arch = "wasm32")))]
+#[cfg(feature = "sso-login")]
 pub use client::SsoLoginBuilder;
 pub use client::{Client, ClientBuildError, ClientBuilder, LoginBuilder, LoopCtrl};
 #[cfg(feature = "image-proc")]


### PR DESCRIPTION
… instead of through `compile_error!` invocations. This helps avoid unhelpful errors from the unsupported feature configuration by aborting compilation earlier.