### PR TITLE
Add pagination loading indicator as a virtual timeline item

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -159,6 +159,7 @@ impl TimelineItem {
                 Some(VirtualTimelineItem::DayDivider { year: *year, month: *month, day: *day })
             }
             Item::Virtual(VItem::ReadMarker) => Some(VirtualTimelineItem::ReadMarker),
+            Item::Virtual(VItem::LoadingIndicator) => Some(VirtualTimelineItem::LoadingIndicator),
             Item::Event(_) => None,
         }
     }
@@ -589,8 +590,12 @@ pub enum VirtualTimelineItem {
         /// A value between 1 and 31.
         day: u32,
     },
+
     /// The user's own read marker.
     ReadMarker,
+
+    /// A loading indicator for a pagination request.
+    LoadingIndicator,
 }
 
 #[extension_trait]

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -524,16 +524,11 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                 match position {
                     TimelineItemPosition::Start => {
                         // Check if the earliest day divider has the same date as this event.
-                        if let Some(old_ymd) =
-                            self.timeline_items.get(0).and_then(|item| match item.as_virtual()? {
-                                VirtualTimelineItem::DayDivider { year, month, day } => {
-                                    Some((*year, *month, *day))
-                                }
-                                VirtualTimelineItem::ReadMarker => None,
-                            })
+                        if let Some(VirtualTimelineItem::DayDivider { year, month, day }) =
+                            self.timeline_items.get(0).and_then(|item| item.as_virtual())
                         {
                             if let Some(day_divider_item) = maybe_create_day_divider_from_ymd(
-                                old_ymd,
+                                (*year, *month, *day),
                                 timestamp_to_ymd(*origin_server_ts),
                             ) {
                                 self.timeline_items.insert_cloned(
@@ -556,11 +551,8 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                     }
                     TimelineItemPosition::End => {
                         // Check if the latest event has the same date as this event.
-                        if let Some(latest_event) = self
-                            .timeline_items
-                            .iter()
-                            .rfind(|item| item.as_event().is_some())
-                            .and_then(|item| item.as_event())
+                        if let Some(latest_event) =
+                            self.timeline_items.iter().rev().find_map(|item| item.as_event())
                         {
                             let old_ts = latest_event.timestamp();
 

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -145,6 +145,28 @@ impl TimelineInner {
         }
     }
 
+    #[instrument(skip_all)]
+    pub(super) fn add_loading_indicator(&self) {
+        let mut lock = self.items.lock_mut();
+        if lock.first().map_or(false, |item| item.is_loading_indicator()) {
+            warn!("There is already a loading indicator");
+            return;
+        }
+
+        lock.insert_cloned(0, Arc::new(TimelineItem::loading_indicator()));
+    }
+
+    #[instrument(skip_all)]
+    pub(super) fn remove_loading_indicator(&self) {
+        let mut lock = self.items.lock_mut();
+        if !lock.first().map_or(false, |item| item.is_loading_indicator()) {
+            warn!("There is no loading indicator");
+            return;
+        }
+
+        lock.remove(0);
+    }
+
     pub(super) async fn handle_fully_read(&self, raw: Raw<FullyReadEvent>) {
         let fully_read_event = match raw.deserialize() {
             Ok(ev) => ev.content.event_id,

--- a/crates/matrix-sdk/src/room/timeline/virtual_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/virtual_item.rs
@@ -28,8 +28,12 @@ pub enum VirtualTimelineItem {
         /// A value between 1 and 31.
         day: u32,
     },
+
     /// The user's own read marker.
     ReadMarker,
+
+    /// A loading indicator for a pagination request.
+    LoadingIndicator,
 }
 
 impl VirtualTimelineItem {


### PR DESCRIPTION
This will be especially useful once we expose a backpagination function that does multiple requests in a loop to fetch a certain minimum number of extra items.