### PR TITLE
Start using #[uniffi::export] for matrix-sdk-crypto-ffi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Check the spelling of the files in our repo
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.12.8
 
   clippy:
     name: Run clippy

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
-name = "matrix_crypto_ffi"
 
 [dependencies]
 anyhow = "1.0.57"

--- a/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
@@ -59,6 +59,19 @@ pub struct MegolmV1BackupKey {
     pub backup_algorithm: String,
 }
 
+#[uniffi::export]
+impl BackupRecoveryKey {
+    /// Convert the recovery key to a base 58 encoded string.
+    pub fn to_base58(&self) -> String {
+        self.inner.to_base58()
+    }
+
+    /// Convert the recovery key to a base 64 encoded string.
+    pub fn to_base64(&self) -> String {
+        self.inner.to_base64()
+    }
+}
+
 impl BackupRecoveryKey {
     const KEY_SIZE: usize = 32;
     const SALT_SIZE: usize = 32;
@@ -132,16 +145,6 @@ impl BackupRecoveryKey {
             passphrase_info: self.passphrase_info.clone(),
             backup_algorithm: public_key.backup_algorithm().to_owned(),
         }
-    }
-
-    /// Convert the recovery key to a base 58 encoded string.
-    pub fn to_base58(&self) -> String {
-        self.inner.to_base58()
-    }
-
-    /// Convert the recovery key to a base 64 encoded string.
-    pub fn to_base64(&self) -> String {
-        self.inner.to_base64()
     }
 
     /// Try to decrypt a message that was encrypted using the public part of the

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -467,6 +467,10 @@ fn parse_user_id(user_id: &str) -> Result<OwnedUserId, CryptoStoreError> {
     ruma::UserId::parse(user_id).map_err(|e| CryptoStoreError::InvalidUserId(user_id.to_owned(), e))
 }
 
+mod uniffi_types {
+    pub use crate::{backup_recovery_key::BackupRecoveryKey, machine::OlmMachine};
+}
+
 #[allow(warnings)]
 mod generated {
     use super::*;

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -67,6 +67,28 @@ pub struct KeyRequestPair {
     pub key_request: Request,
 }
 
+#[uniffi::export]
+impl OlmMachine {
+    /// Get the user ID of the owner of this `OlmMachine`.
+    pub fn user_id(&self) -> String {
+        self.inner.user_id().to_string()
+    }
+
+    /// Get the device ID of the device of this `OlmMachine`.
+    pub fn device_id(&self) -> String {
+        self.inner.device_id().to_string()
+    }
+
+    /// Get our own identity keys.
+    pub fn identity_keys(&self) -> HashMap<String, String> {
+        let identity_keys = self.inner.identity_keys();
+        let curve_key = identity_keys.curve25519.to_base64();
+        let ed25519_key = identity_keys.ed25519.to_base64();
+
+        HashMap::from([("ed25519".to_owned(), ed25519_key), ("curve25519".to_owned(), curve_key)])
+    }
+}
+
 impl OlmMachine {
     /// Create a new `OlmMachine`
     ///
@@ -114,16 +136,6 @@ impl OlmMachine {
             inner: runtime.block_on(InnerMachine::with_store(&user_id, device_id, store))?,
             runtime,
         })
-    }
-
-    /// Get the user ID of the owner of this `OlmMachine`.
-    pub fn user_id(&self) -> String {
-        self.inner.user_id().to_string()
-    }
-
-    /// Get the device ID of the device of this `OlmMachine`.
-    pub fn device_id(&self) -> String {
-        self.inner.device_id().to_string()
     }
 
     /// Get the display name of our own device.
@@ -311,15 +323,6 @@ impl OlmMachine {
             .devices()
             .map(|d| d.into())
             .collect())
-    }
-
-    /// Get our own identity keys.
-    pub fn identity_keys(&self) -> HashMap<String, String> {
-        let identity_keys = self.inner.identity_keys();
-        let curve_key = identity_keys.curve25519.to_base64();
-        let ed25519_key = identity_keys.ed25519.to_base64();
-
-        HashMap::from([("ed25519".to_owned(), ed25519_key), ("curve25519".to_owned(), curve_key)])
     }
 
     /// Get the list of outgoing requests that need to be sent to the

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -1,4 +1,4 @@
-namespace olm {
+namespace matrix_sdk_crypto_ffi {
     void set_logger(Logger logger);
     [Throws=MigrationError]
     void migrate(

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -256,10 +256,6 @@ interface OlmMachine {
         string? passphrase
     );
 
-    record<DOMString, string> identity_keys();
-    string user_id();
-    string device_id();
-
     [Throws=CryptoStoreError]
     string receive_sync_changes([ByRef] string events,
                               DeviceLists device_changes,
@@ -438,8 +434,6 @@ interface BackupRecoveryKey {
     constructor(string key);
     [Name=from_base58, Throws=DecodeError]
     constructor(string key);
-    string to_base58();
-    string to_base64();
     MegolmV1BackupKey megolm_v1_public_key();
     [Throws=PkDecryptionError]
     string decrypt_v1(string ephemeral_key, string mac, string ciphertext);

--- a/bindings/matrix-sdk-crypto-ffi/uniffi.toml
+++ b/bindings/matrix-sdk-crypto-ffi/uniffi.toml
@@ -1,2 +1,5 @@
+[bindings.kotlin]
+package_name = "org.matrix.sdk.crypto"
+
 [bindings.swift]
 module_name = "MatrixSDKCrypto"


### PR DESCRIPTION
Do we want to merge this now? Or should we stay with just the one crate using the proc-macro frontend while it's still as incomplete as it is now?