### PR TITLE
feat(crypto-js): Implement `OlmMachine.get_identity`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -6,7 +6,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     future::future_to_promise,
     identifiers::{self, DeviceId, UserId},
-    types, verification, vodozemac,
+    impl_from_to_inner, types, verification, vodozemac,
 };
 
 /// A device represents a E2EE capable client of an user.
@@ -16,11 +16,7 @@ pub struct Device {
     pub(crate) inner: matrix_sdk_crypto::Device,
 }
 
-impl From<matrix_sdk_crypto::Device> for Device {
-    fn from(inner: matrix_sdk_crypto::Device) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::Device => Device);
 
 #[wasm_bindgen]
 impl Device {
@@ -228,11 +224,7 @@ pub struct UserDevices {
     pub(crate) inner: matrix_sdk_crypto::UserDevices,
 }
 
-impl From<matrix_sdk_crypto::UserDevices> for UserDevices {
-    fn from(inner: matrix_sdk_crypto::UserDevices) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::UserDevices => UserDevices);
 
 #[wasm_bindgen]
 impl UserDevices {

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -6,7 +6,9 @@ use wasm_bindgen::prelude::*;
 use crate::{
     future::future_to_promise,
     identifiers::{self, DeviceId, UserId},
-    impl_from_to_inner, types, verification, vodozemac,
+    impl_from_to_inner,
+    js::try_array_to_vec,
+    types, verification, vodozemac,
 };
 
 /// A device represents a E2EE capable client of an user.
@@ -23,16 +25,8 @@ impl Device {
     /// Request an interactive verification with this device.
     #[wasm_bindgen(js_name = "requestVerification")]
     pub fn request_verification(&self, methods: Option<Array>) -> Result<Promise, JsError> {
-        let methods = methods
-            .map(|array| {
-                array
-                    .iter()
-                    .map(|method| {
-                        verification::VerificationMethod::try_from(method).map(Into::into)
-                    })
-                    .collect::<Result<_, _>>()
-            })
-            .transpose()?;
+        let methods =
+            methods.map(try_array_to_vec::<verification::VerificationMethod, _>).transpose()?;
         let me = self.inner.clone();
 
         Ok(future_to_promise(async move {

--- a/bindings/matrix-sdk-crypto-js/src/identifiers.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identifiers.rs
@@ -279,3 +279,42 @@ impl ServerName {
         self.inner.is_ip_literal()
     }
 }
+
+/// A Matrix [event ID].
+///
+/// An `EventId` is generated randomly or converted from a string
+/// slice, and can be converted back into a string as needed.
+///
+/// [event ID]: https://spec.matrix.org/v1.2/appendices/#room-ids-and-event-ids
+#[wasm_bindgen]
+pub struct EventId {
+    inner: ruma::OwnedEventId,
+}
+
+#[wasm_bindgen]
+impl EventId {
+    /// Parse/validate and create a new `EventId`.
+    #[wasm_bindgen(constructor)]
+    pub fn new(id: &str) -> Result<EventId, JsError> {
+        Ok(Self { inner: <&ruma::EventId>::try_from(id)?.to_owned() })
+    }
+
+    /// Returns the event's localpart.
+    #[wasm_bindgen(getter)]
+    pub fn localpart(&self) -> String {
+        self.inner.localpart().to_owned()
+    }
+
+    /// Returns the server name of the event ID.
+    #[wasm_bindgen(getter, js_name = "serverName")]
+    pub fn server_name(&self) -> Option<ServerName> {
+        Some(ServerName { inner: self.inner.server_name()?.to_owned() })
+    }
+
+    /// Return the event ID as a string.
+    #[wasm_bindgen(js_name = "toString")]
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(&self) -> String {
+        self.inner.as_str().to_owned()
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/identifiers.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identifiers.rs
@@ -288,7 +288,7 @@ impl ServerName {
 /// [event ID]: https://spec.matrix.org/v1.2/appendices/#room-ids-and-event-ids
 #[wasm_bindgen]
 pub struct EventId {
-    inner: ruma::OwnedEventId,
+    pub(crate) inner: ruma::OwnedEventId,
 }
 
 #[wasm_bindgen]

--- a/bindings/matrix-sdk-crypto-js/src/identifiers.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identifiers.rs
@@ -287,6 +287,7 @@ impl ServerName {
 ///
 /// [event ID]: https://spec.matrix.org/v1.2/appendices/#room-ids-and-event-ids
 #[wasm_bindgen]
+#[derive(Debug)]
 pub struct EventId {
     pub(crate) inner: ruma::OwnedEventId,
 }

--- a/bindings/matrix-sdk-crypto-js/src/identifiers.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identifiers.rs
@@ -3,6 +3,8 @@
 
 use wasm_bindgen::prelude::*;
 
+use crate::impl_from_to_inner;
+
 /// A Matrix [user ID].
 ///
 /// [user ID]: https://spec.matrix.org/v1.2/appendices/#user-identifiers
@@ -12,11 +14,7 @@ pub struct UserId {
     pub(crate) inner: ruma::OwnedUserId,
 }
 
-impl From<ruma::OwnedUserId> for UserId {
-    fn from(inner: ruma::OwnedUserId) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(ruma::OwnedUserId => UserId);
 
 #[wasm_bindgen]
 impl UserId {
@@ -66,11 +64,7 @@ pub struct DeviceId {
     pub(crate) inner: ruma::OwnedDeviceId,
 }
 
-impl From<ruma::OwnedDeviceId> for DeviceId {
-    fn from(inner: ruma::OwnedDeviceId) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(ruma::OwnedDeviceId => DeviceId);
 
 #[wasm_bindgen]
 impl DeviceId {
@@ -97,11 +91,7 @@ pub struct DeviceKeyId {
     pub(crate) inner: ruma::OwnedDeviceKeyId,
 }
 
-impl From<ruma::OwnedDeviceKeyId> for DeviceKeyId {
-    fn from(inner: ruma::OwnedDeviceKeyId) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(ruma::OwnedDeviceKeyId => DeviceKeyId);
 
 #[wasm_bindgen]
 impl DeviceKeyId {
@@ -138,11 +128,7 @@ pub struct DeviceKeyAlgorithm {
     pub(crate) inner: ruma::DeviceKeyAlgorithm,
 }
 
-impl From<ruma::DeviceKeyAlgorithm> for DeviceKeyAlgorithm {
-    fn from(inner: ruma::DeviceKeyAlgorithm) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(ruma::DeviceKeyAlgorithm => DeviceKeyAlgorithm);
 
 #[wasm_bindgen]
 impl DeviceKeyAlgorithm {
@@ -221,11 +207,7 @@ pub struct RoomId {
     pub(crate) inner: ruma::OwnedRoomId,
 }
 
-impl From<ruma::OwnedRoomId> for RoomId {
-    fn from(inner: ruma::OwnedRoomId) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(ruma::OwnedRoomId => RoomId);
 
 #[wasm_bindgen]
 impl RoomId {

--- a/bindings/matrix-sdk-crypto-js/src/identities.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identities.rs
@@ -78,7 +78,7 @@ impl OwnUserIdentity {
     }
 
     /// Does our user identity trust our own device, i.e. have we signed our own
-    /// device keys with our self-signing key.
+    /// device keys with our self-signing key?
     #[wasm_bindgen(js_name = "trustsOurOwnDevice")]
     pub fn trusts_our_own_device(&self) -> Promise {
         let me = self.inner.clone();

--- a/bindings/matrix-sdk-crypto-js/src/identities.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identities.rs
@@ -1,0 +1,98 @@
+//! User identities.
+
+use js_sys::{Array, Promise};
+use ruma::events::key::verification::VerificationMethod as RumaVerificationMethod;
+use wasm_bindgen::prelude::*;
+
+use crate::{future::future_to_promise, identifiers, impl_from_to_inner, requests, verification};
+
+pub(crate) struct UserIdentities {
+    inner: matrix_sdk_crypto::UserIdentities,
+}
+
+impl_from_to_inner!(matrix_sdk_crypto::UserIdentities => UserIdentities);
+
+impl From<UserIdentities> for JsValue {
+    fn from(user_identities: UserIdentities) -> Self {
+        use matrix_sdk_crypto::UserIdentities::*;
+
+        match user_identities.inner {
+            Own(own) => JsValue::from(OwnUserIdentity::from(own)),
+            Other(other) => JsValue::from(UserIdentity::from(other)),
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct OwnUserIdentity {
+    inner: matrix_sdk_crypto::OwnUserIdentity,
+}
+
+impl_from_to_inner!(matrix_sdk_crypto::OwnUserIdentity => OwnUserIdentity);
+
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct UserIdentity {
+    inner: matrix_sdk_crypto::UserIdentity,
+}
+
+impl_from_to_inner!(matrix_sdk_crypto::UserIdentity => UserIdentity);
+
+#[wasm_bindgen]
+impl UserIdentity {
+    /// Is this user identity verified?
+    #[wasm_bindgen(js_name = "isVerified")]
+    pub fn is_verified(&self) -> bool {
+        self.inner.is_verified()
+    }
+
+    /// Manually verify this user.
+    ///
+    /// This method will attempt to sign the user identity using our private
+    /// cross signing key.
+    ///
+    /// This method fails if we don't have the private part of our user-signing
+    /// key.
+    ///
+    /// Returns a request that needs to be sent out for the user to be marked as
+    /// verified.
+    pub fn verify(&self) -> Promise {
+        let me = self.inner.clone();
+
+        future_to_promise(async move {
+            Ok(requests::SignatureUploadRequest::try_from(&me.verify().await?)?)
+        })
+    }
+
+    /// Create a `VerificationRequest` object after the verification
+    /// request content has been sent out.  }
+    #[wasm_bindgen(js_name = "requestVerification")]
+    pub fn request_verification(
+        &self,
+        room_id: &identifiers::RoomId,
+        request_event_id: &identifiers::EventId,
+        methods: Option<Array>,
+    ) -> Result<Promise, JsError> {
+        let me = self.inner.clone();
+        let room_id = room_id.inner.clone();
+        let request_event_id = request_event_id.inner.clone();
+        let methods: Option<Vec<RumaVerificationMethod>> = methods
+            .map(|array| {
+                array
+                    .iter()
+                    .map(|method| {
+                        verification::VerificationMethod::try_from(method).map(Into::into)
+                    })
+                    .collect::<Result<_, _>>()
+            })
+            .transpose()?;
+
+        Ok(future_to_promise::<_, verification::VerificationRequest>(async move {
+            Ok(me
+                .request_verification(room_id.as_ref(), request_event_id.as_ref(), methods)
+                .await
+                .into())
+        }))
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/identities.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identities.rs
@@ -1,10 +1,12 @@
 //! User identities.
 
 use js_sys::{Array, Promise};
-use ruma::events::key::verification::VerificationMethod as RumaVerificationMethod;
 use wasm_bindgen::prelude::*;
 
-use crate::{future::future_to_promise, identifiers, impl_from_to_inner, requests, verification};
+use crate::{
+    future::future_to_promise, identifiers, impl_from_to_inner, js::try_array_to_vec, requests,
+    verification,
+};
 
 pub(crate) struct UserIdentities {
     inner: matrix_sdk_crypto::UserIdentities,
@@ -77,16 +79,8 @@ impl UserIdentity {
         let me = self.inner.clone();
         let room_id = room_id.inner.clone();
         let request_event_id = request_event_id.inner.clone();
-        let methods: Option<Vec<RumaVerificationMethod>> = methods
-            .map(|array| {
-                array
-                    .iter()
-                    .map(|method| {
-                        verification::VerificationMethod::try_from(method).map(Into::into)
-                    })
-                    .collect::<Result<_, _>>()
-            })
-            .transpose()?;
+        let methods =
+            methods.map(try_array_to_vec::<verification::VerificationMethod, _>).transpose()?;
 
         Ok(future_to_promise::<_, verification::VerificationRequest>(async move {
             Ok(me

--- a/bindings/matrix-sdk-crypto-js/src/js.rs
+++ b/bindings/matrix-sdk-crypto-js/src/js.rs
@@ -1,0 +1,40 @@
+use js_sys::{Array, Object, Reflect};
+use wasm_bindgen::{convert::RefFromWasmAbi, prelude::*};
+
+/// A really hacky and dirty code to downcast a `JsValue` to `T:
+/// RefFromWasmAbi`, inspired by
+/// https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-656293288.
+///
+/// The returned value is likely to be a `wasm_bindgen::__ref::Ref<T>`.
+pub(crate) fn downcast<T>(value: &JsValue, classname: &str) -> Result<T::Anchor, JsError>
+where
+    T: RefFromWasmAbi<Abi = u32>,
+{
+    let constructor_name = Object::get_prototype_of(value).constructor().name();
+
+    if constructor_name == classname {
+        let pointer = Reflect::get(value, &JsValue::from_str("ptr"))
+            .map_err(|_| JsError::new("Failed to read the `JsValue` pointer"))?;
+        let pointer = pointer
+            .as_f64()
+            .ok_or_else(|| JsError::new("Failed to read the `JsValue` pointer as a `f64`"))?
+            as u32;
+
+        Ok(unsafe { T::ref_from_abi(pointer) })
+    } else {
+        Err(JsError::new(&format!(
+            "Expect an `{classname}` instance, received `{constructor_name}` instead",
+        )))
+    }
+}
+
+/// Transform a value `JS` from JavaScript to a Rust wrapper, to a
+/// Rust wrapped type.
+pub(crate) fn try_array_to_vec<JS, Rust>(
+    array: Array,
+) -> Result<Vec<Rust>, <JS as TryFrom<JsValue>>::Error>
+where
+    JS: TryFrom<JsValue> + Into<Rust>,
+{
+    array.iter().map(|item| JS::try_from(item).map(Into::into)).collect()
+}

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -23,6 +23,7 @@ pub mod encryption;
 pub mod events;
 mod future;
 pub mod identifiers;
+pub mod identities;
 pub mod machine;
 pub mod olm;
 mod macros;

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -25,6 +25,7 @@ mod future;
 pub mod identifiers;
 pub mod machine;
 pub mod olm;
+mod macros;
 pub mod requests;
 pub mod responses;
 pub mod store;

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -10,7 +10,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     device, downcast, encryption,
     future::future_to_promise,
-    identifiers, olm, requests,
+    identifiers, identities, olm, requests,
     requests::OutgoingRequest,
     responses::{self, response_from_string},
     store, sync_events, types, verification, vodozemac,
@@ -410,6 +410,17 @@ impl OlmMachine {
             );
 
             Ok(tuple)
+        })
+    }
+
+    /// Get the cross signing user identity of a user.
+    #[wasm_bindgen(js_name = "getIdentity")]
+    pub fn get_identity(&self, user_id: &identifiers::UserId) -> Promise {
+        let me = self.inner.clone();
+        let user_id = user_id.inner.clone();
+
+        future_to_promise(async move {
+            Ok(me.get_identity(user_id.as_ref(), None).await?.map(identities::UserIdentities::from))
         })
     }
 

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -8,9 +8,11 @@ use serde_json::Value as JsonValue;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    device, downcast, encryption,
+    device, encryption,
     future::future_to_promise,
-    identifiers, identities, olm, requests,
+    identifiers, identities,
+    js::downcast,
+    olm, requests,
     requests::OutgoingRequest,
     responses::{self, response_from_string},
     store, sync_events, types, verification, vodozemac,

--- a/bindings/matrix-sdk-crypto-js/src/macros.rs
+++ b/bindings/matrix-sdk-crypto-js/src/macros.rs
@@ -1,0 +1,33 @@
+/// We have the following pattern quite often in our code:
+///
+/// ```rust
+/// struct Foo {
+///     inner: Bar,
+/// }
+///
+/// impl From<Bar> for Foo {
+///     fn from(inner: Bar) -> Self {
+///         Self { inner }
+///     }
+/// }
+/// ```
+///
+/// Because I feel lazy, let's do a macro to write this:
+///
+/// ```rust
+/// struct Foo {
+///     inner: Bar,
+/// }
+///
+/// impl_from_to_inner!(Bar => Foo);
+/// ```
+#[macro_export]
+macro_rules! impl_from_to_inner {
+    ($from:ty => $to:ty) => {
+        impl From<$from> for $to {
+            fn from(inner: $from) -> Self {
+                Self { inner }
+            }
+        }
+    };
+}

--- a/bindings/matrix-sdk-crypto-js/src/olm.rs
+++ b/bindings/matrix-sdk-crypto-js/src/olm.rs
@@ -2,6 +2,8 @@
 
 use wasm_bindgen::prelude::*;
 
+use crate::impl_from_to_inner;
+
 /// Struct representing the state of our private cross signing keys,
 /// it shows which private cross signing keys we have locally stored.
 #[wasm_bindgen]
@@ -10,11 +12,7 @@ pub struct CrossSigningStatus {
     inner: matrix_sdk_crypto::olm::CrossSigningStatus,
 }
 
-impl From<matrix_sdk_crypto::olm::CrossSigningStatus> for CrossSigningStatus {
-    fn from(inner: matrix_sdk_crypto::olm::CrossSigningStatus) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::olm::CrossSigningStatus => CrossSigningStatus);
 
 #[wasm_bindgen]
 impl CrossSigningStatus {

--- a/bindings/matrix-sdk-crypto-js/src/store.rs
+++ b/bindings/matrix-sdk-crypto-js/src/store.rs
@@ -2,6 +2,8 @@
 
 use wasm_bindgen::prelude::*;
 
+use crate::impl_from_to_inner;
+
 /// A struct containing private cross signing keys that can be backed
 /// up or uploaded to the secret store.
 #[wasm_bindgen]
@@ -10,11 +12,7 @@ pub struct CrossSigningKeyExport {
     pub(crate) inner: matrix_sdk_crypto::store::CrossSigningKeyExport,
 }
 
-impl From<matrix_sdk_crypto::store::CrossSigningKeyExport> for CrossSigningKeyExport {
-    fn from(inner: matrix_sdk_crypto::store::CrossSigningKeyExport) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::store::CrossSigningKeyExport => CrossSigningKeyExport);
 
 #[wasm_bindgen]
 impl CrossSigningKeyExport {

--- a/bindings/matrix-sdk-crypto-js/src/sync_events.rs
+++ b/bindings/matrix-sdk-crypto-js/src/sync_events.rs
@@ -3,7 +3,7 @@
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
 
-use crate::{downcast, identifiers};
+use crate::{identifiers, js::downcast};
 
 /// Information on E2E device updates.
 #[wasm_bindgen]

--- a/bindings/matrix-sdk-crypto-js/src/types.rs
+++ b/bindings/matrix-sdk-crypto-js/src/types.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     identifiers::{DeviceKeyId, UserId},
+    impl_from_to_inner,
     vodozemac::Ed25519Signature,
 };
 
@@ -15,11 +16,7 @@ pub struct Signatures {
     inner: matrix_sdk_crypto::types::Signatures,
 }
 
-impl From<matrix_sdk_crypto::types::Signatures> for Signatures {
-    fn from(inner: matrix_sdk_crypto::types::Signatures) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::types::Signatures => Signatures);
 
 #[wasm_bindgen]
 impl Signatures {
@@ -97,11 +94,7 @@ pub struct Signature {
     inner: matrix_sdk_crypto::types::Signature,
 }
 
-impl From<matrix_sdk_crypto::types::Signature> for Signature {
-    fn from(inner: matrix_sdk_crypto::types::Signature) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::types::Signature => Signature);
 
 #[wasm_bindgen]
 impl Signature {
@@ -129,11 +122,7 @@ pub struct MaybeSignature {
     inner: MaybeSignatureInner,
 }
 
-impl From<MaybeSignatureInner> for MaybeSignature {
-    fn from(inner: MaybeSignatureInner) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(MaybeSignatureInner => MaybeSignature);
 
 #[wasm_bindgen]
 impl MaybeSignature {

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -14,7 +14,9 @@ use wasm_bindgen::prelude::*;
 use crate::{
     future::future_to_promise,
     identifiers::{DeviceId, RoomId, UserId},
-    impl_from_to_inner, requests,
+    impl_from_to_inner,
+    js::try_array_to_vec,
+    requests,
 };
 
 /// List of available verification methods.
@@ -788,14 +790,7 @@ impl VerificationRequest {
         other_user_id: &UserId,
         methods: Option<Array>,
     ) -> Result<String, JsError> {
-        let methods: Option<Vec<RumaVerificationMethod>> = methods
-            .map(|array| {
-                array
-                    .iter()
-                    .map(|method| VerificationMethod::try_from(method).map(Into::into))
-                    .collect::<Result<_, _>>()
-            })
-            .transpose()?;
+        let methods = methods.map(try_array_to_vec::<VerificationMethod, _>).transpose()?;
 
         Ok(serde_json::to_string(&matrix_sdk_crypto::VerificationRequest::request(
             &own_user_id.inner,
@@ -936,10 +931,7 @@ impl VerificationRequest {
     /// or `undefined`.
     #[wasm_bindgen(js_name = "acceptWithMethods")]
     pub fn accept_with_methods(&self, methods: Array) -> Result<JsValue, JsError> {
-        let methods: Vec<RumaVerificationMethod> = methods
-            .iter()
-            .map(|method| VerificationMethod::try_from(method).map(Into::into))
-            .collect::<Result<_, _>>()?;
+        let methods = try_array_to_vec::<VerificationMethod, _>(methods)?;
 
         self.inner
             .accept_with_methods(methods)

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -14,7 +14,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     future::future_to_promise,
     identifiers::{DeviceId, RoomId, UserId},
-    requests,
+    impl_from_to_inner, requests,
 };
 
 /// List of available verification methods.
@@ -136,11 +136,7 @@ pub struct Sas {
     inner: matrix_sdk_crypto::Sas,
 }
 
-impl From<matrix_sdk_crypto::Sas> for Sas {
-    fn from(inner: matrix_sdk_crypto::Sas) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::Sas => Sas);
 
 #[wasm_bindgen]
 impl Sas {
@@ -376,11 +372,7 @@ pub struct Qr {
 }
 
 #[cfg(feature = "qrcode")]
-impl From<matrix_sdk_crypto::QrVerification> for Qr {
-    fn from(inner: matrix_sdk_crypto::QrVerification) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::QrVerification => Qr);
 
 #[cfg(feature = "qrcode")]
 #[wasm_bindgen]
@@ -555,11 +547,7 @@ pub struct CancelInfo {
     inner: matrix_sdk_crypto::CancelInfo,
 }
 
-impl From<matrix_sdk_crypto::CancelInfo> for CancelInfo {
-    fn from(inner: matrix_sdk_crypto::CancelInfo) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::CancelInfo => CancelInfo);
 
 #[wasm_bindgen]
 impl CancelInfo {
@@ -694,11 +682,7 @@ pub struct Emoji {
     inner: matrix_sdk_crypto::Emoji,
 }
 
-impl From<matrix_sdk_crypto::Emoji> for Emoji {
-    fn from(inner: matrix_sdk_crypto::Emoji) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::Emoji => Emoji);
 
 #[wasm_bindgen]
 impl Emoji {
@@ -731,11 +715,7 @@ impl fmt::Debug for QrCode {
 }
 
 #[cfg(feature = "qrcode")]
-impl From<matrix_sdk_qrcode::qrcode::QrCode> for QrCode {
-    fn from(inner: matrix_sdk_qrcode::qrcode::QrCode) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_qrcode::qrcode::QrCode => QrCode);
 
 #[cfg(feature = "qrcode")]
 #[wasm_bindgen]
@@ -762,11 +742,7 @@ pub struct QrCodeScan {
 }
 
 #[cfg(feature = "qrcode")]
-impl From<matrix_sdk_qrcode::QrVerificationData> for QrCodeScan {
-    fn from(inner: matrix_sdk_qrcode::QrVerificationData) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_qrcode::QrVerificationData => QrCodeScan);
 
 #[cfg(feature = "qrcode")]
 #[wasm_bindgen]
@@ -797,11 +773,7 @@ pub struct VerificationRequest {
     inner: matrix_sdk_crypto::VerificationRequest,
 }
 
-impl From<matrix_sdk_crypto::VerificationRequest> for VerificationRequest {
-    fn from(inner: matrix_sdk_crypto::VerificationRequest) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::VerificationRequest => VerificationRequest);
 
 #[wasm_bindgen]
 impl VerificationRequest {
@@ -1078,15 +1050,11 @@ impl VerificationRequest {
 // JavaScript has no complex enums like Rust. To return structs of
 // different types, we have no choice that hiding everything behind a
 // `JsValue`.
-pub(crate) struct OutgoingVerificationRequest(
-    pub(crate) matrix_sdk_crypto::OutgoingVerificationRequest,
-);
-
-impl From<matrix_sdk_crypto::OutgoingVerificationRequest> for OutgoingVerificationRequest {
-    fn from(inner: matrix_sdk_crypto::OutgoingVerificationRequest) -> Self {
-        Self(inner)
-    }
+pub(crate) struct OutgoingVerificationRequest {
+    pub(crate) inner: matrix_sdk_crypto::OutgoingVerificationRequest,
 }
+
+impl_from_to_inner!(matrix_sdk_crypto::OutgoingVerificationRequest => OutgoingVerificationRequest);
 
 impl TryFrom<OutgoingVerificationRequest> for JsValue {
     type Error = serde_json::Error;
@@ -1094,9 +1062,9 @@ impl TryFrom<OutgoingVerificationRequest> for JsValue {
     fn try_from(outgoing_request: OutgoingVerificationRequest) -> Result<Self, Self::Error> {
         use matrix_sdk_crypto::OutgoingVerificationRequest::*;
 
-        let request_id = outgoing_request.0.request_id().to_string();
+        let request_id = outgoing_request.inner.request_id().to_string();
 
-        Ok(match outgoing_request.0 {
+        Ok(match outgoing_request.inner {
             ToDevice(request) => {
                 JsValue::from(requests::ToDeviceRequest::try_from((request_id, &request))?)
             }

--- a/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
+++ b/bindings/matrix-sdk-crypto-js/src/vodozemac.rs
@@ -2,6 +2,8 @@
 
 use wasm_bindgen::prelude::*;
 
+use crate::impl_from_to_inner;
+
 /// An Ed25519 public key, used to verify digital signatures.
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
@@ -25,11 +27,7 @@ impl Ed25519PublicKey {
     }
 }
 
-impl From<vodozemac::Ed25519PublicKey> for Ed25519PublicKey {
-    fn from(inner: vodozemac::Ed25519PublicKey) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(vodozemac::Ed25519PublicKey => Ed25519PublicKey);
 
 /// An Ed25519 digital signature, can be used to verify the
 /// authenticity of a message.
@@ -39,11 +37,7 @@ pub struct Ed25519Signature {
     pub(crate) inner: vodozemac::Ed25519Signature,
 }
 
-impl From<vodozemac::Ed25519Signature> for Ed25519Signature {
-    fn from(inner: vodozemac::Ed25519Signature) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(vodozemac::Ed25519Signature => Ed25519Signature);
 
 #[wasm_bindgen]
 impl Ed25519Signature {
@@ -85,11 +79,7 @@ impl Curve25519PublicKey {
     }
 }
 
-impl From<vodozemac::Curve25519PublicKey> for Curve25519PublicKey {
-    fn from(inner: vodozemac::Curve25519PublicKey) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(vodozemac::Curve25519PublicKey => Curve25519PublicKey);
 
 /// Struct holding the two public identity keys of an account.
 #[wasm_bindgen(getter_with_clone)]
@@ -122,11 +112,7 @@ pub struct DeviceKey {
     inner: matrix_sdk_crypto::types::DeviceKey,
 }
 
-impl From<matrix_sdk_crypto::types::DeviceKey> for DeviceKey {
-    fn from(inner: matrix_sdk_crypto::types::DeviceKey) -> Self {
-        Self { inner }
-    }
-}
+impl_from_to_inner!(matrix_sdk_crypto::types::DeviceKey => DeviceKey);
 
 #[wasm_bindgen]
 impl DeviceKey {

--- a/bindings/matrix-sdk-crypto-js/tests/identifiers.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/identifiers.test.js
@@ -1,4 +1,13 @@
-const { UserId, DeviceId, DeviceKeyId, DeviceKeyAlgorithm, DeviceKeyAlgorithmName, RoomId, ServerName } = require('../pkg/matrix_sdk_crypto_js');
+const {
+    DeviceId,
+    DeviceKeyAlgorithm,
+    DeviceKeyAlgorithmName,
+    DeviceKeyId,
+    EventId,
+    RoomId,
+    ServerName,
+    UserId,
+} = require('../pkg/matrix_sdk_crypto_js');
 
 describe(UserId.name, () => {
     test('cannot be invalid', () => {
@@ -116,3 +125,57 @@ describe(ServerName.name, () => {
         expect(new ServerName('foo.org').isIpLiteral()).toStrictEqual(false);
     });
 });
+
+describe(EventId.name, () => {
+    test('cannot be invalid', () => {
+        expect(() => { new EventId('%foo') }).toThrow();
+    });
+
+    describe('Versions 1 & 2', () => {
+        const room = new EventId('$h29iv0s8:foo.org');
+
+        test('localpart is present', () => {
+            expect(room.localpart).toStrictEqual('h29iv0s8');
+        });
+
+        test('server name is present', () => {
+            expect(room.serverName).toBeInstanceOf(ServerName);
+        });
+
+        test('can read the room ID as string', () => {
+            expect(room.toString()).toStrictEqual('$h29iv0s8:foo.org');
+        });
+    });
+
+    describe('Version 3', () => {
+        const room = new EventId('$acR1l0raoZnm60CBwAVgqbZqoO/mYU81xysh1u7XcJk');
+
+        test('localpart is present', () => {
+            expect(room.localpart).toStrictEqual('acR1l0raoZnm60CBwAVgqbZqoO/mYU81xysh1u7XcJk');
+        });
+
+        test('server name is present', () => {
+            expect(room.serverName).toBeUndefined();
+        });
+
+        test('can read the room ID as string', () => {
+            expect(room.toString()).toStrictEqual('$acR1l0raoZnm60CBwAVgqbZqoO/mYU81xysh1u7XcJk');
+        });
+    });
+
+    describe('Version 4', () => {
+        const room = new EventId('$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg');
+
+        test('localpart is present', () => {
+            expect(room.localpart).toStrictEqual('Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg');
+        });
+
+        test('server name is present', () => {
+            expect(room.serverName).toBeUndefined();
+        });
+
+        test('can read the room ID as string', () => {
+            expect(room.toString()).toStrictEqual('$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg');
+        });
+    });
+})

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -86,7 +86,7 @@ impl From<UserIdentity> for UserIdentities {
 
 /// Struct representing a cross signing identity of a user.
 ///
-/// This is the user identity of a user that isn't our own. Other users will
+/// This is the user identity of a user that is our own. Other users will
 /// only contain a master key and a self signing key, meaning that only device
 /// signatures can be checked with this identity.
 ///


### PR DESCRIPTION
Related to https://github.com/matrix-org/matrix-rust-sdk/issues/1016.

This PR does the following::

* Implement `EventId` (with tests for version 1 to 4),
* Simplify a little bit the code with one `impl_from_to_inner!` simple macro,
* Simplify a little bit the code with a small helper `try_array_to_vec`, it will probably be revamped later with a more general approach,
* Implement `OlmMachine.get_identity` with `OwnUserIdentity` and `UserIdentity`.