### PR TITLE
feat(sdk): Re-export matrix-sdk-crypto errors

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -105,41 +105,55 @@ pub enum MegolmError {
     Store(#[from] CryptoStoreError),
 }
 
+/// Error that occurs when decrypting an event that is malformed.
 #[derive(Error, Debug)]
 pub enum EventError {
+    /// The Olm message has a unsupported type.
     #[error("the Olm message has a unsupported type, got {0}, expected 0 or 1")]
     UnsupportedOlmType(u64),
 
+    /// The Encrypted message has been encrypted with a unsupported algorithm.
     #[error("the Encrypted message has been encrypted with a unsupported algorithm.")]
     UnsupportedAlgorithm,
 
+    /// The provided JSON value isn't an object.
     #[error("the provided JSON value isn't an object")]
     NotAnObject,
 
+    /// The Encrypted message doesn't contain a ciphertext for our device.
     #[error("the Encrypted message doesn't contain a ciphertext for our device")]
     MissingCiphertext,
 
+    /// The Encrypted message is missing the signing key of the sender.
     #[error("the Encrypted message is missing the signing key of the sender")]
     MissingSigningKey,
 
+    /// The Encrypted message is missing the sender key.
     #[error("the Encrypted message is missing the sender key")]
     MissingSenderKey,
 
+    /// The Encrypted message is missing a field.
     #[error("the Encrypted message is missing the field {0}")]
     MissingField(String),
 
+    /// The sender of the plaintext doesn't match the sender of the encrypted
+    /// message.
     #[error(
         "the sender of the plaintext doesn't match the sender of the encrypted \
         message, got {0}, expected {1}"
     )]
     MismatchedSender(OwnedUserId, OwnedUserId),
 
+    /// The public key that was part of the message doesn't match the key we
+    /// have stored.
     #[error(
-        "the public that was part of the message doesn't match to the key we \
+        "the public key that was part of the message doesn't match the key we \
         have stored, expected {0}, got {1}"
     )]
     MismatchedKeys(Box<Ed25519PublicKey>, Box<Ed25519PublicKey>),
 
+    /// The room ID of the room key doesn't match the room ID of the decrypted
+    /// event.
     #[error(
         "the room id of the room key doesn't match the room id of the \
         decrypted event: expected {0}, got {1:?}"
@@ -147,7 +161,7 @@ pub enum EventError {
     MismatchedRoom(OwnedRoomId, Option<OwnedRoomId>),
 }
 
-/// Error type describin different errors that happen when we check or create
+/// Error type describing different errors that happen when we check or create
 /// signatures for a Matrix JSON object.
 #[derive(Error, Debug)]
 pub enum SignatureError {
@@ -201,34 +215,51 @@ impl From<SerdeError> for SignatureError {
     }
 }
 
+/// Error that occurs when a room key can't be converted into a valid Megolm
+/// session.
 #[derive(Error, Debug)]
 pub enum SessionCreationError {
+    /// The requested one-time key isn't a signed curve key.
     #[error(
         "Failed to create a new Olm session for {0} {1}, the requested \
         one-time key isn't a signed curve key"
     )]
     OneTimeKeyNotSigned(OwnedUserId, OwnedDeviceId),
+
+    /// The signed one-time key is missing.
     #[error(
         "Tried to create a new Olm session for {0} {1}, but the signed \
         one-time key is missing"
     )]
     OneTimeKeyMissing(OwnedUserId, OwnedDeviceId),
+
+    /// The one-time key algorithm is unsupported.
     #[error(
         "Tried to create a new Olm session for {0} {1}, but the one-time \
         key algorithm is unsupported"
     )]
     OneTimeKeyUnknown(OwnedUserId, OwnedDeviceId),
+
+    /// Failed to verify the one-time key signatures.
     #[error("Failed to verify the one-time key signatures for {0} {1}: {2:?}")]
     InvalidSignature(OwnedUserId, OwnedDeviceId, SignatureError),
+
+    /// The user's device is missing a curve25519 key.
     #[error(
         "Tried to create an Olm session for {0} {1}, but the device is missing \
         a curve25519 key"
     )]
     DeviceMissingCurveKey(OwnedUserId, OwnedDeviceId),
