### PR TITLE
Upgrade UniFFI to 0.23

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,7 @@ target-applies-to-host = false
 
 [alias]
 xtask = "run --package xtask --"
+uniffi-bindgen = "run --package uniffi-bindgen --"
 
 [doc.extern-map.registries]
 crates-io = "https://docs.rs/"

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -16,8 +16,6 @@ env:
   CARGO_TERM_COLOR: always
   MATRIX_SDK_CRYPTO_NODEJS_PATH: bindings/matrix-sdk-crypto-nodejs
   MATRIX_SDK_CRYPTO_JS_PATH: bindings/matrix-sdk-crypto-js
-  # keep in sync with uniffi dependency in root Cargo.toml
-  UNIFFI_REV: 249a78b6f3f35661f1530e53811134e1bf012608
 
 jobs:
   xtask-linux:
@@ -73,12 +71,6 @@ jobs:
         with:
           path: target/debug/xtask
           key: xtask-linux-${{ hashFiles('Cargo.toml', 'xtask/**') }}
-
-      - name: Install Uniffi
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: uniffi_bindgen --git https://github.com/mozilla/uniffi-rs --rev ${{ env.UNIFFI_REV }}
 
       - name: Build library & generate bindings
         run: target/debug/xtask ci bindings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,8 +2780,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "vodozemac",
  "zeroize",
 ]
@@ -2848,8 +2846,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "zeroize",
 ]
 
@@ -4446,6 +4442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5171,29 +5173,36 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "uniffi"
-version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=249a78b6f3f35661f1530e53811134e1bf012608#249a78b6f3f35661f1530e53811134e1bf012608"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f71cc01459bc34cfe43fabf32b39f1228709bc6db1b3a664a92940af3d062376"
 dependencies = [
  "anyhow",
- "bytes",
  "camino",
- "log",
- "once_cell",
- "paste",
- "static_assertions",
+ "clap 3.2.23",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
  "uniffi_macros",
 ]
 
 [[package]]
+name = "uniffi-bindgen"
+version = "0.1.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
 name = "uniffi_bindgen"
