### PR TITLE
test: Use a weak password hash for crypto-store testing

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -328,9 +328,13 @@ impl IndexeddbStateStoreBuilder {
                 StoreCipher::import(passphrase, &inner)?
             } else {
                 let cipher = StoreCipher::new()?;
+                #[cfg(not(test))]
+                let export = cipher.export(passphrase)?;
+                #[cfg(test)]
+                let export = cipher._insecure_export_fast_for_testing(passphrase)?;
                 ob.put_key_val(
                     &JsValue::from_str(KEYS::STORE_KEY),
-                    &JsValue::from_serde(&StoreKeyWrapper(cipher.export(passphrase)?))?,
+                    &JsValue::from_serde(&StoreKeyWrapper(export))?,
                 )?;
                 cipher
             };

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -244,7 +244,11 @@ impl SledStateStoreBuilder {
                 Some(StoreCipher::import(passphrase, &inner)?.into())
             } else {
                 let cipher = StoreCipher::new()?;
-                db.insert("store_cipher".encode(), cipher.export(passphrase)?)?;
+                #[cfg(not(test))]
+                let export = cipher.export(passphrase)?;
+                #[cfg(test)]
+                let export = cipher._insecure_export_fast_for_testing(passphrase)?;
+                db.insert("store_cipher".encode(), export)?;
                 Some(cipher.into())
             }
         } else {


### PR DESCRIPTION
This speeds up the crypto-store tests a lot.

I benchmarked the sled `crypto_store::tests` and `crypto_store::encrypted_tests` with this, it makes a huge difference:

```
tests before:  2.08s
tests after:   0.17s

encrypted_tests before:  11.69s
encrypted_tests after:   0.29s
```