### PR TITLE
feat(sdk): `SlidingSync::get_room` now takes a ref to `RoomId`.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -13,7 +13,7 @@ use matrix_sdk::ruma::{
         v4::RoomSubscription as RumaRoomSubscription,
         UnreadNotificationsCount as RumaUnreadNotificationsCount,
     },
-    assign, IdParseError, OwnedRoomId, UInt,
+    assign, IdParseError, OwnedRoomId, RoomId, UInt,
 };
 pub use matrix_sdk::{
     room::timeline::Timeline, ruma::api::client::sync::sync_events::v4::SyncRequestListFilters,
@@ -643,7 +643,7 @@ impl SlidingSync {
     pub fn get_room(&self, room_id: String) -> anyhow::Result<Option<Arc<SlidingSyncRoom>>> {
         let runner = self.inner.clone();
 
-        Ok(self.inner.get_room(&OwnedRoomId::try_from(room_id)?).map(|inner| {
+        Ok(self.inner.get_room(<&RoomId>::try_from(room_id.as_str())?).map(|inner| {
             Arc::new(SlidingSyncRoom {
                 inner,
                 runner,

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -642,7 +642,8 @@ impl SlidingSync {
 
     pub fn get_room(&self, room_id: String) -> anyhow::Result<Option<Arc<SlidingSyncRoom>>> {
         let runner = self.inner.clone();
-        Ok(self.inner.get_room(OwnedRoomId::try_from(room_id)?).map(|inner| {
+
+        Ok(self.inner.get_room(&OwnedRoomId::try_from(room_id)?).map(|inner| {
             Arc::new(SlidingSyncRoom {
                 inner,
                 runner,

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -814,8 +814,8 @@ impl SlidingSync {
     }
 
     /// Lookup a specific room
-    pub fn get_room(&self, room_id: OwnedRoomId) -> Option<SlidingSyncRoom> {
-        self.rooms.lock_ref().get(&room_id).cloned()
+    pub fn get_room(&self, room_id: &OwnedRoomId) -> Option<SlidingSyncRoom> {
+        self.rooms.lock_ref().get(room_id).cloned()
     }
 
     fn update_to_device_since(&self, since: String) {

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -814,7 +814,7 @@ impl SlidingSync {
     }
 
     /// Lookup a specific room
-    pub fn get_room(&self, room_id: &OwnedRoomId) -> Option<SlidingSyncRoom> {
+    pub fn get_room(&self, room_id: &RoomId) -> Option<SlidingSyncRoom> {
         self.rooms.lock_ref().get(room_id).cloned()
     }
 


### PR DESCRIPTION
Before this patch, `SlidingSync::get_room` was taking ownership of an `OwnedRoomId`, to only use it as a reference. Thus, calling this method was creating useless clones.

This patch updates `SlidingSync::get_room` to receive a reference to `RoomId`.