### PR TITLE
Update the verification support in the Uniffi based bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2740,6 +2740,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "futures-util",
  "hmac",
  "http",
  "js_int",

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 anyhow = "1.0.57"
 base64 = "0.13.0"
+futures-util = "0.3.25"
 hmac = "0.12.1"
 http = "0.2.6"
 pbkdf2 = "0.11.0"

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -45,8 +45,8 @@ use ruma::{
 use serde::{Deserialize, Serialize};
 pub use users::UserIdentity;
 pub use verification::{
-    CancelInfo, ConfirmVerificationResult, QrCode, RequestVerificationResult, Sas, ScanResult,
-    StartSasResult, Verification, VerificationRequest,
+    CancelInfo, ConfirmVerificationResult, QrCode, RequestVerificationResult, Sas, SasListener,
+    SasState, ScanResult, StartSasResult, Verification, VerificationRequest,
 };
 
 /// Struct collecting data that is important to migrate to the rust-sdk

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -146,19 +146,21 @@ dictionary StartSasResult {
     OutgoingVerificationRequest request;
 };
 
-dictionary Sas {
-    string other_user_id;
-    string other_device_id;
-    string flow_id;
-    string? room_id;
-    boolean we_started;
-    boolean has_been_accepted;
-    boolean can_be_presented;
-    boolean supports_emoji;
-    boolean have_we_confirmed;
-    boolean is_done;
-    boolean is_cancelled;
-    CancelInfo? cancel_info;
+interface Sas {
+    string other_user_id();
+    string other_device_id();
+    string flow_id();
+    string? room_id();
+    boolean we_started();
+    boolean is_done();
+
+    OutgoingVerificationRequest? accept();
+    [Throws=CryptoStoreError]
+    ConfirmVerificationResult? confirm();
+    OutgoingVerificationRequest? cancel([ByRef] string cancel_code);
+
+    sequence<i32>? get_emoji_indices();
+    sequence<i32>? get_decimals();
 };
 
 dictionary ScanResult {
@@ -166,34 +168,44 @@ dictionary ScanResult {
     OutgoingVerificationRequest request;
 };
 
-dictionary QrCode {
-    string other_user_id;
-    string other_device_id;
-    string flow_id;
-    string? room_id;
-    boolean we_started;
-    boolean other_side_scanned;
-    boolean has_been_confirmed;
-    boolean reciprocated;
-    boolean is_done;
-    boolean is_cancelled;
-    CancelInfo? cancel_info;
+interface QrCode {
+    string other_user_id();
+    string other_device_id();
+    string flow_id();
+    string? room_id();
+    boolean we_started();
+    boolean is_done();
+    CancelInfo? cancel_info();
+
+    boolean reciprocated();
+    boolean has_been_scanned();
+
+    ConfirmVerificationResult? confirm();
+    OutgoingVerificationRequest? cancel([ByRef] string cancel_code);
+    string? generate_qr_code();
 };
 
-dictionary VerificationRequest {
-    string other_user_id;
-    string? other_device_id;
-    string flow_id;
-    string? room_id;
-    boolean we_started;
-    boolean is_ready;
-    boolean is_passive;
-    boolean is_done;
-    boolean is_cancelled;
-    CancelInfo? cancel_info;
-    sequence<string>? their_methods;
-    sequence<string>? our_methods;
+interface VerificationRequest {
+    string other_user_id();
+    string? other_device_id();
+    string flow_id();
+    string? room_id();
+    boolean we_started();
+    boolean is_ready();
+    boolean is_done();
+    boolean is_passive();
 
+    sequence<string>? their_supported_methods();
+    sequence<string>? our_supported_methods();
+
+    OutgoingVerificationRequest? accept(sequence<string> methods);
+
+    [Throws=CryptoStoreError]
+    StartSasResult? start_sas_verification();
+
+    [Throws=CryptoStoreError]
+    QrCode? start_qr_verification();
+    ScanResult? scan_qr_code([ByRef] string data);
 };
 
 dictionary RequestVerificationResult {
@@ -206,10 +218,9 @@ dictionary ConfirmVerificationResult {
     SignatureUploadRequest? signature_request;
 };
 
-[Enum]
 interface Verification {
-    SasV1(Sas sas);
-    QrCodeV1(QrCode qrcode);
+    QrCode? as_qr();
+    Sas? as_sas();
 };
 
 dictionary KeyRequestPair {
@@ -361,32 +372,8 @@ interface OlmMachine {
         sequence<string> methods
     );
 
-    OutgoingVerificationRequest? accept_verification_request(
-        [ByRef] string user_id,
-        [ByRef] string flow_id,
-        sequence<string> methods
-    );
-
-    [Throws=CryptoStoreError]
-    ConfirmVerificationResult? confirm_verification([ByRef] string user_id, [ByRef] string flow_id);
-    OutgoingVerificationRequest? cancel_verification(
-        [ByRef] string user_id,
-        [ByRef] string flow_id,
-        [ByRef] string cancel_code
-    );
-
     [Throws=CryptoStoreError]
     StartSasResult? start_sas_with_device([ByRef] string user_id, [ByRef] string device_id);
-    [Throws=CryptoStoreError]
-    StartSasResult? start_sas_verification([ByRef] string user_id, [ByRef] string flow_id);
-    OutgoingVerificationRequest? accept_sas_verification([ByRef] string user_id, [ByRef] string flow_id);
-    sequence<i32>? get_emoji_index([ByRef] string user_id, [ByRef] string flow_id);
-    sequence<i32>? get_decimals([ByRef] string user_id, [ByRef] string flow_id);
-
-    [Throws=CryptoStoreError]
-    QrCode? start_qr_verification([ByRef] string user_id, [ByRef] string flow_id);
-    ScanResult? scan_qr_code([ByRef] string user_id, [ByRef] string flow_id, [ByRef] string data);
-    string? generate_qr_code([ByRef] string user_id, [ByRef] string flow_id);
 
     [Throws=DecryptionError]
     KeyRequestPair request_room_key([ByRef] string event, [ByRef] string room_id);

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -161,6 +161,23 @@ interface Sas {
 
     sequence<i32>? get_emoji_indices();
     sequence<i32>? get_decimals();
+
+    void changes(SasListener callback);
+    SasState state();
+};
+
+[Enum]
+interface SasState {
+  Started();
+  Accepted();
+  KeysExchanged(sequence<i32>? emojis, sequence<i32> decimals);
+  Confirmed();
+  Done();
+  Cancelled(CancelInfo cancel_info);
+};
+
+callback interface SasListener {
+    void on_change(SasState state);
 };
 
 dictionary ScanResult {

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -162,7 +162,7 @@ interface Sas {
     sequence<i32>? get_emoji_indices();
     sequence<i32>? get_decimals();
 
-    void changes(SasListener callback);
+    void set_changes_listener(SasListener callback);
     SasState state();
 };
 
@@ -192,6 +192,7 @@ interface QrCode {
     string? room_id();
     boolean we_started();
     boolean is_done();
+    boolean is_cancelled();
     CancelInfo? cancel_info();
 
     boolean reciprocated();
@@ -211,6 +212,8 @@ interface VerificationRequest {
     boolean is_ready();
     boolean is_done();
     boolean is_passive();
+    boolean is_cancelled();
+    CancelInfo? cancel_info();
 
     sequence<string>? their_supported_methods();
     sequence<string>? our_supported_methods();
@@ -223,6 +226,8 @@ interface VerificationRequest {
     [Throws=CryptoStoreError]
     QrCode? start_qr_verification();
     ScanResult? scan_qr_code([ByRef] string data);
+
+    OutgoingVerificationRequest? cancel();
 };
 
 dictionary RequestVerificationResult {

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -194,7 +194,7 @@ impl Sas {
         self.inner.decimals().map(|v| [v.0.into(), v.1.into(), v.2.into()].to_vec())
     }
 
-    /// Listen for changes in the SAS verification process.
+    /// Set a listener for changes in the SAS verification process.
     ///
     /// The given callback will be called whenever the state changes.
     ///
@@ -239,7 +239,7 @@ impl Sas {
     ///                │  Done │
     ///                └───────┘
     /// ```
-    pub fn changes(&self, callback: Box<dyn SasListener>) {
+    pub fn set_changes_listener(&self, callback: Box<dyn SasListener>) {
         let stream = self.inner.changes();
 
         self.runtime.spawn(Self::changes_callback(stream, callback));
@@ -300,6 +300,11 @@ impl QrCode {
     /// Is the QR code verification done.
     pub fn is_done(&self) -> bool {
         self.inner.is_done()
+    }
+
+    /// Has the verification flow been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
     }
 
     /// Did we initiate the verification flow.
@@ -467,6 +472,17 @@ impl VerificationRequest {
     /// Has the verification request been answered by another device.
     pub fn is_passive(&self) -> bool {
         self.inner.is_passive()
+    }
+
+    /// Has the verification flow that been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Get info about the cancellation if the verification request has been
+    /// cancelled.
+    pub fn cancel_info(&self) -> Option<CancelInfo> {
+        self.inner.cancel_info().map(|v| v.into())
     }
 
     /// Get the supported verification methods of the other side.

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -1,101 +1,224 @@
+use std::sync::Arc;
+
+use base64::{decode_config, encode_config, STANDARD_NO_PAD};
 use matrix_sdk_crypto::{
-    CancelInfo as RustCancelInfo, QrVerification as InnerQr, Sas as InnerSas,
+    matrix_sdk_qrcode::QrVerificationData, CancelInfo as RustCancelInfo, QrVerification as InnerQr,
+    Sas as InnerSas, Verification as InnerVerification,
     VerificationRequest as InnerVerificationRequest,
 };
+use ruma::events::key::verification::VerificationMethod;
+use tokio::runtime::Handle;
 
-use crate::{OutgoingVerificationRequest, SignatureUploadRequest};
+use crate::{CryptoStoreError, OutgoingVerificationRequest, SignatureUploadRequest};
 
 /// Enum representing the different verification flows we support.
-pub enum Verification {
-    /// The `m.sas.v1` verification flow.
-    SasV1 {
-        #[allow(missing_docs)]
-        sas: Sas,
-    },
-    /// The `m.qr_code.scan.v1`, `m.qr_code.show.v1`, and `m.reciprocate.v1`
-    /// verification flow.
-    QrCodeV1 {
-        #[allow(missing_docs)]
-        qrcode: QrCode,
-    },
+pub struct Verification {
+    pub(crate) inner: InnerVerification,
+    pub(crate) runtime: Handle,
+}
+
+impl Verification {
+    /// Try to represent the `Verification` as an `Sas` verification object,
+    /// returns `None` if the verification is not a `Sas` verification.
+    pub fn as_sas(&self) -> Option<Arc<Sas>> {
+        if let InnerVerification::SasV1(sas) = &self.inner {
+            Some(Sas { inner: sas.to_owned(), runtime: self.runtime.to_owned() }.into())
+        } else {
+            None
+        }
+    }
+
+    /// Try to represent the `Verification` as an `QrCode` verification object,
+    /// returns `None` if the verification is not a `QrCode` verification.
+    pub fn as_qr(&self) -> Option<Arc<QrCode>> {
+        if let InnerVerification::QrV1(qr) = &self.inner {
+            Some(QrCode { inner: qr.to_owned() }.into())
+        } else {
+            None
+        }
+    }
 }
 
 /// The `m.sas.v1` verification flow.
 pub struct Sas {
-    /// The other user that is participating in the verification flow
-    pub other_user_id: String,
-    /// The other user's device that is participating in the verification flow
-    pub other_device_id: String,
-    /// The unique ID of this verification flow, will be a random string for
-    /// to-device events or a event ID for in-room events.
-    pub flow_id: String,
-    /// The room ID where this verification is happening, will be `None` if the
-    /// verification is going through to-device messages
-    pub room_id: Option<String>,
-    /// Did we initiate the verification flow
-    pub we_started: bool,
-    /// Has the non-initiating side accepted the verification flow
-    pub has_been_accepted: bool,
-    /// Can the short auth string be presented
-    pub can_be_presented: bool,
-    /// Does the flow support the emoji representation of the short auth string
-    pub supports_emoji: bool,
-    /// Have we confirmed that the short auth strings match
-    pub have_we_confirmed: bool,
-    /// Has the verification completed successfully
-    pub is_done: bool,
-    /// Has the flow been cancelled
-    pub is_cancelled: bool,
-    /// Information about the cancellation of the flow, will be `None` if the
-    /// flow hasn't been cancelled
-    pub cancel_info: Option<CancelInfo>,
+    pub(crate) inner: InnerSas,
+    pub(crate) runtime: Handle,
+}
+
+impl Sas {
+    /// Get the user id of the other side.
+    pub fn other_user_id(&self) -> String {
+        self.inner.other_user_id().to_string()
+    }
+
+    /// Get the device ID of the other side.
+    pub fn other_device_id(&self) -> String {
+        self.inner.other_device_id().to_string()
+    }
+
+    /// Get the unique ID that identifies this SAS verification flow.
+    pub fn flow_id(&self) -> String {
+        self.inner.flow_id().as_str().to_owned()
+    }
+
+    /// Get the room id if the verification is happening inside a room.
+    pub fn room_id(&self) -> Option<String> {
+        self.inner.room_id().map(|r| r.to_string())
+    }
+
+    /// Is the SAS flow done.
+    pub fn is_done(&self) -> bool {
+        self.inner.is_done()
+    }
+
+    /// Did we initiate the verification flow.
+    pub fn we_started(&self) -> bool {
+        self.inner.we_started()
+    }
+
+    /// Accept that we're going forward with the short auth string verification.
+    pub fn accept(&self) -> Option<OutgoingVerificationRequest> {
+        self.inner.accept().map(|r| r.into())
+    }
+
+    /// Confirm a verification was successful.
+    ///
+    /// This method should be called if a short auth string should be confirmed
+    /// as matching.
+    pub fn confirm(&self) -> Result<Option<ConfirmVerificationResult>, CryptoStoreError> {
+        let (requests, signature_request) = self.runtime.block_on(self.inner.confirm())?;
+
+        let requests = requests.into_iter().map(|r| r.into()).collect();
+
+        Ok(Some(ConfirmVerificationResult {
+            requests,
+            signature_request: signature_request.map(|s| s.into()),
+        }))
+    }
+
+    /// Cancel the SAS verification using the given cancel code.
+    ///
+    /// # Arguments
+    ///
+    /// * `cancel_code` - The error code for why the verification was cancelled,
+    /// manual cancellatio usually happens with `m.user` cancel code. The full
+    /// list of cancel codes can be found in the [spec]
+    ///
+    /// [spec]: https://spec.matrix.org/unstable/client-server-api/#mkeyverificationcancel
+    pub fn cancel(&self, cancel_code: &str) -> Option<OutgoingVerificationRequest> {
+        self.inner.cancel_with_code(cancel_code.into()).map(|r| r.into())
+    }
+
+    /// Get a list of emoji indices of the emoji representation of the short
+    /// auth string.
+    ///
+    /// *Note*: A SAS verification needs to be started and in the presentable
+    /// state for this to return the list of emoji indices, otherwise returns
+    /// `None`.
+    pub fn get_emoji_indices(&self) -> Option<Vec<i32>> {
+        self.inner.emoji_index().map(|v| v.iter().map(|i| (*i).into()).collect())
+    }
+
+    /// Get the decimal representation of the short auth string.
+    ///
+    /// *Note*: A SAS verification needs to be started and in the presentable
+    /// state for this to return the list of decimals, otherwise returns
+    /// `None`.
+    pub fn get_decimals(&self) -> Option<Vec<i32>> {
+        self.inner.decimals().map(|v| [v.0.into(), v.1.into(), v.2.into()].to_vec())
+    }
 }
 
 /// The `m.qr_code.scan.v1`, `m.qr_code.show.v1`, and `m.reciprocate.v1`
 /// verification flow.
 pub struct QrCode {
-    /// The other user that is participating in the verification flow
-    pub other_user_id: String,
-    /// The other user's device that is participating in the verification flow
-    pub other_device_id: String,
-    /// The unique ID of this verification flow, will be a random string for
-    /// to-device events or a event ID for in-room events.
-    pub flow_id: String,
-    /// The room ID where this verification is happening, will be `None` if the
-    /// verification is going through to-device messages
-    pub room_id: Option<String>,
-    /// Did we initiate the verification flow
-    pub we_started: bool,
-    /// Has the QR code been scanned by the other side
-    pub other_side_scanned: bool,
-    /// Has the scanning of the QR code been confirmed by us
-    pub has_been_confirmed: bool,
-    /// Did we scan the QR code and sent out a reciprocation
-    pub reciprocated: bool,
-    /// Has the verification completed successfully
-    pub is_done: bool,
-    /// Has the flow been cancelled
-    pub is_cancelled: bool,
-    /// Information about the cancellation of the flow, will be `None` if the
-    /// flow hasn't been cancelled
-    pub cancel_info: Option<CancelInfo>,
+    pub(crate) inner: InnerQr,
 }
 
-impl From<InnerQr> for QrCode {
-    fn from(qr: InnerQr) -> Self {
-        Self {
-            other_user_id: qr.other_user_id().to_string(),
-            flow_id: qr.flow_id().as_str().to_owned(),
-            is_cancelled: qr.is_cancelled(),
-            is_done: qr.is_done(),
-            cancel_info: qr.cancel_info().map(|c| c.into()),
-            reciprocated: qr.reciprocated(),
-            we_started: qr.we_started(),
-            other_side_scanned: qr.has_been_scanned(),
-            has_been_confirmed: qr.has_been_confirmed(),
-            other_device_id: qr.other_device_id().to_string(),
-            room_id: qr.room_id().map(|r| r.to_string()),
-        }
+impl QrCode {
+    /// Get the user id of the other side.
+    pub fn other_user_id(&self) -> String {
+        self.inner.other_user_id().to_string()
+    }
+
+    /// Get the device ID of the other side.
+    pub fn other_device_id(&self) -> String {
+        self.inner.other_device_id().to_string()
+    }
+
+    /// Get the unique ID that identifies this QR code verification flow.
+    pub fn flow_id(&self) -> String {
+        self.inner.flow_id().as_str().to_owned()
+    }
+
+    /// Get the room id if the verification is happening inside a room.
+    pub fn room_id(&self) -> Option<String> {
+        self.inner.room_id().map(|r| r.to_string())
+    }
+
+    /// Is the QR code verification done.
+    pub fn is_done(&self) -> bool {
+        self.inner.is_done()
+    }
+
+    /// Did we initiate the verification flow.
+    pub fn we_started(&self) -> bool {
+        self.inner.we_started()
+    }
+
+    /// Get the CancelInfo of this QR code verification object.
+    ///
+    /// Will be `None` if the flow has not been cancelled.
+    pub fn cancel_info(&self) -> Option<CancelInfo> {
+        self.inner.cancel_info().map(|c| c.into())
+    }
+
+    /// Has the QR verification been scanned by the other side.
+    ///
+    /// When the verification object is in this state it's required that the
+    /// user confirms that the other side has scanned the QR code.
+    pub fn has_been_scanned(&self) -> bool {
+        self.inner.has_been_scanned()
+    }
+
+    /// Have we successfully scanned the QR code and are able to send a
+    /// reciprocation event.
+    pub fn reciprocated(&self) -> bool {
+        self.inner.reciprocated()
+    }
+
+    /// Cancel the QR code verification using the given cancel code.
+    ///
+    /// # Arguments
+    ///
+    /// * `cancel_code` - The error code for why the verification was cancelled,
+    /// manual cancellatio usually happens with `m.user` cancel code. The full
+    /// list of cancel codes can be found in the [spec]
+    ///
+    /// [spec]: https://spec.matrix.org/unstable/client-server-api/#mkeyverificationcancel
+    pub fn cancel(&self, cancel_code: &str) -> Option<OutgoingVerificationRequest> {
+        self.inner.cancel_with_code(cancel_code.into()).map(|r| r.into())
+    }
+
+    /// Confirm a verification was successful.
+    ///
+    /// This method should be called if we want to confirm that the other side
+    /// has scanned our QR code.
+    pub fn confirm(&self) -> Option<ConfirmVerificationResult> {
+        self.inner.confirm_scanning().map(|r| ConfirmVerificationResult {
+            requests: vec![r.into()],
+            signature_request: None,
+        })
+    }
+
+    /// Generate data that should be encoded as a QR code.
+    ///
+    /// This method should be called right before a QR code should be displayed,
+    /// the returned data is base64 encoded (without padding) and needs to be
+    /// decoded on the other side before it can be put through a QR code
+    /// generator.
+    pub fn generate_qr_code(&self) -> Option<String> {
+        self.inner.to_bytes().map(|data| encode_config(data, STANDARD_NO_PAD)).ok()
     }
 }
 
@@ -122,7 +245,7 @@ impl From<RustCancelInfo> for CancelInfo {
 /// A result type for starting SAS verifications.
 pub struct StartSasResult {
     /// The SAS verification object that got created.
-    pub sas: Sas,
+    pub sas: Arc<Sas>,
     /// The request that needs to be sent out to notify the other side that a
     /// SAS verification should start.
     pub request: OutgoingVerificationRequest,
@@ -131,35 +254,16 @@ pub struct StartSasResult {
 /// A result type for scanning QR codes.
 pub struct ScanResult {
     /// The QR code verification object that got created.
-    pub qr: QrCode,
+    pub qr: Arc<QrCode>,
     /// The request that needs to be sent out to notify the other side that a
     /// QR code verification should start.
     pub request: OutgoingVerificationRequest,
 }
 
-impl From<InnerSas> for Sas {
-    fn from(sas: InnerSas) -> Self {
-        Self {
-            other_user_id: sas.other_user_id().to_string(),
-            other_device_id: sas.other_device_id().to_string(),
-            flow_id: sas.flow_id().as_str().to_owned(),
-            is_cancelled: sas.is_cancelled(),
-            is_done: sas.is_done(),
-            can_be_presented: sas.can_be_presented(),
-            supports_emoji: sas.supports_emoji(),
-            have_we_confirmed: sas.have_we_confirmed(),
-            we_started: sas.we_started(),
-            room_id: sas.room_id().map(|r| r.to_string()),
-            has_been_accepted: sas.has_been_accepted(),
-            cancel_info: sas.cancel_info().map(|c| c.into()),
-        }
-    }
-}
-
 /// A result type for requesting verifications.
 pub struct RequestVerificationResult {
     /// The verification request object that got created.
-    pub verification: VerificationRequest,
+    pub verification: Arc<VerificationRequest>,
     /// The request that needs to be sent out to notify the other side that
     /// we're requesting verification to begin.
     pub request: OutgoingVerificationRequest,
@@ -178,55 +282,155 @@ pub struct ConfirmVerificationResult {
 /// The verificatoin request object which then can transition into some concrete
 /// verification method
 pub struct VerificationRequest {
-    /// The other user that is participating in the verification flow
-    pub other_user_id: String,
-    /// The other user's device that is participating in the verification flow
-    pub other_device_id: Option<String>,
-    /// The unique ID of this verification flow, will be a random string for
-    /// to-device events or a event ID for in-room events.
-    pub flow_id: String,
-    /// The room ID where this verification is happening, will be `None` if the
-    /// verification is going through to-device messages
-    pub room_id: Option<String>,
-    /// Did we initiate the verification flow
-    pub we_started: bool,
-    /// Did both parties aggree to verification
-    pub is_ready: bool,
-    /// Did another device respond to the verification request
-    pub is_passive: bool,
-    /// Has the verification completed successfully
-    pub is_done: bool,
-    /// Has the flow been cancelled
-    pub is_cancelled: bool,
-    /// The list of verification methods that the other side advertised as
-    /// supported
-    pub their_methods: Option<Vec<String>>,
-    /// The list of verification methods that we advertised as supported
-    pub our_methods: Option<Vec<String>>,
-    /// Information about the cancellation of the flow, will be `None` if the
-    /// flow hasn't been cancelled
-    pub cancel_info: Option<CancelInfo>,
+    pub(crate) inner: InnerVerificationRequest,
+    pub(crate) runtime: Handle,
 }
 
-impl From<InnerVerificationRequest> for VerificationRequest {
-    fn from(v: InnerVerificationRequest) -> Self {
-        Self {
-            other_user_id: v.other_user().to_string(),
-            other_device_id: v.other_device_id().map(|d| d.to_string()),
-            flow_id: v.flow_id().as_str().to_owned(),
-            is_cancelled: v.is_cancelled(),
-            is_done: v.is_done(),
-            is_ready: v.is_ready(),
-            room_id: v.room_id().map(|r| r.to_string()),
-            we_started: v.we_started(),
-            is_passive: v.is_passive(),
-            cancel_info: v.cancel_info().map(|c| c.into()),
-            their_methods: v
-                .their_supported_methods()
-                .map(|v| v.into_iter().map(|m| m.to_string()).collect()),
-            our_methods: v
-                .our_supported_methods()
-                .map(|v| v.into_iter().map(|m| m.to_string()).collect()),
+impl VerificationRequest {
+    /// The id of the other user that is participating in this verification
+    /// request.
+    pub fn other_user_id(&self) -> String {
+        self.inner.other_user().to_string()
+    }
+
+    /// The id of the other device that is participating in this verification.
+    pub fn other_device_id(&self) -> Option<String> {
+        self.inner.other_device_id().map(|d| d.to_string())
+    }
+
+    /// Get the unique ID of this verification request
+    pub fn flow_id(&self) -> String {
+        self.inner.flow_id().as_str().to_owned()
+    }
+
+    /// Get the room id if the verification is happening inside a room.
+    pub fn room_id(&self) -> Option<String> {
+        self.inner.room_id().map(|r| r.to_string())
+    }
+
+    /// Has the verification flow that was started with this request finished.
+    pub fn is_done(&self) -> bool {
+        self.inner.is_done()
+    }
+
+    /// Is the verification request ready to start a verification flow.
+    pub fn is_ready(&self) -> bool {
+        self.inner.is_ready()
+    }
+
+    /// Did we initiate the verification request
+    pub fn we_started(&self) -> bool {
+        self.inner.we_started()
+    }
+
+    /// Has the verification request been answered by another device.
+    pub fn is_passive(&self) -> bool {
+        self.inner.is_passive()
+    }
+
+    /// Get the supported verification methods of the other side.
+    ///
+    /// Will be present only if the other side requested the verification or if
+    /// we're in the ready state.
+    pub fn their_supported_methods(&self) -> Option<Vec<String>> {
+        self.inner.their_supported_methods().map(|m| m.iter().map(|m| m.to_string()).collect())
+    }
+
+    /// Get our own supported verification methods that we advertised.
+    ///
+    /// Will be present only we requested the verification or if we're in the
+    /// ready state.
+    pub fn our_supported_methods(&self) -> Option<Vec<String>> {
+        self.inner.our_supported_methods().map(|m| m.iter().map(|m| m.to_string()).collect())
+    }
+
+    /// Accept a verification requests that we share with the given user with
+    /// the given flow id.
+    ///
+    /// This will move the verification request into the ready state.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The ID of the user for which we would like to accept the
+    /// verification requests.
+    ///
+    /// * `flow_id` - The ID that uniquely identifies the verification flow.
+    ///
+    /// * `methods` - A list of verification methods that we want to advertise
+    /// as supported.
+    pub fn accept(&self, methods: Vec<String>) -> Option<OutgoingVerificationRequest> {
+        let methods = methods.into_iter().map(VerificationMethod::from).collect();
+        self.inner.accept_with_methods(methods).map(|r| r.into())
+    }
+
+    /// Cancel a verification for the given user with the given flow id using
+    /// the given cancel code.
+    pub fn cancel(&self) -> Option<OutgoingVerificationRequest> {
+        self.inner.cancel().map(|r| r.into())
+    }
+
+    /// Transition from a verification request into short auth string based
+    /// verification.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The ID of the user for which we would like to start the
+    /// SAS verification.
+    ///
+    /// * `flow_id` - The ID of the verification request that initiated the
+    /// verification flow.
+    pub fn start_sas_verification(&self) -> Result<Option<StartSasResult>, CryptoStoreError> {
+        Ok(self.runtime.block_on(self.inner.start_sas())?.map(|(sas, r)| StartSasResult {
+            sas: Arc::new(Sas { inner: sas, runtime: self.runtime.clone() }),
+            request: r.into(),
+        }))
+    }
+
+    /// Transition from a verification request into QR code verification.
+    ///
+    /// This method should be called when one wants to display a QR code so the
+    /// other side can scan it and move the QR code verification forward.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The ID of the user for which we would like to start the
+    /// QR code verification.
+    ///
+    /// * `flow_id` - The ID of the verification request that initiated the
+    /// verification flow.
+    pub fn start_qr_verification(&self) -> Result<Option<Arc<QrCode>>, CryptoStoreError> {
+        Ok(self
+            .runtime
+            .block_on(self.inner.generate_qr_code())?
+            .map(|qr| QrCode { inner: qr }.into()))
+    }
+
+    /// Pass data from a scanned QR code to an active verification request and
+    /// transition into QR code verification.
+    ///
+    /// This requires an active `VerificationRequest` to succeed, returns `None`
+    /// if no `VerificationRequest` is found or if the QR code data is invalid.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The ID of the user for which we would like to start the
+    /// QR code verification.
+    ///
+    /// * `flow_id` - The ID of the verification request that initiated the
+    /// verification flow.
+    ///
+    /// * `data` - The data that was extracted from the scanned QR code as an
+    /// base64 encoded string, without padding.
+    pub fn scan_qr_code(&self, data: &str) -> Option<ScanResult> {
+        let data = decode_config(data, STANDARD_NO_PAD).ok()?;
+        let data = QrVerificationData::from_bytes(data).ok()?;
+
+        if let Some(qr) = self.runtime.block_on(self.inner.scan_qr_code(data)).ok()? {
+            let request = qr.reciprocate()?;
+
+            Some(ScanResult { qr: QrCode { inner: qr }.into(), request: request.into() })
+        } else {
+            None
         }
     }
 }


### PR DESCRIPTION
This is the continuation of #1124 and #1145. This now exposes the `changes()` method of our `Sas` object over FFI.

@Anderas and @BillCarsonFr this should interest you. If the `changes()` method is workable for you we can continue introducing it to the rest of the verification support.

This closes #708.