### PR TITLE
crypto(fix): Fail to decrypt if there's a key mismatch

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -88,20 +88,20 @@ pub enum MegolmError {
     #[error("decryption failed because the room key is missing")]
     MissingRoomKey,
 
-    /// Decryption failed because of a key mismatch between the identity keys of
-    /// the device and the keys that were recorded when the room key was
-    /// received.
+    /// Decryption failed because of a mismatch between the identity keys of the
+    /// device we received the room key from and the identity keys recorded in the
+    /// plaintext of the room key to-device message.
     #[error(
-        "decryption failed because the keys room key don't match the identity keys for the device"
+        "decryption failed because of mismatched identity keys of the sending device and those recorded in the to-device message"
     )]
     MismatchedIdentityKeys {
-        /// The Ed25519 key that was bound to the room key.
+        /// The Ed25519 key recorded in the room key's to-device message.
         ed25519: Box<Ed25519PublicKey>,
-        /// The Ed25519 identity key of the device.
+        /// The Ed25519 identity key of the device sending the room key.
         device_ed25519: Option<Box<Ed25519PublicKey>>,
-        /// The Curve25519 key that was bound to the room key.
+        /// The Curve25519 key recorded in the room key's to-device message.
         curve25519: Box<Curve25519PublicKey>,
-        /// The Curve25519 identity key of the device.
+        /// The Curve25519 identity key of the device sending the room key.
         device_curve25519: Option<Box<Curve25519PublicKey>>,
     },
 

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -96,11 +96,11 @@ pub enum MegolmError {
     )]
     MismatchedIdentityKeys {
         /// The Ed25519 key recorded in the room key's to-device message.
-        ed25519: Box<Ed25519PublicKey>,
+        key_ed25519: Box<Ed25519PublicKey>,
         /// The Ed25519 identity key of the device sending the room key.
         device_ed25519: Option<Box<Ed25519PublicKey>>,
         /// The Curve25519 key recorded in the room key's to-device message.
-        curve25519: Box<Curve25519PublicKey>,
+        key_curve25519: Box<Curve25519PublicKey>,
         /// The Curve25519 identity key of the device sending the room key.
         device_curve25519: Option<Box<Curve25519PublicKey>>,
     },

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -88,6 +88,23 @@ pub enum MegolmError {
     #[error("decryption failed because the room key is missing")]
     MissingRoomKey,
 
+    /// Decryption failed because of a key mismatch between the identity keys of
+    /// the device and the keys that were recorded when the room key was
+    /// received.
+    #[error(
+        "decryption failed because the keys room key don't match the identity keys for the device"
+    )]
+    MismatchedIdentityKeys {
+        /// The Ed25519 key that was bound to the room key.
+        ed25519: Box<Ed25519PublicKey>,
+        /// The Ed25519 identity key of the device.
+        device_ed25519: Option<Box<Ed25519PublicKey>>,
+        /// The Curve25519 key that was bound to the room key.
+        curve25519: Box<Curve25519PublicKey>,
+        /// The Curve25519 identity key of the device.
+        device_curve25519: Option<Box<Curve25519PublicKey>>,
+    },
+
     /// The encrypted megolm message couldn't be decoded.
     #[error(transparent)]
     Decode(#[from] vodozemac::DecodeError),

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -89,8 +89,8 @@ pub enum MegolmError {
     MissingRoomKey,
 
     /// Decryption failed because of a mismatch between the identity keys of the
-    /// device we received the room key from and the identity keys recorded in the
-    /// plaintext of the room key to-device message.
+    /// device we received the room key from and the identity keys recorded in
+    /// the plaintext of the room key to-device message.
     #[error(
         "decryption failed because of mismatched identity keys of the sending device and those recorded in the to-device message"
     )]

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -178,7 +178,8 @@ impl Device {
                 }),
                 // If both keys match, we have ourselves an owner.
                 (Some(true), Some(true)) => Ok(true),
