### PR TITLE
Make sync_token accessor private

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -654,7 +654,7 @@ impl BaseClient {
         // that case we already received this response and there's nothing to
         // do.
         if self.store.sync_token.read().await.as_ref() == Some(&next_batch) {
-            return Ok(SyncResponse::new(next_batch));
+            return Ok(SyncResponse::default());
         }
 
         let now = Instant::now();
@@ -845,7 +845,6 @@ impl BaseClient {
         info!("Processed a sync response in {:?}", now.elapsed());
 
         let response = SyncResponse {
-            next_batch,
             rooms: new_rooms,
             presence,
             account_data: account_data.events,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -232,7 +232,6 @@ impl BaseClient {
         tracing::debug!("applied changes");
 
         Ok(SyncResponse {
-            next_batch: "test".into(),
             rooms: new_rooms,
             ambiguity_changes: AmbiguityChanges { changes: ambiguity_cache.changes },
             notifications: changes.notifications,

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -33,12 +33,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::deserialized_responses::AmbiguityChanges;
 
-/// The processed response of a `/sync` request.
+/// Internal representation of a `/sync` response.
+///
+/// This type is intended to be applicable regardless of the endpoint used for
+/// syncing.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SyncResponse {
-    /// The batch token to supply in the `since` param of the next `/sync`
-    /// request.
-    pub next_batch: String,
     /// Updates to rooms.
     pub rooms: Rooms,
     /// Updates to the presence status of other users.
@@ -58,15 +58,6 @@ pub struct SyncResponse {
     pub ambiguity_changes: AmbiguityChanges,
     /// New notifications per room.
     pub notifications: BTreeMap<OwnedRoomId, Vec<Notification>>,
-}
-
-impl SyncResponse {
-    /// Creates a new, empty `SyncResponse`.
-    ///
-    /// Equivalent to `SyncResponse::default()`.
-    pub fn new(next_batch: String) -> Self {
-        Self { next_batch, ..Default::default() }
-    }
 }
 
 /// Updates to rooms in a [`SyncResponse`].

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2338,7 +2338,7 @@ impl Client {
 
     /// Get the current, if any, sync token of the client.
     /// This will be None if the client didn't sync at least once.
-    pub async fn sync_token(&self) -> Option<String> {
+    pub(crate) async fn sync_token(&self) -> Option<String> {
         self.inner.base_client.sync_token().await
     }
 

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -1103,6 +1103,7 @@ impl Client {
     ) -> Result<SyncResponse> {
         let response = self.base_client().process_sliding_sync(response).await?;
         tracing::debug!("done processing on base_client");
-        self.handle_sync_response(response).await
+        self.handle_sync_response(&response).await?;
+        Ok(response)
     }
 }

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -17,14 +17,12 @@ impl Client {
         response: sync_events::v3::Response,
     ) -> Result<SyncResponse> {
         let response = self.base_client().receive_sync_response(response).await?;
-        self.handle_sync_response(response).await
+        self.handle_sync_response(&response).await?;
+        Ok(response)
     }
 
     #[tracing::instrument(skip(self, response))]
-    pub(crate) async fn handle_sync_response(
-        &self,
-        response: SyncResponse,
-    ) -> Result<SyncResponse> {
+    pub(crate) async fn handle_sync_response(&self, response: &SyncResponse) -> Result<()> {
         let SyncResponse {
             next_batch: _,
             rooms,
@@ -35,7 +33,7 @@ impl Client {
             device_one_time_keys_count: _,
             ambiguity_changes: _,
             notifications,
-        } = &response;
+        } = response;
 
         self.handle_sync_events(HandlerKind::GlobalAccountData, &None, account_data).await?;
         self.handle_sync_events(HandlerKind::Presence, &None, &presence.events).await?;
@@ -110,7 +108,7 @@ impl Client {
             fut.await;
         }
 
-        Ok(response)
+        Ok(())
     }
 
     async fn sleep() {

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -263,8 +263,6 @@ async fn sync() {
     let response = client.sync_once(sync_settings).await.unwrap();
 
     assert_ne!(response.next_batch, "");
-
-    assert!(client.sync_token().await.is_some());
 }
 
 #[async_test]
@@ -370,7 +368,7 @@ async fn join_leave_room() {
     let room = client.get_joined_room(room_id);
     assert!(room.is_none());
 
-    client.sync_once(SyncSettings::default()).await.unwrap();
+    let sync_token = client.sync_once(SyncSettings::default()).await.unwrap().next_batch;
 
     let room = client.get_left_room(room_id);
     assert!(room.is_none());
@@ -378,7 +376,6 @@ async fn join_leave_room() {
     let room = client.get_joined_room(room_id);
     assert!(room.is_some());
 
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, &*test_json::LEAVE_SYNC_EVENT, Some(sync_token.clone())).await;
 
     client.sync_once(SyncSettings::default().token(sync_token)).await.unwrap();

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -62,14 +62,13 @@ async fn room_names() {
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let _response = client.sync_once(sync_settings).await.unwrap();
+    let sync_token = client.sync_once(sync_settings).await.unwrap().next_batch;
 
     assert_eq!(client.rooms().len(), 1);
     let room = client.get_joined_room(&test_json::DEFAULT_SYNC_ROOM_ID).unwrap();
 
     assert_eq!(DisplayName::Aliased("tutorial".to_owned()), room.display_name().await.unwrap());
 
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, &*test_json::INVITE_SYNC, Some(sync_token.clone())).await;
 
     let _response = client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
@@ -203,7 +202,7 @@ async fn room_route() {
     );
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
-    client.sync_once(SyncSettings::new()).await.unwrap();
+    let sync_token = client.sync_once(SyncSettings::new()).await.unwrap().next_batch;
     let room = client.get_room(room_id).unwrap();
 
     let route = room.route().await.unwrap();
@@ -214,9 +213,9 @@ async fn room_route() {
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
         bulk_room_members(batch, 0..1, "localhost", &MembershipState::Join),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
-    client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
+    let sync_token =
+        client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
     let route = room.route().await.unwrap();
     assert_eq!(route.len(), 1);
@@ -227,9 +226,9 @@ async fn room_route() {
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
         bulk_room_members(batch, 0..15, "notarealhs", &MembershipState::Join),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
-    client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
+    let sync_token =
+        client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
     let route = room.route().await.unwrap();
     assert_eq!(route.len(), 2);
@@ -241,9 +240,9 @@ async fn room_route() {
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
         bulk_room_members(batch, 0..5, "mymatrix", &MembershipState::Join),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
-    client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
+    let sync_token =
+        client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
     let route = room.route().await.unwrap();
     assert_eq!(route.len(), 3);
@@ -256,9 +255,9 @@ async fn room_route() {
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
         bulk_room_members(batch, 0..10, "yourmatrix", &MembershipState::Join),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
-    client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
+    let sync_token =
+        client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
     let route = room.route().await.unwrap();
     assert_eq!(route.len(), 3);
@@ -281,9 +280,9 @@ async fn room_route() {
             "type": "m.room.power_levels",
         })),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
-    client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
+    let sync_token =
+        client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
     let route = room.route().await.unwrap();
     assert_eq!(route.len(), 3);
@@ -307,9 +306,9 @@ async fn room_route() {
             "type": "m.room.power_levels",
         })),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
-    client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
+    let sync_token =
+        client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
     let route = room.route().await.unwrap();
     assert_eq!(route.len(), 3);
@@ -332,7 +331,6 @@ async fn room_route() {
             "type": "m.room.server_acl",
         })),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
 
@@ -366,7 +364,7 @@ async fn room_permalink() {
             )),
     );
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
-    client.sync_once(SyncSettings::new()).await.unwrap();
+    let sync_token = client.sync_once(SyncSettings::new()).await.unwrap().next_batch;
     let room = client.get_room(room_id).unwrap();
 
     assert_eq!(
@@ -391,9 +389,9 @@ async fn room_permalink() {
             "type": "m.room.canonical_alias",
         })),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
-    client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
+    let sync_token =
+        client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
     assert_eq!(
         room.matrix_to_permalink().await.unwrap().to_string(),
@@ -415,7 +413,6 @@ async fn room_permalink() {
             "type": "m.room.canonical_alias",
         })),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
 
@@ -457,7 +454,7 @@ async fn room_event_permalink() {
             )),
     );
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
-    client.sync_once(SyncSettings::new()).await.unwrap();
+    let sync_token = client.sync_once(SyncSettings::new()).await.unwrap().next_batch;
     let room = client.get_room(room_id).unwrap();
 
     assert_eq!(
@@ -483,7 +480,6 @@ async fn room_event_permalink() {
             "type": "m.room.canonical_alias",
         })),
     ));
