### PR TITLE
Remove deprecated functions

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -456,31 +456,6 @@ impl IndexeddbStateStore {
             .and_then(|c| c.value().as_string()))
     }
 
-    #[allow(dead_code)]
-    #[deprecated(note = "Use IndexeddbStateStoreBuilder instead.")]
-    pub async fn open() -> StoreResult<Self> {
-        IndexeddbStateStore::builder()
-            .name("state".to_owned())
-            .build()
-            .await
-            .map_err(StoreError::backend)
-    }
-
-    #[deprecated(note = "Use IndexeddbStateStoreBuilder instead.")]
-    pub async fn open_with_passphrase(name: String, passphrase: &str) -> StoreResult<Self> {
-        IndexeddbStateStore::builder()
-            .name(name)
-            .passphrase(passphrase.to_owned())
-            .build()
-            .await
-            .map_err(StoreError::backend)
-    }
-
-    #[deprecated(note = "Use IndexeddbStateStoreBuilder instead.")]
-    pub async fn open_with_name(name: String) -> StoreResult<Self> {
-        IndexeddbStateStore::builder().name(name).build().await.map_err(StoreError::backend)
-    }
-
     fn serialize_event(&self, event: &impl Serialize) -> Result<JsValue> {
         Ok(match &self.store_cipher {
             Some(cipher) => JsValue::from_serde(&cipher.encrypt_value_typed(event)?)?,

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -14,7 +14,7 @@
 
 use std::{
     collections::BTreeSet,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
@@ -350,7 +350,6 @@ impl std::fmt::Debug for SledStateStore {
     }
 }
 
-#[allow(deprecated)]
 impl SledStateStore {
     fn open_helper(
         db: Db,
@@ -427,25 +426,6 @@ impl SledStateStore {
     /// Generate a SledStateStoreBuilder with default parameters
     pub fn builder() -> SledStateStoreBuilder {
         SledStateStoreBuilder::default()
-    }
-
-    #[deprecated(note = "Use SledStateStoreBuilder instead.")]
-    pub fn open() -> StoreResult<Self> {
-        SledStateStore::builder().build().map_err(StoreError::backend)
-    }
-
-    #[deprecated(note = "Use SledStateStoreBuilder instead.")]
-    pub fn open_with_passphrase(path: impl AsRef<Path>, passphrase: &str) -> StoreResult<Self> {
-        SledStateStore::builder()
-            .path(path.as_ref().into())
-            .passphrase(passphrase.to_owned())
-            .build()
-            .map_err(StoreError::backend)
-    }
-
-    #[deprecated(note = "Use SledStateStoreBuilder instead.")]
-    pub fn open_with_path(path: impl AsRef<Path>) -> StoreResult<Self> {
-        SledStateStore::builder().path(path.as_ref().into()).build().map_err(StoreError::backend)
     }
 
     fn drop_tables(self) -> StoreResult<()> {

--- a/crates/matrix-sdk/README.md
+++ b/crates/matrix-sdk/README.md
@@ -33,7 +33,7 @@ use matrix_sdk::{
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let alice = user_id!("@alice:example.org");
-    let client = Client::builder().user_id(alice).build().await?;
+    let client = Client::builder().server_name(alice.server_name()).build().await?;
 
     // First we need to log in.
     client.login_username(alice, "password").send().await?;

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -69,7 +69,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// let user = "example";
     /// let client = Client::new(homeserver).await?;
-    /// client.login(user, "password", None, None).await?;
+    /// client.login_username(user, "password").send().await?;
     ///
     /// if let Some(name) = client.account().get_display_name().await? {
     ///     println!("Logged in as user '{user}' with display name '{name}'");
@@ -94,7 +94,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// let user = "example";
     /// let client = Client::new(homeserver).await?;
-    /// client.login(user, "password", None, None).await?;
+    /// client.login_username(user, "password").send().await?;
     ///
     /// client.account().set_display_name(Some("Alice")).await?;
     /// # anyhow::Ok(()) });
@@ -117,7 +117,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// # let user = "example";
     /// let client = Client::new(homeserver).await?;
-    /// client.login(user, "password", None, None).await?;
+    /// client.login_username(user, "password").send().await?;
     ///
     /// if let Some(url) = client.account().get_avatar_url().await? {
     ///     println!("Your avatar's mxc url is {url}");
@@ -166,7 +166,7 @@ impl Account {
     /// # let homeserver = Url::parse("http://example.com")?;
     /// # let user = "example";
     /// let client = Client::new(homeserver).await?;
-    /// client.login(user, "password", None, None).await?;
+    /// client.login_username(user, "password").send().await?;
     ///
     /// if let Some(avatar) = client.account().get_avatar(MediaFormat::File).await?
     /// {

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -106,8 +106,9 @@ impl ClientBuilder {
 
     /// Set the homeserver URL to use.
     ///
-    /// This method is mutually exclusive with [`user_id()`][Self::user_id], if
-    /// you set both whatever was set last will be used.
+    /// This method is mutually exclusive with
+    /// [`server_name()`][Self::server_name], if you set both whatever was set
+    /// last will be used.
     pub fn homeserver_url(mut self, url: impl AsRef<str>) -> Self {
         self.homeserver_cfg = Some(HomeserverConfig::Url(url.as_ref().to_owned()));
         self

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -20,11 +20,11 @@ use async_once_cell::OnceCell;
 use matrix_sdk_base::{
     locks::{Mutex, RwLock},
     store::StoreConfig,
-    BaseClient, StateStore,
+    BaseClient,
 };
 use ruma::{
     api::{client::discovery::discover_homeserver, error::FromHttpResponseError, MatrixVersion},
-    OwnedServerName, ServerName, UserId,
+    OwnedServerName, ServerName,
 };
 use thiserror::Error;
 #[cfg(not(target_arch = "wasm32"))]
@@ -113,19 +113,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Set the user ID to discover the homeserver from.
-    ///
-    /// `builder.user_id(id)` is a shortcut for
-    /// <code>builder.[server_name](Self::server_name)(id.server_name())</code>.
-    ///
-    /// This method is mutually exclusive with
-    /// [`homeserver_url()`][Self::homeserver_url], if you set both whatever was
-    /// set last will be used.
-    #[deprecated = "Use `server_name(user_id.server_name())` instead"]
-    pub fn user_id(self, user_id: &UserId) -> Self {
-        self.server_name(user_id.server_name())
-    }
-
     /// Set the server name to discover the homeserver from.
     ///
     /// This method is mutually exclusive with
@@ -188,36 +175,6 @@ impl ClientBuilder {
     /// [`store`]: crate::store
     pub fn store_config(mut self, store_config: StoreConfig) -> Self {
         self.store_config = store_config;
-        self
-    }
-
-    /// Set a custom implementation of a `StateStore`.
-    ///
-    /// The state store should be opened before being set.
-    #[deprecated = "\
-        Use [`store_config`](#method.store_config), \
-        [`sled_store`](#method.sled_store) or \
-        [`indexeddb_store`](#method.indexeddb_store) instead
-    "]
-    pub fn state_store(mut self, store: impl StateStore + 'static) -> Self {
-        self.store_config = self.store_config.state_store(store);
-        self
-    }
-
-    /// Set a custom implementation of a `CryptoStore`.
-    ///
-    /// The crypto store should be opened before being set.
-    #[deprecated = "\
-        Use [`store_config`](#method.store_config), \
-        [`sled_store`](#method.sled_store) or \
-        [`indexeddb_store`](#method.indexeddb_store) instead
-    "]
-    #[cfg(feature = "e2e-encryption")]
-    pub fn crypto_store(
-        mut self,
-        store: impl matrix_sdk_base::crypto::store::CryptoStore + 'static,
-    ) -> Self {
-        self.store_config = self.store_config.crypto_store(store);
         self
     }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1185,7 +1185,7 @@ impl Client {
     /// ```
     ///
     /// The `Session` object can also be created from the response the
-    /// [`Client::login()`] method returns:
+    /// [`LoginBuilder::send()`] method returns:
     ///
     /// ```no_run
     /// use matrix_sdk::{Client, Session};
@@ -1197,7 +1197,7 @@ impl Client {
     /// let client = Client::new(homeserver).await?;
     ///
     /// let session: Session =
-    ///     client.login("example", "my-password", None, None).await?.into();
+    ///     client.login_username("example", "my-password").send().await?.into();
     ///
     /// // Persist the `Session` so it can later be used to restore the login.
     /// client.restore_login(session).await?;
@@ -2085,7 +2085,7 @@ impl Client {
     /// };
     ///
     /// let client = Client::new(homeserver).await?;
-    /// client.login(&username, &password, None, None).await?;
+    /// client.login_username(&username, &password).send().await?;
     ///
     /// // Register our handler so we start responding once we receive a new
     /// // event.
@@ -2296,7 +2296,7 @@ impl Client {
     /// use matrix_sdk::{config::SyncSettings, Client};
     ///
     /// let client = Client::new(homeserver).await?;
-    /// client.login(&username, &password, None, None).await?;
+    /// client.login_username(&username, &password).send().await?;
     ///
     /// let mut sync_stream =
     ///     Box::pin(client.sync_stream(SyncSettings::default()).await);

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -650,18 +650,6 @@ impl Client {
         self.add_event_handler_impl(handler, Some(room_id.to_owned()))
     }
 
-    #[allow(missing_docs)]
-    #[deprecated = "Use [`Client::add_event_handler`](#method.add_event_handler) instead"]
-    pub async fn register_event_handler<Ev, Ctx, H>(&self, handler: H) -> &Self
-    where
-        Ev: SyncEvent + DeserializeOwned + Send + 'static,
-        H: EventHandler<Ev, Ctx>,
-        <H::Future as Future>::Output: EventHandlerResult,
-    {
-        self.add_event_handler(handler);
-        self
-    }
-
     /// Remove the event handler associated with the handle.
     ///
     /// Note that you **must not** call `remove_event_handler` from the
@@ -778,16 +766,6 @@ impl Client {
         T: Clone + Send + Sync + 'static,
     {
         self.inner.event_handlers.add_context(ctx);
-    }
-
-    #[allow(missing_docs)]
-    #[deprecated = "Use [`Client::add_event_handler_context`](#method.add_event_handler_context) instead"]
-    pub fn register_event_handler_context<T>(&self, ctx: T) -> &Self
-    where
-        T: Clone + Send + Sync + 'static,
-    {
-        self.add_event_handler_context(ctx);
-        self
     }
 
     /// Register a handler for a notification.
@@ -1146,84 +1124,6 @@ impl Client {
         Fut: Future<Output = Result<()>> + Send,
     {
         SsoLoginBuilder::new(self.clone(), use_sso_login_url)
-    }
-
-    /// Login to the server with a username and password.
-    #[deprecated = "Replaced by [`Client::login_username`](#method.login_username)"]
-    #[instrument(skip(self, user, password))]
-    pub async fn login(
-        &self,
-        user: impl AsRef<str>,
-        password: &str,
-        device_id: Option<&str>,
-        initial_device_display_name: Option<&str>,
-    ) -> Result<login::v3::Response> {
-        let mut builder = self.login_username(&user, password);
-        if let Some(value) = device_id {
-            builder = builder.device_id(value);
-        }
-        if let Some(value) = initial_device_display_name {
-            builder = builder.initial_device_display_name(value);
-        }
-
-        builder.send().await
-    }
-
-    /// Login to the server via Single Sign-On.
-    #[deprecated = "Replaced by [`Client::login_sso`](#method.login_sso)"]
-    #[cfg(feature = "sso-login")]
-    #[deny(clippy::future_not_send)]
-    pub async fn login_with_sso<C>(
-        &self,
-        use_sso_login_url: impl FnOnce(String) -> C + Send,
-        server_url: Option<&str>,
-        server_response: Option<&str>,
-        device_id: Option<&str>,
-        initial_device_display_name: Option<&str>,
-        idp_id: Option<&str>,
-    ) -> Result<login::v3::Response>
-    where
-        C: Future<Output = Result<()>> + Send,
-    {
-        let mut builder = self.login_sso(use_sso_login_url);
-        if let Some(value) = server_url {
-            builder = builder.server_url(value);
-        }
-        if let Some(value) = server_response {
-            builder = builder.server_response(value);
-        }
-        if let Some(value) = device_id {
-            builder = builder.device_id(value);
-        }
-        if let Some(value) = initial_device_display_name {
-            builder = builder.initial_device_display_name(value);
-        }
-        if let Some(value) = idp_id {
-            builder = builder.identity_provider_id(value);
-        }
-
-        builder.send().await
-    }
-
-    /// Login to the server with a token.
-    #[deprecated = "Replaced by [`Client::login_token`](#method.login_token)"]
-    #[instrument(skip(self, token))]
-    #[cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
-    pub async fn login_with_token(
-        &self,
-        token: &str,
-        device_id: Option<&str>,
-        initial_device_display_name: Option<&str>,
-    ) -> Result<login::v3::Response> {
-        let mut builder = self.login_token(token);
-        if let Some(value) = device_id {
-            builder = builder.device_id(value);
-        }
-        if let Some(value) = initial_device_display_name {
-            builder = builder.initial_device_display_name(value);
-        }
-
-        builder.send().await
     }
 
     /// Receive a login response and update the homeserver and the base client

--- a/crates/matrix-sdk/src/docs/encryption.md
+++ b/crates/matrix-sdk/src/docs/encryption.md
@@ -165,10 +165,8 @@ unverified devices, verifying devices is **not** necessary for encryption
 to work.
 
 1. Make sure the `encryption` feature is enabled.
-2. To persist the encryption keys, you can use one of the provided backend
-constructors as described in the documentation of the [`store`] module or you
-can provide your own backend that implements [`CryptoStore`] in a
-[`StoreConfig`] or via [`ClientBuilder::crypto_store()`].
+2. To persist the encryption keys, you can use [`ClientBuilder::store_config`]
+   or of the other `_store` methods on [`ClientBuilder`].
 
 ## Restoring a client
 
@@ -176,6 +174,7 @@ Restoring a Client is relatively easy, still some things need to be kept in
 mind before doing so.
 
 There are two ways one might wish to restore a [`Client`]:
+
 1. Using an access token
 2. Using the password
 
@@ -189,8 +188,7 @@ have been uploaded and tied to a device ID.
 
 ### Using an access token
 
-1. Log in with the password using [`Client::login()`] setting the
-   `device_id` argument to `None`.
+1. Log in with the password using [`Client::login_username()`].
 2. Store the access token, preferably somewhere secure.
 3. Use [`Client::restore_login()`] the next time the client starts.
 
@@ -201,13 +199,13 @@ the device ID.
 
 ### Using a password.
 
-1. Log in using [`Client::login()`] setting the `device_id` argument to `None`.
+1. Log in using [`Client::login_username()`].
 2. Store the `device_id` that was returned in the login response from the
-server.
-3. Use [`Client::login()`] the next time the client starts, make sure to
-**set** `device_id` this time to the stored `device_id` from the previous
-step. This will replace the access token from the previous login call but
-won't create a new device.
+   server.
+3. Use [`Client::login_username()`] the next time the client starts, make sure
+   to set `device_id` to the stored `device_id` from the previous step. This
+   will replace the access token from the previous login call, but won't create
+   a new device.
 
 **Note** that the default store supports only a single device, logging in
 with a different device ID (either `None` or a device ID of another client)
@@ -233,4 +231,5 @@ is **not** supported using the default store.
 [`store`]: crate::store
 [`CryptoStore`]: matrix_sdk_base::crypto::store::CryptoStore
 [`StoreConfig`]: crate::config::StoreConfig
-[`ClientBuilder::crypto_store()`]: crate::ClientBuilder::crypto_store()
+[`ClientBuilder`]: crate::ClientBuilder
+[`ClientBuilder::store_config`]: crate::ClientBuilder::store_config

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -147,7 +147,7 @@ impl Common {
     /// # block_on(async {
     /// # let user = "example";
     /// let client = Client::new(homeserver).await.unwrap();
-    /// client.login(user, "password", None, None).await.unwrap();
+    /// client.login_username(user, "password").send().await.unwrap();
     /// let room_id = room_id!("!roomid:example.com");
     /// let room = client.get_joined_room(&room_id).unwrap();
     /// if let Some(avatar) = room.avatar(MediaFormat::File).await.unwrap() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
     match Xtask::parse().cmd {
         Command::Ci(ci) => ci.run(),
         Command::Fixup(cfg) => cfg.run(),
-        Command::Doc { open } => build_docs(open.then(|| "--open"), DenyWarnings::No),
+        Command::Doc { open } => build_docs(open.then_some("--open"), DenyWarnings::No),
     }
 }
 


### PR DESCRIPTION
Now that 0.6.0 is out, we can remove all the stuff we previously deprecated!

@poljar there is one more deprecated function that I didn't remove because I don't really know whether there's still a potential use case for it:

```rust
// In crates/matrix-sdk/src/encryption/identities/devices.rs
// impl Device {
#[deprecated(
    since = "0.4.0",
    note = "directly starting a verification is deprecated in the spec. \
            Users should instead use request_verification()"
)]
pub async fn start_verification(&self) -> Result<SasVerification> {
```

Should I remove that one as well?