### PR TITLE
feat(crypto-js): Support Reference Types

### DIFF
--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ['-Oz']
+wasm-opt = ['-Oz', '--enable-reference-types']
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -37,7 +37,7 @@
         "node": ">= 10"
     },
     "scripts": {
-        "build": "cross-env RUSTFLAGS='-C opt-level=z' wasm-pack build --release --target nodejs --scope matrix-org --out-dir ./pkg",
+        "build": "cross-env RUSTFLAGS='-C opt-level=z' WASM_BINDGEN_EXTERNREF=1 wasm-pack build --release --target nodejs --scope matrix-org --out-dir ./pkg",
         "test": "jest --verbose",
         "doc": "typedoc --tsconfig .",
         "prepack": "npm run build && npm run test",


### PR DESCRIPTION
In WebAssembly, reference types (`externtype`) act like an opaque type, thus
simplifying the boundary code to interop with the host. Learn more by reading
https://github.com/WebAssembly/spec/blob/main/proposals/reference-types/Overview.md.

If we instruct `wasm-bindgen` to support reference types, the generated JS glue
code will be smaller. In our case, it saves 3-4Kb. It's also more efficient.
Learn more by reading
https://rustwasm.github.io/docs/wasm-bindgen/reference/reference-types.html.

Browser support is generally good, see https://webassembly.org/roadmap/, I
reckon it's quite common now and fits into Matrix's clients needs in terms of
browser support.