### PR TITLE
Work around duplicate events from sync

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -50,7 +50,7 @@ use ruma::{
     },
     serde::Raw,
     uint, EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedMxcUri,
-    OwnedTransactionId, OwnedUserId, UInt, UserId,
+    OwnedTransactionId, OwnedUserId, TransactionId, UInt, UserId,
 };
 
 /// An item in the timeline that represents at least one event.
@@ -81,6 +81,19 @@ impl EventTimelineItem {
         match self {
             Self::Local(_) => None,
             Self::Remote(remote_event_item) => Some(remote_event_item),
+        }
+    }
+
+    /// Get the transaction ID of this item.
+    ///
+    /// The transaction ID is only kept until the remote echo for a local event
+    /// is received, at which point the `EventTimelineItem::Local` is
+    /// transformed to `EventTimelineItem::Remote` and the transaction ID
+    /// discarded.
+    pub fn transaction_id(&self) -> Option<&TransactionId> {
+        match self {
+            Self::Local(local) => Some(&local.transaction_id),
+            Self::Remote(_) => None,
         }
     }
 

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -826,7 +826,7 @@ impl TestTimeline {
     }
 
     async fn handle_live_redaction(&self, sender: &UserId, redacts: &EventId) {
-        let ev = json! ({
+        let ev = json!({
             "type": "m.room.redaction",
             "content": {},
             "redacts": redacts,


### PR DESCRIPTION
We were previously not checking for event duplication when the event had a txn-id. With this refactoring, our event-handling code should be more robust against duplicate events from sync (but we will likely need to tweak things more in the long run to account for the potential of duplicate events from pagination, especially forwards-pagination which we haven't implemented yet).