### PR TITLE
feat(crypto-js): `OlmMachine.initialize` is the new constructor

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -28,6 +28,16 @@ pub struct OlmMachine {
 
 #[wasm_bindgen]
 impl OlmMachine {
+    /// Constructor will always fail. To create a new `OlmMachine`, please use
+    /// the `initialize` method.
+    ///
+    /// Why this pattern? `initialize` returns a `Promise`. Returning a
+    // `Promise` from a constructor is not idiomatic in JavaScript.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Result<OlmMachine, JsError> {
+        Err(JsError::new("To build an `OlmMachine`, please use the `initialize` method"))
+    }
+
     /// Create a new memory based `OlmMachine`.
     ///
     /// The created machine will keep the encryption keys either in a IndexedDB
@@ -49,9 +59,7 @@ impl OlmMachine {
     ///
     /// * `store_passphrase` - The passphrase that should be used to encrypt the
     ///   IndexedDB based
-    #[wasm_bindgen(constructor)]
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(
+    pub fn initialize(
         user_id: &identifiers::UserId,
         device_id: &identifiers::DeviceId,
         store_name: Option<String>,

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -38,7 +38,7 @@ impl OlmMachine {
         Err(JsError::new("To build an `OlmMachine`, please use the `initialize` method"))
     }
 
-    /// Create a new memory based `OlmMachine`.
+    /// Create a new `OlmMachine`.
     ///
     /// The created machine will keep the encryption keys either in a IndexedDB
     /// based store, or in a memory store and once the objects is dropped,

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -53,7 +53,7 @@ describe(OlmMachine.name, () => {
     const room = new RoomId('!baz:matrix.org');
 
     function machine(new_user, new_device) {
-        return new OlmMachine(new_user || user, new_device || device);
+        return OlmMachine.initialize(new_user || user, new_device || device);
     }
 
     test('can read user devices', async () => {
@@ -116,7 +116,7 @@ describe('Key Verification', () => {
     const deviceId2 = new DeviceId('bob_device');
 
     function machine(new_user, new_device) {
-        return new OlmMachine(new_user || userId1, new_device || deviceId1);
+        return OlmMachine.initialize(new_user || userId1, new_device || deviceId1);
     }
 
     describe('SAS', () => {

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -25,7 +25,7 @@ require('fake-indexeddb/auto');
 
 describe(OlmMachine.name, () => {
     test('can be instantiated with the async initializer', async () => {
-        expect(await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'))).toBeInstanceOf(OlmMachine);
+        expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'))).toBeInstanceOf(OlmMachine);
     });
 
     test('can be instantiated with a store', async () => {
@@ -36,7 +36,7 @@ describe(OlmMachine.name, () => {
         let store_passphrase = 'world';
 
         // Creating a new Olm machine.
-        expect(await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase)).toBeInstanceOf(OlmMachine);
+        expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase)).toBeInstanceOf(OlmMachine);
 
         // Oh, there is 2 databases now, prefixed by `store_name`.
         let databases = await indexedDB.databases();
@@ -48,7 +48,7 @@ describe(OlmMachine.name, () => {
         ]);
 
         // Creating a new Olm machine, with the stored state.
-        expect(await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase)).toBeInstanceOf(OlmMachine);
+        expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase)).toBeInstanceOf(OlmMachine);
 
         // Same number of databases.
         expect(await indexedDB.databases()).toHaveLength(2);
@@ -62,7 +62,7 @@ describe(OlmMachine.name, () => {
             let err = null;
 
             try {
-                await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase);
+                await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase);
             } catch (error) {
                 err = error;
             }
@@ -77,7 +77,7 @@ describe(OlmMachine.name, () => {
             let err = null;
 
             try {
-                await new OlmMachine(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase);
+                await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), store_name, store_passphrase);
             } catch (error) {
                 err = error;
             }
@@ -91,7 +91,7 @@ describe(OlmMachine.name, () => {
     const room = new RoomId('!baz:matrix.org');
 
     function machine(new_user, new_device) {
-        return new OlmMachine(new_user || user, new_device || device);
+        return OlmMachine.initialize(new_user || user, new_device || device);
     }
 
     test('can read user ID', async () => {

--- a/bindings/matrix-sdk-crypto-js/tests/tracing.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/tracing.test.js
@@ -68,7 +68,7 @@ describe(Tracing.name, () => {
                 };
 
                 // Do something that emits a `DEBUG` log.
-                await new OlmMachine(new UserId('@alice:example.org'), new DeviceId('foo'));
+                await OlmMachine.initialize(new UserId('@alice:example.org'), new DeviceId('foo'));
 
                 console.debug = originalConsoleDebug;
                 testPostState();


### PR DESCRIPTION
While technically a type constructor can return a `Promise`, it's not considered as idiomatic JavaScript to do that. We are changing `new OlmMachine` to `OlmMachine.initialize`. The rest of the code is strictly the same.