### PR TITLE
Add slow_get_all_rooms for sliding sync for bot support 

### DIFF
--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -39,7 +39,7 @@ pub mod room;
 pub mod sync;
 
 #[cfg(feature = "experimental-sliding-sync")]
-mod sliding_sync;
+pub mod sliding_sync;
 
 #[cfg(feature = "e2e-encryption")]
 pub mod encryption;


### PR DESCRIPTION
Add support for the missing `slow_get_all_rooms`-view-type that we added for bot scenarios in sliding sync. With an integration test of course :) .

Built on top of #1467.
Fixes #1475 .