### PR TITLE
Add an error type to the CryptoStore trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,6 +3040,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "vodozemac",
 ]
 
 [[package]]

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -25,7 +25,7 @@ use futures_signals::signal::ReadOnlyMutable;
 use matrix_sdk_common::{instant::Instant, locks::RwLock};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_crypto::{
-    store::CryptoStore, EncryptionSettings, OlmError, OlmMachine, ToDeviceRequest,
+    store::DynCryptoStore, EncryptionSettings, OlmError, OlmMachine, ToDeviceRequest,
 };
 #[cfg(feature = "e2e-encryption")]
 use once_cell::sync::OnceCell;
@@ -82,7 +82,7 @@ pub struct BaseClient {
     /// This field is only meant to be used for `OlmMachine` initialization.
     /// All operations on it happen inside the `OlmMachine`.
     #[cfg(feature = "e2e-encryption")]
-    crypto_store: Arc<dyn CryptoStore>,
+    crypto_store: Arc<DynCryptoStore>,
     /// The olm-machine that is created once the
     /// [`SessionMeta`][crate::session::SessionMeta] is set via
     /// [`BaseClient::set_session_meta`]

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -42,7 +42,7 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use matrix_sdk_common::{locks::RwLock, AsyncTraitDeps};
 #[cfg(feature = "e2e-encryption")]
-use matrix_sdk_crypto::store::{CryptoStore, IntoCryptoStore};
+use matrix_sdk_crypto::store::{DynCryptoStore, IntoCryptoStore};
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
 use ruma::{
     api::client::push::get_notifications::v3::Notification,
@@ -832,7 +832,7 @@ impl StateChanges {
 #[derive(Clone)]
 pub struct StoreConfig {
     #[cfg(feature = "e2e-encryption")]
-    pub(crate) crypto_store: Arc<dyn CryptoStore>,
+    pub(crate) crypto_store: Arc<DynCryptoStore>,
     pub(crate) state_store: Arc<dyn StateStore>,
 }
 
@@ -849,7 +849,7 @@ impl StoreConfig {
     pub fn new() -> Self {
         Self {
             #[cfg(feature = "e2e-encryption")]
-            crypto_store: Arc::new(matrix_sdk_crypto::store::MemoryStore::new()),
+            crypto_store: matrix_sdk_crypto::store::MemoryStore::new().into_crypto_store(),
             state_store: Arc::new(MemoryStore::new()),
         }
     }

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1011,7 +1011,7 @@ mod tests {
         identities::{LocalTrust, ReadOnlyDevice},
         olm::{Account, OutboundGroupSession, PrivateCrossSigningIdentity, ReadOnlyAccount},
         session_manager::GroupSessionCache,
-        store::{Changes, CryptoStore, MemoryStore, Store},
+        store::{Changes, IntoCryptoStore, MemoryStore, Store},
         types::{
             events::{
                 forwarded_room_key::ForwardedRoomKeyContent,
@@ -1068,7 +1068,7 @@ mod tests {
         let device_id = DeviceId::new();
 
         let account = ReadOnlyAccount::new(&user_id, &device_id);
-        let store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
+        let store = MemoryStore::new().into_crypto_store();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
         let store = Store::new(user_id.to_owned(), identity, store, verification);
@@ -1090,7 +1090,7 @@ mod tests {
         let another_device =
             ReadOnlyDevice::from_account(&ReadOnlyAccount::new(&user_id, alice2_device_id())).await;
 
-        let store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
+        let store = MemoryStore::new().into_crypto_store();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
 

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -41,7 +41,7 @@ use crate::{
     error::{EventError, OlmError, OlmResult, SignatureError},
     identities::{ReadOnlyOwnUserIdentity, ReadOnlyUserIdentities},
     olm::{InboundGroupSession, Session, SignedJsonObject, VerifyJson},
-    store::{Changes, CryptoStore, DeviceChanges, Result as StoreResult},
+    store::{Changes, DeviceChanges, DynCryptoStore, Result as StoreResult},
     types::{
         events::{
             forwarded_room_key::ForwardedRoomKeyContent,
@@ -570,7 +570,7 @@ impl ReadOnlyDevice {
 
     pub(crate) async fn encrypt(
         &self,
-        store: &dyn CryptoStore,
+        store: &DynCryptoStore,
         event_type: &str,
         content: Value,
     ) -> OlmResult<(Session, Raw<ToDeviceEncryptedEventContent>)> {

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -667,7 +667,7 @@ pub(crate) mod testing {
         identities::IdentityManager,
         machine::testing::response_from_file,
         olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
-        store::{CryptoStore, MemoryStore, Store},
+        store::{DynCryptoStore, IntoCryptoStore, MemoryStore, Store},
         types::DeviceKeys,
         verification::VerificationMachine,
         UploadSigningKeysRequest,
@@ -690,10 +690,14 @@ pub(crate) mod testing {
         let identity = Arc::new(Mutex::new(identity));
         let user_id = Arc::from(user_id());
         let account = ReadOnlyAccount::new(&user_id, device_id());
-        let store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
+        let store: Arc<DynCryptoStore> = MemoryStore::new().into_crypto_store();
         let verification = VerificationMachine::new(account, identity.clone(), store);
-        let store =
-            Store::new(user_id.clone(), identity, Arc::new(MemoryStore::new()), verification);
+        let store = Store::new(
+            user_id.clone(),
+            identity,
+            MemoryStore::new().into_crypto_store(),
+            verification,
+        );
         IdentityManager::new(user_id, device_id().into(), store)
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1061,7 +1061,7 @@ pub(crate) mod tests {
             Device, MasterPubkey, SelfSigningPubkey, UserSigningPubkey,
         },
         olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
-        store::MemoryStore,
+        store::{IntoCryptoStore, MemoryStore},
         types::CrossSigningKey,
         verification::VerificationMachine,
     };
@@ -1105,7 +1105,7 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             ReadOnlyAccount::new(second.user_id(), second.device_id()),
             private_identity,
-            Arc::new(MemoryStore::new()),
+            MemoryStore::new().into_crypto_store(),
         );
 
         let first = Device {
@@ -1146,7 +1146,7 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             ReadOnlyAccount::new(device.user_id(), device.device_id()),
             id.clone(),
-            Arc::new(MemoryStore::new()),
+            MemoryStore::new().into_crypto_store(),
         );
 
         let public_identity = identity.to_public_identity().await.unwrap();

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -66,7 +66,7 @@ use crate::{
     requests::{IncomingResponse, OutgoingRequest, UploadSigningKeysRequest},
     session_manager::{GroupSessionManager, SessionManager},
     store::{
-        Changes, CryptoStore, DeviceChanges, IdentityChanges, IntoCryptoStore, MemoryStore,
+        Changes, DeviceChanges, DynCryptoStore, IdentityChanges, IntoCryptoStore, MemoryStore,
         Result as StoreResult, SecretImportError, Store,
     },
     types::{
@@ -153,7 +153,7 @@ impl OlmMachine {
     fn new_helper(
         user_id: &UserId,
         device_id: &DeviceId,
-        store: Arc<dyn CryptoStore>,
+        store: Arc<DynCryptoStore>,
         account: ReadOnlyAccount,
         user_identity: PrivateCrossSigningIdentity,
     ) -> Self {

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -415,7 +415,7 @@ mod tests {
         identities::{KeysQueryListener, ReadOnlyDevice},
         olm::{Account, PrivateCrossSigningIdentity, ReadOnlyAccount},
         session_manager::GroupSessionCache,
-        store::{CryptoStore, MemoryStore, Store},
+        store::{IntoCryptoStore, MemoryStore, Store},
         verification::VerificationMachine,
     };
 
@@ -464,7 +464,7 @@ mod tests {
 
         let users_for_key_claim = Arc::new(DashMap::new());
         let account = ReadOnlyAccount::new(user_id, device_id);
-        let store: Arc<dyn CryptoStore> = Arc::new(MemoryStore::new());
+        let store = MemoryStore::new().into_crypto_store();
         store.save_account(account.clone()).await.unwrap();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id)));
         let verification =

--- a/crates/matrix-sdk-crypto/src/store/error.rs
+++ b/crates/matrix-sdk-crypto/src/store/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fmt::Debug, io::Error as IoError};
+use std::{convert::Infallible, fmt::Debug, io::Error as IoError};
 
 use ruma::{IdParseError, OwnedDeviceId, OwnedUserId};
 use serde_json::Error as SerdeError;
@@ -90,5 +90,11 @@ impl CryptoStoreError {
         E: std::error::Error + Send + Sync + 'static,
     {
         Self::Backend(Box::new(error))
+    }
+}
+
+impl From<Infallible> for CryptoStoreError {
+    fn from(never: Infallible) -> Self {
+        match never {}
     }
 }

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, convert::Infallible, sync::Arc};
 
 use async_trait::async_trait;
 use dashmap::{DashMap, DashSet};
@@ -23,8 +23,7 @@ use ruma::{
 
 use super::{
     caches::{DeviceStore, GroupSessionStore, SessionStore},
-    BackupKeys, Changes, CryptoStore, InboundGroupSession, ReadOnlyAccount, Result, RoomKeyCounts,
-    Session,
+    BackupKeys, Changes, CryptoStore, InboundGroupSession, ReadOnlyAccount, RoomKeyCounts, Session,
 };
 use crate::{
     gossiping::{GossipRequest, SecretInfo},
@@ -99,9 +98,13 @@ impl MemoryStore {
     }
 }
 
+type Result<T> = std::result::Result<T, Infallible>;
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CryptoStore for MemoryStore {
+    type Error = Infallible;
+
     async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
         Ok(None)
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -81,7 +81,7 @@ pub mod integration_tests;
 
 pub use error::{CryptoStoreError, Result};
 pub use memorystore::MemoryStore;
-pub use traits::{CryptoStore, IntoCryptoStore};
+pub use traits::{CryptoStore, DynCryptoStore, IntoCryptoStore};
 
 pub use crate::gossiping::{GossipRequest, SecretInfo};
 
@@ -95,7 +95,7 @@ pub use crate::gossiping::{GossipRequest, SecretInfo};
 pub(crate) struct Store {
     user_id: Arc<UserId>,
     identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
-    inner: Arc<dyn CryptoStore>,
+    inner: Arc<DynCryptoStore>,
     verification_machine: VerificationMachine,
     tracked_users_cache: Arc<DashSet<OwnedUserId>>,
     users_for_key_query_cache: Arc<DashSet<OwnedUserId>>,
@@ -279,7 +279,7 @@ impl Store {
     pub fn new(
         user_id: Arc<UserId>,
         identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
-        store: Arc<dyn CryptoStore>,
+        store: Arc<DynCryptoStore>,
         verification_machine: VerificationMachine,
     ) -> Self {
         Self {
@@ -698,7 +698,7 @@ impl Store {
 }
 
 impl Deref for Store {
-    type Target = dyn CryptoStore;
+    type Target = DynCryptoStore;
 
     fn deref(&self) -> &Self::Target {
         self.inner.deref()

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
 use matrix_sdk_common::{locks::Mutex, AsyncTraitDeps};
 use ruma::{DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId};
 
-use super::{BackupKeys, Changes, Result, RoomKeyCounts};
+use super::{BackupKeys, Changes, CryptoStoreError, Result, RoomKeyCounts};
 use crate::{
     olm::{
         InboundGroupSession, OlmMessageHash, OutboundGroupSession, PrivateCrossSigningIdentity,
@@ -33,32 +33,38 @@ use crate::{
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CryptoStore: AsyncTraitDeps {
+    /// The error type used by this crypto store.
+    type Error: fmt::Debug + Into<CryptoStoreError>;
+
     /// Load an account that was previously stored.
-    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>>;
+    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>, Self::Error>;
 
     /// Save the given account in the store.
     ///
     /// # Arguments
     ///
     /// * `account` - The account that should be stored.
-    async fn save_account(&self, account: ReadOnlyAccount) -> Result<()>;
+    async fn save_account(&self, account: ReadOnlyAccount) -> Result<(), Self::Error>;
 
     /// Try to load a private cross signing identity, if one is stored.
-    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>>;
+    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>, Self::Error>;
 
     /// Save the set of changes to the store.
     ///
     /// # Arguments
     ///
     /// * `changes` - The set of changes that should be stored.
-    async fn save_changes(&self, changes: Changes) -> Result<()>;
+    async fn save_changes(&self, changes: Changes) -> Result<(), Self::Error>;
 
     /// Get all the sessions that belong to the given sender key.
     ///
     /// # Arguments
     ///
     /// * `sender_key` - The sender key that was used to establish the sessions.
-    async fn get_sessions(&self, sender_key: &str) -> Result<Option<Arc<Mutex<Vec<Session>>>>>;
+    async fn get_sessions(
+        &self,
+        sender_key: &str,
+    ) -> Result<Option<Arc<Mutex<Vec<Session>>>>, Self::Error>;
 
     /// Get the inbound group session from our store.
     ///
@@ -72,40 +78,40 @@ pub trait CryptoStore: AsyncTraitDeps {
         &self,
         room_id: &RoomId,
         session_id: &str,
-    ) -> Result<Option<InboundGroupSession>>;
+    ) -> Result<Option<InboundGroupSession>, Self::Error>;
 
     /// Get all the inbound group sessions we have stored.
-    async fn get_inbound_group_sessions(&self) -> Result<Vec<InboundGroupSession>>;
+    async fn get_inbound_group_sessions(&self) -> Result<Vec<InboundGroupSession>, Self::Error>;
 
     /// Get the number inbound group sessions we have and how many of them are
     /// backed up.
-    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts>;
+    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts, Self::Error>;
 
     /// Get all the inbound group sessions we have not backed up yet.
     async fn inbound_group_sessions_for_backup(
         &self,
         limit: usize,
-    ) -> Result<Vec<InboundGroupSession>>;
+    ) -> Result<Vec<InboundGroupSession>, Self::Error>;
 
     /// Reset the backup state of all the stored inbound group sessions.
-    async fn reset_backup_state(&self) -> Result<()>;
+    async fn reset_backup_state(&self) -> Result<(), Self::Error>;
 
     /// Get the backup keys we have stored.
-    async fn load_backup_keys(&self) -> Result<BackupKeys>;
+    async fn load_backup_keys(&self) -> Result<BackupKeys, Self::Error>;
 
     /// Get the outbound group session we have stored that is used for the
     /// given room.
     async fn get_outbound_group_session(
         &self,
         room_id: &RoomId,
-    ) -> Result<Option<OutboundGroupSession>>;
+    ) -> Result<Option<OutboundGroupSession>, Self::Error>;
 
     /// Load the list of users whose devices we are keeping track of.
-    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>>;
+    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>, Self::Error>;
 
     /// Save a list of users and their respective dirty/outdated flags to the
     /// store.
-    async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<()>;
+    async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<(), Self::Error>;
 
     /// Get the device for the given user with the given device ID.
     ///
@@ -118,7 +124,7 @@ pub trait CryptoStore: AsyncTraitDeps {
         &self,
         user_id: &UserId,
         device_id: &DeviceId,
-    ) -> Result<Option<ReadOnlyDevice>>;
+    ) -> Result<Option<ReadOnlyDevice>, Self::Error>;
 
     /// Get all the devices of the given user.
     ///
@@ -128,17 +134,20 @@ pub trait CryptoStore: AsyncTraitDeps {
     async fn get_user_devices(
         &self,
         user_id: &UserId,
-    ) -> Result<HashMap<OwnedDeviceId, ReadOnlyDevice>>;
+    ) -> Result<HashMap<OwnedDeviceId, ReadOnlyDevice>, Self::Error>;
 
     /// Get the user identity that is attached to the given user id.
     ///
     /// # Arguments
     ///
     /// * `user_id` - The user for which we should get the identity.
-    async fn get_user_identity(&self, user_id: &UserId) -> Result<Option<ReadOnlyUserIdentities>>;
+    async fn get_user_identity(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<ReadOnlyUserIdentities>, Self::Error>;
 
     /// Check if a hash for an Olm message stored in the database.
-    async fn is_message_known(&self, message_hash: &OlmMessageHash) -> Result<bool>;
+    async fn is_message_known(&self, message_hash: &OlmMessageHash) -> Result<bool, Self::Error>;
 
     /// Get an outgoing secret request that we created that matches the given
     /// request id.
@@ -150,7 +159,7 @@ pub trait CryptoStore: AsyncTraitDeps {
     async fn get_outgoing_secret_requests(
         &self,
         request_id: &TransactionId,
-    ) -> Result<Option<GossipRequest>>;
+    ) -> Result<Option<GossipRequest>, Self::Error>;
 
     /// Get an outgoing key request that we created that matches the given
     /// requested key info.
@@ -161,10 +170,10 @@ pub trait CryptoStore: AsyncTraitDeps {
     async fn get_secret_request_by_info(
         &self,
         secret_info: &SecretInfo,
-    ) -> Result<Option<GossipRequest>>;
+    ) -> Result<Option<GossipRequest>, Self::Error>;
 
     /// Get all outgoing secret requests that we have in the store.
-    async fn get_unsent_secret_requests(&self) -> Result<Vec<GossipRequest>>;
+    async fn get_unsent_secret_requests(&self) -> Result<Vec<GossipRequest>, Self::Error>;
 
     /// Delete an outgoing key request that we created that matches the given
     /// request id.
@@ -173,39 +182,177 @@ pub trait CryptoStore: AsyncTraitDeps {
     ///
     /// * `request_id` - The unique request id that identifies this outgoing key
     /// request.
-    async fn delete_outgoing_secret_requests(&self, request_id: &TransactionId) -> Result<()>;
+    async fn delete_outgoing_secret_requests(
+        &self,
+        request_id: &TransactionId,
+    ) -> Result<(), Self::Error>;
 }
 
-/// A type that can be type-erased into `Arc<dyn CryptoStore>`.
+#[repr(transparent)]
+struct EraseCryptoStoreError<T>(T);
+
+impl<T: fmt::Debug> fmt::Debug for EraseCryptoStoreError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
+    type Error = CryptoStoreError;
+
+    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
+        self.0.load_account().await.map_err(Into::into)
+    }
+
+    async fn save_account(&self, account: ReadOnlyAccount) -> Result<()> {
+        self.0.save_account(account).await.map_err(Into::into)
+    }
+
+    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
+        self.0.load_identity().await.map_err(Into::into)
+    }
+
+    async fn save_changes(&self, changes: Changes) -> Result<()> {
+        self.0.save_changes(changes).await.map_err(Into::into)
+    }
+
+    async fn get_sessions(&self, sender_key: &str) -> Result<Option<Arc<Mutex<Vec<Session>>>>> {
+        self.0.get_sessions(sender_key).await.map_err(Into::into)
+    }
+
+    async fn get_inbound_group_session(
+        &self,
+        room_id: &RoomId,
+        session_id: &str,
+    ) -> Result<Option<InboundGroupSession>> {
+        self.0.get_inbound_group_session(room_id, session_id).await.map_err(Into::into)
+    }
+
+    async fn get_inbound_group_sessions(&self) -> Result<Vec<InboundGroupSession>> {
+        self.0.get_inbound_group_sessions().await.map_err(Into::into)
+    }
+
+    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
+        self.0.inbound_group_session_counts().await.map_err(Into::into)
+    }
+
+    async fn inbound_group_sessions_for_backup(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<InboundGroupSession>> {
+        self.0.inbound_group_sessions_for_backup(limit).await.map_err(Into::into)
+    }
+
+    async fn reset_backup_state(&self) -> Result<()> {
+        self.0.reset_backup_state().await.map_err(Into::into)
+    }
+
+    async fn load_backup_keys(&self) -> Result<BackupKeys> {
+        self.0.load_backup_keys().await.map_err(Into::into)
+    }
+
+    async fn get_outbound_group_session(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Option<OutboundGroupSession>> {
+        self.0.get_outbound_group_session(room_id).await.map_err(Into::into)
+    }
+
+    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>> {
+        self.0.load_tracked_users().await.map_err(Into::into)
+    }
+
+    async fn save_tracked_users(&self, users: &[(&UserId, bool)]) -> Result<()> {
+        self.0.save_tracked_users(users).await.map_err(Into::into)
+    }
+
+    async fn get_device(
+        &self,
+        user_id: &UserId,
+        device_id: &DeviceId,
+    ) -> Result<Option<ReadOnlyDevice>> {
+        self.0.get_device(user_id, device_id).await.map_err(Into::into)
+    }
+
+    async fn get_user_devices(
+        &self,
+        user_id: &UserId,
+    ) -> Result<HashMap<OwnedDeviceId, ReadOnlyDevice>> {
+        self.0.get_user_devices(user_id).await.map_err(Into::into)
+    }
+
+    async fn get_user_identity(&self, user_id: &UserId) -> Result<Option<ReadOnlyUserIdentities>> {
+        self.0.get_user_identity(user_id).await.map_err(Into::into)
+    }
+
+    async fn is_message_known(&self, message_hash: &OlmMessageHash) -> Result<bool> {
+        self.0.is_message_known(message_hash).await.map_err(Into::into)
+    }
+
+    async fn get_outgoing_secret_requests(
+        &self,
+        request_id: &TransactionId,
+    ) -> Result<Option<GossipRequest>> {
+        self.0.get_outgoing_secret_requests(request_id).await.map_err(Into::into)
+    }
+
+    async fn get_secret_request_by_info(
+        &self,
+        secret_info: &SecretInfo,
+    ) -> Result<Option<GossipRequest>> {
+        self.0.get_secret_request_by_info(secret_info).await.map_err(Into::into)
+    }
+
+    async fn get_unsent_secret_requests(&self) -> Result<Vec<GossipRequest>> {
+        self.0.get_unsent_secret_requests().await.map_err(Into::into)
+    }
+
+    async fn delete_outgoing_secret_requests(&self, request_id: &TransactionId) -> Result<()> {
+        self.0.delete_outgoing_secret_requests(request_id).await.map_err(Into::into)
+    }
+}
+
+/// A type-erased [`CryptoStore`].
+pub type DynCryptoStore = dyn CryptoStore<Error = CryptoStoreError>;
+
+/// A type that can be type-erased into `Arc<DynCryptoStore>`.
 ///
 /// This trait is not meant to be implemented directly outside
 /// `matrix-sdk-crypto`, but it is automatically implemented for everything that
 /// implements `CryptoStore`.
 pub trait IntoCryptoStore {
     #[doc(hidden)]
-    fn into_crypto_store(self) -> Arc<dyn CryptoStore>;
+    fn into_crypto_store(self) -> Arc<DynCryptoStore>;
 }
 
 impl<T> IntoCryptoStore for T
 where
     T: CryptoStore + 'static,
 {
-    fn into_crypto_store(self) -> Arc<dyn CryptoStore> {
-        Arc::new(self)
+    fn into_crypto_store(self) -> Arc<DynCryptoStore> {
+        Arc::new(EraseCryptoStoreError(self))
     }
 }
 
+// Turns a given `Arc<T>` into `Arc<DynCryptoStore>` by attaching the
+// CryptoStore impl vtable of `EraseCryptoStoreError<T>`.
 impl<T> IntoCryptoStore for Arc<T>
 where
     T: CryptoStore + 'static,
 {
-    fn into_crypto_store(self) -> Arc<dyn CryptoStore> {
-        self
+    fn into_crypto_store(self) -> Arc<DynCryptoStore> {
+        let ptr: *const T = Arc::into_raw(self);
+        let ptr_erased = ptr as *const EraseCryptoStoreError<T>;
+        // SAFETY: EraseCryptoStoreError is repr(transparent) so T and
+        //         EraseCryptoStoreError<T> have the same layout and ABI
+        unsafe { Arc::from_raw(ptr_erased) }
     }
 }
 
-impl IntoCryptoStore for Arc<dyn CryptoStore> {
-    fn into_crypto_store(self) -> Arc<dyn CryptoStore> {
+impl IntoCryptoStore for Arc<DynCryptoStore> {
+    fn into_crypto_store(self) -> Arc<DynCryptoStore> {
         self
     }
 }

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -40,7 +40,7 @@ use super::{
 use crate::{
     olm::PrivateCrossSigningIdentity,
     requests::OutgoingRequest,
-    store::{CryptoStore, CryptoStoreError},
+    store::{CryptoStoreError, DynCryptoStore},
     OutgoingVerificationRequest, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyUserIdentity,
     RoomMessageRequest, ToDeviceRequest,
 };
@@ -56,7 +56,7 @@ impl VerificationMachine {
     pub(crate) fn new(
         account: ReadOnlyAccount,
         identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
-        store: Arc<dyn CryptoStore>,
+        store: Arc<DynCryptoStore>,
     ) -> Self {
         Self {
             store: VerificationStore { account, private_identity: identity, inner: store },
@@ -534,7 +534,7 @@ mod tests {
     use super::{Sas, VerificationMachine};
     use crate::{
         olm::PrivateCrossSigningIdentity,
-        store::MemoryStore,
+        store::{IntoCryptoStore, MemoryStore},
         verification::{
             cache::VerificationCache,
             event_enums::{AcceptContent, KeyContent, MacContent, OutgoingContent},
@@ -579,7 +579,7 @@ mod tests {
         let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let store = MemoryStore::new();
-        let _ = VerificationMachine::new(alice, identity, Arc::new(store));
+        let _ = VerificationMachine::new(alice, identity, store.into_crypto_store());
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -855,7 +855,7 @@ mod tests {
 
     use crate::{
         olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
-        store::{Changes, CryptoStore, MemoryStore},
+        store::{Changes, DynCryptoStore, IntoCryptoStore, MemoryStore},
         verification::{
             event_enums::{DoneContent, OutgoingContent, StartContent},
             FlowId, VerificationStore,
@@ -867,8 +867,8 @@ mod tests {
         user_id!("@example:localhost")
     }
 
-    fn memory_store() -> Arc<dyn CryptoStore> {
-        Arc::new(MemoryStore::new())
+    fn memory_store() -> Arc<DynCryptoStore> {
+        MemoryStore::new().into_crypto_store()
     }
 
     fn device_id() -> &'static DeviceId {

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -851,8 +851,6 @@ impl AcceptSettings {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use assert_matches::assert_matches;
     use matrix_sdk_common::locks::Mutex;
     use matrix_sdk_test::async_test;
@@ -861,7 +859,7 @@ mod tests {
     use super::Sas;
     use crate::{
         olm::PrivateCrossSigningIdentity,
-        store::MemoryStore,
+        store::{IntoCryptoStore, MemoryStore},
         verification::{
             event_enums::{AcceptContent, KeyContent, MacContent, OutgoingContent, StartContent},
             VerificationStore,
@@ -895,7 +893,7 @@ mod tests {
 
         let alice_store = VerificationStore {
             account: alice.clone(),
-            inner: Arc::new(MemoryStore::new()),
+            inner: MemoryStore::new().into_crypto_store(),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())).into(),
         };
 
@@ -904,7 +902,7 @@ mod tests {
 
         let bob_store = VerificationStore {
             account: bob.clone(),
-            inner: Arc::new(bob_store),
+            inner: bob_store.into_crypto_store(),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(bob_id())).into(),
         };
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -924,6 +924,8 @@ impl Drop for IndexeddbCryptoStore {
 #[cfg(target_arch = "wasm32")]
 #[async_trait(?Send)]
 impl CryptoStore for IndexeddbCryptoStore {
+    type Error = CryptoStoreError;
+
     async fn load_account(&self) -> Result<Option<ReadOnlyAccount>, CryptoStoreError> {
         self.load_account().await.map_err(|e| e.into())
     }

--- a/crates/matrix-sdk-sled/src/crypto_store.rs
+++ b/crates/matrix-sdk-sled/src/crypto_store.rs
@@ -697,6 +697,8 @@ impl SledCryptoStore {
 
 #[async_trait]
 impl CryptoStore for SledCryptoStore {
+    type Error = CryptoStoreError;
+
     async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
         if let Some(pickle) =
             self.account.get("account".encode()).map_err(CryptoStoreError::backend)?

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -35,6 +35,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1.24.2", default-features = false, features = ["sync", "fs"] }
 tracing = { workspace = true }
+vodozemac = { workspace = true }
 
 [dev-dependencies]
 ctor = { workspace = true }

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -524,6 +524,8 @@ impl SqliteObjectCryptoStoreExt for deadpool_sqlite::Object {}
 
 #[async_trait]
 impl CryptoStore for SqliteCryptoStore {
+    type Error = CryptoStoreError;
+
     async fn load_account(&self) -> StoreResult<Option<ReadOnlyAccount>> {
         let conn = self.acquire().await?;
         if let Some(pickle) = conn.get_kv("account").await.map_err(CryptoStoreError::backend)? {

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -27,10 +27,7 @@ use matrix_sdk_crypto::{
         IdentityKeys, InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,
         PrivateCrossSigningIdentity, Session,
     },
-    store::{
-        caches::SessionStore, BackupKeys, Changes, CryptoStore, CryptoStoreError,
-        Result as StoreResult, RoomKeyCounts,
-    },
+    store::{caches::SessionStore, BackupKeys, Changes, CryptoStore, RoomKeyCounts},
     GossipRequest, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyUserIdentities, SecretInfo,
     TrackedUser,
 };
@@ -524,14 +521,14 @@ impl SqliteObjectCryptoStoreExt for deadpool_sqlite::Object {}
 
 #[async_trait]
 impl CryptoStore for SqliteCryptoStore {
-    type Error = CryptoStoreError;
+    type Error = Error;
 
-    async fn load_account(&self) -> StoreResult<Option<ReadOnlyAccount>> {
+    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
         let conn = self.acquire().await?;
-        if let Some(pickle) = conn.get_kv("account").await.map_err(CryptoStoreError::backend)? {
+        if let Some(pickle) = conn.get_kv("account").await? {
             let pickle = self.deserialize_value(&pickle)?;
 
-            let account = ReadOnlyAccount::from_pickle(pickle)?;
+            let account = ReadOnlyAccount::from_pickle(pickle).map_err(|_| Error::Unpickle)?;
 
             let account_info = AccountInfo {
                 user_id: account.user_id.clone(),
@@ -547,7 +544,7 @@ impl CryptoStore for SqliteCryptoStore {
         }
     }
 
-    async fn save_account(&self, account: ReadOnlyAccount) -> StoreResult<()> {
+    async fn save_account(&self, account: ReadOnlyAccount) -> Result<()> {
         let account_info = AccountInfo {
             user_id: account.user_id.clone(),
             device_id: account.device_id.clone(),
@@ -557,29 +554,25 @@ impl CryptoStore for SqliteCryptoStore {
 
         let pickled_account = account.pickle().await;
         let serialized_account = self.serialize_value(&pickled_account)?;
-        self.acquire()
-            .await?
-            .set_kv("account", serialized_account)
-            .await
-            .map_err(CryptoStoreError::backend)?;
+        self.acquire().await?.set_kv("account", serialized_account).await?;
         Ok(())
     }
 
-    async fn load_identity(&self) -> StoreResult<Option<PrivateCrossSigningIdentity>> {
+    async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
         let conn = self.acquire().await?;
-        if let Some(i) = conn.get_kv("identity").await.map_err(CryptoStoreError::backend)? {
+        if let Some(i) = conn.get_kv("identity").await? {
             let pickle = self.deserialize_value(&i)?;
             Ok(Some(
                 PrivateCrossSigningIdentity::from_pickle(pickle)
                     .await
-                    .map_err(|_| CryptoStoreError::UnpicklingError)?,
+                    .map_err(|_| Error::Unpickle)?,
             ))
         } else {
             Ok(None)
         }
     }
 
-    async fn save_changes(&self, changes: Changes) -> StoreResult<()> {
+    async fn save_changes(&self, changes: Changes) -> Result<()> {
         let pickled_account = if let Some(account) = changes.account {
             let account_info = AccountInfo {
                 user_id: account.user_id.clone(),
@@ -703,11 +696,8 @@ impl CryptoStore for SqliteCryptoStore {
         Ok(())
     }
 
-    async fn get_sessions(
-        &self,
-        sender_key: &str,
-    ) -> StoreResult<Option<Arc<Mutex<Vec<Session>>>>> {
-        let account_info = self.get_account_info().ok_or(CryptoStoreError::AccountUnset)?;
+    async fn get_sessions(&self, sender_key: &str) -> Result<Option<Arc<Mutex<Vec<Session>>>>> {
+        let account_info = self.get_account_info().ok_or(Error::AccountUnset)?;
 
         if self.session_cache.get(sender_key).is_none() {
             let sessions = self
@@ -738,7 +728,7 @@ impl CryptoStore for SqliteCryptoStore {
         &self,
         room_id: &RoomId,
         session_id: &str,
-    ) -> StoreResult<Option<InboundGroupSession>> {
+    ) -> Result<Option<InboundGroupSession>> {
         let session_id = self.encode_key("inbound_group_session", session_id);
         let Some((room_id_from_db, value)) =
             self.acquire().await?.get_inbound_group_session(session_id).await?
@@ -757,7 +747,7 @@ impl CryptoStore for SqliteCryptoStore {
         Ok(Some(InboundGroupSession::from_pickle(pickle)?))
     }
 
-    async fn get_inbound_group_sessions(&self) -> StoreResult<Vec<InboundGroupSession>> {
+    async fn get_inbound_group_sessions(&self) -> Result<Vec<InboundGroupSession>> {
         self.acquire()
             .await?
             .get_inbound_group_sessions()
@@ -770,14 +760,14 @@ impl CryptoStore for SqliteCryptoStore {
             .collect()
     }
 
-    async fn inbound_group_session_counts(&self) -> StoreResult<RoomKeyCounts> {
+    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
         Ok(self.acquire().await?.get_inbound_group_session_counts().await?)
     }
 
     async fn inbound_group_sessions_for_backup(
         &self,
         limit: usize,
-    ) -> StoreResult<Vec<InboundGroupSession>> {
+    ) -> Result<Vec<InboundGroupSession>> {
         self.acquire()
             .await?
             .get_inbound_group_sessions_for_backup(limit)
@@ -790,24 +780,22 @@ impl CryptoStore for SqliteCryptoStore {
             .collect()
     }
 
-    async fn reset_backup_state(&self) -> StoreResult<()> {
+    async fn reset_backup_state(&self) -> Result<()> {
         Ok(self.acquire().await?.reset_inbound_group_session_backup_state().await?)
     }
 
-    async fn load_backup_keys(&self) -> StoreResult<BackupKeys> {
+    async fn load_backup_keys(&self) -> Result<BackupKeys> {
         let conn = self.acquire().await?;
 
         let backup_version = conn
             .get_kv("backup_version_v1")
-            .await
-            .map_err(CryptoStoreError::backend)?
+            .await?
             .map(|value| self.deserialize_value(&value))
             .transpose()?;
 
         let recovery_key = conn
             .get_kv("recovery_key_v1")
-            .await
-            .map_err(CryptoStoreError::backend)?
+            .await?
             .map(|value| self.deserialize_value(&value))
             .transpose()?;
 
@@ -817,35 +805,36 @@ impl CryptoStore for SqliteCryptoStore {
     async fn get_outbound_group_session(
         &self,
         room_id: &RoomId,
-    ) -> StoreResult<Option<OutboundGroupSession>> {
+    ) -> Result<Option<OutboundGroupSession>> {
         let room_id = self.encode_key("outbound_group_session", room_id.as_bytes());
         let Some(value) = self.acquire().await?.get_outbound_group_session(room_id).await? else {
             return Ok(None);
         };
 
-        let account_info = self.get_account_info().ok_or(CryptoStoreError::AccountUnset)?;
+        let account_info = self.get_account_info().ok_or(Error::AccountUnset)?;
 
         let pickle = self.deserialize_value(&value)?;
         let session = OutboundGroupSession::from_pickle(
             account_info.device_id,
             account_info.identity_keys,
             pickle,
-        )?;
+        )
+        .map_err(|_| Error::Unpickle)?;
 
         return Ok(Some(session));
     }
 
-    async fn load_tracked_users(&self) -> StoreResult<Vec<TrackedUser>> {
+    async fn load_tracked_users(&self) -> Result<Vec<TrackedUser>> {
         self.acquire()
             .await?
             .get_tracked_users()
             .await?
             .iter()
-            .map(|value| Ok(self.deserialize_value(value)?))
+            .map(|value| self.deserialize_value(value))
             .collect()
     }
 
-    async fn save_tracked_users(&self, tracked_users: &[(&UserId, bool)]) -> StoreResult<()> {
+    async fn save_tracked_users(&self, tracked_users: &[(&UserId, bool)]) -> Result<()> {
         let users: Vec<(Key, Vec<u8>)> = tracked_users
             .iter()
             .map(|(u, d)| {
@@ -863,7 +852,7 @@ impl CryptoStore for SqliteCryptoStore {
         &self,
         user_id: &UserId,
         device_id: &DeviceId,
-    ) -> StoreResult<Option<ReadOnlyDevice>> {
+    ) -> Result<Option<ReadOnlyDevice>> {
         let user_id = self.encode_key("device", user_id.as_bytes());
         let device_id = self.encode_key("device", device_id.as_bytes());
         Ok(self
@@ -878,7 +867,7 @@ impl CryptoStore for SqliteCryptoStore {
     async fn get_user_devices(
         &self,
         user_id: &UserId,
-    ) -> StoreResult<HashMap<OwnedDeviceId, ReadOnlyDevice>> {
+    ) -> Result<HashMap<OwnedDeviceId, ReadOnlyDevice>> {
         let user_id = self.encode_key("device", user_id.as_bytes());
         self.acquire()
             .await?
@@ -892,10 +881,7 @@ impl CryptoStore for SqliteCryptoStore {
             .collect()
     }
 
-    async fn get_user_identity(
-        &self,
-        user_id: &UserId,
-    ) -> StoreResult<Option<ReadOnlyUserIdentities>> {
+    async fn get_user_identity(&self, user_id: &UserId) -> Result<Option<ReadOnlyUserIdentities>> {
         let user_id = self.encode_key("identity", user_id.as_bytes());
         Ok(self
             .acquire()
@@ -909,15 +895,15 @@ impl CryptoStore for SqliteCryptoStore {
     async fn is_message_known(
         &self,
         message_hash: &matrix_sdk_crypto::olm::OlmMessageHash,
-    ) -> StoreResult<bool> {
-        let value = rmp_serde::to_vec(message_hash).map_err(CryptoStoreError::backend)?;
+    ) -> Result<bool> {
+        let value = rmp_serde::to_vec(message_hash)?;
         Ok(self.acquire().await?.has_olm_hash(value).await?)
     }
 
     async fn get_outgoing_secret_requests(
         &self,
         request_id: &TransactionId,
-    ) -> StoreResult<Option<GossipRequest>> {
+    ) -> Result<Option<GossipRequest>> {
         let request_id = self.encode_key("key_requests", request_id.as_bytes());
         Ok(self
             .acquire()
@@ -931,7 +917,7 @@ impl CryptoStore for SqliteCryptoStore {
     async fn get_secret_request_by_info(
         &self,
         key_info: &SecretInfo,
-    ) -> StoreResult<Option<GossipRequest>> {
+    ) -> Result<Option<GossipRequest>> {
         let requests = self.acquire().await?.get_outgoing_secret_requests().await?;
         for (request, sent_out) in requests {
             let request = self.deserialize_key_request(&request, sent_out)?;
@@ -942,7 +928,7 @@ impl CryptoStore for SqliteCryptoStore {
         Ok(None)
     }
 
-    async fn get_unsent_secret_requests(&self) -> StoreResult<Vec<GossipRequest>> {
+    async fn get_unsent_secret_requests(&self) -> Result<Vec<GossipRequest>> {
         self.acquire()
             .await?
             .get_unsent_secret_requests()
@@ -955,7 +941,7 @@ impl CryptoStore for SqliteCryptoStore {
             .collect()
     }
 
-    async fn delete_outgoing_secret_requests(&self, request_id: &TransactionId) -> StoreResult<()> {
+    async fn delete_outgoing_secret_requests(&self, request_id: &TransactionId) -> Result<()> {
         let request_id = self.encode_key("key_requests", request_id.as_bytes());
         Ok(self.acquire().await?.delete_key_request(request_id).await?)
     }

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -52,7 +52,7 @@ pub enum OpenStoreError {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum Error {
+pub enum Error {
     #[error(transparent)]
     Sqlite(rusqlite::Error),
     #[error(transparent)]
@@ -63,6 +63,12 @@ pub(crate) enum Error {
     Decode(rmp_serde::decode::Error),
     #[error(transparent)]
     Encryption(matrix_sdk_store_encryption::Error),
+    #[error("can't save/load sessions or group sessions in the store before an account is stored")]
+    AccountUnset,
+    #[error(transparent)]
+    Pickle(#[from] vodozemac::PickleError),
+    #[error("An object failed to be decrypted while unpickling")]
+    Unpickle,
 }
 
 macro_rules! impl_from {


### PR DESCRIPTION
This makes store implementations cleaner at the expense of some boilerplate code in matrix-sdk-crypto.