### PR TITLE
fix: remove dependency on broken wasm_timer crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ dependencies = [
  "futures-signals",
  "futures-util",
  "getrandom 0.2.8",
+ "gloo-timers",
  "http",
  "hyper",
  "image 0.24.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,6 +1941,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gloo-utils"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,7 +2719,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wasm-bindgen-test",
- "wasm-timer",
  "wiremock",
  "zeroize",
 ]
@@ -2776,6 +2787,7 @@ dependencies = [
  "async-lock",
  "futures-core",
  "futures-util",
+ "gloo-timers",
  "instant",
  "matrix-sdk-test",
  "ruma",
@@ -2784,7 +2796,6 @@ dependencies = [
  "tokio",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "wasm-timer",
 ]
 
 [[package]]
@@ -5976,21 +5987,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { workspace = true }
 async-lock = "2.5.0"
 futures-util = { version = "0.3.21", default-features = false, features = ["channel"] }
 wasm-bindgen-futures = { version = "0.4.33", optional = true }
-wasm-timer = "0.2.5"
+gloo-timers = { version = "0.2.6", features = ["futures"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.24.2", default-features = false, features = ["rt", "sync", "time"] }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -118,7 +118,7 @@ optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-once-cell = "0.4.2"
-wasm-timer = "0.2.5"
+gloo-timers = { version = "0.2.6", features = ["futures"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -184,7 +184,7 @@ impl Client {
 
     async fn sleep() {
         #[cfg(target_arch = "wasm32")]
-        let _ = wasm_timer::Delay::new(Duration::from_secs(1)).await;
+        let _ = gloo_timers::future::TimeoutFuture::new(1_000).await;
 
         #[cfg(not(target_arch = "wasm32"))]
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -184,7 +184,7 @@ impl Client {
 
     async fn sleep() {
         #[cfg(target_arch = "wasm32")]
-        let _ = gloo_timers::future::TimeoutFuture::new(1_000).await;
+        gloo_timers::future::TimeoutFuture::new(1_000).await;
 
         #[cfg(not(target_arch = "wasm32"))]
         tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
`wasm_timer` doesn't work outside the browser, which prevents it being used in tests.

We can replace it with `gloo-timers` wich uses the standard Javascript `setTimeout`.

Fixes: #896
Fixes: #1443.