### PR TITLE
fix(doc): Fix unresolved link in documentation

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -44,7 +44,7 @@ pub enum SasState {
     /// presented to the user.
     KeysExchanged {
         /// The emojis that represent the short auth string, will be `None` if
-        /// the emoji SAS method wasn't part of the [`AcceptedProtocols`].
+        /// the emoji SAS method wasn't one of accepted protocols.
         emojis: Option<Vec<i32>>,
         /// The list of decimals that represent the short auth string.
         decimals: Vec<i32>,


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Fixed link in documentation referring to structure that isn't used in that context with a string description 
- fixes complaining documentation build

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Kateřina Churanová <k.churanova@famedly.com>
