### PR TITLE
Edit messages

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -225,6 +225,9 @@ interface Room {
     void send_reply(string msg, string in_reply_to_event_id, string? txn_id);
 
     [Throws=ClientError]
+    void edit(string new_msg, string original_event_id, string? txn_id);
+
+    [Throws=ClientError]
     void redact(string event_id, string? reason, string? txn_id);
 };
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -11,7 +11,7 @@ use matrix_sdk::{
         Room as SdkRoom,
     },
     ruma::{
-        events::room::message::{RoomMessageEvent, RoomMessageEventContent},
+        events::room::message::{Relation, Replacement, RoomMessageEvent, RoomMessageEventContent},
         EventId, UserId,
     },
 };
@@ -195,6 +195,51 @@ impl Room {
                 RoomMessageEventContent::text_markdown(msg).make_reply_to(original_message);
 
             timeline.send(reply_content.into(), txn_id.as_deref().map(Into::into)).await?;
+
+            Ok(())
+        })
+    }
+
+    pub fn edit(
+        &self,
+        new_msg: String,
+        original_event_id: String,
+        txn_id: Option<String>,
+    ) -> Result<()> {
+        let room = match &self.room {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => bail!("Can't send to a room that isn't in joined state"),
+        };
+
+        let timeline = match &*self.timeline.read().unwrap() {
+            Some(t) => Arc::clone(t),
+            None => bail!("Timeline not set up, can't send message"),
+        };
+
+        let event_id: &EventId =
+            original_event_id.as_str().try_into().context("Failed to create EventId.")?;
+
+        RUNTIME.block_on(async move {
+            let timeline_event = room.event(event_id).await.context("Couldn't find event.")?;
+
+            let event_content = timeline_event
+                .event
+                .deserialize_as::<RoomMessageEvent>()
+                .context("Couldn't deserialise event")?;
+
+            if self.own_user_id() != event_content.sender() {
+                bail!("Can't edit an event not sent by own user")
+            }
+
+            let replacement = Replacement::new(
+                event_id.to_owned(),
+                Box::new(RoomMessageEventContent::text_markdown(new_msg.to_owned())),
+            );
+
+            let mut edited_content = RoomMessageEventContent::text_markdown(new_msg);
+            edited_content.relates_to = Some(Relation::Replacement(replacement));
+
+            timeline.send(edited_content.into(), txn_id.as_deref().map(Into::into)).await?;
 
             Ok(())
         })

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -185,6 +185,10 @@ impl EventTimelineItem {
         self.0.is_own()
     }
 
+    pub fn is_editable(&self) -> bool {
+        self.0.is_editable()
+    }
+
     pub fn content(&self) -> Arc<TimelineItemContent> {
         Arc::new(TimelineItemContent(self.0.content().clone()))
     }

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -168,7 +168,17 @@ impl EventTimelineItem {
 
     /// Flag indicating this timeline item can be edited by current user.
     pub fn is_editable(&self) -> bool {
-        matches!(&self.content, TimelineItemContent::Message(message) if self.is_own() && matches!(message.msgtype(), MessageType::Text(_)))
+        if !self.is_own() {
+            false;
+        }
+        match &self.content {
+            TimelineItemContent::Message(message) => match message.msgtype() {
+                MessageType::Text(_) => true,
+                MessageType::Emote(_) => true,
+                _ => false,
+            },
+            _ => false,
+        }
     }
 
     /// Get the raw JSON representation of the initial event (the one that

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -168,14 +168,10 @@ impl EventTimelineItem {
 
     /// Flag indicating this timeline item can be edited by current user.
     pub fn is_editable(&self) -> bool {
-        if !self.is_own() {
-            false;
-        }
         match &self.content {
-            TimelineItemContent::Message(message) => match message.msgtype() {
-                MessageType::Text(_) => true,
-                MessageType::Emote(_) => true,
-                _ => false,
+            TimelineItemContent::Message(message) => {
+                self.is_own()
+                    && matches!(message.msgtype(), MessageType::Text(_) | MessageType::Emote(_))
             },
             _ => false,
         }

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -166,6 +166,18 @@ impl EventTimelineItem {
         self.is_own
     }
 
+    /// Flag indicating this item can be edited by current user.
+    pub fn is_editable(&self) -> bool {
+        if self.is_own() {
+            match &self.content {
+                TimelineItemContent::Message(message) => message.is_editable(),
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+
     /// Get the raw JSON representation of the initial event (the one that
     /// caused this timeline item to be created).
     ///
@@ -315,6 +327,14 @@ impl Message {
     /// Get the edit state of this message (has been edited: `true` / `false`).
     pub fn is_edited(&self) -> bool {
         self.edited
+    }
+
+    /// Flag indicating this message can be edited by current user.
+    pub fn is_editable(&self) -> bool {
+        match self.msgtype() {
+            MessageType::Text(_) => true,
+            _ => false,
+        }
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -166,16 +166,9 @@ impl EventTimelineItem {
         self.is_own
     }
 
-    /// Flag indicating this item can be edited by current user.
+    /// Flag indicating this timeline item can be edited by current user.
     pub fn is_editable(&self) -> bool {
-        if self.is_own() {
-            match &self.content {
-                TimelineItemContent::Message(message) => message.is_editable(),
-                _ => false,
-            }
-        } else {
-            false
-        }
+        matches!(&self.content, TimelineItemContent::Message(message) if self.is_own() && message.is_editable())
     }
 
     /// Get the raw JSON representation of the initial event (the one that
@@ -329,7 +322,7 @@ impl Message {
         self.edited
     }
 
-    /// Flag indicating this message can be edited by current user.
+    /// Flag indicating this message type is editable.
     pub fn is_editable(&self) -> bool {
         matches!(self.msgtype(), MessageType::Text(_))
     }

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -172,7 +172,7 @@ impl EventTimelineItem {
             TimelineItemContent::Message(message) => {
                 self.is_own()
                     && matches!(message.msgtype(), MessageType::Text(_) | MessageType::Emote(_))
-            },
+            }
             _ => false,
         }
     }

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -331,10 +331,7 @@ impl Message {
 
     /// Flag indicating this message can be edited by current user.
     pub fn is_editable(&self) -> bool {
-        match self.msgtype() {
-            MessageType::Text(_) => true,
-            _ => false,
-        }
+        matches!(self.msgtype(), MessageType::Text(_))
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -168,7 +168,7 @@ impl EventTimelineItem {
 
     /// Flag indicating this timeline item can be edited by current user.
     pub fn is_editable(&self) -> bool {
-        matches!(&self.content, TimelineItemContent::Message(message) if self.is_own() && message.is_editable())
+        matches!(&self.content, TimelineItemContent::Message(message) if self.is_own() && matches!(message.msgtype(), MessageType::Text(_)))
     }
 
     /// Get the raw JSON representation of the initial event (the one that
@@ -320,11 +320,6 @@ impl Message {
     /// Get the edit state of this message (has been edited: `true` / `false`).
     pub fn is_edited(&self) -> bool {
         self.edited
-    }
-
-    /// Flag indicating this message type is editable.
-    pub fn is_editable(&self) -> bool {
-        matches!(self.msgtype(), MessageType::Text(_))
     }
 }
 


### PR DESCRIPTION
Exposes two things:
- `is_editable` on `EventTimelineItem` object: currently only outgoing text messages are editable.
- `edit(...)` method on `Room` object.