### PR TITLE
Call await prior to handle_remote_event

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -96,13 +96,14 @@ impl TimelineInner {
         encryption_info: Option<EncryptionInfo>,
         own_user_id: &UserId,
     ) {
+        let mut metadata_lock = self.metadata.lock().await;
         handle_remote_event(
             raw,
             own_user_id,
             encryption_info,
             TimelineItemPosition::Start,
             &mut self.items.lock_mut(),
-            &mut self.metadata.lock().await,
+            &mut metadata_lock,
         );
     }
 


### PR DESCRIPTION
On building `retry-decrypt` that jplate submitted, I got this error.
```
note: future is not `Send` as this value is used across an await
   --> F:\rust-workspace\.cargo\git\checkouts\matrix-rust-sdk-1f4927f82a3d27bb\fa71122\crates\matrix-sdk\src\room\timeline\event_handler.rs:105:38
    |
104 |             &mut self.items.lock_mut(),
    |                  --------------------- has type `MutableVecLockMut<'_, Arc<TimelineItem>>` which is not `Send`
105 |             &mut self.metadata.lock().await,
    |                                      ^^^^^^ await occurs here, with `self.items.lock_mut()` maybe used later
    |          - `self.items.lock_mut()` is later dropped here
note: required by a bound in `Runtime::spawn`
   --> F:\rust-workspace\.cargo\registry\src\github.com-1ecc6299db9ec823\tokio-1.20.0\src\runtime\mod.rs:398:25
    |
398 |             F: Future + Send + 'static,
    |                         ^^^^ required by this bound in `Runtime::spawn`
```