### PR TITLE
fix(sdk): Aggregate reactions locally

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -250,7 +250,10 @@ impl EventTimelineItem {
                 remote_event_item
                     .reactions()
                     .iter()
-                    .map(|(k, v)| Reaction { key: k.to_owned(), count: v.len() as u64 })
+                    .map(|(k, v)| Reaction {
+                        key: k.to_owned(),
+                        count: v.len().try_into().unwrap(),
+                    })
                     .collect(),
             ),
         }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -213,7 +213,7 @@ impl EventTimelineItem {
         self.0
             .reactions()
             .iter()
-            .map(|(k, v)| Reaction { key: k.to_owned(), count: v.count.into() })
+            .map(|(k, v)| Reaction { key: k.to_owned(), count: v.len() as u64 })
             .collect()
     }
 

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -516,7 +516,14 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
         self.result.item_added = true;
 
         let NewEventTimelineItem { content } = item;
-        let reactions = self.pending_reactions().unwrap_or_default();
+        let mut reactions = self.pending_reactions().unwrap_or_default();
+
+        // Drop pending reactions if the message is redacted.
+        if let TimelineItemContent::RedactedMessage = content {
+            if !reactions.is_empty() {
+                reactions = BundledReactions::default();
+            }
+        }
 
         let item = EventTimelineItem {
             key: self.flow.to_key(),

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -390,7 +390,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                 return;
             } else {
                 let mut reactions = item.reactions.clone();
-                let reaction_group = reactions.bundled.entry(c.relates_to.key.clone()).or_default();
+                let reaction_group = reactions.entry(c.relates_to.key.clone()).or_default();
 
                 if let Some(txn_id) = old_txn_id {
                     // Remove the local echo from the related event.
@@ -463,7 +463,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                 let mut reactions = item.reactions.clone();
 
                 let count = {
-                    let Entry::Occupied(mut group_entry) = reactions.bundled.entry(rel.key.clone()) else {
+                    let Entry::Occupied(mut group_entry) = reactions.entry(rel.key.clone()) else {
                         return None;
                     };
                     let group = group_entry.get_mut();
@@ -480,7 +480,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                 };
 
                 if count == 0 {
-                    reactions.bundled.remove(&rel.key);
+                    reactions.remove(&rel.key);
                 }
 
                 trace!("Removing reaction");
@@ -689,7 +689,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                     group.0.insert(timeline_key, sender.clone());
                 }
 
-                Some(BundledReactions { bundled })
+                Some(bundled)
             }
         }
     }

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -497,8 +497,8 @@ pub type BundledReactions = IndexMap<String, ReactionGroup>;
 
 /// A group of reaction events on the same event with the same key.
 ///
