### PR TITLE
fix(crypto) Fix the zeroizing serialization of to-device events

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1219,7 +1219,7 @@ mod tests {
             .deserialize_as()
             .expect("We can always deserialize the to-device event content");
 
-        ToDeviceEvent { sender: sender.to_owned(), content, other: Default::default() }
+        ToDeviceEvent::new(sender.to_owned(), content)
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1723,6 +1723,7 @@ pub(crate) mod tests {
             sender: alice.user_id().to_owned(),
             content: content.deserialize_as().unwrap(),
             other: Default::default(),
+            event_type: Default::default(),
         };
 
         let decrypted = bob.decrypt_to_device_event(&event).await.unwrap();
@@ -1939,17 +1940,16 @@ pub(crate) mod tests {
         let bob_device =
             alice.get_device(&bob.user_id, &bob.device_id, None).await.unwrap().unwrap();
 
-        let event = ToDeviceEvent {
-            sender: alice.user_id().to_owned(),
-            content: bob_device
+        let event = ToDeviceEvent::new(
+            alice.user_id().to_owned(),
+            bob_device
                 .encrypt("m.dummy", serde_json::to_value(ToDeviceDummyEventContent::new()).unwrap())
                 .await
                 .unwrap()
                 .1
                 .deserialize_as()
                 .unwrap(),
-            other: Default::default(),
-        };
+        );
 
         let event = bob
             .decrypt_to_device_event(&event)
@@ -1978,11 +1978,10 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let event = ToDeviceEvent {
-            sender: alice.user_id().to_owned(),
-            content: to_device_requests_to_content(to_device_requests),
-            other: Default::default(),
-        };
+        let event = ToDeviceEvent::new(
+            alice.user_id().to_owned(),
+            to_device_requests_to_content(to_device_requests),
+        );
         let event = json_convert(&event).unwrap();
 
         let alice_session =
@@ -2027,11 +2026,10 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let event = ToDeviceEvent {
-            sender: alice.user_id().to_owned(),
-            content: to_device_requests_to_content(to_device_requests),
-            other: Default::default(),
-        };
+        let event = ToDeviceEvent::new(
+            alice.user_id().to_owned(),
+            to_device_requests_to_content(to_device_requests),
+        );
 
         let group_session =
             bob.decrypt_to_device_event(&event).await.unwrap().inbound_group_session;

--- a/crates/matrix-sdk-crypto/src/types/events/room_key_request.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_request.rs
@@ -33,6 +33,7 @@ impl Clone for RoomKeyRequestEvent {
             sender: self.sender.clone(),
             content: self.content.clone(),
             other: self.other.clone(),
+            event_type: self.event_type.clone(),
         }
     }
 }


### PR DESCRIPTION
The crypto crate consumes to-device events, if needed decrypts them, and in the end reserializes while zeroizing secrets.

It needs to do this reserialization cycle as loslessly as possible, this is why we have a bunch of BTreeMaps lying in events and contents that capture unknown fields.

The Deserialize implementation of ToDeviceEvent<C> put the event type into this BTreeMap but the Serialize implementation figures it out from the EventType trait of the content.

This patch simplifies things by putting the event type into ToDeviceEvent<C>, this also means that we can just derive the Serialize implementation for ToDeviceEvent<C>.