### PR TITLE
Use workspace dependencies for a few more packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ uniffi_macros = "0.21.0"
 uniffi_bindgen = "0.21.0"
 uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }
 vodozemac = "0.3.0"
+zeroize = "1.3.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default-members = ["benchmarks", "crates/*"]
 resolver = "2"
 
 [workspace.dependencies]
+ruma = { version = "0.7.4", features = ["client-api-c"] }
 uniffi = "0.21.0"
 uniffi_macros = "0.21.0"
 uniffi_bindgen = "0.21.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ uniffi = "0.21.0"
 uniffi_macros = "0.21.0"
 uniffi_bindgen = "0.21.0"
 uniffi_build = { version = "0.21.0", features = ["builtin-bindgen"] }
+vodozemac = "0.3.0"
 
 [profile.release]
 lto = true

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ criterion = { version = "0.3.5", features = ["async", "async_tokio", "html_repor
 matrix-sdk-crypto = { path = "../crates/matrix-sdk-crypto", version = "0.6.0"}
 matrix-sdk-sled = { path = "../crates/matrix-sdk-sled", version = "0.2.0", default-features = false, features = ["crypto-store"] }
 matrix-sdk-test = { path = "../testing/matrix-sdk-test", version = "0.6.0"}
-ruma = "0.7.0"
+ruma = { workspace = true }
 serde_json = "1.0.79"
 tempfile = "3.3.0"
 tokio = { version = "1.17.0", default-features = false, features = ["rt-multi-thread"] }

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
 uniffi = { workspace = true }
 uniffi_macros = { workspace = true }
+vodozemac = { workspace = true }
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [dependencies.js_int]
@@ -54,9 +55,6 @@ features = ["crypto-store"]
 version = "1.17.0"
 default_features = false
 features = ["rt-multi-thread"]
-
-[dependencies.vodozemac]
-version = "0.3.0"
 
 [build-dependencies]
 uniffi_build = { workspace = true, features = ["builtin-bindgen"] }

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -19,7 +19,7 @@ hmac = "0.12.1"
 http = "0.2.6"
 pbkdf2 = "0.11.0"
 rand = "0.8.5"
-ruma = { version = "0.7.0", features = ["client-api-c"] }
+ruma = { workspace = true }
 serde = "1.0.136"
 serde_json = "1.0.79"
 sha2 = "0.10.2"

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -30,7 +30,7 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 uniffi = { workspace = true }
 uniffi_macros = { workspace = true }
 vodozemac = { workspace = true }
-zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [dependencies.js_int]
 version = "0.2.2"

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -32,7 +32,7 @@ matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto"
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../../crates/matrix-sdk-indexeddb", features = ["experimental-nodejs"] }
 matrix-sdk-qrcode = { version = "0.4.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
 ruma = { workspace = true, features = ["js", "rand", "unstable-msc2676", "unstable-msc2677"] }
-vodozemac = { version = "0.3.0", features = ["js"] }
+vodozemac = { workspace = true, features = ["js"] }
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"
 js-sys = "0.3.49"

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -42,4 +42,4 @@ http = "0.2.6"
 anyhow = "1.0.58"
 tracing = { version = "0.1.35", default-features = false, features = ["attributes"] }
 tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std"] }
-zeroize = "1.3.0"
+zeroize = { workspace = true }

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -31,7 +31,7 @@ matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common"
 matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto", features = ["js"] }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../../crates/matrix-sdk-indexeddb", features = ["experimental-nodejs"] }
 matrix-sdk-qrcode = { version = "0.4.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
-ruma = { version = "0.7.0", features = ["client-api-c", "js", "rand", "unstable-msc2676", "unstable-msc2677"] }
+ruma = { workspace = true, features = ["js", "rand", "unstable-msc2676", "unstable-msc2677"] }
 vodozemac = { version = "0.3.0", features = ["js"] }
 wasm-bindgen = "0.2.80"
 wasm-bindgen-futures = "0.4.30"

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -26,7 +26,7 @@ tracing = ["dep:tracing-subscriber"]
 matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto", features = ["js"] }
 matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
 matrix-sdk-sled = { version = "0.2.0", path = "../../crates/matrix-sdk-sled", default-features = false, features = ["crypto-store"] }
-ruma = { version = "0.7.0", features = ["client-api-c", "rand", "unstable-msc2676", "unstable-msc2677"] }
+ruma = { workspace = true, features = ["rand", "unstable-msc2676", "unstable-msc2677"] }
 napi = { version = "2.9.1", default-features = false, features = ["napi6", "tokio_rt"] }
 napi-derive = "2.9.1"
 serde_json = "1.0.79"

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -31,12 +31,9 @@ napi = { version = "2.9.1", default-features = false, features = ["napi6", "toki
 napi-derive = "2.9.1"
 serde_json = "1.0.79"
 http = "0.2.6"
-zeroize = "1.3.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["tracing-log", "time", "smallvec", "fmt", "env-filter"], optional = true }
-
-[dependencies.vodozemac]
-version = "0.3.0"
-features = ["js"]
+vodozemac = { workspace = true, features = ["js"]}
+zeroize = "1.3.0"
 
 [build-dependencies]
 napi-build = "2.0.0"

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = "1.0.79"
 http = "0.2.6"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["tracing-log", "time", "smallvec", "fmt", "env-filter"], optional = true }
 vodozemac = { workspace = true, features = ["js"]}
-zeroize = "1.3.0"
+zeroize = { workspace = true }
 
 [build-dependencies]
 napi-build = "2.0.0"

--- a/crates/matrix-sdk-appservice/Cargo.toml
+++ b/crates/matrix-sdk-appservice/Cargo.toml
@@ -37,7 +37,7 @@ http-body = "0.4.5"
 hyper = { version = "0.14.20", features = ["http1", "http2", "server"] }
 matrix-sdk = { version = "0.6.0", path = "../matrix-sdk", default-features = false, features = ["appservice"] }
 regex = "1.5.5"
-ruma = { version = "0.7.0", features = ["client-api-c", "appservice-api-s"] }
+ruma = { workspace = true, features = ["appservice-api-s"] }
 serde = "1.0.136"
 serde_json = "1.0.79"
 serde_yaml = "0.9.4"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -38,7 +38,7 @@ lru = "0.8.0"
 matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto", optional = true }
 once_cell = "1.10.0"
-ruma = { version = "0.7.0", features = ["client-api-c", "canonical-json"] }
+ruma = { workspace = true, features = ["canonical-json"] }
 serde = { version = "1.0.136", features = ["rc"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -43,7 +43,7 @@ serde = { version = "1.0.136", features = ["rc"] }
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 tracing = "0.1.34"
-zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -21,7 +21,7 @@ js = ["instant/wasm-bindgen", "instant/inaccurate", "wasm-bindgen-futures"]
 [dependencies]
 futures-core = "0.3.21"
 instant = "0.1.12"
-ruma = { version = "0.7.0", features = ["client-api-c"] }
+ruma = { workspace = true }
 serde = "1.0.136"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -49,7 +49,7 @@ sha2 = "0.10.2"
 thiserror = "1.0.30"
 tracing = "0.1.34"
 vodozemac = { workspace = true }
-zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.18", default-features = false, features = ["time"] }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0.79"
 sha2 = "0.10.2"
 thiserror = "1.0.30"
 tracing = "0.1.34"
-vodozemac = "0.3.0"
+vodozemac = { workspace = true }
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -42,7 +42,7 @@ matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 olm-rs = { version = "2.2.0", features = ["serde"], optional = true }
 pbkdf2 = { version = "0.11.0", default-features = false }
 rand = "0.8.5"
-ruma = { version = "0.7.0", features = ["client-api-c", "rand", "canonical-json", "unstable-msc2676", "unstable-msc2677"] }
+ruma = { workspace = true, features = ["rand", "canonical-json", "unstable-msc2676", "unstable-msc2677"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = "1.0.79"
 sha2 = "0.10.2"

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -30,7 +30,7 @@ matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto", features
 matrix-sdk-store-encryption = { version = "0.2.0", path = "../matrix-sdk-store-encryption" }
 indexed_db_futures = "0.2.3"
 indexed_db_futures_nodejs = { version = "0.2.3", package = "indexed_db_futures", git = "https://github.com/Hywan/rust-indexed-db", branch = "feat-factory-nodejs", optional = true }
-ruma = "0.7.0"
+ruma = { workspace = true }
 serde = "1.0.136"
 serde_json = "1.0.79"
 thiserror = "1.0.30"

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -21,9 +21,7 @@ byteorder = "1.4.3"
 qrcode = { version = "0.12.0", default-features = false }
 ruma-common = "0.10.0"
 thiserror = "1.0.30"
-
-[dependencies.vodozemac]
-version = "0.3.0"
+vodozemac = { workspace = true }
 
 [dev-dependencies]
 image = "0.23.0"

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -35,7 +35,7 @@ matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base", optional = t
 matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto", optional = true }
 matrix-sdk-store-encryption = { version = "0.2.0", path = "../matrix-sdk-store-encryption" }
-ruma = "0.7.0"
+ruma = { workspace = true }
 serde = "1.0.136"
 serde_json = "1.0.79"
 sled = "0.34.7"

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha2 = "0.10.2"
 thiserror = "1.0.30"
-zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 anyhow = "1.0.57"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -90,7 +90,7 @@ tokio-stream = { version = "0.1.8", features = ["net"], optional = true }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = "0.1.34"
 url = "2.2.2"
-zeroize = "1.3.0"
+zeroize = { workspace = true }
 
 [dependencies.image]
 version = "0.24.2"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -81,7 +81,8 @@ matrix-sdk-indexeddb = { version = "0.2.0", path = "../matrix-sdk-indexeddb", de
 matrix-sdk-sled = { version = "0.2.0", path = "../matrix-sdk-sled", default-features = false, optional = true }
 mime = "0.3.16"
 rand = { version = "0.8.5", optional = true }
-reqwest = { version = "0.11.10", default_features = false}
+reqwest = { version = "0.11.10", default_features = false }
+ruma = { workspace = true, features = ["compat", "rand", "unstable-msc2448", "unstable-msc2965"] }
 serde = "1.0.136"
 serde_json = "1.0.79"
 thiserror = "1.0.30"
@@ -110,10 +111,6 @@ features = [
     "farbfeld",
 ]
 optional = true
-
-[dependencies.ruma]
-version = "0.7.4"
-features = ["client-api-c", "compat", "rand", "unstable-msc2448", "unstable-msc2965"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-once-cell = "0.4.2"

--- a/labs/sled-state-inspector/Cargo.toml
+++ b/labs/sled-state-inspector/Cargo.toml
@@ -14,7 +14,7 @@ clap = "3.2.4"
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }
 matrix-sdk-base = { path = "../../crates/matrix-sdk-base", version = "0.6.0"}
 matrix-sdk-sled = { path = "../../crates/matrix-sdk-sled", version = "0.2.0"}
-ruma = "0.7.0"
+ruma = { workspace = true }
 rustyline = "10.0.0"
 rustyline-derive = "0.7.0"
 serde = "1.0.136"

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -22,7 +22,7 @@ appservice = []
 http = "0.2.6"
 matrix-sdk-test-macros = { version = "0.3.0", path = "../matrix-sdk-test-macros" }
 once_cell = "1.10.0"
-ruma = { version = "0.7.0", features = ["client-api-c"] }
+ruma = { workspace = true }
 serde = "1.0.136"
 serde_json = "1.0.79"
 


### PR DESCRIPTION
… where we can't use different versions anyways (ruma) or we want to consistently use the latest version we can for security reasons (vodozemac, zeroize).