### PR TITLE
Attach profile information to timeline items

### DIFF
--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -92,8 +92,8 @@ mod uniffi_types {
         timeline::{
             EmoteMessageContent, EncryptedMessage, EventTimelineItem, FileInfo, FileMessageContent,
             FormattedBody, ImageInfo, ImageMessageContent, InsertAtData, Message, MessageFormat,
-            MessageType, NoticeMessageContent, Reaction, TextMessageContent, ThumbnailInfo,
-            TimelineChange, TimelineDiff, TimelineItem, TimelineItemContent,
+            MessageType, NoticeMessageContent, Profile, Reaction, TextMessageContent,
+            ThumbnailInfo, TimelineChange, TimelineDiff, TimelineItem, TimelineItemContent,
             TimelineItemContentKind, TimelineKey, UpdateAtData, VideoInfo, VideoMessageContent,
             VirtualTimelineItem,
         },

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -129,7 +129,7 @@ impl SlidingSyncRoom {
 
     #[allow(clippy::significant_drop_in_scrutinee)]
     pub fn latest_room_message(&self) -> Option<Arc<EventTimelineItem>> {
-        let item = self.inner.latest_event()?;
+        let item = RUNTIME.block_on(self.inner.latest_event())?;
         Some(Arc::new(EventTimelineItem(item)))
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -187,6 +187,10 @@ impl EventTimelineItem {
         self.0.sender().to_string()
     }
 
+    pub fn sender_profile(&self) -> Profile {
+        self.0.sender_profile().into()
+    }
+
     pub fn is_own(&self) -> bool {
         self.0.is_own()
     }
@@ -217,6 +221,21 @@ impl EventTimelineItem {
 
     pub fn fmt_debug(&self) -> String {
         format!("{:#?}", self.0)
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct Profile {
+    display_name: Option<String>,
+    avatar_url: Option<String>,
+}
+
+impl From<&matrix_sdk::room::timeline::Profile> for Profile {
+    fn from(p: &matrix_sdk::room::timeline::Profile) -> Self {
+        Self {
+            display_name: p.display_name.clone(),
+            avatar_url: p.avatar_url.as_ref().map(ToString::to_string),
+        }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -227,6 +227,7 @@ impl EventTimelineItem {
 #[derive(uniffi::Record)]
 pub struct Profile {
     display_name: Option<String>,
+    display_name_ambiguous: bool,
     avatar_url: Option<String>,
 }
 
@@ -234,6 +235,7 @@ impl From<&matrix_sdk::room::timeline::Profile> for Profile {
     fn from(p: &matrix_sdk::room::timeline::Profile) -> Self {
         Self {
             display_name: p.display_name.clone(),
+            display_name_ambiguous: p.display_name_ambiguous,
             avatar_url: p.avatar_url.as_ref().map(ToString::to_string),
         }
     }

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -270,7 +270,7 @@ impl Common {
     /// independent events.
     #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(&self) -> Timeline {
-        Timeline::new(self).await.with_fully_read_tracking().await
+        Timeline::new(self).with_fully_read_tracking().await
     }
 
     /// Fetch the event with the given `EventId` in this room.

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -39,7 +39,7 @@ use ruma::{
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 use super::{
-    event_item::{BundledReactions, Sticker, TimelineDetails},
+    event_item::{BundledReactions, Profile, Sticker, TimelineDetails},
     find_event_by_id, find_event_by_txn_id, find_read_marker, EventTimelineItem, Message,
     TimelineInnerMetadata, TimelineItem, TimelineItemContent, TimelineKey, VirtualTimelineItem,
 };
@@ -84,6 +84,7 @@ impl Flow {
 
 pub(super) struct TimelineEventMetadata {
     pub(super) sender: OwnedUserId,
+    pub(super) sender_profile: Profile,
     pub(super) is_own_event: bool,
     pub(super) relations: BundledRelations,
     pub(super) encryption_info: Option<EncryptionInfo>,
@@ -457,6 +458,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
             key: self.flow.to_key(),
             event_id: None,
             sender: self.meta.sender.to_owned(),
+            sender_profile: self.meta.sender_profile.clone(),
             content,
             reactions,
             timestamp: self.flow.timestamp(),

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -69,20 +69,6 @@ impl fmt::Debug for EventTimelineItem {
     }
 }
 
-macro_rules! build {
-    (
-        $ty:ident {
-            $( $field:ident $(: $value:expr)?, )*
-            ..$this:ident( $($this_field:ident),* $(,)? )
-        }
-    ) => {
-        $ty {
-            $( $field $(: $value)?, )*
-            $( $this_field: $this.$this_field.clone() ),*
-        }
-    }
-}
-
 impl EventTimelineItem {
     /// Get the [`TimelineKey`] of this item.
     pub fn key(&self) -> &TimelineKey {
@@ -156,39 +142,24 @@ impl EventTimelineItem {
     }
 
     pub(super) fn to_redacted(&self) -> Self {
-        build!(Self {
+        Self {
             // FIXME: Change when we support state events
             content: TimelineItemContent::RedactedMessage,
             reactions: BundledReactions::default(),
-            ..self(key, event_id, sender, timestamp, is_own, encryption_info, raw)
-        })
+            ..self.clone()
+        }
     }
 
     pub(super) fn with_event_id(&self, event_id: Option<OwnedEventId>) -> Self {
-        build!(Self {
-            event_id,
-            ..self(key, sender, content, reactions, timestamp, is_own, encryption_info, raw,)
-        })
+        Self { event_id, ..self.clone() }
     }
 
-    #[rustfmt::skip]
     pub(super) fn with_content(&self, content: TimelineItemContent) -> Self {
-        build!(Self {
-            content,
-            ..self(
-                key, event_id, sender, reactions, timestamp, is_own, encryption_info, raw,
-            )
-        })
+        Self { content, ..self.clone() }
     }
 
-    #[rustfmt::skip]
     pub(super) fn with_reactions(&self, reactions: BundledReactions) -> Self {
-        build!(Self {
-            reactions,
-            ..self(
-                key, event_id, sender, content, timestamp, is_own, encryption_info, raw,
-            )
-        })
+        Self { reactions, ..self.clone() }
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -206,6 +206,12 @@ impl PartialEq<TransactionId> for TimelineKey {
 pub struct Profile {
     /// The display name, if set.
     pub display_name: Option<String>,
+    /// Whether the display name is ambiguous.
+    ///
+    /// Note that in rooms with lazy-loading enabled, this could be `false` even
+    /// though the display name is actually ambiguous if not all member events
+    /// have been seen yet.
+    pub display_name_ambiguous: bool,
     /// The avatar URL, if set.
     pub avatar_url: Option<OwnedMxcUri>,
 }

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -27,8 +27,8 @@ use ruma::{
         AnySyncTimelineEvent, MessageLikeEventType, StateEventType,
     },
     serde::Raw,
-    uint, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedTransactionId,
-    OwnedUserId, TransactionId, UInt, UserId,
+    uint, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedMxcUri,
+    OwnedTransactionId, OwnedUserId, TransactionId, UInt, UserId,
 };
 
 /// An item in the timeline that represents at least one event.
@@ -44,6 +44,7 @@ pub struct EventTimelineItem {
     // response.
     pub(super) event_id: Option<OwnedEventId>,
     pub(super) sender: OwnedUserId,
+    pub(super) sender_profile: Profile,
     pub(super) content: TimelineItemContent,
     pub(super) reactions: BundledReactions,
     pub(super) timestamp: MilliSecondsSinceUnixEpoch,
@@ -94,6 +95,11 @@ impl EventTimelineItem {
     /// Get the sender of this item.
     pub fn sender(&self) -> &UserId {
         &self.sender
+    }
+
+    /// Get the profile of the sender.
+    pub fn sender_profile(&self) -> &Profile {
+        &self.sender_profile
     }
 
     /// Get the content of this item.
@@ -193,6 +199,15 @@ impl PartialEq<TransactionId> for TimelineKey {
     fn eq(&self, id: &TransactionId) -> bool {
         matches!(self, TimelineKey::TransactionId(txn_id) if txn_id == id)
     }
+}
+
+/// The display name and avatar URL of a room member.
+#[derive(Clone, Debug)]
+pub struct Profile {
+    /// The display name, if set.
+    pub display_name: Option<String>,
+    /// The avatar URL, if set.
+    pub avatar_url: Option<OwnedMxcUri>,
 }
 
 /// Some details of an [`EventTimelineItem`] that may require server requests

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -314,12 +314,15 @@ impl ProfileProvider for room::Common {
         match self.get_member_no_sync(user_id).await {
             Ok(Some(member)) => Profile {
                 display_name: member.display_name().map(ToOwned::to_owned),
+                display_name_ambiguous: member.name_ambiguous(),
                 avatar_url: member.avatar_url().map(ToOwned::to_owned),
             },
-            Ok(None) => Profile { display_name: None, avatar_url: None },
+            Ok(None) => {
+                Profile { display_name: None, display_name_ambiguous: false, avatar_url: None }
+            }
             Err(e) => {
                 error!(%user_id, "Failed to getch room member information: {e}");
-                Profile { display_name: None, avatar_url: None }
+                Profile { display_name: None, display_name_ambiguous: false, avatar_url: None }
             }
         }
     }

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -178,7 +178,7 @@ impl Timeline {
     pub async fn paginate_backwards(&self, mut opts: PaginationOptions<'_>) -> Result<()> {
         let mut start_lock = self.start_token.lock().await;
         if start_lock.is_none()
-            && self.inner.items.lock_ref().first().map_or(false, |item| item.is_timeline_start())
+            && self.inner.items().first().map_or(false, |item| item.is_timeline_start())
         {
             warn!("Start of timeline reached, ignoring backwards-pagination request");
             return Ok(());
@@ -282,7 +282,7 @@ impl Timeline {
 
     /// Get the latest of the timeline's event items.
     pub fn latest_event(&self) -> Option<EventTimelineItem> {
-        self.inner.items.lock_ref().last()?.as_event().cloned()
+        self.inner.items().last()?.as_event().cloned()
     }
 
     /// Get a signal of the timeline's items.
@@ -293,7 +293,7 @@ impl Timeline {
     /// See [`SignalVecExt`](futures_signals::signal_vec::SignalVecExt) for a
     /// high-level API on top of [`SignalVec`].
     pub fn signal(&self) -> impl SignalVec<Item = Arc<TimelineItem>> {
-        self.inner.items.signal_vec_cloned()
+        self.inner.items_signal()
     }
 
     /// Get a stream of timeline changes.

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -110,7 +110,7 @@ async fn invalid_edit() {
 
     // Can't easily test the non-arrival of an item using the stream. Instead
     // just assert that there is still just a couple items in the timeline.
-    assert_eq!(timeline.inner.items.lock_ref().len(), 2);
+    assert_eq!(timeline.inner.items().len(), 2);
 }
 
 #[async_test]
@@ -151,7 +151,7 @@ async fn edit_redacted() {
     });
     timeline.handle_live_message_event(&ALICE, edit).await;
 
-    assert_eq!(timeline.inner.items.lock_ref().len(), 2);
+    assert_eq!(timeline.inner.items().len(), 2);
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -204,7 +204,7 @@ async fn unable_to_decrypt() {
         )
         .await;
 
-    assert_eq!(timeline.inner.items.lock_ref().len(), 2);
+    assert_eq!(timeline.inner.items().len(), 2);
 
     let _day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
@@ -233,7 +233,7 @@ async fn unable_to_decrypt() {
         )
         .await;
 
-    assert_eq!(timeline.inner.items.lock_ref().len(), 2);
+    assert_eq!(timeline.inner.items().len(), 2);
 
     let item =
         assert_matches!(stream.next().await, Some(VecDiff::UpdateAt { index: 1, value }) => value);
@@ -361,7 +361,7 @@ async fn invalid_event() {
             "type": "m.room.message",
         }))
         .await;
-    assert_eq!(timeline.inner.items.lock_ref().len(), 0);
+    assert_eq!(timeline.inner.items().len(), 0);
 }
 
 #[async_test]
@@ -568,7 +568,7 @@ impl TestTimeline {
     }
 
     fn stream(&self) -> impl Stream<Item = VecDiff<Arc<TimelineItem>>> {
-        self.inner.items.signal_vec_cloned().to_stream()
+        self.inner.items_signal().to_stream()
     }
 
     async fn handle_live_message_event<C>(&self, sender: &UserId, content: C)

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -616,7 +616,7 @@ impl ProfileProvider for TestProfileProvider {
     }
 
     async fn profile(&self, _user_id: &UserId) -> Profile {
-        Profile { display_name: None, avatar_url: None }
+        Profile { display_name: None, display_name_ambiguous: false, avatar_url: None }
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/to_device.rs
+++ b/crates/matrix-sdk/src/room/timeline/to_device.rs
@@ -61,17 +61,7 @@ async fn retry_decryption(
         return;
     };
 
-    let Some(own_user_id) = client.user_id() else {
-        error!("The user's own ID isn't available");
-        return;
-    };
-
     inner
-        .retry_event_decryption(
-            &room_id,
-            olm_machine,
-            iter::once(session_id.as_str()).collect(),
-            own_user_id,
-        )
+        .retry_event_decryption(&room_id, olm_machine, iter::once(session_id.as_str()).collect())
         .await;
 }

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -235,16 +235,16 @@ impl SlidingSyncRoom {
     /// `Timeline` of this room
     #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(&self) -> Option<Timeline> {
-        Some(self.timeline_no_fully_read_tracking()?.with_fully_read_tracking().await)
+        Some(self.timeline_no_fully_read_tracking().await?.with_fully_read_tracking().await)
     }
 
-    fn timeline_no_fully_read_tracking(&self) -> Option<Timeline> {
+    async fn timeline_no_fully_read_tracking(&self) -> Option<Timeline> {
         if let Some(room) = self.client.get_room(&self.room_id) {
             let current_timeline = self.timeline.lock_ref().to_vec();
             let prev_batch = self.prev_batch.lock_ref().clone();
-            Some(Timeline::with_events(&room, prev_batch, current_timeline))
+            Some(Timeline::with_events(&room, prev_batch, current_timeline).await)
         } else if let Some(invited_room) = self.client.get_invited_room(&self.room_id) {
-            Some(Timeline::with_events(&invited_room, None, vec![]))
+            Some(Timeline::with_events(&invited_room, None, vec![]).await)
         } else {
             error!(
                 room_id = ?self.room_id,
@@ -259,8 +259,8 @@ impl SlidingSyncRoom {
     /// Use `Timeline::latest_event` instead if you already have a timeline for
     /// this `SlidingSyncRoom`.
     #[cfg(feature = "experimental-timeline")]
-    pub fn latest_event(&self) -> Option<EventTimelineItem> {
-        self.timeline_no_fully_read_tracking()?.latest_event()
+    pub async fn latest_event(&self) -> Option<EventTimelineItem> {
+        self.timeline_no_fully_read_tracking().await?.latest_event()
     }
 
     /// This rooms name as calculated by the server, if any


### PR DESCRIPTION
It seems very likely that this is going to trigger tokio runtime panics in EX again. If so, we need to either hack around it and intentionally disable profile fetching for fetching the latest message of a room in the sliding sync API, or wait for uniffi-async.