### PR TITLE
ci: Replace unmaintained actions-rs actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,12 +15,9 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@nightly
       with:
-        toolchain: nightly
         components: rustfmt
-        profile: minimal
-        override: true
 
     - name: Run Benchmarks
       run: cargo bench | tee benchmark-output.txt

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -38,11 +38,7 @@ jobs:
 
       - name: Install rust stable toolchain
         if: steps.xtask-cache.outputs.cache-hit != 'true'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build
         if: steps.xtask-cache.outputs.cache-hit != 'true'
@@ -67,11 +63,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -111,11 +103,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -169,12 +157,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -220,11 +205,7 @@ jobs:
 
       - name: Install rust stable toolchain
         if: steps.xtask-cache.outputs.cache-hit != 'true'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build
         if: steps.xtask-cache.outputs.cache-hit != 'true'
@@ -249,11 +230,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install aarch64-apple-ios target
         run: rustup target install aarch64-apple-ios

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -42,10 +42,8 @@ jobs:
 
       - name: Build
         if: steps.xtask-cache.outputs.cache-hit != 'true'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p xtask
+        run: |
+          cargo build -p xtask
 
   test-uniffi-codegen:
     name: Test UniFFI bindings generation
@@ -209,10 +207,8 @@ jobs:
 
       - name: Build
         if: steps.xtask-cache.outputs.cache-hit != 'true'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p xtask
+        run: |
+          cargo build -p xtask
 
   test-apple:
     name: matrix-rust-components-swift

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,7 @@ jobs:
 
       - name: Install rust stable toolchain
         if: steps.xtask-cache.outputs.cache-hit != 'true'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build
         if: steps.xtask-cache.outputs.cache-hit != 'true'
@@ -73,11 +69,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -108,11 +100,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -143,11 +131,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -198,11 +182,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@${{ matrix.rust }}
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -265,13 +245,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: clippy
-          profile: minimal
-          override: true
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
@@ -323,11 +300,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -357,12 +330,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           components: rustfmt
-          profile: minimal
-          override: true
 
       - name: Cargo fmt
         uses: actions-rs/cargo@v1
@@ -398,12 +368,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
           components: clippy
-          profile: minimal
-          override: true
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -431,11 +398,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2
@@ -493,11 +456,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,8 @@ jobs:
 
       - name: Build
         if: steps.xtask-cache.outputs.cache-hit != 'true'
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: -p xtask
+        run: |
+          cargo build -p xtask
 
   test-matrix-sdk-features:
     name: 🐧 [m], ${{ matrix.name }}
@@ -84,10 +82,8 @@ jobs:
           key: xtask-${{ hashFiles('xtask/**') }}
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p xtask -- ci test-features ${{ matrix.name }}
+        run: |
+          cargo run -p xtask -- ci test-features ${{ matrix.name }}
 
   test-matrix-sdk-examples:
     name: 🐧 [m]-examples
@@ -115,10 +111,8 @@ jobs:
           key: xtask-${{ hashFiles('xtask/**') }}
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p xtask -- ci examples
+        run: |
+          cargo run -p xtask -- ci examples
 
   test-matrix-sdk-crypto:
     name: 🐧 [m]-crypto
@@ -146,10 +140,8 @@ jobs:
           key: xtask-${{ hashFiles('xtask/**') }}
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p xtask -- ci test-crypto
+        run: |
+          cargo run -p xtask -- ci test-crypto
 
   test-all-crates:
     name: ${{ matrix.name }}
@@ -191,16 +183,13 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --workspace --exclude matrix-sdk-integration-testing --exclude sliding-sync-integration-test
+        run: |
+          cargo nextest run --workspace \
+            --exclude matrix-sdk-integration-testing --exclude sliding-sync-integration-test
 
       - name: Test documentation
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc
+        run: |
+          cargo test --doc
 
   test-wasm:
     name: 🕸️ ${{ matrix.name }}
@@ -268,16 +257,12 @@ jobs:
           key: xtask-${{ hashFiles('xtask/**') }}
 
       - name: Rust Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p xtask -- ci wasm ${{ matrix.cmd }}
+        run: |
+          cargo run -p xtask -- ci wasm ${{ matrix.cmd }}
 
       - name: Wasm-Pack test
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p xtask -- ci wasm-pack ${{ matrix.cmd }}
+        run: |
+          cargo run -p xtask -- ci wasm-pack ${{ matrix.cmd }}
 
   test-appservice:
     name: ${{ matrix.os-name }} [m]-appservice
