### PR TITLE
ci: Cancel all CI jobs for old commits when pushing to a PR branch

### DIFF
--- a/.github/workflows/cancel_others.yml
+++ b/.github/workflows/cancel_others.yml
@@ -10,3 +10,4 @@ jobs:
         uses: styfle/cancel-workflow-action@0.11.0
         with:
           workflow_id: all
+          all_but_latest: true

--- a/.github/workflows/cancel_others.yml
+++ b/.github/workflows/cancel_others.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel workflows for older commits
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           workflow_id: all

--- a/.github/workflows/cancel_others.yml
+++ b/.github/workflows/cancel_others.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  cancel-others:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel workflows for older commits
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          workflow_id: all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  cancel-others:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-        with:
-          access_token: ${{ github.token }}
-
   xtask:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
(not just jobs from the ci workflow file)