### PR TITLE
Generate a Package.swift in XCFramework xtask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ emsdk-*
 .idea/
 .env
 .build
+/Package.swift
 
 ## User settings
 xcuserdata/

--- a/bindings/apple/Debug-Package.swift
+++ b/bindings/apple/Debug-Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:5.6
+
+// A package manifest for local development. This file will be copied
+// into the root of the repo when generating an XCFramework.
+
+import PackageDescription
+
+let package = Package(
+    name: "MatrixRustSDK",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12)
+    ],
+    products: [
+        .library(name: "MatrixRustSDK",
+                 targets: ["MatrixRustSDK"]),
+    ],
+    targets: [
+        .binaryTarget(name: "MatrixSDKFFI", path: "bindings/apple/generated/MatrixSDKFFI.xcframework"),
+        .target(name: "MatrixRustSDK",
+                dependencies: [.target(name: "MatrixSDKFFI")],
+                path: "bindings/apple/generated/swift")
+    ]
+)


### PR DESCRIPTION
This PR tweaks the Swift xtask to create a Package.swift in the repo's root when building an XCFramework. This allows the repo to be used as a Swift package directly which provides the advantage of all the source files being available to the debugger compared to using a copy located in the matrix-rust-components-swift repo.