### PR TITLE
refactor(crypto): Utilize the decrypted Olm event type more

### DIFF
--- a/crates/matrix-sdk-common/src/timeout.rs
+++ b/crates/matrix-sdk-common/src/timeout.rs
@@ -46,7 +46,7 @@ where
             Result::<T, ElapsedError>::Ok(output)
         };
 
-        return try_future.timeout(duration).await;
+        try_future.timeout(duration).await
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -746,7 +746,7 @@ impl OlmMachine {
                     decrypted.result.raw_event.deserialize_as()
                 {
                     e.content.secret_name = name;
-                    decrypted.result.raw_event = Raw::from_json(to_raw_value(&e)?)
+                    decrypted.result.raw_event = Raw::from_json(to_raw_value(&e)?);
                 }
             }
             AnyDecryptedOlmEvent::Custom(e) => {

--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -19,13 +19,12 @@
 //! the type is dropped.
 
 pub mod forwarded_room_key;
-mod olm_v1;
+pub mod olm_v1;
 pub mod room;
 pub mod room_key;
 pub mod secret_send;
 mod to_device;
 
-pub use olm_v1::DecryptedOlmV1Event;
 use ruma::serde::Raw;
 pub use to_device::{ToDeviceCustomEvent, ToDeviceEvent, ToDeviceEvents};
 


### PR DESCRIPTION
This patch adds some more stronger guarantees that received room key events and other similarly security critical event types are only handled if they have been received over a secure Olm channel.