### PR TITLE
feat: Expose client of rooms for extensions

### DIFF
--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -166,6 +166,13 @@ impl Common {
         self.client.join_room_by_id(self.room_id()).await
     }
 
+    /// Get the inner client saved in this room instance.
+    ///
+    /// Returns the client this room is part of.
+    pub fn client(&self) -> Client {
+        self.client.clone()
+    }
+
     /// Gets the avatar of this room, if set.
     ///
     /// Returns the avatar.


### PR DESCRIPTION
Adds a getter for retrieving the client of rooms. This allows to create extension traits and such on rooms. For example, one could make methods to send custom events or join/leave without waiting for the sync.