### PR TITLE
Compile Crypto FFI for MacOS

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -162,7 +162,7 @@ jobs:
         with:
           command: install
           # keep in sync with uniffi dependency in Cargo.toml's
-          args: uniffi_bindgen --git https://github.com/mozilla/uniffi-rs --rev 17ee82b50ab01182b09a3597b3a340baeca1c9a8
+          args: uniffi_bindgen --git https://github.com/mozilla/uniffi-rs --rev 0eee77f67b716c4896494606e5931d249871b23a
 
       - name: Generate .xcframework
         working-directory: bindings/apple

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2479,6 +2479,7 @@ dependencies = [
  "tracing-subscriber",
  "uniffi",
  "uniffi_build",
+ "uniffi_macros",
  "vodozemac",
  "zeroize",
 ]
@@ -4791,7 +4792,7 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 [[package]]
 name = "uniffi"
 version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=17ee82b50ab01182b09a3597b3a340baeca1c9a8#17ee82b50ab01182b09a3597b3a340baeca1c9a8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4807,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=17ee82b50ab01182b09a3597b3a340baeca1c9a8#17ee82b50ab01182b09a3597b3a340baeca1c9a8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
 dependencies = [
  "anyhow",
  "askama",
@@ -4829,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=17ee82b50ab01182b09a3597b3a340baeca1c9a8#17ee82b50ab01182b09a3597b3a340baeca1c9a8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
 dependencies = [
  "anyhow",
  "camino",
@@ -4839,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=17ee82b50ab01182b09a3597b3a340baeca1c9a8#17ee82b50ab01182b09a3597b3a340baeca1c9a8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
 dependencies = [
  "bincode",
  "camino",
@@ -4857,7 +4858,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=17ee82b50ab01182b09a3597b3a340baeca1c9a8#17ee82b50ab01182b09a3597b3a340baeca1c9a8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
 dependencies = [
  "serde",
 ]
@@ -5195,7 +5196,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=17ee82b50ab01182b09a3597b3a340baeca1c9a8#17ee82b50ab01182b09a3597b3a340baeca1c9a8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
 dependencies = [
  "nom",
 ]

--- a/bindings/apple/MatrixSDKCrypto.podspec
+++ b/bindings/apple/MatrixSDKCrypto.podspec
@@ -1,13 +1,15 @@
 Pod::Spec.new do |s|
 
     s.name                  = "MatrixSDKCrypto"
-    s.version               = "0.1.0"
+    s.version               = "0.1.2"
     s.summary               = "Uniffi based bindings for the Rust SDK crypto crate."
     s.homepage              = "https://github.com/matrix-org/matrix-rust-sdk"
     s.license               = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
     s.author                = { "matrix.org" => "support@matrix.org" }
 
     s.ios.deployment_target = "11.0"
+    s.osx.deployment_target = "10.10"
+
     s.swift_versions = ['5.0']
 
     s.source                = { :http => "https://github.com/matrix-org/matrix-rust-sdk/releases/download/matrix-sdk-crypto-ffi-#{s.version}/MatrixSDKCryptoFFI.zip" }

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -27,7 +27,7 @@ The `build_xcframework.sh` script will go through all the steps required to gene
 ## Building only the Crypto SDK
 
 ```
-sh build_crypto_xcframework.sh
+build_crypto_xcframework.sh
 ```
 
 The `build_crypto_xcframework.sh` script will go through all the steps required to generate a fully usable `.xcframework`:
@@ -51,3 +51,10 @@ Once all the generated components are available running it should be as easy as 
 ## Distribution
 
 The generated framework and Swift code can be distributed and integrated directly but in order to make things simpler we bundle them together as a Swift package available [TBD](here) in the case of SDK, and as CocoaPods podspec in the case of Crypto SDK.
+
+### Publishing MatrixSDKCrypto
+1. Run `build_crypto_xcframework.sh` script which generates a .zip file with the framework
+2. Increment the version in `MatrixSDKCrypto.podspec`
+3. Create a new [GitHub release](https://github.com/matrix-org/matrix-rust-sdk/releases) with the same version (see [example](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.1.0) for naming)
+4. Upload the .zip file to this release
+5. Push new Podspec version to Cocoapods via `pod trunk push MatrixSDKCrypto.podspec --allow-warnings`

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -10,7 +10,7 @@ TARGET_DIR="${SRC_ROOT}/target"
 
 GENERATED_DIR="${SRC_ROOT}/generated"
 if [ -d "${GENERATED_DIR}" ]; then rm -rf "${GENERATED_DIR}"; fi
-mkdir -p ${GENERATED_DIR}
+mkdir -p "${GENERATED_DIR}/macos" "${GENERATED_DIR}/simulator"
 
 REL_FLAG="--release"
 REL_TYPE_DIR="release"
@@ -20,19 +20,35 @@ TARGET_CRATE=matrix-sdk-crypto-ffi
 # Build static libs for all the different architectures
 
 # iOS
+echo -e "Building for iOS [1/5]"
 cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios"
 
+# MacOS
+echo -e "\nBuilding for macOS (Apple Silicon) [2/5]"
+cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-darwin"
+echo -e "\nBuilding for macOS (Intel) [3/5]"
+cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "x86_64-apple-darwin"
+
 # iOS Simulator
+echo -e "\nBuilding for iOS Simulator (Apple Silicon) [4/5]"
 cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios-sim"
+echo -e "\nBuilding for iOS Simulator (Intel) [5/5]"
 cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "x86_64-apple-ios"
 
+echo -e "\nCreating XCFramework"
 # Lipo together the libraries for the same platform
+
+# MacOS
+lipo -create \
+  "${TARGET_DIR}/x86_64-apple-darwin/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
+  "${TARGET_DIR}/aarch64-apple-darwin/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
+  -output "${GENERATED_DIR}/macos/libmatrix_crypto_ffi.a"
 
 # iOS Simulator
 lipo -create \
   "${TARGET_DIR}/x86_64-apple-ios/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
   "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
-  -output "${GENERATED_DIR}/libmatrix_crypto_ffi.a"
+  -output "${GENERATED_DIR}/simulator/libmatrix_crypto_ffi.a"
 
 # Generate uniffi files
 uniffi-bindgen generate "${SRC_ROOT}/bindings/${TARGET_CRATE}/src/olm.udl" --language swift --config "${SRC_ROOT}/bindings/${TARGET_CRATE}/uniffi.toml" --out-dir ${GENERATED_DIR}
@@ -57,17 +73,21 @@ if [ -d "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework" ]; then rm -rf "${GENE
 xcodebuild -create-xcframework \
   -library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
   -headers ${HEADERS_DIR} \
-  -library "${GENERATED_DIR}/libmatrix_crypto_ffi.a" \
+  -library "${GENERATED_DIR}/macos/libmatrix_crypto_ffi.a" \
+  -headers ${HEADERS_DIR} \
+  -library "${GENERATED_DIR}/simulator/libmatrix_crypto_ffi.a" \
   -headers ${HEADERS_DIR} \
   -output "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"
 
 # Cleanup
-
-if [ -f "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" ]; then rm -rf "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a"; fi
-if [ -f "${GENERATED_DIR}/libmatrix_crypto_ffi.a" ]; then rm -rf "${GENERATED_DIR}/libmatrix_crypto_ffi.a"; fi
+if [ -d "${GENERATED_DIR}/macos" ]; then rm -rf "${GENERATED_DIR}/macos"; fi
+if [ -d "${GENERATED_DIR}/simulator" ]; then rm -rf "${GENERATED_DIR}/simulator"; fi
 if [ -d ${HEADERS_DIR} ]; then rm -rf ${HEADERS_DIR}; fi
 
 # Zip up framework, sources and LICENSE, ready to be uploaded to GitHub Releases and used by MatrixSDKCrypto.podspec
 cp ${SRC_ROOT}/LICENSE $GENERATED_DIR
 cd $GENERATED_DIR
 zip -r MatrixSDKCryptoFFI.zip MatrixSDKCryptoFFI.xcframework Sources LICENSE
+rm LICENSE
+
+echo "XCFramework is ready 🚀"

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -10,7 +10,7 @@ TARGET_DIR="${SRC_ROOT}/target"
 
 GENERATED_DIR="${SRC_ROOT}/generated"
 if [ -d "${GENERATED_DIR}" ]; then rm -rf "${GENERATED_DIR}"; fi
-mkdir -p "${GENERATED_DIR}/macos" "${GENERATED_DIR}/simulator"
+mkdir -p ${GENERATED_DIR}/{macos,simulator}
 
 REL_FLAG="--release"
 REL_TYPE_DIR="release"
@@ -40,15 +40,15 @@ echo -e "\nCreating XCFramework"
 
 # MacOS
 lipo -create \
-  "${TARGET_DIR}/x86_64-apple-darwin/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
-  "${TARGET_DIR}/aarch64-apple-darwin/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
-  -output "${GENERATED_DIR}/macos/libmatrix_crypto_ffi.a"
+  "${TARGET_DIR}/x86_64-apple-darwin/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+  "${TARGET_DIR}/aarch64-apple-darwin/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+  -output "${GENERATED_DIR}/macos/libmatrix_sdk_crypto_ffi.a"
 
 # iOS Simulator
 lipo -create \
-  "${TARGET_DIR}/x86_64-apple-ios/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
-  "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
-  -output "${GENERATED_DIR}/simulator/libmatrix_crypto_ffi.a"
+  "${TARGET_DIR}/x86_64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+  "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+  -output "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a"
 
 # Generate uniffi files
 uniffi-bindgen generate "${SRC_ROOT}/bindings/${TARGET_CRATE}/src/olm.udl" --language swift --config "${SRC_ROOT}/bindings/${TARGET_CRATE}/uniffi.toml" --out-dir ${GENERATED_DIR}
@@ -71,11 +71,11 @@ mv ${GENERATED_DIR}/*.swift ${SWIFT_DIR}
 if [ -d "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework" ]; then rm -rf "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"; fi
 
 xcodebuild -create-xcframework \
-  -library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_crypto_ffi.a" \
+  -library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
   -headers ${HEADERS_DIR} \
-  -library "${GENERATED_DIR}/macos/libmatrix_crypto_ffi.a" \
+  -library "${GENERATED_DIR}/macos/libmatrix_sdk_crypto_ffi.a" \
   -headers ${HEADERS_DIR} \
-  -library "${GENERATED_DIR}/simulator/libmatrix_crypto_ffi.a" \
+  -library "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a" \
   -headers ${HEADERS_DIR} \
   -output "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"
 

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -27,7 +27,8 @@ thiserror = "1.0.30"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "17ee82b50ab01182b09a3597b3a340baeca1c9a8" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
+uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [dependencies.js_int]
@@ -58,7 +59,7 @@ features = ["rt-multi-thread"]
 version = "0.3.0"
 
 [build-dependencies]
-uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "17ee82b50ab01182b09a3597b3a340baeca1c9a8", features = ["builtin-bindgen"] }
+uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a", features = ["builtin-bindgen"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -4,6 +4,7 @@
 //! client or client library in any of the language targets Uniffi supports.
 
 #![warn(missing_docs)]
+#![allow(unused_qualifications)]
 
 mod backup_recovery_key;
 mod device;
@@ -11,6 +12,7 @@ mod error;
 mod logger;
 mod machine;
 mod responses;
+mod uniffi_api;
 mod users;
 mod verification;
 
@@ -470,14 +472,6 @@ fn parse_user_id(user_id: &str) -> Result<OwnedUserId, CryptoStoreError> {
 mod uniffi_types {
     pub use crate::{backup_recovery_key::BackupRecoveryKey, machine::OlmMachine};
 }
-
-#[allow(warnings)]
-mod generated {
-    use super::*;
-    include!(concat!(env!("OUT_DIR"), "/olm.uniffi.rs"));
-}
-
-pub use generated::*;
 
 #[cfg(test)]
 mod test {

--- a/bindings/matrix-sdk-crypto-ffi/src/uniffi_api.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/uniffi_api.rs
@@ -1,0 +1,5 @@
+#![allow(clippy::all)]
+
+use crate::*;
+
+uniffi_macros::include_scaffolding!("olm");

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/matrix-org/matrix-rust-sdk"
 crate-type = ["staticlib"]
 
 [build-dependencies]
-uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "17ee82b50ab01182b09a3597b3a340baeca1c9a8", features = ["builtin-bindgen"] }
+uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a", features = ["builtin-bindgen"] }
 
 [dependencies]
 anyhow = "1.0.51"
@@ -34,5 +34,5 @@ tokio-stream = "0.1.8"
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-crypto-ffi, and uniffi_bindgen in ffi CI job
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "17ee82b50ab01182b09a3597b3a340baeca1c9a8" }
-uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "17ee82b50ab01182b09a3597b3a340baeca1c9a8" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
+uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }


### PR DESCRIPTION
- Add steps to compile Crypto FFI for macOS
- Upgrade uniff-rs to include swift [codegen bug fix](https://github.com/mozilla/uniffi-rs/pull/1365)
- Update Podspec version to release new CocoaPods version