### PR TITLE
feat(crypto-js): Request types have fields extracted from their “body” directly

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/identities.rs
+++ b/bindings/matrix-sdk-crypto-js/src/identities.rs
@@ -130,7 +130,7 @@ impl UserIdentity {
     }
 
     /// Create a `VerificationRequest` object after the verification
-    /// request content has been sent out.  }
+    /// request content has been sent out.
     #[wasm_bindgen(js_name = "requestVerification")]
     pub fn request_verification(
         &self,

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -638,8 +638,15 @@ impl OlmMachine {
     /// This method can be used to pass verification events that are happening
     /// in rooms to the `OlmMachine`. The event should be in the decrypted form.
     #[wasm_bindgen(js_name = "receiveVerificationEvent")]
-    pub fn receive_verification_event(&self, event: &str) -> Result<Promise, JsError> {
-        let event: ruma::events::AnyMessageLikeEvent = serde_json::from_str(event)?;
+    pub fn receive_verification_event(
+        &self,
+        event: &str,
+        room_id: &identifiers::RoomId,
+    ) -> Result<Promise, JsError> {
+        let room_id = room_id.inner.clone();
+        let event: ruma::events::AnySyncMessageLikeEvent = serde_json::from_str(event)?;
+        let event = event.into_full_event(room_id);
+
         let me = self.inner.clone();
 
         Ok(future_to_promise(async move {

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -39,15 +39,15 @@ pub struct KeysUploadRequest {
     /// A JSON-encoded string containing the rest of the payload: `device_keys`,
     /// `one_time_keys`, `fallback_keys`.
     #[wasm_bindgen(readonly)]
-    pub extra: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysUploadRequest {
     /// Create a new `KeysUploadRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, extra: JsString) -> KeysUploadRequest {
-        Self { id: Some(id), extra }
+    pub fn new(id: JsString, body: JsString) -> KeysUploadRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -73,15 +73,15 @@ pub struct KeysQueryRequest {
     /// A JSON-encoded string containing the rest of the payload: `timeout`,
     /// `device_keys`, `token`.
     #[wasm_bindgen(readonly)]
-    pub extra: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysQueryRequest {
     /// Create a new `KeysQueryRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, extra: JsString) -> KeysQueryRequest {
-        Self { id: Some(id), extra }
+    pub fn new(id: JsString, body: JsString) -> KeysQueryRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -108,15 +108,15 @@ pub struct KeysClaimRequest {
     /// A JSON-encoded string containing the rest of the payload: `timeout`,
     /// `one_time_keys`.
     #[wasm_bindgen(readonly)]
-    pub extra: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysClaimRequest {
     /// Create a new `KeysClaimRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, extra: JsString) -> KeysClaimRequest {
-        Self { id: Some(id), extra }
+    pub fn new(id: JsString, body: JsString) -> KeysClaimRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -150,7 +150,7 @@ pub struct ToDeviceRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `messages`.
     #[wasm_bindgen(readonly)]
-    pub extra: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
@@ -161,9 +161,9 @@ impl ToDeviceRequest {
         id: JsString,
         event_type: JsString,
         txn_id: JsString,
-        extra: JsString,
+        body: JsString,
     ) -> ToDeviceRequest {
-        Self { id: Some(id), event_type, txn_id, extra }
+        Self { id: Some(id), event_type, txn_id, body }
     }
 
     /// Get its request type.
@@ -188,15 +188,15 @@ pub struct SignatureUploadRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `signed_keys`.
     #[wasm_bindgen(readonly)]
-    pub extra: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl SignatureUploadRequest {
     /// Create a new `SignatureUploadRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, extra: JsString) -> SignatureUploadRequest {
-        Self { id: Some(id), extra }
+    pub fn new(id: JsString, body: JsString) -> SignatureUploadRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -272,15 +272,15 @@ pub struct KeysBackupRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `rooms`.
     #[wasm_bindgen(readonly)]
-    pub extra: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysBackupRequest {
     /// Create a new `KeysBackupRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, extra: JsString) -> KeysBackupRequest {
-        Self { id: Some(id), extra }
+    pub fn new(id: JsString, body: JsString) -> KeysBackupRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -305,7 +305,7 @@ pub struct SigningKeysUploadRequest {
     /// A JSON-encoded string containing the rest of the payload: `master_key`,
     /// `self_signing_key`, `user_signing_key`.
     #[wasm_bindgen(readonly)]
-    pub extra: JsString,
+    pub body: JsString,
 }
 
 macro_rules! request {
@@ -358,7 +358,7 @@ macro_rules! request {
                     )*
                 )?
                 $(
-                    extra: {
+                    body: {
                         let mut map = serde_json::Map::new();
                         $(
                             map.insert(stringify!($grouped_field_name).to_owned(), serde_json::to_value(&$request.$grouped_field_name).unwrap());

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -36,15 +36,15 @@ pub struct KeysUploadRequest {
     /// A JSON-encoded string containing the rest of the payload: `device_keys`,
     /// `one_time_keys`, `fallback_keys`.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub extra: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysUploadRequest {
     /// Create a new `KeysUploadRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> KeysUploadRequest {
-        Self { id: Some(id), body }
+    pub fn new(id: JsString, extra: JsString) -> KeysUploadRequest {
+        Self { id: Some(id), extra }
     }
 
     /// Get its request type.
@@ -70,15 +70,15 @@ pub struct KeysQueryRequest {
     /// A JSON-encoded string containing the rest of the payload: `timeout`,
     /// `device_keys`, `token`.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub extra: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysQueryRequest {
     /// Create a new `KeysQueryRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> KeysQueryRequest {
-        Self { id: Some(id), body }
+    pub fn new(id: JsString, extra: JsString) -> KeysQueryRequest {
+        Self { id: Some(id), extra }
     }
 
     /// Get its request type.
@@ -105,15 +105,15 @@ pub struct KeysClaimRequest {
     /// A JSON-encoded string containing the rest of the payload: `timeout`,
     /// `one_time_keys`.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub extra: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysClaimRequest {
     /// Create a new `KeysClaimRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> KeysClaimRequest {
-        Self { id: Some(id), body }
+    pub fn new(id: JsString, extra: JsString) -> KeysClaimRequest {
+        Self { id: Some(id), extra }
     }
 
     /// Get its request type.
@@ -147,7 +147,7 @@ pub struct ToDeviceRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `messages`.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub extra: JsString,
 }
 
 #[wasm_bindgen]
@@ -158,9 +158,9 @@ impl ToDeviceRequest {
         id: JsString,
         event_type: JsString,
         txn_id: JsString,
-        body: JsString,
+        extra: JsString,
     ) -> ToDeviceRequest {
-        Self { id: Some(id), event_type, txn_id, body }
+        Self { id: Some(id), event_type, txn_id, extra }
     }
 
     /// Get its request type.
@@ -185,15 +185,15 @@ pub struct SignatureUploadRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `signed_keys`.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub extra: JsString,
 }
 
 #[wasm_bindgen]
 impl SignatureUploadRequest {
     /// Create a new `SignatureUploadRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> SignatureUploadRequest {
-        Self { id: Some(id), body }
+    pub fn new(id: JsString, extra: JsString) -> SignatureUploadRequest {
+        Self { id: Some(id), extra }
     }
 
     /// Get its request type.
@@ -228,7 +228,7 @@ pub struct RoomMessageRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `content`.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub extra: JsString,
 }
 
 #[wasm_bindgen]
@@ -239,9 +239,9 @@ impl RoomMessageRequest {
         id: JsString,
         room_id: JsString,
         txn_id: JsString,
-        body: JsString,
+        extra: JsString,
     ) -> RoomMessageRequest {
-        Self { id: Some(id), room_id, txn_id, body }
+        Self { id: Some(id), room_id, txn_id, extra }
     }
 
     /// Get its request type.
@@ -264,15 +264,15 @@ pub struct KeysBackupRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `rooms`.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub extra: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysBackupRequest {
     /// Create a new `KeysBackupRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> KeysBackupRequest {
-        Self { id: Some(id), body }
+    pub fn new(id: JsString, extra: JsString) -> KeysBackupRequest {
+        Self { id: Some(id), extra }
     }
 
     /// Get its request type.
@@ -297,7 +297,7 @@ pub struct SigningKeysUploadRequest {
     /// A JSON-encoded string containing the rest of the payload: `master_key`,
     /// `self_signing_key`, `user_signing_key`.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub extra: JsString,
 }
 
 macro_rules! request {
@@ -350,7 +350,7 @@ macro_rules! request {
                     )*
                 )?
                 $(
-                    body: {
+                    extra: {
                         let mut map = serde_json::Map::new();
                         $(
                             map.insert(stringify!($grouped_field).to_owned(), serde_json::to_value(&$request.$grouped_field).unwrap());
@@ -364,20 +364,8 @@ macro_rules! request {
         }
     };
 
-    ( @__field as json (request = $request:expr, field = $field:ident) ) => {
-        serde_json::to_string(&$request.$field)?.into()
-    };
-
     ( @__field as string (request = $request:expr, field = $field:ident) ) => {
         $request.$field.to_string().into()
-    };
-
-    ( @__field as duration (request = $request:expr, field = $field:ident) ) => {
-        $request.$field.map(|duration| duration.as_millis() as u64)
-    };
-
-    ( @__field as native (request = $request:expr, field = $field:ident) ) => {
-        $request.$field.clone()
     };
 }
 

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -243,8 +243,8 @@ pub struct RoomMessageRequest {
     #[wasm_bindgen(readonly)]
     pub event_type: JsString,
 
-    /// A JSON-encoded string containing the message's content.
-    #[wasm_bindgen(readonly)]
+    /// A JSON-encoded string containing the message's body.
+    #[wasm_bindgen(readonly, js_name = "body")]
     pub content: JsString,
 }
 

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -38,6 +38,8 @@ pub struct KeysUploadRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `device_keys`,
     /// `one_time_keys`, `fallback_keys`.
+    ///
+    /// It represents the body of the HTTP request.
     #[wasm_bindgen(readonly)]
     pub body: JsString,
 }
@@ -72,6 +74,8 @@ pub struct KeysQueryRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `timeout`,
     /// `device_keys`, `token`.
+    ///
+    /// It represents the body of the HTTP request.
     #[wasm_bindgen(readonly)]
     pub body: JsString,
 }
@@ -107,6 +111,8 @@ pub struct KeysClaimRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `timeout`,
     /// `one_time_keys`.
+    ///
+    /// It represents the body of the HTTP request.
     #[wasm_bindgen(readonly)]
     pub body: JsString,
 }
@@ -149,6 +155,8 @@ pub struct ToDeviceRequest {
     pub txn_id: JsString,
 
     /// A JSON-encoded string containing the rest of the payload: `messages`.
+    ///
+    /// It represents the body of the HTTP request.
     #[wasm_bindgen(readonly)]
     pub body: JsString,
 }
@@ -187,6 +195,8 @@ pub struct SignatureUploadRequest {
     pub id: Option<JsString>,
 
     /// A JSON-encoded string containing the rest of the payload: `signed_keys`.
+    ///
+    /// It represents the body of the HTTP request.
     #[wasm_bindgen(readonly)]
     pub body: JsString,
 }
@@ -271,6 +281,8 @@ pub struct KeysBackupRequest {
     pub id: Option<JsString>,
 
     /// A JSON-encoded string containing the rest of the payload: `rooms`.
+    ///
+    /// It represents the body of the HTTP request.
     #[wasm_bindgen(readonly)]
     pub body: JsString,
 }
@@ -304,6 +316,8 @@ pub struct SigningKeysUploadRequest {
 
     /// A JSON-encoded string containing the rest of the payload: `master_key`,
     /// `self_signing_key`, `user_signing_key`.
+    ///
+    /// It represents the body of the HTTP request.
     #[wasm_bindgen(readonly)]
     pub body: JsString,
 }
@@ -375,15 +389,6 @@ macro_rules! request {
     ( @__field $field_name:ident : $field_type:ident ; request = $request:expr ) => {
         request!(@__field_type as $field_type ; request = $request, field_name = $field_name)
     };
-
-    /*
-    ( @__field $field_name:ident : $field_mapper:block ; request = $request:expr ) => {
-        {
-            let mapper = $field_mapper;
-            mapper($request)
-        }
-    };
-    */
 
     ( @__field_type as string ; request = $request:expr, field_name = $field_name:ident ) => {
         $request.$field_name.to_string().into()

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -33,34 +33,18 @@ pub struct KeysUploadRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded string representing identity keys for the device.
-    ///
-    /// May be absent if no new identity keys are required.
+    /// A JSON-encoded string containing the rest of the payload: `device_keys`,
+    /// `one_time_keys`, `fallback_keys`.
     #[wasm_bindgen(readonly)]
-    pub device_keys: JsString,
-
-    /// A JSON-encoded string representing one-time public keys for “pre-key”
-    /// messages.
-    #[wasm_bindgen(readonly)]
-    pub one_time_keys: JsString,
-
-    /// A JSON-encoded string representing fallback public keys for “pre-key”
-    /// messages.
-    #[wasm_bindgen(readonly)]
-    pub fallback_keys: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysUploadRequest {
     /// Create a new `KeysUploadRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(
-        id: JsString,
-        device_keys: JsString,
-        one_time_keys: JsString,
-        fallback_keys: JsString,
-    ) -> KeysUploadRequest {
-        Self { id: Some(id), device_keys, one_time_keys, fallback_keys }
+    pub fn new(id: JsString, body: JsString) -> KeysUploadRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -83,37 +67,18 @@ pub struct KeysQueryRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// An optional integer representing the time (in milliseconds) to wait when
-    /// downloading keys from remote servers. 10 seconds is the recommended
-    /// default.
+    /// A JSON-encoded string containing the rest of the payload: `timeout`,
+    /// `device_keys`, `token`.
     #[wasm_bindgen(readonly)]
-    pub timeout: Option<u64>,
-
-    /// A JSON-encoded string representing the keys to be downloaded. An empty
-    /// list indicates all devices for the corresponding user.
-    #[wasm_bindgen(readonly)]
-    pub device_keys: JsString,
-
-    /// An optional string representing if the client is fetching keys as a
-    /// result of a device update received in a sync request, this should be the
-    /// `since` token of that sync request, or any later sync token. This allows
-    /// the server to ensure its response contains the keys advertised by the
-    /// notification in that sync.
-    #[wasm_bindgen(readonly)]
-    pub token: Option<String>,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysQueryRequest {
     /// Create a new `KeysQueryRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(
-        id: JsString,
-        timeout: Option<u64>,
-        device_keys: JsString,
-        token: Option<String>,
-    ) -> KeysQueryRequest {
-        Self { id: Some(id), timeout, device_keys, token }
+    pub fn new(id: JsString, body: JsString) -> KeysQueryRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -137,23 +102,18 @@ pub struct KeysClaimRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// An optional integer representing the time (in milliseconds) to wait when
-    /// downloading keys from remote servers. 10 seconds is the recommended
-    /// default.
+    /// A JSON-encoded string containing the rest of the payload: `timeout`,
+    /// `one_time_keys`.
     #[wasm_bindgen(readonly)]
-    pub timeout: Option<u64>,
-
-    /// A JSON-encoded string representing the keys to be claimed.
-    #[wasm_bindgen(readonly)]
-    pub one_time_keys: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysClaimRequest {
     /// Create a new `KeysClaimRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, timeout: Option<u64>, one_time_keys: JsString) -> KeysClaimRequest {
-        Self { id: Some(id), timeout, one_time_keys }
+    pub fn new(id: JsString, body: JsString) -> KeysClaimRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -185,12 +145,9 @@ pub struct ToDeviceRequest {
     #[wasm_bindgen(readonly)]
     pub txn_id: JsString,
 
-    /// A JSON-encoded string representing a map of users to devices to a
-    /// content for a message event to be sent to the user's device. Individual
-    /// message events can be sent to devices, but all events must be of the
-    /// same type.
+    /// A JSON-encoded string containing the rest of the payload: `messages`.
     #[wasm_bindgen(readonly)]
-    pub messages: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
@@ -201,9 +158,9 @@ impl ToDeviceRequest {
         id: JsString,
         event_type: JsString,
         txn_id: JsString,
-        messages: JsString,
+        body: JsString,
     ) -> ToDeviceRequest {
-        Self { id: Some(id), event_type, txn_id, messages }
+        Self { id: Some(id), event_type, txn_id, body }
     }
 
     /// Get its request type.
@@ -226,17 +183,17 @@ pub struct SignatureUploadRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded string representing the signed keys.
+    /// A JSON-encoded string containing the rest of the payload: `signed_keys`.
     #[wasm_bindgen(readonly)]
-    pub signed_keys: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl SignatureUploadRequest {
     /// Create a new `SignatureUploadRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, signed_keys: JsString) -> SignatureUploadRequest {
-        Self { id: Some(id), signed_keys }
+    pub fn new(id: JsString, body: JsString) -> SignatureUploadRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -269,9 +226,9 @@ pub struct RoomMessageRequest {
     #[wasm_bindgen(readonly)]
     pub txn_id: JsString,
 
-    /// A JSON-encoded string representing the event content to send.
+    /// A JSON-encoded string containing the rest of the payload: `content`.
     #[wasm_bindgen(readonly)]
-    pub content: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
@@ -282,9 +239,9 @@ impl RoomMessageRequest {
         id: JsString,
         room_id: JsString,
         txn_id: JsString,
-        content: JsString,
+        body: JsString,
     ) -> RoomMessageRequest {
-        Self { id: Some(id), room_id, txn_id, content }
+        Self { id: Some(id), room_id, txn_id, body }
     }
 
     /// Get its request type.
@@ -305,18 +262,17 @@ pub struct KeysBackupRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded string representing the map from room ID to a backed up
-    /// room key that we're going to upload to the server.
+    /// A JSON-encoded string containing the rest of the payload: `rooms`.
     #[wasm_bindgen(readonly)]
-    pub rooms: JsString,
+    pub body: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysBackupRequest {
     /// Create a new `KeysBackupRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, rooms: JsString) -> KeysBackupRequest {
-        Self { id: Some(id), rooms }
+    pub fn new(id: JsString, body: JsString) -> KeysBackupRequest {
+        Self { id: Some(id), body }
     }
 
     /// Get its request type.
@@ -338,30 +294,28 @@ pub struct SigningKeysUploadRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded string representing the user's master key..
+    /// A JSON-encoded string containing the rest of the payload: `master_key`,
+    /// `self_signing_key`, `user_signing_key`.
     #[wasm_bindgen(readonly)]
-    pub master_key: JsString,
-
-    /// A JSON-encoded string representing the user's self-signing key. Must
-    /// be signed with the accompanied master, or by the user's most recently
-    /// uploaded master key if no master key is included in the request.
-    #[wasm_bindgen(readonly)]
-    pub self_signing_key: JsString,
-
-    /// A JSON-encoded string representing the user's user-signing key. Must
-    /// be signed with the accompanied master, or by the user's most recently
-    /// uploaded master key if no master key is included in the request.
-    #[wasm_bindgen(readonly)]
-    pub user_signing_key: JsString,
+    pub body: JsString,
 }
 
 macro_rules! request {
-    ( $destination_request:ident from $source_request:ident maps fields $( $field:ident: $field_type:ident ),+ $(,)? ) => {
+    (
+        $destination_request:ident from $source_request:ident
+        $( extracts fields $( $field:ident: $field_type:ident ),+ $(,)? )?
+        $( $( and )? groups fields $( $grouped_field:ident ),+ $(,)? )?
+    ) => {
         impl TryFrom<&$source_request> for $destination_request {
             type Error = serde_json::Error;
 
             fn try_from(request: &$source_request) -> Result<Self, Self::Error> {
-                request!(@__try_from $destination_request from $source_request (request_id = None, request = request) maps fields $( $field: $field_type, )+ )
+                request!(
+                    @__try_from $destination_request from $source_request
+                    (request_id = None, request = request)
+                    $( extracts [ $( $field: $field_type, )+ ] )?
+                    $( groups [ $( $grouped_field, )+ ] )?
+                )
             }
         }
 
@@ -371,18 +325,41 @@ macro_rules! request {
             fn try_from(
                 (request_id, request): (String, &$source_request),
             ) -> Result<Self, Self::Error> {
-                request!(@__try_from $destination_request from $source_request (request_id = Some(request_id.into()), request = request) maps fields $( $field: $field_type, )+ )
+                request!(
+                    @__try_from $destination_request from $source_request
+                    (request_id = Some(request_id.into()), request = request)
+                    $( extracts [ $( $field: $field_type, )+ ] )?
+                    $( groups [ $( $grouped_field, )+ ] )?
+                )
             }
         }
     };
 
-    ( @__try_from $destination_request:ident from $source_request:ident (request_id = $request_id:expr, request = $request:expr) maps fields $( $field:ident: $field_type:ident ),+ $(,)? ) => {
+    (
+        @__try_from $destination_request:ident from $source_request:ident
+        (request_id = $request_id:expr, request = $request:expr)
+        $( extracts [ $( $field:ident: $field_type:ident ),* $(,)? ] )?
+        $( groups [ $( $grouped_field:ident ),* $(,)? ] )?
+    ) => {
         {
             Ok($destination_request {
                 id: $request_id,
                 $(
-                    $field: request!(@__field as $field_type (request = $request, field = $field)),
-                )+
+                    $(
+                        $field: request!(@__field as $field_type (request = $request, field = $field)),
+                    )*
+                )?
+                $(
+                    body: {
+                        let mut map = serde_json::Map::new();
+                        $(
+                            map.insert(stringify!($grouped_field).to_owned(), serde_json::to_value(&$request.$grouped_field).unwrap());
+                        )*
+                        let object = serde_json::Value::Object(map);
+
+                        serde_json::to_string(&object)?.into()
+                    }
+                )?
             })
         }
     };
@@ -405,16 +382,16 @@ macro_rules! request {
 }
 
 // Outgoing Requests
-request!(KeysUploadRequest from OriginalKeysUploadRequest maps fields device_keys: json, one_time_keys: json, fallback_keys: json);
-request!(KeysQueryRequest from OriginalKeysQueryRequest maps fields timeout: duration, device_keys: json, token: native);
-request!(KeysClaimRequest from OriginalKeysClaimRequest maps fields timeout: duration, one_time_keys: json);
-request!(ToDeviceRequest from OriginalToDeviceRequest maps fields event_type: string, txn_id: string, messages: json);
-request!(SignatureUploadRequest from OriginalSignatureUploadRequest maps fields signed_keys: json);
-request!(RoomMessageRequest from OriginalRoomMessageRequest maps fields room_id: string, txn_id: string, content: json);
-request!(KeysBackupRequest from OriginalKeysBackupRequest maps fields rooms: json);
+request!(KeysUploadRequest from OriginalKeysUploadRequest groups fields device_keys, one_time_keys, fallback_keys);
+request!(KeysQueryRequest from OriginalKeysQueryRequest groups fields timeout, device_keys, token);
+request!(KeysClaimRequest from OriginalKeysClaimRequest groups fields timeout, one_time_keys);
+request!(ToDeviceRequest from OriginalToDeviceRequest extracts fields event_type: string, txn_id: string and groups fields messages);
+request!(SignatureUploadRequest from OriginalSignatureUploadRequest groups fields signed_keys);
+request!(RoomMessageRequest from OriginalRoomMessageRequest extracts fields room_id: string, txn_id: string and groups fields content);
+request!(KeysBackupRequest from OriginalKeysBackupRequest groups fields rooms);
 
 // Other Requests
-request!(SigningKeysUploadRequest from OriginalUploadSigningKeysRequest maps fields master_key: json, self_signing_key: json, user_signing_key: json);
+request!(SigningKeysUploadRequest from OriginalUploadSigningKeysRequest groups fields master_key, self_signing_key, user_signing_key);
 
 // JavaScript has no complex enums like Rust. To return structs of
 // different types, we have no choice that hiding everything behind a

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -33,21 +33,34 @@ pub struct KeysUploadRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded object of form:
+    /// A JSON-encoded string representing identity keys for the device.
     ///
-    /// ```json
-    /// {"device_keys": …, "one_time_keys": …, "fallback_keys": …}
-    /// ```
+    /// May be absent if no new identity keys are required.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub device_keys: JsString,
+
+    /// A JSON-encoded string representing one-time public keys for “pre-key”
+    /// messages.
+    #[wasm_bindgen(readonly)]
+    pub one_time_keys: JsString,
+
+    /// A JSON-encoded string representing fallback public keys for “pre-key”
+    /// messages.
+    #[wasm_bindgen(readonly)]
+    pub fallback_keys: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysUploadRequest {
     /// Create a new `KeysUploadRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> KeysUploadRequest {
-        Self { id: Some(id), body }
+    pub fn new(
+        id: JsString,
+        device_keys: JsString,
+        one_time_keys: JsString,
+        fallback_keys: JsString,
+    ) -> KeysUploadRequest {
+        Self { id: Some(id), device_keys, one_time_keys, fallback_keys }
     }
 
     /// Get its request type.
@@ -70,21 +83,37 @@ pub struct KeysQueryRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded object of form:
-    ///
-    /// ```json
-    /// {"timeout": …, "device_keys": …, "token": …}
-    /// ```
+    /// An optional integer representing the time (in milliseconds) to wait when
+    /// downloading keys from remote servers. 10 seconds is the recommended
+    /// default.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub timeout: Option<u64>,
+
+    /// A JSON-encoded string representing the keys to be downloaded. An empty
+    /// list indicates all devices for the corresponding user.
+    #[wasm_bindgen(readonly)]
+    pub device_keys: JsString,
+
+    /// An optional string representing if the client is fetching keys as a
+    /// result of a device update received in a sync request, this should be the
+    /// `since` token of that sync request, or any later sync token. This allows
+    /// the server to ensure its response contains the keys advertised by the
+    /// notification in that sync.
+    #[wasm_bindgen(readonly)]
+    pub token: Option<String>,
 }
 
 #[wasm_bindgen]
 impl KeysQueryRequest {
     /// Create a new `KeysQueryRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> KeysQueryRequest {
-        Self { id: Some(id), body }
+    pub fn new(
+        id: JsString,
+        timeout: Option<u64>,
+        device_keys: JsString,
+        token: Option<String>,
+    ) -> KeysQueryRequest {
+        Self { id: Some(id), timeout, device_keys, token }
     }
 
     /// Get its request type.
@@ -108,21 +137,23 @@ pub struct KeysClaimRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded object of form:
-    ///
-    /// ```json
-    /// {"timeout": …, "one_time_keys": …}
-    /// ```
+    /// An optional integer representing the time (in milliseconds) to wait when
+    /// downloading keys from remote servers. 10 seconds is the recommended
+    /// default.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub timeout: Option<u64>,
+
+    /// A JSON-encoded string representing the keys to be claimed.
+    #[wasm_bindgen(readonly)]
+    pub one_time_keys: JsString,
 }
 
 #[wasm_bindgen]
 impl KeysClaimRequest {
     /// Create a new `KeysClaimRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> KeysClaimRequest {
-        Self { id: Some(id), body }
+    pub fn new(id: JsString, timeout: Option<u64>, one_time_keys: JsString) -> KeysClaimRequest {
+        Self { id: Some(id), timeout, one_time_keys }
     }
 
     /// Get its request type.
@@ -145,21 +176,34 @@ pub struct ToDeviceRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded object of form:
-    ///
-    /// ```json
-    /// {"event_type": …, "txn_id": …, "messages": …}
-    /// ```
+    /// A string representing the type of event being sent to each devices.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub event_type: JsString,
+
+    /// A string representing a request identifier unique to the access token
+    /// used to send the request.
+    #[wasm_bindgen(readonly)]
+    pub txn_id: JsString,
+
+    /// A JSON-encoded string representing a map of users to devices to a
+    /// content for a message event to be sent to the user's device. Individual
+    /// message events can be sent to devices, but all events must be of the
+    /// same type.
+    #[wasm_bindgen(readonly)]
+    pub messages: JsString,
 }
 
 #[wasm_bindgen]
 impl ToDeviceRequest {
     /// Create a new `ToDeviceRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> ToDeviceRequest {
-        Self { id: Some(id), body }
+    pub fn new(
+        id: JsString,
+        event_type: JsString,
+        txn_id: JsString,
+        messages: JsString,
+    ) -> ToDeviceRequest {
+        Self { id: Some(id), event_type, txn_id, messages }
     }
 
     /// Get its request type.
@@ -182,21 +226,17 @@ pub struct SignatureUploadRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded object of form:
-    ///
-    /// ```json
-    /// {"signed_keys": …, "txn_id": …, "messages": …}
-    /// ```
+    /// A JSON-encoded string representing the signed keys.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub signed_keys: JsString,
 }
 
 #[wasm_bindgen]
 impl SignatureUploadRequest {
     /// Create a new `SignatureUploadRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> SignatureUploadRequest {
-        Self { id: Some(id), body }
+    pub fn new(id: JsString, signed_keys: JsString) -> SignatureUploadRequest {
+        Self { id: Some(id), signed_keys }
     }
 
     /// Get its request type.
@@ -217,21 +257,34 @@ pub struct RoomMessageRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded object of form:
-    ///
-    /// ```json
-    /// {"room_id": …, "txn_id": …, "content": …}
-    /// ```
+    /// A string representing the room to send the event to.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub room_id: JsString,
+
+    /// A string representing the transaction ID for this event.
+    ///
+    /// Clients should generate an ID unique across requests with the same
+    /// access token; it will be used by the server to ensure idempotency of
+    /// requests.
+    #[wasm_bindgen(readonly)]
+    pub txn_id: JsString,
+
+    /// A JSON-encoded string representing the event content to send.
+    #[wasm_bindgen(readonly)]
+    pub content: JsString,
 }
 
 #[wasm_bindgen]
 impl RoomMessageRequest {
     /// Create a new `RoomMessageRequest`.
     #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> RoomMessageRequest {
-        Self { id: Some(id), body }
+    pub fn new(
+        id: JsString,
+        room_id: JsString,
+        txn_id: JsString,
+        content: JsString,
+    ) -> RoomMessageRequest {
+        Self { id: Some(id), room_id, txn_id, content }
     }
 
     /// Get its request type.
@@ -252,13 +305,25 @@ pub struct KeysBackupRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded object of form:
-    ///
-    /// ```json
-    /// {"rooms": …}
-    /// ```
+    /// A JSON-encoded string representing the map from room ID to a backed up
+    /// room key that we're going to upload to the server.
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
+    pub rooms: JsString,
+}
+
+#[wasm_bindgen]
+impl KeysBackupRequest {
+    /// Create a new `KeysBackupRequest`.
+    #[wasm_bindgen(constructor)]
+    pub fn new(id: JsString, rooms: JsString) -> KeysBackupRequest {
+        Self { id: Some(id), rooms }
+    }
+
+    /// Get its request type.
+    #[wasm_bindgen(getter, js_name = "type")]
+    pub fn request_type(&self) -> RequestType {
+        RequestType::KeysBackup
+    }
 }
 
 /** Other Requests * */
@@ -273,52 +338,30 @@ pub struct SigningKeysUploadRequest {
     #[wasm_bindgen(readonly)]
     pub id: Option<JsString>,
 
-    /// A JSON-encoded object of form:
-    ///
-    /// ```json
-    /// {"master_key": …, "self_signing_key": …, "user_signing_key": …}
-    /// ```
+    /// A JSON-encoded string representing the user's master key..
     #[wasm_bindgen(readonly)]
-    pub body: JsString,
-}
+    pub master_key: JsString,
 
-#[wasm_bindgen]
-impl KeysBackupRequest {
-    /// Create a new `KeysBackupRequest`.
-    #[wasm_bindgen(constructor)]
-    pub fn new(id: JsString, body: JsString) -> KeysBackupRequest {
-        Self { id: Some(id), body }
-    }
+    /// A JSON-encoded string representing the user's self-signing key. Must
+    /// be signed with the accompanied master, or by the user's most recently
+    /// uploaded master key if no master key is included in the request.
+    #[wasm_bindgen(readonly)]
+    pub self_signing_key: JsString,
 
-    /// Get its request type.
-    #[wasm_bindgen(getter, js_name = "type")]
-    pub fn request_type(&self) -> RequestType {
-        RequestType::KeysBackup
-    }
+    /// A JSON-encoded string representing the user's user-signing key. Must
+    /// be signed with the accompanied master, or by the user's most recently
+    /// uploaded master key if no master key is included in the request.
+    #[wasm_bindgen(readonly)]
+    pub user_signing_key: JsString,
 }
 
 macro_rules! request {
-    ($destination_request:ident from $source_request:ident maps fields $( $field:ident ),+ $(,)? ) => {
-        impl $destination_request {
-            pub(crate) fn to_json(request: &$source_request) -> Result<String, serde_json::Error> {
-                let mut map = serde_json::Map::new();
-                $(
-                    map.insert(stringify!($field).to_owned(), serde_json::to_value(&request.$field).unwrap());
-                )+
-                let object = serde_json::Value::Object(map);
-
-                serde_json::to_string(&object)
-            }
-        }
-
+    ( $destination_request:ident from $source_request:ident maps fields $( $field:ident: $field_type:ident ),+ $(,)? ) => {
         impl TryFrom<&$source_request> for $destination_request {
             type Error = serde_json::Error;
 
             fn try_from(request: &$source_request) -> Result<Self, Self::Error> {
-                Ok($destination_request {
-                    id: None,
-                    body: Self::to_json(request)?.into(),
-                })
+                request!(@__try_from $destination_request from $source_request (request_id = None, request = request) maps fields $( $field: $field_type, )+ )
             }
         }
 
@@ -328,26 +371,50 @@ macro_rules! request {
             fn try_from(
                 (request_id, request): (String, &$source_request),
             ) -> Result<Self, Self::Error> {
-                Ok($destination_request {
-                    id: Some(request_id.into()),
-                    body: Self::to_json(request)?.into(),
-                })
+                request!(@__try_from $destination_request from $source_request (request_id = Some(request_id.into()), request = request) maps fields $( $field: $field_type, )+ )
             }
         }
+    };
+
+    ( @__try_from $destination_request:ident from $source_request:ident (request_id = $request_id:expr, request = $request:expr) maps fields $( $field:ident: $field_type:ident ),+ $(,)? ) => {
+        {
+            Ok($destination_request {
+                id: $request_id,
+                $(
+                    $field: request!(@__field as $field_type (request = $request, field = $field)),
+                )+
+            })
+        }
+    };
+
+    ( @__field as json (request = $request:expr, field = $field:ident) ) => {
+        serde_json::to_string(&$request.$field)?.into()
+    };
+
+    ( @__field as string (request = $request:expr, field = $field:ident) ) => {
+        $request.$field.to_string().into()
+    };
+
+    ( @__field as duration (request = $request:expr, field = $field:ident) ) => {
+        $request.$field.map(|duration| duration.as_millis() as u64)
+    };
+
+    ( @__field as native (request = $request:expr, field = $field:ident) ) => {
+        $request.$field.clone()
     };
 }
 
 // Outgoing Requests
-request!(KeysUploadRequest from OriginalKeysUploadRequest maps fields device_keys, one_time_keys, fallback_keys);
-request!(KeysQueryRequest from OriginalKeysQueryRequest maps fields timeout, device_keys, token);
-request!(KeysClaimRequest from OriginalKeysClaimRequest maps fields timeout, one_time_keys);
-request!(ToDeviceRequest from OriginalToDeviceRequest maps fields event_type, txn_id, messages);
-request!(SignatureUploadRequest from OriginalSignatureUploadRequest maps fields signed_keys);
-request!(RoomMessageRequest from OriginalRoomMessageRequest maps fields room_id, txn_id, content);
-request!(KeysBackupRequest from OriginalKeysBackupRequest maps fields rooms);
+request!(KeysUploadRequest from OriginalKeysUploadRequest maps fields device_keys: json, one_time_keys: json, fallback_keys: json);
+request!(KeysQueryRequest from OriginalKeysQueryRequest maps fields timeout: duration, device_keys: json, token: native);
+request!(KeysClaimRequest from OriginalKeysClaimRequest maps fields timeout: duration, one_time_keys: json);
+request!(ToDeviceRequest from OriginalToDeviceRequest maps fields event_type: string, txn_id: string, messages: json);
+request!(SignatureUploadRequest from OriginalSignatureUploadRequest maps fields signed_keys: json);
+request!(RoomMessageRequest from OriginalRoomMessageRequest maps fields room_id: string, txn_id: string, content: json);
+request!(KeysBackupRequest from OriginalKeysBackupRequest maps fields rooms: json);
 
 // Other Requests
-request!(SigningKeysUploadRequest from OriginalUploadSigningKeysRequest maps fields master_key, self_signing_key, user_signing_key);
+request!(SigningKeysUploadRequest from OriginalUploadSigningKeysRequest maps fields master_key: json, self_signing_key: json, user_signing_key: json);
 
 // JavaScript has no complex enums like Rust. To return structs of
 // different types, we have no choice that hiding everything behind a

--- a/bindings/matrix-sdk-crypto-js/tests/attachment.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/attachment.test.js
@@ -6,7 +6,7 @@ describe(Attachment.name, () => {
     const textDecoder = new TextDecoder();
 
     let encryptedAttachment;
-    
+
     test('can encrypt data', () => {
         encryptedAttachment = Attachment.encrypt(textEncoder.encode(originalData));
 

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -177,7 +177,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -228,7 +228,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification ready to `m1`.
@@ -281,7 +281,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the SAS start to `m1`.
@@ -326,7 +326,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the SAS accept to `m2`.
@@ -349,7 +349,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.body).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(toDeviceRequest.extra).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send te SAS key to `m1`.
@@ -369,7 +369,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.body).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(toDeviceRequest.extra).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS key to `m2`.
@@ -438,7 +438,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS confirmation to `m2`.
@@ -462,7 +462,7 @@ describe('Key Verification', () => {
                 const toDeviceEvents = [{
                     sender: userId2.toString(),
                     type: outgoingVerificationRequest.event_type,
-                    content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
+                    content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
                 }];
 
                 // Let's send te SAS confirmation to `m1`.
@@ -479,7 +479,7 @@ describe('Key Verification', () => {
                 const toDeviceEvents = [{
                     sender: userId2.toString(),
                     type: outgoingVerificationRequest.event_type,
-                    content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
+                    content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
                 }];
 
                 // Let's send te SAS done to `m1`.
@@ -499,7 +499,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.body).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(toDeviceRequest.extra).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS key to `m2`.
@@ -585,7 +585,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -639,7 +639,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification ready to `m1`.
@@ -796,7 +796,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -816,7 +816,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification request to `m2`.

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -172,14 +172,12 @@ describe('Key Verification', () => {
             expect(verificationRequest1.isCancelled()).toStrictEqual(false);
 
             expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.request');
 
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -225,13 +223,12 @@ describe('Key Verification', () => {
             expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
 
             // The request verification is ready.
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.ready');
 
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification ready to `m1`.
@@ -279,14 +276,12 @@ describe('Key Verification', () => {
             expect(sas2.decimals()).toBeUndefined();
 
             expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.start');
 
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the SAS start to `m1`.
@@ -324,15 +319,14 @@ describe('Key Verification', () => {
 
             // Let's accept thet SAS start request.
             let outgoingVerificationRequest = sas1.accept();
-            expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
 
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
+            expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.accept');
 
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the SAS accept to `m2`.
@@ -350,22 +344,18 @@ describe('Key Verification', () => {
             let toDeviceRequest = outgoingRequests.find((request) => request.type == RequestType.ToDevice);
 
             expect(toDeviceRequest).toBeInstanceOf(ToDeviceRequest);
-            const toDeviceRequestId = toDeviceRequest.id;
-            const toDeviceRequestType = toDeviceRequest.type;
-
-            toDeviceRequest = JSON.parse(toDeviceRequest.body);
             expect(toDeviceRequest.event_type).toStrictEqual('m.key.verification.key');
 
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: toDeviceRequest.event_type,
-                content: toDeviceRequest.messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(toDeviceRequest.messages)[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send te SAS key to `m1`.
             await m1.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
 
-            m2.markRequestAsSent(toDeviceRequestId, toDeviceRequestType, '{}');
+            m2.markRequestAsSent(toDeviceRequest.id, toDeviceRequest.type, '{}');
         });
 
         test('other side sends back verification key (`m.key.verification.key`)', async () => {
@@ -374,22 +364,18 @@ describe('Key Verification', () => {
             let toDeviceRequest = outgoingRequests.find((request) => request.type == RequestType.ToDevice);
 
             expect(toDeviceRequest).toBeInstanceOf(ToDeviceRequest);
-            const toDeviceRequestId = toDeviceRequest.id;
-            const toDeviceRequestType = toDeviceRequest.type;
-
-            toDeviceRequest = JSON.parse(toDeviceRequest.body);
             expect(toDeviceRequest.event_type).toStrictEqual('m.key.verification.key');
 
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: toDeviceRequest.event_type,
-                content: toDeviceRequest.messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(toDeviceRequest.messages)[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS key to `m2`.
             await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
 
-            m1.markRequestAsSent(toDeviceRequestId, toDeviceRequestType, '{}');
+            m1.markRequestAsSent(toDeviceRequest.id, toDeviceRequest.type, '{}');
         });
 
         test('emojis match from both sides', () => {
@@ -447,14 +433,12 @@ describe('Key Verification', () => {
             let outgoingVerificationRequest = outgoingVerificationRequests[0];
 
             expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.mac');
 
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS confirmation to `m2`.
@@ -473,14 +457,12 @@ describe('Key Verification', () => {
                 let outgoingVerificationRequest = outgoingVerificationRequests[0];
 
                 expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-                outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
                 expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.mac');
 
                 const toDeviceEvents = [{
                     sender: userId2.toString(),
                     type: outgoingVerificationRequest.event_type,
-                    content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
+                    content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
                 }];
 
                 // Let's send te SAS confirmation to `m1`.
@@ -492,14 +474,12 @@ describe('Key Verification', () => {
                 let outgoingVerificationRequest = outgoingVerificationRequests[1];
 
                 expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-                outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
                 expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.done');
 
                 const toDeviceEvents = [{
                     sender: userId2.toString(),
                     type: outgoingVerificationRequest.event_type,
-                    content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
+                    content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
                 }];
 
                 // Let's send te SAS done to `m1`.
@@ -514,22 +494,18 @@ describe('Key Verification', () => {
             let toDeviceRequest = outgoingRequests.find((request) => request.type == RequestType.ToDevice);
 
             expect(toDeviceRequest).toBeInstanceOf(ToDeviceRequest);
-            const toDeviceRequestId = toDeviceRequest.id;
-            const toDeviceRequestType = toDeviceRequest.type;
-
-            toDeviceRequest = JSON.parse(toDeviceRequest.body);
             expect(toDeviceRequest.event_type).toStrictEqual('m.key.verification.done');
 
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: toDeviceRequest.event_type,
-                content: toDeviceRequest.messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(toDeviceRequest.messages)[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS key to `m2`.
             await m2.receiveSyncChanges(JSON.stringify(toDeviceEvents), new DeviceLists(), new Map(), new Set());
 
-            m1.markRequestAsSent(toDeviceRequestId, toDeviceRequestType, '{}');
+            m1.markRequestAsSent(toDeviceRequest.id, toDeviceRequest.type, '{}');
         });
 
         test('can see if verification is done', () => {
@@ -604,14 +580,12 @@ describe('Key Verification', () => {
             expect(verificationRequest1.isCancelled()).toStrictEqual(false);
 
             expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.request');
 
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -660,13 +634,12 @@ describe('Key Verification', () => {
             expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
 
             // The request verification is ready.
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.ready');
 
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification ready to `m1`.
@@ -818,14 +791,12 @@ describe('Key Verification', () => {
             let outgoingVerificationRequest = qr1.reciprocate();
 
             expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.start');
 
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -840,14 +811,12 @@ describe('Key Verification', () => {
             let outgoingVerificationRequest = qr2.confirmScanning();
 
             expect(outgoingVerificationRequest).toBeInstanceOf(ToDeviceRequest);
-
-            outgoingVerificationRequest = JSON.parse(outgoingVerificationRequest.body);
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.done');
 
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: outgoingVerificationRequest.messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification request to `m2`.

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -177,7 +177,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -228,7 +228,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification ready to `m1`.
@@ -281,7 +281,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the SAS start to `m1`.
@@ -326,7 +326,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the SAS accept to `m2`.
@@ -349,7 +349,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.extra).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(toDeviceRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send te SAS key to `m1`.
@@ -369,7 +369,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.extra).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(toDeviceRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS key to `m2`.
@@ -438,7 +438,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS confirmation to `m2`.
@@ -462,7 +462,7 @@ describe('Key Verification', () => {
                 const toDeviceEvents = [{
                     sender: userId2.toString(),
                     type: outgoingVerificationRequest.event_type,
-                    content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
+                    content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
                 }];
 
                 // Let's send te SAS confirmation to `m1`.
@@ -479,7 +479,7 @@ describe('Key Verification', () => {
                 const toDeviceEvents = [{
                     sender: userId2.toString(),
                     type: outgoingVerificationRequest.event_type,
-                    content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
+                    content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
                 }];
 
                 // Let's send te SAS done to `m1`.
@@ -499,7 +499,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.extra).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(toDeviceRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS key to `m2`.
@@ -585,7 +585,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -639,7 +639,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification ready to `m1`.
@@ -796,7 +796,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -816,7 +816,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.extra).messages[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification request to `m2`.

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -177,7 +177,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -228,7 +228,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification ready to `m1`.
@@ -281,7 +281,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the SAS start to `m1`.
@@ -326,7 +326,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the SAS accept to `m2`.
@@ -349,7 +349,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.messages)[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(toDeviceRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send te SAS key to `m1`.
@@ -369,7 +369,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.messages)[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(toDeviceRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS key to `m2`.
@@ -438,7 +438,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS confirmation to `m2`.
@@ -462,7 +462,7 @@ describe('Key Verification', () => {
                 const toDeviceEvents = [{
                     sender: userId2.toString(),
                     type: outgoingVerificationRequest.event_type,
-                    content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
+                    content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
                 }];
 
                 // Let's send te SAS confirmation to `m1`.
@@ -479,7 +479,7 @@ describe('Key Verification', () => {
                 const toDeviceEvents = [{
                     sender: userId2.toString(),
                     type: outgoingVerificationRequest.event_type,
-                    content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
+                    content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
                 }];
 
                 // Let's send te SAS done to `m1`.
@@ -499,7 +499,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: toDeviceRequest.event_type,
-                content: JSON.parse(toDeviceRequest.messages)[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(toDeviceRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send te SAS key to `m2`.
@@ -585,7 +585,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -639,7 +639,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification ready to `m1`.
@@ -796,7 +796,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId1.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId2.toString()][deviceId2.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId2.toString()][deviceId2.toString()],
             }];
 
             // Let's send the verification request to `m2`.
@@ -816,7 +816,7 @@ describe('Key Verification', () => {
             const toDeviceEvents = [{
                 sender: userId2.toString(),
                 type: outgoingVerificationRequest.event_type,
-                content: JSON.parse(outgoingVerificationRequest.messages)[userId1.toString()][deviceId1.toString()],
+                content: JSON.parse(outgoingVerificationRequest.body).messages[userId1.toString()][deviceId1.toString()],
             }];
 
             // Let's send the verification request to `m2`.

--- a/bindings/matrix-sdk-crypto-js/tests/helper.js
+++ b/bindings/matrix-sdk-crypto-js/tests/helper.js
@@ -30,9 +30,9 @@ async function addMachineToMachine(machineToAdd, machine) {
         expect(outgoingRequests[0]).toBeInstanceOf(KeysUploadRequest);
         expect(outgoingRequests[0].id).toBeDefined();
         expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
-        expect(outgoingRequests[0].extra).toBeDefined();
+        expect(outgoingRequests[0].body).toBeDefined();
 
-        const body = JSON.parse(outgoingRequests[0].extra);
+        const body = JSON.parse(outgoingRequests[0].body);
         expect(body.device_keys).toBeDefined();
         expect(body.one_time_keys).toBeDefined();
 
@@ -64,9 +64,9 @@ async function addMachineToMachine(machineToAdd, machine) {
         const userId = machineToAdd.userId.toString();
         const deviceId = machineToAdd.deviceId.toString();
         keyQueryResponse.device_keys[userId] = {};
-        keyQueryResponse.device_keys[userId][deviceId] = JSON.parse(keysUploadRequest.extra).device_keys;
+        keyQueryResponse.device_keys[userId][deviceId] = JSON.parse(keysUploadRequest.body).device_keys;
 
-        const keys = JSON.parse(signingKeysUploadRequest.extra);
+        const keys = JSON.parse(signingKeysUploadRequest.body);
         keyQueryResponse.master_keys[userId] = keys.master_key;
         keyQueryResponse.self_signing_keys[userId] = keys.self_signing_key;
         keyQueryResponse.user_signing_keys[userId] = keys.user_signing_key;

--- a/bindings/matrix-sdk-crypto-js/tests/helper.js
+++ b/bindings/matrix-sdk-crypto-js/tests/helper.js
@@ -30,9 +30,11 @@ async function addMachineToMachine(machineToAdd, machine) {
         expect(outgoingRequests[0]).toBeInstanceOf(KeysUploadRequest);
         expect(outgoingRequests[0].id).toBeDefined();
         expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
+        expect(outgoingRequests[0].body).toBeDefined();
 
-        expect(outgoingRequests[0].device_keys).toBeDefined();
-        expect(outgoingRequests[0].one_time_keys).toBeDefined();
+        const body = JSON.parse(outgoingRequests[0].body);
+        expect(body.device_keys).toBeDefined();
+        expect(body.one_time_keys).toBeDefined();
 
         // https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3keysupload
         const hypothetical_response = JSON.stringify({
@@ -62,10 +64,12 @@ async function addMachineToMachine(machineToAdd, machine) {
         const userId = machineToAdd.userId.toString();
         const deviceId = machineToAdd.deviceId.toString();
         keyQueryResponse.device_keys[userId] = {};
-        keyQueryResponse.device_keys[userId][deviceId] = JSON.parse(keysUploadRequest.device_keys);
-        keyQueryResponse.master_keys[userId] = JSON.parse(signingKeysUploadRequest.master_key);
-        keyQueryResponse.self_signing_keys[userId] = JSON.parse(signingKeysUploadRequest.self_signing_key);
-        keyQueryResponse.user_signing_keys[userId] = JSON.parse(signingKeysUploadRequest.user_signing_key);
+        keyQueryResponse.device_keys[userId][deviceId] = JSON.parse(keysUploadRequest.body).device_keys;
+
+        const keys = JSON.parse(signingKeysUploadRequest.body);
+        keyQueryResponse.master_keys[userId] = keys.master_key;
+        keyQueryResponse.self_signing_keys[userId] = keys.self_signing_key;
+        keyQueryResponse.user_signing_keys[userId] = keys.user_signing_key;
 
         const marked = await machine.markRequestAsSent(outgoingRequests[1].id, outgoingRequests[1].type, JSON.stringify(keyQueryResponse));
         expect(marked).toStrictEqual(true);

--- a/bindings/matrix-sdk-crypto-js/tests/helper.js
+++ b/bindings/matrix-sdk-crypto-js/tests/helper.js
@@ -30,9 +30,9 @@ async function addMachineToMachine(machineToAdd, machine) {
         expect(outgoingRequests[0]).toBeInstanceOf(KeysUploadRequest);
         expect(outgoingRequests[0].id).toBeDefined();
         expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
-        expect(outgoingRequests[0].body).toBeDefined();
+        expect(outgoingRequests[0].extra).toBeDefined();
 
-        const body = JSON.parse(outgoingRequests[0].body);
+        const body = JSON.parse(outgoingRequests[0].extra);
         expect(body.device_keys).toBeDefined();
         expect(body.one_time_keys).toBeDefined();
 
@@ -64,9 +64,9 @@ async function addMachineToMachine(machineToAdd, machine) {
         const userId = machineToAdd.userId.toString();
         const deviceId = machineToAdd.deviceId.toString();
         keyQueryResponse.device_keys[userId] = {};
-        keyQueryResponse.device_keys[userId][deviceId] = JSON.parse(keysUploadRequest.body).device_keys;
+        keyQueryResponse.device_keys[userId][deviceId] = JSON.parse(keysUploadRequest.extra).device_keys;
 
-        const keys = JSON.parse(signingKeysUploadRequest.body);
+        const keys = JSON.parse(signingKeysUploadRequest.extra);
         keyQueryResponse.master_keys[userId] = keys.master_key;
         keyQueryResponse.self_signing_keys[userId] = keys.self_signing_key;
         keyQueryResponse.user_signing_keys[userId] = keys.user_signing_key;

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -198,9 +198,9 @@ describe(OlmMachine.name, () => {
             expect(outgoingRequests[0]).toBeInstanceOf(KeysUploadRequest);
             expect(outgoingRequests[0].id).toBeDefined();
             expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
-            expect(outgoingRequests[0].body).toBeDefined();
+            expect(outgoingRequests[0].extra).toBeDefined();
 
-            const body = JSON.parse(outgoingRequests[0].body)
+            const body = JSON.parse(outgoingRequests[0].extra)
             expect(body.device_keys).toBeDefined();
             expect(body.one_time_keys).toBeDefined();
         }
@@ -209,9 +209,9 @@ describe(OlmMachine.name, () => {
             expect(outgoingRequests[1]).toBeInstanceOf(KeysQueryRequest);
             expect(outgoingRequests[1].id).toBeDefined();
             expect(outgoingRequests[1].type).toStrictEqual(RequestType.KeysQuery);
-            expect(outgoingRequests[1].body).toBeDefined();
+            expect(outgoingRequests[1].extra).toBeDefined();
 
-            const body = JSON.parse(outgoingRequests[1].body);
+            const body = JSON.parse(outgoingRequests[1].extra);
             expect(body.timeout).toBeDefined();
             expect(body.device_keys).toBeDefined();
             expect(body.token).toBeDefined();

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -198,9 +198,9 @@ describe(OlmMachine.name, () => {
             expect(outgoingRequests[0]).toBeInstanceOf(KeysUploadRequest);
             expect(outgoingRequests[0].id).toBeDefined();
             expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
-            expect(outgoingRequests[0].extra).toBeDefined();
+            expect(outgoingRequests[0].body).toBeDefined();
 
-            const body = JSON.parse(outgoingRequests[0].extra)
+            const body = JSON.parse(outgoingRequests[0].body)
             expect(body.device_keys).toBeDefined();
             expect(body.one_time_keys).toBeDefined();
         }
@@ -209,9 +209,9 @@ describe(OlmMachine.name, () => {
             expect(outgoingRequests[1]).toBeInstanceOf(KeysQueryRequest);
             expect(outgoingRequests[1].id).toBeDefined();
             expect(outgoingRequests[1].type).toStrictEqual(RequestType.KeysQuery);
-            expect(outgoingRequests[1].extra).toBeDefined();
+            expect(outgoingRequests[1].body).toBeDefined();
 
-            const body = JSON.parse(outgoingRequests[1].extra);
+            const body = JSON.parse(outgoingRequests[1].body);
             expect(body.timeout).toBeDefined();
             expect(body.device_keys).toBeDefined();
             expect(body.token).toBeDefined();

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -198,21 +198,17 @@ describe(OlmMachine.name, () => {
             expect(outgoingRequests[0]).toBeInstanceOf(KeysUploadRequest);
             expect(outgoingRequests[0].id).toBeDefined();
             expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
-
-            const body = JSON.parse(outgoingRequests[0].body);
-            expect(body.device_keys).toBeDefined();
-            expect(body.one_time_keys).toBeDefined();
+            expect(outgoingRequests[0].device_keys).toBeDefined();
+            expect(outgoingRequests[0].one_time_keys).toBeDefined();
         }
 
         {
             expect(outgoingRequests[1]).toBeInstanceOf(KeysQueryRequest);
             expect(outgoingRequests[1].id).toBeDefined();
             expect(outgoingRequests[1].type).toStrictEqual(RequestType.KeysQuery);
-
-            const body = JSON.parse(outgoingRequests[1].body);
-            expect(body.timeout).toBeDefined();
-            expect(body.device_keys).toBeDefined();
-            expect(body.token).toBeDefined();
+            expect(outgoingRequests[1].timeout).toBeUndefined();
+            expect(outgoingRequests[1].device_keys).toBeDefined();
+            expect(outgoingRequests[1].token).toBeUndefined();
         }
     });
 

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -802,10 +802,10 @@ describe(OlmMachine.name, () => {
             expect(outgoingVerificationRequest.room_id).toStrictEqual(room.toString());
             expect(outgoingVerificationRequest.txn_id).toBeDefined();
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.start');
-            expect(outgoingVerificationRequest.content).toBeDefined();
+            expect(outgoingVerificationRequest.body).toBeDefined();
 
-            const content = JSON.parse(outgoingVerificationRequest.content);
-            expect(content).toMatchObject({
+            const body = JSON.parse(outgoingVerificationRequest.body);
+            expect(body).toMatchObject({
                 from_device: expect.any(String),
                 method: 'm.sas.v1',
                 key_agreement_protocols: [expect.any(String)],

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -198,17 +198,23 @@ describe(OlmMachine.name, () => {
             expect(outgoingRequests[0]).toBeInstanceOf(KeysUploadRequest);
             expect(outgoingRequests[0].id).toBeDefined();
             expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
-            expect(outgoingRequests[0].device_keys).toBeDefined();
-            expect(outgoingRequests[0].one_time_keys).toBeDefined();
+            expect(outgoingRequests[0].body).toBeDefined();
+
+            const body = JSON.parse(outgoingRequests[0].body)
+            expect(body.device_keys).toBeDefined();
+            expect(body.one_time_keys).toBeDefined();
         }
 
         {
             expect(outgoingRequests[1]).toBeInstanceOf(KeysQueryRequest);
             expect(outgoingRequests[1].id).toBeDefined();
             expect(outgoingRequests[1].type).toStrictEqual(RequestType.KeysQuery);
-            expect(outgoingRequests[1].timeout).toBeUndefined();
-            expect(outgoingRequests[1].device_keys).toBeDefined();
-            expect(outgoingRequests[1].token).toBeUndefined();
+            expect(outgoingRequests[1].body).toBeDefined();
+
+            const body = JSON.parse(outgoingRequests[1].body);
+            expect(body.timeout).toBeDefined();
+            expect(body.device_keys).toBeDefined();
+            expect(body.token).toBeDefined();
         }
     });
 

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -99,7 +99,7 @@ describe(OlmMachine.name, () => {
     test('can drop/close', async () => {
         m = await machine();
         m.close();
-    })
+    });
 
     test('can drop/close with a store', async () => {
         let store_name = 'temporary';
@@ -133,7 +133,7 @@ describe(OlmMachine.name, () => {
             deleting.onerror = () => { throw new Error('failed to remove the database (error)') };
             deleting.onblocked = () => { throw new Error('failed to remove the database (blocked)') };
         }
-    })
+    });
 
     test('can read user ID', async () => {
         expect((await machine()).userId.toString()).toStrictEqual(user.toString());
@@ -200,7 +200,7 @@ describe(OlmMachine.name, () => {
             expect(outgoingRequests[0].type).toStrictEqual(RequestType.KeysUpload);
             expect(outgoingRequests[0].body).toBeDefined();
 
-            const body = JSON.parse(outgoingRequests[0].body)
+            const body = JSON.parse(outgoingRequests[0].body);
             expect(body.device_keys).toBeDefined();
             expect(body.one_time_keys).toBeDefined();
         }

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -803,6 +803,20 @@ describe(OlmMachine.name, () => {
             expect(outgoingVerificationRequest.txn_id).toBeDefined();
             expect(outgoingVerificationRequest.event_type).toStrictEqual('m.key.verification.start');
             expect(outgoingVerificationRequest.content).toBeDefined();
+
+            const content = JSON.parse(outgoingVerificationRequest.content);
+            expect(content).toMatchObject({
+                from_device: expect.any(String),
+                method: 'm.sas.v1',
+                key_agreement_protocols: [expect.any(String)],
+                hashes: [expect.any(String)],
+                message_authentication_codes: [expect.any(String), expect.any(String)],
+                short_authentication_string: ['decimal', 'emoji'],
+                'm.relates_to': {
+                    rel_type: 'm.reference',
+                    event_id: eventId.toString(),
+                }
+            });
         })
     });
 });

--- a/bindings/matrix-sdk-crypto-js/tests/requests.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/requests.test.js
@@ -11,25 +11,3 @@ describe('RequestType', () => {
         expect(RequestType.KeysBackup).toStrictEqual(6);
     });
 });
-
-for (const [request, requestType] of [
-    [KeysUploadRequest, RequestType.KeysUpload],
-    [KeysQueryRequest, RequestType.KeysQuery],
-    [KeysClaimRequest, RequestType.KeysClaim],
-    [ToDeviceRequest, RequestType.ToDevice],
-    [SignatureUploadRequest, RequestType.SignatureUpload],
-    [RoomMessageRequest, RequestType.RoomMessage],
-    [KeysBackupRequest, RequestType.KeysBackup],
-]) {
-    describe(request.name, () => {
-        test('can be instantiated', () => {
-            const r = new (request)('foo', '{"bar": "baz"}');
-
-            expect(r).toBeInstanceOf(request);
-            expect(r.id).toStrictEqual('foo');
-            expect(r.body).toStrictEqual('{"bar": "baz"}');
-            expect(r.type).toStrictEqual(requestType);
-        });
-    })
-
-}


### PR DESCRIPTION
It's kind of intuitive to understand with an example.

Before:

```rust
pub struct ToDeviceRequest {
    pub id: Option<JsString>,
    pub body: JsString,
}
```

After:

```rust
pub struct ToDeviceRequest {
    pub id: Option<JsString>,
    pub event_type: JsString,
    pub txn_id: JsString,
    pub body: JsString,
}
```

Previously, `body` was containing a JSON map containing `event_type`, `txn_id` and `messages`. Now it's part of the struct itself.

Some types have been _extracted_ as individual fields, and the others are _grouped_ inside `extra`.

The documentation explains which fields is a regular JS string, or a JSON-encoded string. In this case, `event_type` and `txn_id` are regular ID, while `messages` is part a JSON encoded string inside `body`. Supported “field types” are:

* `json` to JSON-encode the field's value,
* `string` to get a JS string from the field's value,
* More types can be added super easily inside the macro.

The `request!` has been updated and holds up the magic. It now defines `ToDeviceRequest` has:

```rust
request!(ToDeviceRequest from OriginalToDeviceRequest maps fields event_type: string, txn_id: string and grouped fields messages);
```

Edit to add the TypeScript type definition:

```typescript
export class ToDeviceRequest {
  free(): void;

  constructor(id: string, event_type: string, txn_id: string, messages: string);

  readonly body: string;
  readonly event_type: string;
  readonly id: string | undefined;
  readonly txn_id: string;
  readonly type: number;
}
```

The rest of the patch is just adding documentation to the new fields and updating the tests accordingly.

cc @richvdh you've requested this
cc @turt2live for https://github.com/matrix-org/matrix-rust-sdk/issues/1291, would it solve your issue?