### PR TITLE
feat(sdk): Allow event enums to be used as the first event handler argument

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -427,8 +427,6 @@ impl ClientBuilder {
             members_request_locks: Default::default(),
             typing_notice_times: Default::default(),
             event_handlers: Default::default(),
-            event_handler_data: Default::default(),
-            event_handler_counter: Default::default(),
             notification_handlers: Default::default(),
             appservice_mode: self.appservice_mode,
             respect_login_well_known: self.respect_login_well_known,

--- a/crates/matrix-sdk/src/event_handler/context.rs
+++ b/crates/matrix-sdk/src/event_handler/context.rs
@@ -1,0 +1,104 @@
+// Copyright 2021 Jonas Platte
+// Copyright 2022 Famedly GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Deref;
+
+use matrix_sdk_base::deserialized_responses::EncryptionInfo;
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::{EventHandlerData, EventHandlerHandle};
+use crate::{room, Client};
+
+/// Context for an event handler.
+///
+/// This trait defines the set of types that may be used as additional arguments
+/// in event handler functions after the event itself.
+pub trait EventHandlerContext: Sized {
+    #[doc(hidden)]
+    fn from_data(_: &EventHandlerData<'_>) -> Option<Self>;
+}
+
+impl EventHandlerContext for Client {
+    fn from_data(data: &EventHandlerData<'_>) -> Option<Self> {
+        Some(data.client.clone())
+    }
+}
+
+impl EventHandlerContext for EventHandlerHandle {
+    fn from_data(data: &EventHandlerData<'_>) -> Option<Self> {
+        Some(data.handle.clone())
+    }
+}
+
+/// This event handler context argument is only applicable to room-specific
+/// events.
+///
+/// Trying to use it in the event handler for another event, for example a
+/// global account data or presence event, will result in the event handler
+/// being skipped and an error getting logged.
+impl EventHandlerContext for room::Room {
+    fn from_data(data: &EventHandlerData<'_>) -> Option<Self> {
+        data.room.clone()
+    }
+}
+
+/// The raw JSON form of an event.
+///
+/// Used as a context argument for event handlers (see
+/// [`Client::add_event_handler`]).
+// FIXME: This could be made to not own the raw JSON value with some changes to
+//        the traits above, but only with GATs.
+#[derive(Clone, Debug)]
+pub struct RawEvent(Box<RawJsonValue>);
+
+impl Deref for RawEvent {
+    type Target = RawJsonValue;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl EventHandlerContext for RawEvent {
+    fn from_data(data: &EventHandlerData<'_>) -> Option<Self> {
+        Some(Self(data.raw.to_owned()))
+    }
+}
+
+impl EventHandlerContext for Option<EncryptionInfo> {
+    fn from_data(data: &EventHandlerData<'_>) -> Option<Self> {
+        Some(data.encryption_info.cloned())
+    }
+}
+
+/// A custom value registered with
+/// [`.add_event_handler_context`][Client::add_event_handler_context].
+#[derive(Debug)]
+pub struct Ctx<T>(pub T);
+
+impl<T: Clone + Send + Sync + 'static> EventHandlerContext for Ctx<T> {
+    fn from_data(data: &EventHandlerData<'_>) -> Option<Self> {
+        let map = data.client.inner.event_handlers.context.read().unwrap();
+        map.get::<T>().cloned().map(Ctx)
+    }
+}
+
+impl<T> Deref for Ctx<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crates/matrix-sdk/src/event_handler/maps.rs
+++ b/crates/matrix-sdk/src/event_handler/maps.rs
@@ -23,7 +23,9 @@ use super::{EventHandlerFn, EventHandlerHandle, EventHandlerWrapper, EventKind};
 
 #[derive(Default)]
 pub(super) struct EventHandlerMaps {
+    by_kind: BTreeMap<EventKind, Vec<EventHandlerWrapper>>,
     by_kind_type: BTreeMap<KindTypeWrap, Vec<EventHandlerWrapper>>,
+    by_kind_roomid: BTreeMap<KindRoomId, Vec<EventHandlerWrapper>>,
     by_kind_type_roomid: BTreeMap<KindTypeRoomIdWrap, Vec<EventHandlerWrapper>>,
 }
 
@@ -32,8 +34,14 @@ impl EventHandlerMaps {
         let wrapper = EventHandlerWrapper { handler_id: handle.handler_id, handler_fn };
 
         match Key::new(handle) {
+            Key::Kind(key) => {
+                self.by_kind.entry(key).or_default().push(wrapper);
+            }
             Key::KindType(key) => {
                 self.by_kind_type.entry(key).or_default().push(wrapper);
+            }
+            Key::KindRoomId(key) => {
+                self.by_kind_roomid.entry(key).or_default().push(wrapper);
             }
             Key::KindTypeRoomId(key) => {
                 self.by_kind_type_roomid.entry(key).or_default().push(wrapper)
@@ -47,43 +55,56 @@ impl EventHandlerMaps {
         ev_type: &str,
         room_id: Option<&'a RoomId>,
     ) -> impl Iterator<Item = (EventHandlerHandle, &'a EventHandlerFn)> + 'a {
-        let non_room_key = KindType { ev_kind, ev_type };
-        let maybe_room_key =
-            room_id.map(|room_id| KindTypeRoomId { ev_kind, ev_type, room_id: room_id.to_owned() });
-
         // Use get_key_value instead of just get to be able to access the event_type
         // from the BTreeMap key as &'static str, required for EventHandlerHandle.
-        let non_room_kv = self
+        let kind_kv = self.by_kind.get_key_value(&ev_kind).map(|(_, handlers)| (None, handlers));
+        let kind_type_kv = self
             .by_kind_type
-            .get_key_value(&non_room_key)
-            .map(|(key, handlers)| (key.0.ev_type, handlers));
-        let maybe_room_kv = maybe_room_key.and_then(|room_key| {
-            self.by_kind_type_roomid
-                .get_key_value(&room_key)
-                .map(|(key, handlers)| (key.0.ev_type, handlers))
-        });
+            .get_key_value(&KindType { ev_kind, ev_type })
+            .map(|(key, handlers)| (Some(key.0.ev_type), handlers));
+        let maybe_roomid_kvs = room_id
+            .map(|r_id| {
+                let room_id = r_id.to_owned();
+                let kind_roomid_kv = self
+                    .by_kind_roomid
+                    .get_key_value(&KindRoomId { ev_kind, room_id })
+                    .map(|(_, handlers)| (None, handlers));
 
-        non_room_kv.into_iter().chain(maybe_room_kv).flat_map(move |(ev_type, handlers)| {
-            handlers.iter().map(move |wrap| {
-                let handle = EventHandlerHandle {
-                    ev_kind,
-                    ev_type,
-                    room_id: room_id.map(ToOwned::to_owned),
-                    handler_id: wrap.handler_id,
-                };
+                let room_id = r_id.to_owned();
+                let kind_type_roomid_kv = self
+                    .by_kind_type_roomid
+                    .get_key_value(&KindTypeRoomId { ev_kind, ev_type, room_id })
+                    .map(|(key, handlers)| (Some(key.0.ev_type), handlers));
 
-                (handle, &*wrap.handler_fn)
+                [kind_roomid_kv, kind_type_roomid_kv]
             })
-        })
+            .into_iter()
+            .flatten();
+
+        [kind_kv, kind_type_kv].into_iter().chain(maybe_roomid_kvs).flatten().flat_map(
+            move |(ev_type, handlers)| {
+                handlers.iter().map(move |wrap| {
+                    let handle = EventHandlerHandle {
+                        ev_kind,
+                        ev_type,
+                        room_id: room_id.map(ToOwned::to_owned),
+                        handler_id: wrap.handler_id,
+                    };
+
+                    (handle, &*wrap.handler_fn)
+                })
+            },
+        )
     }
 
     pub fn remove(&mut self, handle: EventHandlerHandle) {
         // Generic closure would be a lot nicer
         fn remove_entry<K: Ord>(
-            entry: btree_map::Entry<'_, K, Vec<EventHandlerWrapper>>,
+            map: &mut BTreeMap<K, Vec<EventHandlerWrapper>>,
+            key: K,
             handler_id: u64,
         ) {
-            if let btree_map::Entry::Occupied(mut o) = entry {
+            if let btree_map::Entry::Occupied(mut o) = map.entry(key) {
                 let v = o.get_mut();
                 v.retain(|e| e.handler_id != handler_id);
 
@@ -95,11 +116,17 @@ impl EventHandlerMaps {
 
         let handler_id = handle.handler_id;
         match Key::new(handle) {
+            Key::Kind(key) => {
+                remove_entry(&mut self.by_kind, key, handler_id);
+            }
             Key::KindType(key) => {
-                remove_entry(self.by_kind_type.entry(key), handler_id);
+                remove_entry(&mut self.by_kind_type, key, handler_id);
+            }
+            Key::KindRoomId(key) => {
+                remove_entry(&mut self.by_kind_roomid, key, handler_id);
             }
             Key::KindTypeRoomId(key) => {
-                remove_entry(self.by_kind_type_roomid.entry(key), handler_id);
+                remove_entry(&mut self.by_kind_type_roomid, key, handler_id);
             }
         }
     }
@@ -111,16 +138,20 @@ impl EventHandlerMaps {
 }
 
 enum Key {
+    Kind(EventKind),
     KindType(KindTypeWrap),
+    KindRoomId(KindRoomId),
     KindTypeRoomId(KindTypeRoomIdWrap),
 }
 
 impl Key {
     fn new(handle: EventHandlerHandle) -> Self {
         let EventHandlerHandle { ev_kind, ev_type, room_id, .. } = handle;
-        match room_id {
-            None => Key::KindType(KindTypeWrap(KindType { ev_kind, ev_type })),
-            Some(room_id) => {
+        match (ev_type, room_id) {
+            (None, None) => Key::Kind(ev_kind),
+            (Some(ev_type), None) => Key::KindType(KindTypeWrap(KindType { ev_kind, ev_type })),
+            (None, Some(room_id)) => Key::KindRoomId(KindRoomId { ev_kind, room_id }),
+            (Some(ev_type), Some(room_id)) => {
                 let inner = KindTypeRoomId { ev_kind, ev_type, room_id };
                 Key::KindTypeRoomId(KindTypeRoomIdWrap(inner))
             }
@@ -135,6 +166,12 @@ struct KindTypeWrap(KindType<'static>);
 struct KindType<'a> {
     ev_kind: EventKind,
     ev_type: &'a str,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct KindRoomId {
+    ev_kind: EventKind,
+    room_id: OwnedRoomId,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/matrix-sdk/src/event_handler/maps.rs
+++ b/crates/matrix-sdk/src/event_handler/maps.rs
@@ -1,0 +1,162 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    borrow::Borrow,
+    collections::{btree_map, BTreeMap},
+};
+
+use ruma::{OwnedRoomId, RoomId};
+
+use super::{EventHandlerFn, EventHandlerHandle, EventHandlerWrapper, EventKind};
+
+#[derive(Default)]
+pub(super) struct EventHandlerMaps {
+    by_kind_type: BTreeMap<KindTypeWrap, Vec<EventHandlerWrapper>>,
+    by_kind_type_roomid: BTreeMap<KindTypeRoomIdWrap, Vec<EventHandlerWrapper>>,
+}
+
+impl EventHandlerMaps {
+    pub fn add(&mut self, handle: EventHandlerHandle, handler_fn: Box<EventHandlerFn>) {
+        let wrapper = EventHandlerWrapper { handler_id: handle.handler_id, handler_fn };
+
+        match Key::new(handle) {
+            Key::KindType(key) => {
+                self.by_kind_type.entry(key).or_default().push(wrapper);
+            }
+            Key::KindTypeRoomId(key) => {
+                self.by_kind_type_roomid.entry(key).or_default().push(wrapper)
+            }
+        }
+    }
+
+    pub fn get_handlers<'a>(
+        &'a self,
+        ev_kind: EventKind,
+        ev_type: &str,
+        room_id: Option<&'a RoomId>,
+    ) -> impl Iterator<Item = (EventHandlerHandle, &'a EventHandlerFn)> + 'a {
+        let non_room_key = KindType { ev_kind, ev_type };
+        let maybe_room_key =
+            room_id.map(|room_id| KindTypeRoomId { ev_kind, ev_type, room_id: room_id.to_owned() });
+
+        // Use get_key_value instead of just get to be able to access the event_type
+        // from the BTreeMap key as &'static str, required for EventHandlerHandle.
+        let non_room_kv = self
+            .by_kind_type
+            .get_key_value(&non_room_key)
+            .map(|(key, handlers)| (key.0.ev_type, handlers));
+        let maybe_room_kv = maybe_room_key.and_then(|room_key| {
+            self.by_kind_type_roomid
+                .get_key_value(&room_key)
+                .map(|(key, handlers)| (key.0.ev_type, handlers))
+        });
+
+        non_room_kv.into_iter().chain(maybe_room_kv).flat_map(move |(ev_type, handlers)| {
+            handlers.iter().map(move |wrap| {
+                let handle = EventHandlerHandle {
+                    ev_kind,
+                    ev_type,
+                    room_id: room_id.map(ToOwned::to_owned),
+                    handler_id: wrap.handler_id,
+                };
+
+                (handle, &*wrap.handler_fn)
+            })
+        })
+    }
+
+    pub fn remove(&mut self, handle: EventHandlerHandle) {
+        // Generic closure would be a lot nicer
+        fn remove_entry<K: Ord>(
+            entry: btree_map::Entry<'_, K, Vec<EventHandlerWrapper>>,
+            handler_id: u64,
+        ) {
+            if let btree_map::Entry::Occupied(mut o) = entry {
+                let v = o.get_mut();
+                v.retain(|e| e.handler_id != handler_id);
+
+                if v.is_empty() {
+                    o.remove();
+                }
+            }
+        }
+
+        let handler_id = handle.handler_id;
+        match Key::new(handle) {
+            Key::KindType(key) => {
+                remove_entry(self.by_kind_type.entry(key), handler_id);
+            }
+            Key::KindTypeRoomId(key) => {
+                remove_entry(self.by_kind_type_roomid.entry(key), handler_id);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.by_kind_type.len() + self.by_kind_type_roomid.len()
+    }
+}
+
+enum Key {
+    KindType(KindTypeWrap),
+    KindTypeRoomId(KindTypeRoomIdWrap),
+}
+
+impl Key {
+    fn new(handle: EventHandlerHandle) -> Self {
+        let EventHandlerHandle { ev_kind, ev_type, room_id, .. } = handle;
+        match room_id {
+            None => Key::KindType(KindTypeWrap(KindType { ev_kind, ev_type })),
+            Some(room_id) => {
+                let inner = KindTypeRoomId { ev_kind, ev_type, room_id };
+                Key::KindTypeRoomId(KindTypeRoomIdWrap(inner))
+            }
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct KindTypeWrap(KindType<'static>);
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct KindType<'a> {
+    ev_kind: EventKind,
+    ev_type: &'a str,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct KindTypeRoomIdWrap(KindTypeRoomId<'static>);
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct KindTypeRoomId<'a> {
+    ev_kind: EventKind,
+    ev_type: &'a str,
+    room_id: OwnedRoomId,
+}
+
+// These lifetime-generic impls are what makes it possible to obtain a
+// &'static str event type from get_key_value in call_event_handlers.
+impl<'a> Borrow<KindType<'a>> for KindTypeWrap {
+    fn borrow(&self) -> &KindType<'a> {
+        &self.0
+    }
+}
+
+impl<'a> Borrow<KindTypeRoomId<'a>> for KindTypeRoomIdWrap {
+    fn borrow(&self) -> &KindTypeRoomId<'a> {
+        &self.0
+    }
+}

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -1,0 +1,142 @@
+// Copyright 2021 Jonas Platte
+// Copyright 2022 Famedly GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ruma::{
+    events::{
+        self,
+        presence::{PresenceEvent, PresenceEventContent},
+        EphemeralRoomEventContent, GlobalAccountDataEventContent, MessageLikeEventContent,
+        RedactContent, RedactedEventContent, RoomAccountDataEventContent, StateEventContent,
+        StaticEventContent, ToDeviceEventContent,
+    },
+    serde::Raw,
+};
+
+use super::{EventKind, SyncEvent};
+
+impl<C> SyncEvent for events::GlobalAccountDataEvent<C>
+where
+    C: StaticEventContent + GlobalAccountDataEventContent,
+{
+    const KIND: EventKind = EventKind::GlobalAccountData;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::RoomAccountDataEvent<C>
+where
+    C: StaticEventContent + RoomAccountDataEventContent,
+{
+    const KIND: EventKind = EventKind::RoomAccountData;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::SyncEphemeralRoomEvent<C>
+where
+    C: StaticEventContent + EphemeralRoomEventContent,
+{
+    const KIND: EventKind = EventKind::EphemeralRoomData;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::SyncMessageLikeEvent<C>
+where
+    C: StaticEventContent + MessageLikeEventContent + RedactContent,
+    C::Redacted: MessageLikeEventContent + RedactedEventContent,
+{
+    const KIND: EventKind = EventKind::MessageLike;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::OriginalSyncMessageLikeEvent<C>
+where
+    C: StaticEventContent + MessageLikeEventContent,
+{
+    const KIND: EventKind = EventKind::OriginalMessageLike;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::RedactedSyncMessageLikeEvent<C>
+where
+    C: StaticEventContent + MessageLikeEventContent + RedactedEventContent,
+{
+    const KIND: EventKind = EventKind::RedactedMessageLike;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl SyncEvent for events::room::redaction::SyncRoomRedactionEvent {
+    const KIND: EventKind = EventKind::MessageLike;
+    const TYPE: &'static str = events::room::redaction::RoomRedactionEventContent::TYPE;
+}
+
+impl SyncEvent for events::room::redaction::OriginalSyncRoomRedactionEvent {
+    const KIND: EventKind = EventKind::OriginalMessageLike;
+    const TYPE: &'static str = events::room::redaction::RoomRedactionEventContent::TYPE;
+}
+
+impl SyncEvent for events::room::redaction::RedactedSyncRoomRedactionEvent {
+    const KIND: EventKind = EventKind::RedactedMessageLike;
+    const TYPE: &'static str = events::room::redaction::RoomRedactionEventContent::TYPE;
+}
+
+impl<C> SyncEvent for events::SyncStateEvent<C>
+where
+    C: StaticEventContent + StateEventContent + RedactContent,
+    C::Redacted: StateEventContent + RedactedEventContent,
+{
+    const KIND: EventKind = EventKind::State;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::OriginalSyncStateEvent<C>
+where
+    C: StaticEventContent + StateEventContent,
+{
+    const KIND: EventKind = EventKind::OriginalState;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::RedactedSyncStateEvent<C>
+where
+    C: StaticEventContent + StateEventContent + RedactedEventContent,
+{
+    const KIND: EventKind = EventKind::RedactedState;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::StrippedStateEvent<C>
+where
+    C: StaticEventContent + StateEventContent,
+{
+    const KIND: EventKind = EventKind::StrippedState;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl<C> SyncEvent for events::ToDeviceEvent<C>
+where
+    C: StaticEventContent + ToDeviceEventContent,
+{
+    const KIND: EventKind = EventKind::ToDevice;
+    const TYPE: &'static str = C::TYPE;
+}
+
+impl SyncEvent for PresenceEvent {
+    const KIND: EventKind = EventKind::Presence;
+    const TYPE: &'static str = PresenceEventContent::TYPE;
+}
+
+impl<T: SyncEvent> SyncEvent for Raw<T> {
+    const KIND: EventKind = T::KIND;
+    const TYPE: &'static str = T::TYPE;
+}

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -1,5 +1,6 @@
 // Copyright 2021 Jonas Platte
 // Copyright 2022 Famedly GmbH
+// Copyright 2022 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +18,8 @@ use ruma::{
     events::{
         self,
         presence::{PresenceEvent, PresenceEventContent},
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+        AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnyToDeviceEvent,
         EphemeralRoomEventContent, GlobalAccountDataEventContent, MessageLikeEventContent,
         RedactContent, RedactedEventContent, RoomAccountDataEventContent, StateEventContent,
         StaticEventContent, ToDeviceEventContent,
@@ -31,7 +34,7 @@ where
     C: StaticEventContent + GlobalAccountDataEventContent,
 {
     const KIND: EventKind = EventKind::GlobalAccountData;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::RoomAccountDataEvent<C>
@@ -39,7 +42,7 @@ where
     C: StaticEventContent + RoomAccountDataEventContent,
 {
     const KIND: EventKind = EventKind::RoomAccountData;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::SyncEphemeralRoomEvent<C>
@@ -47,7 +50,7 @@ where
     C: StaticEventContent + EphemeralRoomEventContent,
 {
     const KIND: EventKind = EventKind::EphemeralRoomData;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::SyncMessageLikeEvent<C>
@@ -56,7 +59,7 @@ where
     C::Redacted: MessageLikeEventContent + RedactedEventContent,
 {
     const KIND: EventKind = EventKind::MessageLike;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::OriginalSyncMessageLikeEvent<C>
@@ -64,7 +67,7 @@ where
     C: StaticEventContent + MessageLikeEventContent,
 {
     const KIND: EventKind = EventKind::OriginalMessageLike;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::RedactedSyncMessageLikeEvent<C>
@@ -72,22 +75,25 @@ where
     C: StaticEventContent + MessageLikeEventContent + RedactedEventContent,
 {
     const KIND: EventKind = EventKind::RedactedMessageLike;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl SyncEvent for events::room::redaction::SyncRoomRedactionEvent {
     const KIND: EventKind = EventKind::MessageLike;
-    const TYPE: &'static str = events::room::redaction::RoomRedactionEventContent::TYPE;
+    const TYPE: Option<&'static str> =
+        Some(events::room::redaction::RoomRedactionEventContent::TYPE);
 }
 
 impl SyncEvent for events::room::redaction::OriginalSyncRoomRedactionEvent {
     const KIND: EventKind = EventKind::OriginalMessageLike;
-    const TYPE: &'static str = events::room::redaction::RoomRedactionEventContent::TYPE;
+    const TYPE: Option<&'static str> =
+        Some(events::room::redaction::RoomRedactionEventContent::TYPE);
 }
 
 impl SyncEvent for events::room::redaction::RedactedSyncRoomRedactionEvent {
     const KIND: EventKind = EventKind::RedactedMessageLike;
-    const TYPE: &'static str = events::room::redaction::RoomRedactionEventContent::TYPE;
+    const TYPE: Option<&'static str> =
+        Some(events::room::redaction::RoomRedactionEventContent::TYPE);
 }
 
 impl<C> SyncEvent for events::SyncStateEvent<C>
@@ -96,7 +102,7 @@ where
     C::Redacted: StateEventContent + RedactedEventContent,
 {
     const KIND: EventKind = EventKind::State;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::OriginalSyncStateEvent<C>
@@ -104,7 +110,7 @@ where
     C: StaticEventContent + StateEventContent,
 {
     const KIND: EventKind = EventKind::OriginalState;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::RedactedSyncStateEvent<C>
@@ -112,7 +118,7 @@ where
     C: StaticEventContent + StateEventContent + RedactedEventContent,
 {
     const KIND: EventKind = EventKind::RedactedState;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::StrippedStateEvent<C>
@@ -120,7 +126,7 @@ where
     C: StaticEventContent + StateEventContent,
 {
     const KIND: EventKind = EventKind::StrippedState;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl<C> SyncEvent for events::ToDeviceEvent<C>
@@ -128,15 +134,50 @@ where
     C: StaticEventContent + ToDeviceEventContent,
 {
     const KIND: EventKind = EventKind::ToDevice;
-    const TYPE: &'static str = C::TYPE;
+    const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl SyncEvent for PresenceEvent {
     const KIND: EventKind = EventKind::Presence;
-    const TYPE: &'static str = PresenceEventContent::TYPE;
+    const TYPE: Option<&'static str> = Some(PresenceEventContent::TYPE);
+}
+
+impl SyncEvent for AnyGlobalAccountDataEvent {
+    const KIND: EventKind = EventKind::GlobalAccountData;
+    const TYPE: Option<&'static str> = None;
+}
+
+impl SyncEvent for AnyRoomAccountDataEvent {
+    const KIND: EventKind = EventKind::RoomAccountData;
+    const TYPE: Option<&'static str> = None;
+}
+
+impl SyncEvent for AnySyncEphemeralRoomEvent {
+    const KIND: EventKind = EventKind::EphemeralRoomData;
+    const TYPE: Option<&'static str> = None;
+}
+
+impl SyncEvent for AnySyncMessageLikeEvent {
+    const KIND: EventKind = EventKind::MessageLike;
+    const TYPE: Option<&'static str> = None;
+}
+
+impl SyncEvent for AnySyncStateEvent {
+    const KIND: EventKind = EventKind::State;
+    const TYPE: Option<&'static str> = None;
+}
+
+impl SyncEvent for AnyStrippedStateEvent {
+    const KIND: EventKind = EventKind::StrippedState;
+    const TYPE: Option<&'static str> = None;
+}
+
+impl SyncEvent for AnyToDeviceEvent {
+    const KIND: EventKind = EventKind::ToDevice;
+    const TYPE: Option<&'static str> = None;
 }
 
 impl<T: SyncEvent> SyncEvent for Raw<T> {
     const KIND: EventKind = T::KIND;
-    const TYPE: &'static str = T::TYPE;
+    const TYPE: Option<&'static str> = T::TYPE;
 }


### PR DESCRIPTION
Plus a few refactorings to make the actual change easier, and the code more readable.

Motivation: We want to handle all timeline events in the event handler registered for the timeline API. If we just register event handlers for all known event types we'll miss custom ones, that we want to support for a "show hidden events" mode found in some Matrix clients (including Element).