### PR TITLE
Post-merge sqlite crypto store cleanup

### DIFF
--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -34,10 +34,7 @@ rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { version = "1.24.2", default-features = false, features = [
-    "sync",
-    "fs",
-] }
+tokio = { version = "1.24.2", default-features = false, features = ["sync", "fs"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
@@ -48,8 +45,5 @@ matrix-sdk-crypto = { path = "../matrix-sdk-crypto", features = ["testing"] }
 matrix-sdk-test = { path = "../../testing/matrix-sdk-test" }
 once_cell = { workspace = true }
 tempfile = "3.3.0"
-tokio = { version = "1.24.2", default-features = false, features = [
-    "rt-multi-thread",
-    "macros",
-] }
+tokio = { version = "1.24.2", default-features = false, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -14,6 +14,7 @@
 
 use std::{
     collections::HashMap,
+    fmt,
     path::{Path, PathBuf},
     sync::{Arc, RwLock},
 };
@@ -102,12 +103,12 @@ pub struct SqliteCryptoStore {
     session_cache: SessionStore,
 }
 
-impl std::fmt::Debug for SqliteCryptoStore {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for SqliteCryptoStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(path) = &self.path {
-            f.debug_struct("SledCryptoStore").field("path", &path).finish()
+            f.debug_struct("SqliteCryptoStore").field("path", &path).finish()
         } else {
-            f.debug_struct("SledCryptoStore").field("path", &"memory store").finish()
+            f.debug_struct("SqliteCryptoStore").field("path", &"memory store").finish()
         }
     }
 }


### PR DESCRIPTION
Debug string was referencing `sled`, and we seem to have accidentally pulled in some unusual auto-formatting.