### PR TITLE
chore: Ignore Swift's .build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ master.zip
 emsdk-*
 .idea/
 .env
+.build
 
 ## User settings
 xcuserdata/


### PR DESCRIPTION
This folder is created when building or testing the Swift package in `bindings/apple`.