### PR TITLE
Verification request and QR signalling

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -45,8 +45,9 @@ use ruma::{
 use serde::{Deserialize, Serialize};
 pub use users::UserIdentity;
 pub use verification::{
-    CancelInfo, ConfirmVerificationResult, QrCode, RequestVerificationResult, Sas, SasListener,
-    SasState, ScanResult, StartSasResult, Verification, VerificationRequest,
+    CancelInfo, ConfirmVerificationResult, QrCode, QrCodeListener, QrCodeState,
+    RequestVerificationResult, Sas, SasListener, SasState, ScanResult, StartSasResult,
+    Verification, VerificationRequest, VerificationRequestListener, VerificationRequestState,
 };
 
 /// Struct collecting data that is important to migrate to the rust-sdk

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -162,7 +162,7 @@ interface Sas {
     sequence<i32>? get_emoji_indices();
     sequence<i32>? get_decimals();
 
-    void set_changes_listener(SasListener callback);
+    void set_changes_listener(SasListener listener);
     SasState state();
 };
 
@@ -201,6 +201,23 @@ interface QrCode {
     ConfirmVerificationResult? confirm();
     OutgoingVerificationRequest? cancel([ByRef] string cancel_code);
     string? generate_qr_code();
+
+    void set_changes_listener(QrCodeListener listener);
+    QrCodeState state();
+};
+
+[Enum]
+interface QrCodeState {
+  Started();
+  Scanned();
+  Confirmed();
+  Reciprocated();
+  Done();
+  Cancelled(CancelInfo cancel_info);
+};
+
+callback interface QrCodeListener {
+    void on_change(QrCodeState state);
 };
 
 interface VerificationRequest {
@@ -228,6 +245,21 @@ interface VerificationRequest {
     ScanResult? scan_qr_code([ByRef] string data);
 
     OutgoingVerificationRequest? cancel();
+
+    void set_changes_listener(VerificationRequestListener listener);
+    VerificationRequestState state();
+};
+
+[Enum]
+interface VerificationRequestState {
+  Requested();
+  Ready();
+  Done();
+  Cancelled(CancelInfo cancel_info);
+};
+
+callback interface VerificationRequestListener {
+    void on_change(VerificationRequestState state);
 };
 
 dictionary RequestVerificationResult {

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -253,7 +253,7 @@ interface VerificationRequest {
 [Enum]
 interface VerificationRequestState {
   Requested();
-  Ready();
+  Ready(sequence<string> their_methods, sequence<string> our_methods);
   Done();
   Cancelled(CancelInfo cancel_info);
 };

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -4,15 +4,16 @@ use base64::{decode_config, encode_config, STANDARD_NO_PAD};
 use futures_util::{Stream, StreamExt};
 use matrix_sdk_crypto::{
     matrix_sdk_qrcode::QrVerificationData, CancelInfo as RustCancelInfo, QrVerification as InnerQr,
-    Sas as InnerSas, SasState as RustSasState, Verification as InnerVerification,
-    VerificationRequest as InnerVerificationRequest,
+    QrVerificationState, Sas as InnerSas, SasState as RustSasState,
+    Verification as InnerVerification, VerificationRequest as InnerVerificationRequest,
+    VerificationRequestState as RustVerificationRequestState,
 };
 use ruma::events::key::verification::VerificationMethod;
 use tokio::runtime::Handle;
 
 use crate::{CryptoStoreError, OutgoingVerificationRequest, SignatureUploadRequest};
 
-/// Callback that will be passed over the FFI to report changes to a SAS
+/// Listener that will be passed over the FFI to report changes to a SAS
 /// verification.
 pub trait SasListener: Send {
     /// The callback that should be called on the Rust side
@@ -21,15 +22,6 @@ pub trait SasListener: Send {
     ///
     /// * `state` - The current state of the SAS verification.
     fn on_change(&self, state: SasState);
-}
-
-impl<T: Fn(SasState)> SasListener for T
-where
-    T: Send,
-{
-    fn on_change(&self, state: SasState) {
-        self(state)
-    }
 }
 
 /// An Enum describing the state the SAS verification is in.
@@ -98,7 +90,7 @@ impl Verification {
     /// returns `None` if the verification is not a `QrCode` verification.
     pub fn as_qr(&self) -> Option<Arc<QrCode>> {
         if let InnerVerification::QrV1(qr) = &self.inner {
-            Some(QrCode { inner: qr.to_owned() }.into())
+            Some(QrCode { inner: qr.to_owned(), runtime: self.runtime.to_owned() }.into())
         } else {
             None
         }
@@ -239,10 +231,10 @@ impl Sas {
     ///                │  Done │
     ///                └───────┘
     /// ```
-    pub fn set_changes_listener(&self, callback: Box<dyn SasListener>) {
+    pub fn set_changes_listener(&self, listener: Box<dyn SasListener>) {
         let stream = self.inner.changes();
 
-        self.runtime.spawn(Self::changes_callback(stream, callback));
+        self.runtime.spawn(Self::changes_listener(stream, listener));
     }
 
     /// Get the current state of the SAS verification process.
@@ -250,9 +242,9 @@ impl Sas {
         self.inner.state().into()
     }
 
-    async fn changes_callback(
+    async fn changes_listener(
         mut stream: impl Stream<Item = RustSasState> + std::marker::Unpin,
-        callback: Box<dyn SasListener>,
+        listener: Box<dyn SasListener>,
     ) {
         while let Some(state) = stream.next().await {
             // If we receive a done or a cancelled state we're at the end of our road, we
@@ -261,7 +253,7 @@ impl Sas {
             let should_break =
                 matches!(state, RustSasState::Done { .. } | RustSasState::Cancelled { .. });
 
-            callback.on_change(state.into());
+            listener.on_change(state.into());
 
             if should_break {
                 break;
@@ -270,10 +262,55 @@ impl Sas {
     }
 }
 
+/// Listener that will be passed over the FFI to report changes to a QrCode
+/// verification.
+pub trait QrCodeListener: Send {
+    /// The callback that should be called on the Rust side
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - The current state of the QrCode verification.
+    fn on_change(&self, state: QrCodeState);
+}
+
+/// An Enum describing the state the QrCode verification is in.
+pub enum QrCodeState {
+    /// The QR verification has been started.
+    Started,
+    /// The QR verification has been scanned by the other side.
+    Scanned,
+    /// The scanning of the QR code has been confirmed by us.
+    Confirmed,
+    /// We have successfully scanned the QR code and are able to send a
+    /// reciprocation event.
+    Reciprocated,
+    /// The verification process has been successfully concluded.
+    Done,
+    /// The verification process has been cancelled.
+    Cancelled {
+        /// Information about the reason of the cancellation.
+        cancel_info: CancelInfo,
+    },
+}
+
+impl From<QrVerificationState> for QrCodeState {
+    fn from(value: QrVerificationState) -> Self {
+        match value {
+            QrVerificationState::Started => Self::Started,
+            QrVerificationState::Scanned => Self::Scanned,
+            QrVerificationState::Confirmed => Self::Confirmed,
+            QrVerificationState::Reciprocated => Self::Reciprocated,
+            QrVerificationState::Done { .. } => Self::Done,
+            QrVerificationState::Cancelled(c) => Self::Cancelled { cancel_info: c.into() },
+        }
+    }
+}
+
 /// The `m.qr_code.scan.v1`, `m.qr_code.show.v1`, and `m.reciprocate.v1`
 /// verification flow.
 pub struct QrCode {
     pub(crate) inner: InnerQr,
+    pub(crate) runtime: Handle,
 }
 
 impl QrCode {
@@ -366,6 +403,41 @@ impl QrCode {
     pub fn generate_qr_code(&self) -> Option<String> {
         self.inner.to_bytes().map(|data| encode_config(data, STANDARD_NO_PAD)).ok()
     }
+
+    /// Set a listener for changes in the QrCode verification process.
+    ///
+    /// The given callback will be called whenever the state changes.
+    pub fn set_changes_listener(&self, listener: Box<dyn QrCodeListener>) {
+        let stream = self.inner.changes();
+
+        self.runtime.spawn(Self::changes_listener(stream, listener));
+    }
+
+    /// Get the current state of the QrCode verification process.
+    pub fn state(&self) -> QrCodeState {
+        self.inner.state().into()
+    }
+
+    async fn changes_listener(
+        mut stream: impl Stream<Item = QrVerificationState> + std::marker::Unpin,
+        listener: Box<dyn QrCodeListener>,
+    ) {
+        while let Some(state) = stream.next().await {
+            // If we receive a done or a cancelled state we're at the end of our road, we
+            // break out of the loop to deallocate the stream and finish the
+            // task.
+            let should_break = matches!(
+                state,
+                QrVerificationState::Done { .. } | QrVerificationState::Cancelled { .. }
+            );
+
+            listener.on_change(state.into());
+
+            if should_break {
+                break;
+            }
+        }
+    }
 }
 
 /// Information on why a verification flow has been cancelled and by whom.
@@ -423,6 +495,45 @@ pub struct ConfirmVerificationResult {
     /// A request that will upload signatures of the verified device or user, if
     /// the verification is completed and we're able to sign devices or users
     pub signature_request: Option<SignatureUploadRequest>,
+}
+
+/// Listener that will be passed over the FFI to report changes to a
+/// verification request.
+pub trait VerificationRequestListener: Send {
+    /// The callback that should be called on the Rust side
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - The current state of the verification request.
+    fn on_change(&self, state: VerificationRequestState);
+}
+
+/// An Enum describing the state the QrCode verification is in.
+pub enum VerificationRequestState {
+    /// The verification request was sent
+    Requested,
+    /// The verification request is ready to start a verification flow.
+    Ready,
+    /// The verification flow that was started with this request has finished.
+    Done,
+    /// The verification process has been cancelled.
+    Cancelled {
+        /// Information about the reason of the cancellation.
+        cancel_info: CancelInfo,
+    },
+}
+
+impl From<RustVerificationRequestState> for VerificationRequestState {
+    fn from(value: RustVerificationRequestState) -> Self {
+        match value {
+            // The clients do not need to distinguish `Created` and `Requested` state
+            RustVerificationRequestState::Created { .. } => Self::Requested,
+            RustVerificationRequestState::Requested { .. } => Self::Requested,
+            RustVerificationRequestState::Ready { .. } => Self::Ready,
+            RustVerificationRequestState::Done => Self::Done,
+            RustVerificationRequestState::Cancelled(c) => Self::Cancelled { cancel_info: c.into() },
+        }
+    }
 }
 
 /// The verificatoin request object which then can transition into some concrete
@@ -559,7 +670,7 @@ impl VerificationRequest {
         Ok(self
             .runtime
             .block_on(self.inner.generate_qr_code())?
-            .map(|qr| QrCode { inner: qr }.into()))
+            .map(|qr| QrCode { inner: qr, runtime: self.runtime.clone() }.into()))
     }
 
     /// Pass data from a scanned QR code to an active verification request and
@@ -585,9 +696,48 @@ impl VerificationRequest {
         if let Some(qr) = self.runtime.block_on(self.inner.scan_qr_code(data)).ok()? {
             let request = qr.reciprocate()?;
 
-            Some(ScanResult { qr: QrCode { inner: qr }.into(), request: request.into() })
+            Some(ScanResult {
+                qr: QrCode { inner: qr, runtime: self.runtime.clone() }.into(),
+                request: request.into(),
+            })
         } else {
             None
+        }
+    }
+
+    /// Set a listener for changes in the verification request
+    ///
+    /// The given callback will be called whenever the state changes.
+    pub fn set_changes_listener(&self, listener: Box<dyn VerificationRequestListener>) {
+        let stream = self.inner.changes();
+
+        self.runtime.spawn(Self::changes_listener(stream, listener));
+    }
+
+    /// Get the current state of the verification request.
+    pub fn state(&self) -> VerificationRequestState {
+        self.inner.state().into()
+    }
+
+    async fn changes_listener(
+        mut stream: impl Stream<Item = RustVerificationRequestState> + std::marker::Unpin,
+        listener: Box<dyn VerificationRequestListener>,
+    ) {
+        while let Some(state) = stream.next().await {
+            // If we receive a done or a cancelled state we're at the end of our road, we
+            // break out of the loop to deallocate the stream and finish the
+            // task.
+            let should_break = matches!(
+                state,
+                RustVerificationRequestState::Done { .. }
+                    | RustVerificationRequestState::Cancelled { .. }
+            );
+
+            listener.on_change(state.into());
+
+            if should_break {
+                break;
+            }
         }
     }
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -513,7 +513,13 @@ pub enum VerificationRequestState {
     /// The verification request was sent
     Requested,
     /// The verification request is ready to start a verification flow.
-    Ready,
+    Ready {
+        /// The verification methods supported by the other side.
+        their_methods: Vec<String>,
+
+        /// The verification methods supported by the us.
+        our_methods: Vec<String>,
+    },
     /// The verification flow that was started with this request has finished.
     Done,
     /// The verification process has been cancelled.
@@ -529,7 +535,14 @@ impl From<RustVerificationRequestState> for VerificationRequestState {
             // The clients do not need to distinguish `Created` and `Requested` state
             RustVerificationRequestState::Created { .. } => Self::Requested,
             RustVerificationRequestState::Requested { .. } => Self::Requested,
-            RustVerificationRequestState::Ready { .. } => Self::Ready,
+            RustVerificationRequestState::Ready {
+                their_methods,
+                our_methods,
+                other_device_id: _,
+            } => Self::Ready {
+                their_methods: their_methods.iter().map(|m| m.to_string()).collect(),
+                our_methods: our_methods.iter().map(|m| m.to_string()).collect(),
+            },
             RustVerificationRequestState::Done => Self::Done,
             RustVerificationRequestState::Cancelled(c) => Self::Cancelled { cancel_info: c.into() },
         }

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -89,10 +89,10 @@ pub use requests::{
 pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretImportError, SecretInfo};
 pub use verification::{
     format_emojis, AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString, Sas,
-    SasState, Verification, VerificationRequest,
+    SasState, Verification, VerificationRequest, VerificationRequestState,
 };
 #[cfg(feature = "qrcode")]
-pub use verification::{QrVerification, ScanError};
+pub use verification::{QrVerification, QrVerificationState, ScanError};
 
 /// Re-exported Error types from the [vodozemac](https://crates.io/crates/vodozemac) crate.
 pub mod vodozemac {

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -26,8 +26,8 @@ use event_enums::OutgoingContent;
 pub use machine::VerificationMachine;
 use matrix_sdk_common::locks::Mutex;
 #[cfg(feature = "qrcode")]
-pub use qrcode::{QrVerification, ScanError};
-pub use requests::VerificationRequest;
+pub use qrcode::{QrVerification, QrVerificationState, ScanError};
+pub use requests::{VerificationRequest, VerificationRequestState};
 #[cfg(feature = "qrcode")]
 use ruma::events::key::verification::done::{
     KeyVerificationDoneEventContent, ToDeviceKeyVerificationDoneEventContent,

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
+use futures_core::Stream;
+use futures_signals::signal::{Mutable, SignalExt};
+use futures_util::StreamExt;
 use matrix_sdk_qrcode::{
     qrcode::QrCode, EncodingError, QrVerificationData, SelfVerificationData,
     SelfVerificationNoMasterKey, VerificationData,
@@ -88,12 +91,51 @@ pub enum ScanError {
     },
 }
 
+/// An Enum describing the state the QrCode verification is in.
+#[derive(Debug, Clone)]
+pub enum QrVerificationState {
+    /// The QR verification has been started.
+    Started,
+    /// The QR verification has been scanned by the other side.
+    Scanned,
+    /// The scanning of the QR code has been confirmed by us.
+    Confirmed,
+    /// We have successfully scanned the QR code and are able to send a
+    /// reciprocation event.
+    Reciprocated,
+    /// The verification process has been successfully concluded.
+    Done {
+        /// The list of devices that has been verified.
+        verified_devices: Vec<ReadOnlyDevice>,
+        /// The list of user identities that has been verified.
+        verified_identities: Vec<ReadOnlyUserIdentities>,
+    },
+    /// The verification process has been cancelled.
+    Cancelled(CancelInfo),
+}
+
+impl From<&InnerState> for QrVerificationState {
+    fn from(value: &InnerState) -> Self {
+        match value {
+            InnerState::Created(_) => Self::Started,
+            InnerState::Scanned(_) => Self::Scanned,
+            InnerState::Confirmed(_) => Self::Confirmed,
+            InnerState::Reciprocated(_) => Self::Reciprocated,
+            InnerState::Done(s) => Self::Done {
+                verified_devices: s.state.verified_devices.to_vec(),
+                verified_identities: s.state.verified_master_keys.to_vec(),
+            },
+            InnerState::Cancelled(s) => Self::Cancelled(s.state.to_owned().into()),
+        }
+    }
+}
+
 /// An object controlling QR code style key verification flows.
 #[derive(Clone)]
 pub struct QrVerification {
     flow_id: FlowId,
     inner: Arc<QrVerificationData>,
-    state: Arc<Mutex<InnerState>>,
+    state: Arc<Mutable<InnerState>>,
     identities: IdentitiesBeingVerified,
     request_handle: Option<RequestHandle>,
     we_started: bool,
@@ -104,7 +146,7 @@ impl std::fmt::Debug for QrVerification {
         f.debug_struct("QrVerification")
             .field("flow_id", &self.flow_id)
             .field("inner", self.inner.as_ref())
-            .field("state", &self.state.lock().unwrap())
+            .field("state", &self.state.lock_ref())
             .finish()
     }
 }
@@ -115,12 +157,12 @@ impl QrVerification {
     /// When the verification object is in this state it's required that the
     /// user confirms that the other side has scanned the QR code.
     pub fn has_been_scanned(&self) -> bool {
-        matches!(&*self.state.lock().unwrap(), InnerState::Scanned(_))
+        matches!(&*self.state.lock_ref(), InnerState::Scanned(_))
     }
 
     /// Has the scanning of the QR code been confirmed by us.
     pub fn has_been_confirmed(&self) -> bool {
-        matches!(&*self.state.lock().unwrap(), InnerState::Confirmed(_))
+        matches!(&*self.state.lock_ref(), InnerState::Confirmed(_))
     }
 
     /// Get our own user id.
@@ -147,7 +189,7 @@ impl QrVerification {
     /// Get info about the cancellation if the verification flow has been
     /// cancelled.
     pub fn cancel_info(&self) -> Option<CancelInfo> {
-        if let InnerState::Cancelled(c) = &*self.state.lock().unwrap() {
+        if let InnerState::Cancelled(c) = &*self.state.lock_ref() {
             Some(c.state.clone().into())
         } else {
             None
@@ -156,12 +198,12 @@ impl QrVerification {
 
     /// Has the verification flow completed.
     pub fn is_done(&self) -> bool {
-        matches!(&*self.state.lock().unwrap(), InnerState::Done(_))
+        matches!(&*self.state.lock_ref(), InnerState::Done(_))
     }
 
     /// Has the verification flow been cancelled.
     pub fn is_cancelled(&self) -> bool {
-        matches!(&*self.state.lock().unwrap(), InnerState::Cancelled(_))
+        matches!(&*self.state.lock_ref(), InnerState::Cancelled(_))
     }
 
     /// Is this a verification that is veryfying one of our own devices
@@ -172,7 +214,7 @@ impl QrVerification {
     /// Have we successfully scanned the QR code and are able to send a
     /// reciprocation event.
     pub fn reciprocated(&self) -> bool {
-        matches!(&*self.state.lock().unwrap(), InnerState::Reciprocated(_))
+        matches!(&*self.state.lock_ref(), InnerState::Reciprocated(_))
     }
 
     /// Get the unique ID that identifies this QR code verification flow.
@@ -226,7 +268,7 @@ impl QrVerification {
     ///
     /// [`cancel()`]: #method.cancel
     pub fn cancel_with_code(&self, code: CancelCode) -> Option<OutgoingVerificationRequest> {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self.state.lock_mut();
 
         if let Some(request) = &self.request_handle {
             request.cancel_with_code(&code);
@@ -254,7 +296,7 @@ impl QrVerification {
     /// This will return some `OutgoingContent` if the object is in the correct
     /// state to start the verification flow, otherwise `None`.
     pub fn reciprocate(&self) -> Option<OutgoingVerificationRequest> {
-        match &*self.state.lock().unwrap() {
+        match &*self.state.lock_ref() {
             InnerState::Reciprocated(s) => {
                 Some(self.content_to_request(s.as_content(self.flow_id())))
             }
@@ -268,7 +310,7 @@ impl QrVerification {
 
     /// Confirm that the other side has scanned our QR code.
     pub fn confirm_scanning(&self) -> Option<OutgoingVerificationRequest> {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self.state.lock_mut();
 
         match &*state {
             InnerState::Scanned(s) => {
@@ -324,7 +366,8 @@ impl QrVerification {
                 VerificationResult::SignatureUpload(s) => (None, Some(s)),
             };
 
-        *self.state.lock().unwrap() = new_state;
+        let mut guard = self.state.lock_mut();
+        *guard = new_state;
 
         Ok((content.map(|c| self.content_to_request(c)), request))
     }
@@ -336,7 +379,7 @@ impl QrVerification {
         (Option<OutgoingVerificationRequest>, Option<SignatureUploadRequest>),
         CryptoStoreError,
     > {
-        let state = (*self.state.lock().unwrap()).clone();
+        let state = (*self.state.lock_ref()).clone();
 
         Ok(match state {
             InnerState::Confirmed(s) => {
@@ -389,7 +432,7 @@ impl QrVerification {
         &self,
         content: &StartContent<'_>,
     ) -> Option<OutgoingVerificationRequest> {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self.state.lock_mut();
 
         match &*state {
             InnerState::Created(s) => match s.clone().receive_reciprocate(content) {
@@ -413,7 +456,7 @@ impl QrVerification {
 
     pub(crate) fn receive_cancel(&self, sender: &UserId, content: &CancelContent<'_>) {
         if sender == self.other_user_id() {
-            let mut state = self.state.lock().unwrap();
+            let mut state = self.state.lock_mut();
 
             let new_state = match &*state {
                 InnerState::Created(s) => s.clone().into_cancelled(content),
@@ -587,7 +630,7 @@ impl QrVerification {
         Ok(Self {
             flow_id,
             inner: qr_code.into(),
-            state: Mutex::new(InnerState::Reciprocated(QrState {
+            state: Mutable::new(InnerState::Reciprocated(QrState {
                 state: Reciprocated { secret, own_device_id },
             }))
             .into(),
@@ -609,11 +652,26 @@ impl QrVerification {
         Self {
             flow_id,
             inner: inner.into(),
-            state: Mutex::new(InnerState::Created(QrState { state: Created { secret } })).into(),
+            state: Mutable::new(InnerState::Created(QrState { state: Created { secret } })).into(),
             identities,
             we_started,
             request_handle,
         }
+    }
+
+    /// Listen for changes in the QrCode verification process.
+    ///
+    /// The changes are presented as a stream of [`QrVerificationState`] values.
+    pub fn changes(&self) -> impl Stream<Item = QrVerificationState> {
+        self.state.signal_cloned().to_stream().map(|s| (&s).into())
+    }
+
+    /// Get the current state the verification process is in.
+    ///
+    /// To listen to changes to the [`QrVerificationState`] use the
+    /// [`QrVerification::changes`] method.
+    pub fn state(&self) -> QrVerificationState {
+        (&*self.state.lock_ref()).into()
     }
 }
 
@@ -789,6 +847,7 @@ impl QrState<Reciprocated> {
 mod tests {
     use std::sync::Arc;
 
+    use matches::assert_matches;
     use matrix_sdk_common::locks::Mutex;
     use matrix_sdk_qrcode::QrVerificationData;
     use matrix_sdk_test::async_test;
@@ -801,7 +860,7 @@ mod tests {
             event_enums::{DoneContent, OutgoingContent, StartContent},
             FlowId, VerificationStore,
         },
-        QrVerification, ReadOnlyDevice,
+        QrVerification, QrVerificationState, ReadOnlyDevice,
     };
 
     fn user_id() -> &'static UserId {
@@ -847,6 +906,7 @@ mod tests {
             None,
         );
 
+        assert_matches!(verification.state(), QrVerificationState::Started);
         assert_eq!(verification.inner.first_key(), device_key);
         assert_eq!(verification.inner.second_key(), master_key);
 
@@ -859,6 +919,7 @@ mod tests {
             None,
         );
 
+        assert_matches!(verification.state(), QrVerificationState::Started);
         assert_eq!(verification.inner.first_key(), master_key);
         assert_eq!(verification.inner.second_key(), device_key);
 
@@ -873,6 +934,7 @@ mod tests {
         let verification =
             QrVerification::new_cross(flow_id, master_key, bob_master_key, identities, false, None);
 
+        assert_matches!(verification.state(), QrVerificationState::Started);
         assert_eq!(verification.inner.first_key(), master_key);
         assert_eq!(verification.inner.second_key(), bob_master_key);
     }
@@ -918,6 +980,7 @@ mod tests {
                 false,
                 None,
             );
+            assert_matches!(alice_verification.state(), QrVerificationState::Started);
 
             let bob_store = memory_store();
 
@@ -949,12 +1012,17 @@ mod tests {
             .unwrap();
 
             let request = bob_verification.reciprocate().unwrap();
+            assert_matches!(bob_verification.state(), QrVerificationState::Reciprocated);
+
             let content = OutgoingContent::try_from(request).unwrap();
             let content = StartContent::try_from(&content).unwrap();
 
             alice_verification.receive_reciprocation(&content);
+            assert_matches!(alice_verification.state(), QrVerificationState::Scanned);
 
             let request = alice_verification.confirm_scanning().unwrap();
+            assert_matches!(alice_verification.state(), QrVerificationState::Confirmed);
+
             let content = OutgoingContent::try_from(request).unwrap();
             let content = DoneContent::try_from(&content).unwrap();
 
@@ -966,6 +1034,8 @@ mod tests {
             let content = DoneContent::try_from(&content).unwrap();
             alice_verification.receive_done(&content).await.unwrap();
 
+            assert_matches!(alice_verification.state(), QrVerificationState::Done { .. });
+            assert_matches!(bob_verification.state(), QrVerificationState::Done { .. });
             assert!(alice_verification.is_done());
             assert!(bob_verification.is_done());
 


### PR DESCRIPTION
This change is a continuation of adding signalling to [SAS verification](https://github.com/matrix-org/matrix-rust-sdk/pull/1184), adding `changes` stream to `VerificationRequest` and `QrCode`