### PR TITLE
chore(sdk): Re-export the AmbiguityChange type

### DIFF
--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -19,8 +19,8 @@
 pub use async_trait::async_trait;
 pub use bytes;
 pub use matrix_sdk_base::{
-    deserialized_responses::AmbiguityChange, DisplayName, Room as BaseRoom, RoomInfo,
-    RoomMember as BaseRoomMember, RoomType, Session, StateChanges, StoreError,
+    deserialized_responses, DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember,
+    RoomType, Session, StateChanges, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -19,8 +19,8 @@
 pub use async_trait::async_trait;
 pub use bytes;
 pub use matrix_sdk_base::{
-    DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomType, Session,
-    StateChanges, StoreError,
+    deserialized_responses::AmbiguityChange, DisplayName, Room as BaseRoom, RoomInfo,
+    RoomMember as BaseRoomMember, RoomType, Session, StateChanges, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;


### PR DESCRIPTION
This was forgotten to be re-exposed after it was moved to the base crate.