### PR TITLE
Update to clap v4 in jack-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,15 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,7 +283,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -679,21 +670,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -704,23 +680,23 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap"
-version = "4.0.26"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive 4.0.21",
  "clap_lex 0.3.0",
+ "is-terminal",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
 ]
 
@@ -730,7 +706,7 @@ version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -743,7 +719,7 @@ version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1141,7 +1117,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -1506,7 +1482,7 @@ name = "example-emoji-verification"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.32",
  "futures",
  "matrix-sdk",
  "tokio",
@@ -1564,7 +1540,7 @@ name = "example-timeline"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.26",
+ "clap 4.0.32",
  "futures",
  "futures-signals",
  "matrix-sdk",
@@ -1950,15 +1926,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -1968,6 +1935,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -2278,6 +2254,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2286,7 @@ version = "0.2.0"
 dependencies = [
  "app_dirs2",
  "chrono",
+ "clap 4.0.32",
  "dialoguer",
  "eyre",
  "futures",
@@ -2308,7 +2297,6 @@ dependencies = [
  "matrix-sdk-sled",
  "sanitize-filename-reader-friendly",
  "serde_json",
- "structopt",
  "tokio",
  "tracing",
  "tracing-flame",
@@ -3222,7 +3210,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -4053,9 +4041,9 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.36.2"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203974af07ea769452490ee8de3e5947971efc3a090dca8a779dd432d3fa46a7"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -4511,39 +4499,9 @@ checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "subtle"
@@ -4655,15 +4613,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -5188,7 +5137,7 @@ dependencies = [
  "fs-err",
  "glob",
  "goblin",
- "heck 0.4.0",
+ "heck",
  "once_cell",
  "paste",
  "serde",
@@ -5310,12 +5259,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -5763,7 +5706,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "camino",
- "clap 4.0.26",
+ "clap 4.0.32",
  "fs_extra",
  "serde",
  "serde_json",

--- a/labs/jack-in/Cargo.toml
+++ b/labs/jack-in/Cargo.toml
@@ -11,6 +11,7 @@ file-logging = ["dep:log4rs"]
 [dependencies]
 app_dirs2 = "2"
 chrono = "0.4.23"
+clap = { version = "4.0.29", features = ["derive", "env"] }
 dialoguer = "0.10.2"
 eyre = "0.6"
 futures = { version = "0.3.1" }
@@ -20,7 +21,6 @@ matrix-sdk-common = { path = "../../crates/matrix-sdk-common", version = "0.6.0"
 matrix-sdk-sled = { path = "../../crates/matrix-sdk-sled", features = ["state-store", "crypto-store"], version = "0.2.0" }
 sanitize-filename-reader-friendly = "2.2.1"
 serde_json = "1.0.85"
-structopt = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
 tracing-flame = "0.2"
 tracing-subscriber = "0.3.15"

--- a/labs/jack-in/README.md
+++ b/labs/jack-in/README.md
@@ -30,7 +30,7 @@ Options:
       --sliding-sync-proxy <PROXY>
           The address of the sliding sync server to connect (probs the proxy) [env: JACKIN_SYNC_PROXY=] [default: http://localhost:8008]
       --full-sync-mode <FULL_SYNC_MODE>
-          Activate growing window rather than pagination for full-sync [default: Paging] [possible values: Growing, Paging]
+          Activate growing window rather than pagination for full-sync [default: paging] [possible values: growing, paging]
       --limit <LIMIT>
           Limit the growing/paging to this number of maximum items to caonsider "done"
       --batch-size <BATCH_SIZE>

--- a/labs/jack-in/README.md
+++ b/labs/jack-in/README.md
@@ -10,23 +10,35 @@ You will need a [running sliding sync proxy](https://github.com/matrix-org/slidi
 From the roof of this workspace, run jack-in via `cargo run -p jack-in` . Please note that you need to specify the access-token and username, both can be done via environment variables, too. As well as the homeserver (or `http://localhost:8008` will be assumed). See below for how to acquire an access token.
 
 ```
-jack-in 0.2.0
 Your experimental sliding-sync jack into the matrix
 
-USAGE:
-    jack-in [OPTIONS] --token <token> --user <user>
+Usage: jack-in [OPTIONS] --user <USER>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-        --flames <flames>                            Activate tracing and write the flamegraph to the specified file
-    -s, --sliding-sync-proxy <sliding-sync-proxy>
-            The address of the sliding sync server to connect (probs the proxy) [env: JACKIN_SYNC_PROXY=]  [default:
-            http://localhost:8008]
-    -t, --token <token>                              Your access token to connect via the [env: JACKIN_TOKEN=]
-    -u, --user <user>                                The userID associated with this access token [env: JACKIN_USER=]
+Options:
+  -p, --password <PASSWORD>
+          The password of your account. If not given and no database found, it will prompt you for it [env: JACKIN_PASSWORD=]
+      --fresh
+          Create a fresh database, drop all existing cache
+  -l, --log <LOG>
+          RUST_LOG log-levels [env: JACKIN_LOG=] [default: jack_in=info,warn]
+  -u, --user <USER>
+          The userID to log in with [env: JACKIN_USER=]
+      --store-pass <STORE_PASS>
+          The password to encrypt the store  with [env: JACKIN_STORE_PASSWORD=]
+      --flames <FLAMES>
+          Activate tracing and write the flamegraph to the specified file
+      --sliding-sync-proxy <PROXY>
+          The address of the sliding sync server to connect (probs the proxy) [env: JACKIN_SYNC_PROXY=] [default: http://localhost:8008]
+      --full-sync-mode <FULL_SYNC_MODE>
+          Activate growing window rather than pagination for full-sync [default: Paging] [possible values: Growing, Paging]
+      --limit <LIMIT>
+          Limit the growing/paging to this number of maximum items to caonsider "done"
+      --batch-size <BATCH_SIZE>
+          define the batch_size per request
+      --timeline-limit <TIMELINE_LIMIT>
+          define the timeline items to load
+  -h, --help
+          Print help information
 ```
 
 

--- a/labs/jack-in/src/config.rs
+++ b/labs/jack-in/src/config.rs
@@ -1,47 +1,45 @@
 use std::path::PathBuf;
 
+use clap::{Args, Parser, ValueEnum};
 use matrix_sdk::SlidingSyncMode;
-use structopt::{clap::arg_enum, StructOpt};
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "jack-in", about = "Your experimental sliding-sync jack into the matrix")]
+#[derive(Debug, Parser)]
+#[command(name = "jack-in", about = "Your experimental sliding-sync jack into the matrix")]
 pub struct Opt {
     /// The password of your account. If not given and no database found, it
     /// will prompt you for it
-    #[structopt(short, long, env = "JACKIN_PASSWORD")]
+    #[arg(short, long, env = "JACKIN_PASSWORD")]
     pub password: Option<String>,
 
     /// Create a fresh database, drop all existing cache
-    #[structopt(long)]
+    #[arg(long)]
     pub fresh: bool,
 
     /// RUST_LOG log-levels
-    #[structopt(short, long, env = "JACKIN_LOG", default_value = "jack_in=info,warn")]
+    #[arg(short, long, env = "JACKIN_LOG", default_value = "jack_in=info,warn")]
     pub log: String,
 
     /// The userID to log in with
-    #[structopt(short, long, env = "JACKIN_USER")]
+    #[arg(short, long, env = "JACKIN_USER")]
     pub user: String,
 
     /// The password to encrypt the store  with
-    #[structopt(long, env = "JACKIN_STORE_PASSWORD")]
+    #[arg(long, env = "JACKIN_STORE_PASSWORD")]
     pub store_pass: Option<String>,
 
-    #[structopt(long)]
+    #[arg(long)]
     /// Activate tracing and write the flamegraph to the specified file
     pub flames: Option<PathBuf>,
 
-    #[structopt(flatten)]
+    #[command(flatten)]
     /// Sliding Sync configuration flags
     pub sliding_sync: SlidingSyncConfig,
 }
 
-arg_enum! {
-    #[derive(Debug)]
-    pub enum FullSyncMode {
-        Growing,
-        Paging,
-    }
+#[derive(Debug, Clone, ValueEnum)]
+pub enum FullSyncMode {
+    Growing,
+    Paging,
 }
 
 impl From<FullSyncMode> for SlidingSyncMode {
@@ -53,10 +51,10 @@ impl From<FullSyncMode> for SlidingSyncMode {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct SlidingSyncConfig {
     /// The address of the sliding sync server to connect (probs the proxy)
-    #[structopt(
+    #[arg(
         long = "sliding-sync-proxy",
         default_value = "http://localhost:8008",
         env = "JACKIN_SYNC_PROXY"
@@ -64,19 +62,19 @@ pub struct SlidingSyncConfig {
     pub proxy: String,
 
     /// Activate growing window rather than pagination for full-sync
-    #[structopt(long, default_value = "SlidingSyncMode::Paging")]
+    #[arg(long, default_value = "SlidingSyncMode::Paging")]
     pub full_sync_mode: FullSyncMode,
 
     /// Limit the growing/paging to this number of maximum items to caonsider
     /// "done"
-    #[structopt(long)]
+    #[arg(long)]
     pub limit: Option<u32>,
 
     /// define the batch_size per request
-    #[structopt(long)]
+    #[arg(long)]
     pub batch_size: Option<u32>,
 
     /// define the timeline items to load
-    #[structopt(long)]
+    #[arg(long)]
     pub timeline_limit: Option<u32>,
 }

--- a/labs/jack-in/src/config.rs
+++ b/labs/jack-in/src/config.rs
@@ -37,6 +37,7 @@ pub struct Opt {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
+#[value(rename_all = "PascalCase")]
 pub enum FullSyncMode {
     Growing,
     Paging,
@@ -62,7 +63,7 @@ pub struct SlidingSyncConfig {
     pub proxy: String,
 
     /// Activate growing window rather than pagination for full-sync
-    #[arg(long, default_value = "SlidingSyncMode::Paging")]
+    #[arg(long, default_value = "Paging")]
     pub full_sync_mode: FullSyncMode,
 
     /// Limit the growing/paging to this number of maximum items to caonsider

--- a/labs/jack-in/src/config.rs
+++ b/labs/jack-in/src/config.rs
@@ -37,7 +37,7 @@ pub struct Opt {
 }
 
 #[derive(Debug, Clone, ValueEnum)]
-#[value(rename_all = "PascalCase")]
+#[value(rename_all = "lower")]
 pub enum FullSyncMode {
     Growing,
     Paging,
@@ -63,7 +63,7 @@ pub struct SlidingSyncConfig {
     pub proxy: String,
 
     /// Activate growing window rather than pagination for full-sync
-    #[arg(long, default_value = "Paging")]
+    #[arg(long, default_value = "paging")]
     pub full_sync_mode: FullSyncMode,
 
     /// Limit the growing/paging to this number of maximum items to caonsider

--- a/labs/jack-in/src/main.rs
+++ b/labs/jack-in/src/main.rs
@@ -5,6 +5,7 @@
 use std::{path::Path, time::Duration};
 
 use app_dirs2::{app_root, AppDataType, AppInfo};
+use clap::Parser;
 use dialoguer::{theme::ColorfulTheme, Password};
 use eyre::{eyre, Result};
 use futures_signals::signal_vec::VecDiff;
@@ -16,7 +17,6 @@ use matrix_sdk::{
 };
 use matrix_sdk_sled::make_store_config;
 use sanitize_filename_reader_friendly::sanitize;
-use structopt::StructOpt;
 use tracing::{error, log};
 use tracing_flame::FlameLayer;
 use tracing_subscriber::prelude::*;
@@ -103,7 +103,7 @@ fn setup_flames(path: &Path) -> impl Drop {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let user_id: OwnedUserId = opt.user.clone().parse()?;
 


### PR DESCRIPTION
Updated jack-in to use `clap` instead of `structopt` and changed the README.md of jack-in with the new help output.

Fixes #1274