### PR TITLE
ffi: Replace RestoreToken string with Session dictionary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2703,7 +2703,6 @@ dependencies = [
  "matrix-sdk",
  "once_cell",
  "sanitize-filename-reader-friendly",
- "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -30,7 +30,6 @@ futures-util = { version = "0.3.17", default-features = false }
 matrix-sdk = { path = "../../crates/matrix-sdk", features = ["anyhow", "experimental-timeline", "markdown", "sliding-sync", "socks"], version = "0.6.0" }
 once_cell = "1.10.0"
 sanitize-filename-reader-friendly = "2.2.1"
-serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 thiserror = "1.0.30"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -152,10 +152,10 @@ interface Client {
     void login(string username, string password, string? initial_device_name, string? device_id);
 
     [Throws=ClientError]
-    void restore_login(string restore_token);
+    void restore_login(Session session);
 
     [Throws=ClientError]
-    string restore_token();
+    Session session();
 
     [Throws=ClientError]
     string user_id();
@@ -189,6 +189,15 @@ interface Client {
 
     [Throws=ClientError]
     void logout();
+};
+
+dictionary Session {
+    string access_token;
+    string? refresh_token;
+    string user_id;
+    string device_id;
+    string homeserver_url;
+    boolean is_soft_logout;
 };
 
 interface Room {

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -118,7 +118,7 @@ impl AuthenticationService {
 
         // Create a new client to setup the store path now the user ID is known.
         let homeserver_url = client.homeserver();
-        let session = client.session().ok_or(AuthenticationError::SessionMissing)?;
+        let session = client.client.session().ok_or(AuthenticationError::SessionMissing)?;
         let client = Arc::new(ClientBuilder::new())
             .base_path(self.base_path.clone())
             .homeserver_url(homeserver_url)

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -98,7 +98,7 @@ impl Client {
 
     /// Restores the client from a `RestoreToken`.
     pub fn restore_login(&self, restore_token: String) -> anyhow::Result<()> {
-        let RestoreToken { session, homeurl: _, is_guest: _, is_soft_logout } =
+        let RestoreToken { session, homeurl: _, is_soft_logout } =
             serde_json::from_str(&restore_token)?;
 
         // update soft logout state
@@ -152,7 +152,6 @@ impl Client {
             Ok(serde_json::to_string(&RestoreToken {
                 session,
                 homeurl,
-                is_guest: self.state.read().unwrap().is_guest,
                 is_soft_logout: self.state.read().unwrap().is_soft_logout,
             })?)
         })
@@ -313,11 +312,6 @@ impl Client {
     /// Indication whether we are currently syncing
     pub fn is_syncing(&self) -> bool {
         self.state.read().unwrap().has_first_synced
-    }
-
-    /// Is this a guest account?
-    pub fn is_guest(&self) -> bool {
-        self.state.read().unwrap().is_guest
     }
 
     /// Flag indicating whether the session is in soft logout mode

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -34,9 +34,7 @@ use std::io;
 
 use client::Client;
 use client_builder::ClientBuilder;
-use matrix_sdk::Session;
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
 use tokio::runtime::Runtime;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 pub use uniffi_api::*;
@@ -59,14 +57,6 @@ pub struct ClientState {
     has_first_synced: bool,
     is_syncing: bool,
     should_stop_syncing: bool,
-    is_soft_logout: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-struct RestoreToken {
-    homeurl: String,
-    session: Session,
-    #[serde(default)]
     is_soft_logout: bool,
 }
 

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -56,7 +56,6 @@ pub use self::{
 
 #[derive(Default, Debug)]
 pub struct ClientState {
-    is_guest: bool,
     has_first_synced: bool,
     is_syncing: bool,
     should_stop_syncing: bool,
@@ -65,7 +64,6 @@ pub struct ClientState {
 
 #[derive(Serialize, Deserialize)]
 struct RestoreToken {
-    is_guest: bool,
     homeurl: String,
     session: Session,
     #[serde(default)]


### PR DESCRIPTION
This makes the FFI API a little less opaque and allows users to pull out the homeserver URL for supplying it to `ClientBuilder` while using the rest of the `Session` to restore the client's state after creation.