### PR TITLE
refactor(sdk)!: Make room type constructors private

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -850,7 +850,7 @@ impl Client {
         self.base_client()
             .get_rooms()
             .into_iter()
-            .filter_map(|room| room::Joined::new(self.clone(), room))
+            .filter_map(|room| room::Joined::new(self, room))
             .collect()
     }
 
@@ -859,7 +859,7 @@ impl Client {
         self.base_client()
             .get_stripped_rooms()
             .into_iter()
-            .filter_map(|room| room::Invited::new(self.clone(), room))
+            .filter_map(|room| room::Invited::new(self, room))
             .collect()
     }
 
@@ -868,7 +868,7 @@ impl Client {
         self.base_client()
             .get_rooms()
             .into_iter()
-            .filter_map(|room| room::Left::new(self.clone(), room))
+            .filter_map(|room| room::Left::new(self, room))
             .collect()
     }
 
@@ -889,7 +889,7 @@ impl Client {
     ///
     /// `room_id` - The unique id of the room that should be fetched.
     pub fn get_joined_room(&self, room_id: &RoomId) -> Option<room::Joined> {
-        self.base_client().get_room(room_id).and_then(|room| room::Joined::new(self.clone(), room))
+        self.base_client().get_room(room_id).and_then(|room| room::Joined::new(self, room))
     }
 
     /// Get an invited room with the given room id.
@@ -898,7 +898,7 @@ impl Client {
     ///
     /// `room_id` - The unique id of the room that should be fetched.
     pub fn get_invited_room(&self, room_id: &RoomId) -> Option<room::Invited> {
-        self.base_client().get_room(room_id).and_then(|room| room::Invited::new(self.clone(), room))
+        self.base_client().get_room(room_id).and_then(|room| room::Invited::new(self, room))
     }
 
     /// Get a left room with the given room id.
@@ -907,7 +907,7 @@ impl Client {
     ///
     /// `room_id` - The unique id of the room that should be fetched.
     pub fn get_left_room(&self, room_id: &RoomId) -> Option<room::Left> {
-        self.base_client().get_room(room_id).and_then(|room| room::Left::new(self.clone(), room))
+        self.base_client().get_room(room_id).and_then(|room| room::Left::new(self, room))
     }
 
     /// Resolve a room alias to a room id and a list of servers which know

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -100,8 +100,7 @@ impl Common {
     /// * `client` - The client used to make requests.
     ///
     /// * `room` - The underlying room.
-    pub fn new(client: Client, room: BaseRoom) -> Self {
-        // TODO: Make this private
+    pub(crate) fn new(client: Client, room: BaseRoom) -> Self {
         Self { inner: room, client }
     }
 

--- a/crates/matrix-sdk/src/room/invited.rs
+++ b/crates/matrix-sdk/src/room/invited.rs
@@ -42,10 +42,9 @@ impl Invited {
     /// * `client` - The client used to make requests.
     ///
     /// * `room` - The underlying room.
-    pub fn new(client: Client, room: BaseRoom) -> Option<Self> {
-        // TODO: Make this private
+    pub(crate) fn new(client: &Client, room: BaseRoom) -> Option<Self> {
         if room.room_type() == RoomType::Invited {
-            Some(Self { inner: Common::new(client, room) })
+            Some(Self { inner: Common::new(client.clone(), room) })
         } else {
             None
         }

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -77,10 +77,9 @@ impl Joined {
     /// * `client` - The client used to make requests.
     ///
     /// * `room` - The underlying room.
-    pub fn new(client: Client, room: BaseRoom) -> Option<Self> {
-        // TODO: Make this private
+    pub(crate) fn new(client: &Client, room: BaseRoom) -> Option<Self> {
         if room.room_type() == RoomType::Joined {
-            Some(Self { inner: Common::new(client, room) })
+            Some(Self { inner: Common::new(client.clone(), room) })
         } else {
             None
         }

--- a/crates/matrix-sdk/src/room/left.rs
+++ b/crates/matrix-sdk/src/room/left.rs
@@ -25,10 +25,9 @@ impl Left {
     /// * `client` - The client used to make requests.
     ///
     /// * `room` - The underlying room.
-    pub fn new(client: Client, room: BaseRoom) -> Option<Self> {
-        // TODO: Make this private
+    pub(crate) fn new(client: &Client, room: BaseRoom) -> Option<Self> {
         if room.room_type() == RoomType::Left {
-            Some(Self { inner: Common::new(client, room) })
+            Some(Self { inner: Common::new(client.clone(), room) })
         } else {
             None
         }


### PR DESCRIPTION
… and avoid unnecessary clones before calling them.

These constructors were never called from any other crate in the workspace, and I don't see why one would want to use them directly rather than use the other existing means to obtain a room object.