### PR TITLE
Add uploading media and setting display name to FFI

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -21,6 +21,7 @@ extension-trait = "1.0.1"
 futures-core = "0.3.17"
 futures-signals = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.17", default-features = false }
+mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014
 once_cell = "1.10.0"
@@ -31,7 +32,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-stream = "0.1.8"
 uniffi = { workspace = true }
 uniffi_macros = { workspace = true }
-mime = "0.3.16"
+
 
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-stream = "0.1.8"
 uniffi = { workspace = true }
 uniffi_macros = { workspace = true }
+mime = "0.3.16"
 
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -34,7 +34,6 @@ uniffi = { workspace = true }
 uniffi_macros = { workspace = true }
 
 
-
 [target.'cfg(target_os = "android")'.dependencies]
 tracing = { version = "0.1.29", default-features = false, features = ["log"] }
 android_logger = "0.11"

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -162,6 +162,9 @@ interface Client {
 
     [Throws=ClientError]
     string display_name();
+    
+    [Throws=ClientError]
+    void set_display_name(string name);
 
     [Throws=ClientError]
     string avatar_url();

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -177,6 +177,9 @@ interface Client {
 
     [Throws=ClientError]
     void set_account_data(string event_type, string content);
+    
+    [Throws=ClientError]
+    string upload_media(string mime, sequence<u8> content);
 
     [Throws=ClientError]
     sequence<u8> get_media_content(MediaSource source);

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -179,7 +179,7 @@ interface Client {
     void set_account_data(string event_type, string content);
     
     [Throws=ClientError]
-    string upload_media(string mime, sequence<u8> content);
+    string upload_media(string mime_type, sequence<u8> content);
 
     [Throws=ClientError]
     sequence<u8> get_media_content(MediaSource source);

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -239,8 +239,7 @@ impl Client {
 
         RUNTIME.block_on(async move {
             let as_mime: mime::Mime = mime.parse().unwrap();
-            let as_array = data.as_slice();
-            let response = l.media().upload(&as_mime, as_array).await?;
+            let response = l.media().upload(&as_mime, data).await?;
             Ok(String::from(response.content_uri))
         })
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -234,6 +234,17 @@ impl Client {
         })
     }
 
+    pub fn upload_media(&self, mime: String, data: Vec<u8>) -> anyhow::Result<String> {
+        let l = self.client.clone();
+
+        RUNTIME.block_on(async move {
+            let as_mime: mime::Mime = mime.parse().unwrap();
+            let as_array = data.as_slice();
+            let response = l.media().upload(&as_mime, as_array).await?;
+            Ok(String::from(response.content_uri))
+        })
+    }
+
     pub fn get_media_content(&self, media_source: Arc<MediaSource>) -> anyhow::Result<Vec<u8>> {
         let l = self.client.clone();
         let source = (*media_source).clone();

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -187,6 +187,18 @@ impl Client {
         })
     }
 
+    pub fn set_display_name(&self, name: String) -> anyhow::Result<()> {
+        let l = self.client.clone();
+        RUNTIME.block_on(async move {
+            let result = l
+                .account()
+                .set_display_name(Some(name.as_str()))
+                .await
+                .context("Unable to set display name");
+            result
+        })
+    }
+
     pub fn avatar_url(&self) -> anyhow::Result<String> {
         let l = self.client.clone();
         RUNTIME.block_on(async move {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -234,7 +234,7 @@ impl Client {
         })
     }
 
-    pub fn upload_media(&self, mime: String, data: Vec<u8>) -> anyhow::Result<String> {
+    pub fn upload_media(&self, mime_type: String, data: Vec<u8>) -> anyhow::Result<String> {
         let l = self.client.clone();
 
         RUNTIME.block_on(async move {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -188,14 +188,13 @@ impl Client {
     }
 
     pub fn set_display_name(&self, name: String) -> anyhow::Result<()> {
-        let l = self.client.clone();
+        let client = self.client.clone();
         RUNTIME.block_on(async move {
-            let result = l
+            client
                 .account()
                 .set_display_name(Some(name.as_str()))
                 .await
-                .context("Unable to set display name");
-            result
+                .context("Unable to set display name")
         })
     }
 
@@ -238,8 +237,8 @@ impl Client {
         let l = self.client.clone();
 
         RUNTIME.block_on(async move {
-            let as_mime: mime::Mime = mime.parse().unwrap();
-            let response = l.media().upload(&as_mime, data).await?;
+            let mime_type: mime::Mime = mime_type.parse()?;
+            let response = l.media().upload(&mime_type, data).await?;
             Ok(String::from(response.content_uri))
         })
     }


### PR DESCRIPTION
Adds `upload_media` to `Client` in order to allow uploading media. And `set_display_name` to `Client` to allow for changing display name