### PR TITLE
refactor(sdk): Provide day divider as a timestamp

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -157,8 +157,8 @@ impl TimelineItem {
     pub fn as_virtual(self: Arc<Self>) -> Option<VirtualTimelineItem> {
         use matrix_sdk::room::timeline::{TimelineItem as Item, VirtualTimelineItem as VItem};
         match &self.0 {
-            Item::Virtual(VItem::DayDivider { year, month, day }) => {
-                Some(VirtualTimelineItem::DayDivider { year: *year, month: *month, day: *day })
+            Item::Virtual(VItem::DayDivider(ts)) => {
+                Some(VirtualTimelineItem::DayDivider { ts: ts.0.into() })
             }
             Item::Virtual(VItem::ReadMarker) => Some(VirtualTimelineItem::ReadMarker),
             Item::Virtual(VItem::LoadingIndicator) => Some(VirtualTimelineItem::LoadingIndicator),
@@ -613,16 +613,9 @@ impl From<&matrix_sdk::room::timeline::TimelineKey> for TimelineKey {
 pub enum VirtualTimelineItem {
     /// A divider between messages of two days.
     DayDivider {
-        /// The year.
-        year: i32,
-        /// The month of the year.
-        ///
-        /// A value between 1 and 12.
-        month: u32,
-        /// The day of the month.
-        ///
-        /// A value between 1 and 31.
-        day: u32,
+        /// A timestamp in milliseconds since Unix Epoch on that day in local
+        /// time.
+        ts: u64,
     },
 
     /// The user's own read marker.

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -27,7 +27,7 @@ use matrix_sdk_base::{
 use ruma::{
     assign,
     events::{fully_read::FullyReadEventContent, AnyMessageLikeEventContent},
-    EventId, TransactionId,
+    EventId, MilliSecondsSinceUnixEpoch, TransactionId,
 };
 use tracing::{error, instrument, warn};
 
@@ -382,9 +382,9 @@ impl TimelineItem {
         }
     }
 
-    /// Creates a new day divider from the given year, month and day.
-    fn day_divider(year: i32, month: u32, day: u32) -> Self {
-        Self::Virtual(VirtualTimelineItem::DayDivider { year, month, day })
+    /// Creates a new day divider from the given timestamp.
+    fn day_divider(ts: MilliSecondsSinceUnixEpoch) -> Self {
+        Self::Virtual(VirtualTimelineItem::DayDivider(ts))
     }
 
     fn read_marker() -> Self {

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -21,6 +21,7 @@ use std::sync::{
 
 use assert_matches::assert_matches;
 use async_trait::async_trait;
+use chrono::{Datelike, Local, TimeZone};
 use futures_core::Stream;
 use futures_signals::signal_vec::{SignalVecExt, VecDiff};
 use futures_util::StreamExt;
@@ -435,13 +436,14 @@ async fn day_divider() {
         .await;
 
     let day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let (year, month, day) = assert_matches!(
+    let ts = assert_matches!(
         day_divider.as_virtual().unwrap(),
-        VirtualTimelineItem::DayDivider { year, month, day } => (*year, *month, *day)
+        VirtualTimelineItem::DayDivider(ts) => *ts
     );
-    assert_eq!(year, 2022);
-    assert_eq!(month, 12);
-    assert_eq!(day, 1);
+    let date = Local.timestamp_millis_opt(ts.0.into()).single().unwrap();
+    assert_eq!(date.year(), 2022);
+    assert_eq!(date.month(), 12);
+    assert_eq!(date.day(), 1);
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     item.as_event().unwrap();
@@ -476,13 +478,14 @@ async fn day_divider() {
         .await;
 
     let day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let (year, month, day) = assert_matches!(
+    let ts = assert_matches!(
         day_divider.as_virtual().unwrap(),
-        VirtualTimelineItem::DayDivider { year, month, day } => (*year, *month, *day)
+        VirtualTimelineItem::DayDivider(ts) => *ts
     );
-    assert_eq!(year, 2022);
-    assert_eq!(month, 12);
-    assert_eq!(day, 2);
+    let date = Local.timestamp_millis_opt(ts.0.into()).single().unwrap();
+    assert_eq!(date.year(), 2022);
+    assert_eq!(date.month(), 12);
+    assert_eq!(date.day(), 2);
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     item.as_event().unwrap();

--- a/crates/matrix-sdk/src/room/timeline/virtual_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/virtual_item.rs
@@ -12,22 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use ruma::MilliSecondsSinceUnixEpoch;
+
 /// A [`TimelineItem`](super::TimelineItem) that doesn't correspond to an event.
 #[derive(Clone, Debug)]
 pub enum VirtualTimelineItem {
     /// A divider between messages of two days.
-    DayDivider {
-        /// The year.
-        year: i32,
-        /// The month of the year.
-        ///
-        /// A value between 1 and 12.
-        month: u32,
-        /// The day of the month.
-        ///
-        /// A value between 1 and 31.
-        day: u32,
-    },
+    ///
+    /// The value is a timestamp in milliseconds since Unix Epoch on the given
+    /// day in local time.
+    DayDivider(MilliSecondsSinceUnixEpoch),
 
     /// The user's own read marker.
     ReadMarker,

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -278,7 +278,7 @@ async fn back_pagination() {
         timeline_stream.next().await,
         Some(VecDiff::Push { value }) => value
     );
-    assert_matches!(day_divider.as_virtual().unwrap(), VirtualTimelineItem::DayDivider { .. });
+    assert_matches!(day_divider.as_virtual().unwrap(), VirtualTimelineItem::DayDivider(_));
 
     let message = assert_matches!(
         timeline_stream.next().await,


### PR DESCRIPTION
As discussed in the Dev room on Matrix ([start of discussion](https://matrix.to/#/!qSsPTKDfMGYqhgiLPJ:flipdot.org/$EufjrkHosf_6ZVCrLEEh1TIlp0vIdffSZBim-WNang8?via=flipdot.org&via=matrix.org&via=famedly.de)).

I was hesitating to change the timestamp to a significant time in the day (like midnight for example), but I'm not sure it would be useful.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>