### PR TITLE
feat(crypto-js): Implement `OlmMachine.export_room_keys` and `.import_room_keys`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -690,4 +690,42 @@ impl OlmMachine {
             }))?)
         }))
     }
+
+    /// Encrypt the list of exported room keys using the given passphrase.
+    ///
+    /// `exported_room_keys` is a list of sessions that should be encrypted
+    /// (it's generally returned by `export_room_keys`). `passphrase` is the
+    /// passphrase that will be used to encrypt the exported room keys. And
+    /// `rounds` is the number of rounds that should be used for the key
+    /// derivation when the passphrase gets turned into an AES key. More rounds
+    /// are increasingly computationnally intensive and as such help against
+    /// brute-force attacks. Should be at least `10_000`, while values in the
+    /// `100_000` ranges should be preferred.
+    #[wasm_bindgen(js_name = "encryptExportedRoomKeys")]
+    pub fn encrypt_exported_room_keys(
+        exported_room_keys: &str,
+        passphrase: &str,
+        rounds: u32,
+    ) -> Result<String, JsError> {
+        let exported_room_keys: Vec<matrix_sdk_crypto::olm::ExportedRoomKey> =
+            serde_json::from_str(exported_room_keys)?;
+
+        Ok(matrix_sdk_crypto::encrypt_room_key_export(&exported_room_keys, passphrase, rounds)?)
+    }
+
+    /// Try to decrypt a reader into a list of exported room keys.
+    ///
+    /// `encrypted_exported_room_keys` is the result from
+    /// `encrypt_exported_room_keys`. `passphrase` is the passphrase that was
+    /// used when calling `encrypt_exported_room_keys`.
+    #[wasm_bindgen(js_name = "decryptExportedRoomKeys")]
+    pub fn decrypt_exported_room_keys(
+        encrypted_exported_room_keys: &str,
+        passphrase: &str,
+    ) -> Result<String, JsError> {
+        Ok(serde_json::to_string(&matrix_sdk_crypto::decrypt_room_key_export(
+            encrypted_exported_room_keys.as_bytes(),
+            passphrase,
+        )?)?)
+    }
 }

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -658,6 +658,9 @@ impl OlmMachine {
     /// `exported_keys` is a list of previously exported keys that should be
     /// imported into our store. If we already have a better version of a key,
     /// the key will _not_ be imported.
+    ///
+    /// `progress_listener` is a closure that takes 2 arguments: `progress` and
+    /// `total`, and returns nothing.
     #[wasm_bindgen(js_name = "importRoomKeys")]
     pub fn import_room_keys(
         &self,

--- a/bindings/matrix-sdk-crypto-js/src/olm.rs
+++ b/bindings/matrix-sdk-crypto-js/src/olm.rs
@@ -2,7 +2,7 @@
 
 use wasm_bindgen::prelude::*;
 
-use crate::impl_from_to_inner;
+use crate::{identifiers, impl_from_to_inner};
 
 /// Struct representing the state of our private cross signing keys,
 /// it shows which private cross signing keys we have locally stored.
@@ -34,5 +34,38 @@ impl CrossSigningStatus {
     #[wasm_bindgen(getter, js_name = "hasUserSigning")]
     pub fn has_user_signing(&self) -> bool {
         self.inner.has_user_signing
+    }
+}
+
+/// Inbound group session.
+///
+/// Inbound group sessions are used to exchange room messages between a group of
+/// participants. Inbound group sessions are used to decrypt the room messages.
+#[wasm_bindgen]
+pub struct InboundGroupSession {
+    inner: matrix_sdk_crypto::olm::InboundGroupSession,
+}
+
+impl_from_to_inner!(matrix_sdk_crypto::olm::InboundGroupSession => InboundGroupSession);
+
+#[wasm_bindgen]
+impl InboundGroupSession {
+    /// The room where this session is used in.
+    #[wasm_bindgen(getter, js_name = "roomId")]
+    pub fn room_id(&self) -> identifiers::RoomId {
+        self.inner.room_id().to_owned().into()
+    }
+
+    /// Returns the unique identifier for this session.
+    #[wasm_bindgen(getter, js_name = "sessionId")]
+    pub fn session_id(&self) -> String {
+        self.inner.session_id().to_owned()
+    }
+
+    /// Has the session been imported from a file or server-side backup? As
+    /// opposed to being directly received as an `m.room_key` event.
+    #[wasm_bindgen(js_name = "hasBeenImported")]
+    pub fn has_been_imported(&self) -> bool {
+        self.inner.has_been_imported()
     }
 }

--- a/bindings/matrix-sdk-crypto-js/src/olm.rs
+++ b/bindings/matrix-sdk-crypto-js/src/olm.rs
@@ -42,6 +42,7 @@ impl CrossSigningStatus {
 /// Inbound group sessions are used to exchange room messages between a group of
 /// participants. Inbound group sessions are used to decrypt the room messages.
 #[wasm_bindgen]
+#[derive(Debug)]
 pub struct InboundGroupSession {
     inner: matrix_sdk_crypto::olm::InboundGroupSession,
 }

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -28,7 +28,6 @@ const {
     QrCode,
     QrCodeScan,
 } = require('../pkg/matrix_sdk_crypto_js');
-const { LoggerLevel, Tracing } = require('../pkg/matrix_sdk_crypto_js');
 const { zip, addMachineToMachine } = require('./helper');
 
 describe('LocalTrust', () => {

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -505,6 +505,8 @@ describe(OlmMachine.name, () => {
             exportedRoomKeys = await m.exportRoomKeys(session => {
                 expect(session).toBeInstanceOf(InboundGroupSession);
                 expect(session.roomId.toString()).toStrictEqual(room.toString());
+                expect(session.sessionId).toBeDefined();
+                expect(session.hasBeenImported()).toStrictEqual(false);
 
                 return true;
             });


### PR DESCRIPTION
Related to #1016.

### Progress

* [x] Implement `InboundGroupSession` with a minimal API,
* [x] Implement `OlmMachine.export_room_keys` with a predicate (!),
* [x] Implement `OlmMachine.import_room_keys`,
* [x] Implement `OlmMachine.encrypt_room_key_export` (static function),
* [x] Implement `OlmMachine.decrypt_room_key_export` (static function).