### PR TITLE
Switch ffi layer logs output to stderr instead of stdout

### DIFF
--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -13,6 +13,8 @@ pub mod session_verification;
 pub mod sliding_sync;
 mod uniffi_api;
 
+use std::io;
+
 use client::Client;
 use client_builder::ClientBuilder;
 use matrix_sdk::Session;
@@ -66,7 +68,7 @@ impl From<anyhow::Error> for ClientError {
 fn setup_tracing(configuration: String) {
     tracing_subscriber::registry()
         .with(EnvFilter::new(configuration))
-        .with(fmt::layer().with_ansi(false))
+        .with(fmt::layer().with_ansi(false).with_writer(io::stderr))
         .init();
 }
 


### PR DESCRIPTION
The swift side uses stderr as the default log destination and redirects that to a log file when no debugger is attached. This is important for getting rageshake log files from client devices. Rust on the other hand uses stdout by default. This PR switches the FFI layer to stderr as well.
I think there's also a discussion to be had on whether stderr should the default throughout the rust sdk or whether the destination should be configurable on the FFI layer.