### PR TITLE
matrix-sdk-crypto-js: Make our promises reject with `Error`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/future.rs
+++ b/bindings/matrix-sdk-crypto-js/src/future.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use js_sys::Promise;
-use wasm_bindgen::{JsValue, UnwrapThrowExt};
+use wasm_bindgen::{JsError, JsValue, UnwrapThrowExt};
 use wasm_bindgen_futures::spawn_local;
 
 pub(crate) fn future_to_promise<F, T>(future: F) -> Promise
@@ -17,9 +17,9 @@ where
         spawn_local(async move {
             match future.await {
                 Ok(value) => resolve.call1(&JsValue::UNDEFINED, &value.into()).unwrap_throw(),
-                Err(value) => {
-                    reject.call1(&JsValue::UNDEFINED, &value.to_string().into()).unwrap_throw()
-                }
+                Err(value) => reject
+                    .call1(&JsValue::UNDEFINED, &JsError::new(&value.to_string()).into())
+                    .unwrap_throw(),
             };
         });
     })

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -463,6 +463,21 @@ describe(OlmMachine.name, () => {
         });
     });
 
+    test("failure to decrypt returns a valid error", async () => {
+        const m = await machine();
+        const evt = {
+            type: "m.room.encrypted",
+            event_id: "$xxxxx:example.org",
+            origin_server_ts: Date.now(),
+            sender: user.toString(),
+            content: {
+                algorithm: "m.megolm.v1.aes-sha2",
+                ciphertext: "blah",
+            },
+        };
+        await expect(() => m.decryptRoomEvent(JSON.stringify(evt), room)).rejects.toThrowError();
+    });
+
     test('can read cross-signing status', async () => {
         const m = await machine();
         const crossSigningStatus = await m.crossSigningStatus();


### PR DESCRIPTION
It's not a hard-and-fast-rule that Javascript exceptions should be `Error` instances, but it's certainly a convention, and one that is going to reduce surprises if we follow, rather than throwing strings.
