### PR TITLE
fix(crypto): Make the device update logic a bit more strict and obvious

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -192,6 +192,10 @@ pub enum SignatureError {
     #[error("the given signature is not valid and can't be decoded")]
     InvalidSignature,
 
+    /// The signing key that used to sign the object has been changed.
+    #[error("the signing key that used to sign the object has changed, old: {0:?}, new: {1:?}")]
+    SigningKeyChanged(Option<Box<Ed25519PublicKey>>, Option<Box<Ed25519PublicKey>>),
+
     /// The signed object couldn't be deserialized.
     #[error(transparent)]
     JsonError(#[from] CanonicalJsonError),

--- a/crates/matrix-sdk-crypto/src/types/device_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/device_keys.rs
@@ -20,7 +20,9 @@
 
 use std::collections::BTreeMap;
 
-use ruma::{serde::Raw, DeviceKeyAlgorithm, OwnedDeviceId, OwnedDeviceKeyId, OwnedUserId};
+use ruma::{
+    serde::Raw, DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceId, OwnedDeviceKeyId, OwnedUserId,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{value::to_raw_value, Value};
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};
@@ -83,6 +85,33 @@ impl DeviceKeys {
     /// Serialize the device keys key into a Raw version.
     pub fn to_raw<T>(&self) -> Raw<T> {
         Raw::from_json(to_raw_value(&self).expect("Coulnd't serialize device keys"))
+    }
+
+    /// Get the key of the given key algorithm belonging to this device.
+    pub fn get_key(&self, algorithm: DeviceKeyAlgorithm) -> Option<&DeviceKey> {
+        self.keys.get(&DeviceKeyId::from_parts(algorithm, &self.device_id))
+    }
+
+    /// Get the Curve25519 key of the given device.
+    pub fn curve25519_key(&self) -> Option<Curve25519PublicKey> {
+        self.get_key(DeviceKeyAlgorithm::Curve25519).and_then(|k| {
+            if let DeviceKey::Curve25519(k) = k {
+                Some(*k)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get the Ed25519 key of the given device.
+    pub fn ed25519_key(&self) -> Option<Ed25519PublicKey> {
+        self.get_key(DeviceKeyAlgorithm::Ed25519).and_then(|k| {
+            if let DeviceKey::Ed25519(k) = k {
+                Some(*k)
+            } else {
+                None
+            }
+        })
     }
 }
 


### PR DESCRIPTION
When updating a device after we receive new device keys from a /keys/query call we implicitly check that the user and device id match since we need to fetch the device using the mentioned ids.

This moves the check into the update method as well to make it more explicit. We also prevent upgrades of the Ed25519 key since we don't support any different key type anyways.