### PR TITLE
Remove unused Deserialize, Serialize implementations

### DIFF
--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 
 /// A change in ambiguity of room members that an `m.room.member` event
 /// triggers.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct AmbiguityChange {
     /// Is the member that is contained in the state key of the `m.room.member`
     /// event itself ambiguous because of the event.
@@ -41,7 +41,7 @@ pub struct AmbiguityChange {
 }
 
 /// Collection of ambiguioty changes that room member events trigger.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct AmbiguityChanges {
     /// A map from room id to a map of an event id to the `AmbiguityChange` that
     /// the event with the given id caused.
@@ -51,7 +51,7 @@ pub struct AmbiguityChanges {
 /// A deserialized response for the rooms members API call.
 ///
 /// [`GET /_matrix/client/r0/rooms/{roomId}/members`](https://spec.matrix.org/v1.5/client-server-api/#get_matrixclientv3roomsroomidmembers)
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default)]
 pub struct MembersResponse {
     /// The list of members events.
     pub chunk: Vec<RoomMemberEvent>,

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -50,7 +50,7 @@ pub struct AmbiguityChanges {
 
 /// A deserialized response for the rooms members API call.
 ///
-/// [GET /_matrix/client/r0/rooms/{roomId}/members](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-rooms-roomid-members)
+/// [`GET /_matrix/client/r0/rooms/{roomId}/members`](https://spec.matrix.org/v1.5/client-server-api/#get_matrixclientv3roomsroomidmembers)
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct MembersResponse {
     /// The list of members events.

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 /// A change in ambiguity of room members that an `m.room.member` event
 /// triggers.
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub struct AmbiguityChange {
     /// Is the member that is contained in the state key of the `m.room.member`
     /// event itself ambiguous because of the event.
@@ -42,6 +43,7 @@ pub struct AmbiguityChange {
 
 /// Collection of ambiguioty changes that room member events trigger.
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub struct AmbiguityChanges {
     /// A map from room id to a map of an event id to the `AmbiguityChange` that
     /// the event with the given id caused.

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -41,7 +41,7 @@ pub struct AmbiguityChange {
     pub ambiguated_member: Option<OwnedUserId>,
 }
 
-/// Collection of ambiguioty changes that room member events trigger.
+/// Collection of ambiguity changes that room member events trigger.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct AmbiguityChanges {

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -37,7 +37,7 @@ use crate::deserialized_responses::AmbiguityChanges;
 ///
 /// This type is intended to be applicable regardless of the endpoint used for
 /// syncing.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct SyncResponse {
     /// Updates to rooms.
     pub rooms: Rooms,

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -16,13 +16,12 @@ use ruma::{
     serde::Raw,
     DeviceKeyAlgorithm, OwnedRoomId,
 };
-use serde::{Deserialize, Serialize};
 use tracing::{debug, error, warn};
 
 use crate::{event_handler::HandlerKind, Client, Result};
 
 /// The processed response of a `/sync` request.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct SyncResponse {
     /// The batch token to supply in the `since` param of the next `/sync`
     /// request.


### PR DESCRIPTION
We probably shouldn't be deriving `Deserialize` and `Serialize` on these types if we don't need to serialize it ourselves, as any breaking changes to the serialized format (for example adding a new field) would be very easy to miss.

Also make `AmbigutityChange`(`s`) non-exhaustive, they aren't meant to be constructible outside of `matrix-sdk-base`.