@@ -315,10 +300,8 @@ jobs:
           key: xtask-${{ hashFiles('xtask/**') }}
 
       - name: Run checks
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p xtask -- ci test-appservice
+        run: |
+          cargo run -p xtask -- ci test-appservice
 
   formatting:
     name: Check Formatting
@@ -335,10 +318,8 @@ jobs:
           components: rustfmt
 
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: |
+          cargo fmt -- --check
 
   typos:
     name: Spell Check with Typos
@@ -382,10 +363,8 @@ jobs:
           key: xtask-${{ hashFiles('xtask/**') }}
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: -p xtask -- ci clippy
+        run: |
+          cargo run -p xtask -- ci clippy
 
   integration-tests:
     name: Integration test
@@ -417,10 +396,8 @@ jobs:
           disableRateLimiting: true
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run -p matrix-sdk-integration-testing
+        run: |
+          cargo nextest run -p matrix-sdk-integration-testing
 
 
   sliding-sync-integration-tests:
@@ -485,7 +462,5 @@ jobs:
           options: '-e "SYNCV3_SERVER=http://locahost:8228" -e "SYNCV3_SECRET=SUPER_CI_SECRET" -e "SYNCV3_BINDADDR=:8118" -e "SYNCV3_DB=user=postgres password=postgres dbname=syncv3 sslmode=disable host=postgres" -p 8118:8118'
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run -p sliding-sync-integration-tests
+        run: |
+          cargo nextest run -p sliding-sync-integration-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,18 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Can't use `${{ matrix.* }}` inside uses
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@${{ matrix.rust }}
+        if: matrix.rust == 'stable'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Rust
+        if: matrix.rust == 'beta'
+        uses: dtolnay/rust-toolchain@beta
+
+      - name: Install Rust
+        if: matrix.rust == 'nightly'
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,11 +22,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Load cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,10 +45,8 @@ jobs:
         serverName: "matrix-sdk.rs"
 
     - name: Run tarpaulin
-      uses: actions-rs/cargo@v1
-      with:
-        command: tarpaulin
-        args: --out Xml -e sliding-sync-integration-test
+      run: |
+        cargo tarpaulin --out Xml -e sliding-sync-integration-test
 
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,10 +28,9 @@ jobs:
       uses: Swatinem/rust-cache@v2
 
     - name: Install tarpaulin
-      uses: actions-rs/cargo@v1
+      uses: taiki-e/install-action@v2
       with:
-        command: install
-        args: cargo-tarpaulin
+        tool: cargo-tarpaulin
 
     # set up backend for integration tests
     - uses: actions/setup-python@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,11 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,14 +28,12 @@ jobs:
 
       # Keep in sync with xtask docs
       - name: Build rust documentation
-        uses: actions-rs/cargo@v1
         env:
           # Work around https://github.com/rust-lang/cargo/issues/10744
           CARGO_TARGET_APPLIES_TO_HOST: "true"
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options --cfg docsrs -Dwarnings"
-        with:
-          command: doc
-          args: --no-deps --features docsrs
+        run:
+          cargo doc --no-deps --features docsrs
 
       - name: Build `matrix-sdk-crypto-nodejs` doc
         run: |

--- a/.github/workflows/release-crypto-nodejs.yml
+++ b/.github/workflows/release-crypto-nodejs.yml
@@ -76,12 +76,9 @@ jobs:
       - uses: actions/checkout@v3
         if: "${{ !inputs.tag }}"
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          profile: minimal
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - name: Install Node.js
         uses: actions/setup-node@v3
       - name: Load cache
@@ -117,11 +114,7 @@ jobs:
       - uses: actions/checkout@v3
         if: "${{ !inputs.tag }}"
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
       - name: Install Node.js
         uses: actions/setup-node@v3
       - name: Build lib

--- a/.github/workflows/release_crypto_js.yml
+++ b/.github/workflows/release_crypto_js.yml
@@ -29,12 +29,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: wasm32-unknown-unknown
-          profile: minimal
-          override: true
+          targets: wasm32-unknown-unknown
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
… except for `actions-rs/audit-check`, which we should probably replace with cargo-deny, but that's a little more involved.
