### PR TITLE
chore(sdk): Support receiving `m.dummy` events.

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -784,6 +784,9 @@ impl OlmMachine {
                     decrypted.result.raw_event = Raw::from_json(to_raw_value(&e)?);
                 }
             }
+            AnyDecryptedOlmEvent::Dummy(_) => {
+                info!("Received an encrypted dummy to-device event");
+            }
             AnyDecryptedOlmEvent::Custom(_) => {
                 warn!("Received an unexpected encrypted to-device event");
             }


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Fixes #1230 

Extends the `AnyDecryptedOlmEvent` enum with the new member `Dummy`, which corresponds to `"m.dummy"` events. On receiving such an event, logs at `info` level.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Aditya Rajput <adiraj20072002@gmail.com>
