### PR TITLE
Cancel stoppable spawn on drop, add helper fn subscribe_and_add_timeline_listener

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -116,6 +116,7 @@ interface SlidingSyncView {
 };
 
 interface SlidingSyncRoom {
+    StoppableSpawn? subscribe_and_add_timeline_listener(TimelineListener listener, RoomSubscription? settings);
     StoppableSpawn? add_timeline_listener(TimelineListener listener);
 };
 

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -26,17 +26,24 @@ use crate::{
     TimelineListener,
 };
 
+type StoppableSpawnCallback = Box<dyn FnOnce() + Send + Sync>;
+
 pub struct StoppableSpawn {
     handle: Arc<RwLock<Option<JoinHandle<()>>>>,
+    callback: Arc<RwLock<Option<StoppableSpawnCallback>>>,
 }
 
 impl StoppableSpawn {
     fn with_handle(handle: JoinHandle<()>) -> StoppableSpawn {
-        StoppableSpawn { handle: Arc::new(RwLock::new(Some(handle))) }
+        StoppableSpawn { handle: Arc::new(RwLock::new(Some(handle))), callback: Default::default() }
     }
 
     fn with_handle_ref(handle: Arc<RwLock<Option<JoinHandle<()>>>>) -> StoppableSpawn {
-        StoppableSpawn { handle }
+        StoppableSpawn { handle, callback: Default::default() }
+    }
+
+    fn set_callback(&mut self, f: StoppableSpawnCallback) {
+        *self.callback.write().unwrap() = Some(f)
     }
 }
 
@@ -46,9 +53,18 @@ impl StoppableSpawn {
         if let Some(handle) = self.handle.write().unwrap().take() {
             handle.abort();
         }
+        if let Some(callback) = self.callback.write().unwrap().take() {
+            callback();
+        }
     }
     pub fn is_cancelled(&self) -> bool {
         self.handle.read().unwrap().is_none()
+    }
+}
+
+impl Drop for StoppableSpawn {
+    fn drop(&mut self) {
+        self.cancel();
     }
 }
 
