### PR TITLE
Various smaller sliding sync fixes

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -104,6 +104,9 @@ interface SlidingSyncViewBuilder {
     [Self=ByArc]
     SlidingSyncViewBuilder sync_mode(SlidingSyncMode mode);
 
+    [Self=ByArc]
+    SlidingSyncViewBuilder send_updates_for_items(boolean enable);
+
     [Throws=ClientError, Self=ByArc]
     SlidingSyncView build();
 };

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -18,7 +18,7 @@ pub use matrix_sdk::{
     SlidingSyncBuilder as MatrixSlidingSyncBuilder, SlidingSyncMode, SlidingSyncState,
 };
 use tokio::task::JoinHandle;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, trace, warn};
 
 use super::{Client, Room, RUNTIME};
 use crate::{

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -378,6 +378,12 @@ impl SlidingSyncViewBuilder {
         Arc::new(builder)
     }
 
+    pub fn send_updates_for_items(self: Arc<Self>, enable: bool) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.send_updates_for_items(enable);
+        Arc::new(builder)
+    }
+
     pub fn ranges(self: Arc<Self>, ranges: Vec<(u32, u32)>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.ranges(ranges);
@@ -499,10 +505,8 @@ impl SlidingSyncView {
     ) -> Arc<StoppableSpawn> {
         let mut room_list = self.inner.rooms_list.signal_vec_cloned().to_stream();
         Arc::new(StoppableSpawn::with_handle(RUNTIME.spawn(async move {
-            loop {
-                if let Some(diff) = room_list.next().await {
-                    observer.did_receive_update(diff.into());
-                }
+            if let Some(diff) = room_list.next().await {
+                observer.did_receive_update(diff.into());
             }
         })))
     }

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -1326,7 +1326,7 @@ impl<'a> Iterator for SlidingSyncViewRequestGenerator<'a> {
 
 #[instrument(skip(ops))]
 fn room_ops(
-    rooms_list: &mut MutableVecLockMut<RoomListEntry>,
+    rooms_list: &mut MutableVecLockMut<'_, RoomListEntry>,
     ops: &Vec<v4::SyncOp>,
     room_ranges: &Vec<(usize, usize)>,
 ) -> Result<(), Error> {

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -389,7 +389,7 @@ impl SlidingSyncConfig {
         let mut rooms_found: BTreeMap<OwnedRoomId, SlidingSyncRoom> = BTreeMap::new();
 
         if let Some(storage_key) = storage_key.as_ref() {
-            tracing::trace!(storage_key, "trying to load from cold");
+            trace!(storage_key, "trying to load from cold");
 
             for view in views.iter_mut() {
                 if let Some(frozen_view) = client
@@ -399,7 +399,7 @@ impl SlidingSyncConfig {
                     .map(|v| serde_json::from_slice::<FrozenSlidingSyncView>(&v))
                     .transpose()?
                 {
-                    tracing::trace!(name = view.name, "frozen for view found");
+                    trace!(name = view.name, "frozen for view found");
 
                     let FrozenSlidingSyncView { rooms_count, rooms_list, rooms } = frozen_view;
                     view.set_from_cold(rooms_count, rooms_list);
@@ -420,7 +420,7 @@ impl SlidingSyncConfig {
                 .map(|v| serde_json::from_slice::<FrozenSlidingSync>(&v))
                 .transpose()?
             {
-                tracing::trace!("frozen for generic found");
+                trace!("frozen for generic found");
                 if let Some(since) = f.to_device_since {
                     if let Some(to_device_ext) =
                         extensions.get_or_insert_with(Default::default).to_device.as_mut()
@@ -429,10 +429,10 @@ impl SlidingSyncConfig {
                     }
                 }
             }
-            tracing::trace!("sync unfrozen done");
+            trace!("sync unfrozen done");
         };
 
-        tracing::trace!(len = rooms_found.len(), "rooms unfrozen");
+        trace!(len = rooms_found.len(), "rooms unfrozen");
         let rooms = Arc::new(MutableBTreeMap::with_values(rooms_found));
         // map the roomsmap into the views:
         for v in &mut views {


### PR DESCRIPTION
Various sliding sync fixes, providing tests where possible. ref #1359 


- [x] more tracing around unfreeze code for better performance tracking
- [x] when recovering from cold or going live the first time, we used to fire a bunch of Empty-Insert events for every room in the total count. With this change, we are building the new list once and set it instead, leading to a much more feasible single `Replace` event being triggered
- [x] the view generators would only update upon the next loop iteration following the current cycle and they would update regardless of whether they actually succeeded, leading to two annoying bugs: `live` state only being set at the beginning of the next cycle and growing sync some times skipping beats. This changes the code to do a post-processing of the view-generator code after we've received the new update - based on the data of the update. Leading to one request less before `live` being triggered and fixing beat-skipping.
- [x] selective caching (part 1): we were caching the entire object at once, which meant that if you loaded a lot of rooms, deserializing that would take quite some times (we've seen 800ms being spent on that). The code was refactored to store room data alongside the view it belongs to allowing the API to select the views (by adding them before built) that are even attempted to look up. For me that drops the unfreezing time from 150ms to 30ms for a 14item selective view (ignoring a full-growing-sync-view).
- [x] #1361 allows us to cancel the spawn of the sync loop - but that means we now might also miss updates sent by the server as any `.await` might get interrupted and thus processing of the results could fail. We can see in the logs that this happening and might cause gaps in the room list even. This has been fixed by switching to an `AtomicBool` to inform the inner loop to stop after every iteration rather than cancelling the actual `JoinHandle`. 
- [x] properly reset the timeline if the server tells us to (via `limited` flag) fixes the problem of gappy timelines when the room ran out of scope and came back in. 
- [x] checker whether a given room id is in the visible range and an optional flag to ask the view to trigger updates for rooms that are in the view regardless of whether their positions was updated in the view. 