### PR TITLE
Upgrade Sliding Sync to named-lists JSON upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.7.4"
-source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
+source = "git+https://github.com/ruma/ruma?rev=00045e559f864eabff08295d603f7b3238288b6f#00045e559f864eabff08295d603f7b3238288b6f"
 dependencies = [
  "assign",
  "js_int",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.7.0"
-source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
+source = "git+https://github.com/ruma/ruma?rev=00045e559f864eabff08295d603f7b3238288b6f#00045e559f864eabff08295d603f7b3238288b6f"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -3998,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.15.3"
-source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
+source = "git+https://github.com/ruma/ruma?rev=00045e559f864eabff08295d603f7b3238288b6f#00045e559f864eabff08295d603f7b3238288b6f"
 dependencies = [
  "assign",
  "bytes",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.10.5"
-source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
+source = "git+https://github.com/ruma/ruma?rev=00045e559f864eabff08295d603f7b3238288b6f#00045e559f864eabff08295d603f7b3238288b6f"
 dependencies = [
  "base64 0.20.0",
  "bytes",
@@ -4046,7 +4046,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.6.0"
-source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
+source = "git+https://github.com/ruma/ruma?rev=00045e559f864eabff08295d603f7b3238288b6f#00045e559f864eabff08295d603f7b3238288b6f"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4057,7 +4057,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
+source = "git+https://github.com/ruma/ruma?rev=00045e559f864eabff08295d603f7b3238288b6f#00045e559f864eabff08295d603f7b3238288b6f"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.10.5"
-source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
+source = "git+https://github.com/ruma/ruma?rev=00045e559f864eabff08295d603f7b3238288b6f#00045e559f864eabff08295d603f7b3238288b6f"
 dependencies = [
  "once_cell",
  "proc-macro-crate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-lock"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3888,6 +3901,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
+ "async-compression",
  "base64 0.13.1",
  "bytes",
  "encoding_rs",
@@ -3916,6 +3930,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.7.4"
-source = "git+https://github.com/ruma/ruma?rev=69337d1f4e4790a96c40377e895c0b1e44785e14#69337d1f4e4790a96c40377e895c0b1e44785e14"
+source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
 dependencies = [
  "assign",
  "js_int",
@@ -3972,7 +3972,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.7.0"
-source = "git+https://github.com/ruma/ruma?rev=69337d1f4e4790a96c40377e895c0b1e44785e14#69337d1f4e4790a96c40377e895c0b1e44785e14"
+source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -3983,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.15.3"
-source = "git+https://github.com/ruma/ruma?rev=69337d1f4e4790a96c40377e895c0b1e44785e14#69337d1f4e4790a96c40377e895c0b1e44785e14"
+source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
 dependencies = [
  "assign",
  "bytes",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.10.5"
-source = "git+https://github.com/ruma/ruma?rev=69337d1f4e4790a96c40377e895c0b1e44785e14#69337d1f4e4790a96c40377e895c0b1e44785e14"
+source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
 dependencies = [
  "base64 0.20.0",
  "bytes",
@@ -4031,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.6.0"
-source = "git+https://github.com/ruma/ruma?rev=69337d1f4e4790a96c40377e895c0b1e44785e14#69337d1f4e4790a96c40377e895c0b1e44785e14"
+source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=69337d1f4e4790a96c40377e895c0b1e44785e14#69337d1f4e4790a96c40377e895c0b1e44785e14"
+source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.10.5"
-source = "git+https://github.com/ruma/ruma?rev=69337d1f4e4790a96c40377e895c0b1e44785e14#69337d1f4e4790a96c40377e895c0b1e44785e14"
+source = "git+https://github.com/ruma/ruma?rev=3f293073653847d2c56e3c094e0773e3d5b06cc2#3f293073653847d2c56e3c094e0773e3d5b06cc2"
 dependencies = [
  "once_cell",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ byteorder = "1.4.3"
 ctor = "0.1.26"
 dashmap = "5.2.0"
 http = "0.2.6"
-ruma = { git = "https://github.com/ruma/ruma", rev = "69337d1f4e4790a96c40377e895c0b1e44785e14", features = ["client-api-c"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "69337d1f4e4790a96c40377e895c0b1e44785e14" }
+ruma = {  git = "https://github.com/ruma/ruma", rev = "3f293073653847d2c56e3c094e0773e3d5b06cc2", features = ["client-api-c"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "3f293073653847d2c56e3c094e0773e3d5b06cc2" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ byteorder = "1.4.3"
 ctor = "0.1.26"
 dashmap = "5.2.0"
 http = "0.2.6"
-ruma = {  git = "https://github.com/ruma/ruma", rev = "3f293073653847d2c56e3c094e0773e3d5b06cc2", features = ["client-api-c"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "3f293073653847d2c56e3c094e0773e3d5b06cc2" }
+ruma = {  git = "https://github.com/ruma/ruma", rev = "00045e559f864eabff08295d603f7b3238288b6f", features = ["client-api-c"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "00045e559f864eabff08295d603f7b3238288b6f" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -825,7 +825,6 @@ impl SlidingSyncBuilder {
         Arc::new(builder)
     }
 
-
     pub fn with_all_extensions(self: Arc<Self>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.with_all_extensions();

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -790,6 +790,12 @@ impl SlidingSyncBuilder {
         builder.inner = builder.inner.with_common_extensions();
         Arc::new(builder)
     }
+
+    pub fn with_all_extensions(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.with_all_extensions();
+        Arc::new(builder)
+    }
 }
 
 impl Client {

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -685,8 +685,8 @@ impl SlidingSync {
         self.inner.view(&name).map(|inner| Arc::new(SlidingSyncView { inner }))
     }
 
-    pub fn add_view(&self, view: Arc<SlidingSyncView>) -> Option<u32> {
-        self.inner.add_view(view.inner.clone()).map(|u| u as u32)
+    pub fn add_view(&self, view: Arc<SlidingSyncView>) -> Option<Arc<SlidingSyncView>> {
+        self.inner.add_view(view.inner.clone()).map(|inner| Arc::new(SlidingSyncView { inner }))
     }
 
     pub fn pop_view(&self, name: String) -> Option<Arc<SlidingSyncView>> {

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -693,6 +693,10 @@ impl SlidingSync {
         self.inner.pop_view(&name).map(|inner| Arc::new(SlidingSyncView { inner }))
     }
 
+    pub fn add_common_extensions(&self) {
+        self.inner.add_common_extensions();
+    }
+
     pub fn sync(&self) -> Arc<StoppableSpawn> {
         let inner = self.inner.clone();
         let client = self.client.clone();
@@ -790,6 +794,37 @@ impl SlidingSyncBuilder {
         builder.inner = builder.inner.with_common_extensions();
         Arc::new(builder)
     }
+
+    pub fn without_e2ee_extension(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.without_e2ee_extension();
+        Arc::new(builder)
+    }
+
+    pub fn without_to_device_extension(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.without_to_device_extension();
+        Arc::new(builder)
+    }
+
+    pub fn without_account_data_extension(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.without_account_data_extension();
+        Arc::new(builder)
+    }
+
+    pub fn without_receipt_extension(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.without_receipt_extension();
+        Arc::new(builder)
+    }
+
+    pub fn without_typing_extension(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.without_typing_extension();
+        Arc::new(builder)
+    }
+
 
     pub fn with_all_extensions(self: Arc<Self>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -47,6 +47,7 @@ experimental-timeline = ["ruma/unstable-msc2677", "dep:chrono"]
 experimental-sliding-sync = [
     "matrix-sdk-base/experimental-sliding-sync",
     "experimental-timeline",
+    "reqwest/gzip",
     "dep:derive_builder",
 ]
 

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -517,16 +517,16 @@ impl SlidingSyncBuilder {
                 .get_or_insert_with(Default::default)
                 .get_or_insert_with(Default::default);
             if cfg.to_device.is_none() {
-                cfg.to_device = Some(assign!(ToDeviceConfig::default(), {enabled : Some(true)}));
+                cfg.to_device = Some(assign!(ToDeviceConfig::default(), { enabled: Some(true) }));
             }
 
             if cfg.e2ee.is_none() {
-                cfg.e2ee = Some(assign!(E2EEConfig::default(), {enabled : Some(true)}));
+                cfg.e2ee = Some(assign!(E2EEConfig::default(), { enabled: Some(true) }));
             }
 
             if cfg.account_data.is_none() {
                 cfg.account_data =
-                    Some(assign!(AccountDataConfig::default(), {enabled : Some(true)}));
+                    Some(assign!(AccountDataConfig::default(), { enabled: Some(true) }));
             }
         }
         self
@@ -544,24 +544,24 @@ impl SlidingSyncBuilder {
                 .get_or_insert_with(Default::default)
                 .get_or_insert_with(Default::default);
             if cfg.to_device.is_none() {
-                cfg.to_device = Some(assign!(ToDeviceConfig::default(), {enabled : Some(true)}));
+                cfg.to_device = Some(assign!(ToDeviceConfig::default(), { enabled: Some(true) }));
             }
 
             if cfg.e2ee.is_none() {
-                cfg.e2ee = Some(assign!(E2EEConfig::default(), {enabled : Some(true)}));
+                cfg.e2ee = Some(assign!(E2EEConfig::default(), { enabled: Some(true) }));
             }
 
             if cfg.account_data.is_none() {
                 cfg.account_data =
-                    Some(assign!(AccountDataConfig::default(), {enabled : Some(true)}));
+                    Some(assign!(AccountDataConfig::default(), { enabled: Some(true) }));
             }
 
             if cfg.receipt.is_none() {
-                cfg.receipt = Some(assign!(ReceiptConfig::default(), {enabled : Some(true)}));
+                cfg.receipt = Some(assign!(ReceiptConfig::default(), { enabled: Some(true) }));
             }
 
             if cfg.typing.is_none() {
-                cfg.typing = Some(assign!(TypingConfig::default(), {enabled : Some(true)}));
+                cfg.typing = Some(assign!(TypingConfig::default(), { enabled: Some(true) }));
             }
         }
         self
@@ -801,15 +801,15 @@ impl SlidingSync {
         let mut lock = self.extensions.lock().unwrap();
         let mut cfg = lock.get_or_insert_with(Default::default);
         if cfg.to_device.is_none() {
-            cfg.to_device = Some(assign!(ToDeviceConfig::default(), {enabled : Some(true)}));
+            cfg.to_device = Some(assign!(ToDeviceConfig::default(), { enabled: Some(true) }));
         }
 
         if cfg.e2ee.is_none() {
-            cfg.e2ee = Some(assign!(E2EEConfig::default(), {enabled : Some(true)}));
+            cfg.e2ee = Some(assign!(E2EEConfig::default(), { enabled: Some(true) }));
         }
 
         if cfg.account_data.is_none() {
-            cfg.account_data = Some(assign!(AccountDataConfig::default(), {enabled : Some(true)}));
+            cfg.account_data = Some(assign!(AccountDataConfig::default(), { enabled: Some(true) }));
         }
     }
 
@@ -869,7 +869,7 @@ impl SlidingSync {
         room_ids.map(|room_id| rooms.get(&room_id).cloned()).collect()
     }
 
-    #[instrument(skip_all, fields(views=views.len()))]
+    #[instrument(skip_all, fields(views = views.len()))]
     async fn handle_response(
         &self,
         resp: v4::Response,
@@ -941,7 +941,7 @@ impl SlidingSync {
     /// Create the inner stream for the view.
     ///
     /// Run this stream to receive new updates from the server.
-    pub fn stream<'a>(&self) -> impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_ {
+    pub fn stream(&self) -> impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_ {
         let mut views = {
             let mut views = BTreeMap::new();
             let views_lock = self.views.lock_ref();
@@ -1340,7 +1340,7 @@ impl SlidingSyncViewRequestGenerator {
         self.make_request_for_ranges(vec![(start.into(), end.into())])
     }
 
-    #[instrument(skip(self), fields(name=self.view.name))]
+    #[instrument(skip(self), fields(name = self.view.name))]
     fn make_request_for_ranges(&mut self, ranges: Vec<(UInt, UInt)>) -> v4::SyncRequestList {
         let sort = self.view.sort.clone();
         let required_state = self.view.required_state.clone();
@@ -1374,7 +1374,7 @@ impl SlidingSyncViewRequestGenerator {
         self.make_request_for_ranges(ranges)
     }
 
-    #[instrument(skip_all, fields(name=self.view.name, rooms_count, has_ops=!ops.is_empty()))]
+    #[instrument(skip_all, fields(name = self.view.name, rooms_count, has_ops = !ops.is_empty()))]
     fn handle_response(
         &mut self,
         rooms_count: u32,
@@ -1382,7 +1382,7 @@ impl SlidingSyncViewRequestGenerator {
         rooms: &Vec<OwnedRoomId>,
     ) -> Result<bool, Error> {
         let res = self.view.handle_response(rooms_count, ops, &self.ranges, rooms)?;
-        self.update_state(rooms_count.checked_sub(1).unwrap_or_default()); // index is 0 based, count is 1 based
+        self.update_state(rooms_count.saturating_sub(1)); // index is 0 based, count is 1 based
         Ok(res)
     }
 

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -796,6 +796,27 @@ impl SlidingSync {
         }
     }
 
+    /// Add the common extensions if not already configured
+    pub fn add_common_extensions(&self) {
+        let mut lock = self
+                .extensions
+                .lock()
+                .unwrap();
+        let mut cfg = lock.get_or_insert_with(Default::default);
+        if cfg.to_device.is_none() {
+            cfg.to_device = Some(assign!(ToDeviceConfig::default(), {enabled : Some(true)}));
+        }
+
+        if cfg.e2ee.is_none() {
+            cfg.e2ee = Some(assign!(E2EEConfig::default(), {enabled : Some(true)}));
+        }
+
+        if cfg.account_data.is_none() {
+            cfg.account_data =
+                Some(assign!(AccountDataConfig::default(), {enabled : Some(true)}));
+        }
+    }
+
     /// Lookup a specific room
     pub fn get_room(&self, room_id: OwnedRoomId) -> Option<SlidingSyncRoom> {
         self.rooms.lock_ref().get(&room_id).cloned()

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -35,7 +35,8 @@ use ruma::{
     api::client::{
         error::ErrorKind,
         sync::sync_events::v4::{
-            self, AccountDataConfig, E2EEConfig, ExtensionsConfig, ToDeviceConfig,
+            self, AccountDataConfig, E2EEConfig, ExtensionsConfig, ReceiptConfig, ToDeviceConfig,
+            TypingConfig,
         },
     },
     assign,
@@ -531,6 +532,41 @@ impl SlidingSyncBuilder {
         self
     }
 
+    /// Activate e2ee, to-device-message, account data, typing and receipt
+    /// extensions if not yet configured.
+    ///
+    /// Will leave any extension configuration found untouched, so the order
+    /// does not matter.
+    pub fn with_all_extensions(mut self) -> Self {
+        {
+            let mut cfg = self
+                .extensions
+                .get_or_insert_with(Default::default)
+                .get_or_insert_with(Default::default);
+            if cfg.to_device.is_none() {
+                cfg.to_device = Some(assign!(ToDeviceConfig::default(), {enabled : Some(true)}));
+            }
+
+            if cfg.e2ee.is_none() {
+                cfg.e2ee = Some(assign!(E2EEConfig::default(), {enabled : Some(true)}));
+            }
+
+            if cfg.account_data.is_none() {
+                cfg.account_data =
+                    Some(assign!(AccountDataConfig::default(), {enabled : Some(true)}));
+            }
+
+            if cfg.receipt.is_none() {
+                cfg.receipt = Some(assign!(ReceiptConfig::default(), {enabled : Some(true)}));
+            }
+
+            if cfg.typing.is_none() {
+                cfg.typing = Some(assign!(TypingConfig::default(), {enabled : Some(true)}));
+            }
+        }
+        self
+    }
+
     /// Set the E2EE extension configuration.
     pub fn with_e2ee_extension(mut self, e2ee: E2EEConfig) -> Self {
         self.extensions
@@ -582,6 +618,42 @@ impl SlidingSyncBuilder {
             .get_or_insert_with(Default::default)
             .get_or_insert_with(Default::default)
             .account_data = None;
+        self
+    }
+
+    /// Set the Typing extension configuration.
+    pub fn with_typing_extension(mut self, typing: TypingConfig) -> Self {
+        self.extensions
+            .get_or_insert_with(Default::default)
+            .get_or_insert_with(Default::default)
+            .typing = Some(typing);
+        self
+    }
+
+    /// Unset the Typing extension configuration.
+    pub fn without_typing_extension(mut self) -> Self {
+        self.extensions
+            .get_or_insert_with(Default::default)
+            .get_or_insert_with(Default::default)
+            .typing = None;
+        self
+    }
+
+    /// Set the Receipt extension configuration.
+    pub fn with_receipt_extension(mut self, receipt: ReceiptConfig) -> Self {
+        self.extensions
+            .get_or_insert_with(Default::default)
+            .get_or_insert_with(Default::default)
+            .receipt = Some(receipt);
+        self
+    }
+
+    /// Unset the Receipt extension configuration.
+    pub fn without_receipt_extension(mut self) -> Self {
+        self.extensions
+            .get_or_insert_with(Default::default)
+            .get_or_insert_with(Default::default)
+            .receipt = None;
         self
     }
 

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -798,10 +798,7 @@ impl SlidingSync {
 
     /// Add the common extensions if not already configured
     pub fn add_common_extensions(&self) {
-        let mut lock = self
-                .extensions
-                .lock()
-                .unwrap();
+        let mut lock = self.extensions.lock().unwrap();
         let mut cfg = lock.get_or_insert_with(Default::default);
         if cfg.to_device.is_none() {
             cfg.to_device = Some(assign!(ToDeviceConfig::default(), {enabled : Some(true)}));
@@ -812,8 +809,7 @@ impl SlidingSync {
         }
 
         if cfg.account_data.is_none() {
-            cfg.account_data =
-                Some(assign!(AccountDataConfig::default(), {enabled : Some(true)}));
+            cfg.account_data = Some(assign!(AccountDataConfig::default(), {enabled : Some(true)}));
         }
     }
 

--- a/labs/jack-in/src/client/mod.rs
+++ b/labs/jack-in/src/client/mod.rs
@@ -41,7 +41,7 @@ pub async fn run_client(
         .build()
         .await?;
     let stream = syncer.stream();
-    let view = syncer.views.lock_ref().first().expect("we have the full syncer there").clone();
+    let view = syncer.view("full-sync").expect("we have the full syncer there").clone();
     let state = view.state.clone();
     let mut ssync_state = state::SlidingSyncState::new(view);
     tx.send(ssync_state.clone()).await?;

--- a/testing/sliding-sync-integration-test/.gitignore
+++ b/testing/sliding-sync-integration-test/.gitignore
@@ -1,0 +1,1 @@
+assets/data

--- a/testing/sliding-sync-integration-test/README.md
+++ b/testing/sliding-sync-integration-test/README.md
@@ -30,12 +30,7 @@ that server. If you are using the provided `docker-compose`, the default will be
 To drop the database of your docker-compose run:
 
 ```bash
-docker-compose -f assets/docker-compose.yml stop
-docker volume rm -f matrix-rust-sdk-sliding-sync-ci-data
-```
-
-or simply:
-
-```bash
 docker-compose -f assets/docker-compose.yml down -v
 ```
+
+Then remove the local data stored at `./data`.

--- a/testing/sliding-sync-integration-test/assets/docker-compose.yml
+++ b/testing/sliding-sync-integration-test/assets/docker-compose.yml
@@ -28,8 +28,8 @@ services:
       - ./data/db:/var/lib/postgresql/data
       
   sliding-sync-proxy:
-    # image: ghcr.io/matrix-org/sliding-sync:0.98.1
-    image: ghcr.io/matrix-org/sliding-sync:latest
+    image: ghcr.io/matrix-org/sliding-sync:v0.99.0-rc1
+    # image: ghcr.io/matrix-org/sliding-sync:latest
     links:
       - synapse
       - postgres

--- a/testing/sliding-sync-integration-test/assets/docker-compose.yml
+++ b/testing/sliding-sync-integration-test/assets/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     healthcheck:
       disable: true
     volumes:
-      - matrix-rust-sdk-sliding-sync-ci-data:/data
+      - ./data/synapse:/data
       
     ports:
       - 8228:8008/tcp
@@ -24,6 +24,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    volumes:
+      - ./data/db:/var/lib/postgresql/data
       
   sliding-sync-proxy:
     image: ghcr.io/matrix-org/sliding-sync:v0.98.0
@@ -37,6 +39,3 @@ services:
       SYNCV3_DB: "user=postgres password=postgres dbname=syncv3 sslmode=disable host=postgres"
     ports:
       - 8338:8338
-
-volumes:
-  matrix-rust-sdk-sliding-sync-ci-data:

--- a/testing/sliding-sync-integration-test/assets/docker-compose.yml
+++ b/testing/sliding-sync-integration-test/assets/docker-compose.yml
@@ -28,7 +28,8 @@ services:
       - ./data/db:/var/lib/postgresql/data
       
   sliding-sync-proxy:
-    image: ghcr.io/matrix-org/sliding-sync:v0.98.0
+    # image: ghcr.io/matrix-org/sliding-sync:0.98.1
+    image: ghcr.io/matrix-org/sliding-sync:latest
     links:
       - synapse
       - postgres

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -219,7 +219,7 @@ mod tests {
         // we only heard about the ones we had asked for
         assert_eq!(summary.views, [view_name_1, view_name_2, view_name_3]);
 
-        let Some(view_2) = sync_proxy.pop_view(view_name_2) else {
+        let Some(view_2) = sync_proxy.pop_view(&view_name_2.to_owned()) else {
             bail!("Room exists");
         };
 
@@ -368,11 +368,6 @@ mod tests {
         let _room_summary =
             stream.next().await.context("No room summary found, loop ended unsuccessfully")??;
 
-        let _room_summary = stream.next().await.context(
-            "No room summary found, loop ended
-        unsuccessfully",
-        )??;
-
         let rooms_list = full_view
             .rooms_list
             .lock_ref()
@@ -392,6 +387,7 @@ mod tests {
                 RoomListEntryEasy::Filled,
                 RoomListEntryEasy::Filled,
                 RoomListEntryEasy::Filled,
+                RoomListEntryEasy::Filled, // -- 10
                 RoomListEntryEasy::Filled,
                 RoomListEntryEasy::Filled,
                 RoomListEntryEasy::Filled,
@@ -401,12 +397,11 @@ mod tests {
                 RoomListEntryEasy::Filled,
                 RoomListEntryEasy::Filled,
                 RoomListEntryEasy::Filled,
-                RoomListEntryEasy::Filled,
-                RoomListEntryEasy::Filled,
-                RoomListEntryEasy::Filled,
+                RoomListEntryEasy::Filled, // -- 20
                 RoomListEntryEasy::Filled,
             ]
         );
+
         assert_eq!(full_view.state.get_cloned(), SlidingSyncState::Live, "full isn't live yet");
         Ok(())
     }

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -137,7 +137,7 @@ mod tests {
             }
         }
 
-        assert!(saw_update, "We didn't see the updae come through the pipe");
+        assert!(saw_update, "We didn't see the update come through the pipe");
 
         // and let's update the order of all views again
         let Some(RoomListEntry::Filled(room_id)) = view1
@@ -169,7 +169,7 @@ mod tests {
             }
         }
 
-        assert!(saw_update, "We didn't see the updae come through the pipe");
+        assert!(saw_update, "We didn't see the update come through the pipe");
 
         Ok(())
     }
@@ -178,7 +178,6 @@ mod tests {
     // update later.
     //
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    #[ignore = "removing and re-adding views isn't supported by the protocol yet"]
     async fn live_views() -> anyhow::Result<()> {
         let view_name_1 = "sliding1";
         let view_name_2 = "sliding2";
@@ -244,7 +243,7 @@ mod tests {
 
         let content = RoomMessageEventContent::text_plain("Hello world");
 
-        room.send(content, None).await?; // this should put our room up to the  most recent
+        room.send(content, None).await?; // this should put our room up to the most recent
 
         let mut saw_update = false;
         for _n in 0..2 {
@@ -261,31 +260,13 @@ mod tests {
             }
         }
 
-        assert!(saw_update, "We didn't see the updae come through the pipe");
+        assert!(saw_update, "We didn't see the update come through the pipe");
 
         assert!(sync_proxy.add_view(view_2).is_none());
 
         // we need to restart the stream after every view listing update
         let stream = sync_proxy.stream();
         pin_mut!(stream);
-
-        let mut saw_update = false;
-        for _n in 0..2 {
-            let Some(room_summary ) = stream.next().await else {
-                bail!("sync has closed unexpectedly");
-            };
-            let summary = room_summary?;
-            // we only heard about the ones we had asked for
-            if !summary.views.is_empty() {
-                // only if we saw an update come through
-                assert_eq!(summary.views, [view_name_2]);
-                // we didn't update the other views, so only no 2 should se an update
-                saw_update = true;
-                break;
-            }
-        }
-
-        assert!(saw_update, "We didn't see the updae come through the pipe");
 
         // and let's update the order of all views again
         let Some(RoomListEntry::Filled(room_id)) = view1
@@ -313,13 +294,13 @@ mod tests {
             // we only heard about the ones we had asked for
             if !summary.views.is_empty() {
                 // only if we saw an update come through
-                assert_eq!(summary.views, [view_name_1, view_name_3, view_name_2]); // notice that our view 2 is now the lastview, but all have seen updates
+                assert_eq!(summary.views, [view_name_1, view_name_2, view_name_3]); // all views are visible again
                 saw_update = true;
                 break;
             }
         }
 
-        assert!(saw_update, "We didn't see the updae come through the pipe");
+        assert!(saw_update, "We didn't see the update come through the pipe");
 
         Ok(())
     }


### PR DESCRIPTION
Upgrades the sliding sync from index-based views to named views. Additionally provides support for delta-tokens (once they are implemented) and exposes the new additional extensions to be enabled over ffi. Last but not least, it enabled `gzip` on `reqwest` for on-the-wire-compression whenever the sliding-sync feature is enabled.

Built against https://github.com/ruma/ruma/pull/1460