### PR TITLE
Add EventHandlerDropGuard

### DIFF
--- a/crates/matrix-sdk-appservice/examples/appservice_autojoin.rs
+++ b/crates/matrix-sdk-appservice/examples/appservice_autojoin.rs
@@ -64,15 +64,11 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let virtual_user = appservice.virtual_user(None).await?;
 
     virtual_user.add_event_handler_context(appservice.clone());
-    virtual_user
-        .add_event_handler(
-            move |event: OriginalSyncRoomMemberEvent,
-                  room: Room,
-                  Ctx(appservice): Ctx<AppService>| {
-                handle_room_member(appservice, room, event)
-            },
-        )
-        .await;
+    virtual_user.add_event_handler(
+        move |event: OriginalSyncRoomMemberEvent, room: Room, Ctx(appservice): Ctx<AppService>| {
+            handle_room_member(appservice, room, event)
+        },
+    );
 
     let (host, port) = appservice.registration().get_host_and_port()?;
     appservice.run(host, port).await?;

--- a/crates/matrix-sdk-appservice/src/lib.rs
+++ b/crates/matrix-sdk-appservice/src/lib.rs
@@ -65,13 +65,11 @@
 //!
 //! let mut appservice =
 //!     AppService::new(homeserver_url, server_name, registration).await?;
-//! appservice
-//!     .virtual_user(None)
-//!     .await?
-//!     .add_event_handler(|_ev: SyncRoomMemberEvent| async {
+//! appservice.virtual_user(None).await?.add_event_handler(
+//!     |_ev: SyncRoomMemberEvent| async {
 //!         // do stuff
-//!     })
-//!     .await;
+//!     },
+//! );
 //!
 //! let (host, port) = appservice.registration().get_host_and_port()?;
 //! appservice.run(host, port).await?;
