### PR TITLE
chore(bindings): Exclude the `target` folder from the debug swift pac…

### DIFF
--- a/bindings/apple/Debug-Empty-Package.swift
+++ b/bindings/apple/Debug-Empty-Package.swift
@@ -1,0 +1,8 @@
+// swift-tools-version:5.6
+
+// A package manifest for local development. This file will be copied
+// into the root of the repo when generating an XCFramework.
+
+import PackageDescription
+
+let package = Package()

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -203,6 +203,15 @@ fn build_xcframework(
     // Copy the Swift package manifest to the SDK root for local development.
     copy(apple_dir.join("Debug-Package.swift"), root_dir.join("Package.swift"))?;
 
+    // Copy an empty package to folders we want ignored
+    let ignored_package_folders = ["target"];
+    for path in ignored_package_folders {
+        copy(
+            apple_dir.join("Debug-Empty-Package.swift"),
+            root_dir.join(path).join("Package.swift"),
+        )?;
+    }
+
     // cleaning up the intermediate data
     remove_dir_all(headers_dir.as_path())?;
 


### PR DESCRIPTION
…kage, improve package loading time

Turns out that including all 100k+ files from the `target` folder into the resulting Swift package cripples Xcode.
While there is no official way of excluding folders we found that adding an empty package withing those folders works, and that's good enough for debugging purposes