### PR TITLE
chore(sdk): Make the timeline feature a dependency of the sliding sync one

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -22,7 +22,7 @@ futures-core = "0.3.17"
 futures-signals = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.17", default-features = false }
 mime = "0.3.16"
-# FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce sliding-sync being exposed here..
+# FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014
 once_cell = { workspace = true }
 sanitize-filename-reader-friendly = "2.2.1"
@@ -38,9 +38,9 @@ uniffi_macros = { workspace = true }
 tracing = { version = "0.1.29", default-features = false, features = ["log"] }
 android_logger = "0.11"
 log-panics = { version = "2", features = ["with-backtrace"]}
-matrix-sdk = { path = "../../crates/matrix-sdk", default-features = false, features = ["anyhow", "experimental-timeline", "e2e-encryption", "sled", "markdown", "sliding-sync", "socks", "rustls-tls"], version = "0.6.0" }
+matrix-sdk = { path = "../../crates/matrix-sdk", default-features = false, features = ["anyhow", "experimental-timeline", "e2e-encryption", "sled", "markdown", "experimental-sliding-sync", "socks", "rustls-tls"], version = "0.6.0" }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-matrix-sdk = { path = "../../crates/matrix-sdk", features = ["anyhow", "experimental-timeline", "markdown", "sliding-sync", "socks"], version = "0.6.0" }
+matrix-sdk = { path = "../../crates/matrix-sdk", features = ["anyhow", "experimental-timeline", "markdown", "experimental-sliding-sync", "socks"], version = "0.6.0" }

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 e2e-encryption = ["dep:matrix-sdk-crypto"]
 js = ["matrix-sdk-common/js", "matrix-sdk-crypto?/js", "ruma/js", "matrix-sdk-store-encryption/js"]
 qrcode = ["matrix-sdk-crypto?/qrcode"]
-sliding-sync = ["ruma/unstable-msc3575"]
+experimental-sliding-sync = ["ruma/unstable-msc3575"]
 
 # helpers for testing features build upon this
 testing = ["dep:http"]

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -30,7 +30,7 @@ mod error;
 pub mod media;
 mod rooms;
 mod session;
-#[cfg(feature = "sliding-sync")]
+#[cfg(feature = "experimental-sliding-sync")]
 mod sliding_sync;
 pub mod store;
 pub mod sync;

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -44,8 +44,8 @@ image-rayon = ["image-proc", "image?/jpeg_rayon"]
 
 experimental-timeline = ["ruma/unstable-msc2677", "dep:chrono"]
 
-sliding-sync = [
-    "matrix-sdk-base/sliding-sync",
+experimental-sliding-sync = [
+    "matrix-sdk-base/experimental-sliding-sync",
     "experimental-timeline",
     "dep:derive_builder",
 ]

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -46,6 +46,7 @@ experimental-timeline = ["ruma/unstable-msc2677", "dep:chrono"]
 
 sliding-sync = [
     "matrix-sdk-base/sliding-sync",
+    "experimental-timeline",
     "dep:derive_builder",
 ]
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1708,7 +1708,7 @@ impl Client {
         res
     }
 
-    #[cfg(feature = "sliding-sync")]
+    #[cfg(feature = "experimental-sliding-sync")]
     // FIXME: remove this as soon as Sliding-Sync isn't needing an external server
     // anymore
     pub(crate) async fn send_with_homeserver<Request>(

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -237,7 +237,7 @@ pub enum Error {
     ImageError(#[from] ImageError),
 
     /// An error occurred within sliding-sync
-    #[cfg(feature = "sliding-sync")]
+    #[cfg(feature = "experimental-sliding-sync")]
     #[error(transparent)]
     SlidingSync(#[from] crate::sliding_sync::Error),
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -38,7 +38,7 @@ pub mod media;
 pub mod room;
 pub mod sync;
 
-#[cfg(feature = "sliding-sync")]
+#[cfg(feature = "experimental-sliding-sync")]
 mod sliding_sync;
 
 #[cfg(feature = "e2e-encryption")]
@@ -55,7 +55,7 @@ pub use error::ImageError;
 pub use error::{Error, HttpError, HttpResult, RefreshTokenError, Result, RumaApiError};
 pub use http_client::HttpSend;
 pub use media::Media;
-#[cfg(feature = "sliding-sync")]
+#[cfg(feature = "experimental-sliding-sync")]
 pub use sliding_sync::{
     RoomListEntry, SlidingSync, SlidingSyncBuilder, SlidingSyncMode, SlidingSyncRoom,
     SlidingSyncState, SlidingSyncView, SlidingSyncViewBuilder, UpdateSummary,

--- a/labs/jack-in/Cargo.toml
+++ b/labs/jack-in/Cargo.toml
@@ -16,7 +16,7 @@ dialoguer = "0.10.2"
 eyre = "0.6"
 futures = { version = "0.3.1" }
 futures-signals = "0.3.24"
-matrix-sdk = { path = "../../crates/matrix-sdk", default-features = false, features  = ["e2e-encryption", "anyhow", "native-tls", "sled", "sliding-sync", "experimental-timeline"], version = "0.6.0" }
+matrix-sdk = { path = "../../crates/matrix-sdk", default-features = false, features  = ["e2e-encryption", "anyhow", "native-tls", "sled", "experimental-sliding-sync", "experimental-timeline"], version = "0.6.0" }
 matrix-sdk-common = { path = "../../crates/matrix-sdk-common", version = "0.6.0" }
 matrix-sdk-sled = { path = "../../crates/matrix-sdk-sled", features = ["state-store", "crypto-store"], version = "0.2.0" }
 sanitize-filename-reader-friendly = "2.2.1"

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -174,7 +174,7 @@ fn check_clippy() -> Result<()> {
         "rustup run nightly cargo clippy --workspace --all-targets
             --exclude matrix-sdk-crypto --exclude xtask
             --no-default-features
-            --features native-tls,sliding-sync,sso-login,experimental-timeline
+            --features native-tls,experimental-sliding-sync,sso-login,experimental-timeline
             -- -D warnings"
     )
     .run()?;


### PR DESCRIPTION
Without this, a `cargo test --features sliding-sync` fails to compile.