### PR TITLE
feat(crypto-js): Implement `OlmMachine.sign` and `.cross_signing_status`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/identifiers.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identifiers.rs
@@ -133,6 +133,7 @@ impl DeviceKeyId {
 
 /// The basic key algorithms in the specification.
 #[wasm_bindgen]
+#[derive(Debug)]
 pub struct DeviceKeyAlgorithm {
     inner: ruma::DeviceKeyAlgorithm,
 }
@@ -163,6 +164,7 @@ impl DeviceKeyAlgorithm {
 
 /// The basic key algorithm names in the specification.
 #[wasm_bindgen]
+#[derive(Debug)]
 pub enum DeviceKeyAlgorithmName {
     /// The Ed25519 signature algorithm.
     Ed25519,

--- a/bindings/matrix-sdk-crypto-js/src/identifiers.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identifiers.rs
@@ -88,6 +88,109 @@ impl DeviceId {
     }
 }
 
+/// A Matrix device key ID.
+///
+/// A key algorithm and a device ID, combined with a ‘:’.
+#[wasm_bindgen]
+#[derive(Debug, Clone)]
+pub struct DeviceKeyId {
+    pub(crate) inner: ruma::OwnedDeviceKeyId,
+}
+
+impl From<ruma::OwnedDeviceKeyId> for DeviceKeyId {
+    fn from(inner: ruma::OwnedDeviceKeyId) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl DeviceKeyId {
+    /// Parse/validate and create a new `DeviceKeyId`.
+    #[wasm_bindgen(constructor)]
+    pub fn new(id: String) -> Result<DeviceKeyId, JsError> {
+        Ok(Self::from(ruma::DeviceKeyId::parse(id.as_str())?))
+    }
+
+    /// Returns key algorithm of the device key ID.
+    #[wasm_bindgen(getter)]
+    pub fn algorithm(&self) -> DeviceKeyAlgorithm {
+        self.inner.algorithm().into()
+    }
+
+    /// Returns device ID of the device key ID.
+    #[wasm_bindgen(getter, js_name = "deviceId")]
+    pub fn device_id(&self) -> DeviceId {
+        self.inner.device_id().to_owned().into()
+    }
+
+    /// Return the device key ID as a string.
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
+        self.inner.to_string()
+    }
+}
+
+/// The basic key algorithms in the specification.
+#[wasm_bindgen]
+pub struct DeviceKeyAlgorithm {
+    inner: ruma::DeviceKeyAlgorithm,
+}
+
+impl From<ruma::DeviceKeyAlgorithm> for DeviceKeyAlgorithm {
+    fn from(inner: ruma::DeviceKeyAlgorithm) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl DeviceKeyAlgorithm {
+    /// Read the device key algorithm's name. If the name is
+    /// `Unknown`, one may be interested by the `to_string` method to
+    /// read the original name.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> DeviceKeyAlgorithmName {
+        self.inner.clone().into()
+    }
+
+    /// Return the device key algorithm as a string.
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
+        self.inner.to_string()
+    }
+}
+
+/// The basic key algorithm names in the specification.
+#[wasm_bindgen]
+pub enum DeviceKeyAlgorithmName {
+    /// The Ed25519 signature algorithm.
+    Ed25519,
+
+    /// The Curve25519 ECDH algorithm.
+    Curve25519,
+
+    /// The Curve25519 ECDH algorithm, but the key also contains
+    /// signatures.
+    SignedCurve25519,
+
+    /// An unknown device key algorithm.
+    Unknown,
+}
+
+impl From<ruma::DeviceKeyAlgorithm> for DeviceKeyAlgorithmName {
+    fn from(value: ruma::DeviceKeyAlgorithm) -> Self {
+        use ruma::DeviceKeyAlgorithm::*;
+
+        match value {
+            Ed25519 => Self::Ed25519,
+            Curve25519 => Self::Curve25519,
+            SignedCurve25519 => Self::SignedCurve25519,
+            _ => Self::Unknown,
+        }
+    }
+}
+
 /// A Matrix [room ID].
 ///
 /// [room ID]: https://spec.matrix.org/v1.2/appendices/#room-ids-and-event-ids

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -26,6 +26,7 @@ pub mod olm;
 pub mod requests;
 pub mod responses;
 pub mod sync_events;
+pub mod vodozemac;
 mod tracing;
 
 use js_sys::{Object, Reflect};

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -26,9 +26,9 @@ pub mod olm;
 pub mod requests;
 pub mod responses;
 pub mod sync_events;
+mod tracing;
 pub mod types;
 pub mod vodozemac;
-mod tracing;
 
 use js_sys::{Object, Reflect};
 use wasm_bindgen::{convert::RefFromWasmAbi, prelude::*};

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -26,6 +26,7 @@ pub mod olm;
 pub mod requests;
 pub mod responses;
 pub mod sync_events;
+pub mod types;
 pub mod vodozemac;
 mod tracing;
 

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -22,6 +22,7 @@ pub mod events;
 mod future;
 pub mod identifiers;
 pub mod machine;
+pub mod olm;
 pub mod requests;
 pub mod responses;
 pub mod sync_events;

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -10,9 +10,10 @@ use wasm_bindgen::prelude::*;
 use crate::{
     downcast, encryption,
     future::future_to_promise,
-    olm,
     identifiers, requests,
+    olm,
     requests::OutgoingRequest,
+    vodozemac,
     responses::{self, response_from_string},
     sync_events,
 };
@@ -63,7 +64,7 @@ impl OlmMachine {
 
     /// Get the public parts of our Olm identity keys.
     #[wasm_bindgen(getter, js_name = "identityKeys")]
-    pub fn identity_keys(&self) -> IdentityKeys {
+    pub fn identity_keys(&self) -> vodozemac::IdentityKeys {
         self.inner.identity_keys().into()
     }
 
@@ -387,71 +388,5 @@ impl OlmMachine {
                 None => Ok(JsValue::NULL),
             }
         }))
