### PR TITLE
fix(stores): Separate receipts by thread

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -21,7 +21,7 @@ use futures_util::stream::{self, StreamExt};
 use ruma::{
     api::client::sync::sync_events::v3::RoomSummary as RumaSummary,
     events::{
-        receipt::{Receipt, ReceiptType},
+        receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
             create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
             guest_access::GuestAccess, history_visibility::HistoryVisibility, join_rules::JoinRule,
@@ -483,21 +483,27 @@ impl Room {
     }
 
     /// Get the read receipt as a `EventId` and `Receipt` tuple for the given
-    /// `user_id` in this room.
+    /// `thread` and `user_id` in this room.
     pub async fn user_read_receipt(
         &self,
+        thread: ReceiptThread,
         user_id: &UserId,
     ) -> StoreResult<Option<(OwnedEventId, Receipt)>> {
-        self.store.get_user_room_receipt_event(self.room_id(), ReceiptType::Read, user_id).await
+        self.store
+            .get_user_room_receipt_event(self.room_id(), ReceiptType::Read, thread, user_id)
+            .await
     }
 
     /// Get the read receipts as a list of `UserId` and `Receipt` tuples for the
-    /// given `event_id` in this room.
+    /// given `thread` and `event_id` in this room.
     pub async fn event_read_receipts(
         &self,
+        thread: ReceiptThread,
         event_id: &EventId,
     ) -> StoreResult<Vec<(OwnedUserId, Receipt)>> {
-        self.store.get_event_room_receipt_events(self.room_id(), ReceiptType::Read, event_id).await
+        self.store
+            .get_event_room_receipt_events(self.room_id(), ReceiptType::Read, thread, event_id)
+            .await
     }
 }
 

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -134,7 +134,7 @@ macro_rules! statestore_integration_tests {
             event_id,
             events::{
                 presence::PresenceEvent,
-                receipt::ReceiptType,
+                receipt::{ReceiptType, ReceiptThread},
                 room::{
                     member::{
                         MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent,
@@ -475,7 +475,12 @@ macro_rules! statestore_integration_tests {
                 .await?
                 .is_some());
             assert!(store
-                .get_user_room_receipt_event(room_id, ReceiptType::Read, user_id)
+                .get_user_room_receipt_event(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    user_id
+                )
                 .await?
                 .is_some());
             assert_eq!(
@@ -483,6 +488,7 @@ macro_rules! statestore_integration_tests {
                     .get_event_room_receipt_events(
                         room_id,
                         ReceiptType::Read,
+                        ReceiptThread::Unthreaded,
                         first_receipt_event_id()
                     )
                     .await?
@@ -613,17 +619,32 @@ macro_rules! statestore_integration_tests {
             .expect("json creation failed");
 
             assert!(store
-                .get_user_room_receipt_event(room_id, ReceiptType::Read, user_id())
+                .get_user_room_receipt_event(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    user_id()
+                )
                 .await
                 .expect("failed to read user room receipt")
                 .is_none());
             assert!(store
-                .get_event_room_receipt_events(room_id, ReceiptType::Read, &first_event_id)
+                .get_event_room_receipt_events(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    &first_event_id
+                )
                 .await
                 .expect("failed to read user room receipt for 1")
                 .is_empty());
             assert!(store
-                .get_event_room_receipt_events(room_id, ReceiptType::Read, &second_event_id)
+                .get_event_room_receipt_events(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    &second_event_id
+                )
                 .await
                 .expect("failed to read user room receipt for 2")
                 .is_empty());
@@ -633,13 +654,23 @@ macro_rules! statestore_integration_tests {
 
             store.save_changes(&changes).await.expect("writing changes fauked");
             assert!(store
-                .get_user_room_receipt_event(room_id, ReceiptType::Read, user_id())
+                .get_user_room_receipt_event(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    user_id()
+                )
                 .await
                 .expect("failed to read user room receipt after save")
                 .is_some());
             assert_eq!(
                 store
-                    .get_event_room_receipt_events(room_id, ReceiptType::Read, &first_event_id)
+                    .get_event_room_receipt_events(
+                        room_id,
+                        ReceiptType::Read,
+                        ReceiptThread::Unthreaded,
+                        &first_event_id
+                    )
                     .await
                     .expect("failed to read user room receipt for 1 after save")
                     .len(),
@@ -647,7 +678,12 @@ macro_rules! statestore_integration_tests {
                 "Found a wrong number of receipts for 1 after save"
             );
             assert!(store
-                .get_event_room_receipt_events(room_id, ReceiptType::Read, &second_event_id)
+                .get_event_room_receipt_events(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    &second_event_id
+                )
                 .await
                 .expect("failed to read user room receipt for 2 after save")
                 .is_empty());
@@ -657,18 +693,33 @@ macro_rules! statestore_integration_tests {
 
             store.save_changes(&changes).await.expect("Saving works");
             assert!(store
-                .get_user_room_receipt_event(room_id, ReceiptType::Read, user_id())
+                .get_user_room_receipt_event(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    user_id()
+                )
                 .await
                 .expect("Getting user room receipts failed")
                 .is_some());
             assert!(store
-                .get_event_room_receipt_events(room_id, ReceiptType::Read, &first_event_id)
+                .get_event_room_receipt_events(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    &first_event_id
+                )
                 .await
                 .expect("Getting event room receipt events for first event failed")
                 .is_empty());
             assert_eq!(
                 store
-                    .get_event_room_receipt_events(room_id, ReceiptType::Read, &second_event_id)
+                    .get_event_room_receipt_events(
+                        room_id,
+                        ReceiptType::Read,
+                        ReceiptThread::Unthreaded,
+                        &second_event_id
+                    )
                     .await
                     .expect("Getting event room receipt events for second event failed")
                     .len(),
@@ -803,7 +854,12 @@ macro_rules! statestore_integration_tests {
                 .await?
                 .is_none());
             assert!(store
-                .get_user_room_receipt_event(room_id, ReceiptType::Read, user_id)
+                .get_user_room_receipt_event(
+                    room_id,
+                    ReceiptType::Read,
+                    ReceiptThread::Unthreaded,
+                    user_id
+                )
                 .await?
                 .is_none());
             assert!(
@@ -811,6 +867,7 @@ macro_rules! statestore_integration_tests {
                     .get_event_room_receipt_events(
                         room_id,
                         ReceiptType::Read,
+                        ReceiptThread::Unthreaded,
                         first_receipt_event_id()
                     )
                     .await?

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -25,7 +25,7 @@ use ruma::{
     canonical_json::redact,
     events::{
         presence::PresenceEvent,
-        receipt::{Receipt, ReceiptType},
+        receipt::{Receipt, ReceiptThread, ReceiptType},
         room::member::{MembershipState, StrippedRoomMemberEvent, SyncRoomMemberEvent},
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
@@ -66,10 +66,17 @@ pub struct MemoryStore {
     stripped_joined_user_ids: Arc<DashMap<OwnedRoomId, DashSet<OwnedUserId>>>,
     stripped_invited_user_ids: Arc<DashMap<OwnedRoomId, DashSet<OwnedUserId>>>,
     presence: Arc<DashMap<OwnedUserId, Raw<PresenceEvent>>>,
-    room_user_receipts:
-        Arc<DashMap<OwnedRoomId, DashMap<String, DashMap<OwnedUserId, (OwnedEventId, Receipt)>>>>,
+    room_user_receipts: Arc<
+        DashMap<
+            OwnedRoomId,
+            DashMap<(String, Option<String>), DashMap<OwnedUserId, (OwnedEventId, Receipt)>>,
+        >,
+    >,
     room_event_receipts: Arc<
-        DashMap<OwnedRoomId, DashMap<String, DashMap<OwnedEventId, DashMap<OwnedUserId, Receipt>>>>,
+        DashMap<
+            OwnedRoomId,
+            DashMap<(String, Option<String>), DashMap<OwnedEventId, DashMap<OwnedUserId, Receipt>>>,
+        >,
     >,
     custom: Arc<DashMap<Vec<u8>, Vec<u8>>>,
 }
@@ -317,18 +324,21 @@ impl MemoryStore {
             for (event_id, receipts) in &content.0 {
                 for (receipt_type, receipts) in receipts {
                     for (user_id, receipt) in receipts {
+                        let thread = receipt.thread.as_str().map(ToOwned::to_owned);
                         // Add the receipt to the room user receipts
                         if let Some((old_event, _)) = self
                             .room_user_receipts
                             .entry(room.clone())
                             .or_default()
-                            .entry(receipt_type.to_string())
+                            .entry((receipt_type.to_string(), thread.clone()))
                             .or_default()
                             .insert(user_id.clone(), (event_id.clone(), receipt.clone()))
                         {
                             // Remove the old receipt from the room event receipts
                             if let Some(receipt_map) = self.room_event_receipts.get(room) {
-                                if let Some(event_map) = receipt_map.get(receipt_type.as_ref()) {
+                                if let Some(event_map) =
+                                    receipt_map.get(&(receipt_type.to_string(), thread.clone()))
+                                {
                                     if let Some(user_map) = event_map.get_mut(&old_event) {
                                         user_map.remove(user_id);
                                     }
@@ -340,7 +350,7 @@ impl MemoryStore {
                         self.room_event_receipts
                             .entry(room.clone())
                             .or_default()
-                            .entry(receipt_type.to_string())
+                            .entry((receipt_type.to_string(), thread))
                             .or_default()
                             .entry(event_id.clone())
                             .or_default()
@@ -509,10 +519,12 @@ impl MemoryStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
         Ok(self.room_user_receipts.get(room_id).and_then(|m| {
-            m.get(receipt_type.as_ref()).and_then(|m| m.get(user_id).map(|r| r.clone()))
+            m.get(&(receipt_type.to_string(), thread.as_str().map(ToOwned::to_owned)))
+                .and_then(|m| m.get(user_id).map(|r| r.clone()))
         }))
     }
 
@@ -520,16 +532,20 @@ impl MemoryStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>> {
         Ok(self
             .room_event_receipts
             .get(room_id)
             .and_then(|m| {
-                m.get(receipt_type.as_ref()).and_then(|m| {
-                    m.get(event_id)
-                        .map(|m| m.iter().map(|r| (r.key().clone(), r.value().clone())).collect())
-                })
+                m.get(&(receipt_type.to_string(), thread.as_str().map(ToOwned::to_owned))).and_then(
+                    |m| {
+                        m.get(event_id).map(|m| {
+                            m.iter().map(|r| (r.key().clone(), r.value().clone())).collect()
+                        })
+                    },
+                )
             })
             .unwrap_or_default())
     }
@@ -690,18 +706,20 @@ impl StateStore for MemoryStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
-        self.get_user_room_receipt_event(room_id, receipt_type, user_id).await
+        self.get_user_room_receipt_event(room_id, receipt_type, thread, user_id).await
     }
 
     async fn get_event_room_receipt_events(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>> {
-        self.get_event_room_receipt_events(room_id, receipt_type, event_id).await
+        self.get_event_room_receipt_events(room_id, receipt_type, thread, event_id).await
     }
 
     async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -48,7 +48,7 @@ use ruma::{
     api::client::push::get_notifications::v3::Notification,
     events::{
         presence::PresenceEvent,
-        receipt::{Receipt, ReceiptEventContent, ReceiptType},
+        receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
         room::{
             member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
             redaction::OriginalSyncRoomRedactionEvent,
@@ -289,11 +289,14 @@ pub trait StateStore: AsyncTraitDeps {
     ///
     /// * `receipt_type` - The type of the receipt.
     ///
+    /// * `thread` - The thread containing this receipt.
+    ///
     /// * `user_id` - The id of the user for who the receipt should be fetched.
     async fn get_user_room_receipt_event(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>>;
 
@@ -306,12 +309,15 @@ pub trait StateStore: AsyncTraitDeps {
     ///
     /// * `receipt_type` - The type of the receipts.
     ///
+    /// * `thread` - The thread containing this receipt.
+    ///
     /// * `event_id` - The id of the event for which the receipts should be
     ///   fetched.
     async fn get_event_room_receipt_events(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>>;
 

--- a/crates/matrix-sdk-indexeddb/src/safe_encode.rs
+++ b/crates/matrix-sdk-indexeddb/src/safe_encode.rs
@@ -222,6 +222,62 @@ where
     }
 }
 
+/// Implement SafeEncode for tuple of five elements, separating the escaped
+/// values with with `KEY_SEPARATOR`.
+impl<A, B, C, D, E> SafeEncode for (A, B, C, D, E)
+where
+    A: SafeEncode,
+    B: SafeEncode,
+    C: SafeEncode,
+    D: SafeEncode,
+    E: SafeEncode,
+{
+    fn as_encoded_string(&self) -> String {
+        [
+            &self.0.as_encoded_string(),
+            KEY_SEPARATOR,
+            &self.1.as_encoded_string(),
+            KEY_SEPARATOR,
+            &self.2.as_encoded_string(),
+            KEY_SEPARATOR,
+            &self.3.as_encoded_string(),
+            KEY_SEPARATOR,
+            &self.4.as_encoded_string(),
+        ]
+        .concat()
+    }
+
+    fn as_secure_string(&self, table_name: &str, store_cipher: &StoreCipher) -> String {
+        [
+            &base64_encode(
+                store_cipher.hash_key(table_name, self.0.as_encoded_string().as_bytes()),
+                &STANDARD_NO_PAD,
+            ),
+            KEY_SEPARATOR,
+            &base64_encode(
+                store_cipher.hash_key(table_name, self.1.as_encoded_string().as_bytes()),
+                &STANDARD_NO_PAD,
+            ),
+            KEY_SEPARATOR,
+            &base64_encode(
+                store_cipher.hash_key(table_name, self.2.as_encoded_string().as_bytes()),
+                &STANDARD_NO_PAD,
+            ),
+            KEY_SEPARATOR,
+            &base64_encode(
+                store_cipher.hash_key(table_name, self.3.as_encoded_string().as_bytes()),
+                &STANDARD_NO_PAD,
+            ),
+            KEY_SEPARATOR,
+            &base64_encode(
+                store_cipher.hash_key(table_name, self.4.as_encoded_string().as_bytes()),
+                &STANDARD_NO_PAD,
+            ),
+        ]
+        .concat()
+    }
+}
+
 impl SafeEncode for String {
     fn as_encoded_string(&self) -> String {
         self.replace(KEY_SEPARATOR, ESCAPED)

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -37,7 +37,7 @@ use ruma::{
     canonical_json::redact,
     events::{
         presence::PresenceEvent,
-        receipt::{Receipt, ReceiptType},
+        receipt::{Receipt, ReceiptThread, ReceiptType},
         room::member::{MembershipState, RoomMemberEventContent},
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
         GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
@@ -773,33 +773,51 @@ impl IndexeddbStateStore {
                 for (event_id, receipts) in &content.0 {
                     for (receipt_type, receipts) in receipts {
                         for (user_id, receipt) in receipts {
-                            let key = self.encode_key(
-                                KEYS::ROOM_USER_RECEIPTS,
-                                (room, receipt_type, user_id),
-                            );
+                            let key = match receipt.thread.as_str() {
+                                Some(thread_id) => self.encode_key(
+                                    KEYS::ROOM_USER_RECEIPTS,
+                                    (room, receipt_type, thread_id, user_id),
+                                ),
+                                None => self.encode_key(
+                                    KEYS::ROOM_USER_RECEIPTS,
+                                    (room, receipt_type, user_id),
+                                ),
+                            };
 
                             if let Some((old_event, _)) =
                                 room_user_receipts.get(&key)?.await?.and_then(|f| {
                                     self.deserialize_event::<(OwnedEventId, Receipt)>(f).ok()
                                 })
                             {
-                                room_event_receipts.delete(&self.encode_key(
-                                    KEYS::ROOM_EVENT_RECEIPTS,
-                                    (room, receipt_type, &old_event, user_id),
-                                ))?;
+                                let key = match receipt.thread.as_str() {
+                                    Some(thread_id) => self.encode_key(
+                                        KEYS::ROOM_EVENT_RECEIPTS,
+                                        (room, receipt_type, thread_id, old_event, user_id),
+                                    ),
+                                    None => self.encode_key(
+                                        KEYS::ROOM_EVENT_RECEIPTS,
+                                        (room, receipt_type, old_event, user_id),
+                                    ),
+                                };
+                                room_event_receipts.delete(&key)?;
                             }
 
                             room_user_receipts
                                 .put_key_val(&key, &self.serialize_event(&(event_id, receipt))?)?;
 
                             // Add the receipt to the room event receipts
-                            room_event_receipts.put_key_val(
-                                &self.encode_key(
+                            let key = match receipt.thread.as_str() {
+                                Some(thread_id) => self.encode_key(
+                                    KEYS::ROOM_EVENT_RECEIPTS,
+                                    (room, receipt_type, thread_id, event_id, user_id),
+                                ),
+                                None => self.encode_key(
                                     KEYS::ROOM_EVENT_RECEIPTS,
                                     (room, receipt_type, event_id, user_id),
                                 ),
-                                &self.serialize_event(&(user_id, receipt))?,
-                            )?;
+                            };
+                            room_event_receipts
+                                .put_key_val(&key, &self.serialize_event(&(user_id, receipt))?)?;
                         }
                     }
                 }
@@ -1093,12 +1111,18 @@ impl IndexeddbStateStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
+        let key = match thread.as_str() {
+            Some(thread_id) => self
+                .encode_key(KEYS::ROOM_USER_RECEIPTS, (room_id, receipt_type, thread_id, user_id)),
+            None => self.encode_key(KEYS::ROOM_USER_RECEIPTS, (room_id, receipt_type, user_id)),
+        };
         self.inner
             .transaction_on_one_with_mode(KEYS::ROOM_USER_RECEIPTS, IdbTransactionMode::Readonly)?
             .object_store(KEYS::ROOM_USER_RECEIPTS)?
-            .get(&self.encode_key(KEYS::ROOM_USER_RECEIPTS, (room_id, receipt_type, user_id)))?
+            .get(&key)?
             .await?
             .map(|f| self.deserialize_event(f))
             .transpose()
@@ -1108,10 +1132,18 @@ impl IndexeddbStateStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         event_id: &EventId,
     ) -> Result<Vec<(OwnedUserId, Receipt)>> {
-        let range =
-            self.encode_to_range(KEYS::ROOM_EVENT_RECEIPTS, (room_id, &receipt_type, event_id))?;
+        let range = match thread.as_str() {
+            Some(thread_id) => self.encode_to_range(
+                KEYS::ROOM_EVENT_RECEIPTS,
+                (room_id, receipt_type, thread_id, event_id),
+            ),
+            None => {
+                self.encode_to_range(KEYS::ROOM_EVENT_RECEIPTS, (room_id, receipt_type, event_id))
+            }
+        }?;
         let tx = self.inner.transaction_on_one_with_mode(
             KEYS::ROOM_EVENT_RECEIPTS,
             IdbTransactionMode::Readonly,
@@ -1363,18 +1395,22 @@ impl StateStore for IndexeddbStateStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         user_id: &UserId,
     ) -> StoreResult<Option<(OwnedEventId, Receipt)>> {
-        self.get_user_room_receipt_event(room_id, receipt_type, user_id).await.map_err(|e| e.into())
+        self.get_user_room_receipt_event(room_id, receipt_type, thread, user_id)
+            .await
+            .map_err(|e| e.into())
     }
 
     async fn get_event_room_receipt_events(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         event_id: &EventId,
     ) -> StoreResult<Vec<(OwnedUserId, Receipt)>> {
-        self.get_event_room_receipt_events(room_id, receipt_type, event_id)
+        self.get_event_room_receipt_events(room_id, receipt_type, thread, event_id)
             .await
             .map_err(|e| e.into())
     }

--- a/crates/matrix-sdk-sled/src/encode_key.rs
+++ b/crates/matrix-sdk-sled/src/encode_key.rs
@@ -247,3 +247,44 @@ where
         .concat()
     }
 }
+
+impl<A, B, C, D, E> EncodeKey for (A, B, C, D, E)
+where
+    A: EncodeKey,
+    B: EncodeKey,
+    C: EncodeKey,
+    D: EncodeKey,
+    E: EncodeKey,
+{
+    fn encode(&self) -> Vec<u8> {
+        [
+            self.0.encode_as_bytes().deref(),
+            &[ENCODE_SEPARATOR],
+            self.1.encode_as_bytes().deref(),
+            &[ENCODE_SEPARATOR],
+            self.2.encode_as_bytes().deref(),
+            &[ENCODE_SEPARATOR],
+            self.3.encode_as_bytes().deref(),
+            &[ENCODE_SEPARATOR],
+            self.4.encode_as_bytes().deref(),
+            &[ENCODE_SEPARATOR],
+        ]
+        .concat()
+    }
+
+    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> Vec<u8> {
+        [
+            store_cipher.hash_key(table_name, &self.0.encode_as_bytes()).as_slice(),
+            &[ENCODE_SEPARATOR],
+            store_cipher.hash_key(table_name, &self.1.encode_as_bytes()).as_slice(),
+            &[ENCODE_SEPARATOR],
+            store_cipher.hash_key(table_name, &self.2.encode_as_bytes()).as_slice(),
+            &[ENCODE_SEPARATOR],
+            store_cipher.hash_key(table_name, &self.3.encode_as_bytes()).as_slice(),
+            &[ENCODE_SEPARATOR],
+            store_cipher.hash_key(table_name, &self.4.encode_as_bytes()).as_slice(),
+            &[ENCODE_SEPARATOR],
+        ]
+        .concat()
+    }
+}

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -34,7 +34,7 @@ use ruma::{
     canonical_json::redact,
     events::{
         presence::PresenceEvent,
-        receipt::{Receipt, ReceiptType},
+        receipt::{Receipt, ReceiptThread, ReceiptType},
         room::member::{MembershipState, RoomMemberEventContent},
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
         GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
@@ -796,11 +796,18 @@ impl SledStateStore {
                             for (receipt_type, receipts) in receipts {
                                 for (user_id, receipt) in receipts {
                                     // Add the receipt to the room user receipts
-                                    if let Some(old) = room_user_receipts.insert(
-                                        self.encode_key(
+                                    let key = match receipt.thread.as_str() {
+                                        Some(thread_id) => self.encode_key(
+                                            ROOM_USER_RECEIPT,
+                                            (room, receipt_type, thread_id, user_id),
+                                        ),
+                                        None => self.encode_key(
                                             ROOM_USER_RECEIPT,
                                             (room, receipt_type, user_id),
                                         ),
+                                    };
+                                    if let Some(old) = room_user_receipts.insert(
+                                        key,
                                         self.serialize_value(&(event_id, receipt))
                                             .map_err(ConflictableTransactionError::Abort)?,
                                     )? {
@@ -808,18 +815,32 @@ impl SledStateStore {
                                         let (old_event, _): (OwnedEventId, Receipt) = self
                                             .deserialize_value(&old)
                                             .map_err(ConflictableTransactionError::Abort)?;
-                                        room_event_receipts.remove(self.encode_key(
-                                            ROOM_EVENT_RECEIPT,
-                                            (room, receipt_type, old_event, user_id),
-                                        ))?;
+                                        let key = match receipt.thread.as_str() {
+                                            Some(thread_id) => self.encode_key(
+                                                ROOM_EVENT_RECEIPT,
+                                                (room, receipt_type, thread_id, old_event, user_id),
+                                            ),
+                                            None => self.encode_key(
+                                                ROOM_EVENT_RECEIPT,
+                                                (room, receipt_type, old_event, user_id),
+                                            ),
+                                        };
+                                        room_event_receipts.remove(key)?;
                                     }
 
                                     // Add the receipt to the room event receipts
-                                    room_event_receipts.insert(
-                                        self.encode_key(
+                                    let key = match receipt.thread.as_str() {
+                                        Some(thread_id) => self.encode_key(
+                                            ROOM_EVENT_RECEIPT,
+                                            (room, receipt_type, thread_id, event_id, user_id),
+                                        ),
+                                        None => self.encode_key(
                                             ROOM_EVENT_RECEIPT,
                                             (room, receipt_type, event_id, user_id),
                                         ),
+                                    };
+                                    room_event_receipts.insert(
+                                        key,
                                         self.serialize_value(&(user_id, receipt))
                                             .map_err(ConflictableTransactionError::Abort)?,
                                     )?;
@@ -1095,10 +1116,16 @@ impl SledStateStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         user_id: &UserId,
     ) -> Result<Option<(OwnedEventId, Receipt)>> {
         let db = self.clone();
-        let key = self.encode_key(ROOM_USER_RECEIPT, (room_id, receipt_type, user_id));
+        let key = match thread.as_str() {
+            Some(thread_id) => {
+                self.encode_key(ROOM_USER_RECEIPT, (room_id, receipt_type, thread_id, user_id))
+            }
+            None => self.encode_key(ROOM_USER_RECEIPT, (room_id, receipt_type, user_id)),
+        };
         spawn_blocking(move || {
             db.room_user_receipts.get(key)?.map(|m| db.deserialize_value(&m)).transpose()
         })
@@ -1109,10 +1136,16 @@ impl SledStateStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         event_id: &EventId,
     ) -> StoreResult<Vec<(OwnedUserId, Receipt)>> {
         let db = self.clone();
-        let key = self.encode_key(ROOM_EVENT_RECEIPT, (room_id, receipt_type, event_id));
+        let key = match thread.as_str() {
+            Some(thread_id) => {
+                self.encode_key(ROOM_EVENT_RECEIPT, (room_id, receipt_type, thread_id, event_id))
+            }
+            None => self.encode_key(ROOM_EVENT_RECEIPT, (room_id, receipt_type, event_id)),
+        };
         spawn_blocking(move || {
             db.room_event_receipts
                 .scan_prefix(key)
@@ -1477,18 +1510,22 @@ impl StateStore for SledStateStore {
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         user_id: &UserId,
     ) -> StoreResult<Option<(OwnedEventId, Receipt)>> {
-        self.get_user_room_receipt_event(room_id, receipt_type, user_id).await.map_err(Into::into)
+        self.get_user_room_receipt_event(room_id, receipt_type, thread, user_id)
+            .await
+            .map_err(Into::into)
     }
 
     async fn get_event_room_receipt_events(
         &self,
         room_id: &RoomId,
         receipt_type: ReceiptType,
+        thread: ReceiptThread,
         event_id: &EventId,
     ) -> StoreResult<Vec<(OwnedUserId, Receipt)>> {
-        self.get_event_room_receipt_events(room_id, receipt_type, event_id)
+        self.get_event_room_receipt_events(room_id, receipt_type, thread, event_id)
             .await
             .map_err(Into::into)
     }


### PR DESCRIPTION
Read receipts should only overwrite receipts with the same `thread_id` (or lack thereof).

The key encoding in key-value stores is backwards-compatible so old receipts are counted as unthreaded receipts.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>