### PR TITLE
Expose event sending errors through timeline item

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -259,14 +259,13 @@ interface Room {
     // Raises an exception if there are no timeline listeners.
     [Throws=ClientError]
     void paginate_backwards(PaginationOptions opts);
-    
+
     [Throws=ClientError]
     void send_read_receipt(string event_id);
-    
+
     [Throws=ClientError]
     void send_read_marker(string fully_read_event_id, string? read_receipt_event_id);
 
-    [Throws=ClientError]
     void send(RoomMessageEventContent msg, string? txn_id);
 
     [Throws=ClientError]

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -90,13 +90,12 @@ mod uniffi_types {
             SlidingSyncViewBuilder, StoppableSpawn, UnreadNotificationsCount,
         },
         timeline::{
-            EmoteMessageContent, EncryptedMessage, EventTimelineItem, FileInfo, FileMessageContent,
-            FormattedBody, ImageInfo, ImageMessageContent, InsertAtData,
-            LocalEventTimelineItemSendState, MembershipChange, Message, MessageFormat, MessageType,
-            NoticeMessageContent, OtherState, Profile, Reaction, TextMessageContent, ThumbnailInfo,
-            TimelineChange, TimelineDiff, TimelineItem, TimelineItemContent,
-            TimelineItemContentKind, UpdateAtData, VideoInfo, VideoMessageContent,
-            VirtualTimelineItem,
+            EmoteMessageContent, EncryptedMessage, EventSendState, EventTimelineItem, FileInfo,
+            FileMessageContent, FormattedBody, ImageInfo, ImageMessageContent, InsertAtData,
+            MembershipChange, Message, MessageFormat, MessageType, NoticeMessageContent,
+            OtherState, Profile, Reaction, TextMessageContent, ThumbnailInfo, TimelineChange,
+            TimelineDiff, TimelineItem, TimelineItemContent, TimelineItemContentKind, UpdateAtData,
+            VideoInfo, VideoMessageContent, VirtualTimelineItem,
         },
     };
 }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -177,7 +177,7 @@ pub enum EventSendState {
     NotSendYet,
     /// The local event has been sent to the server, but unsuccessfully: The
     /// sending has failed.
-    SendingFailed,
+    SendingFailed { error: String },
     /// The local event has been sent successfully to the server.
     Sent { event_id: String },
 }
@@ -188,7 +188,7 @@ impl From<&matrix_sdk::room::timeline::EventSendState> for EventSendState {
 
         match value {
             NotSentYet => Self::NotSendYet,
-            SendingFailed => Self::SendingFailed,
+            SendingFailed { error } => Self::SendingFailed { error: error.to_string() },
             Sent { event_id } => Self::Sent { event_id: event_id.to_string() },
         }
     }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -179,17 +179,17 @@ pub enum EventSendState {
     /// sending has failed.
     SendingFailed,
     /// The local event has been sent successfully to the server.
-    Sent,
+    Sent { event_id: String },
 }
 
