### PR TITLE
ci: Improve coverage checks

### DIFF
--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -25,5 +25,6 @@ exclude = [
     "jack-in",
     "sled-state-inspector",
     # repo automation (ci, codegen)
+    "uniffi-bindgen",
     "xtask",
 ]

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -7,6 +7,9 @@ exclude-files = [
     "**/tests/*",
 ]
 workspace = true
+# sqlite crypto store is not tested otherwise because it's only activated by
+# matrix-sdk-crypto-ffi, which is excluded from testing below
+features = "crypto-store"
 exclude = [
     # bindings
     "matrix-sdk-crypto-ffi",


### PR DESCRIPTION
I noticed on codecov that the sqlite `crypto_store.rs` is one of the files with the most uncovered lines, none are counted as covered. I think I've identified why, and fixed it.