-                // In all other cases, we just don't know.
+                // In the remaining cases, the device is missing at least one of the required
+                // identity keys, so we default to a negative answer.
                 _ => Ok(false),
             }
         } else {

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -171,9 +171,9 @@ impl Device {
                 // If we have any of the keys but they don't turn out to match, refuse to decrypt
                 // instead.
                 (_, Some(false)) | (Some(false), _) => Err(MegolmError::MismatchedIdentityKeys {
-                    ed25519: key.into(),
+                    key_ed25519: key.into(),
                     device_ed25519: self.ed25519_key().map(Into::into),
-                    curve25519: session.sender_key().into(),
+                    key_curve25519: session.sender_key().into(),
                     device_curve25519: self.curve25519_key().map(Into::into),
                 }),
                 // If both keys match, we have ourselves an owner.

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1054,7 +1054,7 @@ impl OlmMachine {
         &self,
         session: &InboundGroupSession,
         sender: &UserId,
-    ) -> StoreResult<(VerificationState, Option<OwnedDeviceId>)> {
+    ) -> MegolmResult<(VerificationState, Option<OwnedDeviceId>)> {
         Ok(
             // First find the device corresponding to the Curve25519 identity
             // key that sent us the session (recorded upon successful
@@ -1072,7 +1072,7 @@ impl OlmMachine {
                 //
                 //     a) This is our own device, or
                 //     b) The device itself is considered to be trusted.
-                if device.is_owner_of_session(session)
+                if device.is_owner_of_session(session)?
                     && (device.is_our_own_device() || device.is_verified())
                 {
                     (VerificationState::Trusted, Some(device.device_id().to_owned()))
@@ -1096,7 +1096,7 @@ impl OlmMachine {
         &self,
         session: &InboundGroupSession,
         sender: &UserId,
-    ) -> StoreResult<EncryptionInfo> {
+    ) -> MegolmResult<EncryptionInfo> {
         let (verification_state, device_id) = self.get_verification_state(session, sender).await?;
 
         let sender = sender.to_owned();
@@ -1610,7 +1610,7 @@ pub(crate) mod tests {
                 room::encrypted::{EncryptedToDeviceEvent, ToDeviceEncryptedEventContent},
                 ToDeviceEvent,
             },
-            DeviceKeys, SignedKey,
+            DeviceKeys, SignedKey, SigningKeys,
         },
         utilities::json_convert,
         verification::tests::{outgoing_request_to_event, request_to_event},
@@ -2438,5 +2438,40 @@ pub(crate) mod tests {
         let session = bob.store.get_inbound_group_session(room_id, &session_id).await;
 
         assert!(session.unwrap().is_none());
+    }
+
+    #[async_test]
+    async fn room_key_with_fake_identity_keys() {
+        let room_id = room_id!("!test:localhost");
+        let (alice, _) = get_machine_pair_with_setup_sessions().await;
+        let device = ReadOnlyDevice::from_machine(&alice).await;
+        alice.store.save_devices(&[device]).await.unwrap();
+
+        let (outbound, mut inbound) =
+            alice.account.create_group_session_pair(room_id, Default::default()).await.unwrap();
+
+        let fake_key = Ed25519PublicKey::from_base64("ee3Ek+J2LkkPmjGPGLhMxiKnhiX//xcqaVL4RP6EypE")
+            .unwrap()
+            .into();
+        let signing_keys = SigningKeys::from([(DeviceKeyAlgorithm::Ed25519, fake_key)]);
+        inbound.signing_keys = signing_keys.into();
+
+        let content = json!({});
+        let content = outbound.encrypt(content, "m.dummy").await;
+        alice.store.save_inbound_group_sessions(&[inbound]).await.unwrap();
+
+        let event = json!({
+            "sender": alice.user_id(),
+            "event_id": "$xxxxx:example.org",
+            "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
+            "type": "m.room.encrypted",
+            "content": content,
+        });
+        let event = json_convert(&event).unwrap();
+
+        assert_matches!(
+            alice.decrypt_room_event(&event, room_id).await,
+            Err(MegolmError::MismatchedIdentityKeys { .. })
+        );
     }
 }


### PR DESCRIPTION
A mismatch between the recorded Ed25519 and Curve25519 keys of the room key and the identity keys of a Device used to be just a warning.

Considering that many clients will aggressively try to hide E2EE related warnings let's upgrade this clear error into a full blown decryption failure.
