### PR TITLE
Ignore duplicate verification requests

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -28,7 +28,7 @@ use ruma::{
     uint, DeviceId, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedUserId, RoomId,
     SecondsSinceUnixEpoch, TransactionId, UInt, UserId,
 };
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use super::{
     cache::VerificationCache,
@@ -168,7 +168,7 @@ impl VerificationMachine {
     /// flow_id), both the existing and new request will be cancelled.
     fn insert_request(&self, request: VerificationRequest) {
         if let Some(r) = self.get_request(request.other_user(), request.flow_id().as_str()) {
-            info!(flow_id = r.flow_id().as_str(), "Ignoring known verification request",);
+            debug!(flow_id = r.flow_id().as_str(), "Ignoring known verification request",);
             return;
         }
 


### PR DESCRIPTION
The `decrypt_room_event` method will automatically handle any verification events it decrypts, incl. inserting new verification requests. The existing code ensures that only one request per user exists, but does not check for strict duplicates (i.e. matching flow_id). If the client decrypts the same message multiple times (e.g. via sync + pagination), the cancellation branch will always be triggered.

To solve this add a simple check to ignore verification requests with matching flow_id