### PR TITLE
doc: Add link to online documentation for crypto-js and crypto-nodejs

### DIFF
--- a/bindings/matrix-sdk-crypto-js/README.md
+++ b/bindings/matrix-sdk-crypto-js/README.md
@@ -37,7 +37,11 @@ TBD
 
 ## Documentation
 
-To generate the documentation, please run the following command:
+[The documentation can be found
+online](https://matrix-org.github.io/matrix-rust-sdk/bindings/matrix-sdk-crypto-js/).
+
+To generate the documentation locally, please run the following
+command:
 
 ```sh
 $ npm run doc

--- a/bindings/matrix-sdk-crypto-nodejs/README.md
+++ b/bindings/matrix-sdk-crypto-nodejs/README.md
@@ -186,7 +186,11 @@ to learn more about the `RUST_LOG`/`MATRIX_LOG` environment variable.
 
 ## Documentation
 
-To generate the documentation, please run the following command:
+[The documentation can be found
+online](https://matrix-org.github.io/matrix-rust-sdk/bindings/matrix-sdk-crypto-nodejs/).
+
+To generate the documentation locally, please run the following
+command:
 
 ```sh
 $ npm run doc


### PR DESCRIPTION
Because now we have the documentations on our github.io pages, we need to tell the world about it.