### PR TITLE
Disable keepAlive in download-lib.js, allowing node bindings to work on Node.JS 19

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -92,7 +92,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.0, 16.0, 18.0]
+        node-version: [14.0, 16.0, 18.0, 19.0]
         include:
           - os: ubuntu-latest
             os-name: 🐧

--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -1,6 +1,5 @@
 
 const { Agent } = require('https');
-const { whyIsNodeStillRunning } = require('why-is-node-still-running');
 const { DownloaderHelper } = require('node-downloader-helper');
 const { version } = require("./package.json");
 const { platform, arch } = process
@@ -34,8 +33,6 @@ function download_lib(libname) {
 
     dl.on('end', () => console.info('Download Completed'));
     dl.on('error', (err) => console.info('Download Failed', err));
-    dl.on('stateChanged', (err) => console.info('Download state', err));
-    dl.on('timeout', (err) => console.info('Download timeout', err));
     dl.on('progress', stats => {
         const progress = stats.progress.toFixed(1);
         const speed = byteHelper(stats.speed);
@@ -45,7 +42,7 @@ function download_lib(libname) {
         // print every one second (`progress.throttled` can be used instead)
         const currentTime = new Date();
         const elaspsedTime = currentTime - startTime;
-        if (elaspsedTime > 1000 || stats.progress === 100) {
+        if (elaspsedTime > 1000) {
             startTime = currentTime;
             console.info(`${speed}/s - ${progress}% [${downloaded}/${total}]`);
         }

--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -1,4 +1,3 @@
-
 const { Agent } = require('https');
 const { DownloaderHelper } = require('node-downloader-helper');
 const { version } = require("./package.json");


### PR DESCRIPTION
Fixes #1160 

This is fixed more formally in https://github.com/hgouveia/node-downloader-helper/pull/92, but since it's easy to do without an upstream change I've added the config in here too. Once this gets merged and released, Node.JS 19 users should be able to download the latest binary.