### PR TITLE
Customized event types for room key request

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -25,11 +25,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use dashmap::{mapref::entry::Entry, DashMap, DashSet};
 use ruma::{
     api::client::keys::claim_keys::v3::Request as KeysClaimRequest,
-    events::{
-        room_key_request::{Action, RequestedKeyInfo, ToDeviceRoomKeyRequestEvent},
-        secret::request::{
-            RequestAction, SecretName, ToDeviceSecretRequestEvent as SecretRequestEvent,
-        },
+    events::secret::request::{
+        RequestAction, SecretName, ToDeviceSecretRequestEvent as SecretRequestEvent,
     },
     DeviceId, DeviceKeyAlgorithm, OwnedDeviceId, OwnedTransactionId, OwnedUserId, RoomId,
     TransactionId, UserId,
@@ -39,7 +36,7 @@ use vodozemac::{megolm::SessionOrdering, Curve25519PublicKey};
 
 use super::{GossipRequest, KeyForwardDecision, RequestEvent, RequestInfo, SecretInfo, WaitQueue};
 use crate::{
-    error::{OlmError, OlmResult},
+    error::{EventError, OlmError, OlmResult},
     olm::{InboundGroupSession, Session, ShareState},
     requests::{OutgoingRequest, ToDeviceRequest},
     session_manager::GroupSessionCache,
@@ -48,12 +45,16 @@ use crate::{
         events::{
             forwarded_room_key::{ForwardedMegolmV1AesSha2Content, ForwardedRoomKeyContent},
             olm_v1::{DecryptedForwardedRoomKeyEvent, DecryptedSecretSendEvent},
+            room::encrypted::EncryptedEvent,
+            room_key_request::{
+                Action, MegolmV1AesSha2Content, RequestedKeyInfo, RoomKeyRequestEvent,
+            },
             secret_send::SecretSendContent,
             EventType,
         },
         EventEncryptionAlgorithm,
     },
-    Device,
+    Device, MegolmError,
 };
 
 #[derive(Debug, Clone)]
@@ -144,7 +145,7 @@ impl GossipMachine {
     }
 
     /// Receive a room key request event.
-    pub fn receive_incoming_key_request(&self, event: &ToDeviceRoomKeyRequestEvent) {
+    pub fn receive_incoming_key_request(&self, event: &RoomKeyRequestEvent) {
         self.receive_event(event.clone().into())
     }
 
@@ -309,44 +310,16 @@ impl GossipMachine {
         })
     }
 
-    /// Handle a single incoming key request.
-    async fn handle_key_request(
+    async fn handle_megolm_v1_request(
         &self,
-        event: &ToDeviceRoomKeyRequestEvent,
+        event: &RoomKeyRequestEvent,
+        key_info: &MegolmV1AesSha2Content,
     ) -> OlmResult<Option<Session>> {
-        let key_info = match &event.content.action {
-            Action::Request => {
-                if let Some(info) = &event.content.body {
-                    info
-                } else {
-                    warn!(
-                        sender = event.sender.as_str(),
-                        requesting_device_id = event.content.requesting_device_id.as_str(),
-                        "Received a key request with a request of action, but
-                        no key info was found",
-                    );
-                    return Ok(None);
-                }
-            }
-            // We ignore cancellations here since there's nothing to serve.
-            Action::CancelRequest => return Ok(None),
-            action => {
-                warn!(
-                    sender = event.sender.as_str(),
-                    requesting_device_id = event.content.requesting_device_id.as_str(),
-                    action = action.as_ref(),
-                    "Received a room key request with an unknown action",
-                );
-                return Ok(None);
-            }
-        };
-
         let session = self
             .store
             .get_inbound_group_session(
                 &key_info.room_id,
-                #[allow(deprecated)]
-                &key_info.sender_key,
+                &key_info.sender_key.to_base64(),
                 &key_info.session_id,
             )
             .await?;
@@ -437,6 +410,32 @@ impl GossipMachine {
             self.store.update_tracked_user(&event.sender, true).await?;
 
             Ok(None)
+        }
+    }
+
+    /// Handle a single incoming key request.
+    async fn handle_key_request(&self, event: &RoomKeyRequestEvent) -> OlmResult<Option<Session>> {
+        match &event.content.action {
+            Action::Request(info) => match info {
+                RequestedKeyInfo::MegolmV1AesSha2(i) => {
+                    self.handle_megolm_v1_request(event, i).await
+                }
+                // V2 room key requests don't have a sender_key field, we
+                // currently can't fetch an inbound group session without a
+                // sender key, so ignore the request.
+                #[cfg(feature = "experimental-algorithms")]
+                RequestedKeyInfo::MegolmV2AesSha2(_) => Ok(None),
+                RequestedKeyInfo::Unknown(i) => {
+                    debug!(
+                        sender = %event.sender,
+                        algorithm = %i.algorithm,
+                        "Received a room key request for a unsupported algorithm"
+                    );
+                    Ok(None)
+                }
+            },
+            // We ignore cancellations here since there's nothing to serve.
+            Action::Cancellation => Ok(None),
         }
     }
 
@@ -600,25 +599,16 @@ impl GossipMachine {
     ///
     /// * `room_id` - The id of the room where the key is used in.
     ///
-    /// * `sender_key` - The curve25519 key of the sender that owns the key.
-    ///
-    /// * `session_id` - The id that uniquely identifies the session.
+    /// * `event` - The event for which we would like to request the room key.
     pub async fn request_key(
         &self,
         room_id: &RoomId,
-        sender_key: Curve25519PublicKey,
-        session_id: &str,
-        algorithm: &EventEncryptionAlgorithm,
-    ) -> Result<(Option<OutgoingRequest>, OutgoingRequest), CryptoStoreError> {
-        let key_info = RequestedKeyInfo::new(
-            ruma::EventEncryptionAlgorithm::from(algorithm.as_str()),
-            room_id.to_owned(),
-            sender_key.to_base64(),
-            session_id.to_owned(),
-        )
-        .into();
+        event: &EncryptedEvent,
+    ) -> Result<(Option<OutgoingRequest>, OutgoingRequest), MegolmError> {
+        let secret_info =
+            event.room_key_info(room_id).ok_or(EventError::UnsupportedAlgorithm)?.into();
 
-        let request = self.store.get_secret_request_by_info(&key_info).await?;
+        let request = self.store.get_secret_request_by_info(&secret_info).await?;
 
         if let Some(request) = request {
             let cancel = request.to_cancellation(self.device_id());
@@ -626,7 +616,7 @@ impl GossipMachine {
 
             Ok((Some(cancel), request))
         } else {
-            let request = self.request_key_helper(key_info).await?;
+            let request = self.request_key_helper(secret_info).await?;
 
             Ok((None, request))
         }
@@ -678,27 +668,19 @@ impl GossipMachine {
     /// # Arguments
     /// * `room_id` - The id of the room where the key is used in.
     ///
-    /// * `sender_key` - The curve25519 key of the sender that owns the key.
-    ///
-    /// * `session_id` - The id that uniquely identifies the session.
+    /// * `event` - The event for which we would like to request the room key.
     pub async fn create_outgoing_key_request(
         &self,
         room_id: &RoomId,
-        sender_key: Curve25519PublicKey,
-        session_id: &str,
-        algorithm: &EventEncryptionAlgorithm,
+        event: &EncryptedEvent,
     ) -> Result<bool, CryptoStoreError> {
-        let key_info = RequestedKeyInfo::new(
-            ruma::EventEncryptionAlgorithm::from(algorithm.as_str()),
-            room_id.to_owned(),
-            sender_key.to_base64(),
-            session_id.to_owned(),
-        )
-        .into();
-
-        Ok(if self.should_request_key(&key_info).await? {
-            self.request_key_helper(key_info).await?;
-            true
+        Ok(if let Some(info) = event.room_key_info(room_id).map(|i| i.into()) {
+            if self.should_request_key(&info).await? {
+                self.request_key_helper(info).await?;
+                true
+            } else {
+                false
+            }
         } else {
             false
         })
@@ -716,17 +698,13 @@ impl GossipMachine {
     /// Get an outgoing key info that matches the forwarded room key content.
     async fn get_key_info(
         &self,
-        content: &ForwardedMegolmV1AesSha2Content,
+        event: &DecryptedForwardedRoomKeyEvent,
     ) -> Result<Option<GossipRequest>, CryptoStoreError> {
-        let info = RequestedKeyInfo::new(
-            ruma::EventEncryptionAlgorithm::MegolmV1AesSha2,
-            content.room_id.clone(),
-            content.claimed_sender_key.to_base64(),
-            content.session_id.clone(),
-        )
-        .into();
-
-        self.store.get_secret_request_by_info(&info).await
+        if let Some(info) = event.room_key_info().map(|i| i.into()) {
+            self.store.get_secret_request_by_info(&info).await
+        } else {
+            Ok(None)
+        }
     }
 
     /// Delete the given outgoing key info.
@@ -971,16 +949,18 @@ impl GossipMachine {
     /// supported content types.
     async fn receive_supported_keys(
         &self,
-        sender: &UserId,
         sender_key: Curve25519PublicKey,
+        event: &DecryptedForwardedRoomKeyEvent,
         content: &ForwardedMegolmV1AesSha2Content,
-        algorithm: EventEncryptionAlgorithm,
     ) -> Result<Option<InboundGroupSession>, CryptoStoreError> {
-        if let Some(info) = self.get_key_info(content).await? {
-            self.accept_forwarded_room_key(&info, sender, sender_key, algorithm, content).await
+        let algorithm = event.content.algorithm();
+
+        if let Some(info) = self.get_key_info(event).await? {
+            self.accept_forwarded_room_key(&info, &event.sender, sender_key, algorithm, content)
+                .await
         } else {
             warn!(
-                sender = %sender,
+                sender = %event.sender,
                 sender_key = %sender_key,
                 room_id = %content.room_id,
                 session_id = content.session_id.as_str(),
@@ -999,15 +979,13 @@ impl GossipMachine {
         sender_key: Curve25519PublicKey,
         event: &DecryptedForwardedRoomKeyEvent,
     ) -> Result<Option<InboundGroupSession>, CryptoStoreError> {
-        let algorithm = event.content.algorithm();
-
         match &event.content {
             ForwardedRoomKeyContent::MegolmV1AesSha2(content) => {
-                self.receive_supported_keys(&event.sender, sender_key, content, algorithm).await
+                self.receive_supported_keys(sender_key, event, content).await
             }
             #[cfg(feature = "experimental-algorithms")]
             ForwardedRoomKeyContent::MegolmV2AesSha2(content) => {
-                self.receive_supported_keys(&event.sender, sender_key, content, algorithm).await
+                self.receive_supported_keys(sender_key, event, content).await
             }
             ForwardedRoomKeyContent::Unknown(_) => {
                 warn!(
@@ -1032,16 +1010,17 @@ mod tests {
     use matrix_sdk_common::locks::Mutex;
     use matrix_sdk_test::async_test;
     use ruma::{
-        device_id,
+        device_id, event_id,
         events::{
             secret::request::{RequestAction, SecretName, ToDeviceSecretRequestEventContent},
-            AnyToDeviceEventContent, ToDeviceEvent as RumaToDeviceEvent, ToDeviceEventContent,
+            AnyToDeviceEventContent, ToDeviceEvent as RumaToDeviceEvent,
         },
         room_id,
         serde::Raw,
         user_id, DeviceId, RoomId, UserId,
     };
     use serde::{de::DeserializeOwned, Serialize};
+    use serde_json::json;
 
     use super::{GossipMachine, KeyForwardDecision};
     use crate::{
@@ -1052,7 +1031,7 @@ mod tests {
         types::events::{
             forwarded_room_key::ForwardedRoomKeyContent,
             olm_v1::{AnyDecryptedOlmEvent, DecryptedOlmV1Event},
-            room::encrypted::EncryptedToDeviceEvent,
+            room::encrypted::{EncryptedEvent, EncryptedToDeviceEvent, RoomEncryptedEventContent},
             EventType, ToDeviceEvent,
         },
         verification::VerificationMachine,
@@ -1171,19 +1150,13 @@ mod tests {
         let (group_session, inbound_group_session) =
             bob_machine.store.account().create_group_session_pair_with_defaults(room_id()).await;
 
+        let content = group_session.encrypt(json!({}), "m.dummy").await;
+        let event = wrap_encrypted_content(bob_machine.user_id(), content);
         bob_machine.store.save_inbound_group_sessions(&[inbound_group_session]).await.unwrap();
 
         // Alice wants to request the outbound group session from bob.
         assert!(
-            alice_machine
-                .create_outgoing_key_request(
-                    room_id(),
-                    bob_machine.store.account().identity_keys().curve25519,
-                    group_session.session_id(),
-                    &group_session.settings().algorithm,
-                )
-                .await
-                .unwrap(),
+            alice_machine.create_outgoing_key_request(room_id(), &event,).await.unwrap(),
             "We should request a room key"
         );
 
@@ -1217,6 +1190,22 @@ mod tests {
             .unwrap()
     }
 
+    fn wrap_encrypted_content(
+        sender: &UserId,
+        content: Raw<RoomEncryptedEventContent>,
+    ) -> EncryptedEvent {
+        let content = content.deserialize().unwrap();
+
+        EncryptedEvent {
+            sender: sender.to_owned(),
+            event_id: event_id!("$143273582443PhrSn:example.org").to_owned(),
+            content,
+            origin_server_ts: ruma::MilliSecondsSinceUnixEpoch::now(),
+            unsigned: Default::default(),
+            other: Default::default(),
+        }
+    }
+
     fn request_to_event<C>(
         recipient: &UserId,
         sender: &UserId,
@@ -1233,22 +1222,6 @@ mod tests {
         ToDeviceEvent { sender: sender.to_owned(), content, other: Default::default() }
     }
 
-    fn request_to_ruma_event<C>(
-        recipient: &UserId,
-        sender: &UserId,
-        request: &OutgoingRequest,
-    ) -> RumaToDeviceEvent<C>
-    where
-        C: ToDeviceEventContent + DeserializeOwned,
-    {
-        let content = extract_content(recipient, request);
-        let content: C = content
-            .deserialize_as()
-            .expect("We can always deserialize the to-device event content");
-
-        RumaToDeviceEvent { sender: sender.to_owned(), content }
-    }
-
     #[async_test]
     async fn create_machine() {
         let machine = get_machine().await;
@@ -1261,32 +1234,19 @@ mod tests {
         let machine = get_machine().await;
         let account = account();
 
-        let (_, session) = account.create_group_session_pair_with_defaults(room_id()).await;
+        let (outbound, session) = account.create_group_session_pair_with_defaults(room_id()).await;
+
+        let content = outbound.encrypt(json!({}), "m.dummy").await;
+        let event = wrap_encrypted_content(machine.user_id(), content);
 
         assert!(machine.outgoing_to_device_requests().await.unwrap().is_empty());
-        let (cancel, request) = machine
-            .request_key(
-                session.room_id(),
-                session.sender_key,
-                session.session_id(),
-                session.algorithm(),
-            )
-            .await
-            .unwrap();
+        let (cancel, request) = machine.request_key(session.room_id(), &event).await.unwrap();
 
         assert!(cancel.is_none());
 
         machine.mark_outgoing_request_as_sent(&request.request_id).await.unwrap();
 
-        let (cancel, _) = machine
-            .request_key(
-                session.room_id(),
-                session.sender_key,
-                session.session_id(),
-                session.algorithm(),
-            )
-            .await
-            .unwrap();
+        let (cancel, _) = machine.request_key(session.room_id(), &event).await.unwrap();
 
         assert!(cancel.is_some());
     }
@@ -1302,30 +1262,16 @@ mod tests {
         alice_device.set_trust_state(LocalTrust::Verified);
         machine.store.save_devices(&[alice_device]).await.unwrap();
 
-        let (_, session) = account.create_group_session_pair_with_defaults(room_id()).await;
+        let (outbound, session) = account.create_group_session_pair_with_defaults(room_id()).await;
+        let content = outbound.encrypt(json!({}), "m.dummy").await;
+        let event = wrap_encrypted_content(machine.user_id(), content);
 
         assert!(machine.outgoing_to_device_requests().await.unwrap().is_empty());
-        machine
-            .create_outgoing_key_request(
-                session.room_id(),
-                session.sender_key,
-                session.session_id(),
-                session.algorithm(),
-            )
-            .await
-            .unwrap();
+        machine.create_outgoing_key_request(session.room_id(), &event).await.unwrap();
         assert!(!machine.outgoing_to_device_requests().await.unwrap().is_empty());
         assert_eq!(machine.outgoing_to_device_requests().await.unwrap().len(), 1);
 
-        machine
-            .create_outgoing_key_request(
-                session.room_id(),
-                session.sender_key,
-                session.session_id(),
-                session.algorithm(),
-            )
-            .await
-            .unwrap();
+        machine.create_outgoing_key_request(session.room_id(), &event).await.unwrap();
 
         let requests = machine.outgoing_to_device_requests().await.unwrap();
         assert_eq!(requests.len(), 1);
@@ -1348,16 +1294,11 @@ mod tests {
         alice_device.set_trust_state(LocalTrust::Verified);
         machine.store.save_devices(&[alice_device.clone()]).await.unwrap();
 
-        let (_, session) = account.create_group_session_pair_with_defaults(room_id()).await;
-        machine
-            .create_outgoing_key_request(
-                session.room_id(),
-                session.sender_key,
-                session.session_id(),
-                session.algorithm(),
-            )
-            .await
-            .unwrap();
+        let (outbound, session) = account.create_group_session_pair_with_defaults(room_id()).await;
+        let content = outbound.encrypt(json!({}), "m.dummy").await;
+        let room_event = wrap_encrypted_content(machine.user_id(), content);
+
+        machine.create_outgoing_key_request(session.room_id(), &room_event).await.unwrap();
 
         let requests = machine.outgoing_to_device_requests().await.unwrap();
         let request = requests.get(0).unwrap();
@@ -1403,15 +1344,7 @@ mod tests {
         drop(request);
         machine.mark_outgoing_request_as_sent(&id).await.unwrap();
 
-        machine
-            .create_outgoing_key_request(
-                session.room_id(),
-                session.sender_key,
-                session.session_id(),
-                session.algorithm(),
-            )
-            .await
-            .unwrap();
+        machine.create_outgoing_key_request(session.room_id(), &room_event).await.unwrap();
 
         let requests = machine.outgoing_to_device_requests().await.unwrap();
         let request = &requests[0];
@@ -1578,7 +1511,7 @@ mod tests {
         // Get the request and convert it into a event.
         let requests = alice_machine.outgoing_to_device_requests().await.unwrap();
         let request = &requests[0];
-        let event = request_to_ruma_event(alice_id(), alice_id(), request);
+        let event = request_to_event(alice_id(), alice_id(), request);
 
         alice_machine.mark_outgoing_request_as_sent(&request.request_id).await.unwrap();
 
@@ -1715,7 +1648,7 @@ mod tests {
         // Get the request and convert it into a event.
         let requests = alice_machine.outgoing_to_device_requests().await.unwrap();
         let request = &requests[0];
-        let event = request_to_ruma_event(alice_id(), alice_id(), request);
+        let event = request_to_event(alice_id(), alice_id(), request);
 
         alice_machine.mark_outgoing_request_as_sent(&request.request_id).await.unwrap();
 

--- a/crates/matrix-sdk-crypto/src/gossiping/mod.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/mod.rs
@@ -87,7 +87,6 @@ impl SecretInfo {
     /// comparison
     pub fn as_key(&self) -> String {
         match &self {
-            #[allow(deprecated)]
             SecretInfo::KeyRequest(ref info) => format!(
                 "keyRequest:{:}:{:}:{:}",
                 info.room_id().as_str(),

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1002,24 +1002,7 @@ impl OlmMachine {
         room_id: &RoomId,
     ) -> MegolmResult<(Option<OutgoingRequest>, OutgoingRequest)> {
         let event = event.deserialize()?;
-
-        let content: SupportedEventEncryptionSchemes<'_> = match &event.content.scheme {
-            RoomEventEncryptionScheme::MegolmV1AesSha2(c) => c.into(),
-            #[cfg(feature = "experimental-algorithms")]
-            RoomEventEncryptionScheme::MegolmV2AesSha2(c) => c.into(),
-            _ => return Err(EventError::UnsupportedAlgorithm.into()),
-        };
-
-        Ok(self
-            .key_request_machine
-            .request_key(
-                room_id,
-                #[allow(deprecated)]
-                content.sender_key(),
-                content.session_id(),
-                &content.algorithm(),
-            )
-            .await?)
+        self.key_request_machine.request_key(room_id, &event).await
     }
 
     async fn get_verification_state(
@@ -1155,15 +1138,7 @@ impl OlmMachine {
 
             Ok(TimelineEvent { encryption_info: Some(encryption_info), event: decrypted_event })
         } else {
-            self.key_request_machine
-                .create_outgoing_key_request(
-                    room_id,
-                    #[allow(deprecated)]
-                    content.sender_key(),
-                    content.session_id(),
-                    &content.algorithm(),
-                )
-                .await?;
+            self.key_request_machine.create_outgoing_key_request(room_id, event).await?;
 
             Err(MegolmError::MissingRoomKey)
         }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1088,7 +1088,6 @@ impl OlmMachine {
             .store
             .get_inbound_group_session(
                 room_id,
-                #[allow(deprecated)]
                 &content.sender_key().to_base64(),
                 content.session_id(),
             )
@@ -1127,14 +1126,8 @@ impl OlmMachine {
                 }
             }
 
-            let encryption_info = self
-                .get_encryption_info(
-                    &session,
-                    &event.sender,
-                    #[allow(deprecated)]
-                    content.device_id(),
-                )
-                .await?;
+            let encryption_info =
+                self.get_encryption_info(&session, &event.sender, content.device_id()).await?;
 
             Ok(TimelineEvent { encryption_info: Some(encryption_info), event: decrypted_event })
         } else {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -272,7 +272,7 @@ impl InboundGroupSession {
             self.inner.lock().await.export_at(message_index).expect("Can't export session");
 
         ExportedRoomKey {
-            algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+            algorithm: self.algorithm().to_owned(),
             room_id: (*self.room_id).to_owned(),
             sender_key: self.sender_key,
             session_id: self.session_id().to_owned(),

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -8,14 +8,15 @@ macro_rules! cryptostore_integration_tests {
 
             use matrix_sdk_test::async_test;
             use ruma::{
-                encryption::SignedKey, events::room_key_request::RequestedKeyInfo,
-                serde::Base64, user_id, TransactionId, DeviceId, EventEncryptionAlgorithm, UserId,
+                encryption::SignedKey,
+                serde::Base64, user_id, TransactionId, DeviceId, UserId,
                 room_id, device_id,
             };
 
             use $crate::{
                 SecretInfo,
                 testing::{get_device, get_other_identity, get_own_identity},
+                types::events::room_key_request::MegolmV1AesSha2Content,
                 ReadOnlyDevice,
                 olm::{
                     Curve25519PublicKey, InboundGroupSession, OlmMessageHash,
@@ -530,14 +531,14 @@ macro_rules! cryptostore_integration_tests {
             #[async_test]
             async fn key_request_saving() {
                 let (account, store) = get_loaded_store("key_request_saving").await;
+                let sender_key = Curve25519PublicKey::from_base64("Nn0L2hkcCMFKqynTjyGsJbth7QrVmX3lbrksMkrGOAw").unwrap();
 
                 let id = TransactionId::new();
-                let info: SecretInfo = RequestedKeyInfo::new(
-                    EventEncryptionAlgorithm::MegolmV1AesSha2,
-                    room_id!("!test:localhost").to_owned(),
-                    "test_sender_key".to_owned(),
-                    "test_session_id".to_owned(),
-                )
+                let info: SecretInfo = MegolmV1AesSha2Content {
+                    room_id: room_id!("!test:localhost").to_owned(),
+                    sender_key,
+                    session_id: "test_session_id".to_owned(),
+                }
                 .into();
 
                 let request = GossipRequest {

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -37,9 +37,8 @@ use crate::{
 
 fn encode_key_info(info: &SecretInfo) -> String {
     match info {
-        #[allow(deprecated)]
         SecretInfo::KeyRequest(info) => {
-            format!("{}{}{}{}", info.room_id, info.sender_key, info.algorithm, info.session_id)
+            format!("{}{}{}", info.room_id(), info.algorithm(), info.session_id())
         }
         SecretInfo::SecretRequest(i) => i.as_ref().to_owned(),
     }

--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -22,6 +22,7 @@ pub mod forwarded_room_key;
 pub mod olm_v1;
 pub mod room;
 pub mod room_key;
+pub mod room_key_request;
 pub mod secret_send;
 mod to_device;
 

--- a/crates/matrix-sdk-crypto/src/types/events/room/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/mod.rs
@@ -49,7 +49,7 @@ where
 
     /// Any other unknown data of the room event.
     #[serde(flatten)]
-    other: BTreeMap<String, Value>,
+    pub(crate) other: BTreeMap<String, Value>,
 }
 
 impl<C> Serialize for Event<C>

--- a/crates/matrix-sdk-crypto/src/types/events/room_key_request.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_request.rs
@@ -1,0 +1,368 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for the `m.room_key_request` events.
+
+use std::collections::BTreeMap;
+
+use ruma::{OwnedDeviceId, OwnedRoomId, OwnedTransactionId, RoomId};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use vodozemac::Curve25519PublicKey;
+
+use super::{EventType, ToDeviceEvent};
+use crate::types::{deserialize_curve_key, serialize_curve_key, EventEncryptionAlgorithm};
+
+/// The `m.room_key_request` to-device event.
+pub type RoomKeyRequestEvent = ToDeviceEvent<RoomKeyRequestContent>;
+
+impl Clone for RoomKeyRequestEvent {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            content: self.content.clone(),
+            other: self.other.clone(),
+        }
+    }
+}
+
+/// The content for a `m.room_key_request` event.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RoomKeyRequestContent {
+    /// The action that this room key request is carrying.
+    #[serde(flatten)]
+    pub action: Action,
+    /// The ID of the device that is requesting the room key.
+    pub requesting_device_id: OwnedDeviceId,
+    /// A random string uniquely identifying the request for a key. If the key
+    /// is requested multiple times, it should be reused. It should also reused
+    /// in order to cancel a request.
+    pub request_id: OwnedTransactionId,
+}
+
+impl EventType for RoomKeyRequestContent {
+    const EVENT_TYPE: &'static str = "m.room_key_request";
+}
+
+/// Enum describing different actions a room key request event can be carrying.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "action", content = "body")]
+pub enum Action {
+    /// An action describing a cancellation of a previous room key request.
+    #[serde(rename = "request_cancellation")]
+    Cancellation,
+    /// An action describing a room key request.
+    #[serde(rename = "request")]
+    Request(RequestedKeyInfo),
+}
+
+/// Info about the room key that is being requested.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "RequestedKeyInfoHelper")]
+pub enum RequestedKeyInfo {
+    /// The `m.megolm.v1.aes-sha2` variant of the `m.room_key_request` content.
+    MegolmV1AesSha2(MegolmV1AesSha2Content),
+    /// The `m.megolm.v2.aes-sha2` variant of the `m.room_key_request` content.
+    #[cfg(feature = "experimental-algorithms")]
+    MegolmV2AesSha2(MegolmV2AesSha2Content),
+    /// An unknown and unsupported variant of the `m.room_key_request`
+    /// content.
+    Unknown(UnknownRoomKeyRequest),
+}
+
+impl RequestedKeyInfo {
+    /// Get the algorithm of the room key request content.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        match self {
+            RequestedKeyInfo::MegolmV1AesSha2(_) => EventEncryptionAlgorithm::MegolmV1AesSha2,
+            #[cfg(feature = "experimental-algorithms")]
+            RequestedKeyInfo::MegolmV2AesSha2(_) => EventEncryptionAlgorithm::MegolmV2AesSha2,
+            RequestedKeyInfo::Unknown(c) => c.algorithm.to_owned(),
+        }
+    }
+}
+
+impl From<SupportedKeyInfo> for RequestedKeyInfo {
+    fn from(s: SupportedKeyInfo) -> Self {
+        match s {
+            SupportedKeyInfo::MegolmV1AesSha2(c) => Self::MegolmV1AesSha2(c),
+            #[cfg(feature = "experimental-algorithms")]
+            SupportedKeyInfo::MegolmV2AesSha2(c) => Self::MegolmV2AesSha2(c),
+        }
+    }
+}
+
+impl From<MegolmV1AesSha2Content> for RequestedKeyInfo {
+    fn from(c: MegolmV1AesSha2Content) -> Self {
+        Self::MegolmV1AesSha2(c)
+    }
+}
+
+#[cfg(feature = "experimental-algorithms")]
+impl From<MegolmV2AesSha2Content> for RequestedKeyInfo {
+    fn from(c: MegolmV2AesSha2Content) -> Self {
+        Self::MegolmV2AesSha2(c)
+    }
+}
+
+/// Info about the room key that is being requested.
+///
+/// This is similar to [`RequestedKeyInfo`] but it contains only supported
+/// algorithms.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(try_from = "RequestedKeyInfo", into = "RequestedKeyInfo")]
+pub enum SupportedKeyInfo {
+    /// The `m.megolm.v1.aes-sha2` variant of the `m.room_key_request` content.
+    MegolmV1AesSha2(MegolmV1AesSha2Content),
+    /// The `m.megolm.v2.aes-sha2` variant of the `m.room_key_request` content.
+    #[cfg(feature = "experimental-algorithms")]
+    MegolmV2AesSha2(MegolmV2AesSha2Content),
+}
+
+impl SupportedKeyInfo {
+    /// Get the algorithm of the room key request content.
+    pub fn algorithm(&self) -> EventEncryptionAlgorithm {
+        match self {
+            Self::MegolmV1AesSha2(_) => EventEncryptionAlgorithm::MegolmV1AesSha2,
+            #[cfg(feature = "experimental-algorithms")]
+            Self::MegolmV2AesSha2(_) => EventEncryptionAlgorithm::MegolmV2AesSha2,
+        }
+    }
+
+    /// Get the room ID where the room key is used.
+    pub fn room_id(&self) -> &RoomId {
+        match self {
+            Self::MegolmV1AesSha2(c) => &c.room_id,
+            #[cfg(feature = "experimental-algorithms")]
+            Self::MegolmV2AesSha2(c) => &c.room_id,
+        }
+    }
+
+    /// Get the unique ID of the room key.
+    pub fn session_id(&self) -> &str {
+        match self {
+            Self::MegolmV1AesSha2(c) => &c.session_id,
+            #[cfg(feature = "experimental-algorithms")]
+            Self::MegolmV2AesSha2(c) => &c.session_id,
+        }
+    }
+}
+
+impl TryFrom<RequestedKeyInfo> for SupportedKeyInfo {
+    type Error = &'static str;
+
+    fn try_from(value: RequestedKeyInfo) -> Result<Self, Self::Error> {
+        match value {
+            RequestedKeyInfo::MegolmV1AesSha2(c) => Ok(Self::MegolmV1AesSha2(c)),
+            #[cfg(feature = "experimental-algorithms")]
+            RequestedKeyInfo::MegolmV2AesSha2(c) => Ok(Self::MegolmV2AesSha2(c)),
+            RequestedKeyInfo::Unknown(_) => Err("Unsupported algorithm for a room key request"),
+        }
+    }
+}
+
+impl From<MegolmV1AesSha2Content> for SupportedKeyInfo {
+    fn from(c: MegolmV1AesSha2Content) -> Self {
+        Self::MegolmV1AesSha2(c)
+    }
+}
+
+#[cfg(feature = "experimental-algorithms")]
+impl From<MegolmV2AesSha2Content> for SupportedKeyInfo {
+    fn from(c: MegolmV2AesSha2Content) -> Self {
+        Self::MegolmV2AesSha2(c)
+    }
+}
+
+/// The content for a `m.megolm.v2.aes-sha2` `m.room_key_request` event.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct MegolmV1AesSha2Content {
+    /// The room where the key is used.
+    pub room_id: OwnedRoomId,
+
+    /// The Curve25519 key of the device which initiated the session originally.
+    #[serde(deserialize_with = "deserialize_curve_key", serialize_with = "serialize_curve_key")]
+    pub sender_key: Curve25519PublicKey,
+
+    /// The ID of the session that the key is for.
+    pub session_id: String,
+}
+
+/// The content for a `m.megolm.v1.aes-sha2` `m.room_key_request` event.
+#[cfg(feature = "experimental-algorithms")]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct MegolmV2AesSha2Content {
+    /// The room where the key is used.
+    pub room_id: OwnedRoomId,
+
+    /// The ID of the session that the key is for.
+    pub session_id: String,
+}
+
+/// An unknown and unsupported `m.room_key_request` algorithm.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UnknownRoomKeyRequest {
+    /// The algorithm of the unknown room key request.
+    pub algorithm: EventEncryptionAlgorithm,
+
+    /// The other data of the unknown room key request.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct RequestedKeyInfoHelper {
+    pub algorithm: EventEncryptionAlgorithm,
+    #[serde(flatten)]
+    other: Value,
+}
+
+impl Serialize for RequestedKeyInfo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let other = match self {
+            Self::MegolmV1AesSha2(r) => {
+                serde_json::to_value(r).map_err(serde::ser::Error::custom)?
+            }
+            #[cfg(feature = "experimental-algorithms")]
+            Self::MegolmV2AesSha2(r) => {
+                serde_json::to_value(r).map_err(serde::ser::Error::custom)?
+            }
+            Self::Unknown(r) => {
+                serde_json::to_value(r.other.clone()).map_err(serde::ser::Error::custom)?
+            }
+        };
+
+        let helper = RequestedKeyInfoHelper { algorithm: self.algorithm(), other };
+
+        helper.serialize(serializer)
+    }
+}
+
+impl TryFrom<RequestedKeyInfoHelper> for RequestedKeyInfo {
+    type Error = serde_json::Error;
+
+    fn try_from(value: RequestedKeyInfoHelper) -> Result<Self, Self::Error> {
+        Ok(match value.algorithm {
+            EventEncryptionAlgorithm::MegolmV1AesSha2 => {
+                Self::MegolmV1AesSha2(serde_json::from_value(value.other)?)
+            }
+            #[cfg(feature = "experimental-algorithms")]
+            EventEncryptionAlgorithm::MegolmV2AesSha2 => {
+                Self::MegolmV2AesSha2(serde_json::from_value(value.other)?)
+            }
+            _ => Self::Unknown(UnknownRoomKeyRequest {
+                algorithm: value.algorithm,
+                other: serde_json::from_value(value.other)?,
+            }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use matches::assert_matches;
+    use serde_json::{json, Value};
+
+    use super::{Action, RequestedKeyInfo, RoomKeyRequestEvent};
+
+    pub fn json() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "action": "request",
+                "body": {
+                    "algorithm": "m.megolm.v1.aes-sha2",
+                    "room_id": "!Cuyf34gef24t:localhost",
+                    "sender_key": "RF3s+E7RkTQTGF2d8Deol0FkQvgII2aJDf3/Jp5mxVU",
+                    "session_id": "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ"
+                },
+                "request_id": "1495474790150.19",
+                "requesting_device_id": "RJYKSTBOIE"
+            },
+            "type": "m.room_key_request"
+        })
+    }
+
+    pub fn json_cancellation() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "action": "request_cancellation",
+                "request_id": "1495474790150.19",
+                "requesting_device_id": "RJYKSTBOIE"
+            },
+            "type": "m.room_key_request"
+        })
+    }
+
+    #[cfg(feature = "experimental-algorithms")]
+    pub fn json_megolm_v2() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "action": "request",
+                "body": {
+                    "algorithm": "m.megolm.v2.aes-sha2",
+                    "room_id": "!Cuyf34gef24t:localhost",
+                    "session_id": "X3lUlvLELLYxeTx4yOVu6UDpasGEVO0Jbu+QFnm0cKQ"
+                },
+                "request_id": "1495474790150.19",
+                "requesting_device_id": "RJYKSTBOIE"
+            },
+            "type": "m.room_key_request"
+        })
+    }
+
+    #[test]
+    fn deserialization() -> Result<(), serde_json::Error> {
+        let json = json();
+        let event: RoomKeyRequestEvent = serde_json::from_value(json.clone())?;
+
+        assert_matches!(
+            event.content.action,
+            Action::Request(RequestedKeyInfo::MegolmV1AesSha2(_))
+        );
+        let serialized = serde_json::to_value(event)?;
+        assert_eq!(json, serialized);
+
+        let json = json_cancellation();
+        let event: RoomKeyRequestEvent = serde_json::from_value(json.clone())?;
+
+        assert_matches!(event.content.action, Action::Cancellation);
+        let serialized = serde_json::to_value(event)?;
+        assert_eq!(json, serialized);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(feature = "experimental-algorithms")]
+    fn deserialization_megolm_v2() -> Result<(), serde_json::Error> {
+        let json = json_megolm_v2();
+        let event: RoomKeyRequestEvent = serde_json::from_value(json.clone())?;
+
+        assert_matches!(
+            event.content.action,
+            Action::Request(RequestedKeyInfo::MegolmV2AesSha2(_))
+        );
+
+        let serialized = serde_json::to_value(event)?;
+        assert_eq!(json, serialized);
+
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/events/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/to_device.rs
@@ -23,7 +23,6 @@ use ruma::{
             mac::ToDeviceKeyVerificationMacEvent, ready::ToDeviceKeyVerificationReadyEvent,
             request::ToDeviceKeyVerificationRequestEvent, start::ToDeviceKeyVerificationStartEvent,
         },
-        room_key_request::ToDeviceRoomKeyRequestEvent,
         secret::request::{SecretName, ToDeviceSecretRequestEvent},
         EventContent, ToDeviceEventType,
     },
@@ -41,6 +40,7 @@ use super::{
     forwarded_room_key::{ForwardedRoomKeyContent, ForwardedRoomKeyEvent},
     room::encrypted::EncryptedToDeviceEvent,
     room_key::RoomKeyEvent,
+    room_key_request::RoomKeyRequestEvent,
     secret_send::SecretSendEvent,
     EventType,
 };
@@ -76,7 +76,7 @@ pub enum ToDeviceEvents {
     /// The `m.room_key` to-device event.
     RoomKey(RoomKeyEvent),
     /// The `m.room_key_request` to-device event.
-    RoomKeyRequest(ToDeviceRoomKeyRequestEvent),
+    RoomKeyRequest(RoomKeyRequestEvent),
     /// The `m.forwarded_room_key` to-device event.
     ForwardedRoomKey(Box<ForwardedRoomKeyEvent>),
     /// The `m.secret.send` to-device event.
@@ -128,7 +128,7 @@ impl ToDeviceEvents {
 
             ToDeviceEvents::RoomEncrypted(_) => ToDeviceEventType::RoomEncrypted,
             ToDeviceEvents::RoomKey(_) => ToDeviceEventType::RoomKey,
-            ToDeviceEvents::RoomKeyRequest(e) => e.content.event_type(),
+            ToDeviceEvents::RoomKeyRequest(_) => ToDeviceEventType::RoomKeyRequest,
             ToDeviceEvents::ForwardedRoomKey(_) => ToDeviceEventType::ForwardedRoomKey,
 
             ToDeviceEvents::SecretSend(_) => ToDeviceEventType::SecretSend,

--- a/crates/matrix-sdk-sled/src/crypto_store.rs
+++ b/crates/matrix-sdk-sled/src/crypto_store.rs
@@ -123,7 +123,6 @@ impl EncodeKey for EventEncryptionAlgorithm {
 
 impl EncodeKey for SupportedKeyInfo {
     fn encode(&self) -> Vec<u8> {
-        #[allow(deprecated)]
         (self.room_id(), &self.algorithm(), self.session_id()).encode()
     }
     fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {

--- a/crates/matrix-sdk-sled/src/encode_key.rs
+++ b/crates/matrix-sdk-sled/src/encode_key.rs
@@ -6,8 +6,8 @@ use ruma::{
         receipt::ReceiptType, secret::request::SecretName, GlobalAccountDataEventType,
         RoomAccountDataEventType, StateEventType,
     },
-    DeviceId, EventEncryptionAlgorithm, EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId,
-    RoomId, TransactionId, UserId,
+    DeviceId, EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, TransactionId,
+    UserId,
 };
 
 /// Hold any data to be used as an encoding key
@@ -119,13 +119,6 @@ impl EncodeKey for SecretName {
 }
 
 impl EncodeKey for ReceiptType {
-    fn encode_as_bytes(&self) -> Cow<'_, [u8]> {
-        let s: &str = self.as_ref();
-        s.as_bytes().into()
-    }
-}
-
-impl EncodeKey for EventEncryptionAlgorithm {
     fn encode_as_bytes(&self) -> Cow<'_, [u8]> {
         let s: &str = self.as_ref();
         s.as_bytes().into()


### PR DESCRIPTION
This prepares us for a brave new world where the `sender_key` gets removed from some events.

It is a prerequisite to resurrect #481.