### PR TITLE
Make timeline pagination more flexible and smarter

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -255,7 +255,7 @@ interface Room {
     //
     // Raises an exception if there are no timeline listeners.
     [Throws=ClientError]
-    PaginationOutcome paginate_backwards(u16 limit);
+    void paginate_backwards(PaginationOptions opts);
 
     [Throws=ClientError]
     void send(RoomMessageEventContent msg, string? txn_id);
@@ -286,11 +286,10 @@ dictionary MoveData {
     u32 new_index;
 };
 
-dictionary PaginationOutcome {
-    // Whether there's more messages to be paginated.
-    boolean more_messages;
-    // The number of updated or added timeline items.
-    u16 num_updates;
+[Enum]
+interface PaginationOptions {
+    SingleRequest(u16 event_limit);
+    UntilNumItems(u16 event_limit, u16 items);
 };
 
 interface RoomMessageEventContent {};

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -160,6 +160,7 @@ impl TimelineItem {
             }
             Item::Virtual(VItem::ReadMarker) => Some(VirtualTimelineItem::ReadMarker),
             Item::Virtual(VItem::LoadingIndicator) => Some(VirtualTimelineItem::LoadingIndicator),
+            Item::Virtual(VItem::TimelineStart) => Some(VirtualTimelineItem::TimelineStart),
             Item::Event(_) => None,
         }
     }
@@ -596,6 +597,12 @@ pub enum VirtualTimelineItem {
 
     /// A loading indicator for a pagination request.
     LoadingIndicator,
+
+    /// The beginning of the visible timeline.
+    ///
+    /// There might be earlier events the user is not allowed to see due to
+    /// history visibility.
+    TimelineStart,
 }
 
 #[extension_trait]

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -474,15 +474,13 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                     if let Some(day_divider_item) =
                         maybe_create_day_divider_from_timestamps(old_ts, *timestamp)
                     {
-                        self.timeline_items
-                            .push_cloned(Arc::new(TimelineItem::Virtual(day_divider_item)));
+                        self.timeline_items.push_cloned(Arc::new(day_divider_item));
                     }
                 } else {
                     // If there is no event item, there is no day divider yet.
                     let (year, month, day) = timestamp_to_ymd(*timestamp);
-                    self.timeline_items.push_cloned(Arc::new(TimelineItem::Virtual(
-                        VirtualTimelineItem::day_divider(year, month, day),
-                    )));
+                    self.timeline_items
+                        .push_cloned(Arc::new(TimelineItem::day_divider(year, month, day)));
                 }
 
                 self.timeline_items.push_cloned(item);
@@ -539,19 +537,15 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                                 (*year, *month, *day),
                                 timestamp_to_ymd(*origin_server_ts),
                             ) {
-                                self.timeline_items.insert_cloned(
-                                    offset,
-                                    Arc::new(TimelineItem::Virtual(day_divider_item)),
-                                );
+                                self.timeline_items
+                                    .insert_cloned(offset, Arc::new(day_divider_item));
                             }
                         } else {
                             // The list must always start with a day divider.
                             let (year, month, day) = timestamp_to_ymd(*origin_server_ts);
                             self.timeline_items.insert_cloned(
                                 offset,
-                                Arc::new(TimelineItem::Virtual(VirtualTimelineItem::day_divider(
-                                    year, month, day,
-                                ))),
+                                Arc::new(TimelineItem::day_divider(year, month, day)),
                             );
                         }
 
@@ -567,15 +561,13 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                             if let Some(day_divider_item) =
                                 maybe_create_day_divider_from_timestamps(old_ts, *origin_server_ts)
                             {
-                                self.timeline_items
-                                    .push_cloned(Arc::new(TimelineItem::Virtual(day_divider_item)));
+                                self.timeline_items.push_cloned(Arc::new(day_divider_item));
                             }
                         } else {
                             // If there is not event item, there is no day divider yet.
                             let (year, month, day) = timestamp_to_ymd(*origin_server_ts);
-                            self.timeline_items.push_cloned(Arc::new(TimelineItem::Virtual(
-                                VirtualTimelineItem::day_divider(year, month, day),
-                            )));
+                            self.timeline_items
+                                .push_cloned(Arc::new(TimelineItem::day_divider(year, month, day)));
                         }
 
                         self.timeline_items.push_cloned(item)
