### PR TITLE
docs(sdk): Improve read receipt/marker explanation

### DIFF
--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -229,8 +229,12 @@ impl Joined {
         Ok(())
     }
 
-    /// Send a request to notify this room that the user has read specific
-    /// event.
+    /// Send a request to set a read receipt, notifying this room that the user
+    /// has read a specific event and *some* - but maybe not all - events before
+    /// it.
+    ///
+    /// Use [`read_marker`][Self::read_marker] to indicate that the user has
+    /// read a specific event and *every* message before it.
     ///
     /// # Arguments
     ///
@@ -247,12 +251,15 @@ impl Joined {
         Ok(())
     }
 
-    /// Send a request to notify this room that the user has read up to specific
-    /// event.
+    /// Send a request to set a read marker, notifying this room that the user
+    /// has read a specific event and *all* events before it.
+    ///
+    /// Use [`read_receipt`][Self::read_receipt] to indicate that the user has
+    /// read a specific event and *some* - but maybe not all - events before it.
     ///
     /// # Arguments
     ///
-    /// * fully_read - The `EventId` of the event the user has read to.
+    /// * fully_read - The `EventId` of the event to set the read marker on.
     ///
     /// * read_receipt - An `EventId` to specify the event to set the read
     ///   receipt on.


### PR DESCRIPTION
It was unclear what the relationship between the read receipt and read marker was, so I copied a bit from https://spec.matrix.org/latest/client-server-api/#fully-read-markers and added hyperlinks between the functions.

Signed-off-by: Enterprisey <apersonwiki@gmail.com>

See private accepted DCO signoff at https://github.com/matrix-org/synapse/pull/13818#issuecomment-1257991591
