### PR TITLE
refactor(sdk): Deprecate ClientBuilder::user_id

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -116,11 +116,12 @@ impl ClientBuilder {
     /// Set the user ID to discover the homeserver from.
     ///
     /// `builder.user_id(id)` is a shortcut for
-    /// `builder.server_name(id.server_name())`.
+    /// <code>builder.[server_name](Self::server_name)(id.server_name())</code>.
     ///
     /// This method is mutually exclusive with
     /// [`homeserver_url()`][Self::homeserver_url], if you set both whatever was
     /// set last will be used.
+    #[deprecated = "Use `server_name(user_id.server_name())` instead"]
     pub fn user_id(self, user_id: &UserId) -> Self {
         self.server_name(user_id.server_name())
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2505,7 +2505,7 @@ pub(crate) mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::VERSIONS))
             .mount(&server)
             .await;
-        let client = Client::builder().user_id(&alice).build().await.unwrap();
+        let client = Client::builder().server_name(alice.server_name()).build().await.unwrap();
 
         assert_eq!(client.homeserver().await, Url::parse(server_url.as_ref()).unwrap());
     }
@@ -2524,7 +2524,7 @@ pub(crate) mod tests {
             .await;
 
         assert!(
-            Client::builder().user_id(&alice).build().await.is_err(),
+            Client::builder().server_name(alice.server_name()).build().await.is_err(),
             "Creating a client from a user ID should fail when the .well-known request fails."
         );
     }


### PR DESCRIPTION
I originally wanted to post this PR months ago, but it got lost. The reason this function is deprecated is that it's kind of confusing to have client code pass the user ID twice when logging in (once for the builder, then the login API), and the alternative of `.server_name(user_id.server_name())` makes it more obvious what is going on.