### PR TITLE
Expose MissingRoomKey decryption error

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/error.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/error.rs
@@ -59,8 +59,19 @@ pub enum DecryptionError {
     Serialization(#[from] serde_json::Error),
     #[error(transparent)]
     Identifier(#[from] IdParseError),
-    #[error(transparent)]
-    Megolm(#[from] MegolmError),
+    #[error("Megolm decryption error: {error_message}")]
+    Megolm { error_message: String },
+    #[error("Can't find the room key to decrypt the event")]
+    MissingRoomKey,
     #[error(transparent)]
     Store(#[from] InnerStoreError),
+}
+
+impl From<MegolmError> for DecryptionError {
+    fn from(value: MegolmError) -> Self {
+        match value {
+            MegolmError::MissingRoomKey => Self::MissingRoomKey,
+            _ => Self::Megolm { error_message: value.to_string() },
+        }
+    }
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -59,6 +59,7 @@ enum DecryptionError {
     "Identifier",
     "Serialization",
     "Megolm",
+    "MissingRoomKey",
     "Store",
 };
 


### PR DESCRIPTION
Clients may need to know when we fail to decrypt due to a missing room key (for example to trigger custom analytics event). The existing `MissingRoomKey` is however nested within `MegolmError` and only exposed as string value. It was possible to match against this string value, but any change in that string literal (e.g. [here](https://github.com/matrix-org/matrix-rust-sdk/pull/1391/files#diff-8b7ad755130258ef1d1d8a1ee8c571e33f8a2a83d6c06251c88c609126539fa4R88)) will break the behaviour without warning.

To solve this extract out the `MissingRoomKey` as another enum variant of the FFI `DecryptionError` enum