### PR TITLE
doc: Hint towards test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ Some crates of the **matrix-rust-sdk** can be embedded inside other
 environments, like Swift, Kotlin, JavaScript, Node.js etc. Please,
 explore the [`bindings/`](./bindings/) directory to learn more.
 
+## Testing
+
+You can run most of the tests that also happen in CI also using `cargo xtask ci`.
+This needs a few dependencies to be installed, as it also runs automatic WASM tests:
+
+```bash
+rustup component add clippy
+cargo install cargo-nextest typos-cli wasm-pack
+```
+
+If you want to execute only one part of CI, there are a few sub-commands (see `cargo xtask ci --help`).
+
+Some tests are not automatically run in `cargo xtask ci`, for example the integration tests,
+that need a running synapse instance. These tests reside in `./testing/matrix-sdk-integration-testing`.
+See its [README](./testing/matrix-sdk-integration-testing/README.md) to easily set up a synapse for testing purposes.
+
 ## License
 
 [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/testing/matrix-sdk-integration-testing/README.md
+++ b/testing/matrix-sdk-integration-testing/README.md
@@ -2,7 +2,8 @@
 
 ## Requirements
 
-This requires a synapse backend with a ci patched configuration. You can easily get it up and running with `docker-compose` via:
+This requires a synapse backend with a ci patched configuration. You can easily get
+it up and running with `docker-compose` via:
 
 ```sh
 docker-compose -f assets/docker-compose.yml up -d
@@ -10,11 +11,16 @@ docker-compose -f assets/docker-compose.yml logs --tail 100 -f
 ```
 
 **Patches**
-You can see the patches we do to configuration (namely activate registration and resetting rate limits), check out what `assets/ci-start.sh` changes.
+You can see the patches we do to configuration (namely activate registration and
+resetting rate limits), check out what `assets/ci-start.sh` changes.
 
 ## Running
 
-The integration tests expect environment variables `HOMESERVER_URL` be the http-url to access the synapse server and `HOMESERVER_DOMAIN` to be set to the domain configured in that server. If you are using the provided `docker-compose`, the default will be fine. 
+The integration tests can be run with `cargo test` or `cargo nextest run`.
+
+The integration tests expect the environment variables `HOMESERVER_URL` to be the HTTP URL to
+access the synapse server and `HOMESERVER_DOMAIN` to be set to the domain configured in
+that server. If you are using the provided `docker-compose`, the default will be fine.
 
 ## Maintenance
 
@@ -23,4 +29,10 @@ To drop the database of your docker-compose run:
 ```bash
 docker-compose -f assets/docker-compose.yml stop
 docker volume rm -f assets_marix-rust-sdk-ci-data
+```
+
+or simply:
+
+```bash
+docker-compose -f assets/docker-compose.yml down -v
 ```


### PR DESCRIPTION
I would like to also add a list of dependencies that are needed to run the `xtask ci`, but I don't know which anymore. Do you happen to have a list somewhere?