### PR TITLE
refactor: Don't reserialize member events before storing them

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -893,8 +893,12 @@ mod test {
             heroes: vec![me.to_string(), matthew.to_string()],
         });
 
-        changes.add_stripped_member(room_id, make_stripped_member_event(matthew, "Matthew"));
-        changes.add_stripped_member(room_id, make_stripped_member_event(me, "Me"));
+        changes.add_stripped_member(
+            room_id,
+            matthew,
+            make_stripped_member_event(matthew, "Matthew"),
+        );
+        changes.add_stripped_member(room_id, me, make_stripped_member_event(me, "Me"));
         store.save_changes(&changes).await.unwrap();
 
         room.inner.write().unwrap().update_summary(&summary);
@@ -912,8 +916,12 @@ mod test {
         let me = user_id!("@me:example.org");
         let mut changes = StateChanges::new("".to_owned());
 
-        changes.add_stripped_member(room_id, make_stripped_member_event(matthew, "Matthew"));
-        changes.add_stripped_member(room_id, make_stripped_member_event(me, "Me"));
+        changes.add_stripped_member(
+            room_id,
+            matthew,
+            make_stripped_member_event(matthew, "Matthew"),
+        );
+        changes.add_stripped_member(room_id, me, make_stripped_member_event(me, "Me"));
         store.save_changes(&changes).await.unwrap();
 
         assert_eq!(

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -426,9 +426,10 @@ impl Room {
     /// return a `RoomMember` that can be in a joined, invited, left, banned
     /// state.
     pub async fn get_member(&self, user_id: &UserId) -> StoreResult<Option<RoomMember>> {
-        let Some(member_event) = self.store.get_member_event(self.room_id(), user_id).await? else {
+        let Some(raw_event) = self.store.get_member_event(self.room_id(), user_id).await? else {
             return Ok(None);
         };
+        let member_event = raw_event.deserialize()?;
 
         let presence =
             self.store.get_presence_event(user_id).await?.and_then(|e| e.deserialize().ok());
@@ -788,17 +789,19 @@ mod test {
     use assign::assign;
     use matrix_sdk_test::async_test;
     use ruma::{
-        event_id,
         events::room::{
             canonical_alias::RoomCanonicalAliasEventContent,
             member::{
-                MembershipState, OriginalSyncRoomMemberEvent, RoomMemberEventContent,
-                RoomMemberUnsigned, StrippedRoomMemberEvent, SyncRoomMemberEvent,
+                MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent,
+                SyncRoomMemberEvent,
             },
             name::RoomNameEventContent,
         },
-        room_alias_id, room_id, user_id, MilliSecondsSinceUnixEpoch,
+        room_alias_id, room_id,
+        serde::Raw,
+        user_id,
     };
+    use serde_json::json;
 
     use super::*;
     use crate::{
@@ -814,27 +817,32 @@ mod test {
         (store.clone(), Room::new(user_id, store, room_id, room_type))
     }
 
-    fn make_stripped_member_event(user_id: &UserId, name: &str) -> StrippedRoomMemberEvent {
-        StrippedRoomMemberEvent {
-            content: assign!(RoomMemberEventContent::new(MembershipState::Join), {
+    fn make_stripped_member_event(user_id: &UserId, name: &str) -> Raw<StrippedRoomMemberEvent> {
+        let ev_json = json!({
+            "type": "m.room.member",
+            "content": assign!(RoomMemberEventContent::new(MembershipState::Join), {
                 displayname: Some(name.to_owned())
             }),
-            sender: user_id.to_owned(),
-            state_key: user_id.to_owned(),
-        }
+            "sender": user_id,
+            "state_key": user_id,
+        });
+
+        Raw::new(&ev_json).unwrap().cast()
     }
 
-    fn make_member_event(user_id: &UserId, name: &str) -> SyncRoomMemberEvent {
-        SyncRoomMemberEvent::Original(OriginalSyncRoomMemberEvent {
-            content: assign!(RoomMemberEventContent::new(MembershipState::Join), {
+    fn make_member_event(user_id: &UserId, name: &str) -> Raw<SyncRoomMemberEvent> {
+        let ev_json = json!({
+            "type": "m.room.member",
+            "content": assign!(RoomMemberEventContent::new(MembershipState::Join), {
                 displayname: Some(name.to_owned())
             }),
-            sender: user_id.to_owned(),
-            state_key: user_id.to_owned(),
-            event_id: event_id!("$h29iv0s1:example.com").to_owned(),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(208u32.into()),
-            unsigned: RoomMemberUnsigned::default(),
-        })
+            "sender": user_id,
+            "state_key": user_id,
+            "event_id": "$h29iv0s1:example.com",
+            "origin_server_ts": 208,
+        });
+
+        Raw::new(&ev_json).unwrap().cast()
     }
 
     #[async_test]

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -137,8 +137,8 @@ macro_rules! statestore_integration_tests {
                 receipt::ReceiptType,
                 room::{
                     member::{
-                        MembershipState, OriginalSyncRoomMemberEvent, RoomMemberEventContent,
-                        RoomMemberUnsigned, StrippedRoomMemberEvent, SyncRoomMemberEvent,
+                        MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent,
+                        SyncRoomMemberEvent,
                     },
                     power_levels::RoomPowerLevelsEventContent,
                     topic::{RoomTopicEventContent, OriginalRoomTopicEvent, RedactedRoomTopicEvent},
@@ -150,7 +150,7 @@ macro_rules! statestore_integration_tests {
             },
             room_id,
             serde::Raw,
-            user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, UserId,
+            user_id, EventId,  OwnedEventId, RoomId, UserId,
         };
         use serde_json::{json, Value as JsonValue};
 
@@ -241,7 +241,7 @@ macro_rules! statestore_integration_tests {
             room_ambiguity_map
                 .insert(displayname.clone(), BTreeSet::from([user_id.to_owned()]));
             room_profiles.insert(user_id.to_owned(), (&member_event).into());
-            room_members.insert(user_id.to_owned(), member_event);
+            room_members.insert(user_id.to_owned(), Raw::new(&member_event).unwrap().cast());
 
             let member_state_raw =
                 serde_json::from_value::<Raw<AnySyncStateEvent>>(member_json.clone()).unwrap();
@@ -257,7 +257,10 @@ macro_rules! statestore_integration_tests {
                 .or_default()
                 .insert(invited_user_id.to_owned());
             room_profiles.insert(invited_user_id.to_owned(), (&invited_member_event).into());
-            room_members.insert(invited_user_id.to_owned(), invited_member_event);
+            room_members.insert(
+                invited_user_id.to_owned(),
+                Raw::new(&invited_member_event).unwrap().cast(),
+            );
 
             let invited_member_state_raw =
                 serde_json::from_value::<Raw<AnySyncStateEvent>>(invited_member_json.clone())
@@ -307,9 +310,7 @@ macro_rules! statestore_integration_tests {
             changes.add_stripped_room(stripped_room);
 
             let stripped_member_json: &JsonValue = &test_json::MEMBER_STRIPPED;
-            let stripped_member_event =
-                serde_json::from_value::<StrippedRoomMemberEvent>(stripped_member_json.clone())
-                    .unwrap();
+            let stripped_member_event = Raw::new(&stripped_member_json.clone()).unwrap().cast();
             changes.add_stripped_member(stripped_room_id, stripped_member_event);
 
             store.save_changes(&changes).await?;
@@ -331,34 +332,39 @@ macro_rules! statestore_integration_tests {
             serde_json::from_value(event).unwrap()
         }
 
-            fn stripped_membership_event() -> StrippedRoomMemberEvent {
-                custom_stripped_membership_event(user_id())
-            }
-
-        fn custom_stripped_membership_event(user_id: &UserId) -> StrippedRoomMemberEvent {
-            StrippedRoomMemberEvent {
-                content: RoomMemberEventContent::new(MembershipState::Join),
-                sender: user_id.to_owned(),
-                state_key: user_id.to_owned(),
-            }
+        fn stripped_membership_event() -> Raw<StrippedRoomMemberEvent> {
+            custom_stripped_membership_event(user_id())
         }
 
-        fn membership_event() -> SyncRoomMemberEvent {
+        fn custom_stripped_membership_event(user_id: &UserId) -> Raw<StrippedRoomMemberEvent> {
+            let ev_json = json!({
+                "type": "m.room.member",
+                "content": RoomMemberEventContent::new(MembershipState::Join),
+                "sender": user_id,
+                "state_key": user_id,
+            });
+
+            Raw::new(&ev_json).unwrap().cast()
+        }
+
+        fn membership_event() -> Raw<SyncRoomMemberEvent> {
             custom_membership_event(user_id(), event_id!("$h29iv0s8:example.com").to_owned())
         }
 
         fn custom_membership_event(
             user_id: &UserId,
             event_id: OwnedEventId,
-        ) -> SyncRoomMemberEvent {
-            SyncRoomMemberEvent::Original(OriginalSyncRoomMemberEvent {
-                event_id,
-                content: RoomMemberEventContent::new(MembershipState::Join),
-                sender: user_id.to_owned(),
-                origin_server_ts: MilliSecondsSinceUnixEpoch(198u32.into()),
-                state_key: user_id.to_owned(),
-                unsigned: RoomMemberUnsigned::default(),
-            })
+        ) -> Raw<SyncRoomMemberEvent> {
+            let ev_json = json!({
+                "type": "m.room.member",
+                "content": RoomMemberEventContent::new(MembershipState::Join),
+                "event_id": event_id,
+                "origin_server_ts": 198,
+                "sender": user_id,
+                "state_key": user_id,
+            });
+
+            Raw::new(&ev_json).unwrap().cast()
         }
 
         #[async_test]
@@ -715,10 +721,14 @@ macro_rules! statestore_integration_tests {
             changes.add_room(RoomInfo::new(room_id, RoomType::Left));
             store.save_changes(&changes).await.unwrap();
 
-            assert!(matches!(
-                store.get_member_event(room_id, user_id).await.unwrap(),
-                Some($crate::deserialized_responses::MemberEvent::Sync(_))
-            ));
+            let member_event = store
+                .get_member_event(room_id, user_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .deserialize()
+                .unwrap();
+            assert!(matches!(member_event, $crate::deserialized_responses::MemberEvent::Sync(_)));
             assert_eq!(store.get_room_infos().await.unwrap().len(), 1);
             assert_eq!(store.get_stripped_room_infos().await.unwrap().len(), 0);
 
@@ -730,10 +740,16 @@ macro_rules! statestore_integration_tests {
             changes.add_stripped_room(RoomInfo::new(room_id, RoomType::Invited));
             store.save_changes(&changes).await.unwrap();
 
-            assert!(matches!(
-                store.get_member_event(room_id, user_id).await.unwrap(),
-                Some($crate::deserialized_responses::MemberEvent::Stripped(_))
-            ));
+            let member_event = store
+                .get_member_event(room_id, user_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .deserialize()
+                .unwrap();
+            assert!(
+                matches!(member_event, $crate::deserialized_responses::MemberEvent::Stripped(_))
+            );
             assert_eq!(store.get_room_infos().await.unwrap().len(), 0);
             assert_eq!(store.get_stripped_room_infos().await.unwrap().len(), 1);
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -311,7 +311,7 @@ macro_rules! statestore_integration_tests {
 
             let stripped_member_json: &JsonValue = &test_json::MEMBER_STRIPPED;
             let stripped_member_event = Raw::new(&stripped_member_json.clone()).unwrap().cast();
-            changes.add_stripped_member(stripped_room_id, stripped_member_event);
+            changes.add_stripped_member(stripped_room_id, user_id, stripped_member_event);
 
             store.save_changes(&changes).await?;
             Ok(())
@@ -736,7 +736,7 @@ macro_rules! statestore_integration_tests {
             assert_eq!(members, vec![user_id.to_owned()]);
 
             let mut changes = StateChanges::default();
-            changes.add_stripped_member(room_id, custom_stripped_membership_event(user_id));
+            changes.add_stripped_member(room_id, user_id, custom_stripped_membership_event(user_id));
             changes.add_stripped_room(RoomInfo::new(room_id, RoomType::Invited));
             store.save_changes(&changes).await.unwrap();
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -68,7 +68,7 @@ use serde::de::DeserializeOwned;
 pub type BoxStream<T> = Pin<Box<dyn futures_util::Stream<Item = T> + Send>>;
 
 use crate::{
-    deserialized_responses::MemberEvent,
+    deserialized_responses::RawMemberEvent,
     media::MediaRequest,
     rooms::{RoomInfo, RoomType},
     MinimalRoomMemberEvent, Room, Session, SessionMeta, SessionTokens,
@@ -222,7 +222,7 @@ pub trait StateStore: AsyncTraitDeps {
         &self,
         room_id: &RoomId,
         state_key: &UserId,
-    ) -> Result<Option<MemberEvent>>;
+    ) -> Result<Option<RawMemberEvent>>;
 
     /// Get all the user ids of members for a given room, for stripped and
     /// regular rooms alike.
@@ -677,7 +677,7 @@ pub struct StateChanges {
     pub presence: BTreeMap<OwnedUserId, Raw<PresenceEvent>>,
 
     /// A mapping of `RoomId` to a map of users and their `SyncRoomMemberEvent`.
-    pub members: BTreeMap<OwnedRoomId, BTreeMap<OwnedUserId, SyncRoomMemberEvent>>,
+    pub members: BTreeMap<OwnedRoomId, BTreeMap<OwnedUserId, Raw<SyncRoomMemberEvent>>>,
     /// A mapping of `RoomId` to a map of users and their
     /// `MinimalRoomMemberEvent`.
     pub profiles: BTreeMap<OwnedRoomId, BTreeMap<OwnedUserId, MinimalRoomMemberEvent>>,
@@ -706,7 +706,8 @@ pub struct StateChanges {
     >,
     /// A mapping of `RoomId` to a map of users and their
     /// `StrippedRoomMemberEvent`.
-    pub stripped_members: BTreeMap<OwnedRoomId, BTreeMap<OwnedUserId, StrippedRoomMemberEvent>>,
+    pub stripped_members:
+        BTreeMap<OwnedRoomId, BTreeMap<OwnedUserId, Raw<StrippedRoomMemberEvent>>>,
     /// A map of `RoomId` to `RoomInfo` for stripped rooms (e.g. for invites or
     /// while knocking)
     pub stripped_room_infos: BTreeMap<OwnedRoomId, RoomInfo>,
@@ -764,9 +765,9 @@ impl StateChanges {
 
     /// Update the `StateChanges` struct with the given room with a new
     /// `StrippedMemberEvent`.
-    pub fn add_stripped_member(&mut self, room_id: &RoomId, event: StrippedRoomMemberEvent) {
-        let user_id = event.state_key.clone();
-
+    pub fn add_stripped_member(&mut self, room_id: &RoomId, event: Raw<StrippedRoomMemberEvent>) {
+        let user_id =
+            event.get_field("state_key").expect("TODO deser fail").expect("TODO no state_key");
         self.stripped_members.entry(room_id.to_owned()).or_default().insert(user_id, event);
     }
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -765,10 +765,16 @@ impl StateChanges {
 
     /// Update the `StateChanges` struct with the given room with a new
     /// `StrippedMemberEvent`.
-    pub fn add_stripped_member(&mut self, room_id: &RoomId, event: Raw<StrippedRoomMemberEvent>) {
-        let user_id =
-            event.get_field("state_key").expect("TODO deser fail").expect("TODO no state_key");
-        self.stripped_members.entry(room_id.to_owned()).or_default().insert(user_id, event);
+    pub fn add_stripped_member(
+        &mut self,
+        room_id: &RoomId,
+        user_id: &UserId,
+        event: Raw<StrippedRoomMemberEvent>,
+    ) {
+        self.stripped_members
+            .entry(room_id.to_owned())
+            .or_default()
+            .insert(user_id.to_owned(), event);
     }
 
     /// Update the `StateChanges` struct with the given room with a new

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -123,6 +123,25 @@ impl MinimalRoomMemberEvent {
     }
 }
 
+impl<C> From<SyncStateEvent<C>> for MinimalStateEvent<C>
+where
+    C: StateEventContent + RedactContent,
+    C::Redacted: RedactedStateEventContent,
+{
+    fn from(ev: SyncStateEvent<C>) -> Self {
+        match ev {
+            SyncStateEvent::Original(ev) => Self::Original(OriginalMinimalStateEvent {
+                content: ev.content,
+                event_id: Some(ev.event_id),
+            }),
+            SyncStateEvent::Redacted(ev) => Self::Redacted(RedactedMinimalStateEvent {
+                content: ev.content,
+                event_id: Some(ev.event_id),
+            }),
+        }
+    }
+}
+
 impl<C> From<&SyncStateEvent<C>> for MinimalStateEvent<C>
 where
     C: Clone + StateEventContent + RedactContent,

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -24,7 +24,7 @@ use derive_builder::Builder;
 use futures_core::stream::Stream;
 use futures_util::stream::{self, StreamExt, TryStreamExt};
 use matrix_sdk_base::{
-    deserialized_responses::MemberEvent,
+    deserialized_responses::RawMemberEvent,
     media::{MediaRequest, UniqueKey},
     store::{Result as StoreResult, StateChanges, StateStore, StoreError},
     MinimalStateEvent, RoomInfo,
@@ -550,10 +550,18 @@ impl SledStateStore {
                     stripped_members,
                     stripped_state,
                 )| {
-                    for (room, events) in &changes.members {
+                    for (room, raw_events) in &changes.members {
                         let profile_changes = changes.profiles.get(room);
 
-                        for event in events.values() {
+                        for raw_event in raw_events.values() {
+                            let event = match raw_event.deserialize() {
+                                Ok(ev) => ev,
+                                Err(e) => {
+                                    debug!(event = ?raw_event, "Failed to deserialize event: {e}");
+                                    continue;
+                                }
+                            };
+
                             let key = (room, event.state_key());
 
                             stripped_joined
@@ -586,7 +594,7 @@ impl SledStateStore {
 
                             members.insert(
                                 self.encode_key(MEMBER, key),
-                                self.serialize_value(&event)
+                                self.serialize_value(&raw_event)
                                     .map_err(ConflictableTransactionError::Abort)?,
                             )?;
                             stripped_members.remove(self.encode_key(STRIPPED_ROOM_MEMBER, key))?;
@@ -657,8 +665,16 @@ impl SledStateStore {
                         rooms.remove(self.encode_key(ROOM, room_id))?;
                     }
 
-                    for (room, events) in &changes.stripped_members {
-                        for event in events.values() {
+                    for (room, raw_events) in &changes.stripped_members {
+                        for raw_event in raw_events.values() {
+                            let event = match raw_event.deserialize() {
+                                Ok(ev) => ev,
+                                Err(e) => {
+                                    debug!(event = ?raw_event, "Failed to deserialize event: {e}");
+                                    continue;
+                                }
+                            };
+
                             let key = (room, &event.state_key);
 
                             match event.content.membership {
@@ -689,7 +705,7 @@ impl SledStateStore {
                             }
                             stripped_members.insert(
                                 self.encode_key(STRIPPED_ROOM_MEMBER, key),
-                                self.serialize_value(&event)
+                                self.serialize_value(&raw_event)
                                     .map_err(ConflictableTransactionError::Abort)?,
                             )?;
                         }
@@ -900,7 +916,7 @@ impl SledStateStore {
         &self,
         room_id: &RoomId,
         state_key: &UserId,
-    ) -> Result<Option<MemberEvent>> {
+    ) -> Result<Option<RawMemberEvent>> {
         let db = self.clone();
         let key = self.encode_key(MEMBER, (room_id, state_key));
         let stripped_key = self.encode_key(STRIPPED_ROOM_MEMBER, (room_id, state_key));
@@ -911,11 +927,11 @@ impl SledStateStore {
                 .map(|v| db.deserialize_value(&v))
                 .transpose()?
             {
-                Ok(Some(MemberEvent::Stripped(e)))
+                Ok(Some(RawMemberEvent::Stripped(e)))
             } else if let Some(e) =
                 db.members.get(key)?.map(|v| db.deserialize_value(&v)).transpose()?
             {
-                Ok(Some(MemberEvent::Sync(e)))
+                Ok(Some(RawMemberEvent::Sync(e)))
             } else {
                 Ok(None)
             }
@@ -1377,7 +1393,7 @@ impl StateStore for SledStateStore {
         &self,
         room_id: &RoomId,
         state_key: &UserId,
-    ) -> StoreResult<Option<MemberEvent>> {
+    ) -> StoreResult<Option<RawMemberEvent>> {
         self.get_member_event(room_id, state_key).await.map_err(Into::into)
     }
 

--- a/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
@@ -112,8 +112,13 @@ async fn test_repeated_join_leave() -> Result<()> {
     let joined = karl.store().get_joined_user_ids(room_id).await?;
     assert!(!joined.contains(&karl_id));
 
-    let event =
-        karl.store().get_member_event(room_id, &karl_id).await?.expect("member event should exist");
+    let event = karl
+        .store()
+        .get_member_event(room_id, &karl_id)
+        .await?
+        .expect("member event should exist")
+        .deserialize()
+        .unwrap();
     assert_eq!(*event.membership(), MembershipState::Invite);
 
     // Yay, test succeeded


### PR DESCRIPTION
… so custom or not-yet-known fields are not discarded.