### PR TITLE
fix(sdk): Fix logic if read marker event was not in the timeline

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -277,6 +277,7 @@ fn update_fully_read_item(
             *fully_read_event_in_timeline = false;
         }
         (Some(from), Some(to)) => {
+            *fully_read_event_in_timeline = true;
             items_lock.move_from_to(from, to);
         }
     }


### PR DESCRIPTION
Follow up to #1229.

Since we don't remove the read marker when the fully read event wasn't found, we also need to update `fully_read_event_in_timeline` when both `from` and `to` are `Some`. Otherwise we will call the method for every event, even if we already have the fully read event.

Ping @jplatte.