### PR TITLE
fix(sled): Use proper table name for encoding key when redacting

### DIFF
--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -738,7 +738,7 @@ impl SledStateStore {
 
             let make_room_version = |room_id| {
                 self.room_info
-                    .get(self.encode_key(ROOM_INFO, room_id))
+                    .get(self.encode_key(ROOM, room_id))
                     .ok()
                     .flatten()
                     .map(|r| self.deserialize_value::<RoomInfo>(&r))


### PR DESCRIPTION
Contrary to other tables that use their own name to encode their keys, the `ROOM_INFO` table uses the `ROOM` table name to encode its keys.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
