### PR TITLE
refactor(sdk): Split room member events between membership and profile change

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -4,8 +4,6 @@ use extension_trait::extension_trait;
 use futures_signals::signal_vec::VecDiff;
 pub use matrix_sdk::ruma::events::room::{message::RoomMessageEventContent, MediaSource};
 
-use crate::MembershipState;
-
 #[uniffi::export]
 pub fn media_source_from_url(url: String) -> Arc<MediaSource> {
     Arc::new(MediaSource::Plain(url.into()))
@@ -265,10 +263,31 @@ impl TimelineItemContent {
             Content::UnableToDecrypt(msg) => {
                 TimelineItemContentKind::UnableToDecrypt { msg: EncryptedMessage::new(msg) }
             }
-            Content::RoomMember(room_member) => TimelineItemContentKind::RoomMembership {
-                user_id: room_member.user_id().to_string(),
-                change: room_member.into(),
+            Content::MembershipChange(membership) => TimelineItemContentKind::RoomMembership {
+                user_id: membership.user_id().to_string(),
+                change: membership.change().map(Into::into),
             },
+            Content::ProfileChange(profile) => {
+                let (display_name, prev_display_name) = profile
+                    .displayname_change()
+                    .map(|change| (change.new.clone(), change.old.clone()))
+                    .unzip();
+                let (avatar_url, prev_avatar_url) = profile
+                    .avatar_url_change()
+                    .map(|change| {
+                        (
+                            change.new.as_ref().map(ToString::to_string),
+                            change.old.as_ref().map(ToString::to_string),
+                        )
+                    })
+                    .unzip();
+                TimelineItemContentKind::ProfileChange {
+                    display_name: display_name.flatten(),
+                    prev_display_name: prev_display_name.flatten(),
+                    avatar_url: avatar_url.flatten(),
+                    prev_avatar_url: prev_avatar_url.flatten(),
+                }
+            }
             Content::OtherState(state) => TimelineItemContentKind::State {
                 state_key: state.state_key().to_owned(),
                 content: state.content().into(),
@@ -299,12 +318,37 @@ impl TimelineItemContent {
 pub enum TimelineItemContentKind {
     Message,
     RedactedMessage,
-    Sticker { body: String, info: ImageInfo, url: String },
-    UnableToDecrypt { msg: EncryptedMessage },
-    RoomMembership { user_id: String, change: MembershipChange },
-    State { state_key: String, content: OtherState },
-    FailedToParseMessageLike { event_type: String, error: String },
-    FailedToParseState { event_type: String, state_key: String, error: String },
+    Sticker {
+        body: String,
+        info: ImageInfo,
+        url: String,
+    },
+    UnableToDecrypt {
+        msg: EncryptedMessage,
+    },
+    RoomMembership {
+        user_id: String,
+        change: Option<MembershipChange>,
+    },
+    ProfileChange {
+        display_name: Option<String>,
+        prev_display_name: Option<String>,
+        avatar_url: Option<String>,
+        prev_avatar_url: Option<String>,
+    },
+    State {
+        state_key: String,
+        content: OtherState,
+    },
+    FailedToParseMessageLike {
+        event_type: String,
+        error: String,
+    },
+    FailedToParseState {
+        event_type: String,
+        state_key: String,
+        error: String,
+    },
 }
 
 #[derive(Clone, uniffi::Object)]
@@ -666,67 +710,30 @@ pub enum MembershipChange {
     KnockAccepted,
     KnockRetracted,
     KnockDenied,
-    ProfileChanged {
-        display_name: Option<String>,
-        prev_display_name: Option<String>,
-        avatar_url: Option<String>,
-        prev_avatar_url: Option<String>,
-    },
     NotImplemented,
-    Unknown {
-        membership: MembershipState,
-        display_name: Option<String>,
-        avatar_url: Option<String>,
-    },
 }
 
-impl From<&matrix_sdk::room::timeline::RoomMember> for MembershipChange {
-    fn from(member: &matrix_sdk::room::timeline::RoomMember) -> Self {
-        use matrix_sdk::ruma::events::{
-            room::member::MembershipChange as Change, FullStateEventContent as FullContent,
-        };
-        if let Some(change) = member.membership_change() {
-            match change {
-                Change::None => Self::None,
-                Change::Error => Self::Error,
-                Change::Joined => Self::Joined,
-                Change::Left => Self::Left,
-                Change::Banned => Self::Banned,
-                Change::Unbanned => Self::Unbanned,
-                Change::Kicked => Self::Kicked,
-                Change::Invited => Self::Invited,
-                Change::KickedAndBanned => Self::KickedAndBanned,
-                Change::InvitationAccepted => Self::InvitationAccepted,
-                Change::InvitationRejected => Self::InvitationRejected,
-                Change::InvitationRevoked => Self::InvitationRevoked,
-                Change::Knocked => Self::Knocked,
-                Change::KnockAccepted => Self::KnockAccepted,
-                Change::KnockRetracted => Self::KnockRetracted,
-                Change::KnockDenied => Self::KnockDenied,
-                Change::ProfileChanged { displayname_change, avatar_url_change } => {
-                    let (display_name, prev_display_name) =
-                        displayname_change.map(|change| (change.new, change.old)).unzip();
-                    let (avatar_url, prev_avatar_url) =
-                        avatar_url_change.map(|change| (change.new, change.old)).unzip();
-                    Self::ProfileChanged {
-                        display_name: display_name.flatten().map(ToOwned::to_owned),
-                        prev_display_name: prev_display_name.flatten().map(ToOwned::to_owned),
-                        avatar_url: avatar_url.flatten().map(ToString::to_string),
-                        prev_avatar_url: prev_avatar_url.flatten().map(ToString::to_string),
-                    }
-                }
-                _ => Self::NotImplemented,
-            }
-        } else {
-            let (membership, display_name, avatar_url) = match member.content() {
-                FullContent::Original { content, .. } => (
-                    content.membership.clone().into(),
-                    content.displayname.clone(),
-                    content.avatar_url.as_ref().map(ToString::to_string),
-                ),
-                FullContent::Redacted(content) => (content.membership.clone().into(), None, None),
-            };
-            Self::Unknown { membership, display_name, avatar_url }
+impl From<matrix_sdk::room::timeline::MembershipChange> for MembershipChange {
+    fn from(membership_change: matrix_sdk::room::timeline::MembershipChange) -> Self {
+        use matrix_sdk::room::timeline::MembershipChange as Change;
+        match membership_change {
+            Change::None => Self::None,
+            Change::Error => Self::Error,
+            Change::Joined => Self::Joined,
+            Change::Left => Self::Left,
+            Change::Banned => Self::Banned,
+            Change::Unbanned => Self::Unbanned,
+            Change::Kicked => Self::Kicked,
+            Change::Invited => Self::Invited,
+            Change::KickedAndBanned => Self::KickedAndBanned,
+            Change::InvitationAccepted => Self::InvitationAccepted,
+            Change::InvitationRejected => Self::InvitationRejected,
+            Change::InvitationRevoked => Self::InvitationRevoked,
+            Change::Knocked => Self::Knocked,
+            Change::KnockAccepted => Self::KnockAccepted,
+            Change::KnockRetracted => Self::KnockRetracted,
+            Change::KnockDenied => Self::KnockDenied,
+            Change::NotImplemented => Self::NotImplemented,
         }
     }
 }

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -24,7 +24,7 @@ use ruma::{
         relation::{Annotation, Replacement},
         room::{
             encrypted::{self, RoomEncryptedEventContent},
-            member::RoomMemberEventContent,
+            member::{Change, RoomMemberEventContent},
             message::{self, MessageType, RoomMessageEventContent},
             redaction::{
                 OriginalSyncRoomRedactionEvent, RoomRedactionEventContent, SyncRoomRedactionEvent,
@@ -42,13 +42,13 @@ use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 use super::{
     event_item::{
-        AnyOtherFullStateEventContent, BundledReactions, OtherState, Profile, RoomMember, Sticker,
-        TimelineDetails,
+        AnyOtherFullStateEventContent, BundledReactions, MemberProfileChange, OtherState, Profile,
+        RoomMembershipChange, Sticker, TimelineDetails,
     },
     find_event_by_id, find_event_by_txn_id, find_read_marker, EventTimelineItem, Message,
     TimelineInnerMetadata, TimelineItem, TimelineItemContent, TimelineKey, VirtualTimelineItem,
 };
-use crate::events::SyncTimelineEventWithoutContent;
+use crate::{events::SyncTimelineEventWithoutContent, room::timeline::MembershipChange};
 
 pub(super) enum Flow {
     Local {
@@ -349,7 +349,9 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                     info!("Edit event applies to event that couldn't be decrypted, discarding");
                     return None;
                 }
-                TimelineItemContent::RoomMember { .. } | TimelineItemContent::OtherState { .. } => {
+                TimelineItemContent::MembershipChange(_)
+                | TimelineItemContent::ProfileChange(_)
+                | TimelineItemContent::OtherState { .. } => {
                     info!("Edit event applies to a state event, discarding");
                     return None;
                 }
@@ -754,10 +756,71 @@ impl NewEventTimelineItem {
 
     fn room_member(
         user_id: OwnedUserId,
-        content: FullStateEventContent<RoomMemberEventContent>,
+        full_content: FullStateEventContent<RoomMemberEventContent>,
         sender: OwnedUserId,
     ) -> Self {
-        Self::from_content(TimelineItemContent::RoomMember(RoomMember { user_id, content, sender }))
+        use ruma::events::room::member::MembershipChange as MChange;
+        let item_content = match &full_content {
+            FullStateEventContent::Original { content, prev_content } => {
+                let membership_change = content.membership_change(
+                    prev_content.as_ref().map(|c| c.details()),
+                    &sender,
+                    &user_id,
+                );
+
+                if let MChange::ProfileChanged { displayname_change, avatar_url_change } =
+                    membership_change
+                {
+                    TimelineItemContent::ProfileChange(MemberProfileChange {
+                        user_id,
+                        displayname_change: displayname_change.map(|c| Change {
+                            new: c.new.map(ToOwned::to_owned),
+                            old: c.old.map(ToOwned::to_owned),
+                        }),
+                        avatar_url_change: avatar_url_change.map(|c| Change {
+                            new: c.new.map(ToOwned::to_owned),
+                            old: c.old.map(ToOwned::to_owned),
+                        }),
+                    })
+                } else {
+                    let change = match membership_change {
+                        MChange::None => MembershipChange::None,
+                        MChange::Error => MembershipChange::Error,
+                        MChange::Joined => MembershipChange::Joined,
+                        MChange::Left => MembershipChange::Left,
+                        MChange::Banned => MembershipChange::Banned,
+                        MChange::Unbanned => MembershipChange::Unbanned,
+                        MChange::Kicked => MembershipChange::Kicked,
+                        MChange::Invited => MembershipChange::Invited,
+                        MChange::KickedAndBanned => MembershipChange::KickedAndBanned,
+                        MChange::InvitationAccepted => MembershipChange::InvitationAccepted,
+                        MChange::InvitationRejected => MembershipChange::InvitationRejected,
+                        MChange::InvitationRevoked => MembershipChange::InvitationRevoked,
+                        MChange::Knocked => MembershipChange::Knocked,
+                        MChange::KnockAccepted => MembershipChange::KnockAccepted,
+                        MChange::KnockRetracted => MembershipChange::KnockRetracted,
+                        MChange::KnockDenied => MembershipChange::KnockDenied,
+                        MChange::ProfileChanged { .. } => unreachable!(),
+                        _ => MembershipChange::NotImplemented,
+                    };
+
+                    TimelineItemContent::MembershipChange(RoomMembershipChange {
+                        user_id,
+                        content: full_content,
+                        change: Some(change),
+                    })
+                }
+            }
+            FullStateEventContent::Redacted(_) => {
+                TimelineItemContent::MembershipChange(RoomMembershipChange {
+                    user_id,
+                    content: full_content,
+                    change: None,
+                })
+            }
+        };
+
+        Self::from_content(item_content)
     }
 
     fn other_state(state_key: String, content: AnyOtherFullStateEventContent) -> Self {

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -50,9 +50,9 @@ mod virtual_item;
 
 pub use self::{
     event_item::{
-        AnyOtherFullStateEventContent, EncryptedMessage, EventTimelineItem, Message, OtherState,
-        Profile, ReactionDetails, RoomMember, Sticker, TimelineDetails, TimelineItemContent,
-        TimelineKey,
+        AnyOtherFullStateEventContent, EncryptedMessage, EventTimelineItem, MemberProfileChange,
+        MembershipChange, Message, OtherState, Profile, ReactionDetails, RoomMembershipChange,
+        Sticker, TimelineDetails, TimelineItemContent, TimelineKey,
     },
     pagination::{PaginationOptions, PaginationOutcome},
     virtual_item::VirtualTimelineItem,

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -36,10 +36,7 @@ use ruma::{
             encrypted::{
                 EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
             },
-            member::{
-                MembershipChange, MembershipState, RedactedRoomMemberEventContent,
-                RoomMemberEventContent,
-            },
+            member::{MembershipState, RedactedRoomMemberEventContent, RoomMemberEventContent},
             message::{self, MessageType, RoomMessageEventContent},
             name::RoomNameEventContent,
             topic::RedactedRoomTopicEventContent,
@@ -56,8 +53,9 @@ use ruma::{
 use serde_json::{json, Value as JsonValue};
 
 use super::{
-    event_item::AnyOtherFullStateEventContent, inner::ProfileProvider, EncryptedMessage, Profile,
-    TimelineInner, TimelineItem, TimelineItemContent, TimelineKey, VirtualTimelineItem,
+    event_item::AnyOtherFullStateEventContent, inner::ProfileProvider, EncryptedMessage,
+    MembershipChange, Profile, TimelineInner, TimelineItem, TimelineItemContent, TimelineKey,
+    VirtualTimelineItem,
 };
 
 static ALICE: Lazy<&UserId> = Lazy::new(|| user_id!("@alice:server.name"));
@@ -599,9 +597,9 @@ async fn room_member() {
     let _day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let member = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::RoomMember(ev) => ev);
-    assert_matches!(member.content(), FullStateEventContent::Original { .. });
-    assert_matches!(member.membership_change(), Some(MembershipChange::Invited));
+    let membership = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::MembershipChange(ev) => ev);
+    assert_matches!(membership.content(), FullStateEventContent::Original { .. });
+    assert_matches!(membership.change(), Some(MembershipChange::Invited));
 
     let mut second_room_member_content = RoomMemberEventContent::new(MembershipState::Join);
     second_room_member_content.displayname = Some("Alice".to_owned());
@@ -615,9 +613,9 @@ async fn room_member() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let member = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::RoomMember(ev) => ev);
-    assert_matches!(member.content(), FullStateEventContent::Original { .. });
-    assert_matches!(member.membership_change(), Some(MembershipChange::InvitationAccepted));
+    let membership = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::MembershipChange(ev) => ev);
+    assert_matches!(membership.content(), FullStateEventContent::Original { .. });
+    assert_matches!(membership.change(), Some(MembershipChange::InvitationAccepted));
 
     let mut third_room_member_content = RoomMemberEventContent::new(MembershipState::Join);
     third_room_member_content.displayname = Some("Alice In Wonderland".to_owned());
@@ -631,17 +629,9 @@ async fn room_member() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let member = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::RoomMember(ev) => ev);
-    assert_matches!(member.content(), FullStateEventContent::Original { .. });
-    let (display_name_change, avatar_url_change) = assert_matches!(
-        member.membership_change(),
-        Some(MembershipChange::ProfileChanged {
-            displayname_change,
-            avatar_url_change
-        }) => (displayname_change, avatar_url_change)
-    );
-    assert_matches!(display_name_change, Some(_));
-    assert_matches!(avatar_url_change, None);
+    let profile = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::ProfileChange(ev) => ev);
+    assert_matches!(profile.displayname_change(), Some(_));
+    assert_matches!(profile.avatar_url_change(), None);
 
     timeline
         .handle_live_redacted_state_event_with_state_key(
@@ -652,9 +642,9 @@ async fn room_member() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let member = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::RoomMember(ev) => ev);
-    assert_matches!(member.content(), FullStateEventContent::Redacted(_));
-    assert_matches!(member.membership_change(), None);
+    let membership = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::MembershipChange(ev) => ev);
+    assert_matches!(membership.content(), FullStateEventContent::Redacted(_));
+    assert_matches!(membership.change(), None);
 }
 
 struct TestTimeline {

--- a/labs/jack-in/src/components/details.rs
+++ b/labs/jack-in/src/components/details.rs
@@ -102,14 +102,23 @@ impl Details {
                     e.sender(),
                     s.content().body,
                 ),
-                TimelineItemContent::RoomMember(m) => format!(
-                    "[{}] {}: '{}' state event",
+                TimelineItemContent::MembershipChange(m) => format!(
+                    "[{}] {} - membership change '{:?}' for {}",
                     e.timestamp()
                         .to_system_time()
                         .map(|s| DateTime::<Local>::from(s).format("%Y-%m-%dT%T").to_string())
                         .unwrap_or_default(),
                     e.sender(),
-                    m.content().event_type(),
+                    m.change(),
+                    m.user_id(),
+                ),
+                TimelineItemContent::ProfileChange(_) => format!(
+                    "[{}] {} - profile change",
+                    e.timestamp()
+                        .to_system_time()
+                        .map(|s| DateTime::<Local>::from(s).format("%Y-%m-%dT%T").to_string())
+                        .unwrap_or_default(),
+                    e.sender(),
                 ),
                 TimelineItemContent::OtherState(s) => format!(
                     "[{}] {}: '{}' state event",


### PR DESCRIPTION
As asked in https://github.com/matrix-org/matrix-rust-sdk/pull/1347#discussion_r1071073841.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>

