### PR TITLE
build(crypto-js): Pin yarg-parser to 21.0.1 to prevent upgrade bug

### DIFF
--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -29,7 +29,8 @@
         "wasm-pack": "^0.10.2",
         "jest": "^28.1.0",
         "typedoc": "^0.22.17",
-        "cross-env": "^7.0.3"
+        "cross-env": "^7.0.3",
+        "yargs-parser": "~21.0.1"
     },
     "engines": {
         "node": ">= 10"

--- a/bindings/matrix-sdk-crypto-nodejs/package.json
+++ b/bindings/matrix-sdk-crypto-nodejs/package.json
@@ -15,7 +15,8 @@
     "devDependencies": {
         "@napi-rs/cli": "^2.9.0",
         "jest": "^28.1.0",
-        "typedoc": "^0.22.17"
+        "typedoc": "^0.22.17",
+        "yargs-parser": "~21.0.1"
     },
     "engines": {
         "node": ">= 14"


### PR DESCRIPTION
We are effected by https://github.com/yargs/yargs-parser/issues/452
through the transient dependency of jest on yargs