### PR TITLE
feat(sdk): Add support for AnySyncTimelineEvent in event handlers

### DIFF
--- a/crates/matrix-sdk/src/event_handler/maps.rs
+++ b/crates/matrix-sdk/src/event_handler/maps.rs
@@ -19,11 +19,11 @@ use std::{
 
 use ruma::{OwnedRoomId, RoomId};
 
-use super::{EventHandlerFn, EventHandlerHandle, EventHandlerWrapper, EventKind};
+use super::{EventHandlerFn, EventHandlerHandle, EventHandlerWrapper, HandlerKind};
 
 #[derive(Default)]
 pub(super) struct EventHandlerMaps {
-    by_kind: BTreeMap<EventKind, Vec<EventHandlerWrapper>>,
+    by_kind: BTreeMap<HandlerKind, Vec<EventHandlerWrapper>>,
     by_kind_type: BTreeMap<KindTypeWrap, Vec<EventHandlerWrapper>>,
     by_kind_roomid: BTreeMap<KindRoomId, Vec<EventHandlerWrapper>>,
     by_kind_type_roomid: BTreeMap<KindTypeRoomIdWrap, Vec<EventHandlerWrapper>>,
@@ -51,7 +51,7 @@ impl EventHandlerMaps {
 
     pub fn get_handlers<'a>(
         &'a self,
-        ev_kind: EventKind,
+        ev_kind: HandlerKind,
         ev_type: &str,
         room_id: Option<&'a RoomId>,
     ) -> impl Iterator<Item = (EventHandlerHandle, &'a EventHandlerFn)> + 'a {
@@ -138,7 +138,7 @@ impl EventHandlerMaps {
 }
 
 enum Key {
-    Kind(EventKind),
+    Kind(HandlerKind),
     KindType(KindTypeWrap),
     KindRoomId(KindRoomId),
     KindTypeRoomId(KindTypeRoomIdWrap),
@@ -164,13 +164,13 @@ struct KindTypeWrap(KindType<'static>);
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct KindType<'a> {
-    ev_kind: EventKind,
+    ev_kind: HandlerKind,
     ev_type: &'a str,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct KindRoomId {
-    ev_kind: EventKind,
+    ev_kind: HandlerKind,
     room_id: OwnedRoomId,
 }
 
@@ -179,7 +179,7 @@ struct KindTypeRoomIdWrap(KindTypeRoomId<'static>);
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct KindTypeRoomId<'a> {
-    ev_kind: EventKind,
+    ev_kind: HandlerKind,
     ev_type: &'a str,
     room_id: OwnedRoomId,
 }

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -111,6 +111,7 @@ pub enum HandlerKind {
     GlobalAccountData,
     RoomAccountData,
     EphemeralRoomData,
+    Timeline,
     MessageLike,
     OriginalMessageLike,
     RedactedMessageLike,
@@ -397,6 +398,10 @@ impl Client {
             // Event handlers specifically for redacted OR unredacted timeline events
             self.call_event_handlers(room, raw_event, handler_kind_r, &event_type, encryption_info)
                 .await;
+
+            // Event handlers for `AnySyncTimelineEvent`
+            let kind = HandlerKind::Timeline;
+            self.call_event_handlers(room, raw_event, kind, &event_type, encryption_info).await;
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -27,13 +27,13 @@ use ruma::{
     serde::Raw,
 };
 
-use super::{EventKind, SyncEvent};
+use super::{HandlerKind, SyncEvent};
 
 impl<C> SyncEvent for events::GlobalAccountDataEvent<C>
 where
     C: StaticEventContent + GlobalAccountDataEventContent,
 {
-    const KIND: EventKind = EventKind::GlobalAccountData;
+    const KIND: HandlerKind = HandlerKind::GlobalAccountData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -41,7 +41,7 @@ impl<C> SyncEvent for events::RoomAccountDataEvent<C>
 where
     C: StaticEventContent + RoomAccountDataEventContent,
 {
-    const KIND: EventKind = EventKind::RoomAccountData;
+    const KIND: HandlerKind = HandlerKind::RoomAccountData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -49,7 +49,7 @@ impl<C> SyncEvent for events::SyncEphemeralRoomEvent<C>
 where
     C: StaticEventContent + EphemeralRoomEventContent,
 {
-    const KIND: EventKind = EventKind::EphemeralRoomData;
+    const KIND: HandlerKind = HandlerKind::EphemeralRoomData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -58,7 +58,7 @@ where
     C: StaticEventContent + MessageLikeEventContent + RedactContent,
     C::Redacted: MessageLikeEventContent + RedactedEventContent,
 {
-    const KIND: EventKind = EventKind::MessageLike;
+    const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -66,7 +66,7 @@ impl<C> SyncEvent for events::OriginalSyncMessageLikeEvent<C>
 where
     C: StaticEventContent + MessageLikeEventContent,
 {
-    const KIND: EventKind = EventKind::OriginalMessageLike;
+    const KIND: HandlerKind = HandlerKind::OriginalMessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -74,24 +74,24 @@ impl<C> SyncEvent for events::RedactedSyncMessageLikeEvent<C>
 where
     C: StaticEventContent + MessageLikeEventContent + RedactedEventContent,
 {
-    const KIND: EventKind = EventKind::RedactedMessageLike;
+    const KIND: HandlerKind = HandlerKind::RedactedMessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl SyncEvent for events::room::redaction::SyncRoomRedactionEvent {
-    const KIND: EventKind = EventKind::MessageLike;
+    const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
 }
 
 impl SyncEvent for events::room::redaction::OriginalSyncRoomRedactionEvent {
-    const KIND: EventKind = EventKind::OriginalMessageLike;
+    const KIND: HandlerKind = HandlerKind::OriginalMessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
 }
 
 impl SyncEvent for events::room::redaction::RedactedSyncRoomRedactionEvent {
-    const KIND: EventKind = EventKind::RedactedMessageLike;
+    const KIND: HandlerKind = HandlerKind::RedactedMessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
 }
@@ -101,7 +101,7 @@ where
     C: StaticEventContent + StateEventContent + RedactContent,
     C::Redacted: StateEventContent + RedactedEventContent,
 {
-    const KIND: EventKind = EventKind::State;
+    const KIND: HandlerKind = HandlerKind::State;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -109,7 +109,7 @@ impl<C> SyncEvent for events::OriginalSyncStateEvent<C>
 where
     C: StaticEventContent + StateEventContent,
 {
-    const KIND: EventKind = EventKind::OriginalState;
+    const KIND: HandlerKind = HandlerKind::OriginalState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -117,7 +117,7 @@ impl<C> SyncEvent for events::RedactedSyncStateEvent<C>
 where
     C: StaticEventContent + StateEventContent + RedactedEventContent,
 {
-    const KIND: EventKind = EventKind::RedactedState;
+    const KIND: HandlerKind = HandlerKind::RedactedState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -125,7 +125,7 @@ impl<C> SyncEvent for events::StrippedStateEvent<C>
 where
     C: StaticEventContent + StateEventContent,
 {
-    const KIND: EventKind = EventKind::StrippedState;
+    const KIND: HandlerKind = HandlerKind::StrippedState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
@@ -133,51 +133,51 @@ impl<C> SyncEvent for events::ToDeviceEvent<C>
 where
     C: StaticEventContent + ToDeviceEventContent,
 {
-    const KIND: EventKind = EventKind::ToDevice;
+    const KIND: HandlerKind = HandlerKind::ToDevice;
     const TYPE: Option<&'static str> = Some(C::TYPE);
 }
 
 impl SyncEvent for PresenceEvent {
-    const KIND: EventKind = EventKind::Presence;
+    const KIND: HandlerKind = HandlerKind::Presence;
     const TYPE: Option<&'static str> = Some(PresenceEventContent::TYPE);
 }
 
 impl SyncEvent for AnyGlobalAccountDataEvent {
-    const KIND: EventKind = EventKind::GlobalAccountData;
+    const KIND: HandlerKind = HandlerKind::GlobalAccountData;
     const TYPE: Option<&'static str> = None;
 }
 
 impl SyncEvent for AnyRoomAccountDataEvent {
-    const KIND: EventKind = EventKind::RoomAccountData;
+    const KIND: HandlerKind = HandlerKind::RoomAccountData;
     const TYPE: Option<&'static str> = None;
 }
 
 impl SyncEvent for AnySyncEphemeralRoomEvent {
-    const KIND: EventKind = EventKind::EphemeralRoomData;
+    const KIND: HandlerKind = HandlerKind::EphemeralRoomData;
     const TYPE: Option<&'static str> = None;
 }
 
 impl SyncEvent for AnySyncMessageLikeEvent {
-    const KIND: EventKind = EventKind::MessageLike;
+    const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> = None;
 }
 
 impl SyncEvent for AnySyncStateEvent {
-    const KIND: EventKind = EventKind::State;
+    const KIND: HandlerKind = HandlerKind::State;
     const TYPE: Option<&'static str> = None;
 }
 
 impl SyncEvent for AnyStrippedStateEvent {
-    const KIND: EventKind = EventKind::StrippedState;
+    const KIND: HandlerKind = HandlerKind::StrippedState;
     const TYPE: Option<&'static str> = None;
 }
 
 impl SyncEvent for AnyToDeviceEvent {
-    const KIND: EventKind = EventKind::ToDevice;
+    const KIND: HandlerKind = HandlerKind::ToDevice;
     const TYPE: Option<&'static str> = None;
 }
 
 impl<T: SyncEvent> SyncEvent for Raw<T> {
-    const KIND: EventKind = T::KIND;
+    const KIND: HandlerKind = T::KIND;
     const TYPE: Option<&'static str> = T::TYPE;
 }

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -19,10 +19,11 @@ use ruma::{
         self,
         presence::{PresenceEvent, PresenceEventContent},
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnyToDeviceEvent,
-        EphemeralRoomEventContent, GlobalAccountDataEventContent, MessageLikeEventContent,
-        RedactContent, RedactedEventContent, RoomAccountDataEventContent, StateEventContent,
-        StaticEventContent, ToDeviceEventContent,
+        AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent,
+        AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent,
+        GlobalAccountDataEventContent, MessageLikeEventContent, RedactContent,
+        RedactedEventContent, RoomAccountDataEventContent, StateEventContent, StaticEventContent,
+        ToDeviceEventContent,
     },
     serde::Raw,
 };
@@ -154,6 +155,11 @@ impl SyncEvent for AnyRoomAccountDataEvent {
 
 impl SyncEvent for AnySyncEphemeralRoomEvent {
     const KIND: HandlerKind = HandlerKind::EphemeralRoomData;
+    const TYPE: Option<&'static str> = None;
+}
+
+impl SyncEvent for AnySyncTimelineEvent {
+    const KIND: HandlerKind = HandlerKind::Timeline;
     const TYPE: Option<&'static str> = None;
 }
 


### PR DESCRIPTION
The change from the second commit was suggested by @gnunicorn a while ago. It doesn't add a lot of parallelism since it's probably not even common to have multiple event handlers that react to the same event at all, but it's the most we can do since we need distinct events to be handled sequentially in the general case (people can still parallelize themselves if they don't care about the order).