### PR TITLE
Mark as verified if our own device matches keys

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -540,7 +540,7 @@ impl IdentityManager {
                                     // the identity. We can safely mark the public part of the
                                     // identity as verified.
                                     identity.mark_as_verified();
-                                    trace!("Marked our own identity as verified");
+                                    trace!("Received our own user identity, for which we possess the private key. Marking as verified.");
                                 }
                             }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -532,6 +532,9 @@ impl IdentityManager {
                                 if result.any_cleared() {
                                     changed_identity = Some((*private_identity).clone());
                                     info!(cleared = ?result, "Removed some or all of our private cross signing keys");
+                                } else if new && private_identity.has_master_key().await {
+                                    identity.mark_as_verified();
+                                    trace!("Marked our own identity as verified");
                                 }
                             }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -533,6 +533,12 @@ impl IdentityManager {
                                     changed_identity = Some((*private_identity).clone());
                                     info!(cleared = ?result, "Removed some or all of our private cross signing keys");
                                 } else if new && private_identity.has_master_key().await {
+                                    // If the master key didn't rotate above (`clear_if_differs`),
+                                    // then this means that the public part and the private parts of
+                                    // the master key match. We previously did a signature check, so
+                                    // this means that the private part of the master key has signed
+                                    // the identity. We can safely mark the public part of the
+                                    // identity as verified.
                                     identity.mark_as_verified();
                                     trace!("Marked our own identity as verified");
                                 }

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -643,7 +643,7 @@ impl PrivateCrossSigningIdentity {
 
     /// Get the upload request that is needed to share the public keys of this
     /// identity.
-    pub async fn as_upload_request(&self) -> UploadSigningKeysRequest {
+    pub(crate) async fn as_upload_request(&self) -> UploadSigningKeysRequest {
         let master_key =
             self.master_key.lock().await.as_ref().map(|k| k.public_key.as_ref().clone());
 

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -643,7 +643,7 @@ impl PrivateCrossSigningIdentity {
 
     /// Get the upload request that is needed to share the public keys of this
     /// identity.
-    pub(crate) async fn as_upload_request(&self) -> UploadSigningKeysRequest {
+    pub async fn as_upload_request(&self) -> UploadSigningKeysRequest {
         let master_key =
             self.master_key.lock().await.as_ref().map(|k| k.public_key.as_ref().clone());
 


### PR DESCRIPTION
During migration we only convert private keys but not devices / identities. When we eventually query our own user and recieve current device, we will not consider it verified.

To solve this we mark current device as verified if just inserting it and we have master key stored locally.