### PR TITLE
feat(crypto): Add signalling to the SAS verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.63"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "anymap2"
@@ -648,13 +648,28 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.1",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef582e2c00a63a0c0aa1fb4a4870781c4f5729f51196d3537fa7c1c1992eaa3"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.13",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
 ]
 
 [[package]]
@@ -671,10 +686,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1358,7 +1395,8 @@ name = "example-emoji-verification"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.22",
+ "clap 4.0.16",
+ "futures",
  "matrix-sdk",
  "tokio",
  "tracing-subscriber",
@@ -1415,7 +1453,7 @@ name = "example-timeline"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.22",
+ "clap 4.0.16",
  "futures",
  "futures-signals",
  "matrix-sdk",
@@ -1520,11 +1558,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -1626,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "futures-signals"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6874899c7dc7416c6b30f13b62fb63098671e29ccf3999987270258114f2938"
+checksum = "a3acc659ba666cff13fdf65242d16428f2f11935b688f82e4024ad39667a5132"
 dependencies = [
  "discard",
  "futures-channel",
@@ -1968,11 +2005,10 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -2468,6 +2504,7 @@ name = "matrix-sdk-crypto"
 version = "0.6.0"
 dependencies = [
  "aes",
+ "anyhow",
  "async-trait",
  "atomic",
  "base64",
@@ -2477,6 +2514,8 @@ dependencies = [
  "dashmap",
  "event-listener",
  "futures",
+ "futures-core",
+ "futures-signals",
  "futures-util",
  "hmac",
  "http",
@@ -2918,6 +2957,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,6 +3149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3184,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project"
@@ -4527,9 +4582,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4537,7 +4592,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
@@ -4695,9 +4749,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4727,12 +4781,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
@@ -4960,13 +5014,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
  "serde",
 ]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -34,7 +34,9 @@ byteorder = "1.4.3"
 ctr = "0.9.1"
 dashmap = "5.2.0"
 event-listener = "2.5.2"
+futures-core = "0.3.24"
 futures-util = { version = "0.3.21", default-features = false, features = ["alloc"] }
+futures-signals = { version = "0.3.31", default-features = false }
 hmac = "0.12.1"
 http = { version = "0.2.6", optional = true } # feature = testing only
 matrix-sdk-qrcode = { version = "0.4.0", path = "../matrix-sdk-qrcode", optional = true }
@@ -55,6 +57,7 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 tokio = { version = "1.18", default-features = false, features = ["time"] }
 
 [dev-dependencies]
+anyhow = "1.0.65"
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }
 http = "0.2.6"
 indoc = "1.0.4"

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -88,7 +88,8 @@ pub use requests::{
 };
 pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretImportError, SecretInfo};
 pub use verification::{
-    format_emojis, AcceptSettings, CancelInfo, Emoji, Sas, Verification, VerificationRequest,
+    format_emojis, AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString, Sas,
+    SasState, Verification, VerificationRequest,
 };
 #[cfg(feature = "qrcode")]
 pub use verification::{QrVerification, ScanError};

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -47,7 +47,7 @@ use ruma::{
     DeviceId, EventId, OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId,
     UserId,
 };
