### PR TITLE
feat(sdk): Move `EventTimelineItem.event_id` into `TimelineKey::TransactionId`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -602,7 +602,9 @@ impl From<&matrix_sdk::room::timeline::TimelineKey> for TimelineKey {
         use matrix_sdk::room::timeline::TimelineKey::*;
 
         match timeline_key {
-            TransactionId(txn_id) => TimelineKey::TransactionId { txn_id: txn_id.to_string() },
+            TransactionId { txn_id, .. } => {
+                TimelineKey::TransactionId { txn_id: txn_id.to_string() }
+            }
             EventId(event_id) => TimelineKey::EventId { event_id: event_id.to_string() },
         }
     }

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -68,7 +68,7 @@ impl Flow {
     fn to_key(&self) -> TimelineKey {
         match self {
             Self::Remote { event_id, .. } => TimelineKey::EventId(event_id.to_owned()),
-            Self::Local { txn_id, .. } => TimelineKey::TransactionId(txn_id.to_owned()),
+            Self::Local { txn_id, .. } => TimelineKey::new_transaction_id(txn_id.to_owned()),
         }
     }
 
@@ -488,7 +488,6 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
         let NewEventTimelineItem { content, reactions } = item;
         let item = EventTimelineItem {
             key: self.flow.to_key(),
-            event_id: None,
             sender: self.meta.sender.to_owned(),
             sender_profile: self.meta.sender_profile.clone(),
             content,
@@ -693,10 +692,7 @@ fn find_local_echo_by_event_id<'a>(
         .iter()
         .enumerate()
         .filter_map(|(idx, item)| Some((idx, item.as_event()?)))
-        // Note: not using event_id() method as this is only supposed to find
-        // local echoes, where the event ID is stored in the separate field
-        // rather than the key.
-        .rfind(|(_, it)| it.event_id.as_deref() == Some(event_id))
+        .rfind(|(_, it)| it.key.is_transaction_id_with_event_id(event_id))
 }
 
 /// Converts a timestamp since Unix Epoch to a local date and time.

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -217,8 +217,8 @@ pub enum TimelineKey {
     TransactionId {
         /// The transaction ID.
         txn_id: OwnedTransactionId,
-        /// The event ID received by the server as the new event's response (not
-        /// the sync response).
+        /// The event ID received from the server in the event-sending response
+        /// (not the sync response).
         event_id: Option<OwnedEventId>,
     },
     /// Event ID, for an event that is synced with the server.

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -61,10 +61,6 @@ use ruma::{
 #[derive(Clone)]
 pub struct EventTimelineItem {
     pub(super) key: TimelineKey,
-    // If this item is a local echo that has been acknowledged by the server
-    // but not remote-echoed yet, this field holds the event ID from the send
-    // response.
-    pub(super) event_id: Option<OwnedEventId>,
     pub(super) sender: OwnedUserId,
     pub(super) sender_profile: Profile,
     pub(super) content: TimelineItemContent,
@@ -80,7 +76,6 @@ impl fmt::Debug for EventTimelineItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EventTimelineItem")
             .field("key", &self.key)
-            .field("event_id", &self.event_id)
             .field("sender", &self.sender)
             .field("content", &self.content)
             .field("reactions", &self.reactions)
@@ -109,8 +104,8 @@ impl EventTimelineItem {
     /// of the send request that created the event.
     pub fn event_id(&self) -> Option<&EventId> {
         match &self.key {
-            TimelineKey::TransactionId(_) => self.event_id.as_deref(),
-            TimelineKey::EventId(id) => Some(id),
+            TimelineKey::TransactionId { event_id, .. } => event_id.as_deref(),
+            TimelineKey::EventId(event_id) => Some(event_id),
         }
     }
 
@@ -178,8 +173,15 @@ impl EventTimelineItem {
         }
     }
 
-    pub(super) fn with_event_id(&self, event_id: Option<OwnedEventId>) -> Self {
-        Self { event_id, ..self.clone() }
+    pub(super) fn with_transaction_id_event_id(
+        &self,
+        txn_id: &OwnedTransactionId,
+        event_id: Option<OwnedEventId>,
+    ) -> Self {
+        Self {
+            key: TimelineKey::new_transaction_id_with_event_id(txn_id.clone(), event_id),
+            ..self.clone()
+        }
     }
 
     pub(super) fn with_content(&self, content: TimelineItemContent) -> Self {
@@ -212,14 +214,46 @@ impl EventTimelineItem {
 pub enum TimelineKey {
     /// Transaction ID, for an event that was created locally and hasn't been
     /// acknowledged by the server yet.
-    TransactionId(OwnedTransactionId),
+    TransactionId {
+        /// The transaction ID.
+        txn_id: OwnedTransactionId,
+        /// The event ID received by the server as the new event's response (not
+        /// the sync response).
+        event_id: Option<OwnedEventId>,
+    },
     /// Event ID, for an event that is synced with the server.
     EventId(OwnedEventId),
 }
 
+impl TimelineKey {
+    /// Creates a new `TimelineKey::TransactionId` with only a transaction ID.
+    pub fn new_transaction_id(txn_id: OwnedTransactionId) -> Self {
+        Self::TransactionId { txn_id, event_id: None }
+    }
+
+    /// Creates a new `TimelineKey::TransactionId` with a transaction ID _and_
+    /// an event ID.
+    pub fn new_transaction_id_with_event_id(
+        txn_id: OwnedTransactionId,
+        event_id: Option<OwnedEventId>,
+    ) -> Self {
+        Self::TransactionId { txn_id, event_id }
+    }
+
+    /// Creates a new `TimelineKey::EventId`.
+    pub fn new_event_id(event_id: OwnedEventId) -> Self {
+        Self::EventId(event_id)
+    }
+
+    /// Checks whether `self` is a transaction ID with the given event ID.
+    pub fn is_transaction_id_with_event_id(&self, event_id: &EventId) -> bool {
+        matches!(self, Self::TransactionId { event_id: Some(txn_event_id), .. } if AsRef::<EventId>::as_ref(txn_event_id) == event_id)
+    }
+}
+
 impl PartialEq<TransactionId> for TimelineKey {
     fn eq(&self, id: &TransactionId) -> bool {
-        matches!(self, TimelineKey::TransactionId(txn_id) if txn_id == id)
+        matches!(self, TimelineKey::TransactionId { txn_id, .. } if txn_id == id)
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -146,17 +146,26 @@ impl<P: ProfileProvider> TimelineInner<P> {
         .await
     }
 
+    /// Update the transaction ID by an event ID.
     pub(super) fn add_event_id(&self, txn_id: &TransactionId, event_id: OwnedEventId) {
         let mut lock = self.items.lock_mut();
         if let Some((idx, item)) = find_event_by_txn_id(&lock, txn_id) {
-            if let Some(existing_event_id) = &item.event_id {
-                error!(
-                    ?existing_event_id, new_event_id = ?event_id, ?txn_id,
-                    "Local echo already has an event ID"
+            // It's always a `TimelineKey::TransactionId`
+            if let TimelineKey::TransactionId { txn_id, event_id: txn_event_id } = &item.key {
+                if let Some(existing_event_id) = txn_event_id {
+                    error!(
+                        ?existing_event_id, new_event_id = ?event_id, ?txn_id,
+                        "Local echo already has an event ID"
+                    );
+                }
+
+                lock.set_cloned(
+                    idx,
+                    Arc::new(TimelineItem::Event(
+                        item.with_transaction_id_event_id(txn_id, Some(event_id)),
+                    )),
                 );
             }
-
-            lock.set_cloned(idx, Arc::new(TimelineItem::Event(item.with_event_id(Some(event_id)))));
         } else if find_event_by_id(&lock, &event_id).is_none() {
             // Event isn't found by transaction ID, and also not by event ID
             // (which it would if the remote echo comes in before the send-event

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -150,22 +150,23 @@ impl<P: ProfileProvider> TimelineInner<P> {
     pub(super) fn add_event_id(&self, txn_id: &TransactionId, event_id: OwnedEventId) {
         let mut lock = self.items.lock_mut();
         if let Some((idx, item)) = find_event_by_txn_id(&lock, txn_id) {
-            // It's always a `TimelineKey::TransactionId`
-            if let TimelineKey::TransactionId { txn_id, event_id: txn_event_id } = &item.key {
-                if let Some(existing_event_id) = txn_event_id {
-                    error!(
-                        ?existing_event_id, new_event_id = ?event_id, ?txn_id,
-                        "Local echo already has an event ID"
-                    );
-                }
+            let TimelineKey::TransactionId { txn_id, event_id: txn_event_id } = &item.key else {
+                unreachable!("`find_event_by_txn_id` can only find items with `TimelineKey::TransactionId`")
+            };
 
-                lock.set_cloned(
-                    idx,
-                    Arc::new(TimelineItem::Event(
-                        item.with_transaction_id_event_id(txn_id, Some(event_id)),
-                    )),
+            if let Some(existing_event_id) = txn_event_id {
+                error!(
+                    ?existing_event_id, new_event_id = ?event_id, ?txn_id,
+                    "Local echo already has an event ID"
                 );
             }
+
+            lock.set_cloned(
+                idx,
+                Arc::new(TimelineItem::Event(
+                    item.with_transaction_id_event_id(txn_id, Some(event_id)),
+                )),
+            );
         } else if find_event_by_id(&lock, &event_id).is_none() {
             // Event isn't found by transaction ID, and also not by event ID
             // (which it would if the remote echo comes in before the send-event

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -392,7 +392,7 @@ async fn remote_echo_without_txn_id() {
     let _day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    assert_matches!(item.as_event().unwrap().key(), TimelineKey::TransactionId(_));
+    assert_matches!(item.as_event().unwrap().key(), TimelineKey::TransactionId { .. });
 
     // That has an event ID assigned already (from the response to sending it)…
     let event_id = event_id!("$W6mZSLWMmfuQQ9jhZWeTxFIM");
@@ -400,7 +400,7 @@ async fn remote_echo_without_txn_id() {
 
     let item =
         assert_matches!(stream.next().await, Some(VecDiff::UpdateAt { value, index: 1 }) => value);
-    assert_matches!(item.as_event().unwrap().key(), TimelineKey::TransactionId(_));
+    assert_matches!(item.as_event().unwrap().key(), TimelineKey::TransactionId { .. });
 
     // When an event with the same ID comes in…
     timeline
@@ -446,7 +446,7 @@ async fn remote_echo_new_position() {
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     let txn_id_from_event = assert_matches!(
         item.as_event().unwrap().key(),
-        TimelineKey::TransactionId(txn_id) => txn_id
+        TimelineKey::TransactionId { txn_id, .. } => txn_id
     );
     assert_eq!(txn_id, *txn_id_from_event);
 

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -189,7 +189,7 @@ async fn echo() {
     let item = local_echo.as_event().unwrap();
     assert!(item.event_id().is_none());
     assert!(item.is_own());
-    assert_matches!(item.key(), TimelineKey::TransactionId(_));
+    assert_matches!(item.key(), TimelineKey::TransactionId { .. });
     assert_matches!(item.raw(), None);
 
     let msg = assert_matches!(item.content(), TimelineItemContent::Message(msg) => msg);
@@ -206,7 +206,7 @@ async fn echo() {
     let item = sent_confirmation.as_event().unwrap();
     assert!(item.event_id().is_some());
     assert!(item.is_own());
-    assert_matches!(item.key(), TimelineKey::TransactionId(_));
+    assert_matches!(item.key(), TimelineKey::TransactionId { .. });
     assert_matches!(item.raw(), None);
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(


### PR DESCRIPTION
To create an event next to the server, the event must be accompanied by a transaction ID. When the server receives the event creation request, it responds with a new event ID (which we will name `event_id_1`). Later on, when a sync is done to the server, the server may respond with the transaction ID and a new event ID (which we will name `event_id_2`).

The transaction ID is used to update the state of the local event. The event ID received from the sync may ideally be the same as the one received by the creation request's response.

Knowing that…

`EventTimelineItem` had a field: `event_id: Option<OwnedEventId>`. It was `Some(event_id)` where `event_id` is the event ID responded by the server when an event was created, i.e. it's `event_id_1`; otherwise it was `None`. This is never `event_id_2`. Why?

Because `EventTimelineItem` has an other field: `key: TimelineKey`, which represents the following states:

* `TimelineKey::TransactionId(OwnedTransactionId)`,
* `TimelineKey::EventId(OwnedEventId)`, where the event ID is `event_id_2`!

So it becomes obvious that `event_id_1` should be part of `TimelineKey`, not `EventTimelineItem`. `TimelineKey` is where this transaction ID and event ID logic is managed.

This patch updates `TimelineyKey::TransactionId` to be defined as:

* `TimelineKey::TransactionId { txn_id: OwnedTransactionId, event_id: Option<OwnedEventId> }`.

Why an `Option`? Because before receiving `event_id_1`, we may still want to create a `TimelineKey`, the API must reflect that state.

So basically, `EventTimelineItem.event_id` is moved inside `TimelineyKey::TransactionId`.