### PR TITLE
chore(sliding_sync): remove server versions fetch before being able t…

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -1093,9 +1093,6 @@ impl SlidingSyncView {
 impl Client {
     /// Create a SlidingSyncBuilder tied to this client
     pub async fn sliding_sync(&self) -> SlidingSyncBuilder {
-        // ensure the version has been checked in before, as the proxy doesn't support
-        // that
-        let _ = self.server_versions().await;
         SlidingSyncBuilder::default().client(self.clone())
     }
 


### PR DESCRIPTION
…o use the sliding sync builder; the versions are still fetched but at a later date