### PR TITLE
fix(jack-in): limit log4rs features to minimum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,12 +2271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2299,7 +2293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
- "serde",
 ]
 
 [[package]]
@@ -2319,19 +2312,11 @@ dependencies = [
  "chrono",
  "derivative",
  "fnv",
- "humantime",
- "libc",
  "log",
  "log-mdc",
  "parking_lot 0.12.1",
- "serde",
- "serde-value",
- "serde_json",
- "serde_yaml 0.8.26",
  "thiserror",
  "thread-id",
- "typemap",
- "winapi",
 ]
 
 [[package]]
@@ -2429,7 +2414,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
- "serde_yaml 0.9.10",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tracing",
@@ -3107,15 +3092,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-float"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -4040,16 +4016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float",
- "serde",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4111,18 +4077,6 @@ dependencies = [
  "itoa 1.0.3",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]
@@ -4770,12 +4724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "traitobject"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4832,15 +4780,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "typemap"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653be63c80a3296da5551e1bfd2cca35227e13cdd08c6668903ae2f4f77aa1f6"
-dependencies = [
- "unsafe-any",
 ]
 
 [[package]]
@@ -4979,15 +4918,6 @@ checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",
-]
-
-[[package]]
-name = "unsafe-any"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
-dependencies = [
- "traitobject",
 ]
 
 [[package]]
@@ -5470,15 +5400,6 @@ dependencies = [
  "serde",
  "serde_json",
  "xshell",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/labs/jack-in/Cargo.toml
+++ b/labs/jack-in/Cargo.toml
@@ -25,4 +25,4 @@ tui-logger = "0.8.0"
 
 # file-logging specials
 tracing = { version = "0.1.35", features = ["log"] }
-log4rs = { version = " 1.1.1", features = ["file_appender"], optional = true }
+log4rs = { version = " 1.1.1", default-features = false, features = ["file_appender"], optional = true }

--- a/labs/jack-in/src/main.rs
+++ b/labs/jack-in/src/main.rs
@@ -127,7 +127,6 @@ async fn main() -> Result<()> {
                 config::{Appender, Config, Logger, Root},
                 encode::pattern::PatternEncoder,
             };
-            use tracing::level_filters::LevelFilter;
 
             let file = FileAppender::builder()
                 .encoder(Box::new(PatternEncoder::default()))
@@ -156,8 +155,7 @@ async fn main() -> Result<()> {
                 .build(Root::builder().build(LevelFilter::Error))
                 .unwrap();
 
-            let handle =
-                log4rs::init_config(config).expect("Logging with log4rs failed to initialize");
+            log4rs::init_config(config).expect("Logging with log4rs failed to initialize");
         }
         #[cfg(not(feature = "file-logging"))]
         {


### PR DESCRIPTION
Removes a vulnerable dependency (`traitobject`) from our dependency tree.