-    let sync_token = client.sync_token().await.unwrap();
     mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
 

--- a/examples/command_bot/src/main.rs
+++ b/examples/command_bot/src/main.rs
@@ -62,14 +62,14 @@ async fn login_and_sync(
     // An initial sync to set up state and so our bot doesn't respond to old
     // messages. If the `StateStore` finds saved state in the location given the
     // initial sync will be skipped in favor of loading state from the store
-    client.sync_once(SyncSettings::default()).await.unwrap();
+    let response = client.sync_once(SyncSettings::default()).await.unwrap();
     // add our CommandBot to be notified of incoming messages, we do this after the
     // initial sync to avoid responding to messages before the bot was running.
     client.add_event_handler(on_room_message);
 
     // since we called `sync_once` before we entered our sync loop we must pass
     // that sync token to `sync`
-    let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
+    let settings = SyncSettings::default().token(response.next_batch);
     // this keeps state from the server streaming in to CommandBot via the
     // EventHandler trait
     client.sync(settings).await?;

--- a/examples/custom_events/src/main.rs
+++ b/examples/custom_events/src/main.rs
@@ -82,7 +82,7 @@ async fn on_ping_event(event: SyncPingEvent, room: Room) {
 async fn sync_loop(client: Client) -> anyhow::Result<()> {
     // invite acceptance as in the getting-started-client
     client.add_event_handler(on_stripped_state_member);
-    client.sync_once(SyncSettings::default()).await.unwrap();
+    let response = client.sync_once(SyncSettings::default()).await.unwrap();
 
     // our customisation:
     //  - send `PingEvent` on `!ping` in any room
@@ -90,7 +90,7 @@ async fn sync_loop(client: Client) -> anyhow::Result<()> {
     //  - send `AckEvent` on `PingEvent` in any room
     client.add_event_handler(on_ping_event);
 
-    let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
+    let settings = SyncSettings::default().token(response.next_batch);
     client.sync(settings).await?; // this essentially loops until we kill the bot
 
     Ok(())

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -90,7 +90,7 @@ async fn login_and_sync(
     // An initial sync to set up state and so our bot doesn't respond to old
     // messages. If the `StateStore` finds saved state in the location given the
     // initial sync will be skipped in favor of loading state from the store
-    client.sync_once(SyncSettings::default()).await.unwrap();
+    let sync_token = client.sync_once(SyncSettings::default()).await.unwrap().next_batch;
 
     // now that we've synced, let's attach a handler for incoming room messages, so
     // we can react on it
@@ -98,7 +98,7 @@ async fn login_and_sync(
 
     // since we called `sync_once` before we entered our sync loop we must pass
     // that sync token to `sync`
-    let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
+    let settings = SyncSettings::default().token(sync_token);
     // this keeps state from the server streaming in to the bot via the
     // EventHandler trait
     client.sync(settings).await?; // this essentially loops until we kill the bot

--- a/examples/image_bot/src/main.rs
+++ b/examples/image_bot/src/main.rs
@@ -39,11 +39,11 @@ async fn login_and_sync(
         .send()
         .await?;
 
-    client.sync_once(SyncSettings::default()).await.unwrap();
+    let response = client.sync_once(SyncSettings::default()).await.unwrap();
 
     client.add_event_handler(move |ev, room| on_room_message(ev, room, image.clone()));
 
-    let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
+    let settings = SyncSettings::default().token(response.next_batch);
     client.sync(settings).await?;
 
     Ok(())

--- a/examples/wasm_command_bot/src/lib.rs
+++ b/examples/wasm_command_bot/src/lib.rs
@@ -79,9 +79,9 @@ pub async fn run() -> Result<JsValue, JsValue> {
 
     let bot = WasmBot(client.clone());
 
-    client.sync_once(SyncSettings::default()).await.unwrap();
+    let response = client.sync_once(SyncSettings::default()).await.unwrap();
 
-    let settings = SyncSettings::default().token(client.sync_token().await.unwrap());
+    let settings = SyncSettings::default().token(response.next_batch);
     client.sync_with_callback(settings, |response| bot.on_sync_response(response)).await.unwrap();
 
     Ok(JsValue::NULL)


### PR DESCRIPTION
It's not removed here because that would mean people have to manage it externally for clients that keep non-crypto state across app runs. However, to make use cases with multiple concurrent syncs possible, we could do so in a follow-up and require people to manage the sync token themselves. Many of the examples seem to suggest that it has to be passed manually anyways..

Supersedes #1211.