### PR TITLE
ci: Exclude Debug implementations from coverage reports

### DIFF
--- a/crates/matrix-sdk-base/src/session.rs
+++ b/crates/matrix-sdk-base/src/session.rs
@@ -68,6 +68,7 @@ impl Session {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for Session {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Session")

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -642,6 +642,7 @@ impl Store {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for Store {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Store")

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -195,6 +195,7 @@ impl RecoveryKey {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 impl Debug for RecoveryKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RecoveryKey").finish()
@@ -245,6 +246,7 @@ pub struct CrossSigningKeyExport {
     pub user_signing_key: Option<String>,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl Debug for CrossSigningKeyExport {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CrossSigningKeyExport")

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -67,6 +67,7 @@ pub struct SqliteCryptoStore {
     session_cache: SessionStore,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for SqliteCryptoStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(path) = &self.path {

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -484,6 +484,7 @@ enum BuilderStoreConfig {
     Custom(StoreConfig),
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for BuilderStoreConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         #[allow(clippy::infallible_destructuring_match)]

--- a/crates/matrix-sdk/src/config/sync.rs
+++ b/crates/matrix-sdk/src/config/sync.rs
@@ -34,6 +34,7 @@ impl Default for SyncSettings {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for SyncSettings {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = f.debug_struct("SyncSettings");

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -338,6 +338,7 @@ impl From<RemoteEventTimelineItem> for EventTimelineItem {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for RemoteEventTimelineItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RemoteEventTimelineItem")
@@ -509,6 +510,7 @@ impl Message {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // since timeline items are logged, don't include all fields here so


### PR DESCRIPTION
We don't really want to check for exact representations, and otherwise they are really just invoked in tests that fail.