### PR TITLE
Prepare matrix-sdk-crypto-js v0.1.0-alpha.4

### DIFF
--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-js",
-    "version": "0.1.0-alpha.3",
+    "version": "0.1.0-alpha.4",
     "homepage": "https://github.com/matrix-org/matrix-rust-sdk",
     "description": "Matrix encryption library, for JavaScript",
     "license": "Apache-2.0",


### PR DESCRIPTION
Nothing much has changed in matrix-sdk-crypto-js, but I need to publish a new artifact to NPM to include https://github.com/matrix-org/matrix-rust-sdk/pull/1429.

Is there a better way to do this?