### PR TITLE
fix(stores): Fix broken raw redacted state events

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -46,6 +46,7 @@ use ruma::{
     CanonicalJsonObject, EventId, MxcUri, OwnedEventId, OwnedUserId, RoomId, RoomVersionId, UserId,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 use tracing::{debug, warn};
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
@@ -109,7 +110,7 @@ impl From<IndexeddbStateStoreError> for StoreError {
 mod KEYS {
     // STORES
 
-    pub const CURRENT_DB_VERSION: f64 = 1.1;
+    pub const CURRENT_DB_VERSION: f64 = 1.2;
     pub const CURRENT_META_DB_VERSION: f64 = 2.0;
 
     pub const INTERNAL_STATE: &str = "matrix-sdk-state";
@@ -237,6 +238,74 @@ async fn backup(source: &IdbDatabase, meta: &IdbDatabase) -> Result<()> {
     Ok(())
 }
 
+fn serialize_event(store_cipher: Option<&StoreCipher>, event: &impl Serialize) -> Result<JsValue> {
+    Ok(match store_cipher {
+        Some(cipher) => JsValue::from_serde(&cipher.encrypt_value_typed(event)?)?,
+        None => JsValue::from_serde(event)?,
+    })
+}
+
+fn deserialize_event<T: DeserializeOwned>(
+    store_cipher: Option<&StoreCipher>,
+    event: JsValue,
+) -> Result<T> {
+    match store_cipher {
+        Some(cipher) => Ok(cipher.decrypt_value_typed(event.into_serde()?)?),
+        None => Ok(event.into_serde()?),
+    }
+}
+
+async fn v1_2_fix_store(
+    store: &IdbObjectStore<'_>,
+    store_cipher: Option<&StoreCipher>,
+) -> Result<()> {
+    fn maybe_fix_json(raw_json: &RawJsonValue) -> Result<Option<JsonValue>> {
+        let json = raw_json.get();
+
+        if json.contains(r#""content":null"#) {
+            let mut value: JsonValue = serde_json::from_str(json)?;
+            if let Some(content) = value.get_mut("content") {
+                if matches!(content, JsonValue::Null) {
+                    *content = JsonValue::Object(Default::default());
+                    return Ok(Some(value));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    let cursor = store.open_cursor()?.await?;
+
+    if let Some(cursor) = cursor {
+        loop {
+            let raw_json: Box<RawJsonValue> = deserialize_event(store_cipher, cursor.value())?;
+
+            if let Some(fixed_json) = maybe_fix_json(&raw_json)? {
+                cursor.update(&serialize_event(store_cipher, &fixed_json)?)?.await?;
+            }
+
+            if !cursor.continue_cursor()?.await? {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn migrate_to_v1_2(db: &IdbDatabase, store_cipher: Option<&StoreCipher>) -> Result<()> {
+    let tx = db.transaction_on_multi_with_mode(
+        &[KEYS::ROOM_STATE, KEYS::ROOM_INFOS],
+        IdbTransactionMode::Readwrite,
+    )?;
+
+    v1_2_fix_store(&tx.object_store(KEYS::ROOM_STATE)?, store_cipher).await?;
+    v1_2_fix_store(&tx.object_store(KEYS::ROOM_INFOS)?, store_cipher).await?;
+
+    tx.await.into_result().map_err(|e| e.into())
+}
+
 #[derive(Builder, Debug, PartialEq, Eq)]
 #[builder(name = "IndexeddbStateStoreBuilder", build_fn(skip))]
 pub struct IndexeddbStateStoreBuilderConfig {
@@ -311,7 +380,8 @@ impl IndexeddbStateStoreBuilder {
             None
         };
 
-        let recreate_stores = {
+        let mut recreate_stores = false;
+        {
             // checkup up in a separate call, whether we have to backup or do anything else
             // to the db. Unfortunately the set_on_upgrade_needed doesn't allow async fn
             // which we need to execute the backup.
@@ -337,15 +407,16 @@ impl IndexeddbStateStoreBuilder {
             let old_version = pre_db.version();
 
             if created.load(Ordering::Relaxed) {
-                // this is a fresh DB, return
-                false
+                // this is a fresh DB, nothing to do
             } else if old_version == 1.0 && has_store_cipher {
                 match migration_strategy {
                     MigrationConflictStrategy::BackupAndDrop => {
                         backup(&pre_db, &meta_db).await?;
-                        true
+                        recreate_stores = true;
                     }
-                    MigrationConflictStrategy::Drop => true,
+                    MigrationConflictStrategy::Drop => {
+                        recreate_stores = true;
+                    }
                     MigrationConflictStrategy::Raise => {
                         return Err(IndexeddbStateStoreError::MigrationConflict {
                             name,
@@ -354,11 +425,12 @@ impl IndexeddbStateStoreBuilder {
                         })
                     }
                 }
+            } else if old_version < 1.2 {
+                migrate_to_v1_2(&pre_db, store_cipher.as_deref()).await?;
             } else {
                 // Nothing to be done
-                false
             }
-        };
+        }
 
         let mut db_req: OpenDbRequest = IdbDatabase::open_f64(&name, KEYS::CURRENT_DB_VERSION)?;
         db_req.set_on_upgrade_needed(Some(
@@ -421,17 +493,11 @@ impl IndexeddbStateStore {
     }
 
     fn serialize_event(&self, event: &impl Serialize) -> Result<JsValue> {
-        Ok(match &self.store_cipher {
-            Some(cipher) => JsValue::from_serde(&cipher.encrypt_value_typed(event)?)?,
-            None => JsValue::from_serde(event)?,
-        })
+        serialize_event(self.store_cipher.as_deref(), event)
     }
 
     fn deserialize_event<T: DeserializeOwned>(&self, event: JsValue) -> Result<T> {
-        match &self.store_cipher {
-            Some(cipher) => Ok(cipher.decrypt_value_typed(event.into_serde()?)?),
-            None => Ok(event.into_serde()?),
-        }
+        deserialize_event(self.store_cipher.as_deref(), event)
     }
 
     fn encode_key<T>(&self, table_name: &str, key: T) -> JsValue
@@ -1447,15 +1513,21 @@ mod migration_tests {
 
     use indexed_db_futures::prelude::*;
     use matrix_sdk_test::async_test;
+    use ruma::{
+        events::{AnySyncStateEvent, StateEventType},
+        room_id,
+    };
+    use serde_json::json;
     use uuid::Uuid;
     use wasm_bindgen::JsValue;
 
     use super::{
-        IndexeddbStateStore, IndexeddbStateStoreError, MigrationConflictStrategy, Result,
-        ALL_STORES,
+        serialize_event, IndexeddbStateStore, IndexeddbStateStoreError, MigrationConflictStrategy,
+        Result, ALL_STORES, KEYS,
     };
+    use crate::safe_encode::SafeEncode;
 
-    pub async fn create_fake_db(name: &str, version: f64) -> Result<()> {
+    pub async fn create_fake_db(name: &str, version: f64) -> Result<IdbDatabase> {
         let mut db_req: OpenDbRequest = IdbDatabase::open_f64(name, version)?;
         db_req.set_on_upgrade_needed(Some(
             move |evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
@@ -1467,8 +1539,7 @@ mod migration_tests {
                 Ok(())
             },
         ));
-        db_req.into_future().await?;
-        Ok(())
+        db_req.into_future().await.map_err(Into::into)
     }
 
     #[async_test]
@@ -1559,6 +1630,54 @@ mod migration_tests {
         } else {
             assert!(false, "Conflict didn't raise: {:?}", store_res)
         }
+        Ok(())
+    }
+
+    #[async_test]
+    pub async fn test_migrating_to_v1_2() -> Result<()> {
+        let name = format!("migrating-1.2-{}", Uuid::new_v4().as_hyphenated().to_string());
+        // An event that fails to deserialize.
+        let wrong_redacted_state_event = json!({
+            "content": null,
+            "event_id": "$wrongevent",
+            "origin_server_ts": 1673887516047_u64,
+            "sender": "@example:localhost",
+            "state_key": "",
+            "type": "m.room.topic",
+            "unsigned": {
+                "redacted_because": {
+                    "type": "m.room.redaction",
+                    "sender": "@example:localhost",
+                    "content": {},
+                    "redacts": "$wrongevent",
+                    "origin_server_ts": 1673893816047_u64,
+                    "unsigned": {},
+                    "event_id": "$redactionevent",
+                },
+            },
+        });
+        serde_json::from_value::<AnySyncStateEvent>(wrong_redacted_state_event.clone())
+            .unwrap_err();
+
+        let room_id = room_id!("!some_room:localhost");
+
+        // Populate DB with wrong event.
+        {
+            let db = create_fake_db(&name, 1.1).await?;
+            let tx =
+                db.transaction_on_one_with_mode(KEYS::ROOM_STATE, IdbTransactionMode::Readwrite)?;
+            let state = tx.object_store(KEYS::ROOM_STATE)?;
+            let key = (room_id, StateEventType::RoomTopic, "").encode();
+            state.put_key_val(&key, &serialize_event(None, &wrong_redacted_state_event)?)?;
+            tx.await.into_result()?;
+        }
+
+        // this transparently migrates to the latest version
+        let store = IndexeddbStateStore::builder().name(name).build().await?;
+        let event =
+            store.get_state_event(room_id, StateEventType::RoomTopic, "").await.unwrap().unwrap();
+        event.deserialize().unwrap();
+
         Ok(())
     }
 }

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -44,6 +44,7 @@ use ruma::{
     RoomVersionId, UserId,
 };
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 use sled::{
     transaction::{ConflictableTransactionError, TransactionError},
     Config, Db, Transactional, Tree,
@@ -115,7 +116,7 @@ impl From<SledStoreError> for StoreError {
         }
     }
 }
-const DATABASE_VERSION: u8 = 2;
+const DATABASE_VERSION: u8 = 3;
 
 const VERSION_KEY: &str = "state-store-version";
 
@@ -438,17 +439,17 @@ impl SledStateStore {
 
         debug!(old_version, new_version = DATABASE_VERSION, "Upgrading the Sled state store");
 
-        if old_version == 1 {
-            if self.store_cipher.is_some() {
-                // we stored some fields un-encrypted. Drop them to force re-creation
-                return Err(SledStoreError::MigrationConflict {
-                    path: self.path.take().expect("Path must exist for a migration to fail"),
-                    old_version: old_version.into(),
-                    new_version: DATABASE_VERSION.into(),
-                });
-            }
-            // no migration to handle
-            self.set_db_version(2u8)?;
+        if old_version == 1 && self.store_cipher.is_some() {
+            // we stored some fields un-encrypted. Drop them to force re-creation
+            return Err(SledStoreError::MigrationConflict {
+                path: self.path.take().expect("Path must exist for a migration to fail"),
+                old_version: old_version.into(),
+                new_version: DATABASE_VERSION.into(),
+            });
+        }
+
+        if old_version < 3 {
+            self.migrate_to_v3()?;
             return Ok(());
         }
 
@@ -460,6 +461,54 @@ impl SledStateStore {
             old_version: old_version.into(),
             new_version: DATABASE_VERSION.into(),
         })
+    }
+
+    fn v3_fix_tree(&self, tree: &Tree, batch: &mut sled::Batch) -> Result<()> {
+        fn maybe_fix_json(raw_json: &RawJsonValue) -> Result<Option<JsonValue>> {
+            let json = raw_json.get();
+
+            if json.contains(r#""content":null"#) {
+                let mut value: JsonValue = serde_json::from_str(json)?;
+                if let Some(content) = value.get_mut("content") {
+                    if matches!(content, JsonValue::Null) {
+                        *content = JsonValue::Object(Default::default());
+                        return Ok(Some(value));
+                    }
+                }
+            }
+
+            Ok(None)
+        }
+
+        for entry in tree.iter() {
+            let (key, value) = entry?;
+            let raw_json: Box<RawJsonValue> = self.deserialize_value(&value)?;
+
+            if let Some(fixed_json) = maybe_fix_json(&raw_json)? {
+                batch.insert(key, self.serialize_value(&fixed_json)?);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn migrate_to_v3(&self) -> Result<()> {
+        let mut room_info_batch = sled::Batch::default();
+        self.v3_fix_tree(&self.room_info, &mut room_info_batch)?;
+
+        let mut room_state_batch = sled::Batch::default();
+        self.v3_fix_tree(&self.room_state, &mut room_state_batch)?;
+
+        let ret: Result<(), TransactionError<SledStoreError>> = (&self.room_info, &self.room_state)
+            .transaction(|(room_info, room_state)| {
+                room_info.apply_batch(&room_info_batch)?;
+                room_state.apply_batch(&room_state_batch)?;
+
+                Ok(())
+            });
+        ret?;
+
+        self.set_db_version(3u8)
     }
 
     /// Open a `SledCryptoStore` that uses the same database as this store.
@@ -1544,9 +1593,15 @@ mod encrypted_tests {
 #[cfg(test)]
 mod migration {
     use matrix_sdk_test::async_test;
+    use ruma::{
+        events::{AnySyncStateEvent, StateEventType},
+        room_id,
+    };
+    use serde_json::json;
     use tempfile::TempDir;
 
     use super::{MigrationConflictStrategy, Result, SledStateStore, SledStoreError};
+    use crate::state_store::ROOM_STATE;
 
     #[async_test]
     pub async fn migrating_v1_to_2_plain() -> Result<()> {
@@ -1630,5 +1685,59 @@ mod migration {
         }
         assert_eq!(std::fs::read_dir(folder.path())?.count(), 1);
         Ok(())
+    }
+
+    #[async_test]
+    pub async fn migrating_v2_to_v3() {
+        // An event that fails to deserialize.
+        let wrong_redacted_state_event = json!({
+            "content": null,
+            "event_id": "$wrongevent",
+            "origin_server_ts": 1673887516047_u64,
+            "sender": "@example:localhost",
+            "state_key": "",
+            "type": "m.room.topic",
+            "unsigned": {
+                "redacted_because": {
+                    "type": "m.room.redaction",
+                    "sender": "@example:localhost",
+                    "content": {},
+                    "redacts": "$wrongevent",
+                    "origin_server_ts": 1673893816047_u64,
+                    "unsigned": {},
+                    "event_id": "$redactionevent",
+                },
+            },
+        });
+        serde_json::from_value::<AnySyncStateEvent>(wrong_redacted_state_event.clone())
+            .unwrap_err();
+
+        let room_id = room_id!("!some_room:localhost");
+        let folder = TempDir::new().unwrap();
+
+        let store = SledStateStore::builder()
+            .path(folder.path().to_path_buf())
+            .passphrase("secret".to_owned())
+            .build()
+            .unwrap();
+
+        store
+            .room_state
+            .insert(
+                store.encode_key(ROOM_STATE, (room_id, StateEventType::RoomTopic, "")),
+                store.serialize_value(&wrong_redacted_state_event).unwrap(),
+            )
+            .unwrap();
+        store.set_db_version(2u8).unwrap();
+        drop(store);
+
+        let store = SledStateStore::builder()
+            .path(folder.path().to_path_buf())
+            .passphrase("secret".to_owned())
+            .build()
+            .unwrap();
+        let event =
+            store.get_state_event(room_id, StateEventType::RoomTopic, "").await.unwrap().unwrap();
+        event.deserialize().unwrap();
     }
 }


### PR DESCRIPTION
A fix for (de)serialization of redacted state events in Ruma made
old events undeserializable.
Bump the DB version.

Tested locally in fractal with the sled store and seems to fix the issue. I tried to test it for the IndexedDB store too but it seems I can't get the wasm_command_bot example to start when I enable the store.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>