### PR TITLE
fix(sliding-sync): Do not implictly activate to-device extension upon unfreeze

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -405,11 +405,11 @@ impl SlidingSyncConfig {
                     .collect();
 
                 if let Some(since) = f.to_device_since {
-                    extensions
-                        .get_or_insert_with(Default::default)
-                        .to_device
-                        .get_or_insert_with(Default::default)
-                        .since = Some(since);
+                    if let Some(to_device_ext) =
+                        extensions.get_or_insert_with(Default::default).to_device.as_mut()
+                    {
+                        to_device_ext.since = Some(since);
+                    }
                 }
             }
         };


### PR DESCRIPTION
following #1321 :

Previously, when we found a since-token in the frozen state, we'd always activate the to-device extensions regardless of whether the user had activated it in their builder or didn't. With this change we are only setting the since parameter from cache if the user actually activated the to-device extension.