### PR TITLE
feat(sliding-sync): selectively ignore cold-cache per view

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -434,6 +434,12 @@ impl SlidingSyncViewBuilder {
         Arc::new(builder)
     }
 
+    pub fn cold_cache(self: Arc<Self>, cold_cache: bool) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.cold_cache(cold_cache);
+        Arc::new(builder)
+    }
+
     pub fn no_filters(self: Arc<Self>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.filters(None);


### PR DESCRIPTION
Allows the clients constructing the view to configure whether it may be stored in cold-cache (and recovered from it upon `SlidingSyncBuilder::build()` from it).

Performance improvement, as we were storing all views regardless of whether they would be used or recovered. By disabling this flag, you can prevent the view from ever running those extra path for storing the data (and thus keeping DB recovery lower).