### PR TITLE
fix(sdk): Remove token field from SyncSettings Debug output

### DIFF
--- a/crates/matrix-sdk/src/config/sync.rs
+++ b/crates/matrix-sdk/src/config/sync.rs
@@ -48,7 +48,6 @@ impl<'a> fmt::Debug for SyncSettings<'a> {
 
         opt_field!(filter);
         opt_field!(timeout);
-        opt_field!(token);
 
         s.field("full_state", &self.full_state).finish()
     }


### PR DESCRIPTION
This one was named just `token`, not `access_token`, so I didn't find it on initial review.

Fixes one of the two log-leaks of the token from #1110, the other one was previously fixed in #1117.