### PR TITLE
feat(sdk): `SlidingSyncRoom.timeline` is no longer a `Arc<MutableVec<_>>`

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -241,14 +241,7 @@ impl SlidingSyncRoom {
         if let Some(room) = self.client.get_room(&self.room_id) {
             let current_timeline = &self.timeline;
             let prev_batch = self.prev_batch.lock_ref().clone();
-            Some(
-                Timeline::with_events(
-                    &room,
-                    prev_batch,
-                    current_timeline.iter().cloned().collect(),
-                )
-                .await,
-            )
+            Some(Timeline::with_events(&room, prev_batch, current_timeline.clone()).await)
         } else if let Some(invited_room) = self.client.get_invited_room(&self.room_id) {
             Some(Timeline::with_events(&invited_room, None, vec![]).await)
         } else {


### PR DESCRIPTION
Prior to this patch, the `SlidingSyncRoom.timeline` field was initially of type `AliveRoomTimeline`. This is a type alias to `Arc<MutableVec<SyncTimelineEvent>>`.

No one can listen to the `timeline` field because it's not public. So the `MutableVec` part is not necessary, hence removing many locks. At this step, `AliveRoomTimeline` can simply be defined as `Arc<Vec<SyncTimelineEvent>>`.

But we can go further… There is no need for an `Arc` here. So `timeline`'s type becomes `Vec<SyncTimelineEvent>`. The type is simple enough to remove its type alias `AliveRoomTimeline`. Indeed, `Vec<SyncTimelineEvent>` is used in other types, like `FrozenSlidingSyncRoom` for example. It's not an issue.

To summarize: No more locks, no more clones.

Edit: This patch also removes the conditional `timeline()` method. The `experimental-timeline` feature is always enabled by `experimental-sliding-sync`. It's dead-code basically.