### PR TITLE
chore(ffi): reduce the log level for some not so useful logs

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -60,7 +60,7 @@ impl Client {
                 if let Some(session_verification_controller) = &*ctrl.clone().read().await {
                     session_verification_controller.process_to_device_message(ev).await;
                 } else {
-                    tracing::warn!(
+                    tracing::debug!(
                         "received to-device message, but verification controller isn't ready"
                     );
                 }

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -454,7 +454,7 @@ impl SlidingSync {
         views: &[SlidingSyncView],
     ) -> Result<UpdateSummary, crate::Error> {
         let mut processed = self.client.process_sliding_sync(resp.clone()).await?;
-        tracing::info!("main client processed.");
+        tracing::debug!("main client processed.");
         self.pos.replace(Some(resp.pos));
         let mut updated_views = Vec::new();
         if resp.lists.len() != views.len() {
@@ -1105,7 +1105,7 @@ impl Client {
         response: v4::Response,
     ) -> Result<SyncResponse> {
         let response = self.base_client().process_sliding_sync(response).await?;
-        tracing::info!("done processing on base_client");
+        tracing::debug!("done processing on base_client");
         self.handle_sync_response(response).await
     }
 }


### PR DESCRIPTION
- sliding sync printing out info logs on every successfully processed response
- the session verification controller not being ready for to_device messages processing (identity not available): expected and part of the flow