### PR TITLE
refactor(bindings): Use uniffi::export for most of ClientBuilder's API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -158,18 +158,6 @@ interface SlidingSync {
 interface ClientBuilder {
     constructor();
 
-    [Self=ByArc]
-    ClientBuilder base_path(string path);
-
-    [Self=ByArc]
-    ClientBuilder username(string username);
-
-    [Self=ByArc]
-    ClientBuilder homeserver_url(string url);
-
-    [Self=ByArc]
-    ClientBuilder user_agent(string user_agent);
-
     [Throws=ClientError, Self=ByArc]
     Client build();
 };

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -20,18 +20,8 @@ pub struct ClientBuilder {
     inner: MatrixClientBuilder,
 }
 
+#[uniffi::export]
 impl ClientBuilder {
-    pub fn new() -> Self {
-        Self {
-            base_path: None,
-            username: None,
-            server_name: None,
-            homeserver_url: None,
-            user_agent: None,
-            inner: MatrixClient::builder(),
-        }
-    }
-
     pub fn base_path(self: Arc<Self>, path: String) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.base_path = Some(path);
@@ -60,6 +50,19 @@ impl ClientBuilder {
         let mut builder = unwrap_or_clone_arc(self);
         builder.user_agent = Some(user_agent);
         Arc::new(builder)
+    }
+}
+
+impl ClientBuilder {
+    pub fn new() -> Self {
+        Self {
+            base_path: None,
+            username: None,
+            server_name: None,
+            homeserver_url: None,
+            user_agent: None,
+            inner: MatrixClient::builder(),
+        }
     }
 
     pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<Client>> {

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -78,6 +78,7 @@ mod uniffi_types {
     pub use crate::{
         authentication_service::{AuthenticationService, HomeserverLoginDetails},
         client::Client,
+        client_builder::ClientBuilder,
         messages::AnyMessage,
         room::Room,
         session_verification::SessionVerificationEmoji,


### PR DESCRIPTION
The git rev of UniFFI I ultimately upgraded to in #1063 also allows the use of the `Self` keyword, so we should make use of that.