### PR TITLE
Fix relations when encrypting and decrypting

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,6 +4,7 @@
 Fo = "Fo"
 BA = "BA"
 UE = "UE"
+Ure = "Ure"
 
 [files]
 # Our json files contain a bunch of base64 encoded ed25519 keys which aren't

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -404,8 +404,7 @@ impl InboundGroupSession {
             decrypted_object.get_mut("content").and_then(|c| c.as_object_mut())
         {
             if !decrypted_content.contains_key("m.relates_to") {
-                let content = serde_json::to_value(&event.content)?;
-                if let Some(relation) = content.as_object().and_then(|o| o.get("m.relates_to")) {
+                if let Some(relation) = &event.content.relates_to {
                     decrypted_content.insert("m.relates_to".to_owned(), relation.to_owned());
                 }
             }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -283,7 +283,7 @@ impl OutboundGroupSession {
         });
 
         let plaintext = json_content.to_string();
-        let relates_to = content.get("relates_to").cloned();
+        let relates_to = content.get("m.relates_to").cloned();
 
         let ciphertext = self.encrypt_helper(plaintext).await;
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -295,7 +295,7 @@ impl OutboundGroupSession {
         }
         .into();
 
-        let content = RoomEncryptedEventContent { scheme, relates_to };
+        let content = RoomEncryptedEventContent { scheme, relates_to, other: Default::default() };
 
         Raw::new(&content).expect("m.room.encrypted event content can always be serialized")
     }

--- a/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
@@ -128,8 +128,12 @@ pub struct RoomEncryptedEventContent {
     pub scheme: RoomEventEncryptionScheme,
 
     /// Information about related events.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "m.relates_to", skip_serializing_if = "Option::is_none")]
     pub relates_to: Option<Value>,
+
+    /// The other data of the encryped content.
+    #[serde(flatten)]
+    pub(crate) other: BTreeMap<String, Value>,
 }
 
 impl RoomEncryptedEventContent {
@@ -331,7 +335,11 @@ pub(crate) mod test {
                 "ciphertext": "AwgAEiBQs2LgBD2CcB+RLH2bsgp9VadFUJhBXOtCmcJuttBD\
                                OeDNjL21d9z0AcVSfQFAh9huh4or7sWuNrHcvu9/sMbweTgc\
                                0UtdA5xFLheubHouXy4aewze+ShndWAaTbjWJMLsPSQDUMQH\
-                               BA"
+                               BA",
+                "m.relates_to": {
+                    "rel_type": "m.reference",
+                    "event_id": "$WUreEJERkFzO8i2dk6CmTex01cP1dZ4GWKhKCwkWHrQ"
+                },
             },
             "type": "m.room.encrypted",
             "origin_server_ts": 1632491098485u64,
@@ -370,6 +378,7 @@ pub(crate) mod test {
         let event: EncryptedEvent = serde_json::from_value(json.clone())?;
 
         assert_matches!(event.content.scheme, RoomEventEncryptionScheme::MegolmV1AesSha2(_));
+        assert!(event.content.relates_to.is_some());
         let serialized = serde_json::to_value(event)?;
         assert_eq!(json, serialized);
 
@@ -392,6 +401,7 @@ pub(crate) mod test {
         let event: EncryptedToDeviceEvent = serde_json::from_value(json.clone())?;
 
         assert_matches!(event.content, ToDeviceEncryptedEventContent::OlmV1Curve25519AesSha2(_));
+
         let serialized = serde_json::to_value(event)?;
         assert_eq!(json, serialized);
 


### PR DESCRIPTION
A couple of errors slipped in when switching to our own customized event types with regards to relations.

Added some tests so we don't regress and manually checked that the example now works. 

This PR should fix the first part of #928.