### PR TITLE
fix(indexeddb) + feat(crypto-js): Releasing `IDBDatabase` so that we can delete them

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -756,6 +756,11 @@ impl OlmMachine {
         )?)?)
     }
 
-    /// Force to drop/close the `OlmMachine`.
+    /// Shut down the `OlmMachine`.
+    ///
+    /// The `OlmMachine` cannot be used after this method has been called.
+    ///
+    /// All associated resources will be closed too, like IndexedDB
+    /// connections.
     pub fn close(self) {}
 }

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -755,4 +755,7 @@ impl OlmMachine {
             passphrase,
         )?)?)
     }
+
+    /// Force to drop/close the `OlmMachine`.
+    pub fn close(self) {}
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -283,6 +283,10 @@ impl IndexeddbCryptoStore {
             }
         };
 
+        // Must release the database access manually as it's not done when
+        // dropping it.
+        db.close();
+
         IndexeddbCryptoStore::open_with_store_cipher(prefix, Some(store_cipher.into())).await
     }
 
@@ -940,6 +944,14 @@ impl IndexeddbCryptoStore {
         };
 
         Ok(key)
+    }
+}
+
+impl Drop for IndexeddbCryptoStore {
+    fn drop(&mut self) {
+        // Must release the database access manually as it's not done when
+        // dropping it.
+        self.inner.close();
     }
 }
 


### PR DESCRIPTION
@richvdh has raised an important issue. When initializing a new `OlmMachine` with a store name and a store passphrase, 2 databases (IndexedDB databases) are created. At some point, one may want to delete them. But it's impossible. The sky is crying. The undeads are dancing under a bloody moon. And an exception is thrown saying the databases are _blocked_.

This PR fixes the problem in 3 acts.

## Act 1, closing `IDBDatabase` properly (https://github.com/matrix-org/matrix-rust-sdk/commit/3fe63c328f1dbbfa3092e9aed5f8fe94838684d5)

Surprisingly, `indexed_db_futures::IdbDatabase` is not closed when dropped.
Hopefully, there is a [`IdbDatabase::close(&self)`][close] method, which calls
`web_sys::IdbDatabase.close`, aka [`IDBDatabase.close`][websys-close], so let's
use it!

`IDBDatabase.close` returns immediately and closes the connection in a separate
thread. The connection isn't actually closed until all transactions created
using this connection are complete. No new transactions can be created for this
connection once this method is called. Methods that create transactions throw
an exception if a closing operation is pending.

[close]: https://github.com/Alorel/rust-indexed-db/blob/8c106eb418aecdba2f3fde80d91a4673a875fdf6/src/idb_database.rs#L73-L77
[websys-close]: https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/close

## Act 2, forcing `OlmMachine` to be dropped (https://github.com/matrix-org/matrix-rust-sdk/commit/74d3250bea741c31a0b908025508ed6783f6d55a)

This new `OlmMachine.close` method forces to drop/close the `OlmMachine`
without waiting on the JavaScript garbage collector to collect it. It's just:

```rust
pub fn close(self) {}
```

Lovely Rust.

`wasm-bindgen` generates the following JS glue code:

```js
close() {
    const ptr = this.__destroy_into_raw();
    wasm.olmachine_close(ptr);
}
```

And, `__destroy_into_raw` looks like this:

```js
__destroy_into_raw() {
    const ptr = this.ptr;
    this.ptr = 0;
    OlmMachineFinalization.unregister(this);
    return ptr;
}
```

It unregisters itself from the `FinalizationRegistry` correctly. We are
protected from a double-free.

## Act 3, Adding the appropriate test case (https://github.com/matrix-org/matrix-rust-sdk/commit/622703131d7ee73e988bffe0bfee6f4bcbf119ab)

Finally, we can test that everything works like a charm. And it does.