### PR TITLE
chore: Upgrade UniFFI

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -17,7 +17,7 @@ env:
   MATRIX_SDK_CRYPTO_NODEJS_PATH: bindings/matrix-sdk-crypto-nodejs
   MATRIX_SDK_CRYPTO_JS_PATH: bindings/matrix-sdk-crypto-js
   # keep in sync with uniffi dependency in root Cargo.toml
-  UNIFFI_REV: 89b9dd835b470abb339b1bd492c19f7a08ad872f
+  UNIFFI_REV: 6ee61a46f59736f93b912f3cf45481f005c63115
 
 jobs:
   xtask-linux:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4999,7 +4999,7 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 [[package]]
 name = "uniffi"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=89b9dd835b470abb339b1bd492c19f7a08ad872f#89b9dd835b470abb339b1bd492c19f7a08ad872f"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6ee61a46f59736f93b912f3cf45481f005c63115#6ee61a46f59736f93b912f3cf45481f005c63115"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5015,7 +5015,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=89b9dd835b470abb339b1bd492c19f7a08ad872f#89b9dd835b470abb339b1bd492c19f7a08ad872f"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6ee61a46f59736f93b912f3cf45481f005c63115#6ee61a46f59736f93b912f3cf45481f005c63115"
 dependencies = [
  "anyhow",
  "askama",
@@ -5037,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=89b9dd835b470abb339b1bd492c19f7a08ad872f#89b9dd835b470abb339b1bd492c19f7a08ad872f"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6ee61a46f59736f93b912f3cf45481f005c63115#6ee61a46f59736f93b912f3cf45481f005c63115"
 dependencies = [
  "anyhow",
  "camino",
@@ -5047,7 +5047,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=89b9dd835b470abb339b1bd492c19f7a08ad872f#89b9dd835b470abb339b1bd492c19f7a08ad872f"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6ee61a46f59736f93b912f3cf45481f005c63115#6ee61a46f59736f93b912f3cf45481f005c63115"
 dependencies = [
  "bincode",
  "camino",
@@ -5065,7 +5065,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=89b9dd835b470abb339b1bd492c19f7a08ad872f#89b9dd835b470abb339b1bd492c19f7a08ad872f"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6ee61a46f59736f93b912f3cf45481f005c63115#6ee61a46f59736f93b912f3cf45481f005c63115"
 dependencies = [
  "serde",
 ]
@@ -5374,7 +5374,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=89b9dd835b470abb339b1bd492c19f7a08ad872f#89b9dd835b470abb339b1bd492c19f7a08ad872f"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6ee61a46f59736f93b912f3cf45481f005c63115#6ee61a46f59736f93b912f3cf45481f005c63115"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ resolver = "2"
 [workspace.dependencies]
 ruma = { version = "0.7.4", features = ["client-api-c"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "89b9dd835b470abb339b1bd492c19f7a08ad872f" }
-uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "89b9dd835b470abb339b1bd492c19f7a08ad872f" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "89b9dd835b470abb339b1bd492c19f7a08ad872f" }
-uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "89b9dd835b470abb339b1bd492c19f7a08ad872f", features = ["builtin-bindgen"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6ee61a46f59736f93b912f3cf45481f005c63115" }
+uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "6ee61a46f59736f93b912f3cf45481f005c63115" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "6ee61a46f59736f93b912f3cf45481f005c63115" }
+uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "6ee61a46f59736f93b912f3cf45481f005c63115", features = ["builtin-bindgen"] }
 vodozemac = "0.3.0"
 zeroize = "1.3.0"
 


### PR DESCRIPTION
Now includes a working `Enum` derive.