### PR TITLE
fix: Allow running unit tests on macOS when using debug_build_xcframework.sh

### DIFF
--- a/bindings/apple/Package.swift
+++ b/bindings/apple/Package.swift
@@ -5,7 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "MatrixRustSDK",
-    platforms: [.iOS(.v15)],
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12)
+    ],
     products: [
         .library(name: "MatrixRustSDK",
                  targets: ["MatrixRustSDK"]),

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -38,15 +38,17 @@ The `build_crypto_xcframework.sh` script will go through all the steps required 
 4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS one, and add the header and module map to it under `generated/MatrixSDKCryptoFFI.xcframework`
 5. cleanup and delete the generated files except the .xcframework and the swift sources (that aren't part of the framework)
 
-## Running the Xcode project
+## Building & testing the Swift package
 
-The Xcode project is meant to provide a simple example on how to integrate everything together but also a place to run unit and integration tests from.
+`Package.swift` is meant to provide a simple example on how to integrate everything together but also a place to run unit and integration tests from.
 
 It's pre-configured to link to the generated .xcframework and .swift files so successfully running the script first is necessary for it to compile.
 
-It makes the compiled code available to swift by importing the C header through its bridging header.
+If you're using `debug_build_xcframework.sh`, you can run the script with `PLATFORM=darwin` and use `swift test` to execute the tests. Alternatively, without using the `PLATFORM` environment variable, you can use `xcodebuild` to execute the unit tests in an iOS simulator, e.g.
 
-Once all the generated components are available running it should be as easy as choosing a platform and clicking run.
+```
+xcodebuild test -scheme MatrixRustSDK -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13'
+```
 
 ## Distribution
 


### PR DESCRIPTION
This is a small stopgap until #1023 lands to allow running the unit tests for the Swift bindings on macOS. In a nutshell, you can now run this to compile the bindings and execute the tests:

```
$ PLATFORM=darwin ./debug_build_xcframework.sh
$ swift test
```

I also fixed the documentation which was still referring to the old Xcode project instead of the Swift package.

Fixes: #1077