### PR TITLE
feat(bindings): Expose aliases to the FFI.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -121,6 +121,14 @@ impl Room {
         self.room.is_tombstoned()
     }
 
+    pub fn canonical_alias(&self) -> Option<String> {
+        self.room.canonical_alias().map(|a| a.to_string())
+    }
+
+    pub fn alternative_aliases(&self) -> Vec<String> {
+        self.room.alt_aliases().iter().map(|a| a.to_string()).collect()
+    }
+
     pub fn membership(&self) -> Membership {
         match &self.room {
             SdkRoom::Invited(_) => Membership::Invited,


### PR DESCRIPTION
Exposes `canonical_alias` and `alt_aliases` to the FFI.