### PR TITLE
Revert #1151

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -30,6 +30,7 @@ dictionary UpdateSummary {
     sequence<string> rooms;
 };
 
+
 callback interface SlidingSyncObserver {
     void did_receive_sync_update(UpdateSummary summary);
 };
@@ -101,7 +102,25 @@ interface SlidingSyncViewBuilder {
     constructor();
 
     [Self=ByArc]
+    SlidingSyncViewBuilder timeline_limit(u32 limit);
+
+    [Self=ByArc]
     SlidingSyncViewBuilder sync_mode(SlidingSyncMode mode);
+
+    [Self=ByArc]
+    SlidingSyncViewBuilder batch_size(u32 size);
+
+    [Self=ByArc]
+    SlidingSyncViewBuilder name(string name);
+
+    [Self=ByArc]
+    SlidingSyncViewBuilder sort(sequence<string> sort);
+
+    [Self=ByArc]
+    SlidingSyncViewBuilder add_range(u32 from, u32 to);
+
+    [Self=ByArc]
+    SlidingSyncViewBuilder reset_ranges();
 
     [Self=ByArc]
     SlidingSyncViewBuilder required_state(sequence<RequiredState> required_state);
@@ -146,6 +165,18 @@ interface ClientBuilder {
 interface SlidingSyncBuilder {
     [Throws=ClientError, Self=ByArc]
     SlidingSyncBuilder homeserver(string url);
+
+    [Self=ByArc]
+    SlidingSyncBuilder add_fullsync_view();
+
+    [Self=ByArc]
+    SlidingSyncBuilder no_views();
+
+    [Self=ByArc]
+    SlidingSyncBuilder add_view(SlidingSyncView view);
+
+    [Self=ByArc]
+    SlidingSyncBuilder with_common_extensions();
 
     [Throws=ClientError, Self=ByArc]
     SlidingSync build();
@@ -197,7 +228,15 @@ interface Client {
     void logout();
 };
 
+enum Membership {
+    "Invited",
+    "Joined",
+    "Left",
+};
+
 interface Room {
+    Membership membership();
+
     [Throws=ClientError]
     string display_name();
 
@@ -230,6 +269,8 @@ callback interface TimelineListener {
 };
 
 interface TimelineDiff {
+    TimelineChange change();
+
     [Self=ByArc]
     sequence<TimelineItem>? replace();
     [Self=ByArc]
@@ -240,6 +281,17 @@ interface TimelineDiff {
     MoveData? move();
     [Self=ByArc]
     TimelineItem? push();
+};
+
+enum TimelineChange {
+    "Replace",
+    "InsertAt",
+    "UpdateAt",
+    "RemoveAt",
+    "Move",
+    "Push",
+    "Pop",
+    "Clear",
 };
 
 dictionary InsertAtData {
@@ -260,7 +312,14 @@ dictionary MoveData {
 interface TimelineItem {};
 
 interface EventTimelineItem {
+    TimelineKey key();
     sequence<Reaction> reactions();
+};
+
+[Enum]
+interface TimelineKey {
+  TransactionId(string txn_id);
+  EventId(string event_id);
 };
 
 // Other methods defined via proc-macro
@@ -330,6 +389,8 @@ dictionary Reaction {
     // senders to come
 };
 
+interface VirtualTimelineItem {};
+
 dictionary PaginationOutcome {
     // Whether there's more messages to be paginated.
     boolean more_messages;
@@ -372,6 +433,8 @@ callback interface SessionVerificationControllerDelegate {
 
 interface SessionVerificationController {
     void set_delegate(SessionVerificationControllerDelegate? delegate);
+
+    boolean is_verified();
 
     [Throws=ClientError]
     void request_verification();

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -99,17 +99,14 @@ mod uniffi_types {
         authentication_service::{AuthenticationService, HomeserverLoginDetails},
         client::Client,
         client_builder::ClientBuilder,
-        room::{Membership, Room},
-        session_verification::{SessionVerificationController, SessionVerificationEmoji},
+        room::Room,
+        session_verification::SessionVerificationEmoji,
         sliding_sync::{
-            RequiredState, RoomListEntry, SlidingSync, SlidingSyncBuilder, SlidingSyncRoom,
-            SlidingSyncView, SlidingSyncViewBuilder, StoppableSpawn, UnreadNotificationsCount,
+            SlidingSync, SlidingSyncBuilder, SlidingSyncRoom, SlidingSyncView, StoppableSpawn,
+            UnreadNotificationsCount,
         },
         timeline::{
-            EmoteMessageContent, EventTimelineItem, FormattedBody, ImageInfo, ImageMessageContent,
-            InsertAtData, Message, MessageType, NoticeMessageContent, Reaction, TextMessageContent,
-            ThumbnailInfo, TimelineChange, TimelineDiff, TimelineItem, TimelineItemContent,
-            TimelineKey, UpdateAtData, VirtualTimelineItem,
+            EventTimelineItem, Message, TimelineItem, TimelineItemContent, VirtualTimelineItem,
         },
     };
 }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -20,7 +20,6 @@ use tracing::error;
 use super::RUNTIME;
 use crate::{TimelineDiff, TimelineListener};
 
-#[derive(uniffi::Enum)]
 pub enum Membership {
     Invited,
     Joined,
@@ -70,14 +69,6 @@ impl Room {
         self.room.is_tombstoned()
     }
 
-    pub fn membership(&self) -> Membership {
-        match &self.room {
-            SdkRoom::Invited(_) => Membership::Invited,
-            SdkRoom::Joined(_) => Membership::Joined,
-            SdkRoom::Left(_) => Membership::Left,
-        }
-    }
-
     /// Removes the timeline.
     ///
     /// Timeline items cached in memory as well as timeline listeners are
@@ -117,6 +108,14 @@ impl Room {
             let avatar_url_string = member.display_name().map(|m| m.to_owned());
             Ok(avatar_url_string)
         })
+    }
+
+    pub fn membership(&self) -> Membership {
+        match &self.room {
+            SdkRoom::Invited(_) => Membership::Invited,
+            SdkRoom::Joined(_) => Membership::Joined,
+            SdkRoom::Left(_) => Membership::Left,
+        }
     }
 
     pub fn add_timeline_listener(&self, listener: Box<dyn TimelineListener>) {

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -44,13 +44,6 @@ pub struct SessionVerificationController {
     sas_verification: Arc<RwLock<Option<SasVerification>>>,
 }
 
-#[uniffi::export]
-impl SessionVerificationController {
-    pub fn is_verified(&self) -> bool {
-        self.user_identity.is_verified()
-    }
-}
-
 impl SessionVerificationController {
     pub fn new(user_identity: UserIdentity) -> Self {
         SessionVerificationController {
@@ -63,6 +56,10 @@ impl SessionVerificationController {
 
     pub fn set_delegate(&self, delegate: Option<Box<dyn SessionVerificationControllerDelegate>>) {
         *self.delegate.write().unwrap() = delegate;
+    }
+
+    pub fn is_verified(&self) -> bool {
+        self.user_identity.is_verified()
     }
 
     pub fn request_verification(&self) -> anyhow::Result<()> {

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -154,7 +154,6 @@ pub struct UpdateSummary {
     pub rooms: Vec<String>,
 }
 
-#[derive(uniffi::Record)]
 pub struct RequiredState {
     pub key: String,
     pub value: String,
@@ -242,7 +241,6 @@ impl From<&MatrixRoomEntry> for RoomListEntry {
         }
     }
 }
-
 pub trait SlidingSyncViewRoomItemsObserver: Sync + Send {
     fn did_receive_update(&self);
 }
@@ -274,31 +272,17 @@ impl SlidingSyncViewBuilder {
         Arc::new(builder)
     }
 
+    pub fn sort(self: Arc<Self>, sort: Vec<String>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.sort(sort);
+        Arc::new(builder)
+    }
+
     pub fn required_state(self: Arc<Self>, required_state: Vec<RequiredState>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder
             .inner
             .required_state(required_state.into_iter().map(|s| (s.key.into(), s.value)).collect());
-        Arc::new(builder)
-    }
-
-    pub fn ranges(self: Arc<Self>, ranges: Vec<(u32, u32)>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.ranges(ranges);
-        Arc::new(builder)
-    }
-
-    pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<SlidingSyncView>> {
-        let builder = unwrap_or_clone_arc(self);
-        Ok(Arc::new(builder.inner.build()?.into()))
-    }
-}
-
-#[uniffi::export]
-impl SlidingSyncViewBuilder {
-    pub fn sort(self: Arc<Self>, sort: Vec<String>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.sort(sort);
         Arc::new(builder)
     }
 
@@ -326,6 +310,12 @@ impl SlidingSyncViewBuilder {
         Arc::new(builder)
     }
 
+    pub fn ranges(self: Arc<Self>, ranges: Vec<(u32, u32)>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.ranges(ranges);
+        Arc::new(builder)
+    }
+
     pub fn add_range(self: Arc<Self>, from: u32, to: u32) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.add_range(from, to);
@@ -336,6 +326,11 @@ impl SlidingSyncViewBuilder {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.reset_ranges();
         Arc::new(builder)
+    }
+
+    pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<SlidingSyncView>> {
+        let builder = unwrap_or_clone_arc(self);
+        Ok(Arc::new(builder.inner.build()?.into()))
     }
 }
 
@@ -574,14 +569,6 @@ impl SlidingSyncBuilder {
         Ok(Arc::new(builder))
     }
 
-    pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<SlidingSync>> {
-        let builder = unwrap_or_clone_arc(self);
-        Ok(Arc::new(SlidingSync::new(builder.inner.build()?, builder.client)))
-    }
-}
-
-#[uniffi::export]
-impl SlidingSyncBuilder {
     pub fn add_fullsync_view(self: Arc<Self>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.add_fullsync_view();
@@ -605,6 +592,11 @@ impl SlidingSyncBuilder {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.with_common_extensions();
         Arc::new(builder)
+    }
+
+    pub fn build(self: Arc<Self>) -> anyhow::Result<Arc<SlidingSync>> {
+        let builder = unwrap_or_clone_arc(self);
+        Ok(Arc::new(SlidingSync::new(builder.inner.build()?, builder.client)))
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -153,6 +153,8 @@ pub struct UpdateSummary {
     pub views: Vec<String>,
     pub rooms: Vec<String>,
 }
+
+#[derive(uniffi::Record)]
 pub struct RequiredState {
     pub key: String,
     pub value: String,


### PR DESCRIPTION
Apparently the enum derive is broken. It was merged upstream in https://github.com/mozilla/uniffi-rs/pull/1371 w/o tests because I am not familiar with the code generated for enums in any of the binding languages, and maintainers had nothing to say about that. I have now asked about examples that I can turn into a test in their Matrix channel.