### PR TITLE
fix(sdk): Further relax event / notification handler bounds on WASM

### DIFF
--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -1,8 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations)]
 
-use std::future::Future;
-
 pub use instant;
 
 pub mod deserialized_responses;
@@ -37,13 +35,6 @@ impl<T: Sync> SyncOutsideWasm for T {}
 pub trait SyncOutsideWasm {}
 #[cfg(target_arch = "wasm32")]
 impl<T> SyncOutsideWasm for T {}
-
-/// Alias for `Future + SendOutsideWasm`.
-///
-/// Useful as a separate trait because the former trait bound can't be used
-/// with `dyn`.
-pub trait FutureSendOutsideWasm: Future + SendOutsideWasm {}
-impl<T: Future + SendOutsideWasm> FutureSendOutsideWasm for T {}
 
 /// Super trait that is used for our store traits, this trait will differ if
 /// it's used on WASM. WASM targets will not require `Send` and `Sync` to have


### PR DESCRIPTION
This allows capturing non-`Send` / -`Sync` values in handler closures.

I didn't add a test because this is going to be exercised by #868 anyways.

cc @docweirdo 