### PR TITLE
refactor(crypto): Remove the forwarding chains

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -251,8 +251,6 @@ pub fn migrate(
             InboundGroupSession::from_libolm_pickle(&session.pickle, &data.pickle_key)?.pickle();
 
         let sender_key = Curve25519PublicKey::from_base64(&session.sender_key)?;
-        let forwarding_chains: Result<Vec<Curve25519PublicKey>, _> =
-            session.forwarding_chains.iter().map(|k| Curve25519PublicKey::from_base64(k)).collect();
 
         let pickle = matrix_sdk_crypto::olm::PickledInboundGroupSession {
             pickle,
@@ -268,7 +266,6 @@ pub fn migrate(
                 })
                 .collect::<anyhow::Result<_>>()?,
             room_id: RoomId::parse(session.room_id)?,
-            forwarding_chains: forwarding_chains?,
             imported: session.imported,
             backed_up: session.backed_up,
             history_visibility: None,

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -610,16 +610,16 @@ impl OlmMachine {
         let event_json: Event<'_> = serde_json::from_str(decrypted.event.json().get())?;
 
         Ok(match &encryption_info.algorithm_info {
-            AlgorithmInfo::MegolmV1AesSha2 {
-                curve25519_key,
-                sender_claimed_keys,
-                forwarding_curve25519_key_chain,
-            } => DecryptedEvent {
-                clear_event: serde_json::to_string(&event_json)?,
-                sender_curve25519_key: curve25519_key.to_owned(),
-                claimed_ed25519_key: sender_claimed_keys.get(&DeviceKeyAlgorithm::Ed25519).cloned(),
-                forwarding_curve25519_chain: forwarding_curve25519_key_chain.to_owned(),
-            },
+            AlgorithmInfo::MegolmV1AesSha2 { curve25519_key, sender_claimed_keys } => {
+                DecryptedEvent {
+                    clear_event: serde_json::to_string(&event_json)?,
+                    sender_curve25519_key: curve25519_key.to_owned(),
+                    claimed_ed25519_key: sender_claimed_keys
+                        .get(&DeviceKeyAlgorithm::Ed25519)
+                        .cloned(),
+                    forwarding_curve25519_chain: vec![],
+                }
+            }
         })
     }
 

--- a/bindings/matrix-sdk-crypto-js/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-js/src/responses.rs
@@ -182,12 +182,8 @@ impl DecryptedRoomEvent {
     /// Chain of Curve25519 keys through which this session was
     /// forwarded, via `m.forwarded_room_key` events.
     #[wasm_bindgen(getter, js_name = "forwardingCurve25519KeyChain")]
-    pub fn forwarding_curve25519_key_chain(&self) -> Option<Array> {
-        Some(match &self.encryption_info.as_ref()?.algorithm_info {
-            AlgorithmInfo::MegolmV1AesSha2 { forwarding_curve25519_key_chain, .. } => {
-                forwarding_curve25519_key_chain.iter().map(JsValue::from).collect()
-            }
-        })
+    pub fn forwarding_curve25519_key_chain(&self) -> Array {
+        Array::new()
     }
 
     /// The verification state of the device that sent us the event,

--- a/bindings/matrix-sdk-crypto-nodejs/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/responses.rs
@@ -178,12 +178,8 @@ impl DecryptedRoomEvent {
     /// Chain of Curve25519 keys through which this session was
     /// forwarded, via `m.forwarded_room_key` events.
     #[napi(getter)]
-    pub fn forwarding_curve25519_key_chain(&self) -> Option<Vec<String>> {
-        Some(match &self.encryption_info.as_ref()?.algorithm_info {
-            AlgorithmInfo::MegolmV1AesSha2 { forwarding_curve25519_key_chain, .. } => {
-                forwarding_curve25519_key_chain.clone()
-            }
-        })
+    pub fn forwarding_curve25519_key_chain(&self) -> Vec<String> {
+        vec![]
     }
 
     /// The verification state of the device that sent us the event,

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -68,9 +68,6 @@ pub enum AlgorithmInfo {
         /// decrypt this session. This map will usually contain a single ed25519
         /// key.
         sender_claimed_keys: BTreeMap<DeviceKeyAlgorithm, String>,
-        /// Chain of curve25519 keys through which this session was forwarded,
-        /// via m.forwarded_room_key events.
-        forwarding_curve25519_key_chain: Vec<String>,
     },
 }
 

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -112,9 +112,9 @@ impl MegolmV1BackupKey {
     pub(crate) async fn encrypt(&self, session: InboundGroupSession) -> KeyBackupData {
         let pk = OlmPkEncryption::new(&self.to_base64());
 
-        // It's ok to truncate here, there's a semantic difference only between
-        // 0 and 1+ anyways.
-        let forwarded_count = (session.forwarding_key_chain().len() as u32).into();
+        // The forwarding chains don't mean much, we only care whether we received the
+        // session directly from the creator of the session or not.
+        let forwarded_count = (session.has_been_imported() as u8).into();
         let first_message_index = session.first_known_index().into();
 
         // Convert our key to the backup representation.

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -879,7 +879,7 @@ impl GossipMachine {
         algorithm: EventEncryptionAlgorithm,
         content: &ForwardedMegolmV1AesSha2Content,
     ) -> Result<Option<InboundGroupSession>, CryptoStoreError> {
-        match InboundGroupSession::from_forwarded_key(sender_key, &algorithm, content) {
+        match InboundGroupSession::from_forwarded_key(&algorithm, content) {
             Ok(session) => {
                 let old_session = self
                     .store

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1068,11 +1068,6 @@ impl OlmMachine {
                     .iter()
                     .map(|(k, v)| (k.to_owned(), v.to_base64()))
                     .collect(),
-                forwarding_curve25519_key_chain: session
-                    .forwarding_key_chain()
-                    .iter()
-                    .map(|k| k.to_base64())
-                    .collect(),
             },
             verification_state,
         })

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -303,11 +303,6 @@ macro_rules! cryptostore_integration_tests {
 
                 let mut export = session.export().await;
 
-                let curve_key =
-                    Curve25519PublicKey::from_base64("Nn0L2hkcCMFKqynTjyGsJbth7QrVmX3lbrksMkrGOAw")
-                        .unwrap();
-                export.forwarding_curve25519_key_chain = vec![curve_key];
-
                 let session = InboundGroupSession::from_export(&export).unwrap();
 
                 let changes =
@@ -332,7 +327,6 @@ macro_rules! cryptostore_integration_tests {
                     .unwrap();
                 assert_eq!(session, loaded_session);
                 let export = loaded_session.export().await;
-                assert!(!export.forwarding_curve25519_key_chain.is_empty());
 
                 assert_eq!(store.get_inbound_group_sessions().await.unwrap().len(), 1);
                 assert_eq!(store.inbound_group_session_counts().await.unwrap().total, 1);


### PR DESCRIPTION
These aren't really useful since they can be easily spoofed by any room key forwarder.