-    }
-}
-
-/// An Ed25519 public key, used to verify digital signatures.
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct Ed25519PublicKey {
-    inner: vodozemac::Ed25519PublicKey,
-}
-
-#[wasm_bindgen]
-impl Ed25519PublicKey {
-    /// The number of bytes an Ed25519 public key has.
-    #[wasm_bindgen(getter)]
-    pub fn length(&self) -> usize {
-        vodozemac::Ed25519PublicKey::LENGTH
-    }
-
-    /// Serialize an Ed25519 public key to an unpadded base64
-    /// representation.
-    #[wasm_bindgen(js_name = "toBase64")]
-    pub fn to_base64(&self) -> String {
-        self.inner.to_base64()
-    }
-}
-
-/// A Curve25519 public key.
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
-pub struct Curve25519PublicKey {
-    inner: vodozemac::Curve25519PublicKey,
-}
-
-#[wasm_bindgen]
-impl Curve25519PublicKey {
-    /// The number of bytes a Curve25519 public key has.
-    #[wasm_bindgen(getter)]
-    pub fn length(&self) -> usize {
-        vodozemac::Curve25519PublicKey::LENGTH
-    }
-
-    /// Serialize an Curve25519 public key to an unpadded base64
-    /// representation.
-    #[wasm_bindgen(js_name = "toBase64")]
-    pub fn to_base64(&self) -> String {
-        self.inner.to_base64()
-    }
-}
-
-/// Struct holding the two public identity keys of an account.
-#[wasm_bindgen(getter_with_clone)]
-#[derive(Debug)]
-pub struct IdentityKeys {
-    /// The Ed25519 public key, used for signing.
-    pub ed25519: Ed25519PublicKey,
-
-    /// The Curve25519 public key, used for establish shared secrets.
-    pub curve25519: Curve25519PublicKey,
-}
-
-impl From<matrix_sdk_crypto::olm::IdentityKeys> for IdentityKeys {
-    fn from(value: matrix_sdk_crypto::olm::IdentityKeys) -> Self {
-        Self {
-            ed25519: Ed25519PublicKey { inner: value.ed25519 },
-            curve25519: Curve25519PublicKey { inner: value.curve25519 },
-        }
     }
 }

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -10,13 +10,10 @@ use wasm_bindgen::prelude::*;
 use crate::{
     downcast, encryption,
     future::future_to_promise,
-    identifiers, requests,
-    olm,
+    identifiers, olm, requests,
     requests::OutgoingRequest,
-    vodozemac,
     responses::{self, response_from_string},
-    sync_events,
-    types,
+    sync_events, types, vodozemac,
 };
 
 /// State machine implementation of the Olm/Megolm encryption protocol
