### PR TITLE
fix(sdk): Always send an access token for `get_profile`

### DIFF
--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -240,7 +240,8 @@ impl Account {
     pub async fn get_profile(&self) -> Result<get_profile::v3::Response> {
         let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
         let request = get_profile::v3::Request::new(user_id);
-        Ok(self.client.send(request, None).await?)
+        let request_config = self.client.request_config().force_auth();
+        Ok(self.client.send(request, Some(request_config)).await?)
     }
 
     /// Change the password of the account.


### PR DESCRIPTION
Follow-up to #1117.