-version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=249a78b6f3f35661f1530e53811134e1bf012608#249a78b6f3f35661f1530e53811134e1bf012608"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbbba5103051c18f10b22f80a74439ddf7100273f217a547005d2735b2498994"
 dependencies = [
  "anyhow",
  "askama",
  "bincode",
  "camino",
- "clap 3.2.23",
  "fs-err",
  "glob",
  "goblin",
@@ -5210,8 +5219,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=249a78b6f3f35661f1530e53811134e1bf012608#249a78b6f3f35661f1530e53811134e1bf012608"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1a28368ff3d83717e3d3e2e15a66269c43488c3f036914131bb68892f29fb"
 dependencies = [
  "anyhow",
  "camino",
@@ -5219,9 +5229,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_checksum_derive"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03de61393a42b4ad4984a3763c0600594ac3e57e5aaa1d05cede933958987c03"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2b4852d638d74ca2d70e450475efb6d91fe6d54a7cd8d6bd80ad2ee6cd7daa"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "camino",
+ "cargo_metadata",
+ "log",
+ "once_cell",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
 name = "uniffi_macros"
-version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=249a78b6f3f35661f1530e53811134e1bf012608#249a78b6f3f35661f1530e53811134e1bf012608"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa03394de21e759e0022f1ea8d992d2e39290d735b9ed52b1f74b20a684f794e"
 dependencies = [
  "bincode",
  "camino",
@@ -5238,16 +5275,20 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=249a78b6f3f35661f1530e53811134e1bf012608#249a78b6f3f35661f1530e53811134e1bf012608"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fdab2c436aed7a6391bec64204ec33948bfed9b11b303235740771f85c4ea6"
 dependencies = [
  "serde",
+ "siphasher",
+ "uniffi_checksum_derive",
 ]
 
 [[package]]
 name = "uniffi_testing"
-version = "0.21.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=249a78b6f3f35661f1530e53811134e1bf012608#249a78b6f3f35661f1530e53811134e1bf012608"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b0570953ec41d97ce23e3b92161ac18231670a1f97523258a6d2ab76d7f76c"
 dependencies = [
  "anyhow",
  "camino",
@@ -5546,7 +5587,8 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=249a78b6f3f35661f1530e53811134e1bf012608#249a78b6f3f35661f1530e53811134e1bf012608"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
 dependencies = [
  "nom",
 ]
@@ -5727,6 +5769,7 @@ dependencies = [
  "fs_extra",
  "serde",
  "serde_json",
+ "uniffi",
  "uniffi_bindgen",
  "xshell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "testing/*",
     "examples/*",
     "labs/*",
+    "uniffi-bindgen",
     "xtask",
 ]
 # xtask, labs, testing and the bindings should only be built when invoked explicitly.
@@ -35,10 +36,8 @@ serde_html_form = "0.2.0"
 serde_json = "1.0.91"
 thiserror = "1.0.38"
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "249a78b6f3f35661f1530e53811134e1bf012608" }
-uniffi_macros = { git = "https://github.com/mozilla/uniffi-rs", rev = "249a78b6f3f35661f1530e53811134e1bf012608" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "249a78b6f3f35661f1530e53811134e1bf012608" }
-uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "249a78b6f3f35661f1530e53811134e1bf012608", features = ["builtin-bindgen"] }
+uniffi = "0.23.0"
+uniffi_bindgen = "0.23.0"
 vodozemac = { git = "https://github.com/matrix-org/vodozemac", rev = "12b24e909107c1fac23245376f294eaf48ba186a" }
 zeroize = "1.3.0"
 

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -51,7 +51,7 @@ lipo -create \
   -output "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a"
 
 # Generate uniffi files
-uniffi-bindgen generate \
+cargo uniffi-bindgen generate \
   --language swift \
   --lib-file "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
   --config "${SRC_ROOT}/bindings/${TARGET_CRATE}/uniffi.toml" \

--- a/bindings/kotlin/README.md
+++ b/bindings/kotlin/README.md
@@ -5,7 +5,6 @@ This project and build scripts demonstrate how to create an aar and how to impor
 ## Prerequisites
 
 * the Rust toolchain
-* UniFFI - `cargo install uniffi_bindgen`
 * cargo-ndk < 2.12.0 `cargo install cargo-ndk --version 2.11.0`
 * android targets (e.g. `rustup target add \
   aarch64-linux-android \

--- a/bindings/kotlin/scripts/build_crypto.sh
+++ b/bindings/kotlin/scripts/build_crypto.sh
@@ -45,12 +45,12 @@ cargo ndk --target i686-linux-android -o ${SDK_TARGET_DIR}/ build "${RELEASE_FLA
 
 # Generate uniffi files
 echo -e "Generate uniffi kotlin file"
-uniffi-bindgen generate "${SRC_ROOT}/bindings/${TARGET_CRATE}/src/olm.udl" \
+cargo uniffi-bindgen generate "${SRC_ROOT}/bindings/${TARGET_CRATE}/src/olm.udl" \
   --language kotlin \
   --config "${SRC_ROOT}/bindings/${TARGET_CRATE}/uniffi.toml" \
   --out-dir ${GENERATED_DIR} \
   --lib-file "${BASE_TARGET_DIR}/x86_64-linux-android/${RELEASE_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a"
-  
+
 # Create android library
 cd "${KOTLIN_ROOT}"
 ./gradlew :crypto:crypto-android:assemble
@@ -64,4 +64,3 @@ echo -e "Cleaning up temporary files"
 
 rm -r "${BUILD_DIR}"
 rm -r "${SDK_TARGET_DIR}"
-

--- a/bindings/kotlin/scripts/build_sdk.sh
+++ b/bindings/kotlin/scripts/build_sdk.sh
@@ -43,11 +43,11 @@ cargo ndk --target i686-linux-android -o ${SDK_TARGET_DIR}/ build "${RELEASE_FLA
 
 # Generate uniffi files
 echo -e "Generate uniffi kotlin file"
-uniffi-bindgen generate "${SRC_ROOT}/bindings/matrix-sdk-ffi/src/api.udl" \
+cargo uniffi-bindgen generate "${SRC_ROOT}/bindings/matrix-sdk-ffi/src/api.udl" \
   --language kotlin \
   --out-dir ${GENERATED_DIR} \
   --lib-file "${BASE_TARGET_DIR}/x86_64-linux-android/${RELEASE_TYPE_DIR}/libmatrix_sdk_ffi.a"
-  
+
 # Create android library
 cd "${KOTLIN_ROOT}"
 ./gradlew :sdk:sdk-android:assemble
@@ -61,4 +61,3 @@ echo -e "Cleaning up temporary files"
 
 rm -r "${BUILD_DIR}"
 rm -r "${SDK_TARGET_DIR}"
-

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -29,7 +29,6 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
 uniffi = { workspace = true }
-uniffi_macros = { workspace = true }
 vodozemac = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
@@ -58,7 +57,7 @@ default_features = false
 features = ["rt-multi-thread"]
 
 [build-dependencies]
-uniffi_build = { workspace = true, features = ["builtin-bindgen"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/bindings/matrix-sdk-crypto-ffi/build.rs
+++ b/bindings/matrix-sdk-crypto-ffi/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    uniffi_build::generate_scaffolding("./src/olm.udl").unwrap();
+    uniffi::generate_scaffolding("./src/olm.udl").unwrap();
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/uniffi_api.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/uniffi_api.rs
@@ -2,4 +2,4 @@
 
 use crate::*;
 
-uniffi_macros::include_scaffolding!("olm");
+uniffi::include_scaffolding!("olm");

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/matrix-org/matrix-rust-sdk"
 crate-type = ["cdylib", "staticlib"]
 
 [build-dependencies]
-uniffi_build = { workspace = true, features = ["builtin-bindgen"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dependencies]
 anyhow = { workspace = true }
@@ -31,7 +31,6 @@ thiserror = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-stream = "0.1.8"
 uniffi = { workspace = true }
-uniffi_macros = { workspace = true }
 zeroize = { workspace = true }
 
 

--- a/bindings/matrix-sdk-ffi/build.rs
+++ b/bindings/matrix-sdk-ffi/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    uniffi_build::generate_scaffolding("./src/api.udl").expect("Building the UDL file failed");
+    uniffi::generate_scaffolding("./src/api.udl").expect("Building the UDL file failed");
 }

--- a/bindings/matrix-sdk-ffi/src/uniffi_api.rs
+++ b/bindings/matrix-sdk-ffi/src/uniffi_api.rs
@@ -2,4 +2,4 @@
 
 use crate::*;
 
-uniffi_macros::include_scaffolding!("api");
+uniffi::include_scaffolding!("api");

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -55,8 +55,8 @@ use ruma::{
 /// An item in the timeline that represents at least one event.
 ///
 /// There is always one main event that gives the `EventTimelineItem` its
-/// identity (see [key](Self::key)) but in many cases, additional events like
-/// reactions and edits are also part of the item.
+/// identity but in many cases, additional events like reactions and edits are
+/// also part of the item.
 #[derive(Debug, Clone)]
 pub enum EventTimelineItem {
     /// An event item that has been sent, but not yet acknowledged by the
@@ -117,10 +117,10 @@ impl EventTimelineItem {
     /// If this returns `Some(_)`, the event was successfully created by the
     /// server.
     ///
-    /// Even if the [`key()`](Self::key) of this timeline item holds a
-    /// transaction ID, this can be `Some(_)` as the event ID can be known not
-    /// just from the remote echo via `sync_events`, but also from the response
-    /// of the send request that created the event.
+    /// Even if this is a [`Local`](Self::Local) event,, this can be `Some(_)`
+    /// as the event ID can be known not just from the remote echo via
+    /// `sync_events`, but also from the response of the send request that
+    /// created the event.
     pub fn event_id(&self) -> Option<&EventId> {
         match self {
             Self::Local(local_event) => local_event.event_id.as_deref(),

--- a/uniffi-bindgen/Cargo.toml
+++ b/uniffi-bindgen/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "uniffi-bindgen"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+uniffi = { workspace = true, features = ["cli"] }

--- a/uniffi-bindgen/src/main.rs
+++ b/uniffi-bindgen/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,5 +14,6 @@ clap = { version = "4.0.18", features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 fs_extra = "1"
+uniffi = { workspace = true }
 uniffi_bindgen = { workspace = true }
 xshell = "0.1.17"

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -127,7 +127,7 @@ fn check_bindings() -> Result<()> {
     cmd!("rustup run stable cargo build -p matrix-sdk-crypto-ffi -p matrix-sdk-ffi").run()?;
     cmd!(
         "
-        uniffi-bindgen generate
+        rustup run stable cargo run -p uniffi-bindgen -- generate
             --language kotlin
             --language swift
             --lib-file target/debug/libmatrix_sdk_ffi.a
@@ -138,7 +138,7 @@ fn check_bindings() -> Result<()> {
     .run()?;
     cmd!(
         "
-        uniffi-bindgen generate
+        rustup run stable cargo run -p uniffi-bindgen -- generate
             --language kotlin
             --language swift
             --lib-file target/debug/libmatrix_sdk_crypto_ffi.a


### PR DESCRIPTION
UniFFI made some breaking changes recently, the upside is now there is no longer a need to separately install the `uniffi-bindgen` binary! :)