### PR TITLE
fix(ci): Fix clippy unused imports on macos

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -676,7 +676,7 @@ mod tests {
     }
 
     #[async_test]
-    #[cfg(any(target_os = "linux", target_arch = "wasm32"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_arch = "wasm32"))]
     async fn expiration() -> Result<(), MegolmError> {
         use ruma::SecondsSinceUnixEpoch;
 

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -529,9 +529,9 @@ impl VerificationMachine {
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::Arc, time::Duration};
+    use std::sync::Arc;
 
-    use matrix_sdk_common::{instant::Instant, locks::Mutex};
+    use matrix_sdk_common::locks::Mutex;
     use matrix_sdk_test::async_test;
     use ruma::TransactionId;
 
@@ -644,6 +644,10 @@ mod tests {
     #[allow(unknown_lints, clippy::unchecked_duration_subtraction)]
     #[async_test]
     async fn timing_out() {
+        use std::time::Duration;
+
+        use matrix_sdk_common::instant::Instant;
+
         let (alice_machine, bob) = setup_verification_machine().await;
         let alice = alice_machine.get_sas(bob.user_id(), bob.flow_id().as_str()).unwrap();
 


### PR DESCRIPTION
Conditional compilation erased use of some imported types on macos, which has led to clippy errors and failed `cargo xtask ci` run (unused imports)

- expiration test seems to be safe to run on macos, added it to targets
- timeout test compiles fine now (M1 Pro, macOS 13.0.1 Ventura)