### PR TITLE
Add FailedToParse timeline items

### DIFF
--- a/crates/matrix-sdk/src/events.rs
+++ b/crates/matrix-sdk/src/events.rs
@@ -1,0 +1,147 @@
+use ruma::{
+    events::{
+        EventContent, MessageLikeEventContent, MessageLikeEventType, OriginalSyncMessageLikeEvent,
+        OriginalSyncStateEvent, RedactedEventContent, RedactedMessageLikeEventContent,
+        RedactedStateEventContent, RedactedSyncMessageLikeEvent, RedactedSyncStateEvent, Relations,
+        StateEventContent, StateEventType, StateUnsigned,
+    },
+    serde::from_raw_json_value,
+    EventId, MilliSecondsSinceUnixEpoch, TransactionId, UserId,
+};
+use serde::{de, Deserialize, Serialize};
+use serde_json::value::RawValue as RawJsonValue;
+
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum SyncTimelineEventWithoutContent {
+    OriginalMessageLike(OriginalSyncMessageLikeEvent<NoMessageLikeEventContent>),
+    RedactedMessageLike(RedactedSyncMessageLikeEvent<NoMessageLikeEventContent>),
+    OriginalState(OriginalSyncStateEvent<NoStateEventContent>),
+    RedactedState(RedactedSyncStateEvent<NoStateEventContent>),
+}
+
+impl SyncTimelineEventWithoutContent {
+    pub(crate) fn event_id(&self) -> &EventId {
+        match self {
+            Self::OriginalMessageLike(ev) => &ev.event_id,
+            Self::RedactedMessageLike(ev) => &ev.event_id,
+            Self::OriginalState(ev) => &ev.event_id,
+            Self::RedactedState(ev) => &ev.event_id,
+        }
+    }
+
+    pub(crate) fn origin_server_ts(&self) -> MilliSecondsSinceUnixEpoch {
+        match self {
+            SyncTimelineEventWithoutContent::OriginalMessageLike(ev) => ev.origin_server_ts,
+            SyncTimelineEventWithoutContent::RedactedMessageLike(ev) => ev.origin_server_ts,
+            SyncTimelineEventWithoutContent::OriginalState(ev) => ev.origin_server_ts,
+            SyncTimelineEventWithoutContent::RedactedState(ev) => ev.origin_server_ts,
+        }
+    }
+
+    pub(crate) fn relations(&self) -> Option<&Relations> {
+        match self {
+            SyncTimelineEventWithoutContent::OriginalMessageLike(ev) => {
+                ev.unsigned.relations.as_ref()
+            }
+            SyncTimelineEventWithoutContent::OriginalState(ev) => ev.unsigned.relations.as_ref(),
+            SyncTimelineEventWithoutContent::RedactedMessageLike(_)
+            | SyncTimelineEventWithoutContent::RedactedState(_) => None,
+        }
+    }
+
+    pub(crate) fn sender(&self) -> &UserId {
+        match self {
+            Self::OriginalMessageLike(ev) => &ev.sender,
+            Self::RedactedMessageLike(ev) => &ev.sender,
+            Self::OriginalState(ev) => &ev.sender,
+            Self::RedactedState(ev) => &ev.sender,
+        }
+    }
+
+    pub(crate) fn transaction_id(&self) -> Option<&TransactionId> {
+        match self {
+            SyncTimelineEventWithoutContent::OriginalMessageLike(ev) => {
+                ev.unsigned.transaction_id.as_deref()
+            }
+            SyncTimelineEventWithoutContent::OriginalState(ev) => {
+                ev.unsigned.transaction_id.as_deref()
+            }
+            SyncTimelineEventWithoutContent::RedactedMessageLike(_)
+            | SyncTimelineEventWithoutContent::RedactedState(_) => None,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct EventDeHelper {
+    state_key: Option<de::IgnoredAny>,
+    #[serde(default)]
+    unsigned: UnsignedDeHelper,
+}
+
+#[derive(Deserialize, Default)]
+struct UnsignedDeHelper {
+    redacted_because: Option<de::IgnoredAny>,
+}
+
+impl<'de> Deserialize<'de> for SyncTimelineEventWithoutContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let EventDeHelper { state_key, unsigned } = from_raw_json_value(&json)?;
+
+        Ok(match (state_key.is_some(), unsigned.redacted_because.is_some()) {
+            (false, false) => Self::OriginalMessageLike(from_raw_json_value(&json)?),
+            (false, true) => Self::RedactedMessageLike(from_raw_json_value(&json)?),
+            (true, false) => Self::OriginalState(from_raw_json_value(&json)?),
+            (true, true) => Self::RedactedState(from_raw_json_value(&json)?),
+        })
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct NoMessageLikeEventContent {
+    #[serde(skip)]
+    pub event_type: MessageLikeEventType,
+}
+
+impl EventContent for NoMessageLikeEventContent {
+    type EventType = MessageLikeEventType;
+
+    fn event_type(&self) -> Self::EventType {
+        self.event_type.clone()
+    }
+
+    fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {
+        Ok(Self { event_type: event_type.into() })
+    }
+}
+impl MessageLikeEventContent for NoMessageLikeEventContent {}
+impl RedactedEventContent for NoMessageLikeEventContent {}
+impl RedactedMessageLikeEventContent for NoMessageLikeEventContent {}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct NoStateEventContent {
+    #[serde(skip)]
+    pub event_type: StateEventType,
+}
+
+impl EventContent for NoStateEventContent {
+    type EventType = StateEventType;
+
+    fn event_type(&self) -> Self::EventType {
+        self.event_type.clone()
+    }
+
+    fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {
+        Ok(Self { event_type: event_type.into() })
+    }
+}
+impl StateEventContent for NoStateEventContent {
+    type StateKey = String;
+    type Unsigned = StateUnsigned<Self>;
+}
+impl RedactedEventContent for NoStateEventContent {}
+impl RedactedStateEventContent for NoStateEventContent {}

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -43,6 +43,8 @@ mod sliding_sync;
 
 #[cfg(feature = "e2e-encryption")]
 pub mod encryption;
+#[cfg(feature = "experimental-timeline")]
+mod events;
 
 pub use account::Account;
 #[cfg(feature = "sso-login")]

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -318,6 +318,16 @@ struct TimelineEventMetadata {
     encryption_info: Option<EncryptionInfo>,
 }
 
+#[derive(Clone)]
+enum TimelineEventKind {
+    Message { content: AnyMessageLikeEventContent },
+    RedactedMessage,
+    Redaction { redacts: OwnedEventId, content: RoomRedactionEventContent },
+    // FIXME: Split further for state keys of different type
+    State { _content: AnyStateEventContent },
+    RedactedState, // AnyRedactedStateEventContent
+}
+
 impl From<AnySyncTimelineEvent> for TimelineEventKind {
     fn from(event: AnySyncTimelineEvent) -> Self {
         match event {
@@ -338,16 +348,6 @@ impl From<AnySyncTimelineEvent> for TimelineEventKind {
             },
         }
     }
-}
-
-#[derive(Clone)]
-enum TimelineEventKind {
-    Message { content: AnyMessageLikeEventContent },
-    RedactedMessage,
-    Redaction { redacts: OwnedEventId, content: RoomRedactionEventContent },
-    // FIXME: Split further for state keys of different type
-    State { _content: AnyStateEventContent },
-    RedactedState, // AnyRedactedStateEventContent
 }
 
 enum TimelineItemPosition {

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -698,16 +698,14 @@ impl NewEventTimelineItem {
     }
 
     fn unable_to_decrypt(content: RoomEncryptedEventContent) -> Self {
-        Self {
-            content: TimelineItemContent::UnableToDecrypt(content.into()),
-            reactions: BundledReactions::default(),
-        }
+        Self::from_content(TimelineItemContent::UnableToDecrypt(content.into()))
     }
 
     fn redacted_message() -> Self {
-        Self {
-            content: TimelineItemContent::RedactedMessage,
-            reactions: BundledReactions::default(),
-        }
+        Self::from_content(TimelineItemContent::RedactedMessage)
+    }
+
+    fn from_content(content: TimelineItemContent) -> Self {
+        Self { content, reactions: BundledReactions::default() }
     }
 }

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -439,10 +439,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
             let msg = match &item.content {
                 TimelineItemContent::Message(msg) => msg,
                 TimelineItemContent::RedactedMessage => {
-                    info!(
-                        %event_id,
-                        "Edit event applies to a redacted message, discarding"
-                    );
+                    info!(%event_id, "Edit event applies to a redacted message, discarding");
                     return None;
                 }
                 TimelineItemContent::UnableToDecrypt(_) => {

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use indexmap::IndexMap;
 use matrix_sdk_base::deserialized_responses::EncryptionInfo;
@@ -23,7 +23,7 @@ use ruma::{
             encrypted::{EncryptedEventScheme, MegolmV1AesSha2Content, RoomEncryptedEventContent},
             message::MessageType,
         },
-        AnySyncTimelineEvent,
+        AnySyncTimelineEvent, MessageLikeEventType, StateEventType,
     },
     serde::Raw,
     uint, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedTransactionId,
@@ -266,6 +266,27 @@ pub enum TimelineItemContent {
 
     /// An `m.room.encrypted` event that could not be decrypted.
     UnableToDecrypt(EncryptedMessage),
+
+    /// A message-like event that failed to deserialize.
+    FailedToParseMessageLike {
+        /// The event `type`.
+        event_type: MessageLikeEventType,
+
+        /// The deserialization error.
+        error: Arc<serde_json::Error>,
+    },
+
+    /// A state event that failed to deserialize.
+    FailedToParseState {
+        /// The event `type`.
+        event_type: StateEventType,
+
+        /// The state key.
+        state_key: String,
+
+        /// The deserialization error.
+        error: Arc<serde_json::Error>,
+    },
 }
 
 impl TimelineItemContent {


### PR DESCRIPTION
When a timeline event comes in but we fail to deserialize it, previously we would just ignore it. Now, if we can still parse everything except the content, we add an `EventTimelineItem` with a new kind of content so the fact an event arrived isn't just silently discarded. The raw event and error can be reflected in the UI somehow. If something outside `content` fails to parse, that is either a bug in the server or in our code and we just log an error.

The first case can easily happen by having a buggy or malicious client, so I think it's important we preserve as much information as possible. In the latter case, just logging an error should be fine as it's much less likely (requires a bug in the server, ruma or the SDK).