+
+    /// Error deserializing the one-time key.
     #[error("Error deserializing the one-time key: {0}")]
     InvalidJson(#[from] serde_json::Error),
+
+    /// The given curve25519 key is not a valid key.
     #[error("The given curve25519 key is not a valid key")]
     InvalidCurveKey(#[from] vodozemac::KeyError),
+
+    /// Error when creating an Olm Session from an incoming Olm message.
     #[error(transparent)]
     InboundCreation(#[from] vodozemac::olm::SessionCreationError),
 }

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -108,10 +108,6 @@ pub enum MegolmError {
 /// Error that occurs when decrypting an event that is malformed.
 #[derive(Error, Debug)]
 pub enum EventError {
-    /// The Olm message has a unsupported type.
-    #[error("the Olm message has a unsupported type, got {0}, expected 0 or 1")]
-    UnsupportedOlmType(u64),
-
     /// The Encrypted message has been encrypted with a unsupported algorithm.
     #[error("the Encrypted message has been encrypted with a unsupported algorithm.")]
     UnsupportedAlgorithm,
@@ -131,10 +127,6 @@ pub enum EventError {
     /// The Encrypted message is missing the sender key.
     #[error("the Encrypted message is missing the sender key")]
     MissingSenderKey,
-
-    /// The Encrypted message is missing a field.
-    #[error("the Encrypted message is missing the field {0}")]
-    MissingField(String),
 
     /// The sender of the plaintext doesn't match the sender of the encrypted
     /// message.

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -68,7 +68,7 @@ impl RoomKeyImportResult {
     }
 }
 
-pub use error::{MegolmError, OlmError, SignatureError};
+pub use error::{EventError, MegolmError, OlmError, SessionCreationError, SignatureError};
 pub use file_encryption::{
     decrypt_key_export, encrypt_key_export, AttachmentDecryptor, AttachmentEncryptor,
     DecryptorError, KeyExportError, MediaEncryptionInfo,
@@ -90,3 +90,8 @@ pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretImportError, Secr
 pub use verification::{AcceptSettings, CancelInfo, Emoji, Sas, Verification, VerificationRequest};
 #[cfg(feature = "qrcode")]
 pub use verification::{QrVerification, ScanError};
+pub use vodozemac::{
+    megolm::{DecryptionError as MegolmDecryptionError, SessionKeyDecodeError},
+    olm::{DecryptionError as OlmDecryptionError, SessionCreationError as OlmSessionCreationError},
+    DecodeError, KeyError, PickleError, SignatureError as Ed25519SignatureError,
+};

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -90,8 +90,14 @@ pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretImportError, Secr
 pub use verification::{AcceptSettings, CancelInfo, Emoji, Sas, Verification, VerificationRequest};
 #[cfg(feature = "qrcode")]
 pub use verification::{QrVerification, ScanError};
-pub use vodozemac::{
-    megolm::{DecryptionError as MegolmDecryptionError, SessionKeyDecodeError},
-    olm::{DecryptionError as OlmDecryptionError, SessionCreationError as OlmSessionCreationError},
-    DecodeError, KeyError, PickleError, SignatureError as Ed25519SignatureError,
-};
+
+/// Re-exported Error types from the [vodozemac](https://crates.io/crates/vodozemac) crate.
+pub mod vodozemac {
+    pub use vodozemac::{
+        megolm::{DecryptionError as MegolmDecryptionError, SessionKeyDecodeError},
+        olm::{
+            DecryptionError as OlmDecryptionError, SessionCreationError as OlmSessionCreationError,
+        },
+        DecodeError, KeyError, PickleError, SignatureError,
+    };
+}

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -31,10 +31,9 @@ pub use matrix_sdk_base::crypto::{
         SessionCreationError as MegolmSessionCreationError,
         SessionExportError as OlmSessionExportError,
     },
-    CryptoStoreError, DecodeError, DecryptorError, Ed25519SignatureError, EventError, KeyError,
-    KeyExportError, LocalTrust, MediaEncryptionInfo, MegolmDecryptionError, MegolmError,
-    OlmDecryptionError, OlmError, OlmSessionCreationError, PickleError, RoomKeyImportResult,
-    SecretImportError, SessionCreationError, SessionKeyDecodeError, SignatureError,
+    vodozemac, CryptoStoreError, DecryptorError, EventError, KeyExportError, LocalTrust,
+    MediaEncryptionInfo, MegolmError, OlmError, RoomKeyImportResult, SecretImportError,
+    SessionCreationError, SignatureError,
 };
 use matrix_sdk_base::crypto::{
     CrossSigningStatus, OutgoingRequest, RoomMessageRequest, ToDeviceRequest,

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -26,11 +26,19 @@ use std::{
 };
 
 use futures_util::stream::{self, StreamExt};
-use matrix_sdk_base::crypto::{
-    store::CryptoStoreError, CrossSigningStatus, OutgoingRequest, RoomMessageRequest,
-    ToDeviceRequest,
+pub use matrix_sdk_base::crypto::{
+    olm::{
+        SessionCreationError as MegolmSessionCreationError,
+        SessionExportError as OlmSessionExportError,
+    },
+    CryptoStoreError, DecodeError, DecryptorError, Ed25519SignatureError, EventError, KeyError,
+    KeyExportError, LocalTrust, MediaEncryptionInfo, MegolmDecryptionError, MegolmError,
+    OlmDecryptionError, OlmError, OlmSessionCreationError, PickleError, RoomKeyImportResult,
+    SecretImportError, SessionCreationError, SessionKeyDecodeError, SignatureError,
 };
-pub use matrix_sdk_base::crypto::{LocalTrust, MediaEncryptionInfo, RoomKeyImportResult};
+use matrix_sdk_base::crypto::{
+    CrossSigningStatus, OutgoingRequest, RoomMessageRequest, ToDeviceRequest,
+};
 use matrix_sdk_common::instant::Duration;
 #[cfg(feature = "e2e-encryption")]
 use ruma::OwnedDeviceId;
@@ -52,13 +60,14 @@ use ruma::{
 };
 use tracing::{debug, instrument, trace, warn};
 
+pub use crate::error::RoomKeyImportError;
 use crate::{
     attachment::{AttachmentInfo, Thumbnail},
     encryption::{
         identities::{Device, UserDevices},
         verification::{SasVerification, Verification, VerificationRequest},
     },
-    error::{HttpResult, RoomKeyImportError},
+    error::HttpResult,
     room, Client, Error, Result,
 };
 


### PR DESCRIPTION
Also documents some errors to avoid clippy warnings.