### PR TITLE
Add a new state to the SAS state machine

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -1174,6 +1174,7 @@ impl RequestState<Ready> {
                             device.user_id(),
                             device.device_id(),
                             c,
+                            None,
                         )
                     }
                 }

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -808,7 +808,7 @@ impl Sas {
             flow_id = self.flow_id().as_str(),
             ?old_state,
             ?new_state,
-            "SAS received an event and changed it's state"
+            "SAS received an event and changed its state"
         );
 
         self.update_state(state);


### PR DESCRIPTION
This prevents users from confirming that the short auth string matches before the public keys have been exchanged.