-impl From<matrix_sdk::room::timeline::EventSendState> for EventSendState {
-    fn from(value: matrix_sdk::room::timeline::EventSendState) -> Self {
+impl From<&matrix_sdk::room::timeline::EventSendState> for EventSendState {
+    fn from(value: &matrix_sdk::room::timeline::EventSendState) -> Self {
         use matrix_sdk::room::timeline::EventSendState::*;
 
         match value {
             NotSentYet => Self::NotSendYet,
             SendingFailed => Self::SendingFailed,
-            Sent => Self::Sent,
+            Sent { event_id } => Self::Sent { event_id: event_id.to_string() },
         }
     }
 }
@@ -262,7 +262,7 @@ impl EventTimelineItem {
         use matrix_sdk::room::timeline::EventTimelineItem::*;
 
         match &self.0 {
-            Local(local_event) => Some(local_event.send_state.into()),
+            Local(local_event) => Some((&local_event.send_state).into()),
             Remote(_) => None,
         }
     }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -172,7 +172,7 @@ impl TimelineItem {
 
 /// This type represents the “send state” of a local event timeline item.
 #[derive(Clone, uniffi::Enum)]
-pub enum LocalEventTimelineItemSendState {
+pub enum EventSendState {
     /// The local event has not been sent yet.
     NotSendYet,
     /// The local event has been sent to the server, but unsuccessfully: The
@@ -182,11 +182,9 @@ pub enum LocalEventTimelineItemSendState {
     Sent,
 }
 
-impl From<matrix_sdk::room::timeline::LocalEventTimelineItemSendState>
-    for LocalEventTimelineItemSendState
-{
-    fn from(value: matrix_sdk::room::timeline::LocalEventTimelineItemSendState) -> Self {
-        use matrix_sdk::room::timeline::LocalEventTimelineItemSendState::*;
+impl From<matrix_sdk::room::timeline::EventSendState> for EventSendState {
+    fn from(value: matrix_sdk::room::timeline::EventSendState) -> Self {
+        use matrix_sdk::room::timeline::EventSendState::*;
 
         match value {
             NotSentYet => Self::NotSendYet,
@@ -260,7 +258,7 @@ impl EventTimelineItem {
         self.0.raw().map(|r| r.json().get().to_owned())
     }
 
-    pub fn local_send_state(&self) -> Option<LocalEventTimelineItemSendState> {
+    pub fn local_send_state(&self) -> Option<EventSendState> {
         use matrix_sdk::room::timeline::EventTimelineItem::*;
 
         match &self.0 {

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -512,7 +512,6 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                     EventTimelineItem::Local(LocalEventTimelineItem {
                         send_state: EventSendState::NotSentYet,
                         transaction_id: txn_id.to_owned(),
-                        event_id: None,
                         sender,
                         sender_profile,
                         timestamp: *timestamp,

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -42,9 +42,9 @@ use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 use super::{
     event_item::{
-        AnyOtherFullStateEventContent, BundledReactions, LocalEventTimelineItem,
-        LocalEventTimelineItemSendState, MemberProfileChange, OtherState, Profile,
-        RemoteEventTimelineItem, RoomMembershipChange, Sticker, TimelineDetails,
+        AnyOtherFullStateEventContent, BundledReactions, EventSendState, LocalEventTimelineItem,
+        MemberProfileChange, OtherState, Profile, RemoteEventTimelineItem, RoomMembershipChange,
+        Sticker, TimelineDetails,
     },
     find_read_marker, rfind_event_by_id, rfind_event_item, EventTimelineItem, Message,
     TimelineInnerMetadata, TimelineItem, TimelineItemContent, VirtualTimelineItem,
@@ -510,7 +510,7 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
             match &self.flow {
                 Flow::Local { txn_id, timestamp } => {
                     EventTimelineItem::Local(LocalEventTimelineItem {
-                        send_state: LocalEventTimelineItemSendState::NotSentYet,
+                        send_state: EventSendState::NotSentYet,
                         transaction_id: txn_id.to_owned(),
                         event_id: None,
                         sender,

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -108,7 +108,7 @@ impl EventTimelineItem {
     /// of the send request that created the event.
     pub fn event_id(&self) -> Option<&EventId> {
         match self {
-            Self::Local(local_event) => local_event.event_id.as_deref(),
+            Self::Local(local_event) => local_event.event_id(),
             Self::Remote(remote_event) => Some(&remote_event.event_id),
         }
     }
@@ -194,7 +194,7 @@ impl EventTimelineItem {
 }
 
 /// This type represents the "send state" of a local event timeline item.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum EventSendState {
     /// The local event has not been sent yet.
     NotSentYet,
@@ -202,7 +202,10 @@ pub enum EventSendState {
     /// sending has failed.
     SendingFailed,
     /// The local event has been sent successfully to the server.
-    Sent,
+    Sent {
+        /// The event ID assigned by the server.
+        event_id: OwnedEventId,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -211,8 +214,6 @@ pub struct LocalEventTimelineItem {
     pub send_state: EventSendState,
     /// The transaction ID.
     pub transaction_id: OwnedTransactionId,
-    /// The event ID received from the server in the event-sending response.
-    pub event_id: Option<OwnedEventId>,
     /// The sender of the event.
     pub sender: OwnedUserId,
     /// The sender's profile of the event.
@@ -224,24 +225,19 @@ pub struct LocalEventTimelineItem {
 }
 
 impl LocalEventTimelineItem {
-    /// Clone the current event item, and update its `event_id`.
+    /// Get the event ID of this item.
     ///
-    /// `event_id` is optional:
-    ///   * `Some(_)` means the local event has been sent successfully to the
-    ///     server, its send state will be moved to
-    ///     [`LocalEventTimelineItemSendState::Sent`].
-    ///   * `None` means the local event has been failed to be sent to the
-    ///     server, its send state will be moved to
-    ///     [`LocalEventTimelineItemSendState::SendingFailed`].
-    pub(super) fn with_event_id(&self, event_id: Option<OwnedEventId>) -> Self {
-        Self {
-            send_state: match &event_id {
-                Some(_) => EventSendState::Sent,
-                None => EventSendState::SendingFailed,
-            },
-            event_id,
-            ..self.clone()
+    /// Will be `Some` if and only if `send_state` is `EventSendState::Sent`.
+    pub fn event_id(&self) -> Option<&EventId> {
+        match &self.send_state {
+            EventSendState::Sent { event_id } => Some(event_id),
+            _ => None,
         }
+    }
+
+    /// Clone the current event item, and update its `send_state`.
+    pub(super) fn with_send_state(&self, send_state: EventSendState) -> Self {
+        Self { send_state, ..self.clone() }
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -53,6 +53,8 @@ use ruma::{
     OwnedTransactionId, OwnedUserId, TransactionId, UInt, UserId,
 };
 
+use crate::Error;
+
 /// An item in the timeline that represents at least one event.
 ///
 /// There is always one main event that gives the `EventTimelineItem` its
@@ -194,13 +196,16 @@ impl EventTimelineItem {
 }
 
 /// This type represents the "send state" of a local event timeline item.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub enum EventSendState {
     /// The local event has not been sent yet.
     NotSentYet,
     /// The local event has been sent to the server, but unsuccessfully: The
     /// sending has failed.
-    SendingFailed,
+    SendingFailed {
+        /// Details about how sending the event failed.
+        error: Arc<Error>,
+    },
     /// The local event has been sent successfully to the server.
     Sent {
         /// The event ID assigned by the server.

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -193,9 +193,9 @@ impl EventTimelineItem {
     }
 }
 
-/// This type represents the “send state” of a local event timeline item.
+/// This type represents the "send state" of a local event timeline item.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub enum LocalEventTimelineItemSendState {
+pub enum EventSendState {
     /// The local event has not been sent yet.
     NotSentYet,
     /// The local event has been sent to the server, but unsuccessfully: The
@@ -208,7 +208,7 @@ pub enum LocalEventTimelineItemSendState {
 #[derive(Debug, Clone)]
 pub struct LocalEventTimelineItem {
     /// The send state of this local event.
-    pub send_state: LocalEventTimelineItemSendState,
+    pub send_state: EventSendState,
     /// The transaction ID.
     pub transaction_id: OwnedTransactionId,
     /// The event ID received from the server in the event-sending response.
@@ -236,8 +236,8 @@ impl LocalEventTimelineItem {
     pub(super) fn with_event_id(&self, event_id: Option<OwnedEventId>) -> Self {
         Self {
             send_state: match &event_id {
-                Some(_) => LocalEventTimelineItemSendState::Sent,
-                None => LocalEventTimelineItemSendState::SendingFailed,
+                Some(_) => EventSendState::Sent,
+                None => EventSendState::SendingFailed,
             },
             event_id,
             ..self.clone()

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -19,10 +19,10 @@ use ruma::{
         AnySyncTimelineEvent,
     },
     serde::Raw,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomId,
     TransactionId, UserId,
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, field::debug, info, warn};
 #[cfg(feature = "e2e-encryption")]
 use tracing::{instrument, trace};
 
@@ -31,7 +31,7 @@ use super::{
         update_read_marker, Flow, HandleEventResult, TimelineEventHandler, TimelineEventKind,
         TimelineEventMetadata, TimelineItemPosition,
     },
-    rfind_event_item, EventTimelineItem, Profile, TimelineItem,
+    rfind_event_item, EventSendState, EventTimelineItem, Profile, TimelineItem,
 };
 use crate::{
     events::SyncTimelineEventWithoutContent,
@@ -145,36 +145,40 @@ impl<P: ProfileProvider> TimelineInner<P> {
     ) -> crate::error::Result<()> {
         match response {
             Ok(response) => {
-                self.update_event_id_of_local_event(txn_id, Some(response.event_id));
+                self.update_event_send_state(
+                    txn_id,
+                    EventSendState::Sent { event_id: response.event_id },
+                );
 
                 Ok(())
             }
             Err(error) => {
-                self.update_event_id_of_local_event(txn_id, None);
+                self.update_event_send_state(txn_id, EventSendState::SendingFailed);
 
                 Err(error)
             }
         }
     }
 
-    /// Update the event ID of a local event represented by a transaction ID.
-    ///
-    /// If the event ID is `None`, it means there is no event ID returned by the
-    /// server, so the sending has failed. If the event ID is `Some(_)`, it
-    /// means the sending has been successful.
+    /// Update the send state of a local event represented by a transaction ID.
     ///
     /// If no local event is found, a warning is raised.
-    pub(super) fn update_event_id_of_local_event(
+    pub(super) fn update_event_send_state(
         &self,
         txn_id: &TransactionId,
-        event_id: Option<OwnedEventId>,
+        send_state: EventSendState,
     ) {
         let mut lock = self.items.lock_mut();
+
+        let new_event_id: Option<&EventId> = match &send_state {
+            EventSendState::Sent { event_id } => Some(event_id),
+            _ => None,
+        };
 
         // Look for the local event by the transaction ID or event ID.
         let result = rfind_event_item(&lock, |it| {
             it.transaction_id() == Some(txn_id)
-                || event_id.is_some() && it.event_id() == event_id.as_deref()
+                || new_event_id.is_some() && it.event_id() == new_event_id
         });
 
         let Some((idx, item)) = result else {
@@ -189,16 +193,15 @@ impl<P: ProfileProvider> TimelineInner<P> {
             return;
         };
 
-        // An event ID already exists, that's a broken state, let's emit an
-        // error but also override to the given event ID.
-        if let Some(existing_event_id) = &item.event_id {
-            error!(
-                ?existing_event_id, new_event_id = ?event_id, ?txn_id,
-                "Local echo already has an event ID"
-            );
+        // The event was already marked as sent, that's a broken state, let's
+        // emit an error but also override to the given sent state.
+        if let EventSendState::Sent { event_id: existing_event_id } = &item.send_state {
+            let new_event_id = new_event_id.map(debug);
+            error!(?existing_event_id, ?new_event_id, ?txn_id, "Local echo already marked as sent");
         }
 
-        lock.set_cloned(idx, Arc::new(TimelineItem::Event(item.with_event_id(event_id).into())));
+        let new_item = TimelineItem::Event(item.with_send_state(send_state).into());
+        lock.set_cloned(idx, Arc::new(new_item));
     }
 
     /// Handle a back-paginated event.

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -13,7 +13,6 @@ use matrix_sdk_base::{
     locks::Mutex,
 };
 use ruma::{
-    api::client::message::send_message_event::v3::Response as SendMessageEventResponse,
     events::{
         fully_read::FullyReadEvent, relation::Annotation, AnyMessageLikeEventContent,
         AnySyncTimelineEvent,
@@ -134,30 +133,6 @@ impl<P: ProfileProvider> TimelineInner<P> {
         let mut timeline_items = self.items.lock_mut();
         TimelineEventHandler::new(event_meta, flow, &mut timeline_items, &mut timeline_meta)
             .handle_event(kind);
-    }
-
-    /// Handle the response returned by the server when a local event has been
-    /// sent.
-    pub(super) fn handle_local_event_send_response(
-        &self,
-        txn_id: &TransactionId,
-        response: crate::error::Result<SendMessageEventResponse>,
-    ) -> crate::error::Result<()> {
-        match response {
-            Ok(response) => {
-                self.update_event_send_state(
-                    txn_id,
-                    EventSendState::Sent { event_id: response.event_id },
-                );
-
-                Ok(())
-            }
-            Err(error) => {
-                self.update_event_send_state(txn_id, EventSendState::SendingFailed);
-
-                Err(error)
-            }
-        }
     }
 
     /// Update the send state of a local event represented by a transaction ID.

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -49,10 +49,9 @@ mod virtual_item;
 
 pub use self::{
     event_item::{
-        AnyOtherFullStateEventContent, EncryptedMessage, EventTimelineItem,
-        LocalEventTimelineItemSendState, MemberProfileChange, MembershipChange, Message,
-        OtherState, Profile, ReactionDetails, RoomMembershipChange, Sticker, TimelineDetails,
-        TimelineItemContent,
+        AnyOtherFullStateEventContent, EncryptedMessage, EventSendState, EventTimelineItem,
+        MemberProfileChange, MembershipChange, Message, OtherState, Profile, ReactionDetails,
+        RoomMembershipChange, Sticker, TimelineDetails, TimelineItemContent,
     },
     pagination::{PaginationOptions, PaginationOutcome},
     virtual_item::VirtualTimelineItem,

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -358,11 +358,7 @@ impl Timeline {
     /// [`MessageLikeUnsigned`]: ruma::events::MessageLikeUnsigned
     /// [`SyncMessageLikeEvent`]: ruma::events::SyncMessageLikeEvent
     #[instrument(skip(self, content), fields(room_id = ?self.room().room_id()))]
-    pub async fn send(
-        &self,
-        content: AnyMessageLikeEventContent,
-        txn_id: Option<&TransactionId>,
-    ) -> Result<()> {
+    pub async fn send(&self, content: AnyMessageLikeEventContent, txn_id: Option<&TransactionId>) {
         let txn_id = txn_id.map_or_else(TransactionId::new, ToOwned::to_owned);
         self.inner.handle_local_event(txn_id.clone(), content.clone()).await;
 
@@ -371,7 +367,12 @@ impl Timeline {
         let room = Joined { inner: self.room().clone() };
 
         let response = room.send(content, Some(&txn_id)).await;
-        self.inner.handle_local_event_send_response(&txn_id, response)
+
+        let send_state = match response {
+            Ok(response) => EventSendState::Sent { event_id: response.event_id },
+            Err(error) => EventSendState::SendingFailed { error: Arc::new(error) },
+        };
+        self.inner.update_event_send_state(&txn_id, send_state);
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/tests.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests.rs
@@ -58,7 +58,7 @@ use super::{
     EventTimelineItem, MembershipChange, Profile, TimelineInner, TimelineItem, TimelineItemContent,
     VirtualTimelineItem,
 };
-use crate::room::timeline::event_item::LocalEventTimelineItemSendState;
+use crate::room::timeline::event_item::EventSendState;
 
 static ALICE: Lazy<&UserId> = Lazy::new(|| user_id!("@alice:server.name"));
 static BOB: Lazy<&UserId> = Lazy::new(|| user_id!("@bob:other.server"));
@@ -388,7 +388,7 @@ async fn remote_echo_full_trip() {
     {
         let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
         let event = item.as_event().unwrap().as_local().unwrap();
-        assert_eq!(event.send_state, LocalEventTimelineItemSendState::NotSentYet);
+        assert_eq!(event.send_state, EventSendState::NotSentYet);
     }
 
     // Scenario 2: The local event has not been sent to the server successfully, it
@@ -400,7 +400,7 @@ async fn remote_echo_full_trip() {
 
         let item = assert_matches!(stream.next().await, Some(VecDiff::UpdateAt { value, index: 1 }) => value);
         let event = item.as_event().unwrap().as_local().unwrap();
-        assert_eq!(event.send_state, LocalEventTimelineItemSendState::SendingFailed);
+        assert_eq!(event.send_state, EventSendState::SendingFailed);
     }
 
     // Scenario 3: The local event has been sent successfully to the server and an
@@ -412,7 +412,7 @@ async fn remote_echo_full_trip() {
 
         let item = assert_matches!(stream.next().await, Some(VecDiff::UpdateAt { value, index: 1 }) => value);
         let event = item.as_event().unwrap().as_local().unwrap();
-        assert_eq!(event.send_state, LocalEventTimelineItemSendState::Sent);
+        assert_eq!(event.send_state, EventSendState::Sent);
 
         event_id
     };

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -194,7 +194,7 @@ async fn echo() {
     assert_eq!(text.body, "Hello, World!");
 
     // Wait for the sending to finish and assert everything was successful
-    send_hdl.await.unwrap().unwrap();
+    send_hdl.await.unwrap();
 
     let sent_confirmation = assert_matches!(
         timeline_stream.next().await,

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -8,8 +8,8 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     config::SyncSettings,
     room::timeline::{
-        AnyOtherFullStateEventContent, PaginationOptions, TimelineDetails, TimelineItemContent,
-        VirtualTimelineItem,
+        AnyOtherFullStateEventContent, EventSendState, PaginationOptions, TimelineDetails,
+        TimelineItemContent, VirtualTimelineItem,
     },
     ruma::MilliSecondsSinceUnixEpoch,
 };
@@ -187,7 +187,7 @@ async fn echo() {
     let local_echo =
         assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
     let item = local_echo.as_event().unwrap().as_local().unwrap();
-    assert!(item.event_id.is_none());
+    assert_matches!(&item.send_state, EventSendState::NotSentYet);
 
     let msg = assert_matches!(&item.content, TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(msg.msgtype(), MessageType::Text(text) => text);
@@ -201,7 +201,7 @@ async fn echo() {
         Some(VecDiff::UpdateAt { index: 1, value }) => value
     );
     let item = sent_confirmation.as_event().unwrap().as_local().unwrap();
-    assert!(item.event_id.is_some());
+    assert_matches!(&item.send_state, EventSendState::Sent { .. });
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({

--- a/labs/jack-in/src/app/model.rs
+++ b/labs/jack-in/src/app/model.rs
@@ -215,11 +215,7 @@ impl Update<Msg> for Model {
                     if let Some(tl) = self.sliding_sync.room_timeline.lock_ref().deref() {
                         block_on(async move {
                             // fire and forget
-                            match tl.send(RoomMessageEventContent::text_plain(m).into(), None).await
-                            {
-                                Ok(_r) => tracing::info!("Message send"),
-                                Err(e) => tracing::error!("Sending message failed: {:}", e),
-                            }
+                            tl.send(RoomMessageEventContent::text_plain(m).into(), None).await;
                         });
                     } else {
                         warn!("asked to send message, but no room is selected");


### PR DESCRIPTION
… instead of through the return value of Timeline::send.

I think this should be easier to work with for users of the timeline API. cc @zecakeh 