@@ -303,9 +300,7 @@ impl OlmMachine {
     pub fn sign(&self, message: String) -> Promise {
         let me = self.inner.clone();
 
-        future_to_promise::<_, types::Signatures>(async move {
-            Ok(me.sign(&message).await.into())
-        })
+        future_to_promise::<_, types::Signatures>(async move { Ok(me.sign(&message).await.into()) })
     }
 
     /// Invalidate the currently active outbound group session for the

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -16,6 +16,7 @@ use crate::{
     vodozemac,
     responses::{self, response_from_string},
     sync_events,
+    types,
 };
 
 /// State machine implementation of the Olm/Megolm encryption protocol
@@ -294,6 +295,16 @@ impl OlmMachine {
 
         future_to_promise::<_, olm::CrossSigningStatus>(async move {
             Ok(me.cross_signing_status().await.into())
+        })
+    }
+
+    /// Sign the given message using our device key and if available
+    /// cross-signing master key.
+    pub fn sign(&self, message: String) -> Promise {
+        let me = self.inner.clone();
+
+        future_to_promise::<_, types::Signatures>(async move {
+            Ok(me.sign(&message).await.into())
         })
     }
 

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     downcast, encryption,
     future::future_to_promise,
+    olm,
     identifiers, requests,
     requests::OutgoingRequest,
     responses::{self, response_from_string},
@@ -280,6 +281,19 @@ impl OlmMachine {
 
             Ok(responses::DecryptedRoomEvent::from(room_event))
         }))
+    }
+
+    /// Get the status of the private cross signing keys.
+    ///
+    /// This can be used to check which private cross signing keys we
+    /// have stored locally.
+    #[wasm_bindgen(js_name = "crossSigningStatus")]
+    pub fn cross_signing_status(&self) -> Promise {
+        let me = self.inner.clone();
+
+        future_to_promise::<_, olm::CrossSigningStatus>(async move {
+            Ok(me.cross_signing_status().await.into())
+        })
     }
 
     /// Invalidate the currently active outbound group session for the

