### PR TITLE
feat(bindings): Add sending of reactions to matrix-sdk-ffi

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -203,7 +203,7 @@ dictionary Session {
 interface Room {
     [Throws=ClientError]
     string display_name();
-    
+
     [Throws=ClientError]
     boolean is_encrypted();
 
@@ -232,6 +232,9 @@ interface Room {
 
     [Throws=ClientError]
     void redact(string event_id, string? reason, string? txn_id);
+
+    [Throws=ClientError]
+    void send_reaction(string event_id, string key);
 };
 
 callback interface TimelineListener {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -12,7 +12,8 @@ use matrix_sdk::{
     },
     ruma::{
         events::{
-            relation::Replacement,
+            reaction::ReactionEventContent,
+            relation::{Annotation, Replacement},
             room::message::{
                 ForwardThread, MessageType, Relation, RoomMessageEvent, RoomMessageEventContent,
             },
@@ -278,6 +279,19 @@ impl Room {
         RUNTIME.block_on(async move {
             let event_id = EventId::parse(event_id)?;
             room.redact(&event_id, reason.as_deref(), txn_id.map(Into::into)).await?;
+            Ok(())
+        })
+    }
+
+    pub fn send_reaction(&self, event_id: String, key: String) -> Result<()> {
+        let room = match &self.room {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => bail!("Can't send reaction in a room that isn't in joined state"),
+        };
+
+        RUNTIME.block_on(async move {
+            let event_id = EventId::parse(event_id)?;
+            room.send(ReactionEventContent::new(Annotation::new(event_id, key)), None).await?;
             Ok(())
         })
     }


### PR DESCRIPTION
Adds basic reaction sending to `matrix-sdk-ffi`. Later we will want to add a similar function to the `Timeline` that also does local echoing, but this is a helpful stopgap until we have implemented reaction echoes.

cc @stefanceriu 