### PR TITLE
feat(sdk): add set_presence to SyncSettings

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -61,10 +61,8 @@ use ruma::{
         error::{FromHttpResponseError, ServerError},
         MatrixVersion, OutgoingRequest, SendAccessToken,
     },
-    assign,
-    presence::PresenceState,
-    DeviceId, OwnedDeviceId, OwnedRoomId, OwnedServerName, RoomAliasId, RoomId, RoomOrAliasId,
-    ServerName, UInt, UserId,
+    assign, DeviceId, OwnedDeviceId, OwnedRoomId, OwnedServerName, RoomAliasId, RoomId,
+    RoomOrAliasId, ServerName, UInt, UserId,
 };
 use serde::de::DeserializeOwned;
 #[cfg(not(target_arch = "wasm32"))]
@@ -2057,6 +2055,8 @@ impl Client {
     ///       and where we wish to continue syncing.
     ///     * [`full_state`] - To tell the server that we wish to receive all
     ///       state events, regardless of our configured [`token`].
+    ///     * [`set_presence`] - To tell the server that we wish to receive all
+    ///       state events, regardless of our configured [`token`].
     ///
     /// # Examples
     ///
@@ -2095,6 +2095,7 @@ impl Client {
     /// [`token`]: crate::config::SyncSettings#method.token
     /// [`timeout`]: crate::config::SyncSettings#method.timeout
     /// [`full_state`]: crate::config::SyncSettings#method.full_state
+    /// [`set_presence`]: ruma::presence::PresenceState
     /// [`filter`]: crate::config::SyncSettings#method.filter
     /// [`Filter`]: ruma::api::client::sync::sync_events::v3::Filter
     /// [`next_batch`]: SyncResponse#structfield.next_batch
@@ -2121,7 +2122,7 @@ impl Client {
             filter: sync_settings.filter.as_ref(),
             since: sync_settings.token.as_deref(),
             full_state: sync_settings.full_state,
-            set_presence: &PresenceState::Online,
+            set_presence: &sync_settings.set_presence,
             timeout: sync_settings.timeout,
         });
         let mut request_config = self.request_config();

--- a/crates/matrix-sdk/src/config/sync.rs
+++ b/crates/matrix-sdk/src/config/sync.rs
@@ -14,7 +14,7 @@
 
 use std::{fmt, time::Duration};
 
-use ruma::api::client::sync::sync_events;
+use ruma::{api::client::sync::sync_events, presence::PresenceState};
 
 const DEFAULT_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -25,6 +25,7 @@ pub struct SyncSettings<'a> {
     pub(crate) timeout: Option<Duration>,
     pub(crate) token: Option<String>,
     pub(crate) full_state: bool,
+    pub(crate) set_presence: PresenceState,
 }
 
 impl<'a> Default for SyncSettings<'a> {
@@ -57,7 +58,13 @@ impl<'a> SyncSettings<'a> {
     /// Create new default sync settings.
     #[must_use]
     pub fn new() -> Self {
-        Self { filter: None, timeout: Some(DEFAULT_SYNC_TIMEOUT), token: None, full_state: false }
+        Self {
+            filter: None,
+            timeout: Some(DEFAULT_SYNC_TIMEOUT),
+            token: None,
+            full_state: false,
+            set_presence: PresenceState::Online,
+        }
     }
 
     /// Set the sync token.
@@ -106,6 +113,22 @@ impl<'a> SyncSettings<'a> {
     #[must_use]
     pub fn full_state(mut self, full_state: bool) -> Self {
         self.full_state = full_state;
+        self
+    }
+
+    /// Set the presence state
+    ///  
+    /// `PresenceState::Online` - the client is marked as being online. It's the default preset.
+    ///
+    /// `PresenceState::Offline` - the client is not marked as being online
+    ///
+    /// `PresenceState::Unavailable` - the client is marked as being idle
+    ///
+    /// # Arguments
+    /// * `set_presence` - user's presence state to tell the server the user's status
+    #[must_use]
+    pub fn set_presence(mut self, presence: PresenceState) -> Self {
+        self.set_presence = presence;
         self
     }
 }


### PR DESCRIPTION
### Description
This PR: 
- remove hardcoded `set_presence` from `sync_once` function
- add `set_presence` to `SyncSettings` struct
- add `set_presence` function to `SyncSettings` implementation in order to set a new presence. 