### PR TITLE
ci: Only test one node.js version on macOS

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         node-version: [14.0, 16.0, 18.0]
         include:
           - os: ubuntu-latest
@@ -34,6 +34,7 @@ jobs:
 
           - os: macos-latest
             os-name: 🍏
+            node-version: 18.0
 
           - node-version: 18.0
             build-doc: true


### PR DESCRIPTION
I *think* this config change does the right thing.. `matrix.include` is really confusing.