### PR TITLE
Expose sending read receipts to FFI.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -256,6 +256,12 @@ interface Room {
     // Raises an exception if there are no timeline listeners.
     [Throws=ClientError]
     void paginate_backwards(PaginationOptions opts);
+    
+    [Throws=ClientError]
+    void send_read_receipt(string event_id);
+    
+    [Throws=ClientError]
+    void send_read_marker(string fully_read_event_id, string? read_receipt_event_id);
 
     [Throws=ClientError]
     void send(RoomMessageEventContent msg, string? txn_id);


### PR DESCRIPTION
This PR exposes `read_receipt` and `read_marker` on the FFI's room. Similar to sending reactions, this is likely a method that should be moved elsewhere in order to create local echoes, although I'm not sure on what layer that would be as presumably sliding sync would need to know about that 😕