### PR TITLE
refactor(sdk)!: Remove next_batch from SyncResponse

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -659,7 +659,7 @@ impl BaseClient {
         // that case we already received this response and there's nothing to
         // do.
         if self.store.sync_token.read().await.as_ref() == Some(&next_batch) {
-            return Ok(SyncResponse::new(next_batch));
+            return Ok(SyncResponse::new());
         }
 
         let now = Instant::now();
@@ -843,14 +843,13 @@ impl BaseClient {
 
         let sync_lock = self.sync_lock().write().await;
         self.store.save_changes(&changes).await?;
-        *self.store.sync_token.write().await = Some(next_batch.clone());
+        *self.store.sync_token.write().await = Some(next_batch);
         self.apply_changes(&changes).await;
         drop(sync_lock);
 
         info!("Processed a sync response in {:?}", now.elapsed());
 
         let response = SyncResponse {
-            next_batch,
             rooms: new_rooms,
             presence,
             account_data: account_data.events,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -233,7 +233,6 @@ impl BaseClient {
         tracing::debug!("applied changes");
 
         Ok(SyncResponse {
-            next_batch: "test".into(),
             rooms: new_rooms,
             ambiguity_changes: AmbiguityChanges { changes: ambiguity_cache.changes },
             notifications: changes.notifications,

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -123,9 +123,6 @@ impl From<TimelineEvent> for SyncTimelineEvent {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SyncResponse {
-    /// The batch token to supply in the `since` param of the next `/sync`
-    /// request.
-    pub next_batch: String,
     /// Updates to rooms.
     pub rooms: Rooms,
     /// Updates to the presence status of other users.
@@ -148,8 +145,8 @@ pub struct SyncResponse {
 }
 
 impl SyncResponse {
-    pub fn new(next_batch: String) -> Self {
-        Self { next_batch, ..Default::default() }
+    pub fn new() -> Self {
+        Self { ..Default::default() }
     }
 }
 

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -26,7 +26,6 @@ impl Client {
         response: SyncResponse,
     ) -> Result<SyncResponse> {
         let SyncResponse {
-            next_batch: _,
             rooms,
             presence,
             account_data,
@@ -125,12 +124,10 @@ impl Client {
         &self,
         sync_settings: &mut crate::config::SyncSettings<'_>,
     ) -> Result<SyncResponse> {
-        let response = self.sync_once(sync_settings.clone()).await;
-
-        match response {
-            Ok(r) => {
-                sync_settings.token = Some(r.next_batch.clone());
-                Ok(r)
+        match self.sync_once_inner(sync_settings.clone()).await {
+            Ok((next_batch, response)) => {
+                sync_settings.token = Some(next_batch);
+                Ok(response)
             }
             Err(e) => {
                 error!("Received an invalid response: {e}");

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, str::FromStr, time::Duration};
 
+use assert_matches::assert_matches;
 use matrix_sdk::{
     config::SyncSettings,
     media::{MediaFormat, MediaRequest, MediaThumbnailSize},
@@ -260,11 +261,9 @@ async fn sync() {
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let response = client.sync_once(sync_settings).await.unwrap();
+    client.sync_once(sync_settings).await.unwrap();
 
-    assert_ne!(response.next_batch, "");
-
-    assert!(client.sync_token().await.is_some());
+    assert_matches!(client.sync_token().await, Some(_));
 }
 
 #[async_test]


### PR DESCRIPTION
… so we don't have to set it to a dummy value for sliding sync.