--- a/bindings/matrix-sdk-crypto-js/src/olm.rs
+++ b/bindings/matrix-sdk-crypto-js/src/olm.rs
@@ -1,0 +1,40 @@
+//! Olm types.
+
+use wasm_bindgen::prelude::*;
+
+/// Struct representing the state of our private cross signing keys,
+/// it shows which private cross signing keys we have locally stored.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct CrossSigningStatus {
+    inner: matrix_sdk_crypto::olm::CrossSigningStatus,
+}
+
+impl From<matrix_sdk_crypto::olm::CrossSigningStatus> for CrossSigningStatus {
+    fn from(inner: matrix_sdk_crypto::olm::CrossSigningStatus) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl CrossSigningStatus {
+    /// Do we have the master key?
+    #[wasm_bindgen(getter, js_name = "hasMaster")]
+    pub fn has_master(&self) -> bool {
+        self.inner.has_master
+    }
+
+    /// Do we have the self signing key? This one is necessary to sign
+    /// our own devices.
+    #[wasm_bindgen(getter, js_name = "hasSelfSigning")]
+    pub fn has_self_signing(&self) -> bool {
+        self.inner.has_self_signing
+    }
+
+    /// Do we have the user signing key? This one is necessary to sign
+    /// other users.
+    #[wasm_bindgen(getter, js_name = "hasUserSigning")]
+    pub fn has_user_signing(&self) -> bool {
+        self.inner.has_user_signing
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/types.rs
+++ b/bindings/matrix-sdk-crypto-js/src/types.rs
@@ -1,3 +1,5 @@
+//! Extra types, like `Signatures`.
+
 use js_sys::Map;
 use wasm_bindgen::prelude::*;
 

--- a/bindings/matrix-sdk-crypto-js/src/types.rs
+++ b/bindings/matrix-sdk-crypto-js/src/types.rs
@@ -1,0 +1,165 @@
+use js_sys::Map;
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    identifiers::{DeviceKeyId, UserId},
+    vodozemac::Ed25519Signature,
+};
+
+/// A collection of `Signature`.
+#[wasm_bindgen]
+#[derive(Debug, Default)]
+pub struct Signatures {
+    inner: matrix_sdk_crypto::types::Signatures,
+}
+
+impl From<matrix_sdk_crypto::types::Signatures> for Signatures {
+    fn from(inner: matrix_sdk_crypto::types::Signatures) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl Signatures {
+    /// Creates a new, empty, signatures collection.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        matrix_sdk_crypto::types::Signatures::new().into()
+    }
+
+    /// Add the given signature from the given signer and the given key ID to
+    /// the collection.
+    #[wasm_bindgen(js_name = "addSignature")]
+    pub fn add_signature(
+        &mut self,
+        signer: &UserId,
+        key_id: &DeviceKeyId,
+        signature: &Ed25519Signature,
+    ) -> Option<MaybeSignature> {
+        self.inner
+            .add_signature(signer.inner.clone(), key_id.inner.clone(), signature.inner)
+            .map(Into::into)
+    }
+
+    /// Try to find an Ed25519 signature from the given signer with
+    /// the given key ID.
+    #[wasm_bindgen(js_name = "getSignature")]
+    pub fn get_signature(&self, signer: &UserId, key_id: &DeviceKeyId) -> Option<Ed25519Signature> {
+        self.inner.get_signature(signer.inner.as_ref(), key_id.inner.as_ref()).map(Into::into)
+    }
+
+    /// Get the map of signatures that belong to the given user.
+    pub fn get(&self, signer: &UserId) -> Option<Map> {
+        let map = Map::new();
+
+        for (device_key_id, maybe_signature) in
+            self.inner.get(signer.inner.as_ref()).map(|map| {
+                map.iter().map(|(device_key_id, maybe_signature)| {
+                    (
+                        device_key_id.as_str().to_owned(),
+                        MaybeSignature::from(maybe_signature.clone()),
+                    )
+                })
+            })?
+        {
+            map.set(&device_key_id.into(), &maybe_signature.into());
+        }
+
+        Some(map)
+    }
+
+    /// Remove all the signatures we currently hold.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    /// Do we hold any signatures or is our collection completely
+    /// empty.
+    #[wasm_bindgen(getter, js_name = "isEmpty")]
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// How many signatures do we currently hold.
+    #[wasm_bindgen(getter)]
+    pub fn count(&self) -> usize {
+        self.inner.signature_count()
+    }
+}
+
+/// Represents a potentially decoded signature (but not a validated
+/// one).
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct Signature {
+    inner: matrix_sdk_crypto::types::Signature,
+}
+
+impl From<matrix_sdk_crypto::types::Signature> for Signature {
+    fn from(inner: matrix_sdk_crypto::types::Signature) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl Signature {
+    /// Get the Ed25519 signature, if this is one.
+    #[wasm_bindgen(getter)]
+    pub fn ed25519(&self) -> Option<Ed25519Signature> {
+        self.inner.ed25519().map(Into::into)
+    }
+
+    /// Convert the signature to a base64 encoded string.
+    #[wasm_bindgen(js_name = "toBase64")]
+    pub fn to_base64(&self) -> String {
+        self.inner.to_base64()
+    }
+}
+
+type MaybeSignatureInner =
+    Result<matrix_sdk_crypto::types::Signature, matrix_sdk_crypto::types::InvalidSignature>;
+
+/// Represents a signature that is either valid _or_ that could not be
+/// decoded.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct MaybeSignature {
+    inner: MaybeSignatureInner,
+}
+
+impl From<MaybeSignatureInner> for MaybeSignature {
+    fn from(inner: MaybeSignatureInner) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl MaybeSignature {
+    /// Check whether the signature has been successfully decoded.
+    #[wasm_bindgen(getter, js_name = "isValid")]
+    pub fn is_valid(&self) -> bool {
+        self.inner.is_ok()
+    }
+
+    /// Check whether the signature could not be successfully decoded.
+    #[wasm_bindgen(getter, js_name = "isInvalid")]
+    pub fn is_invalid(&self) -> bool {
+        self.inner.is_err()
+    }
+
+    /// The signature, if successfully decoded.
+    #[wasm_bindgen(getter)]
+    pub fn signature(&self) -> Option<Signature> {
+        self.inner.as_ref().cloned().map(Into::into).ok()
+    }
+
+    /// The base64 encoded string that is claimed to contain a
+    /// signature but could not be decoded, if any.
+    #[wasm_bindgen(getter, js_name = "invalidSignatureSource")]
+    pub fn invalid_signature_source(&self) -> Option<String> {
+        match &self.inner {
+            Ok(_) => None,
+            Err(signature) => Some(signature.source.clone()),
+        }
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
+++ b/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
@@ -1,0 +1,69 @@
+//! Vodozemac types.
+
+use wasm_bindgen::prelude::*;
+
+/// An Ed25519 public key, used to verify digital signatures.
+#[wasm_bindgen]
+#[derive(Debug, Clone)]
+pub struct Ed25519PublicKey {
+    inner: vodozemac::Ed25519PublicKey,
+}
+
+#[wasm_bindgen]
+impl Ed25519PublicKey {
+    /// The number of bytes an Ed25519 public key has.
+    #[wasm_bindgen(getter)]
+    pub fn length(&self) -> usize {
+        vodozemac::Ed25519PublicKey::LENGTH
+    }
+
+    /// Serialize an Ed25519 public key to an unpadded base64
+    /// representation.
+    #[wasm_bindgen(js_name = "toBase64")]
+    pub fn to_base64(&self) -> String {
+        self.inner.to_base64()
+    }
+}
+
+/// A Curve25519 public key.
+#[wasm_bindgen]
+#[derive(Debug, Clone)]
+pub struct Curve25519PublicKey {
+    inner: vodozemac::Curve25519PublicKey,
+}
+
+#[wasm_bindgen]
+impl Curve25519PublicKey {
+    /// The number of bytes a Curve25519 public key has.
+    #[wasm_bindgen(getter)]
+    pub fn length(&self) -> usize {
+        vodozemac::Curve25519PublicKey::LENGTH
+    }
+
+    /// Serialize an Curve25519 public key to an unpadded base64
+    /// representation.
+    #[wasm_bindgen(js_name = "toBase64")]
+    pub fn to_base64(&self) -> String {
+        self.inner.to_base64()
+    }
+}
+
+/// Struct holding the two public identity keys of an account.
+#[wasm_bindgen(getter_with_clone)]
+#[derive(Debug)]
+pub struct IdentityKeys {
+    /// The Ed25519 public key, used for signing.
+    pub ed25519: Ed25519PublicKey,
+
+    /// The Curve25519 public key, used for establish shared secrets.
+    pub curve25519: Curve25519PublicKey,
+}
+
+impl From<matrix_sdk_crypto::olm::IdentityKeys> for IdentityKeys {
+    fn from(value: matrix_sdk_crypto::olm::IdentityKeys) -> Self {
+        Self {
+            ed25519: Ed25519PublicKey { inner: value.ed25519 },
+            curve25519: Curve25519PublicKey { inner: value.curve25519 },
+        }
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
+++ b/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
@@ -25,6 +25,37 @@ impl Ed25519PublicKey {
     }
 }
 
+/// An Ed25519 digital signature, can be used to verify the
+/// authenticity of a message.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct Ed25519Signature {
+    pub(crate) inner: vodozemac::Ed25519Signature,
+}
+
+impl From<vodozemac::Ed25519Signature> for Ed25519Signature {
+    fn from(inner: vodozemac::Ed25519Signature) -> Self {
+        Self { inner }
+    }
+}
+
+#[wasm_bindgen]
+impl Ed25519Signature {
+    /// Try to create an Ed25519 signature from an unpadded base64
+    /// representation.
+    #[wasm_bindgen(constructor)]
+    pub fn new(signature: String) -> Result<Ed25519Signature, JsError> {
+        Ok(Self { inner: vodozemac::Ed25519Signature::from_base64(signature.as_str())? })
+    }
+
+    /// Serialize a Ed25519 signature to an unpadded base64
+    /// representation.
+    #[wasm_bindgen(js_name = "toBase64")]
+    pub fn to_base64(&self) -> String {
+        self.inner.to_base64()
+    }
+}
+
 /// A Curve25519 public key.
 #[wasm_bindgen]
 #[derive(Debug, Clone)]

--- a/bindings/matrix-sdk-crypto-js/tests/identifiers.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/identifiers.test.js
@@ -1,4 +1,4 @@
-const { UserId, DeviceId, RoomId, ServerName } = require('../pkg/matrix_sdk_crypto_js');
+const { UserId, DeviceId, DeviceKeyId, DeviceKeyAlgorithm, DeviceKeyAlgorithmName, RoomId, ServerName } = require('../pkg/matrix_sdk_crypto_js');
 
 describe(UserId.name, () => {
     test('cannot be invalid', () => {
@@ -30,6 +30,52 @@ describe(DeviceId.name, () => {
     test('can read the device ID as a string', () => {
         expect(device.toString()).toStrictEqual('foo');
     })
+});
+
+describe(DeviceKeyId.name, () => {
+    for (const deviceKey of [
+        { name: 'ed25519',
+          id: 'ed25519:foobar',
+          algorithmName: DeviceKeyAlgorithmName.Ed25519,
+          algorithm: 'ed25519',
+          deviceId: 'foobar' },
+
+        { name: 'curve25519',
+          id: 'curve25519:foobar',
+          algorithmName: DeviceKeyAlgorithmName.Curve25519,
+          algorithm: 'curve25519',
+          deviceId: 'foobar' },
+
+        { name: 'signed curve25519',
+          id: 'signed_curve25519:foobar',
+          algorithmName: DeviceKeyAlgorithmName.SignedCurve25519,
+          algorithm: 'signed_curve25519',
+          deviceId: 'foobar' },
+
+        { name: 'unknown',
+          id: 'hello:foobar',
+          algorithmName: DeviceKeyAlgorithmName.Unknown,
+          algorithm: 'hello',
+          deviceId: 'foobar' },
+    ]) {
+        test(`${deviceKey.name} algorithm`, () => {
+            const dk = new DeviceKeyId(deviceKey.id);
+
+            expect(dk.algorithm.name).toStrictEqual(deviceKey.algorithmName);
+            expect(dk.algorithm.toString()).toStrictEqual(deviceKey.algorithm);
+            expect(dk.deviceId.toString()).toStrictEqual(deviceKey.deviceId);
+            expect(dk.toString()).toStrictEqual(deviceKey.id);
+        });
+    }
+});
+
+describe('DeviceKeyAlgorithmName', () => {
+    test('has the correct variants', () => {
+        expect(DeviceKeyAlgorithmName.Ed25519).toStrictEqual(0);
+        expect(DeviceKeyAlgorithmName.Curve25519).toStrictEqual(1);
+        expect(DeviceKeyAlgorithmName.SignedCurve25519).toStrictEqual(2);
+        expect(DeviceKeyAlgorithmName.Unknown).toStrictEqual(3);
+    });
 });
 
 describe(RoomId.name, () => {

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -1,4 +1,4 @@
-const { OlmMachine, UserId, DeviceId, RoomId, DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest, KeysClaimRequest, EncryptionSettings, DecryptedRoomEvent, VerificationState, CrossSigningStatus } = require('../pkg/matrix_sdk_crypto_js');
+const { OlmMachine, UserId, DeviceId, DeviceKeyId, RoomId, DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest, KeysClaimRequest, EncryptionSettings, DecryptedRoomEvent, VerificationState, CrossSigningStatus, MaybeSignature } = require('../pkg/matrix_sdk_crypto_js');
 
 describe(OlmMachine.name, () => {
     test('can be instantiated with the async initializer', async () => {
@@ -349,5 +349,47 @@ describe(OlmMachine.name, () => {
         expect(crossSigningStatus.hasMaster).toStrictEqual(false);
         expect(crossSigningStatus.hasSelfSigning).toStrictEqual(false);
         expect(crossSigningStatus.hasUserSigning).toStrictEqual(false);
+    });
+
+    test('can sign a message', async () => {
+        const m = await machine();
+        const signatures = await m.sign('foo');
+
+        expect(signatures.isEmpty).toStrictEqual(false);
+        expect(signatures.count).toStrictEqual(1);
+
+        let base64;
+
+        // `get`
+        {
+            const signature = signatures.get(user);
+
+            expect(signature.has('ed25519:foobar')).toStrictEqual(true);
+
+            const s = signature.get('ed25519:foobar');
+
+            expect(s).toBeInstanceOf(MaybeSignature);
+
+            expect(s.isValid).toStrictEqual(true);
+            expect(s.isInvalid).toStrictEqual(false);
+            expect(s.invalidSignatureSource).toBeUndefined();
+
+            base64 = s.signature.toBase64();
+
+            expect(base64).toMatch(/^[A-Za-z0-9\+/]+$/);
+            expect(s.signature.ed25519.toBase64()).toStrictEqual(base64);
+        }
+
+        // `getSignature`
+        {
+            const signature = signatures.getSignature(user, new DeviceKeyId('ed25519:foobar'));
+            expect(signature.toBase64()).toStrictEqual(base64);
+        }
+
+        // Unknown signatures.
+        {
+            expect(signatures.get(new UserId('@hello:example.org'))).toBeUndefined();
+            expect(signatures.getSignature(user, new DeviceKeyId('world:foobar'))).toBeUndefined();
+        }
     });
 });

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -1,4 +1,4 @@
-const { OlmMachine, UserId, DeviceId, RoomId, DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest, KeysClaimRequest, EncryptionSettings, DecryptedRoomEvent, VerificationState } = require('../pkg/matrix_sdk_crypto_js');
+const { OlmMachine, UserId, DeviceId, RoomId, DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest, KeysClaimRequest, EncryptionSettings, DecryptedRoomEvent, VerificationState, CrossSigningStatus } = require('../pkg/matrix_sdk_crypto_js');
 
 describe(OlmMachine.name, () => {
     test('can be instantiated with the async initializer', async () => {
@@ -339,5 +339,15 @@ describe(OlmMachine.name, () => {
             expect(decrypted.forwardingCurve25519KeyChain).toHaveLength(0);
             expect(decrypted.verificationState).toStrictEqual(VerificationState.Trusted);
         });
+    });
+
+    test('can read cross-signing status', async () => {
+        const m = await machine();
+        const crossSigningStatus = await m.crossSigningStatus();
+
+        expect(crossSigningStatus).toBeInstanceOf(CrossSigningStatus);
+        expect(crossSigningStatus.hasMaster).toStrictEqual(false);
+        expect(crossSigningStatus.hasSelfSigning).toStrictEqual(false);
+        expect(crossSigningStatus.hasUserSigning).toStrictEqual(false);
     });
 });


### PR DESCRIPTION
This PR implements 2 new methods on `OlmMachine`: `sign` and `cross_signing_status`. It's basically a port from `crypto-nodejs` adapted for Wasm+JS.