@@ -662,7 +654,7 @@ fn timestamp_to_ymd(ts: MilliSecondsSinceUnixEpoch) -> (i32, u32, u32) {
 fn maybe_create_day_divider_from_timestamps(
     old_ts: MilliSecondsSinceUnixEpoch,
     new_ts: MilliSecondsSinceUnixEpoch,
-) -> Option<VirtualTimelineItem> {
+) -> Option<TimelineItem> {
     maybe_create_day_divider_from_ymd(timestamp_to_ymd(old_ts), timestamp_to_ymd(new_ts))
 }
 
@@ -671,11 +663,11 @@ fn maybe_create_day_divider_from_timestamps(
 fn maybe_create_day_divider_from_ymd(
     old_ymd: (i32, u32, u32),
     new_ymd: (i32, u32, u32),
-) -> Option<VirtualTimelineItem> {
+) -> Option<TimelineItem> {
     let (old_year, old_month, old_day) = old_ymd;
     let (new_year, new_month, new_day) = new_ymd;
     if old_year != new_year || old_month != new_month || old_day != new_day {
-        Some(VirtualTimelineItem::day_divider(new_year, new_month, new_day))
+        Some(TimelineItem::day_divider(new_year, new_month, new_day))
     } else {
         None
     }

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -525,7 +525,10 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                         // divider at position 1 and the new event at 2 rather than 0 and 1.
                         let offset =
                             match self.timeline_items.first().and_then(|item| item.as_virtual()) {
-                                Some(VirtualTimelineItem::LoadingIndicator) => 1,
+                                Some(
+                                    VirtualTimelineItem::LoadingIndicator
+                                    | VirtualTimelineItem::TimelineStart,
+                                ) => 1,
                                 _ => 0,
                             };
 

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -609,8 +609,7 @@ pub(crate) fn update_read_marker(
         (None, None) => {}
         (None, Some(idx)) => {
             *fully_read_event_in_timeline = true;
-            let item = TimelineItem::Virtual(VirtualTimelineItem::ReadMarker);
-            items_lock.insert_cloned(idx + 1, item.into());
+            items_lock.insert_cloned(idx + 1, Arc::new(TimelineItem::read_marker()));
         }
         (Some(_), None) => {
             // Keep the current position of the read marker, hopefully we

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -156,15 +156,19 @@ impl TimelineInner {
         lock.insert_cloned(0, Arc::new(TimelineItem::loading_indicator()));
     }
 
-    #[instrument(skip_all)]
-    pub(super) fn remove_loading_indicator(&self) {
+    #[instrument(skip(self))]
+    pub(super) fn remove_loading_indicator(&self, more_messages: bool) {
         let mut lock = self.items.lock_mut();
         if !lock.first().map_or(false, |item| item.is_loading_indicator()) {
             warn!("There is no loading indicator");
             return;
         }
 
-        lock.remove(0);
+        if more_messages {
+            lock.remove(0);
+        } else {
+            lock.set_cloned(0, Arc::new(TimelineItem::timeline_start()))
+        }
     }
 
     pub(super) async fn handle_fully_read(&self, raw: Raw<FullyReadEvent>) {

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -182,8 +182,9 @@ impl Timeline {
             num_updates += self.inner.handle_back_paginated_event(room_ev, own_user_id).await;
         }
 
-        self.inner.remove_loading_indicator();
-        let outcome = PaginationOutcome { more_messages: messages.end.is_some(), num_updates };
+        let more_messages = messages.end.is_some();
+        self.inner.remove_loading_indicator(more_messages);
+        let outcome = PaginationOutcome { more_messages, num_updates };
         *start_lock = messages.end;
 
         Ok(outcome)
@@ -341,6 +342,10 @@ impl TimelineItem {
 
     fn loading_indicator() -> Self {
         Self::Virtual(VirtualTimelineItem::LoadingIndicator)
+    }
+
+    fn timeline_start() -> Self {
+        Self::Virtual(VirtualTimelineItem::TimelineStart)
     }
 
     fn is_read_marker(&self) -> bool {

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -330,8 +330,16 @@ impl TimelineItem {
         }
     }
 
+    fn read_marker() -> Self {
+        Self::Virtual(VirtualTimelineItem::ReadMarker)
+    }
+
     fn loading_indicator() -> Self {
         Self::Virtual(VirtualTimelineItem::LoadingIndicator)
+    }
+
+    fn is_read_marker(&self) -> bool {
+        matches!(self, Self::Virtual(VirtualTimelineItem::ReadMarker))
     }
 
     fn is_loading_indicator(&self) -> bool {
@@ -378,10 +386,5 @@ fn find_event_by_txn_id<'a>(
 }
 
 fn find_read_marker(lock: &[Arc<TimelineItem>]) -> Option<usize> {
-    lock.iter()
-        .enumerate()
-        .rfind(|(_, item)| {
-            item.as_virtual().filter(|v| matches!(v, VirtualTimelineItem::ReadMarker)).is_some()
-        })
-        .map(|(idx, _)| idx)
+    lock.iter().rposition(|item| item.is_read_marker())
 }

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -330,6 +330,11 @@ impl TimelineItem {
         }
     }
 
+    /// Creates a new day divider from the given year, month and day.
+    fn day_divider(year: i32, month: u32, day: u32) -> Self {
+        Self::Virtual(VirtualTimelineItem::DayDivider { year, month, day })
+    }
+
     fn read_marker() -> Self {
         Self::Virtual(VirtualTimelineItem::ReadMarker)
     }

--- a/crates/matrix-sdk/src/room/timeline/pagination.rs
+++ b/crates/matrix-sdk/src/room/timeline/pagination.rs
@@ -9,14 +9,14 @@ impl<'a> PaginationOptions<'a> {
     /// Do a single pagination request, asking the server for the given
     /// maximum number of events.
     ///
-    /// The server may choose to return fewer events, even if the end of the
-    /// visible timeline is not yet reached.
+    /// The server may choose to return fewer events, even if the start or end
+    /// of the visible timeline is not yet reached.
     pub fn single_request(event_limit: u16) -> Self {
         Self::new(PaginationOptionsInner::SingleRequest { event_limit_if_first: Some(event_limit) })
     }
 
     /// Continually paginate with a fixed `limit` until at least the given
-    /// amount of timeline items have been added (unless the end of the
+    /// amount of timeline items have been added (unless the start or end of the
     /// visible timeline is reached).
     ///
     /// The `event_limit` represents the maximum number of events the server

--- a/crates/matrix-sdk/src/room/timeline/pagination.rs
+++ b/crates/matrix-sdk/src/room/timeline/pagination.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+
+/// Options for pagination.
+pub struct PaginationOptions<'a> {
+    inner: PaginationOptionsInner<'a>,
+}
+
+impl<'a> PaginationOptions<'a> {
+    /// Do a single pagination request, asking the server for the given
+    /// maximum number of events.
+    ///
+    /// The server may choose to return fewer events, even if the end of the
+    /// visible timeline is not yet reached.
+    pub fn single_request(event_limit: u16) -> Self {
+        Self::new(PaginationOptionsInner::SingleRequest { event_limit_if_first: Some(event_limit) })
+    }
+
+    /// Continually paginate with a fixed `limit` until at least the given
+    /// amount of timeline items have been added (unless the end of the
+    /// visible timeline is reached).
+    ///
+    /// The `event_limit` represents the maximum number of events the server
+    /// should return in one batch. It may choose to return fewer events per
+    /// response.
+    pub fn until_num_items(event_limit: u16, items: u16) -> Self {
+        Self::new(PaginationOptionsInner::UntilNumItems { event_limit, items })
+    }
+
+    /// Paginate once with the given initial maximum number of events, then
+    /// do more requests based on the user-provided strategy
+    /// callback.
+    ///
+    /// The callback is given numbers on the events and resulting timeline
+    /// items for the last request as well as summed over all
+    /// requests in a `paginate_backwards` call, and can decide
+    /// whether to do another request (by returning
+    /// `Some(next_event_limit)`) or not (by returning `None`).
+    pub fn custom(
+        initial_event_limit: u16,
+        pagination_strategy: impl FnMut(PaginationOutcome) -> Option<u16> + 'a,
+    ) -> Self {
+        Self::new(PaginationOptionsInner::Custom {
+            event_limit_if_first: Some(initial_event_limit),
+            strategy: Box::new(pagination_strategy),
+        })
+    }
+
+    pub(super) fn next_event_limit(
+        &mut self,
+        pagination_outcome: PaginationOutcome,
+    ) -> Option<u16> {
+        match &mut self.inner {
+            PaginationOptionsInner::SingleRequest { event_limit_if_first } => {
+                event_limit_if_first.take()
+            }
+            PaginationOptionsInner::UntilNumItems { items, event_limit } => {
+                (pagination_outcome.total_items_added < *items).then_some(*event_limit)
+            }
+            PaginationOptionsInner::Custom { event_limit_if_first, strategy } => {
+                event_limit_if_first.take().or_else(|| strategy(pagination_outcome))
+            }
+        }
+    }
+
+    fn new(inner: PaginationOptionsInner<'a>) -> Self {
+        Self { inner }
+    }
+}
+
+pub enum PaginationOptionsInner<'a> {
+    SingleRequest {
+        event_limit_if_first: Option<u16>,
+    },
+    UntilNumItems {
+        event_limit: u16,
+        items: u16,
+    },
+    Custom {
+        event_limit_if_first: Option<u16>,
+        strategy: Box<dyn FnMut(PaginationOutcome) -> Option<u16> + 'a>,
+    },
+}
+
+impl<'a> fmt::Debug for PaginationOptions<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.inner {
+            PaginationOptionsInner::SingleRequest { event_limit_if_first } => f
+                .debug_struct("SingleRequest")
+                .field("event_limit_if_first", event_limit_if_first)
+                .finish(),
+            PaginationOptionsInner::UntilNumItems { items, event_limit } => f
+                .debug_struct("UntilNumItems")
+                .field("items", items)
+                .field("event_limit", event_limit)
+                .finish(),
+            PaginationOptionsInner::Custom { event_limit_if_first, .. } => f
+                .debug_struct("Custom")
+                .field("event_limit_if_first", event_limit_if_first)
+                .finish(),
+        }
+    }
+}
+
+/// The result of a successful pagination request.
+#[derive(Clone, Copy, Debug, Default)]
+#[non_exhaustive]
+pub struct PaginationOutcome {
+    /// The number of events received in last pagination response.
+    pub events_received: u16,
+
+    /// The number of timeline items added by the last pagination response.
+    pub items_added: u16,
+
+    /// The number of timeline items updated by the last pagination
+    /// response.
+    pub items_updated: u16,
+
+    /// The number of events received by a `paginate_backwards` call so far.
+    pub total_events_received: u16,
+
+    /// The total number of items added by a `paginate_backwards` call so
+    /// far.
+    pub total_items_added: u16,
+
+    /// The total number of items updated by a `paginate_backwards` call so
+    /// far.
+    pub total_items_updated: u16,
+}
+
+impl PaginationOutcome {
+    pub(super) fn new() -> Self {
+        Self {
+            events_received: 0,
+            items_added: 0,
+            items_updated: 0,
+            total_events_received: 0,
+            total_items_added: 0,
+            total_items_updated: 0,
+        }
+    }
+}

--- a/crates/matrix-sdk/src/room/timeline/virtual_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/virtual_item.rs
@@ -35,11 +35,3 @@ pub enum VirtualTimelineItem {
     /// A loading indicator for a pagination request.
     LoadingIndicator,
 }
-
-impl VirtualTimelineItem {
-    /// Creates a new `VirtualTimelineItem::DayDivider` from the given year,
-    /// month and day.
-    pub(crate) fn day_divider(year: i32, month: u32, day: u32) -> Self {
-        Self::DayDivider { year, month, day }
-    }
-}

--- a/crates/matrix-sdk/src/room/timeline/virtual_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/virtual_item.rs
@@ -34,4 +34,10 @@ pub enum VirtualTimelineItem {
 
     /// A loading indicator for a pagination request.
     LoadingIndicator,
+
+    /// The beginning of the visible timeline.
+    ///
+    /// There might be earlier events the user is not allowed to see due to
+    /// history visibility.
+    TimelineStart,
 }

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -7,7 +7,9 @@ use futures_signals::signal_vec::{SignalVecExt, VecDiff};
 use futures_util::StreamExt;
 use matrix_sdk::{
     config::SyncSettings,
-    room::timeline::{TimelineDetails, TimelineItemContent, TimelineKey, VirtualTimelineItem},
+    room::timeline::{
+        PaginationOptions, TimelineDetails, TimelineItemContent, TimelineKey, VirtualTimelineItem,
+    },
     ruma::MilliSecondsSinceUnixEpoch,
 };
 use matrix_sdk_common::executor::spawn;
@@ -259,7 +261,7 @@ async fn back_pagination() {
         .mount(&server)
         .await;
 
-    timeline.paginate_backwards(uint!(10)).await.unwrap();
+    timeline.paginate_backwards(PaginationOptions::single_request(10)).await.unwrap();
     server.reset().await;
 
     let loading = assert_matches!(
@@ -313,7 +315,7 @@ async fn back_pagination() {
         .mount(&server)
         .await;
 
-    timeline.paginate_backwards(uint!(10)).await.unwrap();
+    timeline.paginate_backwards(PaginationOptions::single_request(10)).await.unwrap();
 
     let loading = assert_matches!(
         timeline_stream.next().await,


### PR DESCRIPTION
- Add `TimelineStart` virtual timeline item
- Don't actually fire off a request when the top of the timeline has already been reached
- Allow making multiple requests without removing the loading indicator in between