### PR TITLE
feat(sliding-sync): Growing Window full sync

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -46,8 +46,10 @@ enum SlidingSyncState {
 };
 
 enum SlidingSyncMode {
-    /// Sync up the entire room list first
-    "FullSync",
+    /// Sync up the entire room list first, page by page
+    "PagingFullSync",
+    /// Sync up the entire room list first through a growing window
+    "GrowingFullSync",
     /// Only ever sync the currently selected window
     "Selective",
 };

--- a/labs/jack-in/src/client/mod.rs
+++ b/labs/jack-in/src/client/mod.rs
@@ -5,17 +5,26 @@ use tracing::{error, info, warn};
 
 pub mod state;
 
-use matrix_sdk::{ruma::OwnedRoomId, Client, SlidingSyncState, SlidingSyncViewBuilder};
+use matrix_sdk::{
+    ruma::OwnedRoomId, Client, SlidingSyncMode, SlidingSyncState, SlidingSyncViewBuilder,
+};
 
 pub async fn run_client(
     client: Client,
     sliding_sync_proxy: String,
     tx: mpsc::Sender<state::SlidingSyncState>,
+    growing_full_sync: bool,
 ) -> Result<()> {
     info!("Starting sliding sync now");
     let builder = client.sliding_sync().await;
-    let full_sync_view =
-        SlidingSyncViewBuilder::default_with_fullsync().timeline_limit(10u32).build()?;
+    let full_sync_view = SlidingSyncViewBuilder::default_with_fullsync()
+        .timeline_limit(10u32)
+        .sync_mode(if growing_full_sync {
+            SlidingSyncMode::GrowingFullSync
+        } else {
+            SlidingSyncMode::PagingFullSync
+        })
+        .build()?;
     let syncer = builder
         .homeserver(sliding_sync_proxy.parse().wrap_err("can't parse sync proxy")?)
         .add_view(full_sync_view)

--- a/labs/jack-in/src/main.rs
+++ b/labs/jack-in/src/main.rs
@@ -96,6 +96,10 @@ struct Opt {
     #[structopt(long)]
     fresh: bool,
 
+    /// Activate growing window rather than pagination for full-sync
+    #[structopt(long)]
+    growing_full_sync: bool,
+
     /// RUST_LOG log-levels
     #[structopt(short, long, env = "JACKIN_LOG", default_value = "jack_in=info,warn")]
     log: String,
@@ -265,9 +269,10 @@ async fn main() -> Result<()> {
 
     let (tx, mut rx) = mpsc::channel(100);
     let model_tx = tx.clone();
+    let growing_full_sync = opt.growing_full_sync;
 
     tokio::spawn(async move {
-        if let Err(e) = client::run_client(sliding_client, proxy, tx).await {
+        if let Err(e) = client::run_client(sliding_client, proxy, tx, growing_full_sync).await {
             warn!("Running the client failed: {:#?}", e);
         }
     });


### PR DESCRIPTION
Add a second full-sync-up mode to sliding sync. Previously - and still the default for backwards compatibility, but now named `PagingFullSync` - was to page through the list by the page-size, de-validating the previous page of items. The newly added `GrowingFullSync` instead grows the window by the given number `batch_size` per request, starting and keeping it from `0`. In the latter we might be pushing more data over the connection and are slightly slower, but the top always stays active and thus reactive to changes.

- [x] add new full-sync-mode
- [ ] add limited sync-up mode (similar to full sync but only to a limit `n`)
- [x] implement sync-up in jack-in 
