### PR TITLE
Work around remote echoes that are missing a transaction ID

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -215,27 +215,9 @@ pub enum TimelineKey {
     EventId(OwnedEventId),
 }
 
-impl PartialEq<TimelineKey> for &TransactionId {
-    fn eq(&self, key: &TimelineKey) -> bool {
-        matches!(key, TimelineKey::TransactionId(txn_id) if txn_id == self)
-    }
-}
-
-impl PartialEq<TimelineKey> for &OwnedTransactionId {
-    fn eq(&self, key: &TimelineKey) -> bool {
-        matches!(key, TimelineKey::TransactionId(txn_id) if txn_id == *self)
-    }
-}
-
-impl PartialEq<TimelineKey> for &EventId {
-    fn eq(&self, key: &TimelineKey) -> bool {
-        matches!(key, TimelineKey::EventId(event_id) if event_id == self)
-    }
-}
-
-impl PartialEq<TimelineKey> for &OwnedEventId {
-    fn eq(&self, key: &TimelineKey) -> bool {
-        matches!(key, TimelineKey::EventId(event_id) if event_id == *self)
+impl PartialEq<TransactionId> for TimelineKey {
+    fn eq(&self, id: &TransactionId) -> bool {
+        matches!(self, TimelineKey::TransactionId(txn_id) if txn_id == id)
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -18,7 +18,7 @@ use super::{
         update_read_marker, Flow, TimelineEventHandler, TimelineEventKind, TimelineEventMetadata,
         TimelineItemPosition,
     },
-    find_event, TimelineInnerMetadata, TimelineItem, TimelineKey,
+    find_event_by_txn_id, TimelineInnerMetadata, TimelineItem, TimelineKey,
 };
 use crate::events::SyncTimelineEventWithoutContent;
 
@@ -107,7 +107,7 @@ impl TimelineInner {
 
     pub(super) fn add_event_id(&self, txn_id: &TransactionId, event_id: OwnedEventId) {
         let mut lock = self.items.lock_mut();
-        if let Some((idx, item)) = find_event(&lock, txn_id) {
+        if let Some((idx, item)) = find_event_by_txn_id(&lock, txn_id) {
             match &item.key {
                 TimelineKey::TransactionId(_) => {
                     lock.set_cloned(


### PR DESCRIPTION
Previously, we were only checking whether remote events were duplicated, now we're also checking whether an event might be a remote echo and thus redundant with a local event, even when it doesn't have a transaction ID. Works around https://github.com/matrix-org/sliding-sync/issues/24.