### PR TITLE
Remove room_id from RoomInfo

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -42,7 +42,7 @@ pub use http;
 #[cfg(feature = "e2e-encryption")]
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
-pub use rooms::{DisplayName, Room, RoomInfo, RoomMember, RoomType};
+pub use rooms::{DisplayName, Room, RoomIdAndInfo, RoomInfo, RoomMember, RoomType};
 pub use store::{StateChanges, StateStore, StoreError};
 pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -4,7 +4,7 @@ mod normal;
 use std::{collections::HashSet, fmt};
 
 pub use members::RoomMember;
-pub use normal::{Room, RoomInfo, RoomType};
+pub use normal::{Room, RoomIdAndInfo, RoomInfo, RoomType};
 use ruma::{
     events::{
         room::{

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -95,10 +95,15 @@ impl BaseClient {
                     let mut room_info = r.clone_info();
                     room_info.mark_as_invited(); // FIXME: this might not be accurate
                     room_info.mark_state_partially_synced();
-                    changes.add_room(room_info);
+                    changes.add_room(room_id.clone(), room_info);
                 }
 
-                self.handle_invited_state(invite_states.as_slice(), &mut room_info, &mut changes);
+                self.handle_invited_state(
+                    invite_states.as_slice(),
+                    &room_id,
+                    &mut room_info,
+                    &mut changes,
+                );
 
                 new_rooms.invite.insert(
                     room_id.clone(),
@@ -118,6 +123,7 @@ impl BaseClient {
                 let mut user_ids = if !room_data.required_state.is_empty() {
                     self.handle_state(
                         &room_data.required_state,
+                        &room_id,
                         &mut room_info,
                         &mut changes,
                         &mut ambiguity_cache,
@@ -201,7 +207,7 @@ impl BaseClient {
                     ),
                 );
 
-                changes.add_room(room_info);
+                changes.add_room(room_id, room_info);
             }
         }
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -114,7 +114,7 @@ macro_rules! statestore_integration_tests {
                 let pushrules_event = pushrules_raw.deserialize().unwrap();
                 changes.add_account_data(pushrules_event, pushrules_raw);
 
-                let mut room = RoomInfo::new(room_id, RoomType::Joined);
+                let mut room = RoomInfo::new(RoomType::Joined);
                 room.mark_as_left();
 
                 let tag_json: &JsonValue = &test_json::TAG;
@@ -191,9 +191,9 @@ macro_rules! statestore_integration_tests {
                 changes.ambiguity_maps.insert(room_id.to_owned(), room_ambiguity_map);
                 changes.profiles.insert(room_id.to_owned(), room_profiles);
                 changes.members.insert(room_id.to_owned(), room_members);
-                changes.add_room(room);
+                changes.add_room(room_id.to_owned(), room);
 
-                let mut stripped_room = RoomInfo::new(stripped_room_id, RoomType::Invited);
+                let mut stripped_room = RoomInfo::new(RoomType::Invited);
 
                 let stripped_name_json: &JsonValue = &test_json::NAME_STRIPPED;
                 let stripped_name_raw = serde_json::from_value::<Raw<AnyStrippedStateEvent>>(
@@ -213,7 +213,7 @@ macro_rules! statestore_integration_tests {
                     )]),
                 );
 
-                changes.add_stripped_room(stripped_room);
+                changes.add_stripped_room(stripped_room_id.to_owned(), stripped_room);
 
                 let stripped_member_json: &JsonValue = &test_json::MEMBER_STRIPPED;
                 let stripped_member_event =
@@ -698,7 +698,7 @@ macro_rules! statestore_integration_tests {
                     .entry(room_id.to_owned())
                     .or_default()
                     .insert(user_id.to_owned(), membership_event());
-                changes.add_room(RoomInfo::new(room_id, RoomType::Left));
+                changes.add_room(room_id.to_owned(), RoomInfo::new(RoomType::Left));
                 store.save_changes(&changes).await.unwrap();
 
                 assert!(matches!(
@@ -713,7 +713,7 @@ macro_rules! statestore_integration_tests {
 
                 let mut changes = StateChanges::default();
                 changes.add_stripped_member(room_id, custom_stripped_membership_event(user_id));
-                changes.add_stripped_room(RoomInfo::new(room_id, RoomType::Invited));
+                changes.add_stripped_room(room_id.to_owned(), RoomInfo::new(RoomType::Invited));
                 store.save_changes(&changes).await.unwrap();
 
                 assert!(matches!(

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -41,7 +41,7 @@ use super::{Result, RoomInfo, StateChanges, StateStore, StoreError};
 use crate::{
     deserialized_responses::MemberEvent,
     media::{MediaRequest, UniqueKey},
-    MinimalRoomMemberEvent,
+    MinimalRoomMemberEvent, RoomIdAndInfo,
 };
 
 /// In-Memory, non-persistent implementation of the `StateStore`
@@ -466,12 +466,18 @@ impl MemoryStore {
             .unwrap_or_default()
     }
 
-    fn get_room_infos(&self) -> Vec<RoomInfo> {
-        self.room_info.iter().map(|r| r.clone()).collect()
+    fn get_room_infos(&self) -> Vec<RoomIdAndInfo> {
+        self.room_info
+            .iter()
+            .map(|r| RoomIdAndInfo::from_parts(r.key().clone(), r.value().clone()))
+            .collect()
     }
 
-    fn get_stripped_room_infos(&self) -> Vec<RoomInfo> {
-        self.stripped_room_infos.iter().map(|r| r.clone()).collect()
+    fn get_stripped_room_infos(&self) -> Vec<RoomIdAndInfo> {
+        self.stripped_room_infos
+            .iter()
+            .map(|r| RoomIdAndInfo::from_parts(r.key().clone(), r.value().clone()))
+            .collect()
     }
 
     async fn get_account_data_event(
@@ -654,11 +660,11 @@ impl StateStore for MemoryStore {
         Ok(self.get_joined_user_ids(room_id))
     }
 
-    async fn get_room_infos(&self) -> Result<Vec<RoomInfo>> {
+    async fn get_room_infos(&self) -> Result<Vec<RoomIdAndInfo>> {
         Ok(self.get_room_infos())
     }
 
-    async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>> {
+    async fn get_stripped_room_infos(&self) -> Result<Vec<RoomIdAndInfo>> {
         Ok(self.get_stripped_room_infos())
     }
 

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -345,8 +345,9 @@ impl Common {
 
             let _guard = mutex.lock().await;
 
+            let room_id = self.inner.room_id();
             let request = get_state_events_for_key::v3::Request::new(
-                self.inner.room_id(),
+                room_id,
                 StateEventType::RoomEncryption,
                 "",
             );
@@ -363,12 +364,12 @@ impl Common {
             room_info.mark_encryption_state_synced();
             room_info.set_encryption_event(response.clone());
             let mut changes = StateChanges::default();
-            changes.add_room(room_info.clone());
+            changes.add_room(room_id.to_owned(), room_info.clone());
             self.client.store().save_changes(&changes).await?;
             self.update_summary(room_info);
             drop(sync_lock);
 
-            self.client.inner.encryption_state_request_locks.remove(self.inner.room_id());
+            self.client.inner.encryption_state_request_locks.remove(room_id);
 
             Ok(response)
         }


### PR DESCRIPTION
Unresolved questions:

* Is this a good idea? It just felt weird to have `Arc`ed data inside a struct that is itself behind an `Arc<RwLock<_>>` and frequently passed by `&mut`; but also this change should reduce store size as well as memory usage by removing unnecessary copies of the room ID
* Am I just overlooking how to decode the encoded sled key, or is that actually a one-way operation?