### PR TITLE
Allow passing the E2EE settings when sharing a room key

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -11,9 +11,8 @@ use js_int::UInt;
 use matrix_sdk_common::deserialized_responses::AlgorithmInfo;
 use matrix_sdk_crypto::{
     backups::MegolmV1BackupKey as RustBackupKey, decrypt_room_key_export, encrypt_room_key_export,
-    matrix_sdk_qrcode::QrVerificationData, olm::ExportedRoomKey, store::RecoveryKey,
-    EncryptionSettings, LocalTrust, OlmMachine as InnerMachine, UserIdentities,
-    Verification as RustVerification,
+    matrix_sdk_qrcode::QrVerificationData, olm::ExportedRoomKey, store::RecoveryKey, LocalTrust,
+    OlmMachine as InnerMachine, UserIdentities, Verification as RustVerification,
 };
 use ruma::{
     api::{
@@ -46,9 +45,9 @@ use crate::{
     responses::{response_from_string, OutgoingVerificationRequest, OwnedResponse},
     BackupKeys, BackupRecoveryKey, BootstrapCrossSigningResult, ConfirmVerificationResult,
     CrossSigningKeyExport, CrossSigningStatus, DecodeError, DecryptedEvent, Device, DeviceLists,
-    KeyImportError, KeysImportResult, MegolmV1BackupKey, ProgressListener, QrCode, Request,
-    RequestType, RequestVerificationResult, RoomKeyCounts, ScanResult, SignatureUploadRequest,
-    StartSasResult, UserIdentity, Verification, VerificationRequest,
+    EncryptionSettings, KeyImportError, KeysImportResult, MegolmV1BackupKey, ProgressListener,
+    QrCode, Request, RequestType, RequestVerificationResult, RoomKeyCounts, ScanResult,
+    SignatureUploadRequest, StartSasResult, UserIdentity, Verification, VerificationRequest,
 };
 
 /// A high level state machine that handles E2EE for Matrix.
@@ -521,6 +520,7 @@ impl OlmMachine {
         &self,
         room_id: &str,
         users: Vec<String>,
+        settings: EncryptionSettings,
     ) -> Result<Vec<Request>, CryptoStoreError> {
         let users: Vec<OwnedUserId> =
             users.into_iter().filter_map(|u| UserId::parse(u).ok()).collect();
@@ -529,7 +529,7 @@ impl OlmMachine {
         let requests = self.runtime.block_on(self.inner.share_room_key(
             &room_id,
             users.iter().map(Deref::deref),
-            EncryptionSettings::default(),
+            settings,
         ))?;
 
         Ok(requests.into_iter().map(|r| r.as_ref().into()).collect())

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -254,6 +254,26 @@ enum LocalTrust {
     "Unset",
 };
 
+enum EventEncryptionAlgorithm {
+    "OlmV1Curve25519AesSha2",
+    "MegolmV1AesSha2",
+};
+
+enum HistoryVisibility {
+    "Invited",
+    "Joined",
+    "Shared",
+    "WorldReadable",
+};
+
+dictionary EncryptionSettings {
+    EventEncryptionAlgorithm algorithm;
+    u64 rotation_period;
+    u64 rotation_period_msgs;
+    HistoryVisibility history_visibility;
+    boolean only_allow_trusted_devices;
+};
+
 interface OlmMachine {
     [Throws=CryptoStoreError]
     constructor(
@@ -301,7 +321,11 @@ interface OlmMachine {
     [Throws=CryptoStoreError]
     Request? get_missing_sessions(sequence<string> users);
     [Throws=CryptoStoreError]
-    sequence<Request> share_room_key([ByRef] string room_id, sequence<string> users);
+    sequence<Request> share_room_key(
+        [ByRef] string room_id,
+        sequence<string> users,
+        EncryptionSettings settings
+    );
 
     [Throws=CryptoStoreError]
     void receive_unencrypted_verification_event([ByRef] string event, [ByRef] string room_id);


### PR DESCRIPTION
@BillCarsonFr as requested, the settings can be now passed to the E2EE layer. @Anderas this probably interests you as well as it's a breaking change.