### PR TITLE
fix(indexeddb): Fix implementation of SafeEncode for tuple of 5 elements

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -5,6 +5,9 @@
 
 #![warn(missing_docs)]
 #![allow(unused_qualifications)]
+// Triggers false positives.
+// See <https://github.com/rust-lang/rust-clippy/issues/10319>.
+#![allow(clippy::extra_unused_type_parameters)]
 
 mod backup_recovery_key;
 mod device;

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -15,7 +15,11 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, missing_debug_implementations)]
-#![allow(clippy::drop_non_drop)] // triggered by wasm_bindgen code
+// triggered by wasm_bindgen code
+#![allow(clippy::drop_non_drop)]
+// Triggers false positives.
+// See <https://github.com/rust-lang/rust-clippy/issues/10319>.
+#![allow(clippy::extra_unused_type_parameters)]
 
 pub mod attachment;
 pub mod device;

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -1,6 +1,9 @@
 // TODO: target-os conditional would be good.
 
 #![allow(unused_qualifications)]
+// Triggers false positives.
+// See <https://github.com/rust-lang/rust-clippy/issues/10319>.
+#![allow(clippy::extra_unused_type_parameters)]
 
 macro_rules! unwrap_or_clone_arc_into_variant {
     (

--- a/crates/matrix-sdk-indexeddb/src/safe_encode.rs
+++ b/crates/matrix-sdk-indexeddb/src/safe_encode.rs
@@ -230,30 +230,20 @@ where
 
     fn as_secure_string(&self, table_name: &str, store_cipher: &StoreCipher) -> String {
         [
-            &base64_encode(
-                store_cipher.hash_key(table_name, self.0.as_encoded_string().as_bytes()),
-                &STANDARD_NO_PAD,
-            ),
+            &STANDARD_NO_PAD
+                .encode(store_cipher.hash_key(table_name, self.0.as_encoded_string().as_bytes())),
             KEY_SEPARATOR,
-            &base64_encode(
-                store_cipher.hash_key(table_name, self.1.as_encoded_string().as_bytes()),
-                &STANDARD_NO_PAD,
-            ),
+            &STANDARD_NO_PAD
+                .encode(store_cipher.hash_key(table_name, self.1.as_encoded_string().as_bytes())),
             KEY_SEPARATOR,
-            &base64_encode(
-                store_cipher.hash_key(table_name, self.2.as_encoded_string().as_bytes()),
-                &STANDARD_NO_PAD,
-            ),
+            &STANDARD_NO_PAD
+                .encode(store_cipher.hash_key(table_name, self.2.as_encoded_string().as_bytes())),
             KEY_SEPARATOR,
-            &base64_encode(
-                store_cipher.hash_key(table_name, self.3.as_encoded_string().as_bytes()),
-                &STANDARD_NO_PAD,
-            ),
+            &STANDARD_NO_PAD
+                .encode(store_cipher.hash_key(table_name, self.3.as_encoded_string().as_bytes())),
             KEY_SEPARATOR,
-            &base64_encode(
-                store_cipher.hash_key(table_name, self.4.as_encoded_string().as_bytes()),
-                &STANDARD_NO_PAD,
-            ),
+            &STANDARD_NO_PAD
+                .encode(store_cipher.hash_key(table_name, self.4.as_encoded_string().as_bytes())),
         ]
         .concat()
     }


### PR DESCRIPTION
Regression introduced by merging commit 9707d73 after efdeba7.

Fixes #1489.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
