### PR TITLE
Replace QR with SAS verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,6 +2473,7 @@ dependencies = [
  "base64",
  "bs58",
  "byteorder",
+ "cfg-if",
  "ctr",
  "dashmap",
  "event-listener",

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -50,6 +50,7 @@ thiserror = "1.0.30"
 tracing = "0.1.34"
 vodozemac = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
+cfg-if = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.18", default-features = false, features = ["time"] }

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -819,7 +819,7 @@ impl ReadOnlyOwnUserIdentity {
             master_key,
             self_signing_key,
             user_signing_key,
-            verified: Arc::new(AtomicBool::new(true)),
+            verified: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -806,6 +806,23 @@ impl ReadOnlyOwnUserIdentity {
         })
     }
 
+    #[cfg(test)]
+    pub(crate) async fn from_private(identity: &crate::olm::PrivateCrossSigningIdentity) -> Self {
+        let master_key = identity.master_key.lock().await.as_ref().unwrap().public_key.clone();
+        let self_signing_key =
+            identity.self_signing_key.lock().await.as_ref().unwrap().public_key.clone();
+        let user_signing_key =
+            identity.user_signing_key.lock().await.as_ref().unwrap().public_key.clone();
+
+        Self {
+            user_id: identity.user_id().into(),
+            master_key,
+            self_signing_key,
+            user_signing_key,
+            verified: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
     /// Get the user id of this identity.
     pub fn user_id(&self) -> &UserId {
         &self.user_id

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -325,7 +325,7 @@ impl Store {
     }
 
     #[cfg(test)]
-    /// Testing helper to allo to save only a set of devices
+    /// Testing helper to allow to save only a set of devices
     pub async fn save_devices(&self, devices: &[ReadOnlyDevice]) -> Result<()> {
         let changes = Changes {
             devices: DeviceChanges { changed: devices.to_vec(), ..Default::default() },

--- a/crates/matrix-sdk-crypto/src/verification/cache.rs
+++ b/crates/matrix-sdk-crypto/src/verification/cache.rs
@@ -56,7 +56,11 @@ impl VerificationCache {
             let old_verification = old.value();
 
             if !old_verification.is_cancelled() {
-                warn!("Received a new verification whilst another one with the same user is ongoing. Cancelling both verifications");
+                warn!(
+                    user_id = verification.other_user().as_str(),
+                    "Received a new verification whilst another one with \
+                    the same user is ongoing. Cancelling both verifications"
+                );
 
                 if let Some(r) = old_verification.cancel() {
                     self.add_request(r.into())

--- a/crates/matrix-sdk-crypto/src/verification/cache.rs
+++ b/crates/matrix-sdk-crypto/src/verification/cache.rs
@@ -58,6 +58,8 @@ impl VerificationCache {
             if !old_verification.is_cancelled() {
                 warn!(
                     user_id = verification.other_user().as_str(),
+                    old_flow_id = old_verification.flow_id(),
+                    new_flow_id = verification.flow_id(),
                     "Received a new verification whilst another one with \
                     the same user is ongoing. Cancelling both verifications"
                 );

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -336,7 +336,21 @@ impl VerificationRequest {
 
         if let Some(future) = fut {
             let qr_verification = future.await?;
-            self.verification_cache.insert_qr(qr_verification.clone());
+
+            // We may have previously started our own QR verification (e.g. two devices
+            // displaying QR code at the same time), so we need to replace it with the newly
+            // scanned code.
+            if self
+                .verification_cache
+                .get_qr(qr_verification.other_user_id(), qr_verification.flow_id().as_str())
+                .is_some()
+            {
+                info!("Replacing existing QR verification");
+                self.verification_cache.replace_qr(qr_verification.clone());
+            } else {
+                info!("Inserting new QR verification");
+                self.verification_cache.insert_qr(qr_verification.clone());
+            }
 
             Ok(Some(qr_verification))
         } else {
@@ -634,7 +648,23 @@ impl VerificationRequest {
                 if let Some((sas, content)) =
                     s.clone().start_sas(self.we_started, self.inner.clone().into()).await?
                 {
-                    self.verification_cache.insert_sas(sas.clone());
+                    // We may have previously started QR verification and generated a QR code. If we
+                    // now switch to SAS flow, the previous verification has to be replaced
+                    if cfg!(feature = "qrcode") {
+                        #[cfg(feature = "qrcode")]
+                        if self
+                            .verification_cache
+                            .get_qr(sas.other_user_id(), sas.flow_id().as_str())
+                            .is_some()
+                        {
+                            info!("We have an ongoing QR verification, replacing with SAS");
+                            self.verification_cache.replace(sas.clone().into())
+                        } else {
+                            self.verification_cache.insert_sas(sas.clone());
+                        }
+                    } else {
+                        self.verification_cache.insert_sas(sas.clone());
+                    }
 
                     let request = match content {
                         OutgoingContent::ToDevice(content) => ToDeviceRequest::with_id(
@@ -1222,7 +1252,11 @@ mod tests {
 
     use std::convert::{TryFrom, TryInto};
 
+    #[cfg(feature = "qrcode")]
+    use matrix_sdk_qrcode::QrVerificationData;
     use matrix_sdk_test::async_test;
+    #[cfg(feature = "qrcode")]
+    use ruma::events::key::verification::VerificationMethod;
     use ruma::{event_id, room_id};
 
     use super::VerificationRequest;
@@ -1384,5 +1418,126 @@ mod tests {
         assert!(!alice_sas.is_cancelled());
         assert!(alice_sas.started_from_request());
         assert!(bob_sas.started_from_request());
+    }
+
+    #[async_test]
+    #[cfg(feature = "qrcode")]
+    async fn can_scan_another_qr_after_creating_mine() {
+        let (alice_store, bob_store) = setup_stores().await;
+
+        let flow_id = FlowId::ToDevice("TEST_FLOW_ID".into());
+
+        // We setup the initial verification request
+        let bob_request = VerificationRequest::new(
+            VerificationCache::new(),
+            bob_store,
+            flow_id.clone(),
+            alice_id(),
+            vec![],
+            Some(vec![VerificationMethod::QrCodeScanV1, VerificationMethod::QrCodeShowV1]),
+        );
+
+        let request = bob_request.request_to_device();
+        let content: OutgoingContent = request.try_into().unwrap();
+        let content = RequestContent::try_from(&content).unwrap();
+
+        let alice_request = VerificationRequest::from_request(
+            VerificationCache::new(),
+            alice_store,
+            bob_id(),
+            flow_id,
+            &content,
+        );
+
+        let content: OutgoingContent = alice_request
+            .accept_with_methods(vec![
+                VerificationMethod::QrCodeScanV1,
+                VerificationMethod::QrCodeShowV1,
+            ])
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let content = ReadyContent::try_from(&content).unwrap();
+        bob_request.receive_ready(alice_id(), &content);
+
+        assert!(bob_request.is_ready());
+        assert!(alice_request.is_ready());
+
+        // Each side can start its own QR verification flow by generating QR code
+        let alice_verification = alice_request.generate_qr_code().await.unwrap();
+        let bob_verification = bob_request.generate_qr_code().await.unwrap();
+
+        assert!(alice_verification.is_some());
+        assert!(bob_verification.is_some());
+
+        // Now only Alice scans Bob's code
+        let bob_qr_code = bob_verification.unwrap().to_bytes().unwrap();
+        let bob_qr_code = QrVerificationData::from_bytes(bob_qr_code).unwrap();
+        let alice_verification = alice_request.scan_qr_code(bob_qr_code).await.unwrap().unwrap();
+
+        // Finally we assert that the verification has been reciprocated rather than
+        // cancelled due to a duplicate verification flow
+        assert!(!alice_verification.is_cancelled());
+        assert!(alice_verification.reciprocated());
+    }
+
+    #[async_test]
+    #[cfg(feature = "qrcode")]
+    async fn can_start_sas_after_generating_qr_code() {
+        let (alice_store, bob_store) = setup_stores().await;
+
+        let flow_id = FlowId::ToDevice("TEST_FLOW_ID".into());
+
+        // We setup the initial verification request
+        let bob_request = VerificationRequest::new(
+            VerificationCache::new(),
+            bob_store,
+            flow_id.clone(),
+            alice_id(),
+            vec![],
+            Some(vec![
+                VerificationMethod::QrCodeScanV1,
+                VerificationMethod::QrCodeShowV1,
+                VerificationMethod::SasV1,
+            ]),
+        );
+
+        let request = bob_request.request_to_device();
+        let content: OutgoingContent = request.try_into().unwrap();
+        let content = RequestContent::try_from(&content).unwrap();
+
+        let alice_request = VerificationRequest::from_request(
+            VerificationCache::new(),
+            alice_store,
+            bob_id(),
+            flow_id,
+            &content,
+        );
+
+        let content: OutgoingContent = alice_request
+            .accept_with_methods(vec![
+                VerificationMethod::QrCodeScanV1,
+                VerificationMethod::QrCodeShowV1,
+            ])
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let content = ReadyContent::try_from(&content).unwrap();
+        bob_request.receive_ready(alice_id(), &content);
+
+        assert!(bob_request.is_ready());
+        assert!(alice_request.is_ready());
+
+        // Each side can start its own QR verification flow by generating QR code
+        let alice_verification = alice_request.generate_qr_code().await.unwrap();
+        let bob_verification = bob_request.generate_qr_code().await.unwrap();
+
+        assert!(alice_verification.is_some());
+        assert!(bob_verification.is_some());
+
+        // Alice can now start SAS verification flow instead of QR without cancelling
+        // the request
+        let (sas, _) = alice_request.start_sas().await.unwrap().unwrap();
+        assert!(!sas.is_cancelled());
     }
 }


### PR DESCRIPTION
Two valid user flows currently lead to the insertion of duplicate verifications and thus the cancellation of both:

1. Two QR-capable devices both generate a QR code (and start qr_verification in the process), but only one of them will scan the other code. Once scanned, this will create a new `QrVerification` and clash with the existing one.
2. A device starts qr_verification and displays QR code, but then "Can't scan" (or similar) button is tapped, which will transition into SAS verification flow. Once again we will have a clashing previous verification.

To avoid the cancellation of these flows, we need to detect when this transition occurs, and explictly replace an existing verification with a new one.

An alternative solution would be to expose new `cancel_verification_flow` and call that from the client side, but this may be confusing, given that `cancel_verification` already exists, which will cancel the entire verification request.