### PR TITLE
download-lib.js: use HTTP proxy to download when provided as environment variable (fix #1263)

### DIFF
--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -29,8 +29,9 @@ function download_lib(libname) {
 
     var proxy = process.env.https_proxy ?? process.env.http_proxy ?? undefined
     if (proxy) {
+      console.info("Using configured HTTP proxy: " + proxy)
       const proxyAgent = new HttpsProxyAgent(proxy);
-      dl.updateOptions( { agent: proxyAgent } )
+      dl.updateOptions({ httpsRequestOptions: { agent: proxyAgent } })
     }
 
     dl.on('end', () => console.info('Download Completed'));

--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -28,7 +28,6 @@ function download_lib(libname) {
 
     const proxy = process.env.https_proxy ?? process.env.HTTPS_PROXY;
     if (proxy) {
-      console.info("Using configured HTTP proxy: " + proxy)
       const proxyAgent = new HttpsProxyAgent(proxy);
       dl.updateOptions({
           httpsRequestOptions: { agent: proxyAgent },

--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -21,7 +21,6 @@ function download_lib(libname) {
 
     const url = `${DOWNLOADS_BASE_URL}/${CURRENT_VERSION}/${libname}`;
     console.info(`Downloading lib ${libname} from ${url}`);
-
     const dl = new DownloaderHelper(url, __dirname, {
         override: true,
     });

--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -27,10 +27,10 @@ function download_lib(libname) {
 
     const proxy = process.env.https_proxy ?? process.env.HTTPS_PROXY;
     if (proxy) {
-      const proxyAgent = new HttpsProxyAgent(proxy);
-      dl.updateOptions({
-          httpsRequestOptions: { agent: proxyAgent },
-      });
+        const proxyAgent = new HttpsProxyAgent(proxy);
+        dl.updateOptions({
+            httpsRequestOptions: { agent: proxyAgent },
+        });
     }
 
     dl.on('end', () => console.info('Download Completed'));

--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -1,4 +1,3 @@
-const { Agent } = require('https');
 const { DownloaderHelper } = require('node-downloader-helper');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { version } = require("./package.json");

--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -26,7 +26,7 @@ function download_lib(libname) {
       override: true,
     });
 
-    var proxy = process.env.https_proxy ?? process.env.http_proxy ?? undefined
+    var proxy = process.env.https_proxy ?? process.env.HTTPS_PROXY
     if (proxy) {
       console.info("Using configured HTTP proxy: " + proxy)
       const proxyAgent = new HttpsProxyAgent(proxy);

--- a/bindings/matrix-sdk-crypto-nodejs/download-lib.js
+++ b/bindings/matrix-sdk-crypto-nodejs/download-lib.js
@@ -1,5 +1,5 @@
-const { DownloaderHelper } = require('node-downloader-helper');
 const { HttpsProxyAgent } = require('https-proxy-agent');
+const { DownloaderHelper } = require('node-downloader-helper');
 const { version } = require("./package.json");
 const { platform, arch } = process
 
@@ -23,14 +23,16 @@ function download_lib(libname) {
     console.info(`Downloading lib ${libname} from ${url}`);
 
     const dl = new DownloaderHelper(url, __dirname, {
-      override: true,
+        override: true,
     });
 
-    var proxy = process.env.https_proxy ?? process.env.HTTPS_PROXY
+    const proxy = process.env.https_proxy ?? process.env.HTTPS_PROXY;
     if (proxy) {
       console.info("Using configured HTTP proxy: " + proxy)
       const proxyAgent = new HttpsProxyAgent(proxy);
-      dl.updateOptions({ httpsRequestOptions: { agent: proxyAgent } })
+      dl.updateOptions({
+          httpsRequestOptions: { agent: proxyAgent },
+      });
     }
 
     dl.on('end', () => console.info('Download Completed'));

--- a/bindings/matrix-sdk-crypto-nodejs/package.json
+++ b/bindings/matrix-sdk-crypto-nodejs/package.json
@@ -29,6 +29,7 @@
         "doc": "typedoc --tsconfig ."
     },
     "dependencies": {
+        "https-proxy-agent": "^5.0.1",
         "node-downloader-helper": "^2.1.1"
     }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

When downloading in `download-lib.js`, first look for an HTTP proxy configured in the `https_proxy` environment variable, and use this proxy when calling `DownloadHelper`. Requires the `https-proxy-agent` library.


Fix #1263


<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Erwan Bousse <erwan.bousse@univ-nantes.fr>
