### PR TITLE
feat(sdk): Implement IntoFuture for LoginBuilder and SsoLoginBuilder

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -983,7 +983,6 @@ impl Client {
     /// let response = client
     ///     .login_username(user, "wordpass")
     ///     .initial_device_display_name("My bot")
-    ///     .send()
     ///     .await?;
     ///
     /// println!(
@@ -1046,7 +1045,6 @@ impl Client {
     /// let response = client
     ///     .login_token(login_token)
     ///     .initial_device_display_name("My app")
-    ///     .send()
     ///     .await
     ///     .unwrap();
     ///
@@ -1107,7 +1105,6 @@ impl Client {
     ///         Ok(())
     ///     })
     ///     .initial_device_display_name("My app")
-    ///     .send()
     ///     .await
     ///     .unwrap();
     ///

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -132,7 +132,6 @@ async fn login_with_sso() {
             Ok(())
         })
         .identity_provider_id(&idp.id)
-        .send()
         .await
         .unwrap();
 

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -82,7 +82,6 @@ async fn login_sso_refresh_token() {
         })
         .identity_provider_id(&idp.id)
         .request_refresh_token()
-        .send()
         .await
         .unwrap();
 

--- a/examples/autojoin/src/main.rs
+++ b/examples/autojoin/src/main.rs
@@ -60,11 +60,7 @@ async fn login_and_sync(
 
     let client = client_builder.build().await?;
 
-    client
-        .login_username(username, password)
-        .initial_device_display_name("autojoin bot")
-        .send()
-        .await?;
+    client.login_username(username, password).initial_device_display_name("autojoin bot").await?;
 
     println!("logged in as {username}");
 

--- a/examples/command_bot/src/main.rs
+++ b/examples/command_bot/src/main.rs
@@ -51,11 +51,7 @@ async fn login_and_sync(
     }
 
     let client = client_builder.build().await.unwrap();
-    client
-        .login_username(&username, &password)
-        .initial_device_display_name("command bot")
-        .send()
-        .await?;
+    client.login_username(&username, &password).initial_device_display_name("command bot").await?;
 
     println!("logged in as {username}");
 

--- a/examples/cross_signing_bootstrap/src/main.rs
+++ b/examples/cross_signing_bootstrap/src/main.rs
@@ -36,11 +36,8 @@ async fn login(homeserver_url: String, username: &str, password: &str) -> matrix
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).await.unwrap();
 
-    let response = client
-        .login_username(username, password)
-        .initial_device_display_name("rust-sdk")
-        .send()
-        .await?;
+    let response =
+        client.login_username(username, password).initial_device_display_name("rust-sdk").await?;
 
     let user_id = &response.user_id;
     let client_ref = &client;

--- a/examples/custom_events/src/main.rs
+++ b/examples/custom_events/src/main.rs
@@ -109,7 +109,6 @@ async fn login_and_sync(
     client
         .login_username(username, password)
         .initial_device_display_name("getting started bot")
-        .send()
         .await?;
 
     // it worked!

--- a/examples/emoji_verification/src/main.rs
+++ b/examples/emoji_verification/src/main.rs
@@ -175,7 +175,6 @@ async fn login(cli: Cli) -> Result<Client> {
     client
         .login_username(&cli.user_name, &cli.password)
         .initial_device_display_name("rust-sdk")
-        .send()
         .await?;
 
     Ok(client)

--- a/examples/get_profiles/src/main.rs
+++ b/examples/get_profiles/src/main.rs
@@ -39,11 +39,7 @@ async fn login(
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).await.unwrap();
 
-    client
-        .login_username(username, password)
-        .initial_device_display_name("rust-sdk")
-        .send()
-        .await?;
+    client.login_username(username, password).initial_device_display_name("rust-sdk").await?;
 
     Ok(client)
 }

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -75,7 +75,6 @@ async fn login_and_sync(
     client
         .login_username(username, password)
         .initial_device_display_name("getting started bot")
-        .send()
         .await?;
 
     // It worked!

--- a/examples/image_bot/src/main.rs
+++ b/examples/image_bot/src/main.rs
@@ -33,11 +33,7 @@ async fn login_and_sync(
     let homeserver_url = Url::parse(&homeserver_url).expect("Couldn't parse the homeserver URL");
     let client = Client::new(homeserver_url).await.unwrap();
 
-    client
-        .login_username(&username, &password)
-        .initial_device_display_name("command bot")
-        .send()
-        .await?;
+    client.login_username(&username, &password).initial_device_display_name("command bot").await?;
 
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
 

--- a/examples/login/src/main.rs
+++ b/examples/login/src/main.rs
@@ -36,11 +36,7 @@ async fn login(homeserver_url: String, username: &str, password: &str) -> matrix
 
     client.add_event_handler(on_room_message);
 
-    client
-        .login_username(username, password)
-        .initial_device_display_name("rust-sdk")
-        .send()
-        .await?;
+    client.login_username(username, password).initial_device_display_name("rust-sdk").await?;
     client.sync(SyncSettings::new()).await?;
 
     Ok(())

--- a/examples/timeline/src/main.rs
+++ b/examples/timeline/src/main.rs
@@ -45,7 +45,6 @@ async fn login(cli: Cli) -> Result<Client> {
     client
         .login_username(&cli.user_name, &cli.password)
         .initial_device_display_name("rust-sdk")
-        .send()
         .await?;
 
     Ok(client)

--- a/examples/wasm_command_bot/src/lib.rs
+++ b/examples/wasm_command_bot/src/lib.rs
@@ -73,7 +73,6 @@ pub async fn run() -> Result<JsValue, JsValue> {
     client
         .login_username(username, password)
         .initial_device_display_name("rust-sdk-wasm")
-        .send()
         .await
         .unwrap();
 

--- a/labs/jack-in/src/main.rs
+++ b/labs/jack-in/src/main.rs
@@ -253,7 +253,7 @@ async fn main() -> Result<()> {
                 .with_prompt(format!("Password for {user_id:} :"))
                 .interact()?,
         };
-        client.login_username(&user_id, &password).send().await?;
+        client.login_username(&user_id, &password).await?;
     }
 
     if let Some(session) = client.session() {

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -71,7 +71,7 @@ pub async fn get_client_for_user(username: String, use_sled_store: bool) -> Resu
             let _ = client.register(request).await;
         }
     }
-    client.login_username(&username, &username).send().await?;
+    client.login_username(&username, &username).await?;
     users.insert(username, (client.clone(), tmp_dir)); // keeping temp dir around so it doesn't get destroyed yet
 
     Ok(client)


### PR DESCRIPTION
This allows `.await`ing the builder directly, rather than first having to call `.send()`.