### PR TITLE
fix(sled): Remove unused `from` on EncodeUnchecked

### DIFF
--- a/crates/matrix-sdk-sled/src/encode_key.rs
+++ b/crates/matrix-sdk-sled/src/encode_key.rs
@@ -14,6 +14,7 @@ use ruma::{
 /// without checking for the existence of `ENCODE_SEPARATOR` within
 pub struct EncodeUnchecked<'a>(&'a [u8]);
 
+#[cfg(feature = "state-store")]
 impl<'a> EncodeUnchecked<'a> {
     /// Wrap any `[u8]`
     pub fn from(bytes: &'a [u8]) -> Self {


### PR DESCRIPTION
The function is not used and Github Actions rightously complains about it.