### PR TITLE
feat(bindings/ffi): Add account data.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -62,6 +62,12 @@ interface Client {
     [Throws=ClientError]
     string device_id();
 
+    [Throws=ClientError]
+    string? account_data(string event_type);
+
+    [Throws=ClientError]
+    void set_account_data(string event_type, string content);
+
     sequence<Room> rooms();
 
     [Throws=ClientError]


### PR DESCRIPTION
Exposes the account data from #964 through the FFI.