### PR TITLE
Improve the emoji example a bit

### DIFF
--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -87,7 +87,9 @@ pub use requests::{
     OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest, UploadSigningKeysRequest,
 };
 pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretImportError, SecretInfo};
-pub use verification::{AcceptSettings, CancelInfo, Emoji, Sas, Verification, VerificationRequest};
+pub use verification::{
+    format_emojis, AcceptSettings, CancelInfo, Emoji, Sas, Verification, VerificationRequest,
+};
 #[cfg(feature = "qrcode")]
 pub use verification::{QrVerification, ScanError};
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -83,6 +83,43 @@ pub struct Emoji {
     pub description: &'static str,
 }
 
+/// Format the the list of emojis as a two line string.
+///
+/// The first line will contain the emojis spread out so the second line can
+/// contain the descriptions centered bellow the emoji.
+pub fn format_emojis(emojis: [Emoji; 7]) -> String {
+    let (emojis, descriptions): (Vec<_>, Vec<_>) =
+        emojis.iter().map(|e| (e.symbol, e.description)).unzip();
+
+    let center_emoji = |emoji: &str| -> String {
+        const EMOJI_WIDTH: usize = 2;
+        // These are emojis that need VARIATION-SELECTOR-16 (U+FE0F) so that they are
+        // rendered with coloured glyphs. For these, we need to add an extra
+        // space after them so that they are rendered properly in terminals.
+        const VARIATION_SELECTOR_EMOJIS: [&str; 7] = ["☁️", "❤️", "☂️", "✏️", "✂️", "☎️", "✈️"];
+
+        // Hack to make terminals behave properly when one of the above is printed.
+        let emoji = if VARIATION_SELECTOR_EMOJIS.contains(&emoji) {
+            format!("{} ", emoji)
+        } else {
+            emoji.to_owned()
+        };
+
+        // This is a trick to account for the fact that emojis are wider than other
+        // monospace characters.
+        let placeholder = ".".repeat(EMOJI_WIDTH);
+
+        format!("{:^12}", placeholder).replace(&placeholder, &emoji)
+    };
+
+    let emoji_string = emojis.iter().map(|e| center_emoji(e)).collect::<Vec<_>>().join("");
+
+    let description =
+        descriptions.iter().map(|d| format!("{:^12}", d)).collect::<Vec<_>>().join("");
+
+    format!("{emoji_string}\n{description}")
+}
+
 impl VerificationStore {
     pub async fn get_device(
         &self,

--- a/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
@@ -32,9 +32,9 @@ use crate::{
     identities::{ReadOnlyDevice, ReadOnlyUserIdentities},
     verification::{
         event_enums::{AnyVerificationContent, OutgoingContent, OwnedAcceptContent, StartContent},
-        Cancelled,
+        Cancelled, Emoji,
     },
-    Emoji, ReadOnlyAccount, ReadOnlyOwnUserIdentity,
+    ReadOnlyAccount, ReadOnlyOwnUserIdentity,
 };
 
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -61,9 +61,9 @@ use crate::{
             AcceptContent, DoneContent, KeyContent, MacContent, OwnedAcceptContent,
             OwnedStartContent, StartContent,
         },
-        Cancelled, FlowId,
+        Cancelled, Emoji, FlowId,
     },
-    Emoji, ReadOnlyAccount, ReadOnlyOwnUserIdentity,
+    ReadOnlyAccount, ReadOnlyOwnUserIdentity,
 };
 
 const KEY_AGREEMENT_PROTOCOLS: &[KeyAgreementProtocol] =

--- a/crates/matrix-sdk/src/encryption/verification/mod.rs
+++ b/crates/matrix-sdk/src/encryption/verification/mod.rs
@@ -35,9 +35,9 @@ mod qrcode;
 mod requests;
 mod sas;
 
+pub use matrix_sdk_base::crypto::{format_emojis, AcceptSettings, CancelInfo, Emoji};
 #[cfg(feature = "qrcode")]
 pub use matrix_sdk_base::crypto::{matrix_sdk_qrcode::QrVerificationData, ScanError};
