### PR TITLE
refactor(sdk): Don't require the whole `Session` for sending

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -379,6 +379,7 @@ impl ClientBuilder {
                         Some(RequestConfig::short_retry()),
                         homeserver,
                         None,
+                        None,
                         &[MatrixVersion::V1_0],
                     )
                     .await

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -344,6 +344,31 @@ impl Client {
         self.base_client().session_tokens().get_cloned()
     }
 
+    /// Get the current access token for this session.
+    ///
+    /// Will be `None` if the client has not been logged in.
+    ///
+    /// After login, this token should only change if support for [refreshing
+    /// access tokens] has been enabled.
+    ///
+    /// [refreshing access tokens]: https://spec.matrix.org/v1.3/client-server-api/#refreshing-access-tokens
+    pub fn access_token(&self) -> Option<String> {
+        self.session_tokens().map(|tokens| tokens.access_token)
+    }
+
+    /// Get the current refresh token for this session.
+    ///
+    /// Will be `None` if the client has not been logged in, or if the access
+    /// token doesn't expire.
+    ///
+    /// After login, this token should only change if support for [refreshing
+    /// access tokens] has been enabled.
+    ///
+    /// [refreshing access tokens]: https://spec.matrix.org/v1.3/client-server-api/#refreshing-access-tokens
+    pub fn refresh_token(&self) -> Option<String> {
+        self.session_tokens().and_then(|tokens| tokens.refresh_token)
+    }
+
     /// [`Signal`] to get notified when the current access token and optional
     /// refresh token for this session change.
     ///
@@ -1384,11 +1409,8 @@ impl Client {
     /// persist_session(client.session());
     ///
     /// // Handle when an `M_UNKNOWN_TOKEN` error is encountered.
-    /// async fn on_unknown_token_err(
-    ///     client: &Client,
-    ///     session: &Session,
-    /// ) -> Result<(), Error> {
-    ///     if session.refresh_token.is_some()
+    /// async fn on_unknown_token_err(client: &Client) -> Result<(), Error> {
+    ///     if client.refresh_token().is_some()
     ///         && client.refresh_access_token().await.is_ok()
     ///     {
     ///         persist_session(client.session());
@@ -1442,7 +1464,8 @@ impl Client {
                     request,
                     None,
                     self.homeserver().await.to_string(),
-                    self.session().as_ref(),
+                    self.access_token().as_deref(),
+                    self.user_id(),
                     self.server_versions().await?,
                 )
                 .await;
@@ -1809,7 +1832,8 @@ impl Client {
                 request,
                 Some(request_config),
                 self.homeserver().await.to_string(),
-                self.session().as_ref(),
+                self.access_token().as_deref(),
+                self.user_id(),
                 self.server_versions().await?,
             )
             .await?)
@@ -1910,7 +1934,8 @@ impl Client {
                 request,
                 config,
                 self.homeserver().await.to_string(),
-                self.session().as_ref(),
+                self.access_token().as_deref(),
+                self.user_id(),
                 self.server_versions().await?,
             )
             .await
@@ -1924,6 +1949,7 @@ impl Client {
                 get_supported_versions::Request::new(),
                 None,
                 self.homeserver().await.to_string(),
+                None,
                 None,
                 &[MatrixVersion::V1_0],
             )

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -98,10 +98,6 @@ pub enum HttpError {
     #[error("The request cannot be cloned")]
     UnableToCloneRequest,
 
-    /// Tried to send a request without `user_id` in the `Session`
-    #[error("missing user_id in session")]
-    UserIdRequired,
-
     /// An error occurred while refreshing the access token.
     #[error(transparent)]
     RefreshToken(#[from] RefreshTokenError),


### PR DESCRIPTION
Allow to send authed requests when only the access token is available, it's a prerequisite for #859, to be able to call `/whoami` to get the user ID.

Remove the unreachable `UserIdRequired` error. Looking at the code, the errors in `.ok_or()` were never reached because, if the session was `None`, the other branch was used. I refactored the code to avoid unwrapping instead.