### PR TITLE
refactor(sdk)!: Split strongly-typed state event functions into two

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.6.3"
-source = "git+https://github.com/ruma/ruma?rev=ca8c66c885241a7ba3805399604eda4a38979f6b#ca8c66c885241a7ba3805399604eda4a38979f6b"
+source = "git+https://github.com/ruma/ruma?rev=1dbb2d9561379c2de5e7901f81d5d5d16d0fb456#1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 dependencies = [
  "assign",
  "js_int",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.6.0"
-source = "git+https://github.com/ruma/ruma?rev=ca8c66c885241a7ba3805399604eda4a38979f6b#ca8c66c885241a7ba3805399604eda4a38979f6b"
+source = "git+https://github.com/ruma/ruma?rev=1dbb2d9561379c2de5e7901f81d5d5d16d0fb456#1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 dependencies = [
  "ruma-common",
  "serde",
@@ -3574,7 +3574,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.14.1"
-source = "git+https://github.com/ruma/ruma?rev=ca8c66c885241a7ba3805399604eda4a38979f6b#ca8c66c885241a7ba3805399604eda4a38979f6b"
+source = "git+https://github.com/ruma/ruma?rev=1dbb2d9561379c2de5e7901f81d5d5d16d0fb456#1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 dependencies = [
  "assign",
  "bytes",
@@ -3590,7 +3590,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.9.2"
-source = "git+https://github.com/ruma/ruma?rev=ca8c66c885241a7ba3805399604eda4a38979f6b#ca8c66c885241a7ba3805399604eda4a38979f6b"
+source = "git+https://github.com/ruma/ruma?rev=1dbb2d9561379c2de5e7901f81d5d5d16d0fb456#1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 dependencies = [
  "base64",
  "bytes",
@@ -3620,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.5.0"
-source = "git+https://github.com/ruma/ruma?rev=ca8c66c885241a7ba3805399604eda4a38979f6b#ca8c66c885241a7ba3805399604eda4a38979f6b"
+source = "git+https://github.com/ruma/ruma?rev=1dbb2d9561379c2de5e7901f81d5d5d16d0fb456#1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -3631,7 +3631,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=ca8c66c885241a7ba3805399604eda4a38979f6b#ca8c66c885241a7ba3805399604eda4a38979f6b"
+source = "git+https://github.com/ruma/ruma?rev=1dbb2d9561379c2de5e7901f81d5d5d16d0fb456#1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 dependencies = [
  "js_int",
  "thiserror",
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.9.2"
-source = "git+https://github.com/ruma/ruma?rev=ca8c66c885241a7ba3805399604eda4a38979f6b#ca8c66c885241a7ba3805399604eda4a38979f6b"
+source = "git+https://github.com/ruma/ruma?rev=1dbb2d9561379c2de5e7901f81d5d5d16d0fb456#1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 dependencies = [
  "once_cell",
  "proc-macro-crate",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ criterion = { version = "0.3.5", features = ["async", "async_tokio", "html_repor
 matrix-sdk-crypto = { path = "../crates/matrix-sdk-crypto", version = "0.5.0" }
 matrix-sdk-sled = { path = "../crates/matrix-sdk-sled", version = "0.1.0", default-features = false, features = ["crypto-store"] }
 matrix-sdk-test = { path = "../testing/matrix-sdk-test", version = "0.5.0" }
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456" }
 serde_json = "1.0.79"
 tempfile = "3.3.0"
 tokio = { version = "1.17.0", default-features = false, features = ["rt-multi-thread"] }

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -20,7 +20,7 @@ hmac = "0.12.1"
 http = "0.2.6"
 pbkdf2 = "0.11.0"
 rand = "0.8.5"
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456", features = ["client-api-c"] }
 serde = "1.0.136"
 serde_json = "1.0.79"
 sha2 = "0.10.2"

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -28,7 +28,7 @@ tracing = []
 [dependencies]
 matrix-sdk-common = { version = "0.5.0", path = "../../crates/matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.5.0", path = "../../crates/matrix-sdk-crypto" }
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456", features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"] }
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"
 js-sys = "0.3.49"

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -26,7 +26,7 @@ tracing = ["dep:tracing-subscriber"]
 matrix-sdk-crypto = { version = "0.5.0", path = "../../crates/matrix-sdk-crypto" }
 matrix-sdk-common = { version = "0.5.0", path = "../../crates/matrix-sdk-common" }
 matrix-sdk-sled = { version = "0.1.0", path = "../../crates/matrix-sdk-sled", default-features = false, features = ["crypto-store"] }
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456", features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"] }
 napi = { git = "https://github.com/Hywan/napi-rs", branch = "fix-napi-strict-on-t-and-ref-t", default-features = false, features = ["napi6", "tokio_rt"] }
 napi-derive = { git = "https://github.com/Hywan/napi-rs", branch = "fix-napi-strict-on-t-and-ref-t" }
 serde_json = "1.0.79"