@@ -89,6 +105,7 @@ impl From<RumaUnreadNotificationsCount> for UnreadNotificationsCount {
 pub struct SlidingSyncRoom {
     inner: matrix_sdk::SlidingSyncRoom,
     timeline: TimelineLock,
+    runner: matrix_sdk::SlidingSync,
     client: Client,
     latest_room_message: Option<Arc<EventTimelineItem>>,
 }
@@ -139,6 +156,26 @@ impl SlidingSyncRoom {
         &self,
         listener: Box<dyn TimelineListener>,
     ) -> Option<Arc<StoppableSpawn>> {
+        Some(Arc::new(self.add_timeline_listener_inner(listener)?))
+    }
+
+    pub fn subscribe_and_add_timeline_listener(
+        &self,
+        listener: Box<dyn TimelineListener>,
+        settings: Option<RoomSubscription>,
+    ) -> Option<Arc<StoppableSpawn>> {
+        let mut spawner = self.add_timeline_listener_inner(listener)?;
+        let room_id = self.inner.room_id().clone();
+        self.runner.subscribe(room_id.clone(), settings.map(Into::into));
+        let runner = self.runner.clone();
+        spawner.set_callback(Box::new(move || runner.unsubscribe(room_id)));
+        Some(Arc::new(spawner))
+    }
+
+    fn add_timeline_listener_inner(
+        &self,
+        listener: Box<dyn TimelineListener>,
+    ) -> Option<StoppableSpawn> {
         let mut timeline_lock = self.timeline.write().unwrap();
         let timeline_signal = match &*timeline_lock {
             Some(timeline) => timeline.signal(),
@@ -155,19 +192,17 @@ impl SlidingSyncRoom {
         };
 
         let listener: Arc<dyn TimelineListener> = listener.into();
-        Some(Arc::new(StoppableSpawn::with_handle(RUNTIME.spawn(timeline_signal.for_each(
-            move |diff| {
-                let listener = listener.clone();
-                let fut = RUNTIME
-                    .spawn_blocking(move || listener.on_update(Arc::new(TimelineDiff::new(diff))));
+        Some(StoppableSpawn::with_handle(RUNTIME.spawn(timeline_signal.for_each(move |diff| {
+            let listener = listener.clone();
+            let fut = RUNTIME
+                .spawn_blocking(move || listener.on_update(Arc::new(TimelineDiff::new(diff))));
 
-                async move {
-                    if let Err(e) = fut.await {
-                        error!("Timeline listener error: {e}");
-                    }
+            async move {
+                if let Err(e) = fut.await {
+                    error!("Timeline listener error: {e}");
                 }
-            },
-        )))))
+            }
+        }))))
     }
 }
 
@@ -188,15 +223,14 @@ pub struct RoomSubscription {
     pub timeline_limit: Option<u32>,
 }
 
-impl TryInto<RumaRoomSubscription> for RoomSubscription {
-    type Error = anyhow::Error;
-    fn try_into(self) -> anyhow::Result<RumaRoomSubscription> {
-        Ok(assign!(RumaRoomSubscription::default(), {
-            required_state: self.required_state.map(|r|
+impl From<RoomSubscription> for RumaRoomSubscription {
+    fn from(val: RoomSubscription) -> Self {
+        assign!(RumaRoomSubscription::default(), {
+            required_state: val.required_state.map(|r|
                 r.into_iter().map(|s| (s.key.into(), s.value)).collect()
             ).unwrap_or_default(),
-            timeline_limit: self.timeline_limit.map(|u| u.into())
-        }))
+            timeline_limit: val.timeline_limit.map(|u| u.into())
+        })
     }
 }
 
@@ -552,9 +586,7 @@ impl SlidingSync {
         room_id: String,
         settings: Option<RoomSubscription>,
     ) -> anyhow::Result<()> {
-        let settings =
-            if let Some(settings) = settings { Some(settings.try_into()?) } else { None };
-        self.inner.subscribe(room_id.try_into()?, settings);
+        self.inner.subscribe(room_id.try_into()?, settings.map(Into::into));
         Ok(())
     }
 
@@ -564,11 +596,13 @@ impl SlidingSync {
     }
 
     pub fn get_room(&self, room_id: String) -> anyhow::Result<Option<Arc<SlidingSyncRoom>>> {
+        let runner = self.inner.clone();
         Ok(self.inner.get_room(OwnedRoomId::try_from(room_id)?).map(|inner| {
             let latest_room_message = RUNTIME
                 .block_on(async { Some(Arc::new(EventTimelineItem(inner.latest_event().await?))) });
             Arc::new(SlidingSyncRoom {
                 inner,
+                runner,
                 client: self.client.clone(),
                 timeline: Default::default(),
                 latest_room_message,
@@ -595,6 +629,7 @@ impl SlidingSync {
                     });
                     Arc::new(SlidingSyncRoom {
                         inner,
+                        runner: self.inner.clone(),
                         client: self.client.clone(),
                         timeline: Default::default(),
                         latest_room_message,

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -29,16 +29,12 @@ use crate::{
 type StoppableSpawnCallback = Box<dyn FnOnce() + Send + Sync>;
 
 pub struct StoppableSpawn {
-    handle: Arc<RwLock<Option<JoinHandle<()>>>>,
-    callback: Arc<RwLock<Option<StoppableSpawnCallback>>>,
+    handle: JoinHandle<()>,
+    callback: RwLock<Option<StoppableSpawnCallback>>,
 }
 
 impl StoppableSpawn {
     fn with_handle(handle: JoinHandle<()>) -> StoppableSpawn {
-        StoppableSpawn { handle: Arc::new(RwLock::new(Some(handle))), callback: Default::default() }
-    }
-
-    fn with_handle_ref(handle: Arc<RwLock<Option<JoinHandle<()>>>>) -> StoppableSpawn {
         StoppableSpawn { handle, callback: Default::default() }
     }
 
@@ -47,18 +43,23 @@ impl StoppableSpawn {
     }
 }
 
+impl From<JoinHandle<()>> for StoppableSpawn {
+    fn from(value: JoinHandle<()>) -> Self {
+        StoppableSpawn::with_handle(value)
+    }
+}
+
 #[uniffi::export]
 impl StoppableSpawn {
     pub fn cancel(&self) {
-        if let Some(handle) = self.handle.write().unwrap().take() {
-            handle.abort();
-        }
+        debug!("stoppable.cancel() called");
+        self.handle.abort();
         if let Some(callback) = self.callback.write().unwrap().take() {
             callback();
         }
     }
-    pub fn is_cancelled(&self) -> bool {
-        self.handle.read().unwrap().is_none()
+    pub fn is_finished(&self) -> bool {
+        self.handle.is_finished()
     }
 }
 
@@ -569,12 +570,11 @@ pub struct SlidingSync {
     inner: matrix_sdk::SlidingSync,
     client: Client,
     observer: Arc<RwLock<Option<Box<dyn SlidingSyncObserver>>>>,
-    sync_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
 }
 
 impl SlidingSync {
     fn new(inner: matrix_sdk::SlidingSync, client: Client) -> Self {
-        SlidingSync { inner, client, observer: Default::default(), sync_handle: Default::default() }
+        SlidingSync { inner, client, observer: Default::default() }
     }
 
     pub fn set_observer(&self, observer: Option<Box<dyn SlidingSyncObserver>>) {
@@ -657,48 +657,37 @@ impl SlidingSync {
 
     pub fn sync(&self) -> Arc<StoppableSpawn> {
         let inner = self.inner.clone();
+        let client = self.client.clone();
         let observer = self.observer.clone();
-        let spawn = Arc::new(StoppableSpawn::with_handle_ref(self.sync_handle.clone()));
-        let inner_spawn = spawn.clone();
-        {
-            let mut sync_handle = self.sync_handle.write().unwrap();
-            let client = self.client.clone();
 
-            if let Some(handle) = sync_handle.take() {
-                handle.abort();
-            }
-
-            *sync_handle = Some(RUNTIME.spawn(async move {
-                let stream = inner.stream().await.unwrap();
-                pin_mut!(stream);
-                loop {
-                    let update = match stream.next().await {
-                        Some(Ok(u)) => u,
-                        Some(Err(e)) => {
-                            if client.process_sync_error(e) == LoopCtrl::Break {
-                                break;
-                            } else {
-                                continue;
+        Arc::new(
+            RUNTIME
+                .spawn(async move {
+                    let stream = inner.stream().await.unwrap();
+                    pin_mut!(stream);
+                    loop {
+                        let update = match stream.next().await {
+                            Some(Ok(u)) => u,
+                            Some(Err(e)) => {
+                                if client.process_sync_error(e) == LoopCtrl::Break {
+                                    warn!("loop was stopped by client error processing");
+                                    break;
+                                } else {
+                                    continue;
+                                }
                             }
+                            None => {
+                                warn!("Inner streaming loop ended unexpectedly");
+                                break;
+                            }
+                        };
+                        if let Some(ref observer) = *observer.read().unwrap() {
+                            observer.did_receive_sync_update(update.into());
                         }
-                        None => {
-                            debug!("No update from loop, cancelled");
-                            break;
-                        }
-                    };
-                    if let Some(ref observer) = *observer.read().unwrap() {
-                        observer.did_receive_sync_update(update.into());
-                    } else {
-                        // when the observer has been removed
-                        // we cancel the loop
-                        inner_spawn.cancel();
-                        break;
                     }
-                }
-            }));
-        }
-
-        spawn
+                })
+                .into(),
+        )
     }
 }
 


### PR DESCRIPTION
Reintroduces #1346 but refactor the stoppable spawn from the old replacing token to a user-has-token-control model. This fixes the problem of sync randomly stopping after introducing the drop cancellation on stoppable spawns.