### PR TITLE
feat(crypto-nodejs): Request types have more fields

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -239,11 +239,11 @@ pub struct RoomMessageRequest {
     #[wasm_bindgen(readonly)]
     pub txn_id: JsString,
 
-    /// A string representing the type of even from the message's content.
+    /// A string representing the type of event to be sent.
     #[wasm_bindgen(readonly)]
     pub event_type: JsString,
 
-    /// A JSON-encoded string containing the message's body.
+    /// A JSON-encoded string containing the message's content.
     #[wasm_bindgen(readonly, js_name = "body")]
     pub content: JsString,
 }


### PR DESCRIPTION
Follow up of #1303, but applied to `crypto-nodejs`.

Instead of putting all request fields inside a single `body` JSON-encoded string  field, there is now more types. There is less need to call `JSON.parse`, and the type system will be able to catch more things.

For example, `ToDeviceRequest` now has 2 more fields: `event_type` and `txn_id`.