### PR TITLE
fix(crypto-nodejs): Hopefully it will make `NPM_TOKEN` available in the script

### DIFF
--- a/.github/workflows/release-crypto-nodejs.yml
+++ b/.github/workflows/release-crypto-nodejs.yml
@@ -27,6 +27,10 @@ on:
         description: "The tag to build with"
         required: true
         type: string
+    secrets:
+      NPM_TOKEN:
+        required: true
+
 jobs:
   upload-assets:
     name: "Upload prebuilt libraries"


### PR DESCRIPTION
We hope that adding this to the workflow will make `NPM_TOKEN` available from within the script.