### PR TITLE
refactor(bindings): Use uniffi proc-macros a little more in sdk-ffi

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -30,7 +30,6 @@ dictionary UpdateSummary {
     sequence<string> rooms;
 };
 
-
 callback interface SlidingSyncObserver {
     void did_receive_sync_update(UpdateSummary summary);
 };
@@ -102,25 +101,7 @@ interface SlidingSyncViewBuilder {
     constructor();
 
     [Self=ByArc]
-    SlidingSyncViewBuilder timeline_limit(u32 limit);
-
-    [Self=ByArc]
     SlidingSyncViewBuilder sync_mode(SlidingSyncMode mode);
-
-    [Self=ByArc]
-    SlidingSyncViewBuilder batch_size(u32 size);
-
-    [Self=ByArc]
-    SlidingSyncViewBuilder name(string name);
-
-    [Self=ByArc]
-    SlidingSyncViewBuilder sort(sequence<string> sort);
-
-    [Self=ByArc]
-    SlidingSyncViewBuilder add_range(u32 from, u32 to);
-
-    [Self=ByArc]
-    SlidingSyncViewBuilder reset_ranges();
 
     [Self=ByArc]
     SlidingSyncViewBuilder required_state(sequence<RequiredState> required_state);
@@ -165,18 +146,6 @@ interface ClientBuilder {
 interface SlidingSyncBuilder {
     [Throws=ClientError, Self=ByArc]
     SlidingSyncBuilder homeserver(string url);
-
-    [Self=ByArc]
-    SlidingSyncBuilder add_fullsync_view();
-
-    [Self=ByArc]
-    SlidingSyncBuilder no_views();
-
-    [Self=ByArc]
-    SlidingSyncBuilder add_view(SlidingSyncView view);
-
-    [Self=ByArc]
-    SlidingSyncBuilder with_common_extensions();
 
     [Throws=ClientError, Self=ByArc]
     SlidingSync build();
@@ -228,15 +197,7 @@ interface Client {
     void logout();
 };
 
-enum Membership {
-    "Invited",
-    "Joined",
-    "Left",
-};
-
 interface Room {
-    Membership membership();
-
     [Throws=ClientError]
     string display_name();
 
@@ -269,8 +230,6 @@ callback interface TimelineListener {
 };
 
 interface TimelineDiff {
-    TimelineChange change();
-
     [Self=ByArc]
     sequence<TimelineItem>? replace();
     [Self=ByArc]
@@ -281,17 +240,6 @@ interface TimelineDiff {
     MoveData? move();
     [Self=ByArc]
     TimelineItem? push();
-};
-
-enum TimelineChange {
-    "Replace",
-    "InsertAt",
-    "UpdateAt",
-    "RemoveAt",
-    "Move",
-    "Push",
-    "Pop",
-    "Clear",
 };
 
 dictionary InsertAtData {
@@ -312,14 +260,7 @@ dictionary MoveData {
 interface TimelineItem {};
 
 interface EventTimelineItem {
-    TimelineKey key();
     sequence<Reaction> reactions();
-};
-
-[Enum]
-interface TimelineKey {
-  TransactionId(string txn_id);
-  EventId(string event_id);
 };
 
 // Other methods defined via proc-macro
@@ -389,8 +330,6 @@ dictionary Reaction {
     // senders to come
 };
 
-interface VirtualTimelineItem {};
-
 dictionary PaginationOutcome {
     // Whether there's more messages to be paginated.
     boolean more_messages;
@@ -433,8 +372,6 @@ callback interface SessionVerificationControllerDelegate {
 
 interface SessionVerificationController {
     void set_delegate(SessionVerificationControllerDelegate? delegate);
-
-    boolean is_verified();
 
     [Throws=ClientError]
     void request_verification();

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -99,14 +99,17 @@ mod uniffi_types {
         authentication_service::{AuthenticationService, HomeserverLoginDetails},
         client::Client,
         client_builder::ClientBuilder,
-        room::Room,
-        session_verification::SessionVerificationEmoji,
+        room::{Membership, Room},
+        session_verification::{SessionVerificationController, SessionVerificationEmoji},
         sliding_sync::{
-            SlidingSync, SlidingSyncBuilder, SlidingSyncRoom, SlidingSyncView, StoppableSpawn,
-            UnreadNotificationsCount,
+            RequiredState, RoomListEntry, SlidingSync, SlidingSyncBuilder, SlidingSyncRoom,
+            SlidingSyncView, SlidingSyncViewBuilder, StoppableSpawn, UnreadNotificationsCount,
         },
         timeline::{
-            EventTimelineItem, Message, TimelineItem, TimelineItemContent, VirtualTimelineItem,
+            EmoteMessageContent, EventTimelineItem, FormattedBody, ImageInfo, ImageMessageContent,
+            InsertAtData, Message, MessageType, NoticeMessageContent, Reaction, TextMessageContent,
+            ThumbnailInfo, TimelineChange, TimelineDiff, TimelineItem, TimelineItemContent,
+            TimelineKey, UpdateAtData, VirtualTimelineItem,
         },
     };
 }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -20,6 +20,7 @@ use tracing::error;
 use super::RUNTIME;
 use crate::{TimelineDiff, TimelineListener};
 
+#[derive(uniffi::Enum)]
 pub enum Membership {
     Invited,
     Joined,
@@ -69,6 +70,14 @@ impl Room {
         self.room.is_tombstoned()
     }
 
+    pub fn membership(&self) -> Membership {
+        match &self.room {
+            SdkRoom::Invited(_) => Membership::Invited,
+            SdkRoom::Joined(_) => Membership::Joined,
+            SdkRoom::Left(_) => Membership::Left,
+        }
+    }
+
     /// Removes the timeline.
     ///
     /// Timeline items cached in memory as well as timeline listeners are
@@ -108,14 +117,6 @@ impl Room {
             let avatar_url_string = member.display_name().map(|m| m.to_owned());
             Ok(avatar_url_string)
         })
-    }
-
-    pub fn membership(&self) -> Membership {
-        match &self.room {
-            SdkRoom::Invited(_) => Membership::Invited,
-            SdkRoom::Joined(_) => Membership::Joined,
-            SdkRoom::Left(_) => Membership::Left,
-        }
     }
 
     pub fn add_timeline_listener(&self, listener: Box<dyn TimelineListener>) {

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -44,6 +44,13 @@ pub struct SessionVerificationController {
     sas_verification: Arc<RwLock<Option<SasVerification>>>,
 }
 
+#[uniffi::export]
+impl SessionVerificationController {
+    pub fn is_verified(&self) -> bool {
+        self.user_identity.is_verified()
+    }
+}
+
 impl SessionVerificationController {
     pub fn new(user_identity: UserIdentity) -> Self {
         SessionVerificationController {
@@ -56,10 +63,6 @@ impl SessionVerificationController {
 
     pub fn set_delegate(&self, delegate: Option<Box<dyn SessionVerificationControllerDelegate>>) {
         *self.delegate.write().unwrap() = delegate;
-    }
-
-    pub fn is_verified(&self) -> bool {
-        self.user_identity.is_verified()
     }
 
     pub fn request_verification(&self) -> anyhow::Result<()> {

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -154,6 +154,7 @@ pub struct UpdateSummary {
     pub rooms: Vec<String>,
 }
 
+#[derive(uniffi::Record)]
 pub struct RequiredState {
     pub key: String,
     pub value: String,
@@ -241,6 +242,7 @@ impl From<&MatrixRoomEntry> for RoomListEntry {
         }
     }
 }
+
 pub trait SlidingSyncViewRoomItemsObserver: Sync + Send {
     fn did_receive_update(&self);
 }
@@ -272,17 +274,31 @@ impl SlidingSyncViewBuilder {
         Arc::new(builder)
     }
 
-    pub fn sort(self: Arc<Self>, sort: Vec<String>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.sort(sort);
-        Arc::new(builder)
-    }
-
     pub fn required_state(self: Arc<Self>, required_state: Vec<RequiredState>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder
             .inner
             .required_state(required_state.into_iter().map(|s| (s.key.into(), s.value)).collect());
+        Arc::new(builder)
+    }
+
+    pub fn ranges(self: Arc<Self>, ranges: Vec<(u32, u32)>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.ranges(ranges);
+        Arc::new(builder)
+    }
+
+    pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<SlidingSyncView>> {
+        let builder = unwrap_or_clone_arc(self);
+        Ok(Arc::new(builder.inner.build()?.into()))
+    }
+}
+
+#[uniffi::export]
+impl SlidingSyncViewBuilder {
+    pub fn sort(self: Arc<Self>, sort: Vec<String>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.sort(sort);
         Arc::new(builder)
     }
 
@@ -310,12 +326,6 @@ impl SlidingSyncViewBuilder {
         Arc::new(builder)
     }
 
-    pub fn ranges(self: Arc<Self>, ranges: Vec<(u32, u32)>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.ranges(ranges);
-        Arc::new(builder)
-    }
-
     pub fn add_range(self: Arc<Self>, from: u32, to: u32) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.add_range(from, to);
@@ -326,11 +336,6 @@ impl SlidingSyncViewBuilder {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.reset_ranges();
         Arc::new(builder)
-    }
-
-    pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<SlidingSyncView>> {
-        let builder = unwrap_or_clone_arc(self);
-        Ok(Arc::new(builder.inner.build()?.into()))
     }
 }
 
@@ -566,6 +571,14 @@ impl SlidingSyncBuilder {
         Ok(Arc::new(builder))
     }
 
+    pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<SlidingSync>> {
+        let builder = unwrap_or_clone_arc(self);
+        Ok(Arc::new(SlidingSync::new(builder.inner.build()?, builder.client)))
+    }
+}
+
+#[uniffi::export]
+impl SlidingSyncBuilder {
     pub fn add_fullsync_view(self: Arc<Self>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.add_fullsync_view();
@@ -589,11 +602,6 @@ impl SlidingSyncBuilder {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.with_common_extensions();
         Arc::new(builder)
-    }
-
-    pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<SlidingSync>> {
-        let builder = unwrap_or_clone_arc(self);
-        Ok(Arc::new(SlidingSync::new(builder.inner.build()?, builder.client)))
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -45,19 +45,6 @@ impl TimelineDiff {
         })
     }
 
-    pub fn change(&self) -> TimelineChange {
-        match &self.0 {
-            VecDiff::Replace { .. } => TimelineChange::Replace,
-            VecDiff::InsertAt { .. } => TimelineChange::InsertAt,
-            VecDiff::UpdateAt { .. } => TimelineChange::UpdateAt,
-            VecDiff::RemoveAt { .. } => TimelineChange::RemoveAt,
-            VecDiff::Move { .. } => TimelineChange::Move,
-            VecDiff::Push { .. } => TimelineChange::Push,
-            VecDiff::Pop {} => TimelineChange::Pop,
-            VecDiff::Clear {} => TimelineChange::Clear,
-        }
-    }
-
     pub fn replace(self: Arc<Self>) -> Option<Vec<Arc<TimelineItem>>> {
         unwrap_or_clone_arc_into_variant!(self, .0, VecDiff::Replace { values } => values)
     }
@@ -96,6 +83,22 @@ impl TimelineDiff {
     }
 }
 
+#[uniffi::export]
+impl TimelineDiff {
+    pub fn change(&self) -> TimelineChange {
+        match &self.0 {
+            VecDiff::Replace { .. } => TimelineChange::Replace,
+            VecDiff::InsertAt { .. } => TimelineChange::InsertAt,
+            VecDiff::UpdateAt { .. } => TimelineChange::UpdateAt,
+            VecDiff::RemoveAt { .. } => TimelineChange::RemoveAt,
+            VecDiff::Move { .. } => TimelineChange::Move,
+            VecDiff::Push { .. } => TimelineChange::Push,
+            VecDiff::Pop {} => TimelineChange::Pop,
+            VecDiff::Clear {} => TimelineChange::Clear,
+        }
+    }
+}
+
 pub struct InsertAtData {
     pub index: u32,
     pub item: Arc<TimelineItem>,
@@ -111,7 +114,7 @@ pub struct MoveData {
     pub new_index: u32,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, uniffi::Enum)]
 pub enum TimelineChange {
     Replace,
     InsertAt,
@@ -155,10 +158,6 @@ impl TimelineItem {
 pub struct EventTimelineItem(pub(crate) matrix_sdk::room::timeline::EventTimelineItem);
 
 impl EventTimelineItem {
-    pub fn key(&self) -> TimelineKey {
-        self.0.key().into()
-    }
-
     pub fn reactions(&self) -> Vec<Reaction> {
         self.0
             .reactions()
@@ -170,6 +169,10 @@ impl EventTimelineItem {
 
 #[uniffi::export]
 impl EventTimelineItem {
+    pub fn key(&self) -> TimelineKey {
+        self.0.key().into()
+    }
+
     pub fn event_id(&self) -> Option<String> {
         self.0.event_id().map(ToString::to_string)
     }
@@ -374,7 +377,7 @@ pub struct ReactionDetails {
     pub sender: String,
 }
 
-#[derive(Clone)]
+#[derive(Clone, uniffi::Enum)]
 pub enum TimelineKey {
     TransactionId { txn_id: String },
     EventId { event_id: String },
@@ -391,7 +394,7 @@ impl From<&matrix_sdk::room::timeline::TimelineKey> for TimelineKey {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, uniffi::Object)]
 pub struct VirtualTimelineItem(matrix_sdk::room::timeline::VirtualTimelineItem);
 
 #[extension_trait]


### PR DESCRIPTION
Smaller version of #1133 that doesn't break binding generation. Through reduction of the initial PR, I now have a pretty clear understanding of what circumstances triggered the previous issue.