### PR TITLE
feat(ffi): add subscribe_and_add_timeline_listener helper fn

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -117,6 +117,7 @@ interface SlidingSyncView {
 };
 
 interface SlidingSyncRoom {
+    StoppableSpawn? subscribe_and_add_timeline_listener(TimelineListener listener, RoomSubscription? settings);
     StoppableSpawn? add_timeline_listener(TimelineListener listener);
 };
 


### PR DESCRIPTION
As requested by the element-x team, this adds a helper fn to the sliding-sync-room FFI interface, that automatically subscribes in the sliding-sync-api for that room and unsubscribes on drop.