### PR TITLE
feat(bindings): Expose redact method to FFI.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -104,6 +104,9 @@ interface Room {
 
     [Throws=ClientError]
     void send(MessageEventContent msg, string? txn_id);
+    
+    [Throws=ClientError]
+    void redact(string event_id, string? reason, string? txn_id);
 };
 
 interface BackwardsStream {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
     room::Room as MatrixRoom,
-    ruma::{events::room::message::RoomMessageEventContent, UserId},
+    ruma::{events::room::message::RoomMessageEventContent, EventId, UserId},
 };
 
 use super::{
@@ -161,6 +161,34 @@ impl Room {
         })?;
 
         Ok(())
+    }
+
+    /// Redacts an event from the room.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - The ID of the event to redact
+    ///
+    /// * `reason` - The reason for the event being redacted (optional).
+    ///
+    /// * `txn_id` - A unique ID that can be attached to this event as
+    /// its transaction ID (optional). If not given one is created.
+    pub fn redact(
+        &self,
+        event_id: String,
+        reason: Option<String>,
+        txn_id: Option<String>,
+    ) -> Result<()> {
+        let room = match &self.room {
+            MatrixRoom::Joined(j) => j.clone(),
+            _ => bail!("Can't redact in a room that isn't in joined state"),
+        };
+
+        RUNTIME.block_on(async move {
+            let event_id = EventId::parse(event_id)?;
+            room.redact(&event_id, reason.as_deref(), txn_id.map(Into::into)).await?;
+            Ok(())
+        })
     }
 }
 


### PR DESCRIPTION
I think the plan is to eventually add a higher level API here along with the react/unreact and edits, but for now here's a PR that adds the existing redact method to the FFI.