### PR TITLE
fix(sdk): Re-export qrcode encoding and decoding error types

### DIFF
--- a/crates/matrix-sdk/src/encryption/verification/mod.rs
+++ b/crates/matrix-sdk/src/encryption/verification/mod.rs
@@ -37,7 +37,10 @@ mod sas;
 
 pub use matrix_sdk_base::crypto::{format_emojis, AcceptSettings, CancelInfo, Emoji};
 #[cfg(feature = "qrcode")]
-pub use matrix_sdk_base::crypto::{matrix_sdk_qrcode::QrVerificationData, ScanError};
+pub use matrix_sdk_base::crypto::{
+    matrix_sdk_qrcode::{DecodingError, EncodingError, QrVerificationData},
+    ScanError,
+};
 #[cfg(feature = "qrcode")]
 pub use qrcode::QrVerification;
 pub use requests::VerificationRequest;


### PR DESCRIPTION
To match errors from `QrVerificationData`.