### PR TITLE
feat(bindings): Expose sled passphrase to the FFI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2830,6 +2830,7 @@ dependencies = [
  "uniffi",
  "uniffi_build",
  "uniffi_macros",
+ "zeroize",
 ]
 
 [[package]]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-stream = "0.1.8"
 uniffi = { workspace = true }
 uniffi_macros = { workspace = true }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-stream = "0.1.8"
 uniffi = { workspace = true }
 uniffi_macros = { workspace = true }
-zeroize = { workspace = true, features = ["zeroize_derive"] }
+zeroize = { workspace = true }
 
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -304,7 +304,7 @@ interface MediaSource {
 };
 
 interface AuthenticationService {
-    constructor(string base_path);
+    constructor(string base_path, string? passphrase);
 };
 
 interface SessionVerificationEmoji {};

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -10,6 +10,7 @@ use super::{client::Client, client_builder::ClientBuilder, RUNTIME};
 
 pub struct AuthenticationService {
     base_path: String,
+    passphrase: Option<String>,
     client: RwLock<Option<Arc<Client>>>,
     homeserver_details: RwLock<Option<Arc<HomeserverLoginDetails>>>,
 }
@@ -59,9 +60,10 @@ impl HomeserverLoginDetails {
 
 impl AuthenticationService {
     /// Creates a new service to authenticate a user with.
-    pub fn new(base_path: String) -> Self {
+    pub fn new(base_path: String, passphrase: Option<String>) -> Self {
         AuthenticationService {
             base_path,
+            passphrase,
             client: RwLock::new(None),
             homeserver_details: RwLock::new(None),
         }
@@ -140,6 +142,7 @@ impl AuthenticationService {
         let session = client.client.session().ok_or(AuthenticationError::SessionMissing)?;
         let client = Arc::new(ClientBuilder::new())
             .base_path(self.base_path.clone())
+            .passphrase(self.passphrase.clone())
             .homeserver_url(homeserver_url)
             .username(whoami.user_id.to_string())
             .build()
@@ -192,6 +195,7 @@ impl AuthenticationService {
         };
         let client = Arc::new(ClientBuilder::new())
             .base_path(self.base_path.clone())
+            .passphrase(self.passphrase.clone())
             .homeserver_url(homeserver_url)
             .username(whoami.user_id.to_string())
             .build()

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -5,6 +5,7 @@ use matrix_sdk::{
     ruma::{OwnedDeviceId, UserId},
     Session,
 };
+use zeroize::Zeroize;
 
 use super::{client::Client, client_builder::ClientBuilder, RUNTIME};
 
@@ -13,6 +14,12 @@ pub struct AuthenticationService {
     passphrase: Option<String>,
     client: RwLock<Option<Arc<Client>>>,
     homeserver_details: RwLock<Option<Arc<HomeserverLoginDetails>>>,
+}
+
+impl Drop for AuthenticationService {
+    fn drop(&mut self) {
+        self.passphrase.zeroize();
+    }
 }
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -16,6 +16,7 @@ pub struct ClientBuilder {
     username: Option<String>,
     server_name: Option<String>,
     homeserver_url: Option<String>,
+    passphrase: Option<String>,
     user_agent: Option<String>,
     inner: MatrixClientBuilder,
 }
@@ -46,6 +47,12 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
+    pub fn passphrase(self: Arc<Self>, passphrase: Option<String>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.passphrase = passphrase;
+        Arc::new(builder)
+    }
+
     pub fn user_agent(self: Arc<Self>, user_agent: String) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.user_agent = Some(user_agent);
@@ -60,6 +67,7 @@ impl ClientBuilder {
             username: None,
             server_name: None,
             homeserver_url: None,
+            passphrase: None,
             user_agent: None,
             inner: MatrixClient::builder(),
         }
@@ -74,7 +82,7 @@ impl ClientBuilder {
             let data_path = PathBuf::from(base_path).join(sanitize(username));
             fs::create_dir_all(&data_path)?;
 
-            inner_builder = inner_builder.sled_store(data_path, None);
+            inner_builder = inner_builder.sled_store(data_path, builder.passphrase.as_deref());
         }
 
         // Determine server either from URL, server name or user ID.

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -6,6 +6,7 @@ use matrix_sdk::{
     Client as MatrixClient, ClientBuilder as MatrixClientBuilder,
 };
 use sanitize_filename_reader_friendly::sanitize;
+use zeroize::Zeroizing;
 
 use super::{client::Client, ClientState, RUNTIME};
 use crate::helpers::unwrap_or_clone_arc;
@@ -16,7 +17,7 @@ pub struct ClientBuilder {
     username: Option<String>,
     server_name: Option<String>,
     homeserver_url: Option<String>,
-    passphrase: Option<String>,
+    passphrase: Zeroizing<Option<String>>,
     user_agent: Option<String>,
     inner: MatrixClientBuilder,
 }
@@ -49,7 +50,7 @@ impl ClientBuilder {
 
     pub fn passphrase(self: Arc<Self>, passphrase: Option<String>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.passphrase = passphrase;
+        builder.passphrase = Zeroizing::new(passphrase);
         Arc::new(builder)
     }
 
@@ -67,7 +68,7 @@ impl ClientBuilder {
             username: None,
             server_name: None,
             homeserver_url: None,
-            passphrase: None,
+            passphrase: Zeroizing::new(None),
             user_agent: None,
             inner: MatrixClient::builder(),
         }


### PR DESCRIPTION
This PR exposes the ability to set the sled passphrase both on the `AuthenticationService` for login and then on the `ClientBuilder` for restoration.