### PR TITLE
Remove a few parking_lot dependencies for faster builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3972,15 +3972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,9 +4302,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.1",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,7 +2402,6 @@ dependencies = [
  "futures-util",
  "matrix-sdk",
  "once_cell",
- "parking_lot 0.12.1",
  "sanitize-filename-reader-friendly",
  "serde",
  "serde_json",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -23,7 +23,6 @@ futures-core = "0.3.17"
 futures-util = { version = "0.3.17", default-features = false }
 matrix-sdk = { path = "../../crates/matrix-sdk", features = ["experimental-timeline", "markdown"] }
 once_cell = "1.10.0"
-parking_lot = "0.12.0"
 sanitize-filename-reader-friendly = "2.2.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -1,11 +1,10 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use futures_util::future::join3;
 use matrix_sdk::{
     ruma::{OwnedDeviceId, UserId},
     Session,
 };
-use parking_lot::RwLock;
 
 use super::{client::Client, client_builder::ClientBuilder, RUNTIME};
 
@@ -66,7 +65,7 @@ impl AuthenticationService {
     }
 
     pub fn homeserver_details(&self) -> Option<Arc<HomeserverLoginDetails>> {
-        self.homeserver_details.read().clone()
+        self.homeserver_details.read().unwrap().clone()
     }
 
     /// Updates the service to authenticate with the homeserver for the
@@ -85,8 +84,8 @@ impl AuthenticationService {
         RUNTIME.block_on(async move {
             let details = Arc::new(self.details_from_client(&client).await?);
 
-            *self.client.write() = Some(client);
-            *self.homeserver_details.write() = Some(details);
+            *self.client.write().unwrap() = Some(client);
+            *self.homeserver_details.write().unwrap() = Some(details);
 
             Ok(())
         })
@@ -98,7 +97,7 @@ impl AuthenticationService {
         username: String,
         password: String,
     ) -> Result<Arc<Client>, AuthenticationError> {
-        match self.client.read().as_ref() {
+        match self.client.read().unwrap().as_ref() {
             Some(client) => {
                 // Login and ask the server for the full user ID as this could be different from
                 // the username that was entered.
@@ -137,7 +136,7 @@ impl AuthenticationService {
         token: String,
         device_id: String,
     ) -> Result<Arc<Client>, AuthenticationError> {
-        match self.client.read().as_ref() {
+        match self.client.read().unwrap().as_ref() {
             Some(client) => {
                 // Restore the client and ask the server for the full user ID as this
                 // could be different from the username that was entered.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use anyhow::anyhow;
 use matrix_sdk::{
@@ -16,7 +16,6 @@ use matrix_sdk::{
     },
     Client as MatrixClient, LoopCtrl, Session,
 };
-use parking_lot::RwLock;
 
 use super::{
     room::Room, session_verification::SessionVerificationController, ClientState, RestoreToken,
@@ -78,7 +77,7 @@ impl Client {
     }
 
     pub fn set_delegate(&self, delegate: Option<Box<dyn ClientDelegate>>) {
-        *self.delegate.write() = delegate;
+        *self.delegate.write().unwrap() = delegate;
     }
 
     /// The homeserver this client is configured to use.
@@ -137,18 +136,18 @@ impl Client {
 
             client
                 .sync_with_callback(sync_settings, |sync_response| async {
-                    if !state.read().has_first_synced {
-                        state.write().has_first_synced = true
+                    if !state.read().unwrap().has_first_synced {
+                        state.write().unwrap().has_first_synced = true;
                     }
 
-                    if state.read().should_stop_syncing {
-                        state.write().is_syncing = false;
+                    if state.read().unwrap().should_stop_syncing {
+                        state.write().unwrap().is_syncing = false;
                         return LoopCtrl::Break;
-                    } else if !state.read().is_syncing {
-                        state.write().is_syncing = true;
+                    } else if !state.read().unwrap().is_syncing {
+                        state.write().unwrap().is_syncing = true;
                     }
 
-                    if let Some(delegate) = &*delegate.read() {
+                    if let Some(delegate) = &*delegate.read().unwrap() {
                         delegate.did_receive_sync_update()
                     }
 
@@ -169,17 +168,17 @@ impl Client {
     /// Indication whether we've received a first sync response since
     /// establishing the client (in memory)
     pub fn has_first_synced(&self) -> bool {
-        self.state.read().has_first_synced
+        self.state.read().unwrap().has_first_synced
     }
 
     /// Indication whether we are currently syncing
     pub fn is_syncing(&self) -> bool {
-        self.state.read().has_first_synced
+        self.state.read().unwrap().has_first_synced
     }
 
     /// Is this a guest account?
     pub fn is_guest(&self) -> bool {
-        self.state.read().is_guest
+        self.state.read().unwrap().is_guest
     }
 
     pub fn restore_token(&self) -> anyhow::Result<String> {
@@ -189,7 +188,7 @@ impl Client {
             Ok(serde_json::to_string(&RestoreToken {
                 session,
                 homeurl,
-                is_guest: self.state.read().is_guest,
+                is_guest: self.state.read().unwrap().is_guest,
             })?)
         })
     }

--- a/examples/autojoin/Cargo.toml
+++ b/examples/autojoin/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-autojoin"
 test = false
 
 [dependencies]
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
 tracing-subscriber = "0.3.15"
 

--- a/examples/command_bot/Cargo.toml
+++ b/examples/command_bot/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 url = "2.2.2"
 

--- a/examples/cross_signing_bootstrap/Cargo.toml
+++ b/examples/cross_signing_bootstrap/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 url = "2.2.2"
 

--- a/examples/custom_events/Cargo.toml
+++ b/examples/custom_events/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 anyhow = "1"
 dirs = "4.0.0"
 serde = "1.0"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 
 [dependencies.matrix-sdk]

--- a/examples/emoji_verification/Cargo.toml
+++ b/examples/emoji_verification/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 url = "2.2.2"
 

--- a/examples/get_profiles/Cargo.toml
+++ b/examples/get_profiles/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 url = "2.2.2"
 

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 dirs = "4.0.0"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 
 [dependencies.matrix-sdk]

--- a/examples/image_bot/Cargo.toml
+++ b/examples/image_bot/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 mime = "0.3.16"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 url = "2.2.2"
 

--- a/examples/login/Cargo.toml
+++ b/examples/login/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 url = "2.2.2"
 

--- a/examples/timeline/Cargo.toml
+++ b/examples/timeline/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 futures = "0.3"
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 url = "2.2.2"
 


### PR DESCRIPTION
Unfortunately we still always pull in parking_lot 0.11 (sled, wasm-timer) which I suspect is not really needed, plus parking_lot 0.12 (but only on `target_os = "linux"` when checking / building `benchmarks`). That is, the overall reduction in dependencies is very small, but at least the parking_lot 0.12 dependency for wasm and macos through the examples is gone, so it should speed up those CI jobs a little bit.