### PR TITLE
Set local trust

### DIFF
--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -51,7 +51,12 @@ lipo -create \
   -output "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a"
 
 # Generate uniffi files
-uniffi-bindgen generate "${SRC_ROOT}/bindings/${TARGET_CRATE}/src/olm.udl" --language swift --config "${SRC_ROOT}/bindings/${TARGET_CRATE}/uniffi.toml" --out-dir ${GENERATED_DIR}
+uniffi-bindgen generate \
+  --language swift \
+  --lib-file "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+  --config "${SRC_ROOT}/bindings/${TARGET_CRATE}/uniffi.toml" \
+  --out-dir ${GENERATED_DIR} \
+  "${SRC_ROOT}/bindings/${TARGET_CRATE}/src/olm.udl"
 
 # Move headers to the right place
 HEADERS_DIR=${GENERATED_DIR}/headers

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -28,7 +28,10 @@ pub use error::{
 use js_int::UInt;
 pub use logger::{set_logger, Logger};
 pub use machine::{KeyRequestPair, OlmMachine};
-use matrix_sdk_crypto::types::{EventEncryptionAlgorithm, SigningKey};
+use matrix_sdk_crypto::{
+    types::{EventEncryptionAlgorithm, SigningKey},
+    LocalTrust,
+};
 pub use responses::{
     BootstrapCrossSigningResult, DeviceLists, KeysImportResult, OutgoingVerificationRequest,
     Request, RequestType, SignatureUploadRequest, UploadSigningKeysRequest,

--- a/bindings/matrix-sdk-crypto-ffi/src/logger.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/logger.rs
@@ -51,6 +51,7 @@ pub fn set_logger(logger: Box<dyn Logger>) {
     let _ = tracing_subscriber::fmt()
         .with_writer(logger)
         .with_env_filter(filter)
+        .with_ansi(false)
         .without_time()
         .try_init();
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -283,11 +283,13 @@ impl OlmMachine {
         }
     }
 
-    /// Mark the device of the given user with the given device ID as trusted.
-    pub fn mark_device_as_trusted(
+    /// Set local trust state for the device of the given user without creating
+    /// or uploading any signatures if verified
+    pub fn set_local_trust(
         &self,
         user_id: &str,
         device_id: &str,
+        trust_state: LocalTrust,
     ) -> Result<(), CryptoStoreError> {
         let user_id = parse_user_id(user_id)?;
 
@@ -295,7 +297,7 @@ impl OlmMachine {
             self.runtime.block_on(self.inner.get_device(&user_id, device_id.into(), None))?;
 
         if let Some(device) = device {
-            self.runtime.block_on(device.set_local_trust(LocalTrust::Verified))?;
+            self.runtime.block_on(device.set_local_trust(trust_state))?;
         }
 
         Ok(())

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -247,6 +247,13 @@ enum RequestType {
     "RoomMessage",
 };
 
+enum LocalTrust {
+    "Verified",
+    "BlackListed",
+    "Ignored",
+    "Unset",
+};
+
 interface OlmMachine {
     [Throws=CryptoStoreError]
     constructor(
@@ -282,7 +289,7 @@ interface OlmMachine {
     [Throws=CryptoStoreError]
     Device? get_device([ByRef] string user_id, [ByRef] string device_id, u32 timeout);
     [Throws=CryptoStoreError]
-    void mark_device_as_trusted([ByRef] string user_id, [ByRef] string device_id);
+    void set_local_trust([ByRef] string user_id, [ByRef] string device_id, LocalTrust trust_state);
     [Throws=SignatureError]
     SignatureUploadRequest verify_device([ByRef] string user_id, [ByRef] string device_id);
     [Throws=CryptoStoreError]


### PR DESCRIPTION
Deprecate unused `mark_device_as_trusted` (one should instead use `verify_device` which will create and upload new signatures) and expose the internal `set_local_trust` instead, which can be used to (un)blacklist a user.