### PR TITLE
chore(crypto): Instrument the receive_sync_changes method

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -875,6 +875,7 @@ impl OlmMachine {
     /// response returned.
     ///
     /// [`decrypt_room_event`]: #method.decrypt_room_event
+    #[instrument(skip_all)]
     pub async fn receive_sync_changes(
         &self,
         to_device_events: Vec<Raw<AnyToDeviceEvent>>,


### PR DESCRIPTION
This is mainly done so we create a span with the name of the function, since we can filter logs by the name of the span we're now able to enable logs for this method only.