### PR TITLE
feat(sdk): `EventTimelineItem` is now an `enum … { Local(…), Remote(…) }`

### DIFF
--- a/CONVENTIONAL_COMMITS.md
+++ b/CONVENTIONAL_COMMITS.md
@@ -79,7 +79,7 @@ section aims at listing all the scopes used inside this project:
       <td>About the <code>matrix-sdk-test</code> and <code>matrix-sdk-test-macros</code> crate.</td>
     </tr>
     <tr>
-      <td rowspan="4">Bindings</td>
+      <td rowspan="5">Bindings</td>
       <td><code>apple</code></td>
       <td>About the <code>matrix-rust-components-swift</code> binding.</td>
     </tr>
@@ -94,6 +94,10 @@ section aims at listing all the scopes used inside this project:
     <tr>
       <td><code>crypto-ffi</code></td>
       <td>About the <code>matrix-sdk-crypto-ffi</code> binding.</td>
+    </tr>
+    <tr>
+      <td><code>ffi</code></td>
+      <td>About the <code>matrix-sdk-ffi</code> binding.</td>
     </tr>
     <tr>
       <td>Labs</td>

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -94,7 +94,7 @@ mod uniffi_types {
             FormattedBody, ImageInfo, ImageMessageContent, InsertAtData, MembershipChange, Message,
             MessageFormat, MessageType, NoticeMessageContent, OtherState, Profile, Reaction,
             TextMessageContent, ThumbnailInfo, TimelineChange, TimelineDiff, TimelineItem,
-            TimelineItemContent, TimelineItemContentKind, TimelineKey, UpdateAtData, VideoInfo,
+            TimelineItemContent, TimelineItemContentKind, UpdateAtData, VideoInfo,
             VideoMessageContent, VirtualTimelineItem,
         },
     };

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -175,9 +175,6 @@ pub struct EventTimelineItem(pub(crate) matrix_sdk::room::timeline::EventTimelin
 
 #[uniffi::export]
 impl EventTimelineItem {
-    pub fn key(&self) -> TimelineKey {
-        self.0.key().into()
-    }
 
     pub fn event_id(&self) -> Option<String> {
         self.0.event_id().map(ToString::to_string)
@@ -631,27 +628,8 @@ pub struct Reaction {
 
 #[derive(Clone)]
 pub struct ReactionDetails {
-    pub id: TimelineKey,
+    pub id: String,
     pub sender: String,
-}
-
-#[derive(Clone, uniffi::Enum)]
-pub enum TimelineKey {
-    TransactionId { txn_id: String },
-    EventId { event_id: String },
-}
-
-impl From<&matrix_sdk::room::timeline::TimelineKey> for TimelineKey {
-    fn from(timeline_key: &matrix_sdk::room::timeline::TimelineKey) -> Self {
-        use matrix_sdk::room::timeline::TimelineKey::*;
-
-        match timeline_key {
-            TransactionId { txn_id, .. } => {
-                TimelineKey::TransactionId { txn_id: txn_id.to_string() }
-            }
-            EventId(event_id) => TimelineKey::EventId { event_id: event_id.to_string() },
-        }
-    }
 }
 
 /// A [`TimelineItem`](super::TimelineItem) that doesn't correspond to an event.

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -175,6 +175,17 @@ pub struct EventTimelineItem(pub(crate) matrix_sdk::room::timeline::EventTimelin
 
 #[uniffi::export]
 impl EventTimelineItem {
+    pub fn is_local(&self) -> bool {
+        use matrix_sdk::room::timeline::EventTimelineItem::*;
+
+        matches!(self.0, Local(_))
+    }
+
+    pub fn is_remote(&self) -> bool {
+        use matrix_sdk::room::timeline::EventTimelineItem::*;
+
+        matches!(self.0, Remote(_))
+    }
 
     pub fn event_id(&self) -> Option<String> {
         self.0.event_id().map(ToString::to_string)

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -215,12 +215,19 @@ impl EventTimelineItem {
         self.0.timestamp().0.into()
     }
 
-    pub fn reactions(&self) -> Vec<Reaction> {
-        self.0
-            .reactions()
-            .iter()
-            .map(|(k, v)| Reaction { key: k.to_owned(), count: v.count.into() })
-            .collect()
+    pub fn reactions(&self) -> Option<Vec<Reaction>> {
+        use matrix_sdk::room::timeline::EventTimelineItem::*;
+
+        match &self.0 {
+            Local(_) => None,
+            Remote(remote_event_item) => Some(
+                remote_event_item
+                    .reactions()
+                    .iter()
+                    .map(|(k, v)| Reaction { key: k.to_owned(), count: v.count.into() })
+                    .collect(),
+            ),
+        }
     }
 
     pub fn raw(&self) -> Option<String> {

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -65,22 +65,6 @@ pub(super) enum Flow {
     },
 }
 
-impl Flow {
-    fn timestamp(&self) -> MilliSecondsSinceUnixEpoch {
-        match self {
-            Flow::Local { timestamp, .. } => *timestamp,
-            Flow::Remote { origin_server_ts, .. } => *origin_server_ts,
-        }
-    }
-
-    fn raw_event(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
-        match self {
-            Flow::Local { .. } => None,
-            Flow::Remote { raw_event, .. } => Some(raw_event),
-        }
-    }
-}
-
 pub(super) struct TimelineEventMetadata {
     pub(super) sender: OwnedUserId,
     pub(super) sender_profile: Profile,

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -376,7 +376,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
 
         update_timeline_item!(self, event_id, "reaction", |event_item| {
             let EventTimelineItem::Remote(remote_event_item) = event_item else {
-                error!("inconsistent state: reaction receives on a non-remote event item");
+                error!("inconsistent state: reaction received on a non-remote event item");
                 return None;
             };
 

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -431,7 +431,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
         if let Some((sender, rel)) = self.reaction_map.remove(&(None, Some(redacts.clone()))) {
             update_timeline_item!(self, &rel.event_id, "redaction", |event_item| {
                 let EventTimelineItem::Remote(remote_event_item) = event_item else {
-                    error!("inconsistent state: reaction receives on a non-remote event item");
+                    error!("inconsistent state: reaction received on a non-remote event item");
                     return None;
                 };
 
@@ -489,7 +489,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
         // directly with the raw event timeline feature (not yet implemented).
         update_timeline_item!(self, &redacts, "redaction", |event_item| {
             let EventTimelineItem::Remote(remote_event_item) = event_item else {
-                    error!("inconsistent state: reaction receives on a non-remote event item");
+                    error!("inconsistent state: reaction received on a non-remote event item");
                     return None;
                 };
 

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -512,32 +512,29 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
         let item = {
             let sender = self.meta.sender.to_owned();
             let sender_profile = self.meta.sender_profile.clone();
-            let timestamp = self.flow.timestamp();
-            let encryption_info = self.meta.encryption_info.clone();
-            let raw = self.flow.raw_event().cloned();
 
             match &self.flow {
-                Flow::Local { txn_id, .. } => EventTimelineItem::Local(LocalEventTimelineItem {
-                    transaction_id: txn_id.to_owned(),
-                    event_id: None,
-                    sender,
-                    sender_profile,
-                    timestamp,
-                    content,
-                    encryption_info,
-                    raw,
-                }),
-                Flow::Remote { event_id, .. } => {
+                Flow::Local { txn_id, timestamp } => {
+                    EventTimelineItem::Local(LocalEventTimelineItem {
+                        transaction_id: txn_id.to_owned(),
+                        event_id: None,
+                        sender,
+                        sender_profile,
+                        timestamp: *timestamp,
+                        content,
+                    })
+                }
+                Flow::Remote { event_id, origin_server_ts, raw_event, .. } => {
                     EventTimelineItem::Remote(RemoteEventTimelineItem {
                         event_id: event_id.clone(),
                         sender,
                         sender_profile,
-                        timestamp,
+                        timestamp: *origin_server_ts,
                         content,
                         reactions,
                         is_own: self.meta.is_own_event,
-                        encryption_info,
-                        raw,
+                        encryption_info: self.meta.encryption_info.clone(),
+                        raw: raw_event.clone(),
                     })
                 }
             }

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -43,7 +43,8 @@ use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 use super::{
     event_item::{
         AnyOtherFullStateEventContent, BundledReactions, LocalEventTimelineItem,
-        MemberProfileChange, OtherState, Profile, RoomMembershipChange, Sticker, TimelineDetails,
+        MemberProfileChange, OtherState, Profile, RemoteEventTimelineItem, RoomMembershipChange,
+        Sticker, TimelineDetails,
     },
     find_event_by_id, find_event_by_txn_id, find_read_marker, EventTimelineItem, Message,
     TimelineInnerMetadata, TimelineItem, TimelineItemContent, VirtualTimelineItem,
@@ -526,7 +527,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                     raw,
                 }),
                 Flow::Remote { event_id, .. } => {
-                    EventTimelineItem::Remote(super::event_item::RemoteEventTimelineItem {
+                    EventTimelineItem::Remote(RemoteEventTimelineItem {
                         event_id: event_id.clone(),
                         sender,
                         sender_profile,

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -207,6 +207,7 @@ pub(super) struct TimelineEventHandler<'a, 'i> {
     meta: TimelineEventMetadata,
     flow: Flow,
     timeline_items: &'a mut MutableVecLockMut<'i, Arc<TimelineItem>>,
+    #[allow(clippy::type_complexity)]
     reaction_map: &'a mut HashMap<
         (Option<OwnedTransactionId>, Option<OwnedEventId>),
         (OwnedUserId, Annotation),

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -161,9 +161,9 @@ impl EventTimelineItem {
     /// Returns `None` if this event hasn't been echoed back by the server
     /// yet.
     pub fn raw(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
-        match self {
-            Self::Local(local_event) => local_event.raw.as_ref(),
-            Self::Remote(remote_event) => remote_event.raw.as_ref(),
+        match &self {
+            Self::Local(local_event) => None,
+            Self::Remote(ref remote_event) => Some(&remote_event.raw),
         }
     }
 
@@ -194,10 +194,6 @@ pub struct LocalEventTimelineItem {
     pub timestamp: MilliSecondsSinceUnixEpoch,
     /// The content of the event.
     pub content: TimelineItemContent,
-    /// Encryption information.
-    pub encryption_info: Option<EncryptionInfo>,
-    // FIXME: Expose the raw JSON of aggregated events somehow
-    pub raw: Option<Raw<AnySyncTimelineEvent>>,
 }
 
 impl LocalEventTimelineItem {
@@ -221,8 +217,6 @@ impl fmt::Debug for LocalEventTimelineItem {
             .field("sender", &self.sender)
             .field("timestamp", &self.timestamp)
             .field("content", &self.content)
-            .field("encryption_info", &self.encryption_info)
-            // skip raw, too noisy
             .finish_non_exhaustive()
     }
 }
@@ -246,7 +240,7 @@ pub struct RemoteEventTimelineItem {
     /// Encryption information.
     pub encryption_info: Option<EncryptionInfo>,
     // FIXME: Expose the raw JSON of aggregated events somehow
-    pub raw: Option<Raw<AnySyncTimelineEvent>>,
+    pub raw: Raw<AnySyncTimelineEvent>,
 }
 
 impl RemoteEventTimelineItem {

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -207,9 +207,9 @@ impl LocalEventTimelineItem {
     }
 }
 
-impl Into<EventTimelineItem> for LocalEventTimelineItem {
-    fn into(self) -> EventTimelineItem {
-        EventTimelineItem::Local(self)
+impl From<LocalEventTimelineItem> for EventTimelineItem {
+    fn from(value: LocalEventTimelineItem) -> Self {
+        Self::Local(value)
     }
 }
 
@@ -274,9 +274,9 @@ impl RemoteEventTimelineItem {
     }
 }
 
-impl Into<EventTimelineItem> for RemoteEventTimelineItem {
-    fn into(self) -> EventTimelineItem {
-        EventTimelineItem::Remote(self)
+impl From<RemoteEventTimelineItem> for EventTimelineItem {
+    fn from(value: RemoteEventTimelineItem) -> Self {
+        Self::Remote(value)
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -65,6 +65,22 @@ pub enum EventTimelineItem {
 }
 
 impl EventTimelineItem {
+    /// Get the `LocalEventTimelineItem` if `self` is `Local`.
+    pub fn as_local(&self) -> Option<&LocalEventTimelineItem> {
+        match self {
+            Self::Local(local_event_item) => Some(local_event_item),
+            Self::Remote(_) => None,
+        }
+    }
+
+    /// Get the `RemoteEventTimelineItem` if `self` is `Remote`.
+    pub fn as_remote(&self) -> Option<&RemoteEventTimelineItem> {
+        match self {
+            Self::Local(_) => None,
+            Self::Remote(remote_event_item) => Some(remote_event_item),
+        }
+    }
+
     /// Get the event ID of this item.
     ///
     /// If this returns `Some(_)`, the event was successfully created by the
@@ -164,20 +180,21 @@ impl EventTimelineItem {
 #[derive(Clone)]
 pub struct LocalEventTimelineItem {
     /// The transaction ID.
-    pub(super) transaction_id: OwnedTransactionId,
+    pub transaction_id: OwnedTransactionId,
     /// The event ID received from the server in the event-sending response.
-    pub(super) event_id: Option<OwnedEventId>,
+    pub event_id: Option<OwnedEventId>,
     /// The sender of the event.
-    pub(super) sender: OwnedUserId,
+    pub sender: OwnedUserId,
     /// The sender's profile of the event.
-    pub(super) sender_profile: Profile,
+    pub sender_profile: Profile,
     /// The timestamp of the event.
-    pub(super) timestamp: MilliSecondsSinceUnixEpoch,
+    pub timestamp: MilliSecondsSinceUnixEpoch,
     /// The content of the event.
-    pub(super) content: TimelineItemContent,
-    pub(super) encryption_info: Option<EncryptionInfo>,
+    pub content: TimelineItemContent,
+    /// Encryption information.
+    pub encryption_info: Option<EncryptionInfo>,
     // FIXME: Expose the raw JSON of aggregated events somehow
-    pub(super) raw: Option<Raw<AnySyncTimelineEvent>>,
+    pub raw: Option<Raw<AnySyncTimelineEvent>>,
 }
 
 impl LocalEventTimelineItem {
@@ -209,22 +226,24 @@ impl fmt::Debug for LocalEventTimelineItem {
 
 #[derive(Clone)]
 pub struct RemoteEventTimelineItem {
-    pub(super) event_id: OwnedEventId,
+    /// The event ID.
+    pub event_id: OwnedEventId,
     /// The sender of the event.
-    pub(super) sender: OwnedUserId,
+    pub sender: OwnedUserId,
     /// The sender's profile of the event.
-    pub(super) sender_profile: Profile,
+    pub sender_profile: Profile,
     /// The timestamp of the event.
-    pub(super) timestamp: MilliSecondsSinceUnixEpoch,
+    pub timestamp: MilliSecondsSinceUnixEpoch,
     /// The content of the event.
-    pub(super) content: TimelineItemContent,
+    pub content: TimelineItemContent,
     /// All bundled reactions about the event.
-    pub(super) reactions: BundledReactions,
+    pub reactions: BundledReactions,
     /// Whether the event has been sent by the the logged-in user themselves..
-    pub(super) is_own: bool,
-    pub(super) encryption_info: Option<EncryptionInfo>,
+    pub is_own: bool,
+    /// Encryption information.
+    pub encryption_info: Option<EncryptionInfo>,
     // FIXME: Expose the raw JSON of aggregated events somehow
-    pub(super) raw: Option<Raw<AnySyncTimelineEvent>>,
+    pub raw: Option<Raw<AnySyncTimelineEvent>>,
 }
 
 impl RemoteEventTimelineItem {
@@ -242,6 +261,13 @@ impl RemoteEventTimelineItem {
             reactions: BundledReactions::default(),
             ..self.clone()
         }
+    }
+
+    /// Get the reactions of this item.
+    pub fn reactions(&self) -> &IndexMap<String, ReactionDetails> {
+        // FIXME: Find out the state of incomplete bundled reactions, adjust
+        //        Ruma if necessary, return the whole BundledReactions field
+        &self.reactions.bundled
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -180,7 +180,7 @@ impl EventTimelineItem {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LocalEventTimelineItem {
     /// The transaction ID.
     pub transaction_id: OwnedTransactionId,
@@ -206,18 +206,6 @@ impl LocalEventTimelineItem {
 impl From<LocalEventTimelineItem> for EventTimelineItem {
     fn from(value: LocalEventTimelineItem) -> Self {
         Self::Local(value)
-    }
-}
-
-impl fmt::Debug for LocalEventTimelineItem {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LocalEventTimelineItem")
-            .field("transaction_id", &self.transaction_id)
-            .field("event_id", &self.event_id)
-            .field("sender", &self.sender)
-            .field("timestamp", &self.timestamp)
-            .field("content", &self.content)
-            .finish_non_exhaustive()
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -161,9 +161,9 @@ impl EventTimelineItem {
     /// Returns `None` if this event hasn't been echoed back by the server
     /// yet.
     pub fn raw(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
-        match &self {
+        match self {
             Self::Local(_local_event) => None,
-            Self::Remote(ref remote_event) => Some(&remote_event.raw),
+            Self::Remote(remote_event) => Some(&remote_event.raw),
         }
     }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -162,7 +162,7 @@ impl EventTimelineItem {
     /// yet.
     pub fn raw(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
         match &self {
-            Self::Local(local_event) => None,
+            Self::Local(_local_event) => None,
             Self::Remote(ref remote_event) => Some(&remote_event.raw),
         }
     }

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -28,7 +28,7 @@ use super::{
         update_read_marker, Flow, HandleEventResult, TimelineEventHandler, TimelineEventKind,
         TimelineEventMetadata, TimelineItemPosition,
     },
-    find_event_by_id, find_event_by_txn_id, EventTimelineItem, Profile, TimelineItem, TimelineKey,
+    find_event_by_id, find_event_by_txn_id, EventTimelineItem, Profile, TimelineItem,
 };
 use crate::{
     events::SyncTimelineEventWithoutContent,
@@ -46,7 +46,8 @@ pub(super) struct TimelineInner<P: ProfileProvider = room::Common> {
 #[derive(Debug, Default)]
 pub(super) struct TimelineInnerMetadata {
     // Reaction event / txn ID => sender and reaction data
-    pub(super) reaction_map: HashMap<TimelineKey, (OwnedUserId, Annotation)>,
+    pub(super) reaction_map:
+        HashMap<(Option<OwnedTransactionId>, Option<OwnedEventId>), (OwnedUserId, Annotation)>,
     pub(super) fully_read_event: Option<OwnedEventId>,
     /// Whether the event that the fully-ready event _refers to_ is part of the
     /// timeline.

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -254,7 +254,6 @@ impl<P: ProfileProvider> TimelineInner<P> {
                         if session_ids.contains(session_id.as_str()) =>
                     {
                         let EventTimelineItem::Remote(RemoteEventTimelineItem { event_id, raw, .. }) = event_item else {
-                        // let TimelineKey::EventId(event_id) = &event_item.key else {
                             error!("Key for unable-to-decrypt timeline item is not an event ID");
                             return None;
                         };

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -163,9 +163,7 @@ impl<P: ProfileProvider> TimelineInner<P> {
 
             lock.set_cloned(
                 idx,
-                Arc::new(TimelineItem::Event(EventTimelineItem::Local(
-                    local_event_item.with_event_id(event_id),
-                ))),
+                Arc::new(TimelineItem::Event(local_event_item.with_event_id(event_id).into())),
             );
         } else if find_event_by_id(&lock, &event_id).is_none() {
             // Event isn't found by transaction ID, and also not by event ID

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -258,11 +258,6 @@ impl<P: ProfileProvider> TimelineInner<P> {
                             return None;
                         };
 
-                        let Some(raw) = raw else {
-                            error!("No raw event in unable-to-decrypt timeline item");
-                            return None;
-                        };
-
                         Some((
                             idx,
                             event_id.to_owned(),

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -437,7 +437,7 @@ fn find_event_by_txn_id<'a>(
             EventTimelineItem::Local(local_event_item) => Some((idx, local_event_item)),
             _ => None,
         })
-        .rfind(|(_, local_event_item)| &local_event_item.transaction_id == txn_id)
+        .rfind(|(_, local_event_item)| local_event_item.transaction_id == txn_id)
 }
 
 fn find_read_marker(items: &[Arc<TimelineItem>]) -> Option<usize> {

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -48,6 +48,11 @@ mod tests;
 mod to_device;
 mod virtual_item;
 
+use self::{
+    event_item::LocalEventTimelineItem,
+    inner::{TimelineInner, TimelineInnerMetadata},
+    to_device::{handle_forwarded_room_key_event, handle_room_key_event},
+};
 pub use self::{
     event_item::{
         AnyOtherFullStateEventContent, EncryptedMessage, EventTimelineItem, MemberProfileChange,
@@ -56,10 +61,6 @@ pub use self::{
     },
     pagination::{PaginationOptions, PaginationOutcome},
     virtual_item::VirtualTimelineItem,
-};
-use self::{
-    inner::{TimelineInner, TimelineInnerMetadata},
-    to_device::{handle_forwarded_room_key_event, handle_room_key_event},
 };
 
 /// A high-level view into a regular¹ room's contents.
@@ -428,12 +429,15 @@ fn find_event_by_id<'a>(
 fn find_event_by_txn_id<'a>(
     items: &'a [Arc<TimelineItem>],
     txn_id: &TransactionId,
-) -> Option<(usize, &'a EventTimelineItem)> {
+) -> Option<(usize, &'a LocalEventTimelineItem)> {
     items
         .iter()
         .enumerate()
-        .filter_map(|(idx, item)| Some((idx, item.as_event()?)))
-        .rfind(|(_, it)| it.key == *txn_id)
+        .filter_map(|(idx, event_item)| match event_item.as_event()? {
+            EventTimelineItem::Local(local_event_item) => Some((idx, local_event_item)),
+            _ => None,
+        })
+        .rfind(|(_, local_event_item)| &local_event_item.transaction_id == txn_id)
 }
 
 fn find_read_marker(items: &[Arc<TimelineItem>]) -> Option<usize> {

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -57,7 +57,7 @@ pub use self::{
     event_item::{
         AnyOtherFullStateEventContent, EncryptedMessage, EventTimelineItem, MemberProfileChange,
         MembershipChange, Message, OtherState, Profile, ReactionDetails, RoomMembershipChange,
-        Sticker, TimelineDetails, TimelineItemContent, TimelineKey,
+        Sticker, TimelineDetails, TimelineItemContent,
     },
     pagination::{PaginationOptions, PaginationOutcome},
     virtual_item::VirtualTimelineItem,

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -56,7 +56,7 @@ use serde_json::{json, Value as JsonValue};
 use super::{
     event_item::AnyOtherFullStateEventContent, inner::ProfileProvider, EncryptedMessage,
     EventTimelineItem, MembershipChange, Profile, TimelineInner, TimelineItem, TimelineItemContent,
-    TimelineKey, VirtualTimelineItem,
+    VirtualTimelineItem,
 };
 
 static ALICE: Lazy<&UserId> = Lazy::new(|| user_id!("@alice:server.name"));

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -55,8 +55,8 @@ use serde_json::{json, Value as JsonValue};
 
 use super::{
     event_item::AnyOtherFullStateEventContent, inner::ProfileProvider, EncryptedMessage,
-    MembershipChange, Profile, TimelineInner, TimelineItem, TimelineItemContent, TimelineKey,
-    VirtualTimelineItem,
+    EventTimelineItem, MembershipChange, Profile, TimelineInner, TimelineItem, TimelineItemContent,
+    TimelineKey, VirtualTimelineItem,
 };
 
 static ALICE: Lazy<&UserId> = Lazy::new(|| user_id!("@alice:server.name"));
@@ -70,26 +70,26 @@ async fn reaction_redaction() {
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("hi!")).await;
     let _day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let event = item.as_event().unwrap();
+    let event = item.as_event().unwrap().as_remote().unwrap();
     assert_eq!(event.reactions().len(), 0);
 
-    let msg_event_id = event.event_id().unwrap();
+    let msg_event_id = &event.event_id;
 
     let rel = Annotation::new(msg_event_id.to_owned(), "+1".to_owned());
     timeline.handle_live_message_event(&BOB, ReactionEventContent::new(rel)).await;
     let item =
         assert_matches!(stream.next().await, Some(VecDiff::UpdateAt { index: 1, value }) => value);
-    let event = item.as_event().unwrap();
+    let event = item.as_event().unwrap().as_remote().unwrap();
     assert_eq!(event.reactions().len(), 1);
 
     // TODO: After adding raw timeline items, check for one here
 
-    let reaction_event_id = event.event_id().unwrap();
+    let reaction_event_id = event.event_id.as_ref();
 
     timeline.handle_live_redaction(&BOB, reaction_event_id).await;
     let item =
         assert_matches!(stream.next().await, Some(VecDiff::UpdateAt { index: 1, value }) => value);
-    let event = item.as_event().unwrap();
+    let event = item.as_event().unwrap().as_remote().unwrap();
     assert_eq!(event.reactions().len(), 0);
 }
 
@@ -101,11 +101,11 @@ async fn invalid_edit() {
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("test")).await;
     let _day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let event = item.as_event().unwrap();
+    let event = item.as_event().unwrap().as_remote().unwrap();
     let msg = event.content.as_message().unwrap();
     assert_eq!(msg.body(), "test");
 
-    let msg_event_id = event.event_id().unwrap();
+    let msg_event_id = &event.event_id;
 
     let edit = assign!(RoomMessageEventContent::text_plain(" * fake"), {
         relates_to: Some(message::Relation::Replacement(Replacement::new(
@@ -244,9 +244,9 @@ async fn unable_to_decrypt() {
 
     let item =
         assert_matches!(stream.next().await, Some(VecDiff::UpdateAt { index: 1, value }) => value);
-    let event = item.as_event().unwrap();
+    let event = item.as_event().unwrap().as_remote().unwrap();
     assert_matches!(&event.encryption_info, Some(_));
-    let text = assert_matches!(event.content(), TimelineItemContent::Message(msg) => msg.body());
+    let text = assert_matches!(&event.content, TimelineItemContent::Message(msg) => msg.body());
     assert_eq!(text, "It's a secret to everybody");
 }
 
@@ -309,15 +309,12 @@ async fn invalid_event_content() {
 
     let _day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let event_item = item.as_event().unwrap();
-    assert_eq!(event_item.sender(), "@alice:example.org");
-    assert_eq!(
-        *event_item.key(),
-        TimelineKey::EventId(event_id!("$eeG0HA0FAZ37wP8kXlNkxx3I").to_owned())
-    );
-    assert_eq!(event_item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(10)));
+    let event_item = item.as_event().unwrap().as_remote().unwrap();
+    assert_eq!(event_item.sender, "@alice:example.org");
+    assert_eq!(event_item.event_id, event_id!("$eeG0HA0FAZ37wP8kXlNkxx3I").to_owned());
+    assert_eq!(event_item.timestamp, MilliSecondsSinceUnixEpoch(uint!(10)));
     let event_type = assert_matches!(
-        event_item.content(),
+        &event_item.content,
         TimelineItemContent::FailedToParseMessageLike { event_type, .. } => event_type
     );
     assert_eq!(*event_type, MessageLikeEventType::RoomMessage);
@@ -336,15 +333,12 @@ async fn invalid_event_content() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let event_item = item.as_event().unwrap();
-    assert_eq!(event_item.sender(), "@alice:example.org");
-    assert_eq!(
-        *event_item.key(),
-        TimelineKey::EventId(event_id!("$d5G0HA0FAZ37wP8kXlNkxx3I").to_owned())
-    );
-    assert_eq!(event_item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(2179)));
+    let event_item = item.as_event().unwrap().as_remote().unwrap();
+    assert_eq!(event_item.sender, "@alice:example.org");
+    assert_eq!(event_item.event_id, event_id!("$d5G0HA0FAZ37wP8kXlNkxx3I").to_owned());
+    assert_eq!(event_item.timestamp, MilliSecondsSinceUnixEpoch(uint!(2179)));
     let (event_type, state_key) = assert_matches!(
-        event_item.content(),
+        &event_item.content,
         TimelineItemContent::FailedToParseState {
             event_type,
             state_key,
@@ -352,7 +346,7 @@ async fn invalid_event_content() {
         } => (event_type, state_key)
     );
     assert_eq!(*event_type, StateEventType::RoomMember);
-    assert_eq!(*state_key, "@alice:example.org");
+    assert_eq!(state_key, "@alice:example.org");
 }
 
 #[async_test]
@@ -390,7 +384,7 @@ async fn remote_echo_without_txn_id() {
     let _day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    assert_matches!(item.as_event().unwrap().key(), TimelineKey::TransactionId { .. });
+    assert_matches!(item.as_event().unwrap(), EventTimelineItem::Local(_));
 
     // That has an event ID assigned already (from the response to sending it)…
     let event_id = event_id!("$W6mZSLWMmfuQQ9jhZWeTxFIM");
@@ -398,7 +392,7 @@ async fn remote_echo_without_txn_id() {
 
     let item =
         assert_matches!(stream.next().await, Some(VecDiff::UpdateAt { value, index: 1 }) => value);
-    assert_matches!(item.as_event().unwrap().key(), TimelineKey::TransactionId { .. });
+    assert_matches!(item.as_event().unwrap(), EventTimelineItem::Local(_));
 
     // When an event with the same ID comes in…
     timeline
@@ -424,7 +418,7 @@ async fn remote_echo_without_txn_id() {
 
     // … and the remote echo is added.
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    assert_matches!(item.as_event().unwrap().key(), TimelineKey::EventId(_));
+    assert_matches!(item.as_event().unwrap(), EventTimelineItem::Remote(_));
 }
 
 #[async_test]
@@ -442,11 +436,8 @@ async fn remote_echo_new_position() {
     let _day_divider = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
 
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    let txn_id_from_event = assert_matches!(
-        item.as_event().unwrap().key(),
-        TimelineKey::TransactionId { txn_id, .. } => txn_id
-    );
-    assert_eq!(txn_id, *txn_id_from_event);
+    let txn_id_from_event = item.as_event().unwrap().as_local().unwrap();
+    assert_eq!(txn_id, *txn_id_from_event.transaction_id);
 
     // … and another event that comes back before the remote echo
     timeline.handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("test")).await;
@@ -475,7 +466,7 @@ async fn remote_echo_new_position() {
 
     // … and the remote echo added
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
-    assert_matches!(item.as_event().unwrap().key(), TimelineKey::EventId(_));
+    assert_matches!(item.as_event().unwrap(), EventTimelineItem::Remote(_));
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -9,7 +9,7 @@ use matrix_sdk::{
     config::SyncSettings,
     room::timeline::{
         AnyOtherFullStateEventContent, PaginationOptions, TimelineDetails, TimelineItemContent,
-        TimelineKey, VirtualTimelineItem,
+        VirtualTimelineItem,
     },
     ruma::MilliSecondsSinceUnixEpoch,
 };

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -189,7 +189,7 @@ async fn echo() {
     let item = local_echo.as_event().unwrap().as_local().unwrap();
     assert!(item.event_id.is_none());
 
-    let msg = assert_matches!(item.content, TimelineItemContent::Message(ref msg) => msg);
+    let msg = assert_matches!(&item.content, TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(msg.msgtype(), MessageType::Text(text) => text);
     assert_eq!(text.body, "Hello, World!");
 
@@ -437,7 +437,7 @@ async fn reaction() {
         Some(VecDiff::UpdateAt { index: 1, value }) => value
     );
     let event_item = updated_message.as_event().unwrap().as_remote().unwrap();
-    let msg = assert_matches!(event_item.content, TimelineItemContent::Message(ref msg) => msg);
+    let msg = assert_matches!(&event_item.content, TimelineItemContent::Message(msg) => msg);
     assert!(!msg.is_edited());
     assert_eq!(event_item.reactions().len(), 0);
 }

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -188,7 +188,6 @@ async fn echo() {
         assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
     let item = local_echo.as_event().unwrap().as_local().unwrap();
     assert!(item.event_id.is_none());
-    assert!(item.raw.is_none());
 
     let msg = assert_matches!(item.content, TimelineItemContent::Message(ref msg) => msg);
     let text = assert_matches!(msg.msgtype(), MessageType::Text(text) => text);
@@ -203,7 +202,6 @@ async fn echo() {
     );
     let item = sent_confirmation.as_event().unwrap().as_local().unwrap();
     assert!(item.event_id.is_some());
-    assert!(item.raw.is_none());
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
@@ -235,7 +233,6 @@ async fn echo() {
     let item = remote_echo.as_event().unwrap().as_remote().unwrap();
     assert!(item.is_own);
     assert_eq!(item.timestamp, MilliSecondsSinceUnixEpoch(uint!(152038280)));
-    assert_matches!(item.raw, Some(_));
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -186,13 +186,11 @@ async fn echo() {
         assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
     let local_echo =
         assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
-    let item = local_echo.as_event().unwrap();
-    assert!(item.event_id().is_none());
-    assert!(item.is_own());
-    assert_matches!(item.key(), TimelineKey::TransactionId { .. });
-    assert_matches!(item.raw(), None);
+    let item = local_echo.as_event().unwrap().as_local().unwrap();
+    assert!(item.event_id.is_none());
+    assert!(item.raw.is_none());
 
-    let msg = assert_matches!(item.content(), TimelineItemContent::Message(msg) => msg);
+    let msg = assert_matches!(item.content, TimelineItemContent::Message(ref msg) => msg);
     let text = assert_matches!(msg.msgtype(), MessageType::Text(text) => text);
     assert_eq!(text.body, "Hello, World!");
 
@@ -203,11 +201,9 @@ async fn echo() {
         timeline_stream.next().await,
         Some(VecDiff::UpdateAt { index: 1, value }) => value
     );
-    let item = sent_confirmation.as_event().unwrap();
-    assert!(item.event_id().is_some());
-    assert!(item.is_own());
-    assert_matches!(item.key(), TimelineKey::TransactionId { .. });
-    assert_matches!(item.raw(), None);
+    let item = sent_confirmation.as_event().unwrap().as_local().unwrap();
+    assert!(item.event_id.is_some());
+    assert!(item.raw.is_none());
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
@@ -236,12 +232,10 @@ async fn echo() {
 
     let remote_echo =
         assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
-    let item = remote_echo.as_event().unwrap();
-    assert!(item.event_id().is_some());
-    assert!(item.is_own());
-    assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(152038280)));
-    assert_matches!(item.key(), TimelineKey::EventId(_));
-    assert_matches!(item.raw(), Some(_));
+    let item = remote_echo.as_event().unwrap().as_remote().unwrap();
+    assert!(item.is_own);
+    assert_eq!(item.timestamp, MilliSecondsSinceUnixEpoch(uint!(152038280)));
+    assert_matches!(item.raw, Some(_));
 }
 
 #[async_test]
@@ -415,8 +409,8 @@ async fn reaction() {
         timeline_stream.next().await,
         Some(VecDiff::UpdateAt { index: 1, value }) => value
     );
-    let event_item = updated_message.as_event().unwrap();
-    let msg = assert_matches!(event_item.content(), TimelineItemContent::Message(msg) => msg);
+    let event_item = updated_message.as_event().unwrap().as_remote().unwrap();
+    let msg = assert_matches!(event_item.content, TimelineItemContent::Message(ref msg) => msg);
     assert!(!msg.is_edited());
     assert_eq!(event_item.reactions().len(), 1);
     let details = &event_item.reactions()["👍"];
@@ -445,8 +439,8 @@ async fn reaction() {
         timeline_stream.next().await,
         Some(VecDiff::UpdateAt { index: 1, value }) => value
     );
-    let event_item = updated_message.as_event().unwrap();
-    let msg = assert_matches!(event_item.content(), TimelineItemContent::Message(msg) => msg);
+    let event_item = updated_message.as_event().unwrap().as_remote().unwrap();
+    let msg = assert_matches!(event_item.content, TimelineItemContent::Message(ref msg) => msg);
     assert!(!msg.is_edited());
     assert_eq!(event_item.reactions().len(), 0);
 }

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -407,7 +407,7 @@ async fn reaction() {
         Some(VecDiff::UpdateAt { index: 1, value }) => value
     );
     let event_item = updated_message.as_event().unwrap().as_remote().unwrap();
-    let msg = assert_matches!(event_item.content, TimelineItemContent::Message(ref msg) => msg);
+    let msg = assert_matches!(&event_item.content, TimelineItemContent::Message(msg) => msg);
     assert!(!msg.is_edited());
     assert_eq!(event_item.reactions().len(), 1);
     let details = &event_item.reactions()["👍"];


### PR DESCRIPTION
`EventTimelineItem` represents an event item that can be either _local_ or _remote_. _Local_ means that the event has been sent to the server, but not acknowledged, and _remote_ means that the server has acknowledged the event.

Before this patch, to differentiate between the _local_ and _remote_ states, one has to use the `key: TimelineKey` field, which has 2 variants: `TransactionId` and `EventId`, resp. for _local_ and _remote_ states. It's not ideal, but on top of that, `EventTimelineItem` has useless fields depending of the state. For instance, `is_own` is useless in the _local_ state, or `reactions` that is useless for the moment in the _local_ state, or even `transaction_id` that is useless in the _remote_ state, or even `raw` that is always `None` in _local_ state and always `Some` in _remote_ state. Well, you get it. Not only we have optional values (`Option<T>`) in multiple places, which is sub-optimal, but it's also error-prone: it's super easy to create broken states.

This patch changes `struct EvenTimelineItem` to be:

```rs
enum EventTimelineItem {
    Local(LocalEventTimelineItem),
    Remote(RemoteEventTimelineItem),
}
```

And thus, this patch also introduces 2 new types:

```rs
pub struct LocalEventTimelineItem {
    pub transaction_id: OwnedTransactionId,
    pub event_id: Option<OwnedEventId>,
    pub sender: OwnedUserId,
    pub sender_profile: Profile,
    pub timestamp: MilliSecondsSinceUnixEpoch,
    pub content: TimelineItemContent,
}

pub struct RemoteEventTimelineItem {
    pub event_id: OwnedEventId,
    pub sender: OwnedUserId,
    pub sender_profile: Profile,
    pub timestamp: MilliSecondsSinceUnixEpoch,
    pub content: TimelineItemContent,
    pub reactions: BundledReactions,
    pub is_own: bool,
    pub encryption_info: Option<EncryptionInfo>,
    pub raw: Raw<AnySyncTimelineEvent>,
}
```

I believe this change will fix the problems mentioned above, but will also simplify the introduction of new features later (without constructing broken states).

Fun fact, now the `TimelineKey` can be removed, as it is useless. It's only used in a `reactions_map`, however it's straightforward to address that.

- [x] Update `matrix-sdk`
  - [x] Migrate `EventTimelineItem`
  - [x] Remove `TimelineKey`
- [x] Update `matrix-sdk-ffi`