### PR TITLE
fix(crypto-nodejs): Pass secrets to the release workflow

### DIFF
--- a/.github/workflows/prep-crypto-nodejs-release.yml
+++ b/.github/workflows/prep-crypto-nodejs-release.yml
@@ -115,3 +115,5 @@ jobs:
     name: "Trigger release Workflow"
     with:
       tag: ${{needs.prepare-release.outputs.tag}}
+    secrets:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecrets.