### PR TITLE
feat(sdk): Allow to fetch replied to messages

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -465,7 +465,7 @@ impl Message {
 
     // This event ID string will be replaced by something more useful later.
     pub fn in_reply_to(&self) -> Option<String> {
-        self.0.in_reply_to().map(ToString::to_string)
+        self.0.in_reply_to().map(|r| r.event_id.to_string())
     }
 
     pub fn is_edited(&self) -> bool {

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -241,6 +241,11 @@ pub enum Error {
     #[error(transparent)]
     SlidingSync(#[from] crate::sliding_sync::Error),
 
+    /// An error occurred in the timeline.
+    #[cfg(feature = "experimental-timeline")]
+    #[error(transparent)]
+    Timeline(#[from] crate::room::timeline::Error),
+
     /// The client is in inconsistent state. This happens when we set a room to
     /// a specific type, but then cannot get it in this type.
     #[error("The internal client state is inconsistent.")]

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -46,8 +46,9 @@ use super::{
         LocalEventTimelineItemSendState, MemberProfileChange, OtherState, Profile,
         RemoteEventTimelineItem, RoomMembershipChange, Sticker,
     },
-    find_read_marker, rfind_event_by_id, rfind_event_item, EventTimelineItem, Message,
-    ReactionGroup, TimelineInnerMetadata, TimelineItem, TimelineItemContent, VirtualTimelineItem,
+    find_read_marker, rfind_event_by_id, rfind_event_item, EventTimelineItem, InReplyToDetails,
+    Message, ReactionGroup, TimelineInnerMetadata, TimelineItem, TimelineItemContent,
+    VirtualTimelineItem,
 };
 use crate::{events::SyncTimelineEventWithoutContent, room::timeline::MembershipChange};
 
@@ -822,10 +823,7 @@ impl NewEventTimelineItem {
         let edited = relations.replace.is_some();
         let content = TimelineItemContent::Message(Message {
             msgtype: c.msgtype,
-            in_reply_to: c.relates_to.and_then(|rel| match rel {
-                message::Relation::Reply { in_reply_to } => Some(in_reply_to.event_id),
-                _ => None,
-            }),
+            in_reply_to: c.relates_to.and_then(InReplyToDetails::from_relation),
             edited,
         });
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -296,6 +296,11 @@ impl RemoteEventTimelineItem {
         Self { reactions, ..self.clone() }
     }
 
+    /// Clone the current event item, and update its `content`.
+    pub(super) fn with_content(&self, content: TimelineItemContent) -> Self {
+        Self { content, ..self.clone() }
+    }
+
     /// Clone the current event item, change its `content` to
     /// [`TimelineItemContent::RedactedMessage`], and reset its `reactions`.
     pub(super) fn to_redacted(&self) -> Self {

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -15,7 +15,7 @@
 use std::{fmt, ops::Deref, sync::Arc};
 
 use indexmap::IndexMap;
-use matrix_sdk_base::deserialized_responses::EncryptionInfo;
+use matrix_sdk_base::deserialized_responses::{EncryptionInfo, TimelineEvent};
 use ruma::{
     events::{
         policy::rule::{
@@ -33,7 +33,7 @@ use ruma::{
             history_visibility::RoomHistoryVisibilityEventContent,
             join_rules::RoomJoinRulesEventContent,
             member::{Change, RoomMemberEventContent},
-            message::MessageType,
+            message::{self, MessageType, Relation},
             name::RoomNameEventContent,
             pinned_events::RoomPinnedEventsEventContent,
             power_levels::RoomPowerLevelsEventContent,
@@ -44,13 +44,16 @@ use ruma::{
         },
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         sticker::StickerEventContent,
-        AnyFullStateEventContent, AnySyncTimelineEvent, FullStateEventContent,
-        MessageLikeEventType, StateEventType,
+        AnyFullStateEventContent, AnyMessageLikeEventContent, AnySyncTimelineEvent,
+        AnyTimelineEvent, FullStateEventContent, MessageLikeEventType, StateEventType,
     },
     serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedEventId, OwnedMxcUri,
     OwnedTransactionId, OwnedUserId, TransactionId, UserId,
 };
+
+use super::inner::ProfileProvider;
+use crate::{Error, Result};
 
 /// An item in the timeline that represents at least one event.
 ///
@@ -363,6 +366,9 @@ pub enum TimelineDetails<T> {
 
     /// The details are available.
     Ready(T),
+
+    /// An error occurred when fetching the details.
+    Error(Arc<Error>),
 }
 
 /// The content of an [`EventTimelineItem`].
@@ -435,10 +441,7 @@ impl TimelineItemContent {
 #[derive(Clone)]
 pub struct Message {
     pub(super) msgtype: MessageType,
-    // TODO: Add everything required to display the replied-to event, plus a
-    // 'loading' state that is entered at first, until the user requests the
-    // reply to be loaded.
-    pub(super) in_reply_to: Option<OwnedEventId>,
+    pub(super) in_reply_to: Option<InReplyToDetails>,
     pub(super) edited: bool,
 }
 
@@ -455,14 +458,18 @@ impl Message {
         self.msgtype.body()
     }
 
-    /// Get the event ID of the event this message is replying to, if any.
-    pub fn in_reply_to(&self) -> Option<&EventId> {
-        self.in_reply_to.as_deref()
+    /// Get the event this message is replying to, if any.
+    pub fn in_reply_to(&self) -> Option<&InReplyToDetails> {
+        self.in_reply_to.as_ref()
     }
 
     /// Get the edit state of this message (has been edited: `true` / `false`).
     pub fn is_edited(&self) -> bool {
         self.edited
+    }
+
+    pub(super) fn with_in_reply_to(&self, in_reply_to: InReplyToDetails) -> Self {
+        Self { in_reply_to: Some(in_reply_to), ..self.clone() }
     }
 }
 
@@ -471,6 +478,85 @@ impl fmt::Debug for Message {
         // since timeline items are logged, don't include all fields here so
         // people don't leak personal data in bug reports
         f.debug_struct("Message").field("edited", &self.edited).finish_non_exhaustive()
+    }
+}
+
+/// Details about an event being replied to.
+#[derive(Clone, Debug)]
+pub struct InReplyToDetails {
+    /// The ID of the event.
+    pub event_id: OwnedEventId,
+
+    /// The details of the event.
+    ///
+    /// Use [`Timeline::fetch_item_details`] to fetch the data if it is
+    /// unavailable. The `replies_nesting_level` field in
+    /// [`TimelineDetailsSettings`] decides if this should be fetched.
+    ///
+    /// [`Timeline::fetch_item_details`]: super::Timeline::fetch_item_details
+    /// [`TimelineDetailsSettings`]: super::TimelineDetailsSettings
+    pub details: TimelineDetails<Box<RepliedToEvent>>,
+}
+
+impl InReplyToDetails {
+    pub(super) fn from_relation<C>(relation: Relation<C>) -> Option<Self> {
+        match relation {
+            message::Relation::Reply { in_reply_to } => {
+                Some(Self { event_id: in_reply_to.event_id, details: TimelineDetails::Unavailable })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// An event that is replied to.
+#[derive(Clone, Debug)]
+pub struct RepliedToEvent {
+    pub(super) message: Message,
+    pub(super) sender: OwnedUserId,
+    pub(super) sender_profile: Profile,
+}
+
+impl RepliedToEvent {
+    /// Get the message of this event.
+    pub fn message(&self) -> &Message {
+        &self.message
+    }
+
+    /// Get the sender of this event.
+    pub fn sender(&self) -> &UserId {
+        &self.sender
+    }
+
+    /// Get the profile of the sender.
+    pub fn sender_profile(&self) -> &Profile {
+        &self.sender_profile
+    }
+
+    pub(super) async fn try_from_timeline_event<P: ProfileProvider>(
+        timeline_event: TimelineEvent,
+        profile_provider: &P,
+    ) -> Result<Self> {
+        let event = match timeline_event.event.deserialize() {
+            Ok(AnyTimelineEvent::MessageLike(event)) => event,
+            _ => {
+                return Err(super::Error::UnsupportedEvent.into());
+            }
+        };
+
+        let Some(AnyMessageLikeEventContent::RoomMessage(c)) = event.original_content() else {
+            return Err(super::Error::UnsupportedEvent.into());
+        };
+
+        let message = Message {
+            msgtype: c.msgtype,
+            in_reply_to: c.relates_to.and_then(InReplyToDetails::from_relation),
+            edited: event.relations().replace.is_some(),
+        };
+        let sender = event.sender().to_owned();
+        let sender_profile = profile_provider.profile(&sender).await;
+
+        Ok(Self { message, sender, sender_profile })
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -417,18 +417,18 @@ impl TimelineInner {
         in_reply_to: &EventId,
     ) -> TimelineDetails<Box<RepliedToEvent>> {
         if let Some((_, item)) = rfind_event_by_id(&self.items(), in_reply_to) {
-            match item.content() {
+            let details = match item.content() {
                 TimelineItemContent::Message(message) => {
-                    return TimelineDetails::Ready(Box::new(RepliedToEvent {
+                    TimelineDetails::Ready(Box::new(RepliedToEvent {
                         message: message.clone(),
                         sender: item.sender().to_owned(),
                         sender_profile: item.sender_profile().clone(),
-                    }));
+                    }))
                 }
-                _ => {
-                    return TimelineDetails::Error(Arc::new(super::Error::UnsupportedEvent.into()))
-                }
-            }
+                _ => TimelineDetails::Error(Arc::new(super::Error::UnsupportedEvent.into())),
+            };
+
+            return details;
         };
 
         self.update_event_item(

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -411,7 +411,7 @@ impl Timeline {
     /// Returns an error if the identifier doesn't match any event with a remote
     /// echo in the timeline, or if the event is removed from the timeline
     /// before all requests are handled.
-    #[instrument(fields(room_id = ?self.room().room_id()))]
+    #[instrument(skip(self), fields(room_id = ?self.room().room_id()))]
     pub async fn fetch_event_details(&self, event_id: &EventId) -> Result<()> {
         let (index, item) = rfind_event_by_id(&self.inner.items(), event_id)
             .and_then(|(pos, item)| item.as_remote().map(|item| (pos, item.clone())))

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -574,8 +574,8 @@ async fn in_reply_to_details() {
 
     // The event doesn't exist.
     assert_matches!(
-        timeline.fetch_event_details(None, Some(event_id!("$fakeevent"))).await,
-        Err(Error::Timeline(TimelineError::EventNotInTimeline))
+        timeline.fetch_event_details(event_id!("$fakeevent")).await,
+        Err(Error::Timeline(TimelineError::RemoteEventNotInTimeline))
     );
 
     ev_builder.add_joined_room(
@@ -626,7 +626,7 @@ async fn in_reply_to_details() {
     assert_matches!(in_reply_to.details, TimelineDetails::Unavailable);
 
     // Fetch details locally first.
-    timeline.fetch_event_details(None, Some(&second_event.event_id)).await.unwrap();
+    timeline.fetch_event_details(&second_event.event_id).await.unwrap();
 
     let second = assert_matches!(timeline_stream.next().await, Some(VecDiff::UpdateAt { index: 2, value }) => value);
     let message = assert_matches!(second.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);
@@ -675,7 +675,7 @@ async fn in_reply_to_details() {
         .await;
 
     // Fetch details remotely if we can't find them locally.
-    timeline.fetch_event_details(None, Some(&third_event.event_id)).await.unwrap();
+    timeline.fetch_event_details(&third_event.event_id).await.unwrap();
     server.reset().await;
 
     let third = assert_matches!(timeline_stream.next().await, Some(VecDiff::UpdateAt { index: 3, value }) => value);
@@ -704,7 +704,7 @@ async fn in_reply_to_details() {
         .mount(&server)
         .await;
 
-    timeline.fetch_event_details(None, Some(&third_event.event_id)).await.unwrap();
+    timeline.fetch_event_details(&third_event.event_id).await.unwrap();
 
     let third = assert_matches!(timeline_stream.next().await, Some(VecDiff::UpdateAt { index: 3, value }) => value);
     let message = assert_matches!(third.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -8,9 +8,11 @@ use futures_util::StreamExt;
 use matrix_sdk::{
     config::SyncSettings,
     room::timeline::{
-        AnyOtherFullStateEventContent, PaginationOptions, TimelineItemContent, VirtualTimelineItem,
+        AnyOtherFullStateEventContent, Error as TimelineError, PaginationOptions, TimelineDetails,
+        TimelineItemContent, VirtualTimelineItem,
     },
     ruma::MilliSecondsSinceUnixEpoch,
+    Error,
 };
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
@@ -551,4 +553,164 @@ async fn read_marker() {
     let marker =
         assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
     assert_matches!(marker.as_virtual().unwrap(), VirtualTimelineItem::ReadMarker);
+}
+
+#[async_test]
+async fn in_reply_to_details() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let mut ev_builder = EventBuilder::new();
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline().await;
+    let mut timeline_stream = timeline.signal().to_stream();
+
+    // The event doesn't exist.
+    assert_matches!(
+        timeline.fetch_event_details(None, Some(event_id!("$fakeevent"))).await,
+        Err(Error::Timeline(TimelineError::EventNotInTimeline))
+    );
+
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                },
+                "event_id": "$event1",
+                "origin_server_ts": 152037280,
+                "sender": "@alice:example.org",
+                "type": "m.room.message",
+            })))
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "hello to you too",
+                    "msgtype": "m.text",
+                    "m.relates_to": {
+                        "m.in_reply_to": {
+                            "event_id": "$event1",
+                        },
+                    },
+                },
+                "event_id": "$event2",
+                "origin_server_ts": 152045456,
+                "sender": "@bob:example.org",
+                "type": "m.room.message",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let _day_divider =
+        assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
+    let first =
+        assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
+    assert_matches!(first.as_event().unwrap().content(), TimelineItemContent::Message(_));
+    let second =
+        assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
+    let second_event = second.as_event().unwrap().as_remote().unwrap();
+    let message =
+        assert_matches!(&second_event.content, TimelineItemContent::Message(message) => message);
+    let in_reply_to = message.in_reply_to().unwrap();
+    assert_eq!(in_reply_to.event_id, event_id!("$event1"));
+    assert_matches!(in_reply_to.details, TimelineDetails::Unavailable);
+
+    // Fetch details locally first.
+    timeline.fetch_event_details(None, Some(&second_event.event_id)).await.unwrap();
+
+    let second = assert_matches!(timeline_stream.next().await, Some(VecDiff::UpdateAt { index: 2, value }) => value);
+    let message = assert_matches!(second.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);
+    assert_matches!(message.in_reply_to().unwrap().details, TimelineDetails::Ready(_));
+
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+        TimelineTestEvent::Custom(json!({
+            "content": {
+                "body": "you were right",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "m.in_reply_to": {
+                        "event_id": "$remoteevent",
+                    },
+                },
+            },
+            "event_id": "$event3",
+            "origin_server_ts": 152046694,
+            "sender": "@bob:example.org",
+            "type": "m.room.message",
+        })),
+    ));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let third =
+        assert_matches!(timeline_stream.next().await, Some(VecDiff::Push { value }) => value);
+    let third_event = third.as_event().unwrap().as_remote().unwrap();
+    let message =
+        assert_matches!(&third_event.content, TimelineItemContent::Message(message) => message);
+    let in_reply_to = message.in_reply_to().unwrap();
+    assert_eq!(in_reply_to.event_id, event_id!("$remoteevent"));
+    assert_matches!(in_reply_to.details, TimelineDetails::Unavailable);
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/event/\$remoteevent"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "Event not found.",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Fetch details remotely if we can't find them locally.
+    timeline.fetch_event_details(None, Some(&third_event.event_id)).await.unwrap();
+    server.reset().await;
+
+    let third = assert_matches!(timeline_stream.next().await, Some(VecDiff::UpdateAt { index: 3, value }) => value);
+    let message = assert_matches!(third.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);
+    assert_matches!(message.in_reply_to().unwrap().details, TimelineDetails::Pending);
+
+    let third = assert_matches!(timeline_stream.next().await, Some(VecDiff::UpdateAt { index: 3, value }) => value);
+    let message = assert_matches!(third.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);
+    assert_matches!(message.in_reply_to().unwrap().details, TimelineDetails::Error(_));
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/event/\$remoteevent"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content": {
+                "body": "Alice is gonna arrive soon",
+                "msgtype": "m.text",
+            },
+            "room_id": room_id,
+            "event_id": "$event0",
+            "origin_server_ts": 152024004,
+            "sender": "@admin:example.org",
+            "type": "m.room.message",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    timeline.fetch_event_details(None, Some(&third_event.event_id)).await.unwrap();
+
+    let third = assert_matches!(timeline_stream.next().await, Some(VecDiff::UpdateAt { index: 3, value }) => value);
+    let message = assert_matches!(third.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);
+    assert_matches!(message.in_reply_to().unwrap().details, TimelineDetails::Pending);
+
+    let third = assert_matches!(timeline_stream.next().await, Some(VecDiff::UpdateAt { index: 3, value }) => value);
+    let message = assert_matches!(third.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);
+    assert_matches!(message.in_reply_to().unwrap().details, TimelineDetails::Ready(_));
 }


### PR DESCRIPTION
This is a simple implementation of fetching replies for messages in the timeline. I thought it would be better to have this basic implementation first and add complexity later.

`fetch_in_reply_to_details` returns the updated item to be able to fetch other details with the updated item, even if it is unused now.

One thing I was wondering is whether we want to automatically remove the reply fallback (there's a method for that in Ruma).

Things that can be added in other PRs:
- Populate the `InReplyToDetails` as soon as the event is received, if the `RepliedToEvent` is in the timeline.
- Update the `RepliedToEvent` in the current event item when the content of a replied to event item in the timeline is updated.
- Allow to fetch nested `RepliedToEvent`s, to be able to display chain of replies, like Element Web.
- Handle the current event item changing (e.g. being redacted) outside of `fetch_event_details` while the requests are being made. Currently the external change is overriden by this method. 
- Handle replies for events other than messages? It is technically allowed by the spec.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
