### PR TITLE
feat(crypto-js): Implement the Attachment API

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/attachment.rs
+++ b/bindings/matrix-sdk-crypto-js/src/attachment.rs
@@ -1,0 +1,124 @@
+//! Attachment API.
+
+use std::io::{Cursor, Read};
+
+use wasm_bindgen::prelude::*;
+
+/// A type to encrypt and to decrypt anything that can fit in an
+/// `Uint8Array`, usually big buffer.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct Attachment;
+
+#[wasm_bindgen]
+impl Attachment {
+    /// Encrypt the content of the `Uint8Array`.
+    ///
+    /// It produces an `EncryptedAttachment`, which can be used to
+    /// retrieve the media encryption information, or the encrypted
+    /// data.
+    #[wasm_bindgen]
+    pub fn encrypt(array: &[u8]) -> Result<EncryptedAttachment, JsError> {
+        let mut cursor = Cursor::new(array);
+        let mut encryptor = matrix_sdk_crypto::AttachmentEncryptor::new(&mut cursor);
+
+        let mut encrypted_data = Vec::new();
+        encryptor.read_to_end(&mut encrypted_data)?;
+
+        let media_encryption_info = Some(encryptor.finish());
+
+        Ok(EncryptedAttachment { encrypted_data, media_encryption_info })
+    }
+
+    /// Decrypt an `EncryptedAttachment`.
+    ///
+    /// The encrypted attachment can be created manually, or from the
+    /// `encrypt` method.
+    ///
+    /// **Warning**: The encrypted attachment can be used only
+    /// **once**! The encrypted data will still be present, but the
+    /// media encryption info (which contain secrets) will be
+    /// destroyed. It is still possible to get a JSON-encoded backup
+    /// by calling `EncryptedAttachment.mediaEncryptionInfo`.
+    pub fn decrypt(attachment: &mut EncryptedAttachment) -> Result<Vec<u8>, JsError> {
+        let media_encryption_info = match attachment.media_encryption_info.take() {
+            Some(media_encryption_info) => media_encryption_info,
+            None => {
+                return Err(JsError::new(
+                    "The media encryption info are absent from the given encrypted attachment",
+                ))
+            }
+        };
+
+        let encrypted_data: &[u8] = attachment.encrypted_data.as_slice();
+
+        let mut cursor = Cursor::new(encrypted_data);
+        let mut decryptor =
+            matrix_sdk_crypto::AttachmentDecryptor::new(&mut cursor, media_encryption_info)?;
+
+        let mut decrypted_data = Vec::new();
+        decryptor.read_to_end(&mut decrypted_data)?;
+
+        Ok(decrypted_data)
+    }
+}
+
+/// An encrypted attachment, usually created from `Attachment.encrypt`.
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct EncryptedAttachment {
+    media_encryption_info: Option<matrix_sdk_crypto::MediaEncryptionInfo>,
+    encrypted_data: Vec<u8>,
+}
+
+#[wasm_bindgen]
+impl EncryptedAttachment {
+    /// Create a new encrypted attachment manually.
+    ///
+    /// It needs encrypted data, stored in an `Uint8Array`, and a
+    /// [media encryption
+    /// information](https://docs.rs/matrix-sdk-crypto/latest/matrix_sdk_crypto/struct.MediaEncryptionInfo.html),
+    /// as a JSON-encoded string.
+    ///
+    /// The media encryption information aren't stored as a string:
+    /// they are parsed, validated and fully deserialized.
+    ///
+    /// See [the specification to learn
+    /// more](https://spec.matrix.org/unstable/client-server-api/#extensions-to-mroommessage-msgtypes).
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        encrypted_data: Vec<u8>,
+        media_encryption_info: &str,
+    ) -> Result<EncryptedAttachment, JsError> {
+        Ok(Self {
+            encrypted_data,
+            media_encryption_info: Some(serde_json::from_str(media_encryption_info)?),
+        })
+    }
+
+    /// The actual encrypted data.
+    ///
+    /// **Warning**: It returns a **copy** of the entire encrypted
+    /// data; be nice with your memory.
+    #[wasm_bindgen(getter, js_name = "encryptedData")]
+    pub fn encrypted_data(&self) -> Vec<u8> {
+        self.encrypted_data.clone()
+    }
+
+    /// Return the media encryption info as a JSON-encoded string. The
+    /// structure is fully valid.
+    ///
+    /// If the media encryption info have been consumed already, it
+    /// will return `null`.
+    #[wasm_bindgen(getter, js_name = "mediaEncryptionInfo")]
+    pub fn media_encryption_info(&self) -> Option<String> {
+        serde_json::to_string(self.media_encryption_info.as_ref()?).ok()
+    }
+
+    /// Check whether the media encryption info has been consumed by
+    /// `Attachment.decrypt` already.
+    #[wasm_bindgen(getter, js_name = "hasMediaEncryptionInfoBeenConsumed")]
+    pub fn has_media_encryption_info_been_consumed(&self) -> bool {
+        self.media_encryption_info.is_none()
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -17,6 +17,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![allow(clippy::drop_non_drop)] // triggered by wasm_bindgen code
 
+pub mod attachment;
 pub mod encryption;
 pub mod events;
 mod future;

--- a/bindings/matrix-sdk-crypto-js/tests/attachment.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/attachment.test.js
@@ -1,0 +1,77 @@
+const { Attachment, EncryptedAttachment } = require('../pkg/matrix_sdk_crypto_js');
+
+describe(Attachment.name, () => {
+    const originalData = 'hello';
+    const textEncoder = new TextEncoder();
+    const textDecoder = new TextDecoder();
+
+    let encryptedAttachment;
+    
+    test('can encrypt data', () => {
+        encryptedAttachment = Attachment.encrypt(textEncoder.encode(originalData));
+
+        const mediaEncryptionInfo = JSON.parse(encryptedAttachment.mediaEncryptionInfo);
+
+        expect(mediaEncryptionInfo).toMatchObject({
+            v: 'v2',
+            key: {
+                kty: expect.any(String),
+                key_ops: expect.arrayContaining(['encrypt', 'decrypt']),
+                alg: expect.any(String),
+                k: expect.any(String),
+                ext: expect.any(Boolean),
+            },
+            iv: expect.stringMatching(/^[A-Za-z0-9\+/]+$/),
+            hashes: {
+                sha256: expect.stringMatching(/^[A-Za-z0-9\+/]+$/)
+            }
+        });
+
+        const encryptedData = encryptedAttachment.encryptedData;
+        expect(encryptedData.every((i) => { i != 0 })).toStrictEqual(false);
+    });
+
+    test('can decrypt data', () => {
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(false);
+
+        const decryptedAttachment = Attachment.decrypt(encryptedAttachment);
+
+        expect(textDecoder.decode(decryptedAttachment)).toStrictEqual(originalData);
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(true);
+    });
+
+    test('can only decrypt once', () => {
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(true);
+
+        expect(() => { textDecoder.decode(decryptedAttachment) }).toThrow()
+    });
+});
+
+describe(EncryptedAttachment.name, () => {
+    const originalData = 'hello';
+    const textDecoder = new TextDecoder();
+
+    test('can be created manually', () => {
+        const encryptedAttachment = new EncryptedAttachment(
+            new Uint8Array([24, 150, 67, 37, 144]),
+            JSON.stringify({
+                v: 'v2',
+                key: {
+                    kty: 'oct',
+                    key_ops: [ 'encrypt', 'decrypt' ],
+                    alg: 'A256CTR',
+                    k: 'QbNXUjuukFyEJ8cQZjJuzN6mMokg0HJIjx0wVMLf5BM',
+                    ext: true
+                },
+                iv: 'xk2AcWkomiYAAAAAAAAAAA',
+                hashes: {
+                    sha256: 'JsRbDXgOja4xvDiF3DwBuLHdxUzIrVYIuj7W/t3aEok'
+                }
+            })
+        );
+
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(false);
+        expect(textDecoder.decode(Attachment.decrypt(encryptedAttachment))).toStrictEqual(originalData);
+        expect(encryptedAttachment.hasMediaEncryptionInfoBeenConsumed).toStrictEqual(true);
+    });
+});

--- a/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
@@ -17,7 +17,7 @@ pub struct Attachment;
 impl Attachment {
     /// Encrypt the content of the `Uint8Array`.
     ///
-    /// It produces an `EncryptedAttachment`, we can be used to
+    /// It produces an `EncryptedAttachment`, which can be used to
     /// retrieve the media encryption information, or the encrypted
     /// data.
     #[napi]


### PR DESCRIPTION
Implement the `Attachment.encrypt` and `Attachment.decrypt` methods,
along with its `EncryptedAttachment` companion.

The trick is to avoid copies as much as possible. Instead of dealing
with `Uint8Array` as I've initially done, `&[u8]` and `Vec<u8>` is
passed instead. `wasm-bindgen` is smart enough to do as few copies as
possible (from JavaScript to Wasm's memory is required, and we don't
want to do more), while typing everything as `Uint8Array`.

`EncryptedAttachment.encryptedData` returns a copy of the data
everytime it is called, and that's the last copy I'm not happy with.