-pub use sas::{AcceptSettings, Sas};
+pub use sas::{AcceptSettings, AcceptedProtocols, EmojiShortAuthString, Sas, SasState};
 use tracing::{error, info, trace, warn};
 
 use crate::{

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -18,17 +18,18 @@ mod sas_state;
 
 use std::sync::{Arc, Mutex};
 
+use futures_core::Stream;
+use futures_signals::signal::{Mutable, SignalExt};
 use inner_sas::InnerSas;
-#[cfg(test)]
-use matrix_sdk_common::instant::Instant;
 use ruma::{
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
     events::{
-        key::verification::{cancel::CancelCode, ShortAuthenticationString},
+        key::verification::{cancel::CancelCode, start::SasV1Content, ShortAuthenticationString},
         AnyMessageLikeEventContent, AnyToDeviceEventContent,
     },
     DeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, RoomId, TransactionId, UserId,
 };
+pub use sas_state::AcceptedProtocols;
 use tracing::trace;
 
 use super::{
@@ -47,11 +48,139 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct Sas {
     inner: Arc<Mutex<InnerSas>>,
+    state: Arc<Mutable<SasState>>,
     account: ReadOnlyAccount,
     identities_being_verified: IdentitiesBeingVerified,
     flow_id: Arc<FlowId>,
     we_started: bool,
     request_handle: Option<RequestHandle>,
+}
+
+/// The short auth string for the emoji method of SAS verification.
+#[derive(Debug, Clone)]
+pub struct EmojiShortAuthString {
+    /// A list of seven indices that should be used for the SAS verification.
+    ///
+    /// The indices can be put into the emoji table in the [spec] to figure out
+    /// the symbols and descriptions.
+    ///
+    /// If you have a table of [translated descriptions] for the emojis you will
+    /// want to use this field.
+    ///
+    /// [spec]: https://spec.matrix.org/unstable/client-server-api/#sas-method-emoji
+    /// [translated descriptions]: https://github.com/matrix-org/matrix-doc/blob/master/data-definitions/
+    pub indices: [u8; 7],
+
+    /// A list of seven emojis that should be used for the SAS verification.
+    pub emojis: [Emoji; 7],
+}
+
+/// An Enum describing the state the SAS verification is in.
+#[derive(Debug, Clone)]
+pub enum SasState {
+    /// The verification has been started, the protocols that should be used
+    /// have been proposed and can be accepted.
+    Started {
+        /// The protocols that were proposed in the `m.key.verification.start`
+        /// event.
+        protocols: SasV1Content,
+    },
+    /// The verification has been accepted and both sides agreed to a set of
+    /// protocols that will be used for the verification process.
+    Accepted {
+        /// The protocols that were accepted in the `m.key.verification.accept`
+        /// event.
+        accepted_protocols: AcceptedProtocols,
+    },
+    /// The public keys have been exchanged and the short auth string can be
+    /// presented to the user.
+    KeysExchanged {
+        /// The emojis that represent the short auth string, will be `None` if
+        /// the emoji SAS method wasn't part of the [`AcceptedProtocols`].
+        emojis: Option<EmojiShortAuthString>,
+        /// The list of decimals that represent the short auth string.
+        decimals: (u16, u16, u16),
+    },
+    /// The verification process has been confirmed from our side, we're waiting
+    /// for the other side to confirm as well.
+    Confirmed,
+    /// The verification process has been successfully concluded.
+    Done {
+        /// The list of devices that has been verified.
+        verified_devices: Vec<ReadOnlyDevice>,
+        /// The list of user identities that has been verified.
+        verified_identities: Vec<ReadOnlyUserIdentities>,
+    },
+    /// The verification process has been cancelled.
+    Cancelled(CancelInfo),
+}
+
+impl PartialEq for SasState {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Started { .. }, Self::Started { .. })
+                | (Self::Accepted { .. }, Self::Accepted { .. })
+                | (Self::KeysExchanged { .. }, Self::KeysExchanged { .. })
+                | (Self::Confirmed, Self::Confirmed)
+                | (Self::Done { .. }, Self::Done { .. })
+                | (Self::Cancelled(_), Self::Cancelled(_))
+        )
+    }
+}
+
+impl From<&InnerSas> for SasState {
+    fn from(value: &InnerSas) -> Self {
+        match value {
+            InnerSas::Created(s) => {
+                Self::Started { protocols: s.state.protocol_definitions.to_owned() }
+            }
+            InnerSas::Started(s) => {
+                Self::Started { protocols: s.state.protocol_definitions.to_owned() }
+            }
+            InnerSas::Accepted(s) => {
+                Self::Accepted { accepted_protocols: s.state.accepted_protocols.to_owned() }
+            }
+            InnerSas::WeAccepted(s) => {
+                Self::Accepted { accepted_protocols: s.state.accepted_protocols.to_owned() }
+            }
+            InnerSas::KeyReceived(s) => {
+                let emojis = if value.supports_emoji() {
+                    let emojis = s.get_emoji();
+                    let indices = s.get_emoji_index();
+
+                    Some(EmojiShortAuthString { emojis, indices })
+                } else {
+                    None
+                };
+
+                let decimals = s.get_decimal();
+
+                Self::KeysExchanged { emojis, decimals }
+            }
+            InnerSas::MacReceived(s) => {
+                let emojis = if value.supports_emoji() {
+                    let emojis = s.get_emoji();
+                    let indices = s.get_emoji_index();
+
+                    Some(EmojiShortAuthString { emojis, indices })
+                } else {
+                    None
+                };
+
+                let decimals = s.get_decimal();
+
+                Self::KeysExchanged { emojis, decimals }
+            }
+            InnerSas::Confirmed(_) => Self::Confirmed,
+            InnerSas::WaitingForDone(_) => Self::Confirmed,
+            InnerSas::Done(s) => Self::Done {
+                verified_devices: s.verified_devices().to_vec(),
+                verified_identities: s.verified_identities().to_vec(),
+            },
+            InnerSas::Cancelled(c) => Self::Cancelled(c.state.as_ref().clone().into()),
+        }
+    }
 }
 
 impl Sas {
@@ -137,7 +266,7 @@ impl Sas {
 
     #[cfg(test)]
     #[allow(dead_code)]
-    pub(crate) fn set_creation_time(&self, time: Instant) {
+    pub(crate) fn set_creation_time(&self, time: matrix_sdk_common::instant::Instant) {
         self.inner.lock().unwrap().set_creation_time(time)
     }
 
@@ -156,11 +285,13 @@ impl Sas {
             request_handle.is_some(),
         );
 
+        let state = (&inner).into();
         let account = identities.store.account.clone();
 
         (
             Sas {
                 inner: Arc::new(Mutex::new(inner)),
+                state: Mutable::new(state).into(),
                 account,
                 identities_being_verified: identities,
                 flow_id: flow_id.into(),
@@ -241,10 +372,12 @@ impl Sas {
             request_handle.is_some(),
         )?;
 
+        let state = (&inner).into();
         let account = identities.store.account.clone();
 
         Ok(Sas {
             inner: Arc::new(Mutex::new(inner)),
+            state: Mutable::new(state).into(),
             account,
             identities_being_verified: identities,
             flow_id: flow_id.into(),
@@ -271,28 +404,41 @@ impl Sas {
         &self,
         settings: AcceptSettings,
     ) -> Option<OutgoingVerificationRequest> {
-        let mut guard = self.inner.lock().unwrap();
-        let sas: InnerSas = (*guard).clone();
-        let methods = settings.allowed_methods;
+        let (request, state) = {
+            let mut guard = self.inner.lock().unwrap();
+            let sas: InnerSas = (*guard).clone();
+            let methods = settings.allowed_methods;
 
-        if let Some((sas, content)) = sas.accept(methods) {
-            *guard = sas;
+            if let Some((sas, content)) = sas.accept(methods) {
+                let state: SasState = (&sas).into();
 
-            Some(match content {
-                OwnedAcceptContent::ToDevice(c) => {
-                    let content = AnyToDeviceEventContent::KeyVerificationAccept(c);
-                    self.content_to_request(content).into()
-                }
-                OwnedAcceptContent::Room(room_id, content) => RoomMessageRequest {
-                    room_id,
-                    txn_id: TransactionId::new(),
-                    content: AnyMessageLikeEventContent::KeyVerificationAccept(content),
-                }
-                .into(),
-            })
-        } else {
-            None
+                *guard = sas;
+
+                (
+                    Some(match content {
+                        OwnedAcceptContent::ToDevice(c) => {
+                            let content = AnyToDeviceEventContent::KeyVerificationAccept(c);
+                            self.content_to_request(content).into()
+                        }
+                        OwnedAcceptContent::Room(room_id, content) => RoomMessageRequest {
+                            room_id,
+                            txn_id: TransactionId::new(),
+                            content: AnyMessageLikeEventContent::KeyVerificationAccept(content),
+                        }
+                        .into(),
+                    }),
+                    Some(state),
+                )
+            } else {
+                (None, None)
+            }
+        };
+
+        if let Some(new_state) = state {
+            self.update_state(new_state);
         }
+
+        request
     }
 
     /// Confirm the Sas verification.
@@ -306,13 +452,15 @@ impl Sas {
         &self,
     ) -> Result<(Vec<OutgoingVerificationRequest>, Option<SignatureUploadRequest>), CryptoStoreError>
     {
-        let (contents, done) = {
+        let (contents, done, state) = {
             let mut guard = self.inner.lock().unwrap();
+
             let sas: InnerSas = (*guard).clone();
             let (sas, contents) = sas.confirm();
+            let state: SasState = (&sas).into();
 
             *guard = sas;
-            (contents, guard.is_done())
+            (contents, guard.is_done(), state)
         };
 
         let mac_requests = contents
@@ -339,10 +487,17 @@ impl Sas {
                 VerificationResult::Cancel(c) => {
                     Ok((self.cancel_with_code(c).into_iter().collect(), None))
                 }
-                VerificationResult::Ok => Ok((mac_requests, None)),
-                VerificationResult::SignatureUpload(r) => Ok((mac_requests, Some(r))),
+                VerificationResult::Ok => {
+                    self.update_state(state);
+                    Ok((mac_requests, None))
+                }
+                VerificationResult::SignatureUpload(r) => {
+                    self.update_state(state);
+                    Ok((mac_requests, Some(r)))
+                }
             }
         } else {
+            self.update_state(state);
             Ok((mac_requests, None))
         }
     }
@@ -377,21 +532,32 @@ impl Sas {
     ///
     /// [`cancel()`]: #method.cancel
     pub fn cancel_with_code(&self, code: CancelCode) -> Option<OutgoingVerificationRequest> {
-        let mut guard = self.inner.lock().unwrap();
+        let (content, state) = {
+            let mut guard = self.inner.lock().unwrap();
 
-        if let Some(request) = &self.request_handle {
-            request.cancel_with_code(&code);
-        }
-
-        let sas: InnerSas = (*guard).clone();
-        let (sas, content) = sas.cancel(true, code);
-        *guard = sas;
-        content.map(|c| match c {
-            OutgoingContent::Room(room_id, content) => {
-                RoomMessageRequest { room_id, txn_id: TransactionId::new(), content }.into()
+            if let Some(request) = &self.request_handle {
+                request.cancel_with_code(&code);
             }
-            OutgoingContent::ToDevice(c) => self.content_to_request(c).into(),
-        })
+
+            let sas: InnerSas = (*guard).clone();
+            let (sas, content) = sas.cancel(true, code);
+            let state: SasState = (&sas).into();
+            *guard = sas;
+
+            (
+                content.map(|c| match c {
+                    OutgoingContent::Room(room_id, content) => {
+                        RoomMessageRequest { room_id, txn_id: TransactionId::new(), content }.into()
+                    }
+                    OutgoingContent::ToDevice(c) => self.content_to_request(c).into(),
+                }),
+                state,
+            )
+        };
+
+        self.update_state(state);
+
+        content
     }
 
     pub(crate) fn cancel_if_timed_out(&self) -> Option<OutgoingVerificationRequest> {
@@ -451,15 +617,132 @@ impl Sas {
         self.inner.lock().unwrap().decimals()
     }
 
+    /// Listen for changes in the SAS verification process.
+    ///
+    /// The changes are presented as a stream of [`SasState`] values.
+    ///
+    /// This method can be used to react to changes in the state of the
+    /// verification process, or rather the method can be used to handle
+    /// each step of the verification process.
+    ///
+    /// # Flowchart
+    ///
+    /// The flow of the verification process is pictured bellow. Please note
+    /// that the process can be cancelled at each step of the process.
+    /// Either side can cancel the process.
+    ///
+    /// ```text
+    ///                ┌───────┐
+    ///                │Started│
+    ///                └───┬───┘
+    ///                    │
+    ///               ┌────⌄───┐
+    ///               │Accepted│
+    ///               └────┬───┘
+    ///                    │
+    ///            ┌───────⌄──────┐
+    ///            │Keys Exchanged│
+    ///            └───────┬──────┘
+    ///                    │
+    ///            ________⌄________
+    ///           ╱                 ╲       ┌─────────┐
+    ///          ╱   Does the short  ╲______│Cancelled│
+    ///          ╲ auth string match ╱ no   └─────────┘
+    ///           ╲_________________╱
+    ///                    │yes
+    ///                    │
+    ///               ┌────⌄────┐
+    ///               │Confirmed│
+    ///               └────┬────┘
+    ///                    │
+    ///                ┌───⌄───┐
+    ///                │  Done │
+    ///                └───────┘
+    /// ```
+    /// # Example
+    ///
+    /// ```no_run
+    /// use futures::stream::{Stream, StreamExt};
+    /// use matrix_sdk_crypto::{Sas, SasState};
+    ///
+    /// # futures::executor::block_on(async {
+    /// # let sas: Sas = unimplemented!();
+    ///
+    /// while let Some(state) = sas.changes().next().await {
+    ///     match state {
+    ///         SasState::KeysExchanged { emojis, decimals: _ } => {
+    ///             let emojis =
+    ///                 emojis.expect("We only support emoji verification");
+    ///             println!("Do these emojis match {emojis:#?}");
+    ///
+    ///             // Ask the user to confirm or cancel here.
+    ///         }
+    ///         SasState::Done { .. } => {
+    ///             let device = sas.other_device();
+    ///
+    ///             println!(
+    ///                 "Successfully verified device {} {} {:?}",
+    ///                 device.user_id(),
+    ///                 device.device_id(),
+    ///                 device.local_trust_state()
+    ///             );
+    ///
+    ///             break;
+    ///         }
+    ///         SasState::Cancelled(cancel_info) => {
+    ///             println!(
+    ///                 "The verification has been cancelled, reason: {}",
+    ///                 cancel_info.reason()
+    ///             );
+    ///             break;
+    ///         }
+    ///         SasState::Started { .. }
+    ///         | SasState::Accepted { .. }
+    ///         | SasState::Confirmed => (),
+    ///     }
+    /// }
+    /// # anyhow::Ok(()) });
+    /// ```
+    pub fn changes(&self) -> impl Stream<Item = SasState> {
+        self.state.signal_cloned().to_stream()
+    }
+
+    /// Get the current state of the verification process.
+    pub fn state(&self) -> SasState {
+        self.state.lock_ref().to_owned()
+    }
+
+    fn update_state(&self, new_state: SasState) {
+        let mut lock = self.state.lock_mut();
+
+        // Only update the state if it differs, this is important so clients don't end
+        // up printing the emoji twice. For example, the internal state might
+        // change into a MacReceived, because the other side already confirmed,
+        // but our side still needs to just show the emoji and wait for
+        // confirmation.
+        if *lock != new_state {
+            *lock = new_state;
+        }
+    }
+
     pub(crate) fn receive_any_event(
         &self,
         sender: &UserId,
         content: &AnyVerificationContent<'_>,
     ) -> Option<OutgoingContent> {
-        let mut guard = self.inner.lock().unwrap();
-        let sas: InnerSas = (*guard).clone();
-        let (sas, content) = sas.receive_any_event(sender, content);
-        *guard = sas;
+        let (content, state) = {
+            let mut guard = self.inner.lock().unwrap();
+            let sas: InnerSas = (*guard).clone();
+            let (sas, content) = sas.receive_any_event(sender, content);
+
+            let state: SasState = (&sas).into();
+
+            *guard = sas;
+
+            (content, state)
+        };
+
+        self.update_state(state);
 
         content
     }
@@ -527,7 +810,7 @@ mod tests {
             event_enums::{AcceptContent, KeyContent, MacContent, OutgoingContent, StartContent},
             VerificationStore,
         },
-        ReadOnlyAccount, ReadOnlyDevice,
+        ReadOnlyAccount, ReadOnlyDevice, SasState,
     };
 
     fn alice_id() -> &'static UserId {
@@ -573,18 +856,25 @@ mod tests {
 
         let (alice, content) = Sas::start(identities, TransactionId::new(), true, None);
 
+        matches!(alice.state(), SasState::Started { .. });
+
         let flow_id = alice.flow_id().to_owned();
         let content = StartContent::try_from(&content).unwrap();
 
         let identities = bob_store.get_identities(alice_device).await.unwrap();
         let bob = Sas::from_start_event(flow_id, &content, identities, None, false).unwrap();
 
+        matches!(bob.state(), SasState::Started { .. });
+
         let request = bob.accept().unwrap();
+
         let content = OutgoingContent::try_from(request).unwrap();
         let content = AcceptContent::try_from(&content).unwrap();
 
         let content = alice.receive_any_event(bob.user_id(), &content.into()).unwrap();
 
+        matches!(alice.state(), SasState::Accepted { .. });
+        matches!(bob.state(), SasState::Accepted { .. });
         assert!(!alice.can_be_presented());
         assert!(!bob.can_be_presented());
 
@@ -592,22 +882,27 @@ mod tests {
         let content = bob.receive_any_event(alice.user_id(), &content.into()).unwrap();
 
         assert!(bob.can_be_presented());
+        matches!(bob.state(), SasState::KeysExchanged { .. });
 
         let content = KeyContent::try_from(&content).unwrap();
         alice.receive_any_event(bob.user_id(), &content.into());
+        matches!(alice.state(), SasState::KeysExchanged { .. });
         assert!(alice.can_be_presented());
 
         assert_eq!(alice.emoji().unwrap(), bob.emoji().unwrap());
         assert_eq!(alice.decimals().unwrap(), bob.decimals().unwrap());
 
         let mut requests = alice.confirm().await.unwrap().0;
+        matches!(alice.state(), SasState::Confirmed);
         assert!(requests.len() == 1);
         let request = requests.pop().unwrap();
         let content = OutgoingContent::try_from(request).unwrap();
         let content = MacContent::try_from(&content).unwrap();
         bob.receive_any_event(alice.user_id(), &content.into());
+        matches!(bob.state(), SasState::KeysExchanged { .. });
 
         let mut requests = bob.confirm().await.unwrap().0;
+        matches!(bob.state(), SasState::Confirmed);
         assert!(requests.len() == 1);
         let request = requests.pop().unwrap();
         let content = OutgoingContent::try_from(request).unwrap();
@@ -616,5 +911,7 @@ mod tests {
 
         assert!(alice.verified_devices().unwrap().contains(alice.other_device()));
         assert!(bob.verified_devices().unwrap().contains(bob.other_device()));
+        matches!(alice.state(), SasState::Done { .. });
+        matches!(bob.state(), SasState::Done { .. });
     }
 }

--- a/crates/matrix-sdk/src/encryption/verification/mod.rs
+++ b/crates/matrix-sdk/src/encryption/verification/mod.rs
@@ -35,7 +35,10 @@ mod qrcode;
 mod requests;
 mod sas;
 
-pub use matrix_sdk_base::crypto::{format_emojis, AcceptSettings, CancelInfo, Emoji};
+pub use matrix_sdk_base::crypto::{
+    format_emojis, AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString,
+    SasState,
+};
 #[cfg(feature = "qrcode")]
 pub use matrix_sdk_base::crypto::{
     matrix_sdk_qrcode::{DecodingError, EncodingError, QrVerificationData},

--- a/examples/emoji_verification/Cargo.toml
+++ b/examples/emoji_verification/Cargo.toml
@@ -10,10 +10,11 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }
-clap = { version = "3.2.20", features = ["derive"] }
-tracing-subscriber = "0.3.15"
-url = "2.2.2"
+tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
+clap = { version = "4.0.15", features = ["derive"] }
+futures = "0.3.24"
+tracing-subscriber = "0.3.16"
+url = "2.3.1"
 
 [dependencies.matrix-sdk]
 path = "../../crates/matrix-sdk"

--- a/examples/timeline/Cargo.toml
+++ b/examples/timeline/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-clap = "3.2.22"
+clap = "4.0.16"
 futures = "0.3"
 futures-signals = { version = "0.3.30", default-features = false }
 tokio = { version = "1.20.1", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
This patch adds a way for users to listen to changes in the state of a SAS verification.

This makes it much more pleasant to go through the verification flow and incidentally easier to document it.