### PR TITLE
feat(sdk): Remove `SlidingSyncView.rooms`

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -818,6 +818,11 @@ impl SlidingSync {
         self.rooms.lock_ref().get(&room_id).cloned()
     }
 
+    /// Check the number of rooms.
+    pub fn get_number_of_rooms(&self) -> usize {
+        self.rooms.lock_ref().len()
+    }
+
     fn update_to_device_since(&self, since: String) {
         self.extensions
             .lock()
@@ -867,6 +872,11 @@ impl SlidingSync {
     ) -> Vec<Option<SlidingSyncRoom>> {
         let rooms = self.rooms.lock_ref();
         room_ids.map(|room_id| rooms.get(&room_id).cloned()).collect()
+    }
+
+    /// Get all rooms.
+    pub fn get_all_rooms(&self) -> Vec<SlidingSyncRoom> {
+        self.rooms.lock_ref().iter().map(|(_, room)| room.clone()).collect()
     }
 
     #[instrument(skip_all, fields(views = views.len()))]

--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -1126,15 +1126,14 @@ pub struct SlidingSyncView {
     /// The state this view is in
     #[builder(private, default)]
     pub state: ViewState,
+
     /// The total known number of rooms,
     #[builder(private, default)]
     pub rooms_count: RoomsCount,
+
     /// The rooms in order
     #[builder(private, default)]
     pub rooms_list: RoomsList,
-    /// The rooms details
-    #[builder(private, default)]
-    pub rooms: RoomsMap,
 
     /// The ranges windows of the view
     #[builder(setter(name = "ranges_raw"), default)]
@@ -1675,28 +1674,7 @@ impl SlidingSyncView {
         self
     }
 
-    /// Return the subset of rooms, starting at offset (default 0) returning
-    /// count (or to the end) items
-    pub fn get_rooms(
-        &self,
-        offset: Option<usize>,
-        count: Option<usize>,
-    ) -> Vec<v4::SlidingSyncRoom> {
-        let start = offset.unwrap_or(0);
-        let rooms = self.rooms.lock_ref();
-        let listing = self.rooms_list.lock_ref();
-        let count = count.unwrap_or(listing.len() - start);
-        listing
-            .iter()
-            .skip(start)
-            .filter_map(|id| id.as_room_id())
-            .filter_map(|id| rooms.get(id))
-            .map(|r| r.inner.clone())
-            .take(count)
-            .collect()
-    }
-
-    /// Find the current valid position of the room in the vies room_list.
+    /// Find the current valid position of the room in the view room_list.
     ///
     /// Only matches against the current ranges and only against filled items.
     /// Invalid items are ignore. Return the total position the item was
@@ -1799,7 +1777,6 @@ impl SlidingSyncView {
         {
             // keep the lock scoped so that the later find_rooms_in_view doesn't deadlock
             let mut rooms_list = self.rooms_list.lock_mut();
-            let _rooms_map = self.rooms.lock_mut();
 
             if !ops.is_empty() {
                 room_ops(&mut rooms_list, ops, ranges)?;

--- a/labs/jack-in/src/client/mod.rs
+++ b/labs/jack-in/src/client/mod.rs
@@ -43,7 +43,7 @@ pub async fn run_client(
     let stream = syncer.stream();
     let view = syncer.view("full-sync").expect("we have the full syncer there").clone();
     let state = view.state.clone();
-    let mut ssync_state = state::SlidingSyncState::new(view);
+    let mut ssync_state = state::SlidingSyncState::new(syncer.clone(), view);
     tx.send(ssync_state.clone()).await?;
 
     info!("starting polling");

--- a/labs/jack-in/src/client/state.rs
+++ b/labs/jack-in/src/client/state.rs
@@ -136,7 +136,7 @@ impl SlidingSyncState {
     }
 
     pub fn get_room(&self, room_id: &RoomId) -> Option<SlidingSyncRoom> {
-        self.syncer.get_room(room_id.to_owned())
+        self.syncer.get_room(room_id)
     }
 
     pub fn get_all_rooms(&self) -> Vec<SlidingSyncRoom> {

--- a/labs/jack-in/src/components/details.rs
+++ b/labs/jack-in/src/components/details.rs
@@ -47,7 +47,7 @@ impl Details {
 
     pub fn refresh_data(&mut self) {
         let Some(room_id) = self.sstate.selected_room.lock_ref().clone() else { return };
-        let Some(room_data) = self.sstate.view().rooms.lock_ref().get(&room_id).cloned() else {
+        let Some(room_data) = self.sstate.get_room(&room_id) else {
             return;
         };
 

--- a/labs/jack-in/src/components/rooms.rs
+++ b/labs/jack-in/src/components/rooms.rs
@@ -30,7 +30,7 @@ impl Rooms {
     }
 
     pub fn select_dir(&mut self, count: i32) {
-        let rooms_count = self.sstate.view().get_rooms(None, None).len() as i32;
+        let rooms_count = self.sstate.loaded_rooms_count() as i32;
         let current = self.tablestate.selected().unwrap_or_default() as i32;
         let next = {
             let next = current + count;
@@ -63,8 +63,9 @@ impl MockComponent for Rooms {
 
         let mut paras = vec![];
 
-        for r in self.sstate.view().get_rooms(None, None) {
-            let mut cells = vec![Cell::from(r.name.unwrap_or_else(|| "unknown".to_owned()))];
+        for r in self.sstate.get_all_rooms() {
+            let mut cells =
+                vec![Cell::from(r.name.clone().unwrap_or_else(|| "unknown".to_owned()))];
             if let Some(c) = r.unread_notifications.notification_count {
                 let count: u32 = c.try_into().unwrap_or_default();
                 if count > 0 {


### PR DESCRIPTION
`SlidingSyncView` exposes a `room` field. Problem: It's not updated correctly and leads to error. The canonical way to get a room is by using `SlidingSync::get_room`. This patch thus removes `SlidingSyncView.rooms` entirely.