### PR TITLE
feat(crypto-js): Add store configuration to the `OlmMachine` constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,8 +1931,7 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexed_db_futures"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26ac735f676c52305becf53264b91cea9866a8de61ccbf464405b377b9cbca9"
+source = "git+https://github.com/Hywan/rust-indexed-db?branch=feat-factory-nodejs#5dab67890cea0ab88b967031adc09179a537d77c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2365,6 +2364,7 @@ dependencies = [
  "js-sys",
  "matrix-sdk-common",
  "matrix-sdk-crypto",
+ "matrix-sdk-indexeddb",
  "ruma",
  "serde_json",
  "tracing",
@@ -2372,6 +2372,7 @@ dependencies = [
  "vodozemac",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "zeroize",
 ]
 
 [[package]]

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -28,6 +28,7 @@ tracing = []
 [dependencies]
 matrix-sdk-common = { version = "0.5.0", path = "../../crates/matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.5.0", path = "../../crates/matrix-sdk-crypto" }
+matrix-sdk-indexeddb = { version = "0.1.0", path = "../../crates/matrix-sdk-indexeddb" }
 ruma = { git = "https://github.com/ruma/ruma", rev = "173eb15147c904d7dc0ee894de6114743926e33e", features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"] }
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"
@@ -38,6 +39,7 @@ http = "0.2.6"
 anyhow = "1.0.58"
 tracing = { version = "0.1.35", default-features = false, features = ["attributes"] }
 tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std"] }
+zeroize = "1.3.0"
 
 [dependencies.vodozemac]
 git = "https://github.com/matrix-org/vodozemac/"

--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -30,7 +30,8 @@
         "jest": "^28.1.0",
         "typedoc": "^0.22.17",
         "cross-env": "^7.0.3",
-        "yargs-parser": "~21.0.1"
+        "yargs-parser": "~21.0.1",
+        "fake-indexeddb": "^4.0"
     },
     "engines": {
         "node": ">= 10"

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -1,6 +1,6 @@
 //! The crypto specific Olm objects.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 
 use js_sys::{Array, Map, Promise, Set};
 use ruma::{serde::Raw, DeviceKeyAlgorithm, OwnedTransactionId, UInt};
@@ -64,6 +64,8 @@ impl OlmMachine {
                 // always compiled for `wasm32`.
                 #[cfg(target_arch = "wasm32")]
                 (Some(store_name), Some(mut store_passphrase)) => {
+                    use std::sync::Arc;
+
                     let store = Some(
                         matrix_sdk_indexeddb::IndexeddbCryptoStore::open_with_passphrase(
                             &store_name,

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -74,7 +74,7 @@ impl OlmMachine {
 
                 (Some(_), None) => return Err(anyhow::Error::msg("The `store_name` has been set, and so, it expects a `store_passphrase`, which is not set; please provide one")),
 
-                (None, Some(_)) => return Err(anyhow::Error::msg("The `store_passphrase` has been set, but it has an effect only if `store_name` is set, but it's not; please provide one")),
+                (None, Some(_)) => return Err(anyhow::Error::msg("The `store_passphrase` has been set, but it has an effect only if `store_name` is set, which is not; please provide one")),
 
                 _ => None,
             };

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -42,8 +42,8 @@ impl OlmMachine {
     /// state of the machine will persist in a database named
     /// `store_name` where its content is encrypted by the passphrase
     /// given by `store_passphrase`. If they are not both set, the
-    /// created machine machine will keep the encryption keys only in
-    /// memory, and once the object is dropped, the keys will be lost.
+    /// created machine will keep the encryption keys only in memory,
+    /// and once the object is dropped, the keys will be lost.
     #[wasm_bindgen(constructor)]
     #[allow(clippy::new_ret_no_self)]
     pub fn new(

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -1,7 +1,6 @@
 //! The crypto specific Olm objects.
 
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use js_sys::{Array, Map, Promise, Set};
 use ruma::{serde::Raw, DeviceKeyAlgorithm, OwnedTransactionId, UInt};

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -6,7 +6,6 @@ use js_sys::{Array, Map, Promise, Set};
 use ruma::{serde::Raw, DeviceKeyAlgorithm, OwnedTransactionId, UInt};
 use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
-use zeroize::Zeroize;
 
 use crate::{
     downcast, encryption,
@@ -65,6 +64,7 @@ impl OlmMachine {
                 #[cfg(target_arch = "wasm32")]
                 (Some(store_name), Some(mut store_passphrase)) => {
                     use std::sync::Arc;
+                    use zeroize::Zeroize;
 
                     let store = Some(
                         matrix_sdk_indexeddb::IndexeddbCryptoStore::open_with_passphrase(

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -36,6 +36,14 @@ impl OlmMachine {
     /// `user_id` represents the unique ID of the user that owns this
     /// machine. `device_id` represents the unique ID of the device
     /// that owns this machine.
+    ///
+    /// `store_name` and `store_passphrase` are both optional, but
+    /// must be both set to have an effect. If they are both set, the
+    /// state of the machine will persist in a database named
+    /// `store_name` where its content is encrypted by the passphrase
+    /// given by `store_passphrase`. If they are not both set, the
+    /// created machine machine will keep the encryption keys only in
+    /// memory, and once the object is dropped, the keys will be lost.
     #[wasm_bindgen(constructor)]
     #[allow(clippy::new_ret_no_self)]
     pub fn new(
@@ -63,6 +71,10 @@ impl OlmMachine {
 
                     store
                 }
+
+                (Some(_), None) => return Err(anyhow::Error::msg("The `store_name` has been set, and so, it expects a `store_passphrase`, which is not set; please provide one")),
+
+                (None, Some(_)) => return Err(anyhow::Error::msg("The `store_passphrase` has been set, but it has an effect only if `store_name` is set, but it's not; please provide one")),
 
                 _ => None,
             };

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -56,6 +56,13 @@ impl OlmMachine {
 
         future_to_promise(async move {
             let store = match (store_name, store_passphrase) {
+                // We need this `#[cfg]` because `IndexeddbCryptoStore`
+                // implements `CryptoStore` only on `target_arch =
+                // "wasm32"`. Without that, we could have a compilation
+                // error when checking the entire workspace. In
+                // practise, it doesn't impact this crate because it's
+                // always compiled for `wasm32`.
+                #[cfg(target_arch = "wasm32")]
                 (Some(store_name), Some(mut store_passphrase)) => {
                     let store = Some(
                         matrix_sdk_indexeddb::IndexeddbCryptoStore::open_with_passphrase(

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -7,10 +7,29 @@ describe(OlmMachine.name, () => {
     });
 
     test('can be instantiated with a store', async () => {
+        // No databases.
+        expect(await indexedDB.databases()).toHaveLength(0);
+
         let store_name = 'hello';
         let store_passphrase = 'world';
 
+        // Creating a new Olm machine.
         expect(await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase)).toBeInstanceOf(OlmMachine);
+
+        // Oh, there is 2 databases now, prefixed by `store_name`.
+        let databases = await indexedDB.databases();
+
+        expect(databases).toHaveLength(2);
+        expect(databases).toStrictEqual([
+            { name: `${store_name}::matrix-sdk-crypto-meta`, version: 1 },
+            { name: `${store_name}::matrix-sdk-crypto`, version: 1 },
+        ]);
+
+        // Creating a new Olm machine, with the stored state.
+        expect(await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase)).toBeInstanceOf(OlmMachine);
+
+        // Same number of databases.
+        expect(await indexedDB.databases()).toHaveLength(2);
     });
 
     describe('cannot be instantiated with a store', () => {

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -13,6 +13,38 @@ describe(OlmMachine.name, () => {
         expect(await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase)).toBeInstanceOf(OlmMachine);
     });
 
+    describe('cannot be instantiated with a store', () => {
+        test('store name is missing', async () => {
+            let store_name = null;
+            let store_passphrase = 'world';
+
+            let err = null;
+
+            try {
+                await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase);
+            } catch (error) {
+                err = error;
+            }
+
+            expect(err).toBeDefined();
+        });
+
+        test('store passphrase is missing', async () => {
+            let store_name = 'hello';
+            let store_passphrase = null;
+
+            let err = null;
+
+            try {
+                await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase);
+            } catch (error) {
+                err = error;
+            }
+
+            expect(err).toBeDefined();
+        });
+    });
+
     const user = new UserId('@alice:example.org');
     const device = new DeviceId('foobar');
     const room = new RoomId('!baz:matrix.org');

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -1,8 +1,16 @@
 const { OlmMachine, UserId, DeviceId, RoomId, DeviceLists, RequestType, KeysUploadRequest, KeysQueryRequest, KeysClaimRequest, EncryptionSettings, DecryptedRoomEvent, VerificationState } = require('../pkg/matrix_sdk_crypto_js');
+require('fake-indexeddb/auto');
 
 describe(OlmMachine.name, () => {
     test('can be instantiated with the async initializer', async () => {
         expect(await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'))).toBeInstanceOf(OlmMachine);
+    });
+
+    test('can be instantiated with a store', async () => {
+        let store_name = 'hello';
+        let store_passphrase = 'world';
+
+        expect(await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase)).toBeInstanceOf(OlmMachine);
     });
 
     const user = new UserId('@alice:example.org');

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -26,7 +26,7 @@ base64 = "0.13.0"
 dashmap = { version = "5.2.0", optional = true }
 derive_builder = "0.11.2"
 futures-util = { version = " 0.3.21", default-features = false, features = ["alloc"], optional = true }
-indexed_db_futures = "0.2.3"
+indexed_db_futures = { git = "https://github.com/Hywan/rust-indexed-db", branch = "feat-factory-nodejs" }
 js-sys = { version = "0.3.58" }
 matrix-sdk-base = { version = "0.5.0", path = "../matrix-sdk-base" }
 matrix-sdk-crypto = { version = "0.5.0", path = "../matrix-sdk-crypto", optional = true }


### PR DESCRIPTION
The `OlmMachine` constructor now has 2 more optional arguments:
`store_name` and `store_passphrase`, to use Indexed DB as the backend
to store the Olm machine keys, rather than having an in-memory Olm
machine.

Node.js is used to test our binding. Indexed DB is absent of
Node.js. So, firstly, we are using the [`fake-indexeddb`](https://www.npmjs.com/package/fake-indexeddb) JavaScript
library to mimic the same API inside Node.js. And, secondly, we use
our own fork of [the `indexed_db_futures` Rust crate](https://github.com/Alorel/rust-indexed-db) to provide add
support for Node.js too ([PR is
here](https://github.com/Alorel/rust-indexed-db/pull/11)). It
basically looks in the Node.js global environment if the `indexedDB`
getter is present, just like it is already done for `Window` on any
browser, or `WorkerGlobalScope` for workers.