### PR TITLE
fix(sdk): Make sure read marker can't go backwards

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -278,7 +278,11 @@ fn update_read_marker(
         }
         (Some(from), Some(to)) => {
             *fully_read_event_in_timeline = true;
-            items_lock.move_from_to(from, to);
+
+            // The read marker can't move backwards.
+            if from < to {
+                items_lock.move_from_to(from, to);
+            }
         }
     }
 }

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -386,7 +386,7 @@ fn find_event(
         .rfind(|(_, it)| key == it.key)
 }
 
-fn find_fully_read(lock: &[Arc<TimelineItem>]) -> Option<usize> {
+fn find_read_marker(lock: &[Arc<TimelineItem>]) -> Option<usize> {
     lock.iter()
         .enumerate()
         .rfind(|(_, item)| {

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -256,11 +256,15 @@ async fn update_read_marker() {
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     let event_id = item.as_event().unwrap().event_id().unwrap().to_owned();
 
-    timeline.inner.set_fully_read_event(event_id).await;
+    timeline.inner.set_fully_read_event(event_id.clone()).await;
     assert_matches!(stream.next().await, Some(VecDiff::Move { old_index: 1, new_index: 2 }));
 
     // Nothing should happen if the fully read event isn't found.
     timeline.inner.set_fully_read_event(event_id!("$fake_event_id").to_owned()).await;
+
+    // Nothing should happen if the fully read event is set back to the same event
+    // as before.
+    timeline.inner.set_fully_read_event(event_id).await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("C")).await;
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);


### PR DESCRIPTION
I'm not sure it can be called a bug, because I don't think it could happen in the flow, but I believe it's something worth guarding against.

Without this fix, the line added in the test triggers a move of the read marker from index 2 to index 1.