### PR TITLE
feat(client): reuse http2 connections

### DIFF
--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -297,7 +297,10 @@ impl HttpSettings {
             let user_agent =
                 self.user_agent.clone().unwrap_or_else(|| "matrix-rust-sdk".to_owned());
 
-            http_client = http_client.user_agent(user_agent).timeout(self.timeout);
+            http_client = http_client
+                .user_agent(user_agent)
+                .timeout(self.timeout)
+                .http2_keep_alive_interval(Some(Duration::from_secs(30u64)));
         };
 
         Ok(http_client.build()?)


### PR DESCRIPTION
Though our underlying reqwest/hyper has the capability to reuse http-connections in http2 cases through keep-alive, until this change, we didn't have that active yet. This activates that and adds a 30s ping-delay which instructs hyper to ping if there wasn't anything send for that time. 