### PR TITLE
feat(qrcode): Allow `VerificationData` to receive a flow ID

### DIFF
--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -83,7 +83,7 @@ pub enum AnyDecryptedOlmEvent {
     /// The `m.secret.send` decrypted to-device event.
     SecretSend(DecryptedSecretSendEvent),
     /// A decrypted to-device event of an unknown or custom type.
-    Custom(ToDeviceCustomEvent),
+    Custom(Box<ToDeviceCustomEvent>),
 }
 
 impl AnyDecryptedOlmEvent {

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -425,8 +425,8 @@ pub enum FlowId {
 
 impl FlowId {
     pub fn room_id(&self) -> Option<&RoomId> {
-        if let FlowId::InRoom(r, _) = &self {
-            Some(r)
+        if let FlowId::InRoom(room_id, _) = &self {
+            Some(room_id)
         } else {
             None
         }
@@ -434,8 +434,8 @@ impl FlowId {
 
     pub fn as_str(&self) -> &str {
         match self {
-            FlowId::InRoom(_, r) => r.as_str(),
-            FlowId::ToDevice(t) => t.as_str(),
+            FlowId::InRoom(_, event_id) => event_id.as_str(),
+            FlowId::ToDevice(transaction_id) => transaction_id.as_str(),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -493,14 +493,13 @@ impl QrVerification {
     ) -> Self {
         let secret = Self::generate_secret();
 
-        let event_id = if let FlowId::InRoom(_, e) = &flow_id {
-            e.to_owned()
-        } else {
-            panic!("A verification between users is only valid in a room");
-        };
-
-        let inner: QrVerificationData =
-            VerificationData::new(event_id, own_master_key, other_master_key, secret).into();
+        let inner: QrVerificationData = VerificationData::new(
+            flow_id.as_str().to_string(),
+            own_master_key,
+            other_master_key,
+            secret,
+        )
+        .into();
 
         Self::new_helper(flow_id, inner, identities, we_started, request_handle)
     }

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -494,7 +494,7 @@ impl QrVerification {
         let secret = Self::generate_secret();
 
         let inner: QrVerificationData = VerificationData::new(
-            flow_id.as_str().to_string(),
+            flow_id.as_str().to_owned(),
             own_master_key,
             other_master_key,
             secret,

--- a/crates/matrix-sdk-qrcode/src/error.rs
+++ b/crates/matrix-sdk-qrcode/src/error.rs
@@ -30,9 +30,6 @@ pub enum DecodingError {
     /// The QR code data is using an unsupported or invalid verification mode.
     #[error("the QR code contains an invalid verification mode: {0}")]
     Mode(u8),
-    /// The flow id is not a valid event ID.
-    #[error(transparent)]
-    Identifier(#[from] ruma_common::IdParseError),
     #[error(transparent)]
     /// The QR code data does not contain all the necessary fields.
     Read(#[from] std::io::Error),

--- a/crates/matrix-sdk-qrcode/src/lib.rs
+++ b/crates/matrix-sdk-qrcode/src/lib.rs
@@ -183,19 +183,6 @@ mod tests {
     }
 
     #[test]
-    fn decode_invalid_room_id() {
-        let data = b"MATRIX\
-                   \x02\x00\x00\x0f\
-                   test:localhost\
-                   kS /\x92i\x1e6\xcd'g\xf9#\x11\xd8\x8a\xa2\xf61\x05\x1b6\xef\xfc\xa4%\x80\x1a\x0c\xd2\xe8\x04\
-                   \xbdR|\xf8n\x07\xa4\x1f\xb4\xcc3\x0eBT\xe7[~\xfd\x87\xd06B\xdfoVv%\x9b\x86\xae\xbcM\
-                   SECRETISLONGENOUGH";
-
-        let result = QrVerificationData::from_bytes(data);
-        assert!(matches!(result, Err(DecodingError::Identifier(_))))
-    }
-
-    #[test]
     fn decode_invalid_keys() {
         let data = b"MATRIX\
                    \x02\x00\x00\x0f\

--- a/crates/matrix-sdk-qrcode/src/types.rs
+++ b/crates/matrix-sdk-qrcode/src/types.rs
@@ -389,9 +389,7 @@ impl VerificationData {
     /// `m.key.verification.request` event that initiated the
     /// verification flow this QR code should be part of.
     ///
-    /// * `first_master_key` - Our own cross signing master key. Needs to be
-    ///   encoded as
-    /// unpadded base64
+    /// * `first_master_key` - Our own cross signing master key.
     ///
     /// * `second_master_key` - The cross signing master key of the other user.
     ///
@@ -491,14 +489,11 @@ impl SelfVerificationData {
     /// transaction id was sent by the `m.key.verification.request` event
     /// that initiated the verification flow this QR code should be part of.
     ///
-    /// * `master_key` - Our own cross signing master key. Needs to be encoded
-    ///   as
-    /// unpadded base64
+    /// * `master_key` - Our own cross signing master key.
     ///
-    /// * `device_key` - The ed25519 key of the other device, encoded as
-    /// unpadded base64.
+    /// * `device_key` - The ed25519 key of the other device.
     ///
-    /// * ` shared_secret` - A random bytestring encoded as unpadded base64,
+    /// * `shared_secret` - A random bytestring encoded as unpadded base64,
     /// needs to be at least 8 bytes long.
     pub fn new(
         transaction_id: String,
@@ -594,14 +589,11 @@ impl SelfVerificationNoMasterKey {
     /// transaction id was sent by the `m.key.verification.request` event
     /// that initiated the verification flow this QR code should be part of.
     ///
-    /// * `device_key` - The ed25519 key of our own device, encoded as unpadded
-    /// base64.
+    /// * `device_key` - The ed25519 key of our own device.
     ///
-    /// * `master_key` - Our own cross signing master key. Needs to be encoded
-    ///   as
-    /// unpadded base64
+    /// * `master_key` - Our own cross signing master key.
     ///
-    /// * ` shared_secret` - A random bytestring encoded as unpadded base64,
+    /// * `shared_secret` - A random bytestring encoded as unpadded base64,
     /// needs to be at least 8 bytes long.
     pub fn new(
         transaction_id: String,


### PR DESCRIPTION
This PR happens in 2 acts.

### First act, Updating `matrix_sdk_qrcode::VerificationData`

Allow `VerificationData` to receive a flow ID.

[This first patch](https://github.com/matrix-org/matrix-rust-sdk/commit/cc5034f4b990430036d23adad5baf9439e53c872) updates `VerificationData` to receive a flow ID,
represented as an owned `String`, instead of an `OwnedEventId`. Why?
Because QR code verification can happen outside a room. In such
scenario, there is no event ID, but a transaction ID, unified behind
the `matrix_sdk_crypto::FlowId` enum. `VerificationData` doesn't
really care about that details. Proof is that `QrVerificationData`
receives an owned `String`, which is then casted into an
`OwnedEventId` to match this API properly; but at the top, it just
receives a string.

This patch brings also a little bit of clean up while editing code
around.

### Second act, Removing a panic in `matrix_sdk_crypto`

[This second patch](https://github.com/matrix-org/matrix-rust-sdk/commit/12b1ec5ef94300c4d98600e92f5443e9d4734bee) updates `QrVerification::new_cross`, by passing a flow ID
as an owned `String` to `VerificationData`, thus removing a panic, **and
allowing QR code verification to happen outside a room**.

### Motivation

This (allowing QR code verification to happen outside a room) was what
motivated this PR.