### PR TITLE
chore(examples): Use automatic links for some URLs

### DIFF
--- a/examples/get_profiles/src/main.rs
+++ b/examples/get_profiles/src/main.rs
@@ -14,8 +14,8 @@ struct UserProfile {
 }
 
 /// This function calls the GET profile endpoint
-/// Spec: https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-profile-userid
-/// Ruma: https://docs.rs/ruma-client-api/0.9.0/ruma_client_api/r0/profile/get_profile/index.html
+/// Spec: <https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-profile-userid>
+/// Ruma: <https://docs.rs/ruma-client-api/0.9.0/ruma_client_api/r0/profile/get_profile/index.html>
 async fn get_profile(client: Client, mxid: &UserId) -> MatrixResult<UserProfile> {
     // First construct the request you want to make
     // See https://docs.rs/ruma-client-api/0.9.0/ruma_client_api/index.html for all available Endpoints


### PR DESCRIPTION
Not sure why this isn't bothering the CI and if I'm the only poor sod running `xtask ci` locally but an error springs out:

![image](https://user-images.githubusercontent.com/552026/187719663-b3f26346-ab88-460f-91cc-7b3e40d56f11.png)

This patch fixes this.