### PR TITLE
chore: Bump versions of matrix-sdk, matrix-sdk-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,7 +2441,7 @@ checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matrix-sdk"
-version = "0.6.0"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "anymap2",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-base"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "assign",
  "async-stream",

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-base"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = "1.62"
-version = "0.6.0"
+version = "0.6.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = "1.62"
-version = "0.6.0"
+version = "0.6.2"
 
 [package.metadata.docs.rs]
 features = ["docsrs"]


### PR DESCRIPTION
… to bring them up to the released ones from the v0.6.x branch. All changes from those versions are already present on main.

cc #1141 (let's see whether the bot closes that one automatically after this is merged)