-/// This is a map of the timeline key of the reaction to the ID of the sender of
-/// the reaction.
+/// This is a map of the event ID or transaction ID of the reactions to the ID
+/// of the sender of the reaction.
 #[derive(Clone, Debug, Default)]
 pub struct ReactionGroup(
     pub(super) IndexMap<(Option<OwnedTransactionId>, Option<OwnedEventId>), OwnedUserId>,

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -129,10 +129,8 @@ impl EventTimelineItem {
     }
 
     /// Get the reactions of this item.
-    pub fn reactions(&self) -> &IndexMap<String, ReactionGroup> {
-        // FIXME: Find out the state of incomplete bundled reactions, adjust
-        //        Ruma if necessary, return the whole BundledReactions field
-        &self.reactions.bundled
+    pub fn reactions(&self) -> &BundledReactions {
+        &self.reactions
     }
 
     /// Get the timestamp of this item.
@@ -403,14 +401,11 @@ impl From<RoomEncryptedEventContent> for EncryptedMessage {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct BundledReactions {
-    /// The reactions grouped by key.
-    ///
-    /// Key: The reaction, usually an emoji.\
-    /// Value: The group of reactions.
-    pub bundled: IndexMap<String, ReactionGroup>,
-}
+/// The reactions grouped by key.
+///
+/// Key: The reaction, usually an emoji.\
+/// Value: The group of reactions.
+pub type BundledReactions = IndexMap<String, ReactionGroup>;
 
 /// A group of reaction events on the same event with the same key.
 ///

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fmt, sync::Arc};
+use std::{fmt, ops::Deref, sync::Arc};
 
 use indexmap::IndexMap;
 use matrix_sdk_base::deserialized_responses::EncryptionInfo;
@@ -22,7 +22,6 @@ use ruma::{
             room::PolicyRuleRoomEventContent, server::PolicyRuleServerEventContent,
             user::PolicyRuleUserEventContent,
         },
-        relation::{AnnotationChunk, AnnotationType},
         room::{
             aliases::RoomAliasesEventContent,
             avatar::RoomAvatarEventContent,
@@ -49,8 +48,8 @@ use ruma::{
         MessageLikeEventType, StateEventType,
     },
     serde::Raw,
-    uint, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedMxcUri,
-    OwnedTransactionId, OwnedUserId, TransactionId, UInt, UserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedMxcUri,
+    OwnedTransactionId, OwnedUserId, TransactionId, UserId,
 };
 
 /// An item in the timeline that represents at least one event.
@@ -130,7 +129,7 @@ impl EventTimelineItem {
     }
 
     /// Get the reactions of this item.
-    pub fn reactions(&self) -> &IndexMap<String, ReactionDetails> {
+    pub fn reactions(&self) -> &IndexMap<String, ReactionGroup> {
         // FIXME: Find out the state of incomplete bundled reactions, adjust
         //        Ruma if necessary, return the whole BundledReactions field
         &self.reactions.bundled
@@ -404,58 +403,34 @@ impl From<RoomEncryptedEventContent> for EncryptedMessage {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct BundledReactions {
-    /// Whether all reactions are known, or some may be missing.
-    ///
-    /// If this is `false`, the remaining reactions can be fetched via **TODO**.
-    pub complete: bool, // FIXME: Unclear whether this is needed
-
-    /// The reactions.
+    /// The reactions grouped by key.
     ///
     /// Key: The reaction, usually an emoji.\
-    /// Value: The count.
-    pub bundled: IndexMap<String, ReactionDetails>,
+    /// Value: The group of reactions.
+    pub bundled: IndexMap<String, ReactionGroup>,
 }
 
-impl From<Box<AnnotationChunk>> for BundledReactions {
-    fn from(ann: Box<AnnotationChunk>) -> Self {
-        let bundled = ann
-            .chunk
-            .into_iter()
-            .filter_map(|a| {
-                (a.annotation_type == AnnotationType::Reaction).then(|| {
-                    let details =
-                        ReactionDetails { count: a.count, senders: TimelineDetails::Unavailable };
-                    (a.key, details)
-                })
-            })
-            .collect();
+/// A group of reaction events on the same event with the same key.
+///
+/// This is a map of the timeline key of the reaction to the ID of the sender of
+/// the reaction.
+#[derive(Clone, Debug, Default)]
+pub struct ReactionGroup(pub(super) IndexMap<TimelineKey, OwnedUserId>);
 
-        BundledReactions { bundled, complete: ann.next_batch.is_none() }
+impl ReactionGroup {
+    /// The senders of the reactions in this group.
+    pub fn senders(&self) -> impl Iterator<Item = &UserId> {
+        self.values().map(AsRef::as_ref)
     }
 }
 
-impl Default for BundledReactions {
-    fn default() -> Self {
-        Self { complete: true, bundled: IndexMap::new() }
-    }
-}
+impl Deref for ReactionGroup {
+    type Target = IndexMap<TimelineKey, OwnedUserId>;
 
-/// The details of a group of reaction events on the same event with the same
-/// key.
-#[derive(Clone, Debug)]
-pub struct ReactionDetails {
-    /// The amount of reactions with this key.
-    pub count: UInt,
-
-    /// The senders of the reactions.
-    pub senders: TimelineDetails<Vec<OwnedUserId>>,
-}
-
-impl Default for ReactionDetails {
-    fn default() -> Self {
-        Self { count: uint!(0), senders: TimelineDetails::Ready(Vec::new()) }
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -5,6 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures_signals::signal_vec::{MutableVec, MutableVecLockRef, SignalVec};
+use indexmap::IndexSet;
 use matrix_sdk_base::{
     crypto::OlmMachine,
     deserialized_responses::{EncryptionInfo, SyncTimelineEvent, TimelineEvent},
@@ -44,6 +45,8 @@ pub(super) struct TimelineInner<P: ProfileProvider = room::Common> {
 pub(super) struct TimelineInnerMetadata {
     // Reaction event / txn ID => sender and reaction data
     pub(super) reaction_map: HashMap<TimelineKey, (OwnedUserId, Annotation)>,
+    // ID of event that is not in the timeline yet => List of reaction event / txn ID
+    pub(super) pending_reactions: HashMap<OwnedEventId, IndexSet<TimelineKey>>,
     pub(super) fully_read_event: Option<OwnedEventId>,
     pub(super) fully_read_event_in_timeline: bool,
 }

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -49,10 +49,11 @@ pub(super) struct TimelineInner<P: ProfileProvider = room::Common> {
 /// Non-signalling parts of `TimelineInner`.
 #[derive(Debug, Default)]
 pub(super) struct TimelineInnerMetadata {
-    // Reaction event / txn ID => sender and reaction data
+    /// Reaction event / txn ID => sender and reaction data.
     pub(super) reaction_map:
         HashMap<(Option<OwnedTransactionId>, Option<OwnedEventId>), (OwnedUserId, Annotation)>,
-    // ID of event that is not in the timeline yet => List of reaction event / txn ID
+    /// ID of event that is not in the timeline yet => List of reaction event
+    /// IDs.
     pub(super) pending_reactions: HashMap<OwnedEventId, IndexSet<OwnedEventId>>,
     pub(super) fully_read_event: Option<OwnedEventId>,
     /// Whether the event that the fully-ready event _refers to_ is part of the

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -51,7 +51,7 @@ mod virtual_item;
 pub use self::{
     event_item::{
         AnyOtherFullStateEventContent, EncryptedMessage, EventTimelineItem, Message, OtherState,
-        Profile, ReactionDetails, RoomMember, Sticker, TimelineDetails, TimelineItemContent,
+        Profile, ReactionGroup, RoomMember, Sticker, TimelineDetails, TimelineItemContent,
         TimelineKey,
     },
     pagination::{PaginationOptions, PaginationOutcome},

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -8,8 +8,8 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     config::SyncSettings,
     room::timeline::{
-        AnyOtherFullStateEventContent, PaginationOptions, TimelineDetails, TimelineItemContent,
-        TimelineKey, VirtualTimelineItem,
+        AnyOtherFullStateEventContent, PaginationOptions, TimelineItemContent, TimelineKey,
+        VirtualTimelineItem,
     },
     ruma::MilliSecondsSinceUnixEpoch,
 };
@@ -419,10 +419,11 @@ async fn reaction() {
     let msg = assert_matches!(event_item.content(), TimelineItemContent::Message(msg) => msg);
     assert!(!msg.is_edited());
     assert_eq!(event_item.reactions().len(), 1);
-    let details = &event_item.reactions()["👍"];
-    assert_eq!(details.count, uint!(1));
-    let senders = assert_matches!(&details.senders, TimelineDetails::Ready(s) => s);
-    assert_eq!(*senders, vec![user_id!("@bob:example.org").to_owned()]);
+    let group = &event_item.reactions()["👍"];
+    assert_eq!(group.len(), 1);
+    let mut senders = group.senders();
+    assert_eq!(senders.next(), Some(user_id!("@bob:example.org")));
+    assert_eq!(senders.next(), None);
 
     // TODO: After adding raw timeline items, check for one here
 

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -421,9 +421,8 @@ async fn reaction() {
     assert_eq!(event_item.reactions().len(), 1);
     let group = &event_item.reactions()["👍"];
     assert_eq!(group.len(), 1);
-    let mut senders = group.senders();
-    assert_eq!(senders.next(), Some(user_id!("@bob:example.org")));
-    assert_eq!(senders.next(), None);
+    let senders: Vec<_> = group.senders().collect();
+    assert_eq!(senders.as_slice(), [user_id!("@bob:example.org")]);
 
     // TODO: After adding raw timeline items, check for one here
 


### PR DESCRIPTION
The bundled reactions don't have enough data to be usable without extra requests, although we likely have all the necessary data available locally (for now at least as we always start from the end of the timeline).

Tested locally in Fractal.

Fixes #1310.\
Fixes #1311.\
Fixes #1312.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>