### PR TITLE
chore(crypto-js): Add `npm run pack`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -39,7 +39,9 @@
         "build": "cross-env RUSTFLAGS='-C opt-level=z' wasm-pack build --release --target nodejs --scope matrix-org --out-dir ./pkg",
         "test": "jest --verbose",
         "doc": "typedoc --tsconfig .",
-        "prepublish": "$npm_execpath run build && $npm_execpath run test",
-        "publish": "wasm-pack pack && wasm-pack publish"
+        "prepack": "npm run build && npm run test",
+        "pack": "wasm-pack pack",
+        "prepublish": "npm run pack",
+        "publish": "wasm-pack publish"
     }
 }


### PR DESCRIPTION
This patch introduces a new `pack` NPM script, which runs `wasm-pack
pack` behind the scene.

This patch modifies the `publish` NPM script to run the `pack` script
as a pre-script (so… in the `prepublish` script).

Finally, this patch no longer uses `$npm_execpath` as it doesn't work
on Windows. It should be `%npm_execpath%`. It's not obvious to make
scripts interoperable, so we will stick with `npm` for now.

Address #980.