### PR TITLE
fix(sdk): Retry decryption if you initialize a Timeline with some events

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures_signals::signal_vec::{MutableVec, MutableVecLockRef, SignalVec};
-#[cfg(feature = "experimental-sliding-sync")]
+#[cfg((any(test, feature = "experimental-sliding-sync")))]
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_base::{
     crypto::OlmMachine,

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -5,6 +5,8 @@ use std::{
 
 use async_trait::async_trait;
 use futures_signals::signal_vec::{MutableVec, MutableVecLockRef, SignalVec};
+#[cfg(feature = "experimental-sliding-sync")]
+use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_base::{
     crypto::OlmMachine,
     deserialized_responses::{EncryptionInfo, TimelineEvent},
@@ -64,10 +66,7 @@ impl<P: ProfileProvider> TimelineInner<P> {
     }
 
     #[cfg(any(test, feature = "experimental-sliding-sync"))]
-    pub(super) async fn add_initial_events(
-        &mut self,
-        events: Vec<matrix_sdk_base::deserialized_responses::SyncTimelineEvent>,
-    ) {
+    pub(super) async fn add_initial_events(&mut self, events: Vec<SyncTimelineEvent>) {
         if events.is_empty() {
             return;
         }

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures_signals::signal_vec::{MutableVec, MutableVecLockRef, SignalVec};
-#[cfg((any(test, feature = "experimental-sliding-sync")))]
+#[cfg(any(test, feature = "experimental-sliding-sync"))]
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_base::{
     crypto::OlmMachine,

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -63,7 +63,7 @@ impl<P: ProfileProvider> TimelineInner<P> {
         self.items.signal_vec_cloned()
     }
 
-    #[cfg(feature = "experimental-sliding-sync")]
+    #[cfg(any(test, feature = "experimental-sliding-sync"))]
     pub(super) async fn add_initial_events(
         &mut self,
         events: Vec<matrix_sdk_base::deserialized_responses::SyncTimelineEvent>,

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use futures_signals::signal_vec::{MutableVec, MutableVecLockRef, SignalVec};
 use matrix_sdk_base::{
     crypto::OlmMachine,
-    deserialized_responses::{EncryptionInfo, SyncTimelineEvent, TimelineEvent},
+    deserialized_responses::{EncryptionInfo, TimelineEvent},
     locks::Mutex,
 };
 use ruma::{
@@ -63,7 +63,11 @@ impl<P: ProfileProvider> TimelineInner<P> {
         self.items.signal_vec_cloned()
     }
 
-    pub(super) async fn add_initial_events(&mut self, events: Vec<SyncTimelineEvent>) {
+    #[cfg(feature = "experimental-sliding-sync")]
+    pub(super) async fn add_initial_events(
+        &mut self,
+        events: Vec<matrix_sdk_base::deserialized_responses::SyncTimelineEvent>,
+    ) {
         if events.is_empty() {
             return;
         }
@@ -222,18 +226,25 @@ impl<P: ProfileProvider> TimelineInner<P> {
         );
     }
 
-    #[cfg(feature = "e2e-encryption")]
-    #[instrument(skip(self, olm_machine))]
-    pub(super) async fn retry_event_decryption(
+    /// Collect events and their metadata that are unable-to-decrypt (UTD)
+    /// events in the timeline.
+    fn collect_utds(
         &self,
-        room_id: &RoomId,
-        olm_machine: &OlmMachine,
-        session_ids: BTreeSet<&str>,
-    ) {
+        session_ids: Option<BTreeSet<&str>>,
+    ) -> Vec<(usize, OwnedEventId, String, Raw<AnySyncTimelineEvent>)> {
         use super::EncryptedMessage;
 
-        let utds_for_session: Vec<_> = self
-            .items
+        let should_retry = |session_id: &str| {
+            let session_ids = &session_ids;
+
+            if let Some(session_ids) = session_ids {
+                session_ids.contains(session_id)
+            } else {
+                true
+            }
+        };
+
+        self.items
             .lock_ref()
             .iter()
             .enumerate()
@@ -243,7 +254,7 @@ impl<P: ProfileProvider> TimelineInner<P> {
 
                 match utd {
                     EncryptedMessage::MegolmV1AesSha2 { session_id, .. }
-                        if session_ids.contains(session_id.as_str()) =>
+                        if should_retry(session_id) =>
                     {
                         let TimelineKey::EventId(event_id) = &event_item.key else {
                             error!("Key for unable-to-decrypt timeline item is not an event ID");
@@ -261,7 +272,20 @@ impl<P: ProfileProvider> TimelineInner<P> {
                     | EncryptedMessage::Unknown => None,
                 }
             })
-            .collect();
+            .collect()
+    }
+
+    #[cfg(feature = "e2e-encryption")]
+    #[instrument(skip(self, olm_machine))]
+    pub(super) async fn retry_event_decryption(
+        &self,
+        room_id: &RoomId,
+        olm_machine: &OlmMachine,
+        session_ids: Option<BTreeSet<&str>>,
+    ) {
+        debug!("Retrying decryption");
+
+        let utds_for_session = self.collect_utds(session_ids);
 
         if utds_for_session.is_empty() {
             trace!("Found no events to retry decryption for");

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -20,10 +20,7 @@ use std::sync::Arc;
 
 use futures_core::Stream;
 use futures_signals::signal_vec::{SignalVec, SignalVecExt, VecDiff};
-use matrix_sdk_base::{
-    deserialized_responses::{EncryptionInfo, SyncTimelineEvent},
-    locks::Mutex,
-};
+use matrix_sdk_base::{deserialized_responses::EncryptionInfo, locks::Mutex};
 use ruma::{
     assign,
     events::{fully_read::FullyReadEventContent, AnyMessageLikeEventContent},
@@ -88,14 +85,26 @@ impl Timeline {
         Self::from_inner(Arc::new(TimelineInner::new(room.to_owned())), None)
     }
 
+    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) async fn with_events(
         room: &room::Common,
         prev_token: Option<String>,
-        events: Vec<SyncTimelineEvent>,
+        events: Vec<matrix_sdk_base::deserialized_responses::SyncTimelineEvent>,
     ) -> Self {
         let mut inner = TimelineInner::new(room.to_owned());
         inner.add_initial_events(events).await;
-        Self::from_inner(Arc::new(inner), prev_token)
+
+        // The events we're injecting might be encrypted events, but we might
+        // have received the room key to decrypt them while nobody was listening to the
+        // `m.room_key` event, let's retry now.
+        //
+        // TODO: We could spawn a task here and put this into the background, though it
+        // might not be worth it depending on the number of events we injected.
+        // Some measuring needs to be done.
+        let timeline = Self::from_inner(Arc::new(inner), prev_token);
+        timeline.retry_decryption_for_all_events().await;
+
+        timeline
     }
 
     fn from_inner(inner: Arc<TimelineInner>, prev_token: Option<String>) -> Timeline {
@@ -279,7 +288,18 @@ impl Timeline {
             .retry_event_decryption(
                 self.room().room_id(),
                 self.room().client.olm_machine().expect("Olm machine wasn't started"),
-                session_ids.into_iter().map(AsRef::as_ref).collect(),
+                Some(session_ids.into_iter().map(AsRef::as_ref).collect()),
+            )
+            .await;
+    }
+
+    #[cfg(feature = "experimental-sliding-sync")]
+    async fn retry_decryption_for_all_events(&self) {
+        self.inner
+            .retry_event_decryption(
+                self.room().room_id(),
+                self.room().client.olm_machine().expect("Olm machine wasn't started"),
+                None,
             )
             .await;
     }

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -238,7 +238,7 @@ async fn unable_to_decrypt() {
         .retry_event_decryption(
             room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost"),
             &olm_machine,
-            iter::once(SESSION_ID).collect(),
+            Some(iter::once(SESSION_ID).collect()),
         )
         .await;
 

--- a/crates/matrix-sdk/src/room/timeline/to_device.rs
+++ b/crates/matrix-sdk/src/room/timeline/to_device.rs
@@ -62,6 +62,10 @@ async fn retry_decryption(
     };
 
     inner
-        .retry_event_decryption(&room_id, olm_machine, iter::once(session_id.as_str()).collect())
+        .retry_event_decryption(
+            &room_id,
+            olm_machine,
+            Some(iter::once(session_id.as_str()).collect()),
+        )
         .await;
 }


### PR DESCRIPTION
The sliding sync logic has another room type called `SlidingSyncRoom`.

This room type stores a limited amount of events in something called `AliveRoomTimeline` in a in-memory cache. This room also gets persisted to the store via another room type called `FrozenSyncRoom`.

These types are used when clients restore their view of the room, i.e. when the user enters the room to look at messages.

When the client enters a room, a `Timeline` object will be created, but it will be initially populated with events coming from `AliveRoomTimeline`.

In a hot potato contest of who should be responsible to decrypt injected events, everybody claims to be allergic to potatoes.

This patch modifies the `Timeline` constructor that populates the timeline with events from the `AliveTimeline` to retry decryption on the events that the `AliveTimeline` pushes into the `Timeline`.

Note that, because the `AliveRoomTimeline` never replaces encrypted events with decrypted ones, every time the client enters/exits the room events well get re-decrypted.