### PR TITLE
fix(sliding-sync): ensure last index is also invalidated

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -1419,7 +1419,9 @@ impl SlidingSyncView {
                         ));
                     }
 
-                    while pos < end {
+                    // ranges are inclusive up to the last index. e.g. `[0, 10]`; `[0, 0]`.
+                    // ensure we pick them all up
+                    while pos <= end {
                         if pos as usize >= max_len {
                             break; // how does this happen?
                         }


### PR DESCRIPTION
Index ranges are inclusive, but our loop would stop one short. This particularly
tricky when the selective view is moved, as we didn't properly invalidate all items.

Likely cause and fix for https://github.com/vector-im/element-x-ios/issues/396 .