### PR TITLE
Towards simplifying error casts.

### DIFF
--- a/crates/matrix-sdk-appservice/src/error.rs
+++ b/crates/matrix-sdk-appservice/src/error.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::api::{client::uiaa::UiaaInfo, error::MatrixError};
+use ruma::api::client::uiaa::UiaaInfo;
 use thiserror::Error;
 
-use crate::matrix_sdk::IsError;
+use crate::matrix_sdk::implement_is_error;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -101,24 +101,6 @@ impl Error {
         }
     }
 }
-impl IsError<MatrixError> for Error {
-    fn as_error(&self) -> Option<&MatrixError> {
-        match self {
-            Error::Matrix(error) => error.as_error(),
-            _ => None,
-        }
-    }
-}
-
-impl IsError<ruma::api::client::Error> for Error {
-    fn as_error(&self) -> Option<&ruma::api::client::Error> {
-        match self {
-            Error::Matrix(error) => error.as_error(),
-            _ => None,
-        }
-    }
-}
-
 impl warp::reject::Reject for Error {}
 
 impl From<warp::Rejection> for Error {
@@ -138,3 +120,4 @@ impl From<matrix_sdk::StoreError> for Error {
         matrix_sdk::Error::from(e).into()
     }
 }
+implement_is_error!(Error);

--- a/crates/matrix-sdk-appservice/src/error.rs
+++ b/crates/matrix-sdk-appservice/src/error.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::api::client::uiaa::UiaaInfo;
+use ruma::api::{client::uiaa::UiaaInfo, error::MatrixError};
 use thiserror::Error;
+
+use crate::matrix_sdk::IsError;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -80,7 +82,6 @@ pub enum Error {
     #[error("warp rejection: {0}")]
     WarpRejection(String),
 }
-
 impl Error {
     /// Try to destructure the error into an universal interactive auth info.
     ///
@@ -96,6 +97,23 @@ impl Error {
     pub fn uiaa_response(&self) -> Option<&UiaaInfo> {
         match self {
             Error::Matrix(matrix) => matrix.uiaa_response(),
+            _ => None,
+        }
+    }
+}
+impl IsError<MatrixError> for Error {
+    fn as_error(&self) -> Option<&MatrixError> {
+        match self {
+            Error::Matrix(error) => error.as_error(),
+            _ => None,
+        }
+    }
+}
+
+impl IsError<ruma::api::client::Error> for Error {
+    fn as_error(&self) -> Option<&ruma::api::client::Error> {
+        match self {
+            Error::Matrix(error) => error.as_error(),
             _ => None,
         }
     }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -50,7 +50,7 @@ pub use client::SsoLoginBuilder;
 pub use client::{Client, ClientBuildError, ClientBuilder, LoginBuilder, LoopCtrl};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;
-pub use error::{Error, HttpError, HttpResult, RefreshTokenError, Result, RumaApiError};
+pub use error::{Error, HttpError, HttpResult, IsError, RefreshTokenError, Result, RumaApiError};
 pub use http_client::HttpSend;
 pub use media::Media;
 #[cfg(feature = "sliding-sync")]

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -227,7 +227,7 @@ async fn register_error() {
         kind: RegistrationKind::User,
     });
 
-    if let Err(err) = client.register(user).await {
+    if let Err(ref err) = client.register(user).await {
         if let Some(&client_api::Error { ref kind, ref message, ref status_code }) = err.as_error()
         {
             if let client_api::error::ErrorKind::Forbidden = kind {


### PR DESCRIPTION
The Matrix SDK has numerous error enums. This allows precise error control but it makes digging for a specific error tricky. This minor patch makes error digging a little bit easier in common cases. We still need to find a way to generalize the approach, hopefully with some kind of derive.