### PR TITLE
feat(bindings): Add support to output Jaeger JSON files for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
+dependencies = [
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "async-lock"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +595,9 @@ name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cesu8"
@@ -1621,6 +1638,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
 name = "findshlibs"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2287,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2345,6 +2380,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -2819,6 +2863,7 @@ version = "0.2.0"
 dependencies = [
  "android_logger",
  "anyhow",
+ "async-compression",
  "extension-trait",
  "futures-core",
  "futures-signals",
@@ -2827,12 +2872,17 @@ dependencies = [
  "matrix-sdk",
  "mime",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-contrib",
+ "opentelemetry-jaeger",
  "sanitize-filename-reader-friendly",
  "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-tar",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uniffi",
  "uniffi_build",
@@ -3338,6 +3388,101 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-contrib"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6171a92e47498eb95845189db332ab85721a51ba924349243192b28141d3fd8"
+dependencies = [
+ "async-trait",
+ "futures",
+ "opentelemetry",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e785d273968748578931e4dc3b4f5ec86b26e09d9e0d66b55adda7fce742f7a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-executor",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "thiserror",
+ "thrift",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b02e0230abb0ab6636d18e2ba8fa02903ea63772281340ccac18e0af3ec9eeb"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "percent-encoding",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4718,6 +4863,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "thrift"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09678c4cdbb4eed72e18b7c2af1329c69825ed16fcbac62d083fc3e2b0590ff0"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float",
+ "threadpool",
+]
+
+[[package]]
 name = "tiff"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4876,6 +5043,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50188549787c32c1c3d9c8c71ad7e003ccf2f102489c5a96e385c84760477f4"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4999,6 +5181,20 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5680,6 +5876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "xdg"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5735,4 +5940,34 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.5+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc50ffce891ad571e9f9afe5039c4837bede781ac4bb13052ed7ae695518596"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -12,11 +12,23 @@ repository = "https://github.com/matrix-org/matrix-rust-sdk"
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
+[features]
+default = []
+jaeger-rageshakes = [
+    "dep:async-compression",
+    "dep:opentelemetry",
+    "dep:opentelemetry-jaeger",
+    "dep:opentelemetry-contrib",
+    "dep:tokio-tar",
+    "dep:tracing-opentelemetry",
+]
+
 [build-dependencies]
 uniffi_build = { workspace = true, features = ["builtin-bindgen"] }
 
 [dependencies]
 anyhow = { workspace = true }
+async-compression = { version = "0.3.15", features = ["tokio", "zstd"], optional = true }
 extension-trait = "1.0.1"
 futures-core = "0.3.17"
 futures-signals = { version = "0.3.30", default-features = false }
@@ -25,20 +37,24 @@ mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014
 once_cell = { workspace = true }
+opentelemetry = { version = "0.18.0", optional = true }
+opentelemetry-contrib = { version = "0.10.0", features = ["jaeger_json_exporter", "rt-tokio"], optional = true }
+opentelemetry-jaeger = { version = "0.17.0", optional = true }
 sanitize-filename-reader-friendly = "2.2.1"
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-stream = "0.1.8"
+tokio-tar = { version = "0.3.0", optional = true }
+tracing-opentelemetry = { version = "0.18.0", optional = true }
 uniffi = { workspace = true }
 uniffi_macros = { workspace = true }
 zeroize = { workspace = true }
 
-
 [target.'cfg(target_os = "android")'.dependencies]
 tracing = { version = "0.1.29", default-features = false, features = ["log"] }
 android_logger = "0.11"
-log-panics = { version = "2", features = ["with-backtrace"]}
+log-panics = { version = "2", features = ["with-backtrace"] }
 matrix-sdk = { path = "../../crates/matrix-sdk", default-features = false, features = ["anyhow", "experimental-timeline", "e2e-encryption", "sled", "markdown", "experimental-sliding-sync", "socks", "rustls-tls"], version = "0.6.0" }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -21,6 +21,8 @@ macro_rules! unwrap_or_clone_arc_into_variant {
 }
 
 mod platform;
+#[cfg(feature = "jaeger-rageshakes")]
+mod rageshake;
 
 pub mod authentication_service;
 pub mod client;

--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -43,7 +43,7 @@ mod ios {
 
         let runtime = RUNTIME.handle().to_owned();
 
-        let tracer = create_rageshake_tracer(path.into(), &client_name, runtime);
+        let tracer = crate::rageshake::create_rageshake_tracer(path.into(), &client_name, runtime);
         let layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
         tracing_subscriber::registry()

--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -29,10 +29,27 @@ mod ios {
     use std::io;
 
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
     pub fn setup_tracing(configuration: String) {
         tracing_subscriber::registry()
             .with(EnvFilter::new(configuration))
             .with(fmt::layer().with_ansi(false).with_writer(io::stderr))
+            .init();
+    }
+
+    #[cfg(feature = "jaeger-rageshakes")]
+    pub fn setup_tracing_with_jaeger(configuration: String, client_name: String, path: String) {
+        use crate::RUNTIME;
+
+        let runtime = RUNTIME.handle().to_owned();
+
+        let tracer = create_rageshake_tracer(path.into(), &client_name, runtime);
+        let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+        tracing_subscriber::registry()
+            .with(EnvFilter::new(configuration))
+            .with(fmt::layer().with_ansi(true).with_writer(io::stderr))
+            .with(layer)
             .init();
     }
 }
@@ -54,4 +71,24 @@ mod other {
 #[uniffi::export]
 pub fn setup_tracing(filter: String) {
     platform_impl::setup_tracing(filter)
+}
+
+/// Enable tracing where plaintext logs get output to STDOUT and traces in the
+/// Jaeger JSON format[1].
+///
+/// The `client_name` is used to prefix the Jaeger JSON files. `configuration`
+/// is the usual RUST_LOG trace configuration string.
+///
+///
+/// The logger will output the Jaeger JSON files into the given `path`,
+/// periodically those files will be collected and put into a compressed
+/// archive. The source JSON files will be cleaned up, but the compressed
+/// archives will be left. The caller needs to ensure that unneeded archive
+/// files get cleaned up.
+///
+/// [1]: https://www.jaegertracing.io/docs/1.23/apis/
+#[uniffi::export]
+#[cfg(all(target_os = "ios", feature = "jaeger-rageshakes"))]
+pub fn setup_tracing_with_jaeger(configuration: String, client_name: String, path: String) {
+    platform_impl::setup_tracing_with_jaeger(configuration, client_name, path)
 }

--- a/bindings/matrix-sdk-ffi/src/rageshake.rs
+++ b/bindings/matrix-sdk-ffi/src/rageshake.rs
@@ -1,0 +1,223 @@
+use std::{
+    path::{Path, PathBuf},
+    time::UNIX_EPOCH,
+};
+
+use async_compression::tokio::write::ZstdEncoder;
+use futures_core::future::BoxFuture;
+use matrix_sdk::async_trait;
+use opentelemetry::{
+    sdk::{
+        export::trace::ExportResult,
+        trace::{BatchMessage, TraceRuntime, Tracer},
+        util::tokio_interval_stream,
+    },
+    trace::TraceError,
+};
+use opentelemetry_contrib::trace::exporter::jaeger_json::JaegerJsonRuntime;
+use tokio::{
+    fs::{DirEntry, File},
+    io::{AsyncReadExt, AsyncWriteExt},
+    runtime::Handle,
+};
+use tokio_tar::Builder;
+
+/// This is only used on ios for now, so let's allow dead code.
+#[allow(dead_code)]
+pub fn create_rageshake_tracer(path: PathBuf, client_name: &str, runtime: Handle) -> Tracer {
+    use opentelemetry_contrib::trace::exporter::jaeger_json::JaegerJsonExporter;
+
+    let tracer_runtime = RageshakeTracingRuntime {
+        file_prefix: format!("{client_name}-trace"),
+        runtime: runtime.to_owned(),
+        directory: path.to_owned(),
+    };
+
+    let _guard = runtime.enter();
+
+    JaegerJsonExporter::new(
+        path,
+        tracer_runtime.file_prefix.to_owned(),
+        client_name.to_owned(),
+        tracer_runtime,
+    )
+    .install_batch()
+}
+
+#[derive(Clone, Debug)]
+struct RageshakeTracingRuntime {
+    file_prefix: String,
+    runtime: Handle,
+    directory: PathBuf,
+}
+
+impl RageshakeTracingRuntime {
+    const MAX_PLAINTEXT_FILES: usize = 200;
+    const COMPRESSED_FILES_PER_PLAINTEXT: usize = 200;
+
+    async fn is_a_trace_file(&self, entry: &DirEntry) -> std::io::Result<bool> {
+        let file_type = entry.file_type().await?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+
+        Ok(file_name.starts_with(&self.file_prefix)
+            && file_name.ends_with("json")
+            && file_type.is_file())
+    }
+
+    async fn collect_and_compress(&self) -> std::io::Result<()> {
+        let mut dir = tokio::fs::read_dir(&self.directory).await?;
+        let mut files: Vec<_> = vec![];
+
+        while let Some(item) = dir.next_entry().await? {
+            if self.is_a_trace_file(&item).await? {
+                files.push(item);
+            }
+        }
+
+        if files.len() >= Self::MAX_PLAINTEXT_FILES {
+            self.compress_and_cleanup(files).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn archive(path: &Path, files: &[DirEntry]) -> std::io::Result<()> {
+        let archive = File::create(path).await?;
+        let mut archiver = Builder::new(archive);
+
+        for item in files {
+            archiver.append_path_with_name(item.path(), item.file_name()).await?;
+        }
+
+        archiver.finish().await?;
+
+        Ok(())
+    }
+
+    async fn compress(archive_path: &Path) -> std::io::Result<()> {
+        let mut buffer = [0u8; 2048];
+
+        let mut file_path = archive_path.to_owned();
+        file_path.set_extension("tar.zstd");
+
+        let mut archive = File::open(&archive_path).await?;
+        let output_file = File::create(file_path).await?;
+        let mut encoder = ZstdEncoder::new(output_file);
+
+        loop {
+            let read = archive.read(&mut buffer).await?;
+
+            if read == 0 {
+                break;
+            } else {
+                encoder.write(&buffer[..read]).await?;
+            }
+        }
+
+        encoder.shutdown().await?;
+
+        Ok(())
+    }
+
+    /// Collect all trace files we found into an archive and compress it, remove
+    /// the source JSON files afterwards.
+    async fn compress_and_cleanup(&self, mut files: Vec<DirEntry>) -> std::io::Result<()> {
+        files.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+
+        let chunks = files.chunks_exact(Self::COMPRESSED_FILES_PER_PLAINTEXT);
+
+        let now = std::time::SystemTime::now();
+        let duration = now
+            .duration_since(UNIX_EPOCH)
+            .expect("We can always calculate the unix timestamp")
+            .as_secs();
+
+        // We don't want to create a huge tar bomb, so let's limit the amount of files
+        // per archive.
+        for (chunk_number, files) in chunks.enumerate() {
+            let mut path = self.directory.to_owned();
+
+            let file_name = if chunk_number == 0 {
+                format!("weechat-matrix-traces-{}", duration)
+            } else {
+                format!("weechat-matrix-traces-{}-{}", duration, chunk_number)
+            };
+
+            path.push(file_name);
+
+            let mut archive_path = path.to_owned();
+            archive_path.set_extension("tar");
+
+            Self::archive(&archive_path, files).await?;
+            Self::compress(&archive_path).await?;
+
+            tokio::fs::remove_file(archive_path).await?;
+
+            for file in files {
+                tokio::fs::remove_file(file.path()).await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl opentelemetry::runtime::Runtime for RageshakeTracingRuntime {
+    type Interval = tokio_stream::wrappers::IntervalStream;
+    type Delay = ::std::pin::Pin<Box<tokio::time::Sleep>>;
+
+    fn interval(&self, duration: std::time::Duration) -> Self::Interval {
+        let _guard = self.runtime.enter();
+        tokio_interval_stream(duration)
+    }
+
+    fn spawn(&self, future: BoxFuture<'static, ()>) {
+        let _ = self.runtime.spawn(future);
+    }
+
+    fn delay(&self, duration: std::time::Duration) -> Self::Delay {
+        let _guard = self.runtime.enter();
+        Box::pin(tokio::time::sleep(duration))
+    }
+}
+
+impl TraceRuntime for RageshakeTracingRuntime {
+    type Receiver = tokio_stream::wrappers::ReceiverStream<BatchMessage>;
+    type Sender = tokio::sync::mpsc::Sender<BatchMessage>;
+
+    fn batch_message_channel(&self, capacity: usize) -> (Self::Sender, Self::Receiver) {
+        let (sender, receiver) = tokio::sync::mpsc::channel(capacity);
+        (sender, tokio_stream::wrappers::ReceiverStream::new(receiver))
+    }
+}
+
+#[async_trait]
+impl JaegerJsonRuntime for RageshakeTracingRuntime {
+    async fn create_dir(&self, path: &Path) -> ExportResult {
+        let _guard = self.runtime.enter();
+        let path = path.to_owned();
+
+        if tokio::fs::metadata(&path).await.is_err() {
+            tokio::fs::create_dir_all(path).await.map_err(|e| TraceError::Other(Box::new(e)))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn write_to_file(&self, path: &Path, content: &[u8]) -> ExportResult {
+        let _guard = self.runtime.enter();
+        use tokio::io::AsyncWriteExt;
+        let path = path.to_owned();
+        let content = content.to_owned();
+
+        let mut file = File::create(path).await.map_err(|e| TraceError::Other(Box::new(e)))?;
+        file.write_all(&content).await.map_err(|e| TraceError::Other(Box::new(e)))?;
+        file.sync_data().await.map_err(|e| TraceError::Other(Box::new(e)))?;
+
+        // Should we put this in the background?
+        self.collect_and_compress().await.map_err(|e| TraceError::Other(Box::new(e)))?;
+
+        Ok(())
+    }
+}

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -125,6 +125,7 @@ impl CiArgs {
 
 fn check_bindings() -> Result<()> {
     cmd!("rustup run stable cargo build -p matrix-sdk-crypto-ffi -p matrix-sdk-ffi").run()?;
+    cmd!("rustup run stable cargo build -p matrix-sdk-crypto-ffi -p matrix-sdk-ffi --features='jaeger-rageshakes'").run()?;
     cmd!(
         "
         uniffi-bindgen generate


### PR DESCRIPTION
This adds support to output traces in the Jaeger JSOn file format that can later be imported into Jaeger. The traces get output into a directory where they will be periodically collected and compressed.