### PR TITLE
Make Timeline construction sync again

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -125,7 +125,7 @@ impl SlidingSyncRoom {
     #[allow(clippy::significant_drop_in_scrutinee)]
     pub fn latest_room_message(&self) -> Option<Arc<EventTimelineItem>> {
         RUNTIME.block_on(async {
-            let item = self.inner.timeline().await.latest()?.as_event()?.to_owned();
+            let item = self.inner.timeline().await.latest_event()?;
             Some(Arc::new(EventTimelineItem(item)))
         })
     }

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -125,7 +125,7 @@ impl SlidingSyncRoom {
     #[allow(clippy::significant_drop_in_scrutinee)]
     pub fn latest_room_message(&self) -> Option<Arc<EventTimelineItem>> {
         RUNTIME.block_on(async {
-            let item = self.inner.timeline().await.latest_event()?;
+            let item = self.inner.latest_event().await?;
             Some(Arc::new(EventTimelineItem(item)))
         })
     }

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -124,10 +124,8 @@ impl SlidingSyncRoom {
 impl SlidingSyncRoom {
     #[allow(clippy::significant_drop_in_scrutinee)]
     pub fn latest_room_message(&self) -> Option<Arc<EventTimelineItem>> {
-        RUNTIME.block_on(async {
-            let item = self.inner.latest_event().await?;
-            Some(Arc::new(EventTimelineItem(item)))
-        })
+        let item = self.inner.latest_event()?;
+        Some(Arc::new(EventTimelineItem(item)))
     }
 }
 

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -268,7 +268,7 @@ impl Common {
     /// independent events.
     #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(&self) -> Timeline {
-        Timeline::new(self).await
+        Timeline::new(self).await.with_fully_read_tracking().await
     }
 
     /// Fetch the event with the given `EventId` in this room.

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -12,20 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "e2e-encryption")]
-use std::collections::BTreeSet;
 use std::{collections::HashMap, sync::Arc};
 
 use futures_signals::signal_vec::MutableVecLockMut;
 use indexmap::map::Entry;
-#[cfg(feature = "e2e-encryption")]
-use matrix_sdk_base::crypto::OlmMachine;
-use matrix_sdk_base::{deserialized_responses::EncryptionInfo, locks::MutexGuard};
-#[cfg(feature = "e2e-encryption")]
-use ruma::RoomId;
+use matrix_sdk_base::deserialized_responses::EncryptionInfo;
 use ruma::{
     events::{
-        fully_read::FullyReadEvent,
         reaction::ReactionEventContent,
         relation::{Annotation, Replacement},
         room::{
@@ -40,255 +33,17 @@ use ruma::{
     },
     serde::Raw,
     uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
-    UserId,
 };
 use tracing::{debug, error, info, warn};
 
 use super::{
     event_item::{BundledReactions, TimelineDetails},
-    find_event, find_read_marker, EventTimelineItem, Message, TimelineInner, TimelineInnerMetadata,
-    TimelineItem, TimelineItemContent, TimelineKey, VirtualTimelineItem,
+    find_event, find_read_marker, EventTimelineItem, Message, TimelineInnerMetadata, TimelineItem,
+    TimelineItemContent, TimelineKey, VirtualTimelineItem,
 };
 use crate::events::SyncTimelineEventWithoutContent;
 
-impl TimelineInner {
-    pub(super) async fn handle_live_event(
-        &self,
-        raw: Raw<AnySyncTimelineEvent>,
-        encryption_info: Option<EncryptionInfo>,
-        own_user_id: &UserId,
-    ) {
-        let mut timeline_meta = self.metadata.lock().await;
-        handle_remote_event(
-            raw,
-            own_user_id,
-            encryption_info,
-            TimelineItemPosition::End,
-            &mut self.items.lock_mut(),
-            &mut timeline_meta,
-        );
-    }
-
-    pub(super) async fn handle_local_event(
-        &self,
-        txn_id: OwnedTransactionId,
-        content: AnyMessageLikeEventContent,
-        own_user_id: &UserId,
-    ) {
-        let event_meta = TimelineEventMetadata {
-            sender: own_user_id.to_owned(),
-            is_own_event: true,
-            relations: None,
-            // FIXME: Should we supply something here for encrypted rooms?
-            encryption_info: None,
-        };
-
-        let flow = Flow::Local { txn_id };
-        let kind = TimelineEventKind::Message { content };
-
-        let mut timeline_meta = self.metadata.lock().await;
-        let mut timeline_items = self.items.lock_mut();
-        TimelineEventHandler::new(event_meta, flow, &mut timeline_items, &mut timeline_meta)
-            .handle_event(kind);
-    }
-
-    pub(super) async fn handle_back_paginated_event(
-        &self,
-        raw: Raw<AnySyncTimelineEvent>,
-        encryption_info: Option<EncryptionInfo>,
-        own_user_id: &UserId,
-    ) {
-        let mut metadata_lock = self.metadata.lock().await;
-        handle_remote_event(
-            raw,
-            own_user_id,
-            encryption_info,
-            TimelineItemPosition::Start,
-            &mut self.items.lock_mut(),
-            &mut metadata_lock,
-        );
-    }
-
-    pub(super) async fn handle_fully_read(&self, raw: Raw<FullyReadEvent>) {
-        let fully_read_event = match raw.deserialize() {
-            Ok(ev) => ev.content.event_id,
-            Err(error) => {
-                error!(?error, "Failed to deserialize `m.fully_read` account data");
-                return;
-            }
-        };
-
-        self.set_fully_read_event(fully_read_event).await;
-    }
-
-    pub(super) async fn set_fully_read_event(&self, fully_read_event_id: OwnedEventId) {
-        let mut metadata_lock = self.metadata.lock().await;
-
-        if metadata_lock.fully_read_event.as_ref().map_or(false, |id| *id == fully_read_event_id) {
-            return;
-        }
-
-        metadata_lock.fully_read_event = Some(fully_read_event_id);
-
-        let mut items_lock = self.items.lock_mut();
-        let metadata = &mut *metadata_lock;
-        update_read_marker(
-            &mut items_lock,
-            metadata.fully_read_event.as_deref(),
-            &mut metadata.fully_read_event_in_timeline,
-        );
-    }
-
-    #[cfg(feature = "e2e-encryption")]
-    pub(super) async fn retry_event_decryption(
-        &self,
-        room_id: &RoomId,
-        olm_machine: &OlmMachine,
-        session_ids: BTreeSet<&str>,
-        own_user_id: &UserId,
-    ) {
-        use super::EncryptedMessage;
-
-        let utds_for_session: Vec<_> = self
-            .items
-            .lock_ref()
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, item)| {
-                let event_item = &item.as_event()?;
-                let utd = event_item.content.as_unable_to_decrypt()?;
-
-                match utd {
-                    EncryptedMessage::MegolmV1AesSha2 { session_id, .. }
-                        if session_ids.contains(session_id.as_str()) =>
-                    {
-                        let TimelineKey::EventId(event_id) = &event_item.key else {
-                            error!("Key for unable-to-decrypt timeline item is not an event ID");
-                            return None;
-                        };
-                        let Some(raw) = event_item.raw.clone() else {
-                            error!("No raw event in unable-to-decrypt timeline item");
-                            return None;
-                        };
-
-                        Some((idx, event_id.to_owned(), session_id.to_owned(), raw))
-                    }
-                    EncryptedMessage::MegolmV1AesSha2 { .. }
-                    | EncryptedMessage::OlmV1Curve25519AesSha2 { .. }
-                    | EncryptedMessage::Unknown => None,
-                }
-            })
-            .collect();
-
-        if utds_for_session.is_empty() {
-            return;
-        }
-
-        let mut metadata_lock = self.metadata.lock().await;
-        for (idx, event_id, session_id, utd) in utds_for_session.iter().rev() {
-            let event = match olm_machine.decrypt_room_event(utd.cast_ref(), room_id).await {
-                Ok(ev) => ev,
-                Err(e) => {
-                    info!(
-                        %event_id, %session_id,
-                        "Failed to decrypt event after receiving room key: {e}"
-                    );
-                    continue;
-                }
-            };
-
-            // Because metadata is always locked before we attempt to lock the
-            // items, this will never be contended.
-            // Because there is an `.await` in this loop, we have to re-lock
-            // this mutex every iteration because holding it across `.await`
-            // makes the future `!Send`, which makes it not event-handler-safe.
-            let mut items_lock = self.items.lock_mut();
-            handle_remote_event(
-                event.event.cast(),
-                own_user_id,
-                event.encryption_info,
-                TimelineItemPosition::Update(*idx),
-                &mut items_lock,
-                &mut metadata_lock,
-            );
-        }
-    }
-}
-
-fn handle_remote_event(
-    raw: Raw<AnySyncTimelineEvent>,
-    own_user_id: &UserId,
-    encryption_info: Option<EncryptionInfo>,
-    position: TimelineItemPosition,
-    timeline_items: &mut MutableVecLockMut<'_, Arc<TimelineItem>>,
-    timeline_meta: &mut MutexGuard<'_, TimelineInnerMetadata>,
-) {
-    let (event_id, sender, origin_server_ts, txn_id, relations, event_kind) =
-        match raw.deserialize() {
-            Ok(event) => (
-                event.event_id().to_owned(),
-                event.sender().to_owned(),
-                event.origin_server_ts(),
-                event.transaction_id().map(ToOwned::to_owned),
-                event.relations().cloned(),
-                event.into(),
-            ),
-            Err(e) => match raw.deserialize_as::<SyncTimelineEventWithoutContent>() {
-                Ok(event) => (
-                    event.event_id().to_owned(),
-                    event.sender().to_owned(),
-                    event.origin_server_ts(),
-                    event.transaction_id().map(ToOwned::to_owned),
-                    event.relations().cloned(),
-                    TimelineEventKind::failed_to_parse(event, e),
-                ),
-                Err(e) => {
-                    warn!("Failed to deserialize timeline event: {e}");
-                    return;
-                }
-            },
-        };
-
-    let is_own_event = sender == own_user_id;
-    let event_meta = TimelineEventMetadata { sender, is_own_event, relations, encryption_info };
-    let flow = Flow::Remote { event_id, origin_server_ts, raw_event: raw, txn_id, position };
-
-    TimelineEventHandler::new(event_meta, flow, timeline_items, timeline_meta)
-        .handle_event(event_kind)
-}
-
-fn update_read_marker(
-    items_lock: &mut MutableVecLockMut<'_, Arc<TimelineItem>>,
-    fully_read_event: Option<&EventId>,
-    fully_read_event_in_timeline: &mut bool,
-) {
-    let Some(fully_read_event) = fully_read_event else { return };
-    let read_marker_idx = find_read_marker(items_lock);
-    let fully_read_event_idx = find_event(items_lock, fully_read_event).map(|(idx, _)| idx);
-    match (read_marker_idx, fully_read_event_idx) {
-        (None, None) => {}
-        (None, Some(idx)) => {
-            *fully_read_event_in_timeline = true;
-            let item = TimelineItem::Virtual(VirtualTimelineItem::ReadMarker);
-            items_lock.insert_cloned(idx + 1, item.into());
-        }
-        (Some(_), None) => {
-            // Keep the current position of the read marker, hopefully we
-            // should have a new position later.
-            *fully_read_event_in_timeline = false;
-        }
-        (Some(from), Some(to)) => {
-            *fully_read_event_in_timeline = true;
-
-            // The read marker can't move backwards.
-            if from < to {
-                items_lock.move_from_to(from, to);
-            }
-        }
-    }
-}
-
-enum Flow {
+pub(super) enum Flow {
     Local {
         txn_id: OwnedTransactionId,
     },
@@ -324,15 +79,15 @@ impl Flow {
     }
 }
 
-struct TimelineEventMetadata {
-    sender: OwnedUserId,
-    is_own_event: bool,
-    relations: Option<BundledRelations>,
-    encryption_info: Option<EncryptionInfo>,
+pub(super) struct TimelineEventMetadata {
+    pub(super) sender: OwnedUserId,
+    pub(super) is_own_event: bool,
+    pub(super) relations: Option<BundledRelations>,
+    pub(super) encryption_info: Option<EncryptionInfo>,
 }
 
 #[derive(Clone)]
-enum TimelineEventKind {
+pub(super) enum TimelineEventKind {
     Message {
         content: AnyMessageLikeEventContent,
     },
@@ -358,7 +113,10 @@ enum TimelineEventKind {
 }
 
 impl TimelineEventKind {
-    fn failed_to_parse(event: SyncTimelineEventWithoutContent, error: serde_json::Error) -> Self {
+    pub(super) fn failed_to_parse(
+        event: SyncTimelineEventWithoutContent,
+        error: serde_json::Error,
+    ) -> Self {
         let error = Arc::new(error);
         match event {
             SyncTimelineEventWithoutContent::OriginalMessageLike(ev) => {
@@ -403,7 +161,7 @@ impl From<AnySyncTimelineEvent> for TimelineEventKind {
     }
 }
 
-enum TimelineItemPosition {
+pub(super) enum TimelineItemPosition {
     Start,
     End,
     #[cfg(feature = "e2e-encryption")]
@@ -414,7 +172,7 @@ enum TimelineItemPosition {
 // of handling an event (figuring out whether it should update an existing
 // timeline item, transforming that item or creating a new one, updating the
 // reactive Vec).
-struct TimelineEventHandler<'a, 'i> {
+pub(super) struct TimelineEventHandler<'a, 'i> {
     meta: TimelineEventMetadata,
     flow: Flow,
     timeline_items: &'a mut MutableVecLockMut<'i, Arc<TimelineItem>>,
@@ -425,7 +183,7 @@ struct TimelineEventHandler<'a, 'i> {
 }
 
 impl<'a, 'i> TimelineEventHandler<'a, 'i> {
-    fn new(
+    pub(super) fn new(
         event_meta: TimelineEventMetadata,
         flow: Flow,
         timeline_items: &'a mut MutableVecLockMut<'i, Arc<TimelineItem>>,
@@ -442,7 +200,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
         }
     }
 
-    fn handle_event(mut self, event_kind: TimelineEventKind) {
+    pub(super) fn handle_event(mut self, event_kind: TimelineEventKind) {
         match event_kind {
             TimelineEventKind::Message { content } => match content {
                 AnyMessageLikeEventContent::Reaction(c) => self.handle_reaction(c),
@@ -707,6 +465,37 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                 self.fully_read_event.as_deref(),
                 self.fully_read_event_in_timeline,
             );
+        }
+    }
+}
+
+pub(crate) fn update_read_marker(
+    items_lock: &mut MutableVecLockMut<'_, Arc<TimelineItem>>,
+    fully_read_event: Option<&EventId>,
+    fully_read_event_in_timeline: &mut bool,
+) {
+    let Some(fully_read_event) = fully_read_event else { return };
+    let read_marker_idx = find_read_marker(items_lock);
+    let fully_read_event_idx = find_event(items_lock, fully_read_event).map(|(idx, _)| idx);
+    match (read_marker_idx, fully_read_event_idx) {
+        (None, None) => {}
+        (None, Some(idx)) => {
+            *fully_read_event_in_timeline = true;
+            let item = TimelineItem::Virtual(VirtualTimelineItem::ReadMarker);
+            items_lock.insert_cloned(idx + 1, item.into());
+        }
+        (Some(_), None) => {
+            // Keep the current position of the read marker, hopefully we
+            // should have a new position later.
+            *fully_read_event_in_timeline = false;
+        }
+        (Some(from), Some(to)) => {
+            *fully_read_event_in_timeline = true;
+
+            // The read marker can't move backwards.
+            if from < to {
+                items_lock.move_from_to(from, to);
+            }
         }
     }
 }

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, sync::Arc};
 use futures_signals::signal_vec::{MutableVec, MutableVecLockMut};
 use matrix_sdk_base::{
     crypto::OlmMachine,
-    deserialized_responses::{EncryptionInfo, SyncTimelineEvent},
+    deserialized_responses::{EncryptionInfo, SyncTimelineEvent, TimelineEvent},
     locks::Mutex,
 };
 use ruma::{
@@ -91,15 +91,14 @@ impl TimelineInner {
 
     pub(super) async fn handle_back_paginated_event(
         &self,
-        raw: Raw<AnySyncTimelineEvent>,
-        encryption_info: Option<EncryptionInfo>,
+        event: TimelineEvent,
         own_user_id: &UserId,
     ) {
         let mut metadata_lock = self.metadata.lock().await;
         handle_remote_event(
-            raw,
+            event.event.cast(),
             own_user_id,
-            encryption_info,
+            event.encryption_info,
             TimelineItemPosition::Start,
             &mut self.items.lock_mut(),
             &mut metadata_lock,

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -1,0 +1,235 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use futures_signals::signal_vec::{MutableVec, MutableVecLockMut};
+use matrix_sdk_base::{
+    crypto::OlmMachine,
+    deserialized_responses::EncryptionInfo,
+    locks::{Mutex, MutexGuard},
+};
+use ruma::{
+    events::{fully_read::FullyReadEvent, AnyMessageLikeEventContent, AnySyncTimelineEvent},
+    serde::Raw,
+    OwnedEventId, OwnedTransactionId, RoomId, UserId,
+};
+use tracing::{error, info, warn};
+
+use super::{
+    event_handler::{
+        update_read_marker, Flow, TimelineEventHandler, TimelineEventKind, TimelineEventMetadata,
+        TimelineItemPosition,
+    },
+    TimelineInnerMetadata, TimelineItem, TimelineKey,
+};
+use crate::events::SyncTimelineEventWithoutContent;
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct TimelineInner {
+    pub(super) items: MutableVec<Arc<TimelineItem>>,
+    pub(super) metadata: Arc<Mutex<TimelineInnerMetadata>>,
+}
+
+impl TimelineInner {
+    pub(super) async fn handle_live_event(
+        &self,
+        raw: Raw<AnySyncTimelineEvent>,
+        encryption_info: Option<EncryptionInfo>,
+        own_user_id: &UserId,
+    ) {
+        let mut timeline_meta = self.metadata.lock().await;
+        handle_remote_event(
+            raw,
+            own_user_id,
+            encryption_info,
+            TimelineItemPosition::End,
+            &mut self.items.lock_mut(),
+            &mut timeline_meta,
+        );
+    }
+
+    pub(super) async fn handle_local_event(
+        &self,
+        txn_id: OwnedTransactionId,
+        content: AnyMessageLikeEventContent,
+        own_user_id: &UserId,
+    ) {
+        let event_meta = TimelineEventMetadata {
+            sender: own_user_id.to_owned(),
+            is_own_event: true,
+            relations: None,
+            // FIXME: Should we supply something here for encrypted rooms?
+            encryption_info: None,
+        };
+
+        let flow = Flow::Local { txn_id };
+        let kind = TimelineEventKind::Message { content };
+
+        let mut timeline_meta = self.metadata.lock().await;
+        let mut timeline_items = self.items.lock_mut();
+        TimelineEventHandler::new(event_meta, flow, &mut timeline_items, &mut timeline_meta)
+            .handle_event(kind);
+    }
+
+    pub(super) async fn handle_back_paginated_event(
+        &self,
+        raw: Raw<AnySyncTimelineEvent>,
+        encryption_info: Option<EncryptionInfo>,
+        own_user_id: &UserId,
+    ) {
+        let mut metadata_lock = self.metadata.lock().await;
+        handle_remote_event(
+            raw,
+            own_user_id,
+            encryption_info,
+            TimelineItemPosition::Start,
+            &mut self.items.lock_mut(),
+            &mut metadata_lock,
+        );
+    }
+
+    pub(super) async fn handle_fully_read(&self, raw: Raw<FullyReadEvent>) {
+        let fully_read_event = match raw.deserialize() {
+            Ok(ev) => ev.content.event_id,
+            Err(error) => {
+                error!(?error, "Failed to deserialize `m.fully_read` account data");
+                return;
+            }
+        };
+
+        self.set_fully_read_event(fully_read_event).await;
+    }
+
+    pub(super) async fn set_fully_read_event(&self, fully_read_event_id: OwnedEventId) {
+        let mut metadata_lock = self.metadata.lock().await;
+
+        if metadata_lock.fully_read_event.as_ref().map_or(false, |id| *id == fully_read_event_id) {
+            return;
+        }
+
+        metadata_lock.fully_read_event = Some(fully_read_event_id);
+
+        let mut items_lock = self.items.lock_mut();
+        let metadata = &mut *metadata_lock;
+        update_read_marker(
+            &mut items_lock,
+            metadata.fully_read_event.as_deref(),
+            &mut metadata.fully_read_event_in_timeline,
+        );
+    }
+
+    #[cfg(feature = "e2e-encryption")]
+    pub(super) async fn retry_event_decryption(
+        &self,
+        room_id: &RoomId,
+        olm_machine: &OlmMachine,
+        session_ids: BTreeSet<&str>,
+        own_user_id: &UserId,
+    ) {
+        use super::EncryptedMessage;
+
+        let utds_for_session: Vec<_> = self
+            .items
+            .lock_ref()
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, item)| {
+                let event_item = &item.as_event()?;
+                let utd = event_item.content.as_unable_to_decrypt()?;
+
+                match utd {
+                    EncryptedMessage::MegolmV1AesSha2 { session_id, .. }
+                        if session_ids.contains(session_id.as_str()) =>
+                    {
+                        let TimelineKey::EventId(event_id) = &event_item.key else {
+                            error!("Key for unable-to-decrypt timeline item is not an event ID");
+                            return None;
+                        };
+                        let Some(raw) = event_item.raw.clone() else {
+                            error!("No raw event in unable-to-decrypt timeline item");
+                            return None;
+                        };
+
+                        Some((idx, event_id.to_owned(), session_id.to_owned(), raw))
+                    }
+                    EncryptedMessage::MegolmV1AesSha2 { .. }
+                    | EncryptedMessage::OlmV1Curve25519AesSha2 { .. }
+                    | EncryptedMessage::Unknown => None,
+                }
+            })
+            .collect();
+
+        if utds_for_session.is_empty() {
+            return;
+        }
+
+        let mut metadata_lock = self.metadata.lock().await;
+        for (idx, event_id, session_id, utd) in utds_for_session.iter().rev() {
+            let event = match olm_machine.decrypt_room_event(utd.cast_ref(), room_id).await {
+                Ok(ev) => ev,
+                Err(e) => {
+                    info!(
+                        %event_id, %session_id,
+                        "Failed to decrypt event after receiving room key: {e}"
+                    );
+                    continue;
+                }
+            };
+
+            // Because metadata is always locked before we attempt to lock the
+            // items, this will never be contended.
+            // Because there is an `.await` in this loop, we have to re-lock
+            // this mutex every iteration because holding it across `.await`
+            // makes the future `!Send`, which makes it not event-handler-safe.
+            let mut items_lock = self.items.lock_mut();
+            handle_remote_event(
+                event.event.cast(),
+                own_user_id,
+                event.encryption_info,
+                TimelineItemPosition::Update(*idx),
+                &mut items_lock,
+                &mut metadata_lock,
+            );
+        }
+    }
+}
+
+fn handle_remote_event(
+    raw: Raw<AnySyncTimelineEvent>,
+    own_user_id: &UserId,
+    encryption_info: Option<EncryptionInfo>,
+    position: TimelineItemPosition,
+    timeline_items: &mut MutableVecLockMut<'_, Arc<TimelineItem>>,
+    timeline_meta: &mut MutexGuard<'_, TimelineInnerMetadata>,
+) {
+    let (event_id, sender, origin_server_ts, txn_id, relations, event_kind) =
+        match raw.deserialize() {
+            Ok(event) => (
+                event.event_id().to_owned(),
+                event.sender().to_owned(),
+                event.origin_server_ts(),
+                event.transaction_id().map(ToOwned::to_owned),
+                event.relations().cloned(),
+                event.into(),
+            ),
+            Err(e) => match raw.deserialize_as::<SyncTimelineEventWithoutContent>() {
+                Ok(event) => (
+                    event.event_id().to_owned(),
+                    event.sender().to_owned(),
+                    event.origin_server_ts(),
+                    event.transaction_id().map(ToOwned::to_owned),
+                    event.relations().cloned(),
+                    TimelineEventKind::failed_to_parse(event, e),
+                ),
+                Err(e) => {
+                    warn!("Failed to deserialize timeline event: {e}");
+                    return;
+                }
+            },
+        };
+
+    let is_own_event = sender == own_user_id;
+    let event_meta = TimelineEventMetadata { sender, is_own_event, relations, encryption_info };
+    let flow = Flow::Remote { event_id, origin_server_ts, raw_event: raw, txn_id, position };
+
+    TimelineEventHandler::new(event_meta, flow, timeline_items, timeline_meta)
+        .handle_event(event_kind)
+}

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -1,11 +1,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use futures_signals::signal_vec::{MutableVec, MutableVecLockMut};
-use matrix_sdk_base::{
-    crypto::OlmMachine,
-    deserialized_responses::EncryptionInfo,
-    locks::{Mutex, MutexGuard},
-};
+use matrix_sdk_base::{crypto::OlmMachine, deserialized_responses::EncryptionInfo, locks::Mutex};
 use ruma::{
     events::{fully_read::FullyReadEvent, AnyMessageLikeEventContent, AnySyncTimelineEvent},
     serde::Raw,
@@ -198,7 +194,7 @@ fn handle_remote_event(
     encryption_info: Option<EncryptionInfo>,
     position: TimelineItemPosition,
     timeline_items: &mut MutableVecLockMut<'_, Arc<TimelineItem>>,
-    timeline_meta: &mut MutexGuard<'_, TimelineInnerMetadata>,
+    timeline_meta: &mut TimelineInnerMetadata,
 ) {
     let (event_id, sender, origin_server_ts, txn_id, relations, event_kind) =
         match raw.deserialize() {

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -212,13 +212,7 @@ impl Timeline {
 
         let own_user_id = self.room.own_user_id();
         for room_ev in messages.chunk {
-            self.inner
-                .handle_back_paginated_event(
-                    room_ev.event.cast(),
-                    room_ev.encryption_info,
-                    own_user_id,
-                )
-                .await;
+            self.inner.handle_back_paginated_event(room_ev, own_user_id).await;
         }
 
         Ok(outcome)

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -22,11 +22,8 @@ use std::{
 };
 
 use futures_core::Stream;
-use futures_signals::signal_vec::{MutableVec, SignalVec, SignalVecExt, VecDiff};
-use matrix_sdk_base::{
-    deserialized_responses::{EncryptionInfo, SyncTimelineEvent},
-    locks::Mutex,
-};
+use futures_signals::signal_vec::{SignalVec, SignalVecExt, VecDiff};
+use matrix_sdk_base::deserialized_responses::{EncryptionInfo, SyncTimelineEvent};
 use ruma::{
     assign,
     events::{fully_read::FullyReadEventContent, relation::Annotation, AnyMessageLikeEventContent},
@@ -43,10 +40,12 @@ use crate::{
 
 mod event_handler;
 mod event_item;
+mod inner;
 #[cfg(test)]
 mod tests;
 mod virtual_item;
 
+use self::inner::TimelineInner;
 pub use self::{
     event_item::{
         EncryptedMessage, EventTimelineItem, Message, PaginationOutcome, ReactionDetails,
@@ -70,12 +69,6 @@ pub struct Timeline {
     _fully_read_handler_guard: EventHandlerDropGuard,
     #[cfg(feature = "e2e-encryption")]
     _room_key_handler_guard: EventHandlerDropGuard,
-}
-
-#[derive(Clone, Debug, Default)]
-struct TimelineInner {
-    items: MutableVec<Arc<TimelineItem>>,
-    metadata: Arc<Mutex<TimelineInnerMetadata>>,
 }
 
 /// Non-signalling parts of `TimelineInner`.

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -269,9 +269,9 @@ impl Timeline {
             .await;
     }
 
-    /// Get the latest of the timeline's items.
-    pub fn latest(&self) -> Option<Arc<TimelineItem>> {
-        self.inner.items.lock_ref().last().cloned()
+    /// Get the latest of the timeline's event items.
+    pub fn latest_event(&self) -> Option<EventTimelineItem> {
+        self.inner.items.lock_ref().last()?.as_event().cloned()
     }
 
     /// Get a signal of the timeline's items.

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -220,6 +220,10 @@ impl SlidingSyncRoom {
     /// `Timeline` of this room
     #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(&self) -> Timeline {
+        self.timeline_no_fully_read_tracking().await.with_fully_read_tracking().await
+    }
+
+    async fn timeline_no_fully_read_tracking(&self) -> Timeline {
         let current_timeline = self.timeline.lock_ref().to_vec();
         let prev_batch = self.prev_batch.lock_ref().clone();
         let room = self.client.get_room(&self.room_id).unwrap();

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -44,7 +44,7 @@ use thiserror::Error;
 use url::Url;
 
 #[cfg(feature = "experimental-timeline")]
-use crate::room::timeline::Timeline;
+use crate::room::timeline::{EventTimelineItem, Timeline};
 use crate::{Client, HttpError, Result, RumaApiError};
 
 /// Internal representation of errors in Sliding Sync
@@ -228,6 +228,15 @@ impl SlidingSyncRoom {
         let prev_batch = self.prev_batch.lock_ref().clone();
         let room = self.client.get_room(&self.room_id).unwrap();
         Timeline::with_events(&room, prev_batch, current_timeline).await
+    }
+
+    /// The latest timeline item of this room.
+    ///
+    /// Use `Timeline::latest_event` instead if you already have a timeline for
+    /// this `SlidingSyncRoom`.
+    #[cfg(feature = "experimental-timeline")]
+    pub async fn latest_event(&self) -> Option<EventTimelineItem> {
+        self.timeline_no_fully_read_tracking().await.latest_event()
     }
 
     /// This rooms name as calculated by the server, if any

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -220,14 +220,14 @@ impl SlidingSyncRoom {
     /// `Timeline` of this room
     #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(&self) -> Timeline {
-        self.timeline_no_fully_read_tracking().await.with_fully_read_tracking().await
+        self.timeline_no_fully_read_tracking().with_fully_read_tracking().await
     }
 
-    async fn timeline_no_fully_read_tracking(&self) -> Timeline {
+    fn timeline_no_fully_read_tracking(&self) -> Timeline {
         let current_timeline = self.timeline.lock_ref().to_vec();
         let prev_batch = self.prev_batch.lock_ref().clone();
         let room = self.client.get_room(&self.room_id).unwrap();
-        Timeline::with_events(&room, prev_batch, current_timeline).await
+        Timeline::with_events(&room, prev_batch, current_timeline)
     }
 
     /// The latest timeline item of this room.
@@ -235,8 +235,8 @@ impl SlidingSyncRoom {
     /// Use `Timeline::latest_event` instead if you already have a timeline for
     /// this `SlidingSyncRoom`.
     #[cfg(feature = "experimental-timeline")]
-    pub async fn latest_event(&self) -> Option<EventTimelineItem> {
-        self.timeline_no_fully_read_tracking().await.latest_event()
+    pub fn latest_event(&self) -> Option<EventTimelineItem> {
+        self.timeline_no_fully_read_tracking().latest_event()
     }
 
     /// This rooms name as calculated by the server, if any


### PR DESCRIPTION
… at least for the simple case where we just want the latest event item. For fetching the current fully-read marker, which a "full" timeline generally wants, we still need async because of the store.

Also contains lots of small refactorings like breaking the ever-growing `timeline::event_handler` module into two.