### PR TITLE
chore: Fix the conventional commit type for documentation

### DIFF
--- a/CONVENTIONAL_COMMITS.md
+++ b/CONVENTIONAL_COMMITS.md
@@ -18,7 +18,7 @@ project:
 | `feat` | About a new feature. |
 | `fix` | About a bug fix. |
 | `test` | About a test (suite, case, runner…). |
-| `doc` | About a documentation modification. |
+| `docs` | About a documentation modification. |
 | `refactor` | About a refactoring. |
 | `ci` | About a Continuous Integration modification. |
 | `chore` | About some cleanup, or regular tasks. |


### PR DESCRIPTION
The conventional commit specification recommends the "docs" type for documentation related changes. This also matches the initial usage of this type in our commit history.

While the default git-cliff config does specify a regex "^doc", where I suspect our types have been taken from, this regex actually allows "doc" as well as "docs" for the type.

Nevertheless, let's specify that we're using the one recommended in the spec.