### PR TITLE
refactor!(crypto): Move some caches out of the CryptoStore implementations

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -299,7 +299,7 @@ impl GossipMachine {
                 ?secret_name,
                 "Received a secret request form an unknown device",
             );
-            self.store.update_tracked_user(&event.sender, true).await?;
+            self.store.mark_user_as_changed(&event.sender).await?;
 
             None
         })
@@ -372,7 +372,7 @@ impl GossipMachine {
                 device_id = ?event.content.requesting_device_id,
                 "Received a key request from an unknown device",
             );
-            self.store.update_tracked_user(&event.sender, true).await?;
+            self.store.mark_user_as_changed(&event.sender).await?;
 
             return Ok(None);
         };
@@ -821,7 +821,7 @@ impl GossipMachine {
                 secret_name = secret_name.as_ref(),
                 "Received a m.secret.send event from an unknown device"
             );
-            self.store.update_tracked_user(&event.sender, true).await?;
+            self.store.mark_user_as_changed(&event.sender).await?;
         }
 
         Ok(())

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -643,7 +643,7 @@ impl IdentityManager {
 
         for user_id in users {
             if !self.store.is_user_tracked(user_id).await? {
-                tracked_users.push((user_id, true))
+                tracked_users.push((user_id, true));
             }
         }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -191,13 +191,9 @@ impl IdentityManager {
             ..Default::default()
         };
 
-        // TODO: turn this into a single transaction.
         self.store.save_changes(changes).await?;
-        let updated_users: Vec<&UserId> = response.device_keys.keys().map(Deref::deref).collect();
-
-        for user_id in updated_users {
-            self.store.update_tracked_user(user_id, false).await?;
-        }
+        self.mark_tracked_users_as_up_to_date(response.device_keys.keys().map(Deref::deref))
+            .await?;
 
         let changed_devices = devices.changed.iter().fold(BTreeMap::new(), |mut acc, d| {
             acc.entry(d.user_id()).or_insert_with(BTreeSet::new).insert(d.device_id());
@@ -596,7 +592,7 @@ impl IdentityManager {
         // The check for emptiness is done first for performance.
         let users =
             if users.is_empty() && !self.store.tracked_users().await?.contains(self.user_id()) {
-                self.update_tracked_users([self.user_id()]).await?;
+                self.store.mark_user_as_changed(self.user_id()).await?;
                 self.store.users_for_key_query().await?
             } else {
                 users
@@ -616,48 +612,50 @@ impl IdentityManager {
         }
     }
 
-    /// Mark that the given user has changed his devices.
+    /// Receive the list of users that contained changed devices from the
+    /// `/sync` response.
     ///
     /// This will queue up the given user for a key query.
     ///
     /// Note: The user already needs to be tracked for it to be queued up for a
     /// key query.
-    ///
-    /// Returns true if the user was queued up for a key query, false otherwise.
-    pub async fn mark_user_as_changed(&self, user_id: &UserId) -> StoreResult<bool> {
-        if self.store.is_user_tracked(user_id).await? {
-            self.store.update_tracked_user(user_id, true).await?;
-            Ok(true)
-        } else {
-            Ok(false)
+    pub async fn receive_device_changes(
+        &self,
+        users: impl Iterator<Item = &UserId>,
+    ) -> StoreResult<()> {
+        let mut changed_user: Vec<(&UserId, bool)> = Vec::new();
+
+        for user_id in users {
+            if self.store.is_user_tracked(user_id).await? {
+                changed_user.push((user_id, true))
+            }
         }
+
+        self.store.save_tracked_users(&changed_user).await
     }
 
-    /// Update the tracked users.
-    ///
-    /// # Arguments
-    ///
-    /// * `users` - An iterator over user ids that should be marked for
-    /// tracking.
-    ///
-    /// This will mark users that weren't seen before for a key query and
-    /// tracking.
-    ///
-    /// If the user is already known to the Olm machine it will not be
-    /// considered for a key query.
+    /// See the docs for [`OlmMachine::update_tracked_users()`].
     pub async fn update_tracked_users(
         &self,
         users: impl IntoIterator<Item = &UserId>,
     ) -> StoreResult<()> {
-        for user in users {
-            if self.store.is_user_tracked(user).await? {
-                continue;
-            }
+        let mut tracked_users = Vec::new();
 
-            self.store.update_tracked_user(user, true).await?;
+        for user_id in users {
+            if !self.store.is_user_tracked(user_id).await? {
+                tracked_users.push((user_id, true))
+            }
         }
 
-        Ok(())
+        self.store.save_tracked_users(&tracked_users).await
+    }
+
+    pub async fn mark_tracked_users_as_up_to_date(
+        &self,
+        users: impl Iterator<Item = &UserId>,
+    ) -> StoreResult<()> {
+        let updated_users: Vec<(&UserId, bool)> = users.map(|u| (u, false)).collect();
+        self.store.save_tracked_users(&updated_users).await
     }
 }
 
@@ -897,7 +895,7 @@ pub(crate) mod testing {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::time::Duration;
+    use std::{ops::Deref, time::Duration};
 
     use matrix_sdk_test::{async_test, response_from_file};
     use ruma::{
@@ -935,6 +933,26 @@ pub(crate) mod tests {
         let response = response_from_file(&response);
 
         KeysQueryResponse::try_from_http_response(response).unwrap()
+    }
+
+    #[async_test]
+    async fn test_tracked_users() {
+        let manager = manager().await;
+        let alice = user_id!("@alice:example.org");
+
+        assert!(
+            manager.store.tracked_users().await.unwrap().is_empty(),
+            "No users are initially tracked"
+        );
+        manager.receive_device_changes([alice].iter().map(Deref::deref)).await.unwrap();
+        assert!(
+            !manager.store.is_user_tracked(alice).await.unwrap(),
+            "Receiving a device changes update for a user we don't track does nothing"
+        );
+        assert!(
+            !manager.store.users_for_key_query().await.unwrap().contains(alice),
+            "The user we don't track doesn't end up in the `/keys/query` request"
+        );
     }
 
     #[async_test]
@@ -1031,7 +1049,7 @@ pub(crate) mod tests {
             manager.store.tracked_users().await.unwrap().is_empty(),
             "No users are initially tracked"
         );
-        manager.store.update_tracked_user(alice, true).await.unwrap();
+        manager.store.mark_user_as_changed(alice).await.unwrap();
 
         assert!(
             manager.store.tracked_users().await.unwrap().contains(alice),
@@ -1065,7 +1083,7 @@ pub(crate) mod tests {
             .iter()
             .any(|r| r.device_keys.contains_key(alice)));
 
-        manager.store.update_tracked_user(alice, true).await.unwrap();
+        manager.store.mark_user_as_changed(alice).await.unwrap();
         assert!(manager
             .users_for_key_query()
             .await

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -86,7 +86,9 @@ pub use requests::{
     IncomingResponse, KeysBackupRequest, KeysQueryRequest, OutgoingRequest, OutgoingRequests,
     OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest, UploadSigningKeysRequest,
 };
-pub use store::{CrossSigningKeyExport, CryptoStoreError, SecretImportError, SecretInfo};
+pub use store::{
+    CrossSigningKeyExport, CryptoStoreError, SecretImportError, SecretInfo, TrackedUser,
+};
 pub use verification::{
     format_emojis, AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString, Sas,
     SasState, Verification, VerificationRequest, VerificationRequestState,

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1015,10 +1015,12 @@ impl OlmMachine {
 
         self.update_key_counts(one_time_keys_counts, unused_fallback_keys).await;
 
-        for user_id in &changed_devices.changed {
-            if let Err(e) = self.identity_manager.mark_user_as_changed(user_id).await {
-                error!(error = ?e, "Error marking a tracked user as changed");
-            }
+        if let Err(e) = self
+            .identity_manager
+            .receive_device_changes(changed_devices.changed.iter().map(|u| u.as_ref()))
+            .await
+        {
+            error!(error = ?e, "Error marking a tracked user as changed");
         }
 
         for raw_event in to_device_events {

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -40,7 +40,7 @@
 
 pub mod caches;
 mod memorystore;
-
+#[allow(missing_docs)]
 #[cfg(any(test, feature = "testing"))]
 #[macro_use]
 #[allow(missing_docs)]
@@ -51,10 +51,12 @@ use std::{
     fmt::Debug,
     io::Error as IoError,
     ops::Deref,
-    sync::Arc,
+    sync::{atomic::AtomicBool, Arc},
 };
 
 use async_trait::async_trait;
+use atomic::Ordering;
+use dashmap::DashSet;
 use matrix_sdk_common::{locks::Mutex, AsyncTraitDeps};
 pub use memorystore::MemoryStore;
 use ruma::{
@@ -99,6 +101,10 @@ pub struct Store {
     identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
     inner: Arc<dyn CryptoStore>,
     verification_machine: VerificationMachine,
+    tracked_users_cache: Arc<DashSet<OwnedUserId>>,
+    users_for_key_query_cache: Arc<DashSet<OwnedUserId>>,
+    tracked_user_loading_lock: Arc<Mutex<()>>,
+    tracked_users_loaded: Arc<AtomicBool>,
 }
 
 #[derive(Default, Debug)]
@@ -115,6 +121,18 @@ pub struct Changes {
     pub key_requests: Vec<GossipRequest>,
     pub identities: IdentityChanges,
     pub devices: DeviceChanges,
+}
+
+/// A user for which we are tracking the list of devices.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TrackedUser {
+    /// The user ID of the user.
+    pub user_id: OwnedUserId,
+    /// The outdate/dirty flag of the user, remembers if the list of devices for
+    /// the user is considered to be out of date. If the list of devices is
+    /// out of date, a `/keys/query` request should be sent out for this
+    /// user.
+    pub dirty: bool,
 }
 
 impl Changes {
@@ -268,7 +286,16 @@ impl Store {
         store: Arc<dyn CryptoStore>,
         verification_machine: VerificationMachine,
     ) -> Self {
-        Self { user_id, identity, inner: store, verification_machine }
+        Self {
+            user_id,
+            identity,
+            inner: store,
+            verification_machine,
+            tracked_users_cache: DashSet::new().into(),
+            users_for_key_query_cache: DashSet::new().into(),
+            tracked_users_loaded: AtomicBool::new(false).into(),
+            tracked_user_loading_lock: Mutex::new(()).into(),
+        }
     }
 
     /// UserId associated with this store
@@ -587,6 +614,99 @@ impl Store {
 
         Ok(())
     }
+
+    /// Mark that the given user has an outdated device list.
+    ///
+    /// This means that the user will be considered for a `/keys/query` request
+    /// next time [`Store::users_for_key_query()`] is called.
+    pub async fn mark_user_as_changed(&self, user: &UserId) -> Result<()> {
+        self.save_tracked_users(&[(user, true)]).await
+    }
+
+    /// Save the list of users and their outdated/dirty flags to the store.
+    ///
+    /// This method will fill up the store-internal caches, unlike the method on
+    /// the various [`CryptoStore`] implementations.
+    pub async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<()> {
+        for (user, dirty) in users {
+            if *dirty {
+                self.users_for_key_query_cache.insert((*user).to_owned());
+            } else {
+                self.users_for_key_query_cache.remove(*user);
+            }
+
+            self.tracked_users_cache.insert((*user).to_owned());
+        }
+
+        self.inner.save_tracked_users(users).await?;
+
+        Ok(())
+    }
+
+    /// Load the list of users for whom we are tracking their device lists and
+    /// fill out our caches.
+    ///
+    /// This method ensures that we're only going to load the users from the
+    /// actual [`CryptoStore`] once, it will also make sure that any
+    /// concurrent calls to this method get deduplicated.
+    async fn load_tracked_users(&self) -> Result<()> {
+        // If the users are loaded do nothing, otherwise acquire a lock.
+        if !self.tracked_users_loaded.load(Ordering::SeqCst) {
+            let _lock = self.tracked_user_loading_lock.lock().await;
+
+            // Check again if the users have been loaded, in case another call to this
+            // method loaded the tracked users between the time we tried to
+            // acquire the lock and the time we actually acquired the lock.
+            if !self.tracked_users_loaded.load(Ordering::SeqCst) {
+                let tracked_users = self.inner.load_tracked_users().await?;
+
+                for user in tracked_users {
+                    self.tracked_users_cache.insert(user.user_id.to_owned());
+
+                    if user.dirty {
+                        self.users_for_key_query_cache.insert(user.user_id);
+                    }
+                }
+
+                self.tracked_users_loaded.store(true, Ordering::SeqCst);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Are we tracking the list of devices this user has?
+    pub async fn is_user_tracked(&self, user_id: &UserId) -> Result<bool> {
+        self.load_tracked_users().await?;
+
+        Ok(self.tracked_users_cache.contains(user_id))
+    }
+
+    /// Are there any users that have the outdated/dirty flag set for their list
+    /// of devices?
+    pub async fn has_users_for_key_query(&self) -> Result<bool> {
+        self.load_tracked_users().await?;
+
+        Ok(!self.users_for_key_query_cache.is_empty())
+    }
+
+    /// Get the set of users that has the outdate/dirty flag set for their list
+    /// of devices.
+    ///
+    /// This set should be included in a `/keys/query` request which will update
+    /// the device list.
+    pub async fn users_for_key_query(&self) -> Result<HashSet<OwnedUserId>> {
+        self.load_tracked_users().await?;
+
+        Ok(self.users_for_key_query_cache.iter().map(|u| u.clone()).collect())
+    }
+
+    /// See the docs for [`crate::OlmMachine::tracked_users()`].
+    pub async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>> {
+        self.load_tracked_users().await?;
+
+        Ok(self.tracked_users_cache.to_owned().iter().map(|u| u.clone()).collect())
+    }
 }
 
 impl Deref for Store {
@@ -726,29 +846,12 @@ pub trait CryptoStore: AsyncTraitDeps {
         room_id: &RoomId,
     ) -> Result<Option<OutboundGroupSession>>;
 
-    /// Is the given user already tracked.
-    async fn is_user_tracked(&self, user_id: &UserId) -> Result<bool>;
+    /// Load the list of users whose devices we are keeping track of.
+    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>>;
 
-    /// Are there any tracked users that are marked as dirty.
-    async fn has_users_for_key_query(&self) -> Result<bool>;
-
-    /// Set of users that we need to query keys for. This is a subset of
-    /// the tracked users.
-    async fn users_for_key_query(&self) -> Result<HashSet<OwnedUserId>>;
-
-    /// Get all tracked users we know about.
-    async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>>;
-
-    /// Add an user for tracking.
-    ///
-    /// Returns true if the user wasn't already tracked, false otherwise.
-    ///
-    /// # Arguments
-    ///
-    /// * `user` - The user that should be marked as tracked.
-    ///
-    /// * `dirty` - Should the user be also marked for a key query.
-    async fn update_tracked_user(&self, user: &UserId, dirty: bool) -> Result<bool>;
+    /// Save a list of users and their respective dirty/outdated flags to the
+    /// store.
+    async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<()>;
 
     /// Get the device for the given user with the given device ID.
     ///

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -40,7 +40,6 @@
 
 pub mod caches;
 mod memorystore;
-#[allow(missing_docs)]
 #[cfg(any(test, feature = "testing"))]
 #[macro_use]
 #[allow(missing_docs)]
@@ -705,7 +704,7 @@ impl Store {
     pub async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>> {
         self.load_tracked_users().await?;
 
-        Ok(self.tracked_users_cache.to_owned().iter().map(|u| u.clone()).collect())
+        Ok(self.tracked_users_cache.iter().map(|u| u.clone()).collect())
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -40,6 +40,7 @@
 
 pub mod caches;
 mod memorystore;
+
 #[cfg(any(test, feature = "testing"))]
 #[macro_use]
 #[allow(missing_docs)]

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -628,14 +628,14 @@ impl Store {
     /// This method will fill up the store-internal caches, unlike the method on
     /// the various [`CryptoStore`] implementations.
     pub async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<()> {
-        for (user, dirty) in users {
-            if *dirty {
-                self.users_for_key_query_cache.insert((*user).to_owned());
+        for &(user, dirty) in users {
+            if dirty {
+                self.users_for_key_query_cache.insert(user.to_owned());
             } else {
-                self.users_for_key_query_cache.remove(*user);
+                self.users_for_key_query_cache.remove(user);
             }
 
-            self.tracked_users_cache.insert((*user).to_owned());
+            self.tracked_users_cache.insert(user.to_owned());
         }
 
         self.inner.save_tracked_users(users).await?;

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -757,13 +757,7 @@ impl IndexeddbCryptoStore {
         let os = tx.object_store(KEYS::TRACKED_USERS)?;
 
         for (user, dirty) in users {
-            os.put_key_val(
-                &JsValue::from_str(user.as_str()),
-                &match dirty {
-                    true => JsValue::TRUE,
-                    false => JsValue::FALSE,
-                },
-            )?;
+            os.put_key_val(&JsValue::from_str(user.as_str()), &JsValue::from(*dirty))?;
         }
 
         tx.await.into_result()?;

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::{Arc, RwLock},
 };
 
 use async_trait::async_trait;
-use dashmap::DashSet;
 use gloo_utils::format::JsValueSerdeExt;
 use indexed_db_futures::prelude::*;
 use matrix_sdk_base::locks::Mutex;
@@ -31,9 +30,10 @@ use matrix_sdk_crypto::{
         caches::SessionStore, BackupKeys, Changes, CryptoStore, CryptoStoreError, RoomKeyCounts,
     },
     GossipRequest, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyUserIdentities, SecretInfo,
+    TrackedUser,
 };
 use matrix_sdk_store_encryption::StoreCipher;
-use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId, UserId};
+use ruma::{DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId};
 use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
@@ -81,8 +81,6 @@ pub struct IndexeddbCryptoStore {
     store_cipher: Option<Arc<StoreCipher>>,
 
     session_cache: SessionStore,
-    tracked_users_cache: Arc<DashSet<OwnedUserId>>,
-    users_for_key_query_cache: Arc<DashSet<OwnedUserId>>,
 }
 
 impl std::fmt::Debug for IndexeddbCryptoStore {
@@ -193,8 +191,6 @@ impl IndexeddbCryptoStore {
             inner: db,
             store_cipher,
             account_info: RwLock::new(None).into(),
-            tracked_users_cache: DashSet::new().into(),
-            users_for_key_query_cache: DashSet::new().into(),
         })
     }
 
@@ -522,24 +518,24 @@ impl IndexeddbCryptoStore {
         Ok(())
     }
 
-    async fn load_tracked_users(&self) -> Result<()> {
+    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>> {
         let tx = self
             .inner
             .transaction_on_one_with_mode(KEYS::TRACKED_USERS, IdbTransactionMode::Readonly)?;
         let os = tx.object_store(KEYS::TRACKED_USERS)?;
         let user_ids = os.get_all_keys()?.await?;
+
+        let mut users = Vec::new();
+
         for user_id in user_ids.iter() {
             let dirty: bool =
                 !matches!(os.get(&user_id)?.await?.map(|v| v.into_serde()), Some(Ok(false)));
-            let Some(Ok(user)) = user_id.as_string().map(UserId::parse) else { continue };
-            self.tracked_users_cache.insert(user.clone());
+            let Some(Ok(user_id)) = user_id.as_string().map(UserId::parse) else { continue };
 
-            if dirty {
-                self.users_for_key_query_cache.insert(user);
-            }
+            users.push(TrackedUser { user_id, dirty });
         }
 
-        Ok(())
+        Ok(users)
     }
 
     async fn load_outbound_group_session(
@@ -601,8 +597,6 @@ impl IndexeddbCryptoStore {
             .get(&JsValue::from_str(KEYS::ACCOUNT))?
             .await?
         {
-            self.load_tracked_users().await?;
-
             let pickle = self.deserialize_value(pickle)?;
 
             let account = ReadOnlyAccount::from_pickle(pickle).map_err(CryptoStoreError::from)?;
@@ -756,38 +750,24 @@ impl IndexeddbCryptoStore {
         Ok(())
     }
 
-    async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>, CryptoStoreError> {
-        Ok(self.tracked_users_cache.to_owned().iter().map(|u| u.clone()).collect())
-    }
-
-    async fn users_for_key_query(&self) -> Result<HashSet<OwnedUserId>, CryptoStoreError> {
-        Ok(self.users_for_key_query_cache.iter().map(|u| u.clone()).collect())
-    }
-
-    async fn update_tracked_user(&self, user: &UserId, dirty: bool) -> Result<bool> {
-        let already_added = self.tracked_users_cache.insert(user.to_owned());
-
-        if dirty {
-            self.users_for_key_query_cache.insert(user.to_owned());
-        } else {
-            self.users_for_key_query_cache.remove(user);
-        }
-
+    async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<()> {
         let tx = self
             .inner
             .transaction_on_one_with_mode(KEYS::TRACKED_USERS, IdbTransactionMode::Readwrite)?;
         let os = tx.object_store(KEYS::TRACKED_USERS)?;
 
-        os.put_key_val(
-            &JsValue::from_str(user.as_str()),
-            &match dirty {
-                true => JsValue::TRUE,
-                false => JsValue::FALSE,
-            },
-        )?;
+        for (user, dirty) in users {
+            os.put_key_val(
+                &JsValue::from_str(user.as_str()),
+                &match dirty {
+                    true => JsValue::TRUE,
+                    false => JsValue::FALSE,
+                },
+            )?;
+        }
 
         tx.await.into_result()?;
-        Ok(already_added)
+        Ok(())
     }
 
     async fn get_device(
@@ -1017,32 +997,16 @@ impl CryptoStore for IndexeddbCryptoStore {
         self.reset_backup_state().await.map_err(|e| e.into())
     }
 
-    async fn is_user_tracked(&self, user_id: &UserId) -> Result<bool, CryptoStoreError> {
-        Ok(self.tracked_users_cache.contains(user_id))
-    }
-
-    async fn has_users_for_key_query(&self) -> Result<bool, CryptoStoreError> {
-        Ok(!self.users_for_key_query_cache.is_empty())
-    }
-
-    async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>, CryptoStoreError> {
-        self.tracked_users().await
-    }
-
-    async fn users_for_key_query(&self) -> Result<HashSet<OwnedUserId>, CryptoStoreError> {
-        self.users_for_key_query().await
-    }
-
     async fn load_backup_keys(&self) -> Result<BackupKeys, CryptoStoreError> {
         self.load_backup_keys().await.map_err(|e| e.into())
     }
 
-    async fn update_tracked_user(
-        &self,
-        user: &UserId,
-        dirty: bool,
-    ) -> Result<bool, CryptoStoreError> {
-        self.update_tracked_user(user, dirty).await.map_err(|e| e.into())
+    async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<(), CryptoStoreError> {
+        self.save_tracked_users(users).await.map_err(Into::into)
+    }
+
+    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>, CryptoStoreError> {
+        self.load_tracked_users().await.map_err(Into::into)
     }
 
     async fn get_device(

--- a/crates/matrix-sdk-sled/src/crypto_store.rs
+++ b/crates/matrix-sdk-sled/src/crypto_store.rs
@@ -14,16 +14,12 @@
 
 use std::{
     borrow::Cow,
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     path::{Path, PathBuf},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, RwLock,
-    },
+    sync::{Arc, RwLock},
 };
 
 use async_trait::async_trait;
-use dashmap::DashSet;
 use matrix_sdk_common::locks::Mutex;
 use matrix_sdk_crypto::{
     olm::{
@@ -36,10 +32,11 @@ use matrix_sdk_crypto::{
     },
     types::{events::room_key_request::SupportedKeyInfo, EventEncryptionAlgorithm},
     GossipRequest, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyUserIdentities, SecretInfo,
+    TrackedUser,
 };
 use matrix_sdk_store_encryption::StoreCipher;
-use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId, UserId};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use ruma::{DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId};
+use serde::{de::DeserializeOwned, Serialize};
 pub use sled::Error;
 use sled::{
     transaction::{ConflictableTransactionError, TransactionError},
@@ -160,28 +157,18 @@ pub struct AccountInfo {
     identity_keys: Arc<IdentityKeys>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct TrackedUser {
-    user_id: OwnedUserId,
-    dirty: bool,
-}
-
 /// A [sled] based cryptostore.
 ///
 /// [sled]: https://github.com/spacejam/sled#readme
 #[derive(Clone)]
 pub struct SledCryptoStore {
     account_info: Arc<RwLock<Option<AccountInfo>>>,
-    tracked_user_loading_lock: Arc<Mutex<()>>,
-    tracked_users_loaded: Arc<AtomicBool>,
 
     store_cipher: Option<Arc<StoreCipher>>,
     path: Option<PathBuf>,
     inner: Db,
 
     session_cache: SessionStore,
-    tracked_users_cache: Arc<DashSet<OwnedUserId>>,
-    users_for_key_query_cache: Arc<DashSet<OwnedUserId>>,
 
     account: Tree,
     private_identity: Tree,
@@ -404,8 +391,6 @@ impl SledCryptoStore {
 
         let database = Self {
             account_info: RwLock::new(None).into(),
-            tracked_user_loading_lock: Mutex::new(()).into(),
-            tracked_users_loaded: AtomicBool::new(false).into(),
             path,
             inner: db,
             store_cipher,
@@ -413,8 +398,6 @@ impl SledCryptoStore {
             private_identity,
             sessions,
             session_cache,
-            tracked_users_cache: DashSet::new().into(),
-            users_for_key_query_cache: DashSet::new().into(),
             inbound_group_sessions,
             outbound_group_sessions,
             outgoing_secret_requests,
@@ -431,31 +414,17 @@ impl SledCryptoStore {
         Ok(database)
     }
 
-    async fn load_tracked_users(&self) -> Result<()> {
-        // If the users are loaded do nothing, otherwise acquire a lock.
-        if !self.tracked_users_loaded.load(Ordering::SeqCst) {
-            let _lock = self.tracked_user_loading_lock.lock().await;
+    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>> {
+        let mut users = Vec::new();
 
-            // Check again if the users have been loaded, in case another call to this
-            // method loaded the tracked users between the time we tried to
-            // acquire the lock and the time we actually acquired the lock.
-            if !self.tracked_users_loaded.load(Ordering::SeqCst) {
-                for value in &self.tracked_users {
-                    let (_, user) = value.map_err(CryptoStoreError::backend)?;
-                    let user: TrackedUser = self.deserialize_value(&user)?;
+        for value in &self.tracked_users {
+            let (_, user) = value.map_err(CryptoStoreError::backend)?;
+            let user: TrackedUser = self.deserialize_value(&user)?;
 
-                    self.tracked_users_cache.insert(user.user_id.to_owned());
-
-                    if user.dirty {
-                        self.users_for_key_query_cache.insert(user.user_id);
-                    }
-                }
-
-                self.tracked_users_loaded.store(true, Ordering::SeqCst);
-            }
+            users.push(user)
         }
 
-        Ok(())
+        Ok(users)
     }
 
     async fn load_outbound_group_session(
@@ -882,44 +851,14 @@ impl CryptoStore for SledCryptoStore {
         self.load_outbound_group_session(room_id).await
     }
 
-    async fn is_user_tracked(&self, user_id: &UserId) -> Result<bool> {
-        self.load_tracked_users().await?;
-
-        Ok(self.tracked_users_cache.contains(user_id))
+    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>> {
+        self.load_tracked_users().await
     }
 
-    async fn has_users_for_key_query(&self) -> Result<bool> {
-        self.load_tracked_users().await?;
+    async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<()> {
+        self.save_tracked_users(users).await?;
 
-        Ok(!self.users_for_key_query_cache.is_empty())
-    }
-
-    async fn users_for_key_query(&self) -> Result<HashSet<OwnedUserId>> {
-        self.load_tracked_users().await?;
-
-        Ok(self.users_for_key_query_cache.iter().map(|u| u.clone()).collect())
-    }
-
-    async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>> {
-        self.load_tracked_users().await?;
-
-        Ok(self.tracked_users_cache.to_owned().iter().map(|u| u.clone()).collect())
-    }
-
-    async fn update_tracked_user(&self, user: &UserId, dirty: bool) -> Result<bool> {
-        self.load_tracked_users().await?;
-
-        let already_added = self.tracked_users_cache.insert(user.to_owned());
-
-        if dirty {
-            self.users_for_key_query_cache.insert(user.to_owned());
-        } else {
-            self.users_for_key_query_cache.remove(user);
-        }
-
-        self.save_tracked_users(&[(user, dirty)]).await?;
-
-        Ok(already_added)
+        Ok(())
     }
 
     async fn get_device(


### PR DESCRIPTION
This moves the caches we have for tracked users out of the Sled, and IndexedDB, CryptoStore into the Store struct. The Store struct is a wrapper for the CryptoStore trait, so this is the natural place where these caches should live.