### PR TITLE
feat(crypto-js): Use `WeakRef` to avoid calling `free` manually

### DIFF
--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -37,7 +37,7 @@
         "node": ">= 10"
     },
     "scripts": {
-        "build": "cross-env RUSTFLAGS='-C opt-level=z' wasm-pack build --release --target nodejs --scope matrix-org --out-dir ./pkg",
+        "build": "cross-env RUSTFLAGS='-C opt-level=z' WASM_BINDGEN_WEAKREF=1 wasm-pack build --release --target nodejs --scope matrix-org --out-dir ./pkg",
         "test": "jest --verbose",
         "doc": "typedoc --tsconfig .",
         "prepack": "npm run build && npm run test",


### PR DESCRIPTION
By asking `wasm-bindgen` to generate JS glue code for `WeakRef` support, it removes the need to call `free` manually to free objects, thus we reduce potential memory leaks inside Rust. See https:// rustwasm.github.io/docs/wasm- bindgen/reference/weak-references.html to learn more.

It uses [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) under the hood, I reckon it's quite common and fits into Matrix's clients needs in terms of browser support.