### PR TITLE
chore(crypto): Bump vodozemac

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -57,7 +57,7 @@ features = ["rt-multi-thread"]
 
 [dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "779e85258ec83b10ae62ec4d848188b188aa7b42"
+rev = "29a87098ce0c30050ddc9df709148bfce0f221ca"
 
 [build-dependencies]
 uniffi_build = { version = "0.18.0", features = ["builtin-bindgen"] }

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -41,5 +41,5 @@ tracing-subscriber = { version = "0.3.14", default-features = false, features = 
 
 [dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "779e85258ec83b10ae62ec4d848188b188aa7b42"
+rev = "29a87098ce0c30050ddc9df709148bfce0f221ca"
 features = ["js"]

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -36,7 +36,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["t
 
 [dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "779e85258ec83b10ae62ec4d848188b188aa7b42"
+rev = "29a87098ce0c30050ddc9df709148bfce0f221ca"
 features = ["js"]
 
 [build-dependencies]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -62,11 +62,11 @@ features = ["client-api-c", "rand", "canonical-json", "unstable-msc2676", "unsta
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "779e85258ec83b10ae62ec4d848188b188aa7b42"
+rev = "29a87098ce0c30050ddc9df709148bfce0f221ca"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "779e85258ec83b10ae62ec4d848188b188aa7b42"
+rev = "29a87098ce0c30050ddc9df709148bfce0f221ca"
 features = ["js"]
 
 [dev-dependencies]

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -38,7 +38,10 @@ use serde_json::{value::RawValue as RawJsonValue, Value};
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, trace, warn};
 use vodozemac::{
-    olm::{Account as InnerAccount, AccountPickle, IdentityKeys, OlmMessage, PreKeyMessage},
+    olm::{
+        Account as InnerAccount, AccountPickle, IdentityKeys, OlmMessage, PreKeyMessage,
+        SessionConfig,
+    },
     Curve25519PublicKey, Ed25519Signature, KeyId, PickleError,
 };
 
@@ -913,7 +916,11 @@ impl ReadOnlyAccount {
         one_time_key: Curve25519PublicKey,
         fallback_used: bool,
     ) -> Session {
-        let session = self.inner.lock().await.create_outbound_session(identity_key, one_time_key);
+        let session = self.inner.lock().await.create_outbound_session(
+            SessionConfig::version_1(),
+            identity_key,
+            one_time_key,
+        );
 
         let now = SecondsSinceUnixEpoch::now();
         let session_id = session.session_id();

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -35,7 +35,7 @@ use serde_json::Value;
 use vodozemac::{
     megolm::{
         DecryptedMessage, DecryptionError, ExportedSessionKey, InboundGroupSession as InnerSession,
-        InboundGroupSessionPickle, MegolmMessage, SessionOrdering,
+        InboundGroupSessionPickle, MegolmMessage, SessionConfig, SessionOrdering,
     },
     Curve25519PublicKey, PickleError,
 };
@@ -102,7 +102,7 @@ impl InboundGroupSession {
         encryption_algorithm: EventEncryptionAlgorithm,
         history_visibility: Option<HistoryVisibility>,
     ) -> Self {
-        let session = InnerSession::new(session_key);
+        let session = InnerSession::new(session_key, SessionConfig::version_1());
         let session_id = session.session_id();
         let first_known_index = session.first_known_index();
 
@@ -140,7 +140,7 @@ impl InboundGroupSession {
         room_id: &RoomId,
         backup: BackedUpRoomKey,
     ) -> Result<Self, SessionCreationError> {
-        let session = InnerSession::import(&backup.session_key);
+        let session = InnerSession::import(&backup.session_key, SessionConfig::version_1());
         let session_id = session.session_id();
 
         Self::from_export(&ExportedRoomKey {
@@ -170,7 +170,7 @@ impl InboundGroupSession {
         let key = ExportedSessionKey::from_base64(&content.session_key)?;
         let algorithm = EventEncryptionAlgorithm::from(content.algorithm.as_str());
 
-        let session = InnerSession::import(&key);
+        let session = InnerSession::import(&key, SessionConfig::version_1());
 
         let first_known_index = session.first_known_index();
         let mut forwarding_chains = content.forwarding_curve25519_key_chain.clone();
@@ -469,7 +469,7 @@ impl TryFrom<&ExportedRoomKey> for InboundGroupSession {
     type Error = SessionCreationError;
 
     fn try_from(key: &ExportedRoomKey) -> Result<Self, Self::Error> {
-        let session = InnerSession::import(&key.session_key);
+        let session = InnerSession::import(&key.session_key, SessionConfig::version_1());
         let first_known_index = session.first_known_index();
 
         Ok(InboundGroupSession {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -34,7 +34,7 @@ use ruma::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tracing::{debug, error, info};
-use vodozemac::Curve25519PublicKey;
+use vodozemac::{megolm::SessionConfig, Curve25519PublicKey};
 pub use vodozemac::{
     megolm::{GroupSession, GroupSessionPickle, MegolmMessage, SessionKey},
     olm::IdentityKeys,
@@ -163,7 +163,7 @@ impl OutboundGroupSession {
         room_id: &RoomId,
         settings: EncryptionSettings,
     ) -> Self {
-        let session = GroupSession::new();
+        let session = GroupSession::new(SessionConfig::version_1());
         let session_id = session.session_id();
 
         OutboundGroupSession {

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -30,4 +30,4 @@ thiserror = "1.0.30"
 
 [dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"
-rev = "779e85258ec83b10ae62ec4d848188b188aa7b42"
+rev = "29a87098ce0c30050ddc9df709148bfce0f221ca"


### PR DESCRIPTION
Vodozemac got some new knobs to twiddle with. This patch updates vodozemac and sets the knobs to use the olm/megolm v1 supported encryption schemes.