### PR TITLE
Increase default request timeout to 30s

### DIFF
--- a/crates/matrix-sdk/src/http_client.rs
+++ b/crates/matrix-sdk/src/http_client.rs
@@ -30,7 +30,7 @@ use tracing::trace;
 
 use crate::{config::RequestConfig, error::HttpError};
 
-pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Abstraction around the http layer. The allows implementors to use different
 /// http libraries.


### PR DESCRIPTION
Apparently this is what Element clients do, so probably a better default than the much lower value we have now.