### PR TITLE
feat(indexeddb): Introduce the `experimental-nodejs` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,6 +1988,20 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexed_db_futures"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26ac735f676c52305becf53264b91cea9866a8de61ccbf464405b377b9cbca9"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "uuid 0.8.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "indexed_db_futures"
+version = "0.2.3"
 source = "git+https://github.com/Hywan/rust-indexed-db?branch=feat-factory-nodejs#5dab67890cea0ab88b967031adc09179a537d77c"
 dependencies = [
  "cfg-if",
@@ -2544,7 +2558,8 @@ dependencies = [
  "derive_builder",
  "futures-util",
  "getrandom 0.2.7",
- "indexed_db_futures",
+ "indexed_db_futures 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexed_db_futures 0.2.3 (git+https://github.com/Hywan/rust-indexed-db?branch=feat-factory-nodejs)",
  "js-sys",
  "matrix-sdk-base",
  "matrix-sdk-common",

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -28,7 +28,7 @@ tracing = []
 [dependencies]
 matrix-sdk-common = { version = "0.5.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
 matrix-sdk-crypto = { version = "0.5.0", path = "../../crates/matrix-sdk-crypto", features = ["js"] }
-matrix-sdk-indexeddb = { version = "0.1.0", path = "../../crates/matrix-sdk-indexeddb" }
+matrix-sdk-indexeddb = { version = "0.1.0", path = "../../crates/matrix-sdk-indexeddb", features = ["experimental-nodejs"] }
 matrix-sdk-qrcode = { version = "0.3.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
 ruma = { version = "0.7.0", features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"] }
 vodozemac = { version = "0.3.0", features = ["js"] }

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -17,6 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["e2e-encryption"]
 e2e-encryption = ["matrix-sdk-base/e2e-encryption", "dep:matrix-sdk-crypto", "dashmap"]
 experimental-timeline = ["matrix-sdk-base/experimental-timeline", "dep:futures-util"]
+experimental-nodejs = ["indexed_db_futures_nodejs"]
 
 [dependencies]
 anyhow = "1.0.57"
@@ -25,11 +26,12 @@ base64 = "0.13.0"
 dashmap = { version = "5.2.0", optional = true }
 derive_builder = "0.11.2"
 futures-util = { version = " 0.3.21", default-features = false, features = ["alloc"], optional = true }
-indexed_db_futures = { git = "https://github.com/Hywan/rust-indexed-db", branch = "feat-factory-nodejs" }
 js-sys = { version = "0.3.58" }
 matrix-sdk-base = { version = "0.5.0", path = "../matrix-sdk-base", features = ["js"] }
 matrix-sdk-crypto = { version = "0.5.0", path = "../matrix-sdk-crypto", features = ["js"], optional = true }
 matrix-sdk-store-encryption = { version = "0.1.0", path = "../matrix-sdk-store-encryption" }
+indexed_db_futures = "0.2.3"
+indexed_db_futures_nodejs = { package = "indexed_db_futures", git = "https://github.com/Hywan/rust-indexed-db", branch = "feat-factory-nodejs", optional = true }
 ruma = "0.7.0"
 serde = "1.0.136"
 serde_json = "1.0.79"

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -17,9 +17,9 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use crate::indexed_db_futures::prelude::*;
 use async_trait::async_trait;
 use dashmap::DashSet;
-use indexed_db_futures::prelude::*;
 use matrix_sdk_base::locks::Mutex;
 use matrix_sdk_crypto::{
     olm::{
@@ -107,8 +107,8 @@ pub enum IndexeddbCryptoStoreError {
     CryptoStoreError(#[from] CryptoStoreError),
 }
 
-impl From<indexed_db_futures::web_sys::DomException> for IndexeddbCryptoStoreError {
-    fn from(frm: indexed_db_futures::web_sys::DomException) -> IndexeddbCryptoStoreError {
+impl From<crate::indexed_db_futures::web_sys::DomException> for IndexeddbCryptoStoreError {
+    fn from(frm: crate::indexed_db_futures::web_sys::DomException) -> IndexeddbCryptoStoreError {
         IndexeddbCryptoStoreError::DomException {
             name: frm.name(),
             message: frm.message(),

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -17,7 +17,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use crate::indexed_db_futures::prelude::*;
 use async_trait::async_trait;
 use dashmap::DashSet;
 use matrix_sdk_base::locks::Mutex;
@@ -37,7 +36,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
 
-use crate::safe_encode::SafeEncode;
+use crate::{indexed_db_futures::prelude::*, safe_encode::SafeEncode};
 
 #[allow(non_snake_case)]
 mod KEYS {

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -15,6 +15,14 @@ pub use state_store::{
     MigrationConflictStrategy,
 };
 
+mod indexed_db_futures {
+    #[cfg(not(feature = "experimental-nodejs"))]
+    pub use indexed_db_futures::*;
+
+    #[cfg(feature = "experimental-nodejs")]
+    pub use indexed_db_futures_nodejs::*;
+}
+
 /// Create a [`IndexeddbStateStore`] and a [`IndexeddbCryptoStore`] that use the
 /// same name and passphrase.
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-indexeddb/src/lib.rs
+++ b/crates/matrix-sdk-indexeddb/src/lib.rs
@@ -18,7 +18,6 @@ pub use state_store::{
 mod indexed_db_futures {
     #[cfg(not(feature = "experimental-nodejs"))]
     pub use indexed_db_futures::*;
-
     #[cfg(feature = "experimental-nodejs")]
     pub use indexed_db_futures_nodejs::*;
 }

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -20,7 +20,6 @@ use std::{
     },
 };
 
-use crate::indexed_db_futures::prelude::*;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use derive_builder::Builder;
@@ -62,7 +61,7 @@ use tracing::warn;
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
 
-use crate::safe_encode::SafeEncode;
+use crate::{indexed_db_futures::prelude::*, safe_encode::SafeEncode};
 
 #[derive(Clone, Serialize, Deserialize)]
 struct StoreKeyWrapper(Vec<u8>);
@@ -1779,7 +1778,6 @@ mod encrypted_tests {
 mod migration_tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-    use crate::indexed_db_futures::prelude::*;
     use matrix_sdk_test::async_test;
     use uuid::Uuid;
     use wasm_bindgen::JsValue;
@@ -1788,6 +1786,7 @@ mod migration_tests {
         IndexeddbStateStore, IndexeddbStateStoreError, MigrationConflictStrategy, Result,
         ALL_STORES,
     };
+    use crate::indexed_db_futures::prelude::*;
 
     pub async fn create_fake_db(name: &str, version: f64) -> Result<()> {
         let mut db_req: OpenDbRequest = IdbDatabase::open_f64(name, version)?;

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -20,12 +20,12 @@ use std::{
     },
 };
 
+use crate::indexed_db_futures::prelude::*;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use derive_builder::Builder;
 #[cfg(feature = "experimental-timeline")]
 use futures_util::stream;
-use indexed_db_futures::prelude::*;
 use js_sys::Date as JsDate;
 use matrix_sdk_base::{
     deserialized_responses::MemberEvent,
@@ -96,8 +96,8 @@ pub enum MigrationConflictStrategy {
     BackupAndDrop,
 }
 
-impl From<indexed_db_futures::web_sys::DomException> for IndexeddbStateStoreError {
-    fn from(frm: indexed_db_futures::web_sys::DomException) -> IndexeddbStateStoreError {
+impl From<crate::indexed_db_futures::web_sys::DomException> for IndexeddbStateStoreError {
+    fn from(frm: crate::indexed_db_futures::web_sys::DomException) -> IndexeddbStateStoreError {
         IndexeddbStateStoreError::DomException {
             name: frm.name(),
             message: frm.message(),
@@ -450,7 +450,9 @@ impl IndexeddbStateStore {
             .meta
             .transaction_on_one_with_mode(KEYS::BACKUPS_META, IdbTransactionMode::Readonly)?
             .object_store(KEYS::BACKUPS_META)?
-            .open_cursor_with_direction(indexed_db_futures::prelude::IdbCursorDirection::Prev)?
+            .open_cursor_with_direction(
+                crate::indexed_db_futures::prelude::IdbCursorDirection::Prev,
+            )?
             .await?
             .and_then(|c| c.value().as_string()))
     }
@@ -1777,7 +1779,7 @@ mod encrypted_tests {
 mod migration_tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-    use indexed_db_futures::prelude::*;
+    use crate::indexed_db_futures::prelude::*;
     use matrix_sdk_test::async_test;
     use uuid::Uuid;
     use wasm_bindgen::JsValue;


### PR DESCRIPTION
By default, the new `experimental-nodejs` feature is disabled. However, when enabled, it uses our own fork of `indexed_db_futures` that make it work on Node.js, and so this entire `matrix-sdk-indexebdb` crate.