### PR TITLE
fix(sdk)!: Remove SyncEvent implementation for InitialStateEvent

### DIFF
--- a/crates/matrix-sdk/src/event_handler.rs
+++ b/crates/matrix-sdk/src/event_handler.rs
@@ -77,7 +77,6 @@ pub enum EventKind {
     OriginalState,
     RedactedState,
     StrippedState,
-    InitialState,
     ToDevice,
     Presence,
 }
@@ -678,14 +677,6 @@ mod static_events {
         C: StaticEventContent + StateEventContent,
     {
         const KIND: EventKind = EventKind::StrippedState;
-        const TYPE: &'static str = C::TYPE;
-    }
-
-    impl<C> SyncEvent for events::InitialStateEvent<C>
-    where
-        C: StaticEventContent + StateEventContent,
-    {
-        const KIND: EventKind = EventKind::InitialState;
         const TYPE: &'static str = C::TYPE;
     }
 


### PR DESCRIPTION
Initial state events aren't actually received through sync, they're sent from the client to the server when creating a room.

This change makes it impossible to register event handlers for initial state events. Previously, this was allowed, but the event handler was never called.