### PR TITLE
fix(sdk): Fix logic for updating an existing read marker

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -641,6 +641,7 @@ mod tests {
     }
 
     #[cfg(not(target_os = "macos"))]
+    #[allow(unknown_lints, clippy::unchecked_duration_subtraction)]
     #[async_test]
     async fn timing_out() {
         let (alice_machine, bob) = setup_verification_machine().await;

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -949,9 +949,9 @@ struct Ready {
 }
 
 impl RequestState<Ready> {
-    fn to_started_sas<'a>(
+    fn to_started_sas(
         &self,
-        content: &StartContent<'a>,
+        content: &StartContent<'_>,
         identities: IdentitiesBeingVerified,
         we_started: bool,
         request_handle: RequestHandle,

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -256,13 +256,13 @@ fn update_fully_read_item(
 ) {
     let Some(fully_read_event) = fully_read_event else { return };
     let old_idx = find_fully_read(items_lock);
-    let new_idx = find_event(items_lock, fully_read_event).map(|(idx, _)| idx + 1);
+    let new_idx = find_event(items_lock, fully_read_event).map(|(idx, _)| idx);
     match (old_idx, new_idx) {
         (None, None) => {}
         (None, Some(idx)) => {
             *fully_read_event_in_timeline = true;
             let item = TimelineItem::Virtual(VirtualTimelineItem::ReadMarker);
-            items_lock.insert_cloned(idx, item.into());
+            items_lock.insert_cloned(idx + 1, item.into());
         }
         (Some(_), None) => {
             // Keep the current position of the read marker, hopefully we

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -215,8 +215,7 @@ fn build_xcframework(
         create_dir_all(framework_target.as_path())?;
         create_dir_all(swift_target.as_path())?;
 
-        let mut copy_options = fs_extra::dir::CopyOptions::default();
-        copy_options.content_only = true;
+        let copy_options = fs_extra::dir::CopyOptions { content_only: true, ..Default::default() };
 
         fs_extra::dir::copy(xcframework_path.as_path(), framework_target.as_path(), &copy_options)?;
         fs_extra::dir::copy(swift_dir.as_path(), swift_target.as_path(), &copy_options)?;


### PR DESCRIPTION
Ping @zecakeh, can you have a look? I think the `move_from_to` call was previously wrong in that it placed the read marker one position behind where it should be, running out of bounds if it was meant to be moved to the end.