### PR TITLE
refactor(sdk): Split restore_session into two parts at the Client level

### DIFF
--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -534,7 +534,7 @@ impl Store {
 
     /// Restore the access to the Store from the given `Session`, overwrites any
     /// previously existing access to the Store.
-    pub async fn restore_session(&self, session: Session) -> Result<()> {
+    pub async fn restore_session(&self, session: SessionMeta) -> Result<()> {
         for info in self.inner.get_room_infos().await? {
             let room = Room::restore(&session.user_id, self.inner.clone(), info);
             self.rooms.insert(room.room_id().to_owned(), room);
@@ -548,9 +548,7 @@ impl Store {
         let token = self.get_sync_token().await?;
         *self.sync_token.write().await = token;
 
-        let (session_meta, session_tokens) = session.into_parts();
-        self.session_meta.set(session_meta).expect("Session IDs were already set");
-        self.session_tokens.set(Some(session_tokens));
+        self.session_meta.set(session).expect("Session IDs were already set");
 
         Ok(())
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -532,23 +532,27 @@ impl Store {
         &self.sync_lock
     }
 
-    /// Restore the access to the Store from the given `Session`, overwrites any
-    /// previously existing access to the Store.
-    pub async fn restore_session(&self, session: SessionMeta) -> Result<()> {
+    /// Set the meta of the session.
+    ///
+    /// Restores the state of this `Store` from the given `SessionMeta` and the
+    /// inner `StateStore`.
+    ///
+    /// This method panics if it is called twice.
+    pub async fn set_session_meta(&self, session_meta: SessionMeta) -> Result<()> {
         for info in self.inner.get_room_infos().await? {
-            let room = Room::restore(&session.user_id, self.inner.clone(), info);
+            let room = Room::restore(&session_meta.user_id, self.inner.clone(), info);
             self.rooms.insert(room.room_id().to_owned(), room);
         }
 
         for info in self.inner.get_stripped_room_infos().await? {
-            let room = Room::restore(&session.user_id, self.inner.clone(), info);
+            let room = Room::restore(&session_meta.user_id, self.inner.clone(), info);
             self.stripped_rooms.insert(room.room_id().to_owned(), room);
         }
 
         let token = self.get_sync_token().await?;
         *self.sync_token.write().await = token;
 
-        self.session_meta.set(session).expect("Session IDs were already set");
+        self.session_meta.set(session_meta).expect("Session Meta was already set");
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1220,7 +1220,7 @@ impl Client {
     pub async fn restore_session(&self, session: Session) -> Result<()> {
         let (meta, tokens) = session.into_parts();
         self.base_client().set_session_tokens(tokens);
-        Ok(self.base_client().restore_session(meta).await?)
+        Ok(self.base_client().set_session_meta(meta).await?)
     }
 
     /// Refresh the access token.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1218,7 +1218,9 @@ impl Client {
     ///
     /// [`login`]: #method.login
     pub async fn restore_session(&self, session: Session) -> Result<()> {
-        Ok(self.inner.base_client.restore_session(session).await?)
+        let (meta, tokens) = session.into_parts();
+        self.base_client().set_session_tokens(tokens);
+        Ok(self.base_client().restore_session(meta).await?)
     }
 
     /// Refresh the access token.


### PR DESCRIPTION
Tokens are not necessary for the crypto/store restoration, only the meta.

This is required for (experimental) OpenID Connect support where we need to use the tokens to get the meta.