### PR TITLE
chore: Disable testing of crates without tests

### DIFF
--- a/examples/autojoin/Cargo.toml
+++ b/examples/autojoin/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-autojoin"
+test = false
+
 [dependencies]
 tokio = { version = "1.20.1", features = ["full"] }
 anyhow = "1"

--- a/examples/command_bot/Cargo.toml
+++ b/examples/command_bot/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-command-bot"
+test = false
+
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/examples/cross_signing_bootstrap/Cargo.toml
+++ b/examples/cross_signing_bootstrap/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-cross-signing-bootstrap"
+test = false
+
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/examples/custom_events/Cargo.toml
+++ b/examples/custom_events/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-custom-events"
+test = false
+
 [dependencies]
 anyhow = "1"
 dirs = "4.0.0"

--- a/examples/emoji_verification/Cargo.toml
+++ b/examples/emoji_verification/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-emoji-verification"
+test = false
+
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/examples/get_profiles/Cargo.toml
+++ b/examples/get_profiles/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-get-profiles"
+test = false
+
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-getting-started"
+test = false
+
 [dependencies]
 anyhow = "1"
 dirs = "4.0.0"

--- a/examples/image_bot/Cargo.toml
+++ b/examples/image_bot/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-image-bot"
+test = false
+
 [dependencies]
 anyhow = "1"
 mime = "0.3.16"

--- a/examples/login/Cargo.toml
+++ b/examples/login/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-login"
+test = false
+
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.20.1", features = ["full"] }

--- a/examples/timeline/Cargo.toml
+++ b/examples/timeline/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "example-timeline"
+test = false
+
 [dependencies]
 anyhow = "1"
 futures = "0.3"

--- a/examples/wasm_command_bot/Cargo.toml
+++ b/examples/wasm_command_bot/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [lib]
 crate-type = ["cdylib"]
+test = false
 
 [dependencies]
 url = "2.2.2"

--- a/labs/sled-state-inspector/Cargo.toml
+++ b/labs/sled-state-inspector/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "sled-state-inspector"
+test = false
+
 [dependencies]
 atty = "0.2.14"
 clap = "3.2.4"

--- a/testing/matrix-sdk-test-macros/Cargo.toml
+++ b/testing/matrix-sdk-test-macros/Cargo.toml
@@ -14,6 +14,8 @@ publish = false
 
 [lib]
 proc-macro = true
+test = false
+doctest = false
 
 [dependencies]
 proc-macro2 = "1.0.37"

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -12,6 +12,10 @@ rust-version = "1.60"
 version = "0.5.0"
 publish = false
 
+[lib]
+test = false
+doctest = false
+
 [features]
 appservice = []
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[[bin]]
+name = "xtask"
+test = false
+
 [dependencies]
 clap = { version = "3.2.4", features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
This reduces the amount of "running 0 tests" spam when testing the whole workspace and makes testing a little faster overall.

I've left out the crates that *currently* don't have tests but might get some in the future (this includes all the binding crates where I wasn't entirely certain, since one of them actually does have a test).