### PR TITLE
fix(ffi): Fix xcframework release script, add missing module map

### DIFF
--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -179,6 +179,13 @@ fn build_xcframework(
 
     rename(generated_dir.join("matrix_sdk_ffiFFI.h"), headers_dir.join("matrix_sdk_ffiFFI.h"))?;
 
+    // Move and rename the module map to `module.modulemap` to match what
+    // the xcframework expects
+    rename(
+        generated_dir.join("matrix_sdk_ffiFFI.modulemap"),
+        headers_dir.join("module.modulemap"),
+    )?;
+
     rename(generated_dir.join("matrix_sdk_ffi.swift"), swift_dir.join("matrix_sdk_ffi.swift"))?;
 
     println!("-- Generate MatrixSDKFFI.xcframework framework");


### PR DESCRIPTION
Moves missing module map to the headers directory so that it's picked up by `xcodebuild` when creating the .xcframework