### PR TITLE
fix(ffi): Remove duplicate RequireState definition, left over after #1151

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -153,8 +153,6 @@ pub struct UpdateSummary {
     pub views: Vec<String>,
     pub rooms: Vec<String>,
 }
-
-#[derive(uniffi::Record)]
 pub struct RequiredState {
     pub key: String,
     pub value: String,


### PR DESCRIPTION
This was left as a duplicate.