### PR TITLE
Unifiy UniFFI version workspace-wide, use same for xtask job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4859,8 +4859,9 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uniffi"
-version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f54af5ada67d1173457a99a7bb44a7917f63e7466764cb4714865c7a6678b830"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4875,8 +4876,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cc4af3c0180c7e86c4a3acf2b6587af04ba2567b1e948993df10f421796621"
 dependencies = [
  "anyhow",
  "askama",
@@ -4897,8 +4899,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510287c368a9386eb731ebe824a6fc6c82a105e20d020af1aa20519c1c1561db"
 dependencies = [
  "anyhow",
  "camino",
@@ -4907,8 +4910,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8604503caa2cbcf271578dc51ca236d40e3b22e1514ffa2e638e2c39f6ad10"
 dependencies = [
  "bincode",
  "camino",
@@ -4925,8 +4929,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.20.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9417cc653937681436b93838d8c5f97a5b8c58697813982ee8810bd1dc3b57"
 dependencies = [
  "serde",
 ]
@@ -5236,7 +5241,8 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=0eee77f67b716c4896494606e5931d249871b23a#0eee77f67b716c4896494606e5931d249871b23a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
 dependencies = [
  "nom",
 ]
@@ -5389,9 +5395,11 @@ checksum = "4916a4a3cad759e499a3620523bf9545cc162d7a06163727dde97ce9aaa4cf39"
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "camino",
  "clap 3.2.22",
  "serde",
  "serde_json",
+ "uniffi_bindgen",
  "xshell",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,12 @@ members = [
 default-members = ["benchmarks", "crates/*"]
 resolver = "2"
 
+[workspace.dependencies]
+uniffi = "0.21.0"
+uniffi_macros = "0.21.0"
+uniffi_bindgen = "0.21.0"
+uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }
+
 [profile.release]
 lto = true
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The rust-sdk consists of multiple crates that can be picked at your convenience:
 
 ## Minimum Supported Rust Version (MSRV)
 
-These crates are built with the Rust language version 2021 and require a minimum compiler version of `1.62`
+These crates are built with the Rust language version 2021 and require a minimum compiler version of `1.64`
 
 ## Status
 

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -27,8 +27,8 @@ thiserror = "1.0.30"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
-uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
+uniffi = { workspace = true }
+uniffi_macros = { workspace = true }
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [dependencies.js_int]
@@ -59,7 +59,7 @@ features = ["rt-multi-thread"]
 version = "0.3.0"
 
 [build-dependencies]
-uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a", features = ["builtin-bindgen"] }
+uniffi_build = { workspace = true, features = ["builtin-bindgen"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -17,7 +17,7 @@ default = ["experimental-room-preview"] # the whole crate is still very experime
 experimental-room-preview = ["matrix-sdk/experimental-room-preview"]
 
 [build-dependencies]
-uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a", features = ["builtin-bindgen"] }
+uniffi_build = { workspace = true, features = ["builtin-bindgen"] }
 
 [dependencies]
 anyhow = "1.0.51"
@@ -37,6 +37,5 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-stream = "0.1.8"
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# keep in sync with uniffi dependency in matrix-sdk-crypto-ffi, and uniffi_bindgen in ffi CI job
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
-uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
+uniffi = { workspace = true }
+uniffi_macros = { workspace = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,9 +9,9 @@ name = "xtask"
 test = false
 
 [dependencies]
+camino = "1.0.8"
 clap = { version = "3.2.4", features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
+uniffi_bindgen =  { workspace = true }
 xshell = "0.1.17"
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
-camino = "1.0.8"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,3 +13,5 @@ clap = { version = "3.2.4", features = ["derive"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 xshell = "0.1.17"
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "0eee77f67b716c4896494606e5931d249871b23a" }
+camino = "1.0.8"


### PR DESCRIPTION
- [x] switches from using `uniffi-bindgen` system binary to using it as a library and calling that from within xtask
- [x] update uniffi to latest release (`0.21.0`) from yesterday
- [x] switch MSRV to 0.21.0 to allow us to use workspace-wide-definition of dependency
- [x] switch to workspace-wide-dependency usage of uniffi   