### PR TITLE
feat(crypto-nodejs) Implement `OlmMachine.close`

### DIFF
--- a/bindings/matrix-sdk-crypto-nodejs/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/machine.rs
@@ -443,6 +443,11 @@ impl OlmMachine {
     ///
     /// All associated resources will be closed too, like the crypto storage
     /// connections.
+    ///
+    /// # Safety
+    ///
+    /// The caller is responsible to **not** use any objects that came from this
+    /// `OlmMachine` after this `close` method has been called.
     #[napi(strict)]
     pub fn close(&mut self) {
         self.inner = OlmMachineInner::Closed;

--- a/bindings/matrix-sdk-crypto-nodejs/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/machine.rs
@@ -20,7 +20,7 @@ use crate::{
 /// The value used by the `OlmMachine` JS class.
 ///
 /// It has 2 states: `Opened` and `Closed`. Why maintaining the state here?
-/// Because NodeJS has no way to drop an object explicitely, and we want to be
+/// Because NodeJS has no way to drop an object explicitly, and we want to be
 /// able to “close” the `OlmMachine` to free all associated data. More over,
 /// `napi-rs` doesn't allow a function to take the ownership of the type itself
 /// (`fn close(self) { … }`). So we manage the state ourselves.

--- a/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -25,7 +25,7 @@ describe(OlmMachine.name, () => {
             expect(await OlmMachine.initialize(new UserId('@foo:bar.org'), new DeviceId('baz'), temp_directory, 'hello')).toBeInstanceOf(OlmMachine);
         });
     });
-    
+
     const user = new UserId('@alice:example.org');
     const device = new DeviceId('foobar');
     const room = new RoomId('!baz:matrix.org');
@@ -33,6 +33,16 @@ describe(OlmMachine.name, () => {
     function machine(new_user, new_device) {
         return OlmMachine.initialize(new_user || user, new_device || device);
     }
+
+    test('can drop/close, and then re-open', async () => {
+        const temp_directory = await fs.mkdtemp(path.join(os.tmpdir(), 'matrix-sdk-crypto--'));
+
+        let m1 = await OlmMachine.initialize(new UserId('@test:bar.org'), new DeviceId('device'), temp_directory, 'hello')
+        m1.close();
+
+        let m2 = await OlmMachine.initialize(new UserId('@test:bar.org'), new DeviceId('device'), temp_directory, 'hello')
+        m2.close();
+    });
 
     test('can read user ID', async () => {
         expect((await machine()).userId.toString()).toStrictEqual(user.toString());
@@ -179,7 +189,7 @@ describe(OlmMachine.name, () => {
         beforeAll(async () => {
             m = await machine(user, device);
         });
-        
+
         test('can pass keysquery and keysclaim requests directly', async () => {
             {
                 // derived from https://github.com/matrix-org/matrix-rust-sdk/blob/7f49618d350fab66b7e1dc4eaf64ec25ceafd658/benchmarks/benches/crypto_bench/keys_query.json


### PR DESCRIPTION
* This patch fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1379/.
* This is similar to https://github.com/matrix-org/matrix-rust-sdk/pull/1197/.

---

We need to close the `OlmMachine`. Problem, `napi-rs` doesn't allow methods to take ownership of `self`, so the following code:

```rs
fn close(self) {}
````

isn't allowed. There an [`ObjectFinalize`](https://docs.rs/napi/latest/napi/bindgen_prelude/trait.ObjectFinalize.html) trait, but it's only called when the JS value is being collected by the GC. It's not possible to force call `finalize` here.

This patch then introduces a new type:

```rs
enum OlmMachineInner {
  Opened(matrix_sdk_crypto::OlmMachine),
  Closed
}
```

that derefs to `matrix_sdk_crypto::OlmMachine` when its variant is `Opened`, otherwise it panics. Calling the new `OlmMachine::close` method will change the inner state from `Opened` to `Closed`.

Ideally, I wanted to throw an error instead of panicking, but `napi_env` (used to build an `Env`, used to throw an error) is neither `Sync` nor `Send`. Honestly, my knowledge of NodeJS and NAPI is too weak to implement `Sync` and `Send` for `*mut napi_env__` safely. Especially because it can be executed from various threads within `async fn` functions, that are driven by Tokio in `napi-rs`. So, yeah, for the moment, it panics!