-pub use matrix_sdk_base::crypto::{AcceptSettings, CancelInfo, Emoji};
 #[cfg(feature = "qrcode")]
 pub use qrcode::QrVerification;
 pub use requests::VerificationRequest;

--- a/crates/matrix-sdk/src/encryption/verification/sas.rs
+++ b/crates/matrix-sdk/src/encryption/verification/sas.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk_base::crypto::{AcceptSettings, CancelInfo, ReadOnlyDevice, Sas as BaseSas};
+use matrix_sdk_base::crypto::{AcceptSettings, CancelInfo, Emoji, ReadOnlyDevice, Sas as BaseSas};
 use ruma::{events::key::verification::cancel::CancelCode, UserId};
 
 use crate::{error::Result, Client};
@@ -151,7 +151,7 @@ impl SasVerification {
     /// }
     /// # anyhow::Ok(()) });
     /// ```
-    pub fn emoji(&self) -> Option<[super::Emoji; 7]> {
+    pub fn emoji(&self) -> Option<[Emoji; 7]> {
         self.inner.emoji()
     }
 

--- a/examples/emoji_verification/src/main.rs
+++ b/examples/emoji_verification/src/main.rs
@@ -1,5 +1,5 @@
 use std::{
-    io,
+    io::{self, Write},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -11,7 +11,7 @@ use clap::Parser;
 use matrix_sdk::{
     self,
     config::SyncSettings,
-    encryption::verification::{SasVerification, Verification},
+    encryption::verification::{format_emojis, SasVerification, Verification},
     ruma::{
         events::{
             room::message::MessageType, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
@@ -25,9 +25,10 @@ use url::Url;
 
 async fn wait_for_confirmation(client: Client, sas: SasVerification) {
     let emoji = sas.emoji().expect("The emoji should be available now");
-    let emoji: Vec<&str> = emoji.iter().map(|e| e.symbol).collect();
 
-    println!("Does the emoji match: {:?}", emoji);
+    println!("\nDo the emojis match: \n{}", format_emojis(emoji));
+    print!("Confirm with `yes` or cancel with `no`: ");
+    std::io::stdout().flush().expect("We should be able to flush stdout");
 
     let mut input = String::new();
     io::stdin().read_line(&mut input).expect("error: unable to read user input");

--- a/examples/emoji_verification/src/main.rs
+++ b/examples/emoji_verification/src/main.rs
@@ -241,6 +241,10 @@ struct Cli {
     /// Set the proxy that should be used for the connection.
     #[clap(short, long)]
     proxy: Option<Url>,
+
+    /// Enable verbose logging output.
+    #[clap(short, long, action)]
+    verbose: bool,
 }
 
 async fn login(cli: Cli) -> Result<Client> {
@@ -261,8 +265,12 @@ async fn login(cli: Cli) -> Result<Client> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
     let cli = Cli::parse();
+
+    if cli.verbose {
+        tracing_subscriber::fmt::init();
+    }
+
     let client = login(cli).await?;
 
     sync(client).await?;

--- a/examples/emoji_verification/src/main.rs
+++ b/examples/emoji_verification/src/main.rs
@@ -117,7 +117,7 @@ async fn sync(client: Client) -> matrix_sdk::Result<()> {
                         }
                     }
 
-                    AnyToDeviceEvent::KeyVerificationMac(e) => {
+                    AnyToDeviceEvent::KeyVerificationDone(e) => {
                         if let Some(Verification::SasV1(sas)) = client
                             .encryption()
                             .get_verification(&e.sender, e.content.transaction_id.as_str())


### PR DESCRIPTION
We now print a neater output in the emoji example:

![image](https://user-images.githubusercontent.com/552026/188440173-b7976a83-c5a6-4181-a4dc-e5c403c2914a.png)

Individual commits contain more detailed explanations.