@@ -643,17 +641,13 @@ mod tests {
 
         #[allow(clippy::mutex_atomic)]
         let on_state_member = Arc::new(Mutex::new(false));
-        appservice
-            .virtual_user(None)
-            .await?
-            .add_event_handler({
-                let on_state_member = on_state_member.clone();
-                move |_ev: OriginalSyncRoomMemberEvent| {
-                    *on_state_member.lock().unwrap() = true;
-                    future::ready(())
-                }
-            })
-            .await;
+        appservice.virtual_user(None).await?.add_event_handler({
+            let on_state_member = on_state_member.clone();
+            move |_ev: OriginalSyncRoomMemberEvent| {
+                *on_state_member.lock().unwrap() = true;
+                future::ready(())
+            }
+        });
 
         let status = warp::test::request()
             .method("PUT")
@@ -799,17 +793,13 @@ mod tests {
 
         #[allow(clippy::mutex_atomic)]
         let on_state_member = Arc::new(Mutex::new(false));
-        appservice
-            .virtual_user(None)
-            .await?
-            .add_event_handler({
-                let on_state_member = on_state_member.clone();
-                move |_ev: OriginalSyncRoomMemberEvent| {
-                    *on_state_member.lock().unwrap() = true;
-                    future::ready(())
-                }
-            })
-            .await;
+        appservice.virtual_user(None).await?.add_event_handler({
+            let on_state_member = on_state_member.clone();
+            move |_ev: OriginalSyncRoomMemberEvent| {
+                *on_state_member.lock().unwrap() = true;
+                future::ready(())
+            }
+        });
 
         let uri = "/_matrix/app/v1/transactions/1?access_token=hs_token";
 

--- a/crates/matrix-sdk/README.md
+++ b/crates/matrix-sdk/README.md
@@ -38,11 +38,9 @@ async fn main() -> anyhow::Result<()> {
     // First we need to log in.
     client.login_username(alice, "password").send().await?;
 
-    client
-        .add_event_handler(|ev: SyncRoomMessageEvent| async move {
-            println!("Received a message {:?}", ev);
-        })
-        .await;
+    client.add_event_handler(|ev: SyncRoomMessageEvent| async move {
+        println!("Received a message {:?}", ev);
+    });
 
     // Syncing is important to synchronize the client state with the server.
     // This method will never return.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2055,7 +2055,7 @@ impl Client {
     /// };
     ///
     /// let client = Client::new(homeserver).await?;
-    /// client.login(&username, &password, None, None).await?;
+    /// client.login_username(username, password).send().await?;
     ///
     /// // Sync once so we receive the client state and old messages.
     /// client.sync_once(SyncSettings::default()).await?;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2641,7 +2641,7 @@ pub(crate) mod tests {
         Client::builder().homeserver_url(homeserver).server_versions([MatrixVersion::V1_0])
     }
 
-    async fn no_retry_test_client(homeserver_url: Option<String>) -> Client {
+    pub(crate) async fn no_retry_test_client(homeserver_url: Option<String>) -> Client {
         test_client_builder(homeserver_url)
             .request_config(RequestConfig::new().disable_retry())
             .build()

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -428,7 +428,7 @@ impl Client {
                 EventHandlerKeyInner { ev_kind, ev_type, room_id }
             });
 
-            let handlers_lock = self.event_handlers().await;
+            let handlers_lock = self.event_handlers();
 
             iter::once(non_room_handler_key)
                 .chain(room_handler_key)
@@ -660,42 +660,34 @@ mod tests {
         let power_levels_count = Arc::new(AtomicU8::new(0));
         let invited_member_count = Arc::new(AtomicU8::new(0));
 
-        client
-            .add_event_handler({
-                let member_count = member_count.clone();
-                move |_ev: OriginalSyncRoomMemberEvent, _room: room::Room| {
-                    member_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
-        client
-            .add_event_handler({
-                let typing_count = typing_count.clone();
-                move |_ev: SyncTypingEvent| {
-                    typing_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
-        client
-            .add_event_handler({
-                let power_levels_count = power_levels_count.clone();
-                move |_ev: OriginalSyncRoomPowerLevelsEvent, _client: Client, _room: room::Room| {
-                    power_levels_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
-        client
-            .add_event_handler({
-                let invited_member_count = invited_member_count.clone();
-                move |_ev: StrippedRoomMemberEvent| {
-                    invited_member_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
+        client.add_event_handler({
+            let member_count = member_count.clone();
+            move |_ev: OriginalSyncRoomMemberEvent, _room: room::Room| {
+                member_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
+        client.add_event_handler({
+            let typing_count = typing_count.clone();
+            move |_ev: SyncTypingEvent| {
+                typing_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
+        client.add_event_handler({
+            let power_levels_count = power_levels_count.clone();
+            move |_ev: OriginalSyncRoomPowerLevelsEvent, _client: Client, _room: room::Room| {
+                power_levels_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
+        client.add_event_handler({
+            let invited_member_count = invited_member_count.clone();
+            move |_ev: StrippedRoomMemberEvent| {
+                invited_member_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
 
         let response = EventBuilder::default()
             .add_joined_room(
@@ -766,42 +758,34 @@ mod tests {
         let power_levels_count = Arc::new(AtomicU8::new(0));
 
         // Room event handlers for member events in both rooms
-        client
-            .add_room_event_handler(room_id_a, {
-                let member_count = member_count.clone();
-                move |_ev: OriginalSyncRoomMemberEvent, _room: room::Room| {
-                    member_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
-        client
-            .add_room_event_handler(room_id_b, {
-                let member_count = member_count.clone();
-                move |_ev: OriginalSyncRoomMemberEvent, _room: room::Room| {
-                    member_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
+        client.add_room_event_handler(room_id_a, {
+            let member_count = member_count.clone();
+            move |_ev: OriginalSyncRoomMemberEvent, _room: room::Room| {
+                member_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
+        client.add_room_event_handler(room_id_b, {
+            let member_count = member_count.clone();
+            move |_ev: OriginalSyncRoomMemberEvent, _room: room::Room| {
+                member_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
 
         // Power levels event handlers for member events in room A
-        client
-            .add_room_event_handler(room_id_a, {
-                let power_levels_count = power_levels_count.clone();
-                move |_ev: OriginalSyncRoomPowerLevelsEvent, _client: Client, _room: room::Room| {
-                    power_levels_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
+        client.add_room_event_handler(room_id_a, {
+            let power_levels_count = power_levels_count.clone();
+            move |_ev: OriginalSyncRoomPowerLevelsEvent, _client: Client, _room: room::Room| {
+                power_levels_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
 
         // Room name event handler for room name events in room B
-        client
-            .add_room_event_handler(room_id_b, move |_ev: OriginalSyncRoomNameEvent| async {
-                unreachable!("No room event in room B")
-            })
-            .await;
+        client.add_room_event_handler(room_id_b, move |_ev: OriginalSyncRoomNameEvent| async {
+            unreachable!("No room event in room B")
+        });
 
         let response = EventBuilder::default()
             .add_joined_room(
@@ -832,40 +816,32 @@ mod tests {
 
         let member_count = Arc::new(AtomicU8::new(0));
 
-        client
-            .add_event_handler({
-                let member_count = member_count.clone();
-                move |_ev: OriginalSyncRoomMemberEvent| {
-                    member_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
+        client.add_event_handler({
+            let member_count = member_count.clone();
+            move |_ev: OriginalSyncRoomMemberEvent| {
+                member_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
 
-        let handle_a = client
-            .add_event_handler(move |_ev: OriginalSyncRoomMemberEvent| async {
+        let handle_a = client.add_event_handler(move |_ev: OriginalSyncRoomMemberEvent| async {
+            panic!("handler should have been removed");
+        });
+        let handle_b = client.add_room_event_handler(
+            #[allow(unknown_lints, clippy::explicit_auto_deref)] // lint is buggy
+            *DEFAULT_SYNC_ROOM_ID,
+            move |_ev: OriginalSyncRoomMemberEvent| async {
                 panic!("handler should have been removed");
-            })
-            .await;
-        let handle_b = client
-            .add_room_event_handler(
-                #[allow(unknown_lints, clippy::explicit_auto_deref)] // lint is buggy
-                *DEFAULT_SYNC_ROOM_ID,
-                move |_ev: OriginalSyncRoomMemberEvent| async {
-                    panic!("handler should have been removed");
-                },
-            )
-            .await;
+            },
+        );
 
-        client
-            .add_event_handler({
-                let member_count = member_count.clone();
-                move |_ev: OriginalSyncRoomMemberEvent| {
-                    member_count.fetch_add(1, SeqCst);
-                    future::ready(())
-                }
-            })
-            .await;
+        client.add_event_handler({
+            let member_count = member_count.clone();
+            move |_ev: OriginalSyncRoomMemberEvent| {
+                member_count.fetch_add(1, SeqCst);
+                future::ready(())
+            }
+        });
 
         let response = EventBuilder::default()
             .add_joined_room(
@@ -873,8 +849,8 @@ mod tests {
             )
             .build_sync_response();
 
-        client.remove_event_handler(handle_a).await;
-        client.remove_event_handler(handle_b).await;
+        client.remove_event_handler(handle_a);
+        client.remove_event_handler(handle_b);
 
         client.process_sync(response).await?;
 

--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -178,7 +178,7 @@ impl EventHandlerContext for EventHandlerHandle {
 ///
 /// ¹ the only thing stopping such types from existing in stable Rust is that
 /// all manual implementations of the `Fn` traits require a Nightly feature
-pub trait EventHandler<Ev, Ctx>: Clone + Send + Sync + 'static {
+pub trait EventHandler<Ev, Ctx>: Send + Sync + 'static {
     /// The future returned by `handle_event`.
     #[doc(hidden)]
     type Future: Future + Send + 'static;
@@ -327,8 +327,8 @@ impl Client {
         <H::Future as Future>::Output: EventHandlerResult,
     {
         let handler_fn: Box<EventHandlerFn> = Box::new(move |data| {
-            let maybe_fut = serde_json::from_str(data.raw.get())
-                .map(|ev| handler.clone().handle_event(ev, data));
+            let maybe_fut =
+                serde_json::from_str(data.raw.get()).map(|ev| handler.handle_event(ev, data));
 
             Box::pin(async move {
                 match maybe_fut {
@@ -539,7 +539,7 @@ macro_rules! impl_event_handler {
         impl<Ev, Fun, Fut, $($ty),*> EventHandler<Ev, ($($ty,)*)> for Fun
         where
             Ev: SyncEvent,
-            Fun: Fn(Ev, $($ty),*) -> Fut + Clone + Send + Sync + 'static,
+            Fun: Fn(Ev, $($ty),*) -> Fut + Send + Sync + 'static,
             Fut: Future + Send + 'static,
             Fut::Output: EventHandlerResult,
             $($ty: EventHandlerContext),*

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -242,13 +242,13 @@ impl Common {
     /// `room.add_event_handler(hdl)` is equivalent to
     /// `client.add_room_event_handler(room_id, hdl)`. Use whichever one is more
     /// convenient in your use case.
-    pub async fn add_event_handler<Ev, Ctx, H>(&self, handler: H) -> EventHandlerHandle
+    pub fn add_event_handler<Ev, Ctx, H>(&self, handler: H) -> EventHandlerHandle
     where
         Ev: SyncEvent + DeserializeOwned + Send + 'static,
         H: EventHandler<Ev, Ctx>,
         <H::Future as Future>::Output: EventHandlerResult,
     {
-        self.client.add_room_event_handler(self.room_id(), handler).await
+        self.client.add_room_event_handler(self.room_id(), handler)
     }
 
     /// Get a stream for the timeline of this `Room`

--- a/examples/autojoin/src/main.rs
+++ b/examples/autojoin/src/main.rs
@@ -66,7 +66,7 @@ async fn login_and_sync(
 
     println!("logged in as {username}");
 
-    client.add_event_handler(on_stripped_state_member).await;
+    client.add_event_handler(on_stripped_state_member);
 
     client.sync(SyncSettings::default()).await;
 

--- a/examples/command_bot/src/main.rs
+++ b/examples/command_bot/src/main.rs
@@ -66,7 +66,7 @@ async fn login_and_sync(
     client.sync_once(SyncSettings::default()).await.unwrap();
     // add our CommandBot to be notified of incoming messages, we do this after the
     // initial sync to avoid responding to messages before the bot was running.
-    client.add_event_handler(on_room_message).await;
+    client.add_event_handler(on_room_message);
 
     // since we called `sync_once` before we entered our sync loop we must pass
     // that sync token to `sync`

--- a/examples/custom_events/src/main.rs
+++ b/examples/custom_events/src/main.rs
@@ -85,14 +85,14 @@ async fn on_ping_event(event: SyncPingEvent, room: Room) {
 // and run the client
 async fn sync_loop(client: Client) -> anyhow::Result<()> {
     // invite acceptance as in the getting-started-client
-    client.add_event_handler(on_stripped_state_member).await;
+    client.add_event_handler(on_stripped_state_member);
     client.sync_once(SyncSettings::default()).await.unwrap();
 
     // our customisation:
     //  - send `PingEvent` on `!ping` in any room
-    client.add_event_handler(on_regular_room_message).await;
+    client.add_event_handler(on_regular_room_message);
     //  - send `AckEvent` on `PingEvent` in any room
-    client.add_event_handler(on_ping_event).await;
+    client.add_event_handler(on_ping_event);
 
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
     client.sync(settings).await; // this essentially loops until we kill the bot

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -88,7 +88,7 @@ async fn login_and_sync(
     // state events so we want to react to them. We add the event handler before
     // the sync, so this happens also for older messages. All rooms we've
     // already entered won't have stripped states anymore and thus won't fire
-    client.add_event_handler(on_stripped_state_member).await;
+    client.add_event_handler(on_stripped_state_member);
 
     // An initial sync to set up state and so our bot doesn't respond to old
     // messages. If the `StateStore` finds saved state in the location given the
@@ -97,7 +97,7 @@ async fn login_and_sync(
 
     // now that we've synced, let's attach a handler for incoming room messages, so
     // we can react on it
-    client.add_event_handler(on_room_message).await;
+    client.add_event_handler(on_room_message);
 
     // since we called `sync_once` before we entered our sync loop we must pass
     // that sync token to `sync`

--- a/examples/image_bot/src/main.rs
+++ b/examples/image_bot/src/main.rs
@@ -69,7 +69,7 @@ async fn login_and_sync(
     client.sync_once(SyncSettings::default()).await.unwrap();
 
     let image = Arc::new(Mutex::new(image));
-    client.add_event_handler(move |ev, room| on_room_message(ev, room, image.clone())).await;
+    client.add_event_handler(move |ev, room| on_room_message(ev, room, image.clone()));
 
     let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
     client.sync(settings).await;

--- a/examples/login/src/main.rs
+++ b/examples/login/src/main.rs
@@ -34,7 +34,7 @@ async fn login(homeserver_url: String, username: &str, password: &str) -> matrix
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).await.unwrap();
 
-    client.add_event_handler(on_room_message).await;
+    client.add_event_handler(on_room_message);
 
     client
         .login_username(username, password)


### PR DESCRIPTION
Creating such a guard basically makes the event handler temporary, it will be removed again once the guard is dropped – e.g. because of a surrounding future being cancelled, or an error being propagated out of a function that stored the guard on the stack.

cc @docweirdo 