### PR TITLE
feat: experimental-timeline API support for sliding sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,9 +624,9 @@ checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -2265,6 +2265,7 @@ name = "jack-in"
 version = "0.2.0"
 dependencies = [
  "app_dirs2",
+ "chrono",
  "dialoguer",
  "eyre",
  "futures",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -12,10 +12,6 @@ repository = "https://github.com/matrix-org/matrix-rust-sdk"
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
-[features]
-default = ["experimental-room-preview"] # the whole crate is still very experimental, so this is fine
-experimental-room-preview = ["matrix-sdk/experimental-room-preview"]
-
 [build-dependencies]
 uniffi_build = { workspace = true, features = ["builtin-bindgen"] }
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -42,7 +42,6 @@ appservice = ["ruma/appservice-api-s"]
 image-proc = ["dep:image"]
 image-rayon = ["image-proc", "image?/jpeg_rayon"]
 
-experimental-room-preview = []
 experimental-timeline = ["ruma/unstable-msc2677"]
 
 sliding-sync = [

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -16,8 +16,6 @@ use std::fmt;
 
 use indexmap::IndexMap;
 use matrix_sdk_base::deserialized_responses::EncryptionInfo;
-#[cfg(feature = "experimental-room-preview")]
-use ruma::events::room::message::{OriginalSyncRoomMessageEvent, Relation};
 use ruma::{
     events::{
         relation::{AnnotationChunk, AnnotationType},
@@ -85,37 +83,6 @@ macro_rules! build {
 }
 
 impl EventTimelineItem {
-    #[cfg(feature = "experimental-room-preview")]
-    #[doc(hidden)] // FIXME: Remove. Used for matrix-sdk-ffi temporarily.
-    pub fn _new(ev: OriginalSyncRoomMessageEvent, raw: Raw<AnySyncTimelineEvent>) -> Self {
-        let edited = ev.unsigned.relations.as_ref().map_or(false, |r| r.replace.is_some());
-        let reactions = ev
-            .unsigned
-            .relations
-            .and_then(|r| r.annotation)
-            .map(BundledReactions::from)
-            .unwrap_or_default();
-
-        Self {
-            key: TimelineKey::EventId(ev.event_id),
-            event_id: None,
-            sender: ev.sender,
-            content: TimelineItemContent::Message(Message {
-                msgtype: ev.content.msgtype,
-                in_reply_to: ev.content.relates_to.and_then(|rel| match rel {
-                    Relation::Reply { in_reply_to } => Some(in_reply_to.event_id),
-                    _ => None,
-                }),
-                edited,
-            }),
-            reactions,
-            origin_server_ts: Some(ev.origin_server_ts),
-            is_own: false,         // FIXME: Potentially wrong
-            encryption_info: None, // FIXME: Potentially wrong
-            raw: Some(raw),
-        }
-    }
-
     /// Get the [`TimelineKey`] of this item.
     pub fn key(&self) -> &TimelineKey {
         &self.key

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -29,6 +29,8 @@ use ruma::{
 use thiserror::Error;
 use url::Url;
 
+#[cfg(feature = "experimental-timeline")]
+use crate::room::timeline::Timeline;
 use crate::{Client, Result};
 
 /// Internal representation of errors in Sliding Sync
@@ -106,6 +108,7 @@ pub type AliveRoomTimeline = Arc<futures_signals::signal_vec::MutableVec<SyncTim
 /// Room info as giving by the SlidingSync Feature.
 #[derive(Debug, Clone)]
 pub struct SlidingSyncRoom {
+    client: Client,
     room_id: OwnedRoomId,
     inner: v4::SlidingSyncRoom,
     is_loading_more: Mutable<bool>,
@@ -115,6 +118,7 @@ pub struct SlidingSyncRoom {
 
 impl SlidingSyncRoom {
     fn from(
+        client: Client,
         room_id: OwnedRoomId,
         mut inner: v4::SlidingSyncRoom,
         timeline: Vec<SyncTimelineEvent>,
@@ -122,6 +126,7 @@ impl SlidingSyncRoom {
         // we overwrite to only keep one copy
         inner.timeline = vec![];
         Self {
+            client,
             room_id,
             is_loading_more: Mutable::new(false),
             prev_batch: Mutable::new(inner.prev_batch.clone()),
@@ -146,8 +151,18 @@ impl SlidingSyncRoom {
     }
 
     /// `AliveTimeline` of this room
+    #[cfg(not(feature = "experimental-timeline"))]
     pub fn timeline(&self) -> AliveRoomTimeline {
         self.timeline.clone()
+    }
+
+    /// `Timeline` of this room
+    #[cfg(feature = "experimental-timeline")]
+    pub async fn timeline(&self) -> Timeline {
+        let current_timeline = self.timeline.lock_ref().to_vec();
+        let prev_batch = self.prev_batch.lock_ref().clone();
+        let room = self.client.get_room(&self.room_id).unwrap();
+        Timeline::with_events(&room, prev_batch, current_timeline).await
     }
 
     /// This rooms name as calculated by the server, if any
@@ -490,7 +505,7 @@ impl SlidingSync {
             } else {
                 rooms_map.insert_cloned(
                     id.clone(),
-                    SlidingSyncRoom::from(id.clone(), room_data, timeline),
+                    SlidingSyncRoom::from(self.client.clone(), id.clone(), room_data, timeline),
                 );
                 rooms.push(id);
             }

--- a/labs/jack-in/Cargo.toml
+++ b/labs/jack-in/Cargo.toml
@@ -10,11 +10,12 @@ file-logging = ["dep:log4rs"]
 
 [dependencies]
 app_dirs2 = "2"
+chrono = "0.4.23"
 dialoguer = "0.10.2"
 eyre = "0.6"
 futures = { version = "0.3.1" }
 futures-signals = "0.3.24"
-matrix-sdk = { path = "../../crates/matrix-sdk", default-features = false, features  = ["e2e-encryption", "anyhow", "native-tls", "sled", "sliding-sync"], version = "0.6.0" }
+matrix-sdk = { path = "../../crates/matrix-sdk", default-features = false, features  = ["e2e-encryption", "anyhow", "native-tls", "sled", "sliding-sync", "experimental-timeline"], version = "0.6.0" }
 matrix-sdk-common = { path = "../../crates/matrix-sdk-common", version = "0.6.0" }
 matrix-sdk-sled = { path = "../../crates/matrix-sdk-sled", features = ["state-store", "crypto-store"], version = "0.2.0" }
 sanitize-filename-reader-friendly = "2.2.1"
@@ -22,7 +23,7 @@ serde_json = "1.0.85"
 structopt = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing-flame = "0.2"
-tracing-subscriber = "0.3.15" 
+tracing-subscriber = "0.3.15"
 tui-logger = "0.8.1"
 tuirealm = "~1.8"
 tui-realm-stdlib = "1.2.0"

--- a/labs/jack-in/src/main.rs
+++ b/labs/jack-in/src/main.rs
@@ -7,7 +7,9 @@ use std::path::{Path, PathBuf};
 use app_dirs2::{app_root, AppDataType, AppInfo};
 use dialoguer::{theme::ColorfulTheme, Password};
 use eyre::{eyre, Result};
+use futures_signals::signal_vec::VecDiff;
 use matrix_sdk::{
+    room::timeline::TimelineItem,
     ruma::{OwnedRoomId, OwnedUserId},
     Client,
 };
@@ -45,6 +47,7 @@ pub enum Msg {
 pub enum JackInEvent {
     Any, // match all
     SyncUpdate(client::state::SlidingSyncState),
+    RoomDataUpdate(VecDiff<TimelineItem>),
 }
 
 impl PartialOrd for JackInEvent {


### PR DESCRIPTION
When the experimental-timeline feature is activated, sliding-sync room's `.timeline()` now hand over the cached `AliveTimeline` to `Timeline`, which they expose through it. Thus enabling a fast start for the new `Timeline`-API, which should give a visibly faster room-opening impression.

This also updates jack-in to use that new feature to build the timeline as a test-case.