--- a/crates/matrix-sdk-appservice/Cargo.toml
+++ b/crates/matrix-sdk-appservice/Cargo.toml
@@ -34,7 +34,7 @@ http = "0.2.6"
 matrix-sdk = { version = "0.5.0", path = "../matrix-sdk", default-features = false, features = ["appservice"] }
 percent-encoding = "2.1.0"
 regex = "1.5.5"
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "appservice-api-s"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456", features = ["client-api-c", "appservice-api-s"] }
 serde = "1.0.136"
 serde_json = "1.0.79"
 serde_yaml = "0.9.4"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -44,10 +44,10 @@ tracing = "0.1.34"
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "js", "canonical-json"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456", features = ["client-api-c", "js", "canonical-json"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c", "canonical-json"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456", features = ["client-api-c", "canonical-json"] }
 
 [dev-dependencies]
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1075,7 +1075,7 @@ impl BaseClient {
             event.power_levels()
         } else if let Some(event) = self
             .store
-            .get_state_event_static::<RoomPowerLevelsEventContent>(room_id, "")
+            .get_state_event_static::<RoomPowerLevelsEventContent>(room_id)
             .await?
             .and_then(|e| e.deserialize().ok())
         {

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -442,7 +442,7 @@ impl Room {
 
         let power = self
             .store
-            .get_state_event_static(self.room_id(), "")
+            .get_state_event_static(self.room_id())
             .await?
             .and_then(|e| e.deserialize().ok());
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -21,6 +21,7 @@
 //! store.
 
 use std::{
+    borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
     ops::Deref,
     pin::Pin,
@@ -47,7 +48,7 @@ use ruma::{
         receipt::{Receipt, ReceiptEventContent, ReceiptType},
         room::member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, GlobalAccountDataEvent, GlobalAccountDataEventContent,
+        AnySyncStateEvent, EmptyStateKey, GlobalAccountDataEvent, GlobalAccountDataEventContent,
         GlobalAccountDataEventType, RedactContent, RedactedEventContent, RoomAccountDataEvent,
         RoomAccountDataEventContent, RoomAccountDataEventType, StateEventContent, StateEventType,
         StaticEventContent, SyncStateEvent,
@@ -390,13 +391,31 @@ pub trait StateStoreExt: StateStore {
     async fn get_state_event_static<C>(
         &self,
         room_id: &RoomId,
-        state_key: &str,
+    ) -> Result<Option<Raw<SyncStateEvent<C>>>>
+    where
+        C: StaticEventContent + StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+        C::Redacted: StateEventContent + RedactedEventContent,
+    {
+        Ok(self.get_state_event(room_id, C::TYPE.into(), "").await?.map(Raw::cast))
+    }
+
+    /// Get a specific state event of statically-known type.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room the state event was received for.
+    async fn get_state_event_static_for_key<C, K>(
+        &self,
+        room_id: &RoomId,
+        state_key: &K,
     ) -> Result<Option<Raw<SyncStateEvent<C>>>>
     where
         C: StaticEventContent + StateEventContent + RedactContent,
+        C::StateKey: Borrow<K>,
         C::Redacted: StateEventContent + RedactedEventContent,
+        K: AsRef<str> + ?Sized + Sync,
     {
-        Ok(self.get_state_event(room_id, C::TYPE.into(), state_key).await?.map(Raw::cast))
+        Ok(self.get_state_event(room_id, C::TYPE.into(), state_key.as_ref()).await?.map(Raw::cast))
     }
 
     /// Get a list of state events of a statically-known type for a given room.

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -17,7 +17,7 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [dependencies]
 futures-core = "0.3.21"
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456", features = ["client-api-c"] }
 serde = "1.0.136"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -52,12 +52,12 @@ tokio = { version = "1.18", default-features = false, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.ruma]
 git = "https://github.com/ruma/ruma"
-rev = "ca8c66c885241a7ba3805399604eda4a38979f6b"
+rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 features = ["client-api-c", "js", "rand", "canonical-json", "unstable-msc2676", "unstable-msc2677"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.ruma]
 git = "https://github.com/ruma/ruma"
-rev = "ca8c66c885241a7ba3805399604eda4a38979f6b"
+rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 features = ["client-api-c", "rand", "canonical-json", "unstable-msc2676", "unstable-msc2677"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.vodozemac]

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -31,7 +31,7 @@ js-sys = { version = "0.3.58" }
 matrix-sdk-base = { version = "0.5.0", path = "../matrix-sdk-base" }
 matrix-sdk-crypto = { version = "0.5.0", path = "../matrix-sdk-crypto", optional = true }
 matrix-sdk-store-encryption = { version = "0.1.0", path = "../matrix-sdk-store-encryption" }
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456" }
 serde = "1.0.136"
 serde_json = "1.0.79"
 thiserror = "1.0.30"

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -27,7 +27,7 @@ byteorder = "1.4.3"
 image = { version = "0.23.0", optional = true }
 qrcode = { version = "0.12.0", default-features = false }
 rqrr = { version = "0.4.0", optional = true }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456" }
 thiserror = "1.0.30"
 
 [dependencies.vodozemac]

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -39,7 +39,7 @@ matrix-sdk-base = { version = "0.5.0", path = "../matrix-sdk-base", optional = t
 matrix-sdk-common = { version = "0.5.0", path = "../matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.5.0", path = "../matrix-sdk-crypto", optional = true }
 matrix-sdk-store-encryption = { version = "0.1.0", path = "../matrix-sdk-store-encryption" }
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456" }
 serde = "1.0.136"
 serde_json = "1.0.79"
 sled = "0.34.7"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -112,7 +112,7 @@ default_features = false
 
 [dependencies.ruma]
 git = "https://github.com/ruma/ruma"
-rev = "ca8c66c885241a7ba3805399604eda4a38979f6b"
+rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456"
 features = ["client-api-c", "compat", "rand", "unstable-msc2448", "unstable-msc2965"]
 
 [dependencies.tokio-stream]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1430,7 +1430,7 @@ impl Client {
                 .as_ref()
                 .ok_or(RefreshTokenError::RefreshTokenRequired)?
                 .clone();
-            let request = refresh_token::v3::Request::new(refresh_token);
+            let request = refresh_token::v3::Request::new(&refresh_token);
 
             let res = self
                 .inner

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, future::Future, ops::Deref, sync::Arc};
+use std::{borrow::Borrow, collections::BTreeMap, future::Future, ops::Deref, sync::Arc};
 
 use futures_channel::mpsc;
 #[cfg(feature = "experimental-timeline")]
@@ -40,10 +40,10 @@ use ruma::{
             MediaSource,
         },
         tag::{TagInfo, TagName},
-        AnyRoomAccountDataEvent, AnyStateEvent, AnySyncStateEvent, GlobalAccountDataEventType,
-        RedactContent, RedactedEventContent, RoomAccountDataEvent, RoomAccountDataEventContent,
-        RoomAccountDataEventType, StateEventContent, StateEventType, StaticEventContent,
-        SyncStateEvent,
+        AnyRoomAccountDataEvent, AnyStateEvent, AnySyncStateEvent, EmptyStateKey,
+        GlobalAccountDataEventType, RedactContent, RedactedEventContent, RoomAccountDataEvent,
+        RoomAccountDataEventContent, RoomAccountDataEventType, StateEventContent, StateEventType,
+        StaticEventContent, SyncStateEvent,
     },
     serde::Raw,
     uint, EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedServerName, RoomId, UInt, UserId,
@@ -809,7 +809,8 @@ impl Common {
             .map_err(Into::into)
     }
 
-    /// Get a specific state event of statically-known type in this room.
+    /// Get a specific state event of statically-known type with an empty state
+    /// key in this room.
     ///
     /// # Example
     ///
@@ -819,22 +820,49 @@ impl Common {
     /// use matrix_sdk::ruma::events::room::power_levels::SyncRoomPowerLevelsEvent;
     ///
     /// let power_levels: SyncRoomPowerLevelsEvent = room
-    ///     .get_state_event_static("")
+    ///     .get_state_event_static()
     ///     .await?
     ///     .expect("every room has a power_levels event")
     ///     .deserialize()?;
     /// # anyhow::Ok(())
     /// # };
     /// ```
-    pub async fn get_state_event_static<C>(
+    pub async fn get_state_event_static<C>(&self) -> Result<Option<Raw<SyncStateEvent<C>>>>
+    where
+        C: StaticEventContent + StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+        C::Redacted: StateEventContent + RedactedEventContent,
+    {
+        self.get_state_event_static_for_key(&EmptyStateKey).await
+    }
+
+    /// Get a specific state event of statically-known type in this room.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async {
+    /// # let room: matrix_sdk::room::Common = todo!();
+    /// use matrix_sdk::ruma::{
+    ///     events::room::member::SyncRoomMemberEvent, serde::Raw, user_id,
+    /// };
+    ///
+    /// let member_event: Option<Raw<SyncRoomMemberEvent>> = room
+    ///     .get_state_event_static_for_key(user_id!("@alice:example.org"))
+    ///     .await?;
+    /// # anyhow::Ok(())
+    /// # };
+    /// ```
+    pub async fn get_state_event_static_for_key<C, K>(
         &self,
-        state_key: &str,
+        state_key: &K,
     ) -> Result<Option<Raw<SyncStateEvent<C>>>>
     where
         C: StaticEventContent + StateEventContent + RedactContent,
+        C::StateKey: Borrow<K>,
         C::Redacted: StateEventContent + RedactedEventContent,
+        K: AsRef<str> + ?Sized + Sync,
     {
-        Ok(self.client.store().get_state_event_static(self.room_id(), state_key).await?)
+        Ok(self.client.store().get_state_event_static_for_key(self.room_id(), state_key).await?)
     }
 
     /// Get account data in this room.
@@ -1022,7 +1050,7 @@ impl Common {
     /// [routing algorithm]: https://spec.matrix.org/v1.3/appendices/#routing
     pub async fn route(&self) -> Result<Vec<OwnedServerName>> {
         let acl_ev = self
-            .get_state_event_static::<RoomServerAclEventContent>("")
+            .get_state_event_static::<RoomServerAclEventContent>()
             .await?
             .and_then(|ev| ev.deserialize().ok());
         let acl = acl_ev.as_ref().and_then(|ev| ev.as_original()).map(|ev| &ev.content);

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -870,7 +870,7 @@ impl Joined {
         K: AsRef<str> + ?Sized,
     {
         let request =
-            send_state_event::v3::Request::new(self.inner.room_id(), state_key.as_ref(), &content)?;
+            send_state_event::v3::Request::new(self.inner.room_id(), state_key, &content)?;
         let response = self.client.send(request, None).await?;
         Ok(response)
     }

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -33,7 +33,7 @@ async fn login_username_refresh_token() {
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
         .and(body_partial_json(json!({
-            "org.matrix.msc2918.refresh_token": true,
+            "refresh_token": true,
         })))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(&*test_json::LOGIN_WITH_REFRESH_TOKEN),
@@ -57,7 +57,7 @@ async fn login_sso_refresh_token() {
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
         .and(body_partial_json(json!({
-            "org.matrix.msc2918.refresh_token": true,
+            "refresh_token": true,
         })))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(&*test_json::LOGIN_WITH_REFRESH_TOKEN),
@@ -101,7 +101,7 @@ async fn register_refresh_token() {
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/register"))
         .and(body_partial_json(json!({
-            "org.matrix.msc2918.refresh_token": true,
+            "refresh_token": true,
         })))
         .respond_with(
             // Successful registration response is the same as for login,

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -249,7 +249,8 @@ async fn room_state_event_send() {
     let member_event = assign!(RoomMemberEventContent::new(MembershipState::Join), {
         avatar_url: Some(avatar_url.to_owned())
     });
-    let response = room.send_state_event(member_event, "").await.unwrap();
+    let response =
+        room.send_state_event_for_key(user_id!("@foo:bar.com"), member_event).await.unwrap();
     assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id);
 }
 

--- a/labs/sled-state-inspector/Cargo.toml
+++ b/labs/sled-state-inspector/Cargo.toml
@@ -14,7 +14,7 @@ clap = "3.2.4"
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }
 matrix-sdk-base = { path = "../../crates/matrix-sdk-base", version = "0.5.0" }
 matrix-sdk-sled = { path = "../../crates/matrix-sdk-sled", version = "0.1.0" }
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456" }
 rustyline = "10.0.0"
 rustyline-derive = "0.7.0"
 serde = "1.0.136"

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -23,7 +23,7 @@ appservice = []
 http = "0.2.6"
 matrix-sdk-test-macros = { version = "0.2.0", path = "../matrix-sdk-test-macros" }
 once_cell = "1.10.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "ca8c66c885241a7ba3805399604eda4a38979f6b", features = ["client-api-c"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1dbb2d9561379c2de5e7901f81d5d5d16d0fb456", features = ["client-api-c"] }
 serde = "1.0.136"
 serde_json = "1.0.79"
 


### PR DESCRIPTION
Another on of those refactorings I've been thinking about for a while. @Hywan just reminded me of this possibility.

I'm not too sure about the upgrade path here. It should be simple enough for people who read the changelog, but I think we have experienced many people *not* doing that..

Looking for feedback on

* Is this a good idea?
* Naming
* Upgrade path

I also posted a very small related Ruma PR: https://github.com/ruma/ruma/pull/1259