### PR TITLE
fix(crypto): Fix the deserialization of inbound group group_sessions

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -463,8 +463,8 @@ pub struct PickledInboundGroupSession {
     pub signing_key: SigningKeys<DeviceKeyAlgorithm>,
     /// The id of the room that the session is used in.
     pub room_id: OwnedRoomId,
-    /// The list of claimed Curve25519 that forwarded us this key. Will be None
-    /// if we directly received this session.
+    /// The list of claimed Curve25519 keys that forwarded us this key. Will be
+    /// empty if we directly received this session.
     #[serde(
         default,
         deserialize_with = "deserialize_curve_key_vec",
@@ -519,7 +519,7 @@ mod test {
     use crate::olm::InboundGroupSession;
 
     #[async_test]
-    async fn inbound_group_session_seriailization() {
+    async fn inbound_group_session_serialization() {
         let pickle = r#"
         {
             "pickle": {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -28,9 +28,10 @@ pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};
 use vodozemac::{megolm::SessionKeyDecodeError, Curve25519PublicKey};
 
 use crate::types::{
-    deserialize_curve_key,
+    deserialize_curve_key, deserialize_curve_key_vec,
     events::forwarded_room_key::{ForwardedMegolmV1AesSha2Content, ForwardedRoomKeyContent},
-    serialize_curve_key, EventEncryptionAlgorithm, SigningKey, SigningKeys,
+    serialize_curve_key, serialize_curve_key_vec, EventEncryptionAlgorithm, SigningKey,
+    SigningKeys,
 };
 
 /// An error type for the creation of group sessions.
@@ -86,7 +87,11 @@ pub struct ExportedRoomKey {
 
     /// Chain of Curve25519 keys through which this session was forwarded, via
     /// m.forwarded_room_key events.
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_curve_key_vec",
+        serialize_with = "serialize_curve_key_vec"
+    )]
     pub forwarding_curve25519_key_chain: Vec<Curve25519PublicKey>,
 }
 


### PR DESCRIPTION
Inbound group sessions would fail to be deserialized if there was a forwarding curve chain, this patch fixes it so we go through base64 when we deserialize this field.
