### PR TITLE
handle the to-device sliding sync extension correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
 name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,7 +2032,7 @@ checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
  "async-channel",
- "base64",
+ "base64 0.13.1",
  "futures-lite",
  "http",
  "infer",
@@ -2585,6 +2591,7 @@ dependencies = [
  "reqwest",
  "ruma",
  "serde",
+ "serde_html_form",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -2614,6 +2621,7 @@ dependencies = [
  "regex",
  "ruma",
  "serde",
+ "serde_html_form",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -2682,7 +2690,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atomic",
- "base64",
+ "base64 0.13.1",
  "bs58",
  "byteorder",
  "cfg-if",
@@ -2720,7 +2728,7 @@ name = "matrix-sdk-crypto-ffi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "futures-util",
  "hmac",
  "http",
@@ -2818,7 +2826,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "dashmap",
  "derive_builder",
  "getrandom 0.2.8",
@@ -2860,7 +2868,7 @@ dependencies = [
 name = "matrix-sdk-qrcode"
 version = "0.4.0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "image 0.23.14",
  "qrcode",
@@ -3870,7 +3878,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3940,7 +3948,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.7.4"
-source = "git+https://github.com/ruma/ruma?rev=284b797e0513daf56859b64b8c7a506856fb11ec#284b797e0513daf56859b64b8c7a506856fb11ec"
+source = "git+https://github.com/ruma/ruma?rev=022a0c0475f7ffeccd5a26c15b9465edf06ba8b8#022a0c0475f7ffeccd5a26c15b9465edf06ba8b8"
 dependencies = [
  "assign",
  "js_int",
@@ -3954,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.7.0"
-source = "git+https://github.com/ruma/ruma?rev=284b797e0513daf56859b64b8c7a506856fb11ec#284b797e0513daf56859b64b8c7a506856fb11ec"
+source = "git+https://github.com/ruma/ruma?rev=022a0c0475f7ffeccd5a26c15b9465edf06ba8b8#022a0c0475f7ffeccd5a26c15b9465edf06ba8b8"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -3965,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.15.3"
-source = "git+https://github.com/ruma/ruma?rev=284b797e0513daf56859b64b8c7a506856fb11ec#284b797e0513daf56859b64b8c7a506856fb11ec"
+source = "git+https://github.com/ruma/ruma?rev=022a0c0475f7ffeccd5a26c15b9465edf06ba8b8#022a0c0475f7ffeccd5a26c15b9465edf06ba8b8"
 dependencies = [
  "assign",
  "bytes",
@@ -3973,24 +3981,23 @@ dependencies = [
  "js_int",
  "js_option",
  "maplit",
- "percent-encoding",
  "ruma-common",
  "serde",
+ "serde_html_form",
  "serde_json",
 ]
 
 [[package]]
 name = "ruma-common"
 version = "0.10.5"
-source = "git+https://github.com/ruma/ruma?rev=284b797e0513daf56859b64b8c7a506856fb11ec#284b797e0513daf56859b64b8c7a506856fb11ec"
+source = "git+https://github.com/ruma/ruma?rev=022a0c0475f7ffeccd5a26c15b9465edf06ba8b8#022a0c0475f7ffeccd5a26c15b9465edf06ba8b8"
 dependencies = [
- "base64",
+ "base64 0.20.0",
  "bytes",
  "form_urlencoded",
  "getrandom 0.2.8",
  "http",
  "indexmap",
- "itoa",
  "js-sys",
  "js_int",
  "js_option",
@@ -4002,6 +4009,7 @@ dependencies = [
  "ruma-identifiers-validation",
  "ruma-macros",
  "serde",
+ "serde_html_form",
  "serde_json",
  "thiserror",
  "tracing",
@@ -4013,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.6.0"
-source = "git+https://github.com/ruma/ruma?rev=284b797e0513daf56859b64b8c7a506856fb11ec#284b797e0513daf56859b64b8c7a506856fb11ec"
+source = "git+https://github.com/ruma/ruma?rev=022a0c0475f7ffeccd5a26c15b9465edf06ba8b8#022a0c0475f7ffeccd5a26c15b9465edf06ba8b8"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4024,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=284b797e0513daf56859b64b8c7a506856fb11ec#284b797e0513daf56859b64b8c7a506856fb11ec"
+source = "git+https://github.com/ruma/ruma?rev=022a0c0475f7ffeccd5a26c15b9465edf06ba8b8#022a0c0475f7ffeccd5a26c15b9465edf06ba8b8"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4033,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.10.5"
-source = "git+https://github.com/ruma/ruma?rev=284b797e0513daf56859b64b8c7a506856fb11ec#284b797e0513daf56859b64b8c7a506856fb11ec"
+source = "git+https://github.com/ruma/ruma?rev=022a0c0475f7ffeccd5a26c15b9465edf06ba8b8#022a0c0475f7ffeccd5a26c15b9465edf06ba8b8"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4083,7 +4091,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -4273,6 +4281,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53192e38d5c88564b924dbe9b60865ecbb71b81d38c4e61c817cffd3e36ef696"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -5331,7 +5352,7 @@ checksum = "f6f20153a1c82ac5f1243b62e80f067ae608facc415c6ef82f88426a61c79886"
 dependencies = [
  "aes",
  "arrayvec",
- "base64",
+ "base64 0.13.1",
  "cbc",
  "ed25519-dalek",
  "hkdf",
@@ -5708,7 +5729,7 @@ checksum = "249dc68542861d17eae4b4e5e8fb381c2f9e8f255a84f6771d5fdf8b6c03ce3c"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "deadpool",
  "futures",
  "futures-timer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ resolver = "2"
 rust-version = "1.65"
 
 [workspace.dependencies]
-ruma = { git = "https://github.com/ruma/ruma", rev = "284b797e0513daf56859b64b8c7a506856fb11ec", features = ["client-api-c"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "284b797e0513daf56859b64b8c7a506856fb11ec" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "022a0c0475f7ffeccd5a26c15b9465edf06ba8b8", features = ["client-api-c"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "022a0c0475f7ffeccd5a26c15b9465edf06ba8b8" }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "249a78b6f3f35661f1530e53811134e1bf012608" }
 uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "249a78b6f3f35661f1530e53811134e1bf012608" }

--- a/crates/matrix-sdk-appservice/Cargo.toml
+++ b/crates/matrix-sdk-appservice/Cargo.toml
@@ -39,6 +39,7 @@ matrix-sdk = { version = "0.6.0", path = "../matrix-sdk", default-features = fal
 regex = "1.5.5"
 ruma = { workspace = true, features = ["appservice-api-s"] }
 serde = "1.0.136"
+serde_html_form = "0.2.0"
 serde_json = "1.0.79"
 serde_yaml = "0.9.4"
 tokio = { version = "1.17.0", default-features = false, features = ["rt-multi-thread"] }

--- a/crates/matrix-sdk-appservice/src/webserver.rs
+++ b/crates/matrix-sdk-appservice/src/webserver.rs
@@ -31,7 +31,7 @@ use axum::{
 };
 use http::StatusCode;
 use hyper::Body;
-use matrix_sdk::ruma::{self, api::IncomingRequest};
+use matrix_sdk::ruma::api::IncomingRequest;
 use serde::{Deserialize, Serialize};
 use tower::{Service, ServiceBuilder};
 
@@ -241,7 +241,7 @@ async fn validate_access_token<B>(
         req.extensions().get::<AppService>().ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
 
     let query_string = req.uri().query().unwrap_or("");
-    match ruma::serde::urlencoded::from_str::<QueryParameters>(query_string) {
+    match serde_html_form::from_str::<QueryParameters>(query_string) {
         Ok(query) if query.access_token == appservice.registration.hs_token => {
             Ok(next.run(req).await)
         }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -55,9 +55,9 @@ use ruma::{
         },
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncStateEvent, EmptyStateKey, GlobalAccountDataEvent, GlobalAccountDataEventContent,
-        GlobalAccountDataEventType, RedactContent, RedactedStateEventContent, RoomAccountDataEvent,
-        RoomAccountDataEventContent, RoomAccountDataEventType, StateEventContent, StateEventType,
-        StaticEventContent, SyncStateEvent,
+        GlobalAccountDataEventType, OriginalStateEventContent, RedactedStateEventContent,
+        RoomAccountDataEvent, RoomAccountDataEventContent, RoomAccountDataEventType,
+        StateEventType, StaticEventContent, SyncStateEvent,
     },
     serde::Raw,
     EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
@@ -385,7 +385,7 @@ pub trait StateStoreExt: StateStore {
         room_id: &RoomId,
     ) -> Result<Option<Raw<SyncStateEvent<C>>>>
     where
-        C: StaticEventContent + StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+        C: StaticEventContent + OriginalStateEventContent<StateKey = EmptyStateKey>,
         C::Redacted: RedactedStateEventContent + DeserializeOwned,
     {
         Ok(self.get_state_event(room_id, C::TYPE.into(), "").await?.map(Raw::cast))
@@ -402,7 +402,7 @@ pub trait StateStoreExt: StateStore {
         state_key: &K,
     ) -> Result<Option<Raw<SyncStateEvent<C>>>>
     where
-        C: StaticEventContent + StateEventContent + RedactContent,
+        C: StaticEventContent + OriginalStateEventContent,
         C::StateKey: Borrow<K>,
         C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + ?Sized + Sync,
@@ -420,7 +420,7 @@ pub trait StateStoreExt: StateStore {
         room_id: &RoomId,
     ) -> Result<Vec<Raw<SyncStateEvent<C>>>>
     where
-        C: StaticEventContent + StateEventContent + RedactContent,
+        C: StaticEventContent + OriginalStateEventContent,
         C::Redacted: RedactedStateEventContent,
     {
         // FIXME: Could be more efficient, if we had streaming store accessor functions

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -1,8 +1,8 @@
 use ruma::{
     events::{
         room::member::{MembershipState, RoomMemberEventContent},
-        RedactContent, RedactedEventContent, RedactedStateEventContent, StateEventContent,
-        StrippedStateEvent, SyncStateEvent,
+        OriginalStateEventContent, RedactContent, RedactedEventContent, RedactedStateEventContent,
+        StateEventContent, StrippedStateEvent, SyncStateEvent,
     },
     EventId, OwnedEventId, RoomVersionId,
 };
@@ -125,7 +125,7 @@ impl MinimalRoomMemberEvent {
 
 impl<C> From<SyncStateEvent<C>> for MinimalStateEvent<C>
 where
-    C: StateEventContent + RedactContent,
+    C: OriginalStateEventContent,
     C::Redacted: RedactedStateEventContent,
 {
     fn from(ev: SyncStateEvent<C>) -> Self {
@@ -144,7 +144,7 @@ where
 
 impl<C> From<&SyncStateEvent<C>> for MinimalStateEvent<C>
 where
-    C: Clone + StateEventContent + RedactContent,
+    C: Clone + OriginalStateEventContent,
     C::Redacted: Clone + RedactedStateEventContent,
 {
     fn from(ev: &SyncStateEvent<C>) -> Self {

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -83,6 +83,7 @@ rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.11.10", default_features = false }
 ruma = { workspace = true, features = ["compat", "rand", "unstable-msc2448", "unstable-msc2965"] }
 serde = "1.0.136"
+serde_html_form = "0.2.0"
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 tokio-stream = { version = "0.1.8", features = ["net"], optional = true }

--- a/crates/matrix-sdk/src/client/login_builder.rs
+++ b/crates/matrix-sdk/src/client/login_builder.rs
@@ -334,8 +334,8 @@ where
 
             if let Some(data_tx) = data_tx_mutex.lock().unwrap().take() {
                 let query_string = request.uri().query().unwrap_or("");
-                let query: QueryParameters = ruma::serde::urlencoded::from_str(query_string)
-                    .map_err(|_| {
+                let query: QueryParameters =
+                    serde_html_form::from_str(query_string).map_err(|_| {
                         debug!("Failed to deserialize query parameters");
                         StatusCode::BAD_REQUEST
                     })?;

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -21,9 +21,9 @@ use ruma::{
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent,
         AnySyncTimelineEvent, AnyToDeviceEvent, EphemeralRoomEventContent,
-        GlobalAccountDataEventContent, MessageLikeEventContent, RedactContent,
-        RedactedMessageLikeEventContent, RedactedStateEventContent, RoomAccountDataEventContent,
-        StateEventContent, StaticEventContent, ToDeviceEventContent,
+        GlobalAccountDataEventContent, MessageLikeEventContent, OriginalStateEventContent,
+        RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
+        RoomAccountDataEventContent, StateEventContent, StaticEventContent, ToDeviceEventContent,
     },
     serde::Raw,
 };
@@ -99,7 +99,7 @@ impl SyncEvent for events::room::redaction::RedactedSyncRoomRedactionEvent {
 
 impl<C> SyncEvent for events::SyncStateEvent<C>
 where
-    C: StaticEventContent + StateEventContent + RedactContent,
+    C: StaticEventContent + OriginalStateEventContent,
     C::Redacted: RedactedStateEventContent,
 {
     const KIND: HandlerKind = HandlerKind::State;
@@ -108,7 +108,7 @@ where
 
 impl<C> SyncEvent for events::OriginalSyncStateEvent<C>
 where
-    C: StaticEventContent + StateEventContent,
+    C: StaticEventContent + OriginalStateEventContent,
 {
     const KIND: HandlerKind = HandlerKind::OriginalState;
     const TYPE: Option<&'static str> = Some(C::TYPE);

--- a/crates/matrix-sdk/src/events.rs
+++ b/crates/matrix-sdk/src/events.rs
@@ -1,9 +1,10 @@
 use ruma::{
     events::{
         BundledRelations, EventContent, MessageLikeEventContent, MessageLikeEventType,
-        OriginalSyncMessageLikeEvent, OriginalSyncStateEvent, RedactedEventContent,
-        RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedSyncMessageLikeEvent,
-        RedactedSyncStateEvent, StateEventContent, StateEventType, StateUnsigned,
+        OriginalStateEventContent, OriginalSyncMessageLikeEvent, OriginalSyncStateEvent,
+        RedactContent, RedactedEventContent, RedactedMessageLikeEventContent,
+        RedactedStateEventContent, RedactedSyncMessageLikeEvent, RedactedSyncStateEvent,
+        StateEventContent, StateEventType, StateUnsigned,
     },
     serde::from_raw_json_value,
     EventId, MilliSecondsSinceUnixEpoch, TransactionId, UserId,
@@ -138,8 +139,17 @@ impl EventContent for NoStateEventContent {
         Ok(Self { event_type: event_type.into() })
     }
 }
+impl RedactContent for NoStateEventContent {
+    type Redacted = Self;
+
+    fn redact(self, _version: &ruma::RoomVersionId) -> Self::Redacted {
+        self
+    }
+}
 impl StateEventContent for NoStateEventContent {
     type StateKey = String;
+}
+impl OriginalStateEventContent for NoStateEventContent {
     type Unsigned = StateUnsigned<Self>;
 }
 impl RedactedEventContent for NoStateEventContent {}

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -31,9 +31,9 @@ use ruma::{
             server_acl::RoomServerAclEventContent, MediaSource,
         },
         tag::{TagInfo, TagName},
-        AnyRoomAccountDataEvent, AnyStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
-        RedactedStateEventContent, RoomAccountDataEvent, RoomAccountDataEventContent,
-        RoomAccountDataEventType, StateEventContent, StateEventType, StaticEventContent,
+        AnyRoomAccountDataEvent, AnyStateEvent, AnySyncStateEvent, EmptyStateKey,
+        OriginalStateEventContent, RedactedStateEventContent, RoomAccountDataEvent,
+        RoomAccountDataEventContent, RoomAccountDataEventType, StateEventType, StaticEventContent,
         SyncStateEvent,
     },
     serde::Raw,
@@ -579,7 +579,7 @@ impl Common {
     /// ```
     pub async fn get_state_events_static<C>(&self) -> Result<Vec<Raw<SyncStateEvent<C>>>>
     where
-        C: StaticEventContent + StateEventContent + RedactContent,
+        C: StaticEventContent + OriginalStateEventContent,
         C::Redacted: RedactedStateEventContent,
     {
         Ok(self.client.store().get_state_events_static(self.room_id()).await?)
@@ -618,7 +618,7 @@ impl Common {
     /// ```
     pub async fn get_state_event_static<C>(&self) -> Result<Option<Raw<SyncStateEvent<C>>>>
     where
-        C: StaticEventContent + StateEventContent<StateKey = EmptyStateKey> + RedactContent,
+        C: StaticEventContent + OriginalStateEventContent<StateKey = EmptyStateKey>,
         C::Redacted: RedactedStateEventContent,
     {
         self.get_state_event_static_for_key(&EmptyStateKey).await
@@ -646,7 +646,7 @@ impl Common {
         state_key: &K,
     ) -> Result<Option<Raw<SyncStateEvent<C>>>>
     where
-        C: StaticEventContent + StateEventContent + RedactContent,
+        C: StaticEventContent + OriginalStateEventContent,
         C::StateKey: Borrow<K>,
         C::Redacted: RedactedStateEventContent,
         K: AsRef<str> + ?Sized + Sync,

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -778,7 +778,7 @@ impl SlidingSync {
                 .map(SlidingSyncView::request_generator)
                 .collect();
             loop {
-                tracing::debug!("Sync loop running with self.extensions={:?}", self.extensions);
+                tracing::debug!(?self.extensions, "Sync loop running");
 
                 let mut requests = Vec::new();
                 let mut new_remaining_generators = Vec::new();
@@ -867,10 +867,9 @@ impl SlidingSync {
                             *self.pos.lock_mut() = None;
 
                             // reset our extensions to the last known good ones.
-                            *self.extensions.lock().unwrap() = self.sent_extensions.lock().unwrap().clone();
-                            self.sent_extensions.lock().unwrap().take();
+                            *self.extensions.lock().unwrap() = self.sent_extensions.lock().unwrap().take();
 
-                            tracing::debug!("Resetting view stream with self.extensions={:?}", self.extensions);
+                            tracing::debug!(?self.extensions, "Resetting view stream");
 
                             continue
                         }

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -748,7 +748,7 @@ impl SlidingSync {
 
             // track the most recently successfully sent extensions (needed for sticky
             // semantics)
-            if !extensions.is_none() {
+            if extensions.is_some() {
                 *self.sent_extensions.lock().unwrap() = extensions;
             }
 

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -814,7 +814,7 @@ impl SlidingSync {
                     // then we don't know to re-add the sticky extension on the next request. So either we need to retry
                     // and queue all requests as a matter of course - or we need to only pop extensions when we know this
                     // req has succeeded. for now, we make extensions non-sticky to make things work reliably...
-                    extensions: self.extensions.lock().unwrap().as_ref().unwrap().clone(),
+                    extensions: self.extensions.lock().unwrap().clone().unwrap_or_default(),
                 });
                 tracing::debug!("requesting");
 

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -586,13 +586,13 @@ pub struct SlidingSync {
     /// keeping track of retries and failure cunts
     failure_count: Arc<AtomicU8>,
 
-    /// the initial set of extensions used for this sliding sync instance - this is what
-    /// we reset the extensions to when the session expires.
+    /// the initial set of extensions used for this sliding sync instance - this
+    /// is what we reset the extensions to when the session expires.
     initial_extensions: Option<ExtensionsConfig>,
 
-    /// the current state of the extensions being supplied to sliding /sync calls
-    /// may be None, if the extensions are static and sticky, or may contain the latest next_batch
-    /// for to_devices, etc.
+    /// the current state of the extensions being supplied to sliding /sync
+    /// calls may be None, if the extensions are static and sticky, or may
+    /// contain the latest next_batch for to_devices, etc.
     extensions: Arc<Mutex<Option<ExtensionsConfig>>>,
 }
 
@@ -761,7 +761,10 @@ impl SlidingSync {
         let views = self.views.lock_ref().to_vec();
         let client = self.client.clone();
 
-        tracing::debug!("Setting view stream going with self.initial_extensions={:?}", self.initial_extensions);
+        tracing::debug!(
+            "Setting view stream going with self.initial_extensions={:?}",
+            self.initial_extensions
+        );
         tracing::debug!("Setting view stream going with self.extensions={:?}", self.extensions);
 
         Ok(async_stream::stream! {

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -808,7 +808,7 @@ impl SlidingSync {
                     }
                     unsubs
                 };
-                let timeout = Some(Duration::from_secs(30));
+                let timeout = Duration::from_secs(30);
 
                 // implement stickiness by only sending extensions if they have changed since the last time we sent them
                 // TODO: use PartialEq instead rather than comparing JSON forms of ExtensionsConfig?
@@ -822,7 +822,7 @@ impl SlidingSync {
                 let req = assign!(v4::Request::new(), {
                     lists: requests,
                     pos,
-                    timeout,
+                    timeout: Some(timeout),
                     room_subscriptions,
                     unsubscribe_rooms,
                     extensions: extensions.clone().unwrap_or_default(),
@@ -830,7 +830,7 @@ impl SlidingSync {
                 tracing::debug!("requesting");
 
                 // 30s for the long poll + 30s for network delays
-                let request_config = RequestConfig::default().timeout(timeout.unwrap() + Duration::from_secs(30));
+                let request_config = RequestConfig::default().timeout(timeout + Duration::from_secs(30));
                 let req = client.send_with_homeserver(req, Some(request_config), self.homeserver.as_ref().map(ToString::to_string));
 
                 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -809,8 +809,12 @@ impl SlidingSync {
                     pos,
                     room_subscriptions,
                     unsubscribe_rooms,
-                    // extensions are sticky, we pop them here once; they will get rebuilt again if needed
-                    extensions: self.extensions.lock().unwrap().take().unwrap_or_default(),
+                    // extensions are sticky, so we could. pop them here once; they will get rebuilt again if needed
+                    // ...except this doesn't work: if this request fails for some reason (e.g. timing out),
+                    // then we don't know to re-add the sticky extension on the next request. So either we need to retry
+                    // and queue all requests as a matter of course - or we need to only pop extensions when we know this
+                    // req has succeeded. for now, we make extensions non-sticky to make things work reliably...
+                    extensions: self.extensions.lock().unwrap().as_ref().unwrap().clone(),
                 });
                 tracing::debug!("requesting");
 

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -810,15 +810,17 @@ impl SlidingSync {
                 };
                 let timeout = Duration::from_secs(30);
 
-                // implement stickiness by only sending extensions if they have changed since the last time we sent them
-                // TODO: use PartialEq instead rather than comparing JSON forms of ExtensionsConfig?
-                let extensions_json = serde_json::to_string(&self.extensions.lock().unwrap().clone()).unwrap();
-                let sent_extensions_json = serde_json::to_string(&self.sent_extensions.lock().unwrap().clone()).unwrap();
-                let extensions = if extensions_json == sent_extensions_json {
-                    None
-                } else {
-                    self.extensions.lock().unwrap().clone()
+                // implement stickiness by only sending extensions if they have
+                // changed since the last time we sent them
+                let extensions = {
+                    let extensions = self.extensions.lock().unwrap();
+                    if *extensions == *self.sent_extensions.lock().unwrap() {
+                        None
+                    } else {
+                        extensions.clone()
+                    }
                 };
+
                 let req = assign!(v4::Request::new(), {
                     lists: requests,
                     pos,


### PR DESCRIPTION
When SS sessions expire, we need to reset the SS extension to the original config used to set up the SS session in the first place. Instead, we were resetting it to a cache of the SS extension config at the point that a given SS view was created - which could well be 'None' given we clear the SS extension config whenever we send it to the server, given it's sticky. This would then entirely disasble the to-device extension after a session expires, dropping all to-device traffic and breaking E2EE.

It also looks like the since parameter in the sync loop requests was not correctly being updated with the next_batch parameter from the SS responses - it was being applied to the SS's copy of the extension config rather than the one used within the view's loop.  This would cause duplicate to-device messages to be received.

To fix this:
 * We track the initial SS extension config on the main SS struct, so we can reliably reset to it.
 * We directly use the SS extension config from the main SS struct inside the per-view loop, rather than a clone of it that then gets stale.

Empirically, this seems to stop E2EE from breaking whenever a new SS view is created, or whenever a SS session expires, or whenever a SS request times out.

It's worth noting that MSC3885 says that we should always send a `since` token if using the to-device extension, whereas this will only send one if our last response had one in its `next_batch`. This shouldn't be a problem, as the whole extension is sticky, and if there is no `since` token, we shouldn't send the extension at all.

It's also worth noting this may all change very shortly anyway, when @kegsay moves SS to setting extensions per view rather than per sync session (although surely there should only be one to-device extension in play at a time, otherwise we'll get very confused...)

Thanks to @poljar for pairing on this, given my lack of Rust...