### PR TITLE
fix(indexeddb): correctly encode Olm session keys

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -645,13 +645,7 @@ impl IndexeddbCryptoStore {
         let account_info = self.get_account_info().ok_or(CryptoStoreError::AccountUnset)?;
 
         if self.session_cache.get(sender_key).is_none() {
-            let range = sender_key.encode_to_range().map_err(|e| {
-                IndexeddbCryptoStoreError::DomException {
-                    code: 0,
-                    name: "IdbKeyRangeMakeError".to_owned(),
-                    message: e,
-                }
-            })?;
+            let range = self.encode_to_range(KEYS::SESSION, sender_key)?;
             let sessions: Vec<Session> = self
                 .inner
                 .transaction_on_one_with_mode(KEYS::SESSION, IdbTransactionMode::Readonly)?


### PR DESCRIPTION
When we store an Olm session in the database, we encode the sender key and
session ID using the store cipher. That means that we also need to encode them
when we look them up, otherwise we won't find them.