### PR TITLE
Make the code easier to read with new features from Rust 1.65

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           profile: minimal
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ members = [
 default-members = ["benchmarks", "crates/*"]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.65"
+
 [workspace.dependencies]
 ruma = { git = "https://github.com/ruma/ruma", rev = "ed100afddb5fb30f1ccf368d7e712a3a483e63bf", features = ["client-api-c"] }
 ruma-common = { git = "https://github.com/ruma/ruma", rev = "ed100afddb5fb30f1ccf368d7e712a3a483e63bf" }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The rust-sdk consists of multiple crates that can be picked at your convenience:
 
 ## Minimum Supported Rust Version (MSRV)
 
-These crates are built with the Rust language version 2021 and require a minimum compiler version of `1.64`
+These crates are built with the Rust language version 2021 and require a minimum compiler version of `1.65`.
 
 ## Status
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,7 +3,7 @@ name = "benchmarks"
 description = "Matrix SDK benchmarks"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.56"
+rust-version = { workspace = true }
 version = "1.0.0"
 publish = false
 

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -3,7 +3,7 @@ name = "matrix-sdk-crypto-ffi"
 version = "0.1.0"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2021"
-rust-version = "1.62"
+rust-version = { workspace = true }
 description = "Uniffi based bindings for the Rust SDK crypto crate"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 license = "Apache-2.0"

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -797,9 +797,7 @@ impl OlmMachine {
     /// * `user_id` - The ID of the user for which we would like to fetch the
     /// verification requests.
     pub fn get_verification_requests(&self, user_id: &str) -> Vec<VerificationRequest> {
-        let user_id = if let Ok(user_id) = UserId::parse(user_id) {
-            user_id
-        } else {
+        let Ok(user_id) = UserId::parse(user_id) else {
             return vec![];
         };
 

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
-rust-version = "1.62"
+rust-version = { workspace = true }
 version = "0.1.0-alpha.0"
 publish = false
 

--- a/bindings/matrix-sdk-crypto-js/src/attachment.rs
+++ b/bindings/matrix-sdk-crypto-js/src/attachment.rs
@@ -41,13 +41,10 @@ impl Attachment {
     /// destroyed. It is still possible to get a JSON-encoded backup
     /// by calling `EncryptedAttachment.mediaEncryptionInfo`.
     pub fn decrypt(attachment: &mut EncryptedAttachment) -> Result<Vec<u8>, JsError> {
-        let media_encryption_info = match attachment.media_encryption_info.take() {
-            Some(media_encryption_info) => media_encryption_info,
-            None => {
-                return Err(JsError::new(
-                    "The media encryption info are absent from the given encrypted attachment",
-                ))
-            }
+        let Some(media_encryption_info) = attachment.media_encryption_info.take() else {
+            return Err(JsError::new(
+                "The media encryption info are absent from the given encrypted attachment",
+            ));
         };
 
         let encrypted_data: &[u8] = attachment.encrypted_data.as_slice();

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "matrix-sdk-crypto-nodejs"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
-rust-version = "1.62"
+rust-version = { workspace = true }
 version = "0.6.0"
 
 [package.metadata.docs.rs]

--- a/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/attachment.rs
@@ -50,14 +50,11 @@ impl Attachment {
     /// by calling `EncryptedAttachment.mediaEncryptionInfo`.
     #[napi]
     pub fn decrypt(attachment: &mut EncryptedAttachment) -> napi::Result<Uint8Array> {
-        let media_encryption_info = match attachment.media_encryption_info.take() {
-            Some(media_encryption_info) => media_encryption_info,
-            None => {
-                return Err(napi::Error::from_reason(
-                    "The media encryption info are absent from the given encrypted attachment"
-                        .to_owned(),
-                ))
-            }
+        let Some(media_encryption_info) = attachment.media_encryption_info.take() else {
+            return Err(napi::Error::from_reason(
+                "The media encryption info are absent from the given encrypted attachment"
+                    .to_owned(),
+            ));
         };
 
         let encrypted_data: &[u8] = attachment.encrypted_data.deref();

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ffi"]
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.56"
+rust-version = { workspace = true }
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 
 [lib]

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -104,9 +104,8 @@ impl AuthenticationService {
         initial_device_name: Option<String>,
         device_id: Option<String>,
     ) -> Result<Arc<Client>, AuthenticationError> {
-        let client = match &*self.client.read().unwrap() {
-            Some(client) => client.clone(),
-            None => return Err(AuthenticationError::ClientMissing),
+        let Some(client) = self.client.read().unwrap().clone() else {
+            return Err(AuthenticationError::ClientMissing);
         };
 
         // Login and ask the server for the full user ID as this could be different from
@@ -143,9 +142,8 @@ impl AuthenticationService {
         token: String,
         device_id: String,
     ) -> Result<Arc<Client>, AuthenticationError> {
-        let client = match &*self.client.read().unwrap() {
-            Some(client) => client.clone(),
-            None => return Err(AuthenticationError::ClientMissing),
+        let Some(client) = self.client.read().unwrap().clone() else {
+            return Err(AuthenticationError::ClientMissing);
         };
 
         // Restore the client and ask the server for the full user ID as this

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -173,11 +173,10 @@ impl SessionVerificationController {
     }
 
     fn is_transaction_id_valid(&self, transaction_id: String) -> bool {
-        if let Some(verification) = &*self.verification_request.read().unwrap() {
-            return verification.flow_id() == transaction_id;
+        match &*self.verification_request.read().unwrap() {
+            Some(verification) => verification.flow_id() == transaction_id,
+            None => false,
         }
-
-        false
     }
 
     async fn start_sas_verification(&self) {

--- a/crates/matrix-sdk-appservice/Cargo.toml
+++ b/crates/matrix-sdk-appservice/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["matrix", "chat", "messaging", "ruma", "nio", "appservice"]
 license = "Apache-2.0"
 name = "matrix-sdk-appservice"
 version = "0.1.0"
-rust-version = "1.62"
+rust-version = { workspace = true }
 publish = false
 
 [features]

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "matrix-sdk-base"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
-rust-version = "1.62"
+rust-version = { workspace = true }
 version = "0.6.1"
 
 [package.metadata.docs.rs]

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -405,12 +405,9 @@ impl Room {
     /// return a `RoomMember` that can be in a joined, invited, left, banned
     /// state.
     pub async fn get_member(&self, user_id: &UserId) -> StoreResult<Option<RoomMember>> {
-        let member_event =
-            if let Some(m) = self.store.get_member_event(self.room_id(), user_id).await? {
-                m
-            } else {
-                return Ok(None);
-            };
+        let Some(member_event) = self.store.get_member_event(self.room_id(), user_id).await? else {
+            return Ok(None);
+        };
 
         let presence =
             self.store.get_presence_event(user_id).await?.and_then(|e| e.deserialize().ok());

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "matrix-sdk-common"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
-rust-version = "1.62"
+rust-version = { workspace = true }
 version = "0.6.0"
 
 [package.metadata.docs.rs]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "matrix-sdk-crypto"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
-rust-version = "1.62"
+rust-version = { workspace = true }
 version = "0.6.0"
 
 [package.metadata.docs.rs]

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1539,15 +1539,15 @@ mod tests {
 
         let decrypted = alice_account.decrypt_to_device_event(&event).await.unwrap();
 
-        if let AnyDecryptedOlmEvent::ForwardedRoomKey(e) = decrypted.result.event {
-            let session = alice_machine
-                .receive_forwarded_room_key(decrypted.result.sender_key, &e)
-                .await
-                .unwrap();
-            alice_machine.store.save_inbound_group_sessions(&[session.unwrap()]).await.unwrap();
-        } else {
+        let AnyDecryptedOlmEvent::ForwardedRoomKey(ev) = decrypted.result.event else {
             panic!("Invalid decrypted event type");
-        }
+        };
+
+        let session = alice_machine
+            .receive_forwarded_room_key(decrypted.result.sender_key, &ev)
+            .await
+            .unwrap();
+        alice_machine.store.save_inbound_group_sessions(&[session.unwrap()]).await.unwrap();
 
         // Check that alice now does have the session.
         let session = alice_machine
@@ -1597,16 +1597,16 @@ mod tests {
             .is_none());
 
         let decrypted = alice_account.decrypt_to_device_event(&event).await.unwrap();
-        if let AnyDecryptedOlmEvent::ForwardedRoomKey(e) = decrypted.result.event {
-            let session = alice_machine
-                .receive_forwarded_room_key(decrypted.result.sender_key, &e)
-                .await
-                .unwrap();
-
-            assert!(session.is_none(), "We should not receive a room key from another user");
-        } else {
+        let AnyDecryptedOlmEvent::ForwardedRoomKey(ev) = decrypted.result.event else {
             panic!("Invalid decrypted event type");
-        }
+        };
+
+        let session = alice_machine
+            .receive_forwarded_room_key(decrypted.result.sender_key, &ev)
+            .await
+            .unwrap();
+
+        assert!(session.is_none(), "We should not receive a room key from another user");
     }
 
     #[async_test]
@@ -1750,15 +1750,15 @@ mod tests {
 
         let decrypted = alice_account.decrypt_to_device_event(&event).await.unwrap();
 
-        if let AnyDecryptedOlmEvent::ForwardedRoomKey(e) = decrypted.result.event {
-            let session = alice_machine
-                .receive_forwarded_room_key(decrypted.result.sender_key, &e)
-                .await
-                .unwrap();
-            alice_machine.store.save_inbound_group_sessions(&[session.unwrap()]).await.unwrap();
-        } else {
+        let AnyDecryptedOlmEvent::ForwardedRoomKey(ev) = decrypted.result.event else {
             panic!("Invalid decrypted event type");
-        }
+        };
+
+        let session = alice_machine
+            .receive_forwarded_room_key(decrypted.result.sender_key, &ev)
+            .await
+            .unwrap();
+        alice_machine.store.save_inbound_group_sessions(&[session.unwrap()]).await.unwrap();
 
         // Check that alice now does have the session.
         let session = alice_machine

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -208,11 +208,8 @@ impl Device {
 
     /// Get the Olm sessions that belong to this device.
     pub(crate) async fn get_sessions(&self) -> StoreResult<Option<Arc<Mutex<Vec<Session>>>>> {
-        if let Some(k) = self.curve25519_key() {
-            self.verification_machine.store.get_sessions(&k.to_base64()).await
-        } else {
-            Ok(None)
-        }
+        let Some(k) = self.curve25519_key() else { return Ok(None) };
+        self.verification_machine.store.get_sessions(&k.to_base64()).await
     }
 
     /// Is this device considered to be verified.

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -572,9 +572,7 @@ impl ReadOnlyDevice {
         event_type: &str,
         content: Value,
     ) -> OlmResult<(Session, Raw<ToDeviceEncryptedEventContent>)> {
-        let sender_key = if let Some(k) = self.curve25519_key() {
-            k
-        } else {
+        let Some(sender_key) = self.curve25519_key() else {
             warn!(
                 user_id = %self.user_id(),
                 device_id = %self.device_id(),
@@ -592,9 +590,7 @@ impl ReadOnlyDevice {
             None
         };
 
-        let mut session = if let Some(s) = session {
-            s
-        } else {
+        let Some(mut session) = session else {
             warn!(
                 "Trying to encrypt a Megolm session for user {} on device {}, \
                 but no Olm session is found",

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -432,7 +432,7 @@ impl IdentityManager {
 
                     let result = if let Some(mut i) = self.store.get_user_identity(user_id).await? {
                         match &mut i {
-                            ReadOnlyUserIdentities::Own(ref mut identity) => {
+                            ReadOnlyUserIdentities::Own(identity) => {
                                 let user_signing = if let Some(s) = response
                                     .user_signing_keys
                                     .get(user_id)
@@ -452,7 +452,7 @@ impl IdentityManager {
                                     .update(master_key, self_signing, user_signing)
                                     .map(|_| (i, false))
                             }
-                            ReadOnlyUserIdentities::Other(ref mut identity) => {
+                            ReadOnlyUserIdentities::Other(identity) => {
                                 identity.update(master_key, self_signing).map(|_| (i, false))
                             }
                         }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -276,10 +276,8 @@ impl Account {
     ) -> OlmResult<Option<(Session, String)>> {
         let s = self.store.get_sessions(&sender_key.to_base64()).await?;
 
-        // We don't have any existing sessions, return early.
-        let sessions = if let Some(s) = s {
-            s
-        } else {
+        let Some(sessions) = s else {
+            // We don't have any existing sessions, return early.
             return Ok(None);
         };
 
@@ -442,22 +440,21 @@ impl Account {
             // ensures that we receive the room key even if we don't have access
             // to the device.
             if !matches!(event, AnyDecryptedOlmEvent::RoomKey(_)) {
-                if let Some(device) =
-                    self.store.get_device_from_curve_key(event.sender(), sender_key).await?
-                {
-                    if let Some(key) = device.ed25519_key() {
-                        if key != event.keys().ed25519 {
-                            return Err(EventError::MismatchedKeys(
-                                key.into(),
-                                event.keys().ed25519.into(),
-                            )
-                            .into());
-                        }
-                    } else {
+                let Some(device) =
+                    self.store.get_device_from_curve_key(event.sender(), sender_key).await? else {
                         return Err(EventError::MissingSigningKey.into());
-                    }
-                } else {
+                    };
+
+                let Some(key) = device.ed25519_key() else {
                     return Err(EventError::MissingSigningKey.into());
+                };
+
+                if key != event.keys().ed25519 {
+                    return Err(EventError::MismatchedKeys(
+                        key.into(),
+                        event.keys().ed25519.into(),
+                    )
+                    .into());
                 }
             }
 

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -228,13 +228,13 @@ impl PrivateCrossSigningIdentity {
             let master = MasterSigning::from_base64(self.user_id().to_owned(), master_key)?;
 
             if public_identity.master_key() == &master.public_key {
-                Ok(Some(master))
+                Some(master)
             } else {
-                Err(SecretImportError::MismatchedPublicKeys)
+                return Err(SecretImportError::MismatchedPublicKeys);
             }
         } else {
-            Ok(None)
-        }?;
+            None
+        };
 
         let user_signing = if let Some(user_signing_key) = user_signing_key {
             let subkey = UserSigning::from_base64(self.user_id().to_owned(), user_signing_key)?;

--- a/crates/matrix-sdk-crypto/src/olm/utility.rs
+++ b/crates/matrix-sdk-crypto/src/olm/utility.rs
@@ -147,14 +147,15 @@ fn verify_signature(
     signatures: &Signatures,
     canonical_json: &str,
 ) -> Result<(), SignatureError> {
-    if let Some(s) = signatures.get(user_id).and_then(|m| m.get(key_id)) {
-        match s {
-            Ok(Signature::Ed25519(s)) => Ok(public_key.verify(canonical_json.as_bytes(), s)?),
-            Ok(Signature::Other(_)) => Err(SignatureError::UnsupportedAlgorithm),
-            Err(_) => Err(SignatureError::InvalidSignature),
-        }
-    } else {
-        Err(SignatureError::NoSignatureFound)
+    let s = signatures
+        .get(user_id)
+        .and_then(|m| m.get(key_id))
+        .ok_or(SignatureError::NoSignatureFound)?;
+
+    match s {
+        Ok(Signature::Ed25519(s)) => Ok(public_key.verify(canonical_json.as_bytes(), s)?),
+        Ok(Signature::Other(_)) => Err(SignatureError::UnsupportedAlgorithm),
+        Err(_) => Err(SignatureError::InvalidSignature),
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -317,10 +317,7 @@ impl VerificationMachine {
     ) -> Result<(), CryptoStoreError> {
         let event = event.into();
 
-        #[allow(clippy::question_mark)]
-        let flow_id = if let Ok(flow_id) = FlowId::try_from(&event) {
-            flow_id
-        } else {
+        let Ok(flow_id) = FlowId::try_from(&event) else {
             // This isn't a verification event, return early.
             return Ok(());
         };

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -341,178 +341,184 @@ impl VerificationMachine {
             }
         };
 
-        if let Some(content) = event.verification_content() {
-            match &content {
-                AnyVerificationContent::Request(r) => {
-                    info!(
+        let Some(content) = event.verification_content() else { return Ok(()) };
+        match &content {
+            AnyVerificationContent::Request(r) => {
+                info!(
+                    sender = event.sender().as_str(),
+                    from_device = r.from_device().as_str(),
+                    "Received a new verification request",
+                );
+
+                let Some(timestamp) = event.timestamp() else {
+                    warn!(
                         sender = event.sender().as_str(),
                         from_device = r.from_device().as_str(),
-                        "Received a new verification request",
+                        "The key verification request didn't contain a valid timestamp"
                     );
+                    return Ok(());
+                };
 
-                    if let Some(timestamp) = event.timestamp() {
-                        if Self::is_timestamp_valid(timestamp) {
-                            if !event_sent_from_us(&event, r.from_device()) {
-                                let request = VerificationRequest::from_request(
-                                    self.verifications.clone(),
-                                    self.store.clone(),
-                                    event.sender(),
-                                    flow_id,
-                                    r,
-                                );
-
-                                self.insert_request(request);
-                            } else {
-                                trace!(
-                                    sender = event.sender().as_str(),
-                                    from_device = r.from_device().as_str(),
-                                    "The received verification request was sent by us, ignoring it",
-                                );
-                            }
-                        } else {
-                            trace!(
-                                sender = event.sender().as_str(),
-                                from_device = r.from_device().as_str(),
-                                ?timestamp,
-                                "The received verification request was too old or too far into the future",
-                            );
-                        }
-                    } else {
-                        warn!(
-                            sender = event.sender().as_str(),
-                            from_device = r.from_device().as_str(),
-                            "The key verification request didn't contain a valid timestamp"
-                        );
-                    }
+                if !Self::is_timestamp_valid(timestamp) {
+                    trace!(
+                        sender = event.sender().as_str(),
+                        from_device = r.from_device().as_str(),
+                        ?timestamp,
+                        "The received verification request was too old or too far into the future",
+                    );
+                    return Ok(());
                 }
-                AnyVerificationContent::Cancel(c) => {
-                    if let Some(verification) = self.get_request(event.sender(), flow_id.as_str()) {
-                        verification.receive_cancel(event.sender(), c);
-                    }
 
-                    if let Some(verification) =
-                        self.get_verification(event.sender(), flow_id.as_str())
-                    {
-                        match verification {
-                            Verification::SasV1(sas) => {
-                                // This won't produce an outgoing content
-                                let _ = sas.receive_any_event(event.sender(), &content);
-                            }
-                            #[cfg(feature = "qrcode")]
-                            Verification::QrV1(qr) => qr.receive_cancel(event.sender(), c),
-                        }
-                    }
+                if event_sent_from_us(&event, r.from_device()) {
+                    trace!(
+                        sender = event.sender().as_str(),
+                        from_device = r.from_device().as_str(),
+                        "The received verification request was sent by us, ignoring it",
+                    );
+                    return Ok(());
                 }
-                AnyVerificationContent::Ready(c) => {
-                    if let Some(request) = self.get_request(event.sender(), flow_id.as_str()) {
-                        if request.flow_id() == &flow_id {
-                            request.receive_ready(event.sender(), c);
-                        } else {
-                            flow_id_mismatch();
-                        }
-                    }
-                }
-                AnyVerificationContent::Start(c) => {
-                    if let Some(request) = self.get_request(event.sender(), flow_id.as_str()) {
-                        if request.flow_id() == &flow_id {
-                            request.receive_start(event.sender(), c).await?
-                        } else {
-                            flow_id_mismatch();
-                        }
-                    } else if let FlowId::ToDevice(_) = flow_id {
-                        // TODO remove this soon, this has been deprecated by
-                        // MSC3122 https://github.com/matrix-org/matrix-doc/pull/3122
-                        if let Some(device) =
-                            self.store.get_device(event.sender(), c.from_device()).await?
-                        {
-                            let identities = self.store.get_identities(device).await?;
 
-                            match Sas::from_start_event(flow_id, c, identities, None, false) {
-                                Ok(sas) => {
-                                    self.verifications.insert_sas(sas);
-                                }
-                                Err(cancellation) => self.queue_up_content(
-                                    event.sender(),
-                                    c.from_device(),
-                                    cancellation,
-                                    None,
-                                ),
-                            }
-                        }
-                    }
-                }
-                AnyVerificationContent::Accept(_) | AnyVerificationContent::Key(_) => {
-                    if let Some(sas) = self.get_sas(event.sender(), flow_id.as_str()) {
-                        if sas.flow_id() == &flow_id {
-                            if let Some((content, request_info)) =
-                                sas.receive_any_event(event.sender(), &content)
-                            {
-                                self.queue_up_content(
-                                    sas.other_user_id(),
-                                    sas.other_device_id(),
-                                    content,
-                                    request_info,
-                                );
-                            }
-                        } else {
-                            flow_id_mismatch();
-                        }
-                    }
-                }
-                AnyVerificationContent::Mac(_) => {
-                    if let Some(s) = self.get_sas(event.sender(), flow_id.as_str()) {
-                        if s.flow_id() == &flow_id {
-                            let content = s.receive_any_event(event.sender(), &content);
+                let request = VerificationRequest::from_request(
+                    self.verifications.clone(),
+                    self.store.clone(),
+                    event.sender(),
+                    flow_id,
+                    r,
+                );
 
-                            if s.is_done() {
-                                self.mark_sas_as_done(s, content.map(|(c, _)| c)).await?;
-                            } else {
-                                // Even if we are not done (yet), there might be content to send
-                                // out, e.g. in the case where we are done with our side of the
-                                // verification process, but the other side has not yet sent their
-                                // "done".
-                                if let Some((content, request_id)) = content {
-                                    self.queue_up_content(
-                                        s.other_user_id(),
-                                        s.other_device_id(),
-                                        content,
-                                        request_id,
-                                    );
-                                }
-                            }
-                        } else {
-                            flow_id_mismatch();
-                        }
-                    }
+                self.insert_request(request);
+            }
+            AnyVerificationContent::Cancel(c) => {
+                if let Some(verification) = self.get_request(event.sender(), flow_id.as_str()) {
+                    verification.receive_cancel(event.sender(), c);
                 }
-                AnyVerificationContent::Done(c) => {
-                    if let Some(verification) = self.get_request(event.sender(), flow_id.as_str()) {
-                        verification.receive_done(event.sender(), c);
-                    }
 
-                    #[allow(clippy::single_match)]
-                    match self.get_verification(event.sender(), flow_id.as_str()) {
-                        Some(Verification::SasV1(sas)) => {
-                            let content = sas.receive_any_event(event.sender(), &content);
-
-                            if sas.is_done() {
-                                self.mark_sas_as_done(sas, content.map(|(c, _)| c)).await?;
-                            }
+                if let Some(verification) = self.get_verification(event.sender(), flow_id.as_str())
+                {
+                    match verification {
+                        Verification::SasV1(sas) => {
+                            // This won't produce an outgoing content
+                            let _ = sas.receive_any_event(event.sender(), &content);
                         }
                         #[cfg(feature = "qrcode")]
-                        Some(Verification::QrV1(qr)) => {
-                            let (cancellation, request) = qr.receive_done(c).await?;
-
-                            if let Some(c) = cancellation {
-                                self.verifications.add_request(c.into())
-                            }
-
-                            if let Some(s) = request {
-                                self.verifications.add_request(s.into())
-                            }
-                        }
-                        None => (),
+                        Verification::QrV1(qr) => qr.receive_cancel(event.sender(), c),
                     }
+                }
+            }
+            AnyVerificationContent::Ready(c) => {
+                let Some(request) = self.get_request(event.sender(), flow_id.as_str()) else {
+                    return Ok(());
+                };
+
+                if request.flow_id() == &flow_id {
+                    request.receive_ready(event.sender(), c);
+                } else {
+                    flow_id_mismatch();
+                }
+            }
+            AnyVerificationContent::Start(c) => {
+                if let Some(request) = self.get_request(event.sender(), flow_id.as_str()) {
+                    if request.flow_id() == &flow_id {
+                        request.receive_start(event.sender(), c).await?
+                    } else {
+                        flow_id_mismatch();
+                    }
+                } else if let FlowId::ToDevice(_) = flow_id {
+                    // TODO remove this soon, this has been deprecated by
+                    // MSC3122 https://github.com/matrix-org/matrix-doc/pull/3122
+                    if let Some(device) =
+                        self.store.get_device(event.sender(), c.from_device()).await?
+                    {
+                        let identities = self.store.get_identities(device).await?;
+
+                        match Sas::from_start_event(flow_id, c, identities, None, false) {
+                            Ok(sas) => {
+                                self.verifications.insert_sas(sas);
+                            }
+                            Err(cancellation) => self.queue_up_content(
+                                event.sender(),
+                                c.from_device(),
+                                cancellation,
+                                None,
+                            ),
+                        }
+                    }
+                }
+            }
+            AnyVerificationContent::Accept(_) | AnyVerificationContent::Key(_) => {
+                let Some(sas) = self.get_sas(event.sender(), flow_id.as_str()) else {
+                    return Ok(());
+                };
+
+                if sas.flow_id() != &flow_id {
+                    flow_id_mismatch();
+                    return Ok(());
+                }
+
+                let Some((content, request_info)) =
+                    sas.receive_any_event(event.sender(), &content) else { return Ok(()) };
+
+                self.queue_up_content(
+                    sas.other_user_id(),
+                    sas.other_device_id(),
+                    content,
+                    request_info,
+                );
+            }
+            AnyVerificationContent::Mac(_) => {
+                let Some(s) = self.get_sas(event.sender(), flow_id.as_str()) else { return Ok(()) };
+
+                if s.flow_id() != &flow_id {
+                    flow_id_mismatch();
+                    return Ok(());
+                }
+
+                let content = s.receive_any_event(event.sender(), &content);
+
+                if s.is_done() {
+                    self.mark_sas_as_done(s, content.map(|(c, _)| c)).await?;
+                } else {
+                    // Even if we are not done (yet), there might be content to
+                    // send out, e.g. in the case where we are done with our
+                    // side of the verification process, but the other side has
+                    // not yet sent their "done".
+                    let Some((content, request_id)) = content else { return Ok(()) };
+
+                    self.queue_up_content(
+                        s.other_user_id(),
+                        s.other_device_id(),
+                        content,
+                        request_id,
+                    );
+                }
+            }
+            AnyVerificationContent::Done(c) => {
+                if let Some(verification) = self.get_request(event.sender(), flow_id.as_str()) {
+                    verification.receive_done(event.sender(), c);
+                }
+
+                #[allow(clippy::single_match)]
+                match self.get_verification(event.sender(), flow_id.as_str()) {
+                    Some(Verification::SasV1(sas)) => {
+                        let content = sas.receive_any_event(event.sender(), &content);
+
+                        if sas.is_done() {
+                            self.mark_sas_as_done(sas, content.map(|(c, _)| c)).await?;
+                        }
+                    }
+                    #[cfg(feature = "qrcode")]
+                    Some(Verification::QrV1(qr)) => {
+                        let (cancellation, request) = qr.receive_done(c).await?;
+
+                        if let Some(c) = cancellation {
+                            self.verifications.add_request(c.into())
+                        }
+
+                        if let Some(s) = request {
+                            self.verifications.add_request(s.into())
+                        }
+                    }
+                    None => {}
                 }
             }
         }

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -994,19 +994,16 @@ impl RequestState<Ready> {
             return Ok(None);
         }
 
-        let device = if let Some(device) =
-            self.store.get_device(&self.other_user_id, &self.state.other_device_id).await?
-        {
-            device
-        } else {
-            warn!(
-                user_id = self.other_user_id.as_str(),
-                device_id = self.state.other_device_id.as_str(),
-                "Can't create a QR code, the device that accepted the \
-                 verification doesn't exist"
-            );
-            return Ok(None);
-        };
+        let Some(device) =
+            self.store.get_device(&self.other_user_id, &self.state.other_device_id).await? else {
+                warn!(
+                    user_id = self.other_user_id.as_str(),
+                    device_id = self.state.other_device_id.as_str(),
+                    "Can't create a QR code, the device that accepted the \
+                    verification doesn't exist"
+                );
+                return Ok(None);
+            };
 
         let identities = self.store.get_identities(device).await?;
 
@@ -1123,9 +1120,7 @@ impl RequestState<Ready> {
             "Received a new verification start event",
         );
 
-        let device = if let Some(d) = self.store.get_device(sender, content.from_device()).await? {
-            d
-        } else {
+        let Some(device) = self.store.get_device(sender, content.from_device()).await? else {
             warn!(
                 sender = sender.as_str(),
                 device = content.from_device().as_str(),
@@ -1213,19 +1208,16 @@ impl RequestState<Ready> {
         }
 
         // TODO signal why starting the sas flow doesn't work?
-        let device = if let Some(device) =
-            self.store.get_device(&self.other_user_id, &self.state.other_device_id).await?
-        {
-            device
-        } else {
-            warn!(
-                user_id = self.other_user_id.as_str(),
-                device_id = self.state.other_device_id.as_str(),
-                "Can't start the SAS verification flow, the device that \
-                accepted the verification doesn't exist"
-            );
-            return Ok(None);
-        };
+        let Some(device) =
+            self.store.get_device(&self.other_user_id, &self.state.other_device_id).await? else {
+                warn!(
+                    user_id = self.other_user_id.as_str(),
+                    device_id = self.state.other_device_id.as_str(),
+                    "Can't start the SAS verification flow, the device that \
+                    accepted the verification doesn't exist"
+                );
+                return Ok(None);
+            };
 
         let identities = self.store.get_identities(device).await?;
 

--- a/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
@@ -180,20 +180,17 @@ impl InnerSas {
         self,
         methods: Vec<ShortAuthenticationString>,
     ) -> Option<(InnerSas, OwnedAcceptContent)> {
-        if let InnerSas::Started(s) = self {
-            let sas = s.into_we_accepted(methods);
-            let content = sas.as_content();
+        let InnerSas::Started(s) = self else { return None };
+        let sas = s.into_we_accepted(methods);
+        let content = sas.as_content();
 
-            trace!(
-                flow_id = sas.verification_flow_id.as_str(),
-                accepted_protocols = ?sas.state.accepted_protocols,
-                "Accepted a SAS verification"
-            );
+        trace!(
+            flow_id = sas.verification_flow_id.as_str(),
+            accepted_protocols = ?sas.state.accepted_protocols,
+            "Accepted a SAS verification"
+        );
 
-            Some((InnerSas::WeAccepted(sas), content))
-        } else {
-            None
-        }
+        Some((InnerSas::WeAccepted(sas), content))
     }
 
     #[cfg(test)]

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/matrix-org/matrix-rust-sdk"
 description = "Web's IndexedDB Storage backend for matrix-sdk"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = { workspace = true }
 readme = "README.md"
 
 [package.metadata.docs.rs]

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -530,10 +530,7 @@ impl IndexeddbCryptoStore {
         for user_id in user_ids.iter() {
             let dirty: bool =
                 !matches!(os.get(&user_id)?.await?.map(|v| v.into_serde()), Some(Ok(false)));
-            let user = match user_id.as_string().map(UserId::parse) {
-                Some(Ok(user)) => user,
-                _ => continue,
-            };
+            let Some(Ok(user)) = user_id.as_string().map(UserId::parse) else { continue };
             self.tracked_users_cache.insert(user.clone());
 
             if dirty {

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -793,10 +793,7 @@ impl IndexeddbStateStore {
 
             for (room_id, redactions) in &changes.redactions {
                 let range = self.encode_to_range(KEYS::ROOM_STATE, room_id)?;
-                let cursor = match state.open_cursor_with_range(&range)?.await? {
-                    Some(c) => c,
-                    _ => continue,
-                };
+                let Some(cursor) = state.open_cursor_with_range(&range)?.await? else { continue };
 
                 let mut room_version = None;
 

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/matrix-org/matrix-rust-sdk"
 keywords = ["matrix", "chat", "messaging", "ruma", "nio"]
 license = "Apache-2.0"
 readme = "README.md"
-rust-version = "1.62"
+rust-version = { workspace = true }
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 
 [package.metadata.docs.rs]

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Damir Jelić <poljar@termina.org.uk>"]
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 description = "Sled Storage backend for matrix-sdk for native environments"
 license = "Apache-2.0"
-rust-version = "1.62"
+rust-version = { workspace = true }
 readme = "README.md"
 
 [package.metadata.docs.rs]

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Helpers for encrypted storage keys for the Matrix SDK"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 license = "Apache-2.0"
-rust-version = "1.62"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "matrix-sdk"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
-rust-version = "1.62"
+rust-version = { workspace = true }
 version = "0.6.2"
 
 [package.metadata.docs.rs]

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -380,7 +380,7 @@ impl ClientBuilder {
 
                 if let Some(issuer) = well_known.authentication.map(|auth| auth.issuer) {
                     authentication_issuer = Url::parse(&issuer).ok();
-                };
+                }
 
                 well_known.homeserver.base_url
             }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1310,11 +1310,8 @@ impl Client {
         let lock = self.inner.refresh_token_lock.try_lock();
 
         if let Some(mut guard) = lock {
-            let mut session_tokens = if let Some(tokens) = self.session_tokens() {
-                tokens
-            } else {
+            let Some(mut session_tokens) = self.session_tokens() else {
                 *guard = Err(RefreshTokenError::RefreshTokenRequired);
-
                 return Err(RefreshTokenError::RefreshTokenRequired.into());
             };
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -308,11 +308,8 @@ impl Client {
 
     /// The OIDC Provider that is trusted by the homeserver.
     pub async fn authentication_issuer(&self) -> Option<Url> {
-        if let Some(server) = &self.inner.authentication_issuer {
-            Some(server.read().await.clone())
-        } else {
-            None
-        }
+        let server = self.inner.authentication_issuer.as_ref()?;
+        Some(server.read().await.clone())
     }
 
     fn session_meta(&self) -> Option<&SessionMeta> {
@@ -1769,8 +1766,11 @@ impl Client {
         Request: OutgoingRequest + Debug,
         HttpError: From<FromHttpResponseError<Request::EndpointError>>,
     {
-        let homeserver =
-            if let Some(h) = homeserver { h } else { self.homeserver().await.to_string() };
+        let homeserver = match homeserver {
+            Some(hs) => hs,
+            None => self.homeserver().await.to_string(),
+        };
+
         self.inner
             .http_client
             .send(

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -492,11 +492,8 @@ impl Encryption {
     /// This can be used to check which private cross signing keys we have
     /// stored locally.
     pub async fn cross_signing_status(&self) -> Option<CrossSigningStatus> {
-        if let Some(machine) = self.client.olm_machine() {
-            Some(machine.cross_signing_status().await)
-        } else {
-            None
-        }
+        let machine = self.client.olm_machine()?;
+        Some(machine.cross_signing_status().await)
     }
 
     /// Get all the tracked users we know about
@@ -575,12 +572,9 @@ impl Encryption {
         user_id: &UserId,
         device_id: &DeviceId,
     ) -> Result<Option<Device>, CryptoStoreError> {
-        if let Some(machine) = self.client.olm_machine() {
-            let device = machine.get_device(user_id, device_id, None).await?;
-            Ok(device.map(|d| Device { inner: d, client: self.client.clone() }))
-        } else {
-            Ok(None)
-        }
+        let Some(machine) = self.client.olm_machine() else { return Ok(None) };
+        let device = machine.get_device(user_id, device_id, None).await?;
+        Ok(device.map(|d| Device { inner: d, client: self.client.clone() }))
     }
 
     /// Get a map holding all the devices of an user.
@@ -656,20 +650,17 @@ impl Encryption {
     ) -> Result<Option<crate::encryption::identities::UserIdentity>, CryptoStoreError> {
         use crate::encryption::identities::UserIdentity;
 
-        if let Some(olm) = self.client.olm_machine() {
-            let identity = olm.get_identity(user_id, None).await?;
+        let Some(olm) = self.client.olm_machine() else { return Ok(None) };
+        let identity = olm.get_identity(user_id, None).await?;
 
-            Ok(identity.map(|i| match i {
-                matrix_sdk_base::crypto::UserIdentities::Own(i) => {
-                    UserIdentity::new_own(self.client.clone(), i)
-                }
-                matrix_sdk_base::crypto::UserIdentities::Other(i) => {
-                    UserIdentity::new(self.client.clone(), i, self.client.get_dm_room(user_id))
-                }
-            }))
-        } else {
-            Ok(None)
-        }
+        Ok(identity.map(|i| match i {
+            matrix_sdk_base::crypto::UserIdentities::Own(i) => {
+                UserIdentity::new_own(self.client.clone(), i)
+            }
+            matrix_sdk_base::crypto::UserIdentities::Other(i) => {
+                UserIdentity::new(self.client.clone(), i, self.client.get_dm_room(user_id))
+            }
+        }))
     }
 
     /// Create and upload a new cross signing identity.

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -150,12 +150,9 @@ impl Common {
     /// # })
     /// ```
     pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
-        if let Some(url) = self.avatar_url() {
-            let request = MediaRequest { source: MediaSource::Plain(url.to_owned()), format };
-            Ok(Some(self.client.media().get_media_content(&request, true).await?))
-        } else {
-            Ok(None)
-        }
+        let Some(url) = self.avatar_url() else { return Ok(None) };
+        let request = MediaRequest { source: MediaSource::Plain(url.to_owned()), format };
+        Ok(Some(self.client.media().get_media_content(&request, true).await?))
     }
 
     /// Sends a request to `/_matrix/client/r0/rooms/{room_id}/messages` and

--- a/crates/matrix-sdk/src/room/member.rs
+++ b/crates/matrix-sdk/src/room/member.rs
@@ -60,11 +60,8 @@ impl RoomMember {
     /// # })
     /// ```
     pub async fn avatar(&self, format: MediaFormat) -> Result<Option<Vec<u8>>> {
-        if let Some(url) = self.avatar_url() {
-            let request = MediaRequest { source: MediaSource::Plain(url.to_owned()), format };
-            Ok(Some(self.client.media().get_media_content(&request, true).await?))
-        } else {
-            Ok(None)
-        }
+        let Some(url) = self.avatar_url() else { return Ok(None) };
+        let request = MediaRequest { source: MediaSource::Plain(url.to_owned()), format };
+        Ok(Some(self.client.media().get_media_content(&request, true).await?))
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -509,7 +509,7 @@ impl SlidingSync {
     /// Run this stream to receive new updates from the server.
     pub async fn stream<'a>(
         &self,
-    ) -> Result<impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_, crate::Error> {
+    ) -> Result<impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_> {
         let views = self.views.lock_ref().to_vec();
         let extensions = self.extensions.clone();
         let client = self.client.clone();
@@ -525,7 +525,7 @@ impl SlidingSync {
                 let mut new_remaining_generators = Vec::new();
                 let mut new_remaining_views = Vec::new();
 
-                for (mut generator, view) in  std::iter::zip(remaining_generators, remaining_views) {
+                for (mut generator, view) in std::iter::zip(remaining_generators, remaining_views) {
                     if let Some(request) = generator.next() {
                         requests.push(request);
                         new_remaining_generators.push(generator);

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -93,12 +93,9 @@ impl Client {
         let mut futures = Vec::new();
         for handler in &*self.notification_handlers().await {
             for (room_id, room_notifications) in notifications {
-                let room = match self.get_room(room_id) {
-                    Some(room) => room,
-                    None => {
-                        warn!(%room_id, "Can't call notification handler, room not found");
-                        continue;
-                    }
+                let Some(room) = self.get_room(room_id) else {
+                    warn!(%room_id, "Can't call notification handler, room not found");
+                    continue;
                 };
 
                 futures.extend(room_notifications.iter().map(|notification| {

--- a/examples/command_bot/src/main.rs
+++ b/examples/command_bot/src/main.rs
@@ -4,19 +4,18 @@ use matrix_sdk::{
     config::SyncSettings,
     room::Room,
     ruma::events::room::message::{
-        MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent, TextMessageEventContent,
+        MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
     },
     Client,
 };
 
 async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {
     if let Room::Joined(room) = room {
-        let msg_body = match event.content.msgtype {
-            MessageType::Text(TextMessageEventContent { body, .. }) => body,
-            _ => return,
+        let MessageType::Text(text_content) = event.content.msgtype else {
+            return;
         };
 
-        if msg_body.contains("!party") {
+        if text_content.body.contains("!party") {
             let content = RoomMessageEventContent::text_plain("🎉🎊🥳 let's PARTY!! 🥳🎊🎉");
 
             println!("sending");

--- a/examples/custom_events/src/main.rs
+++ b/examples/custom_events/src/main.rs
@@ -19,7 +19,7 @@ use matrix_sdk::{
             macros::EventContent,
             room::{
                 member::StrippedRoomMemberEvent,
-                message::{MessageType, OriginalSyncRoomMessageEvent, TextMessageEventContent},
+                message::{MessageType, OriginalSyncRoomMessageEvent},
             },
         },
         OwnedEventId,
@@ -51,19 +51,15 @@ pub struct AckEventContent {
 
 // we want to start the ping-ack-flow on "!ping" messages.
 async fn on_regular_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {
-    if let Room::Joined(room) = room {
-        let msg_body = match event.content.msgtype {
-            MessageType::Text(TextMessageEventContent { body, .. }) => body,
-            _ => return,
-        };
+    let Room::Joined(room) = room else { return };
+    let MessageType::Text(text_content) = event.content.msgtype else { return };
 
-        if msg_body.contains("!ping") {
-            let content = PingEventContent {};
+    if text_content.body.contains("!ping") {
+        let content = PingEventContent {};
 
-            println!("sending ping");
-            room.send(content, None).await.unwrap();
-            println!("ping sent");
-        }
+        println!("sending ping");
+        room.send(content, None).await.unwrap();
+        println!("ping sent");
     }
 }
 

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -17,10 +17,7 @@ use matrix_sdk::{
     room::Room,
     ruma::events::room::{
         member::StrippedRoomMemberEvent,
-        message::{
-            MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
-            TextMessageEventContent,
-        },
+        message::{MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent},
     },
     Client,
 };
@@ -158,25 +155,21 @@ async fn on_stripped_state_member(
 async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {
     // First, we need to unpack the message: We only want messages from rooms we are
     // still in and that are regular text messages - ignoring everything else.
-    if let Room::Joined(room) = room {
-        let msg_body = match event.content.msgtype {
-            MessageType::Text(TextMessageEventContent { body, .. }) => body,
-            _ => return,
-        };
+    let Room::Joined(room) = room else { return };
+    let MessageType::Text(text_content) = event.content.msgtype else { return };
 
-        // here comes the actual "logic": when the bot see's a `!party` in the message,
-        // it responds
-        if msg_body.contains("!party") {
-            let content = RoomMessageEventContent::text_plain("🎉🎊🥳 let's PARTY!! 🥳🎊🎉");
+    // here comes the actual "logic": when the bot see's a `!party` in the message,
+    // it responds
+    if text_content.body.contains("!party") {
+        let content = RoomMessageEventContent::text_plain("🎉🎊🥳 let's PARTY!! 🥳🎊🎉");
 
-            println!("sending");
+        println!("sending");
 
-            // send our message to the room we found the "!party" command in
-            // the last parameter is an optional transaction id which we don't
-            // care about.
-            room.send(content, None).await.unwrap();
+        // send our message to the room we found the "!party" command in
+        // the last parameter is an optional transaction id which we don't
+        // care about.
+        room.send(content, None).await.unwrap();
 
-            println!("message sent");
-        }
+        println!("message sent");
     }
 }

--- a/examples/image_bot/src/main.rs
+++ b/examples/image_bot/src/main.rs
@@ -5,37 +5,22 @@ use matrix_sdk::{
     attachment::AttachmentConfig,
     config::SyncSettings,
     room::Room,
-    ruma::events::room::message::{
-        MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent, TextMessageEventContent,
-    },
+    ruma::events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
     Client,
 };
 use url::Url;
 
 async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room, image: Arc<[u8]>) {
-    if let Room::Joined(room) = room {
-        let msg_body = if let OriginalSyncRoomMessageEvent {
-            content:
-                RoomMessageEventContent {
-                    msgtype: MessageType::Text(TextMessageEventContent { body: msg_body, .. }),
-                    ..
-                },
-            ..
-        } = event
-        {
-            msg_body
-        } else {
-            return;
-        };
+    let Room::Joined(room) = room else { return };
+    let MessageType::Text(text_content) = event.content.msgtype else { return };
 
-        if msg_body.contains("!image") {
-            println!("sending image");
-            room.send_attachment("cat", &mime::IMAGE_JPEG, &image, AttachmentConfig::new())
-                .await
-                .unwrap();
+    if text_content.body.contains("!image") {
+        println!("sending image");
+        room.send_attachment("cat", &mime::IMAGE_JPEG, &image, AttachmentConfig::new())
+            .await
+            .unwrap();
 
-            println!("message sent");
-        }
+        println!("message sent");
     }
 }
 

--- a/examples/wasm_command_bot/src/lib.rs
+++ b/examples/wasm_command_bot/src/lib.rs
@@ -3,10 +3,7 @@ use matrix_sdk::{
     deserialized_responses::SyncResponse,
     ruma::{
         events::{
-            room::message::{
-                MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
-                TextMessageEventContent,
-            },
+            room::message::{MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent},
             AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
             SyncMessageLikeEvent,
         },
@@ -22,23 +19,11 @@ struct WasmBot(Client);
 
 impl WasmBot {
     async fn on_room_message(&self, room_id: &RoomId, event: &OriginalSyncRoomMessageEvent) {
-        let msg_body = if let OriginalSyncRoomMessageEvent {
-            content:
-                RoomMessageEventContent {
-                    msgtype: MessageType::Text(TextMessageEventContent { body: msg_body, .. }),
-                    ..
-                },
-            ..
-        } = event
-        {
-            msg_body
-        } else {
-            return;
-        };
+        let MessageType::Text(text_content) = &event.content.msgtype else { return };
 
-        console::log_1(&format!("Received message event {:?}", &msg_body).into());
+        console::log_1(&format!("Received message event {:?}", &text_content.body).into());
 
-        if msg_body.contains("!party") {
+        if text_content.body.contains("!party") {
             let content = AnyMessageLikeEventContent::RoomMessage(
                 RoomMessageEventContent::text_plain("🎉🎊🥳 let's PARTY!! 🥳🎊🎉"),
             );

--- a/labs/jack-in/src/components/details.rs
+++ b/labs/jack-in/src/components/details.rs
@@ -45,16 +45,9 @@ impl Details {
     }
 
     pub fn refresh_data(&mut self) {
-        let room_id =
-            if let Some(r) = self.sstate.selected_room.lock_ref().clone() { r } else { return };
-
-        let room_data = {
-            let l = self.sstate.view().rooms.lock_ref();
-            if let Some(room) = l.get(&room_id) {
-                room.clone()
-            } else {
-                return;
-            }
+        let Some(room_id) = self.sstate.selected_room.lock_ref().clone() else { return };
+        let Some(room_data) = self.sstate.view().rooms.lock_ref().get(&room_id).cloned() else {
+            return;
         };
 
         let name = room_data.name.clone().unwrap_or_else(|| "unknown".to_owned());
@@ -122,9 +115,7 @@ impl MockComponent for Details {
             .get_or(Attribute::Borders, AttrValue::Borders(Borders::default()))
             .unwrap_borders();
 
-        let name = if let Some(name) = &self.name {
-            name.clone()
-        } else {
+        let Some(name) = &self.name else {
             // still empty
             frame.render_widget(
                 Table::new(vec![Row::new(vec![Cell::from(
@@ -172,7 +163,7 @@ impl MockComponent for Details {
             chunks[0],
         );
 
-        let title = (name, Alignment::Left);
+        let title = (name.to_owned(), Alignment::Left);
         let focus = self.props.get_or(Attribute::Focus, AttrValue::Flag(false)).unwrap_flag();
 
         let mut details = vec![];

--- a/testing/matrix-sdk-test-macros/Cargo.toml
+++ b/testing/matrix-sdk-test-macros/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "matrix-sdk-test-macros"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
-rust-version = "1.62"
+rust-version = { workspace = true }
 version = "0.3.0"
 
 [lib]

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 name = "matrix-sdk-test"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
-rust-version = "1.62"
+rust-version = { workspace = true }
 version = "0.6.0"
 
 [lib]


### PR DESCRIPTION
It took a while, but don't be discouraged from pushing back on any of the individual changes or the whole PR if you don't find the code more readable than before.

The last commit in particular might not be a good idea, maybe we can factor out parts into a new function there?

Last remark: Unfortunately rustfmt doesn't yet format let-else code at all. Please complain if you find the formatting weird in some place.