### PR TITLE
Revise example of `machine.receiveSyncChanges`

### DIFF
--- a/bindings/matrix-sdk-crypto-nodejs/README.md
+++ b/bindings/matrix-sdk-crypto-nodejs/README.md
@@ -140,7 +140,7 @@ async function main() {
 
     // Let's pretend we have received changes and events from a
     // `/sync` endpoint of a Matrix homeserver, …
-    const toDeviceEvents = "{}"; // JSON-encoded
+    const toDeviceEvents = "[]"; // JSON-encoded list of events
     const changedDevices = new DeviceLists();
     const oneTimeKeyCounts = {};
     const unusedFallbackKeys = [];


### PR DESCRIPTION
Clarify that the JSON-encoded `toDeviceEvents` passed to `OlmMachine.receiveSyncChanges` must be the list of events themselves, instead of a wrapper object that contains the event list.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

As found in https://github.com/turt2live/matrix-bot-sdk/pull/283, a recent change in the Rust SDK changed the expected format of the event list string accepted by `OlmMachine.receiveSyncChanges`.  Since it's a subtle yet consequential change, it's helpful to update the docs to reflect the new format.  There are probably better places/ways to document it, but this PR can be a first step.