### PR TITLE
fix(sliding-sync): set views to preload if we've recovered from frozen

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -924,6 +924,9 @@ impl From<&SlidingSyncView> for FrozenSlidingSyncView {
 impl SlidingSyncView {
     fn set_from_cold(&mut self, v: FrozenSlidingSyncView) {
         let FrozenSlidingSyncView { rooms_count, rooms_list } = v;
+        if *self.sync_mode.lock_ref() == SlidingSyncMode::FullSync {
+            self.state.set(SlidingSyncState::Preload);
+        }
         self.rooms_count.replace(rooms_count);
         self.rooms_list.lock_mut().replace_cloned(rooms_list);
     }

--- a/labs/jack-in/src/client/mod.rs
+++ b/labs/jack-in/src/client/mod.rs
@@ -48,6 +48,7 @@ pub async fn run_client(
             Some(Ok(_)) => {
                 // we are switching into live updates mode next. ignoring
                 let state = state.read_only().get_cloned();
+                ssync_state.set_view_state(state.clone());
 
                 if state == SlidingSyncState::Live {
                     info!("Reached live sync");

--- a/labs/jack-in/src/client/state.rs
+++ b/labs/jack-in/src/client/state.rs
@@ -8,7 +8,9 @@ use futures_signals::{
     signal::Mutable,
     signal_vec::{MutableVec, VecDiff},
 };
-use matrix_sdk::{room::timeline::TimelineItem, ruma::OwnedRoomId, SlidingSyncView};
+use matrix_sdk::{
+    room::timeline::TimelineItem, ruma::OwnedRoomId, SlidingSyncState as ViewState, SlidingSyncView,
+};
 use tokio::task::JoinHandle;
 
 #[derive(Clone, Default)]
@@ -25,6 +27,7 @@ pub struct SlidingSyncState {
     /// the current list selector for the room
     first_render: Option<Duration>,
     full_sync: Option<Duration>,
+    current_state: ViewState,
     tl_handle: Mutable<Option<JoinHandle<()>>>,
     pub selected_room: Mutable<Option<OwnedRoomId>>,
     pub current_timeline: MutableVec<Arc<TimelineItem>>,
@@ -37,6 +40,7 @@ impl SlidingSyncState {
             view,
             first_render: None,
             full_sync: None,
+            current_state: ViewState::default(),
             tl_handle: Default::default(),
             selected_room: Default::default(),
             current_timeline: Default::default(),
@@ -105,6 +109,9 @@ impl SlidingSyncState {
     pub fn time_to_full_sync(&self) -> Option<Duration> {
         self.full_sync
     }
+    pub fn current_state(&self) -> &ViewState {
+        &self.current_state
+    }
 
     pub fn loaded_rooms_count(&self) -> usize {
         self.view.rooms.lock_ref().len()
@@ -124,5 +131,9 @@ impl SlidingSyncState {
 
     pub fn set_full_sync_now(&mut self) {
         self.full_sync = Some(self.started.elapsed())
+    }
+
+    pub fn set_view_state(&mut self, current_state: ViewState) {
+        self.current_state = current_state
     }
 }

--- a/labs/jack-in/src/components/statusbar.rs
+++ b/labs/jack-in/src/components/statusbar.rs
@@ -34,7 +34,8 @@ impl MockComponent for StatusBar {
         let focus = self.props.get_or(Attribute::Focus, AttrValue::Flag(false)).unwrap_flag();
 
         let tabs = {
-            let mut tabs = vec![];
+            let mut tabs =
+                vec![Spans::from(format!("Current state: {:?}", self.sstate.current_state()))];
             if let Some(dur) = self.sstate.time_to_first_render() {
                 tabs.push(Spans::from(format!("First view: {}ms", dur.as_millis())));
 


### PR DESCRIPTION
Sliding sync recovered from cold cache never turned into `live` mode, the reason being that the count was existing and it wasn't considered to be updated yet. This sets the state into `preload` to ensure we are in sync again for further updates.