### PR TITLE
chore(crypto-js): Add a release workflow for `crypto-js`

### DIFF
--- a/.github/workflows/release_crypto_js.yml
+++ b/.github/workflows/release_crypto_js.yml
@@ -1,0 +1,56 @@
+# This workflow releases the `matrix-sdk-crypto-js` project.
+#
+# It is triggered when a new tag matches
+# `matrix-sdk-crypto-js-v[0-9]+.*`, which then build the package for
+# the binding, run its tests to ensure everything is still correct,
+# and publish the package on NPM.
+
+
+name: Release `crypto-js`
+
+env:
+  CARGO_TERM_COLOR: always
+  PKG_PATH: "bindings/matrix-sdk-crypto-js"
+
+on:
+  push:
+    tags:
+      - matrix-sdk-crypto-js-v[0-9]+.*
+
+jobs:
+  publish-matrix-sdk-crypto-js:
+    name: Publish 🕸 [m]-crypto-js
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+
+      - name: Load cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.0
+
+      - name: Install NPM dependencies
+        working-directory: ${{ env.PKG_PATH }}
+        run: npm install
+
+      - name: Configure NPM auth token
+        working-directory: ${{ env.PKG_PATH }}
+        run: npm set "//registry.npmjs.org/:_authToken" "${{ secrets.NPM_TOKEN }}"
+
+      - name: Publish the WebAssembly + JavaScript binding (imply building + testing)
+        working-directory: ${{ env.PKG_PATH }}
+        run: npm run publish

--- a/.github/workflows/release_crypto_js.yml
+++ b/.github/workflows/release_crypto_js.yml
@@ -54,3 +54,9 @@ jobs:
       - name: Publish the WebAssembly + JavaScript binding (imply building + testing)
         working-directory: ${{ env.PKG_PATH }}
         run: npm run publish
+
+      - name: Create the Github release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: ${{ env.PKG_PATH }}/pkg/matrix-org-matrix-sdk-crypto-js-*.tgz

--- a/.github/workflows/release_crypto_js.yml
+++ b/.github/workflows/release_crypto_js.yml
@@ -1,9 +1,10 @@
 # This workflow releases the `matrix-sdk-crypto-js` project.
 #
-# It is triggered when a new tag matches
-# `matrix-sdk-crypto-js-v[0-9]+.*`, which then build the package for
-# the binding, run its tests to ensure everything is still correct,
-# and publish the package on NPM.
+# It is triggered when a new tag appears that matches
+# `matrix-sdk-crypto-js-v[0-9]+.*`. This workflow builds the package
+# for the binding, run its tests to ensure everything is still
+# correct, and publish the package on NPM and on a newly created
+# Github release.
 
 
 name: Release `crypto-js`

--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -38,6 +38,8 @@
     "scripts": {
         "build": "cross-env RUSTFLAGS='-C opt-level=z' wasm-pack build --release --target nodejs --scope matrix-org --out-dir ./pkg",
         "test": "jest --verbose",
-        "doc": "typedoc --tsconfig ."
+        "doc": "typedoc --tsconfig .",
+        "prepublish": "$npm_execpath run build && $npm_execpath run test",
+        "publish": "wasm-pack publish"
     }
 }

--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -40,6 +40,6 @@
         "test": "jest --verbose",
         "doc": "typedoc --tsconfig .",
         "prepublish": "$npm_execpath run build && $npm_execpath run test",
-        "publish": "wasm-pack publish"
+        "publish": "wasm-pack pack && wasm-pack publish"
     }
 }


### PR DESCRIPTION
This patch adds a new `npm run publish` script that:

1. Run `npm run prepublish` (which runs the `build` and `test` scripts),
2. Run `wasm-pack publish`.

Note 1: The `prepublish` script is using the `$npm_execpath`
environment variable instead of just “`npm`”, so that if someone is
using `yarn` or another JavaScript package manager, it _should_ work
(not tested yet).

Note 2: `wasm-pack publish` is run without running `wasm-pack login`
before that. _But_ we are updating the registry URL in the NPM
configuration file in the Github Action workflow, see below.

This patch then creates a new Github Action workflow that is triggered
when a new tag of the form `matrix-sdk-crypto-js-v[0_9]+.*` is
pushed. This workflow runs `npm run publish` basically, but before
that, it updates the NPM configuration file by setting a value for
`//registry.npmjs.org/:_authToken`. Thus, running `wasm-pack login` is
not necessary.

Supersedes and closes #900. Fixes #794.

Edit 🆕:

This patch updates the `publish` NPM script to explicitly run
`wasm-pack pack` to create the NPM package in the `pkg/`
directory. This patch also updates the Github Action workflow for the
`matrix-sdk-crypto-js` release, to create a new Github Release, with
the NPM package attached as an asset file.
