### PR TITLE
Revert "refactor(bindings): Use new uniffi::Enum derive macro in crypto-ffi"

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -474,12 +474,7 @@ fn parse_user_id(user_id: &str) -> Result<OwnedUserId, CryptoStoreError> {
 }
 
 mod uniffi_types {
-    pub use crate::{
-        backup_recovery_key::BackupRecoveryKey,
-        machine::OlmMachine,
-        responses::OutgoingVerificationRequest,
-        verification::{CancelInfo, QrCode, Sas, ScanResult, Verification},
-    };
+    pub use crate::{backup_recovery_key::BackupRecoveryKey, machine::OlmMachine};
 }
 
 #[cfg(test)]

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -160,6 +160,11 @@ dictionary Sas {
     CancelInfo? cancel_info;
 };
 
+dictionary ScanResult {
+    QrCode qr;
+    OutgoingVerificationRequest request;
+};
+
 dictionary QrCode {
     string other_user_id;
     string other_device_id;
@@ -198,6 +203,12 @@ dictionary RequestVerificationResult {
 dictionary ConfirmVerificationResult {
     sequence<OutgoingVerificationRequest> requests;
     SignatureUploadRequest? signature_request;
+};
+
+[Enum]
+interface Verification {
+    SasV1(Sas sas);
+    QrCodeV1(QrCode qrcode);
 };
 
 dictionary KeyRequestPair {
@@ -296,6 +307,7 @@ interface OlmMachine {
     void receive_unencrypted_verification_event([ByRef] string event, [ByRef] string room_id);
     sequence<VerificationRequest> get_verification_requests([ByRef] string user_id);
     VerificationRequest? get_verification_request([ByRef] string user_id, [ByRef] string flow_id);
+    Verification? get_verification([ByRef] string user_id, [ByRef] string flow_id);
 
     [Throws=CryptoStoreError]
     VerificationRequest? request_verification(
@@ -318,18 +330,31 @@ interface OlmMachine {
         sequence<string> methods
     );
 
+    OutgoingVerificationRequest? accept_verification_request(
+        [ByRef] string user_id,
+        [ByRef] string flow_id,
+        sequence<string> methods
+    );
+
     [Throws=CryptoStoreError]
     ConfirmVerificationResult? confirm_verification([ByRef] string user_id, [ByRef] string flow_id);
+    OutgoingVerificationRequest? cancel_verification(
+        [ByRef] string user_id,
+        [ByRef] string flow_id,
+        [ByRef] string cancel_code
+    );
 
     [Throws=CryptoStoreError]
     StartSasResult? start_sas_with_device([ByRef] string user_id, [ByRef] string device_id);
     [Throws=CryptoStoreError]
     StartSasResult? start_sas_verification([ByRef] string user_id, [ByRef] string flow_id);
+    OutgoingVerificationRequest? accept_sas_verification([ByRef] string user_id, [ByRef] string flow_id);
     sequence<i32>? get_emoji_index([ByRef] string user_id, [ByRef] string flow_id);
     sequence<i32>? get_decimals([ByRef] string user_id, [ByRef] string flow_id);
 
     [Throws=CryptoStoreError]
     QrCode? start_qr_verification([ByRef] string user_id, [ByRef] string flow_id);
+    ScanResult? scan_qr_code([ByRef] string user_id, [ByRef] string flow_id, [ByRef] string data);
     string? generate_qr_code([ByRef] string user_id, [ByRef] string flow_id);
 
     [Throws=DecryptionError]

--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -82,7 +82,6 @@ impl From<(RustUploadSigningKeysRequest, RustSignatureUploadRequest)>
     }
 }
 
-#[derive(uniffi::Enum)]
 pub enum OutgoingVerificationRequest {
     ToDevice { request_id: String, event_type: String, body: String },
     InRoom { request_id: String, room_id: String, event_type: String, content: String },

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -6,7 +6,6 @@ use matrix_sdk_crypto::{
 use crate::{OutgoingVerificationRequest, SignatureUploadRequest};
 
 /// Enum representing the different verification flows we support.
-#[derive(uniffi::Enum)]
 pub enum Verification {
     /// The `m.sas.v1` verification flow.
     SasV1 {
@@ -22,7 +21,6 @@ pub enum Verification {
 }
 
 /// The `m.sas.v1` verification flow.
-#[derive(uniffi::Record)]
 pub struct Sas {
     /// The other user that is participating in the verification flow
     pub other_user_id: String,
@@ -55,7 +53,6 @@ pub struct Sas {
 
 /// The `m.qr_code.scan.v1`, `m.qr_code.show.v1`, and `m.reciprocate.v1`
 /// verification flow.
-#[derive(uniffi::Record)]
 pub struct QrCode {
     /// The other user that is participating in the verification flow
     pub other_user_id: String,
@@ -103,7 +100,6 @@ impl From<InnerQr> for QrCode {
 }
 
 /// Information on why a verification flow has been cancelled and by whom.
-#[derive(uniffi::Record)]
 pub struct CancelInfo {
     /// The textual representation of the cancel reason
     pub reason: String,
@@ -133,7 +129,6 @@ pub struct StartSasResult {
 }
 
 /// A result type for scanning QR codes.
-#[derive(uniffi::Record)]
 pub struct ScanResult {
     /// The QR code verification object that got created.
     pub qr: QrCode,


### PR DESCRIPTION
This reverts commit 6b9075aa42dbd30253468a6c41c84cce2a67d06c.

I have a partial fix for UniFFI locally, but am not managing to make it work fully.