### PR TITLE
Specify which version of wasm-pack we want

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
           override: true
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.3.0
+        uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: latest
+          version: v0.10.3
 
       - name: Load cache
         uses: Swatinem/rust-cache@v1


### PR DESCRIPTION
Otherwise the action uses the GitHub API to determine the latest release and falls back on v0.9.1. I suspect it was recently failing because of rate limits, because I saw it hit the fallback a lot.