### PR TITLE
feat: Allow to get or send any type of receipt

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -482,27 +482,27 @@ impl Room {
         }
     }
 
-    /// Get the read receipt as a `EventId` and `Receipt` tuple for the given
-    /// `thread` and `user_id` in this room.
-    pub async fn user_read_receipt(
+    /// Get the receipt as an `OwnedEventId` and `Receipt` tuple for the given
+    /// `receipt_type`, `thread` and `user_id` in this room.
+    pub async fn user_receipt(
         &self,
+        receipt_type: ReceiptType,
         thread: ReceiptThread,
         user_id: &UserId,
     ) -> StoreResult<Option<(OwnedEventId, Receipt)>> {
-        self.store
-            .get_user_room_receipt_event(self.room_id(), ReceiptType::Read, thread, user_id)
-            .await
+        self.store.get_user_room_receipt_event(self.room_id(), receipt_type, thread, user_id).await
     }
 
-    /// Get the read receipts as a list of `UserId` and `Receipt` tuples for the
-    /// given `thread` and `event_id` in this room.
-    pub async fn event_read_receipts(
+    /// Get the receipts as a list of `OwnedUserId` and `Receipt` tuples for the
+    /// given `receipt_type`, `thread` and `event_id` in this room.
+    pub async fn event_receipts(
         &self,
+        receipt_type: ReceiptType,
         thread: ReceiptThread,
         event_id: &EventId,
     ) -> StoreResult<Vec<(OwnedUserId, Receipt)>> {
         self.store
-            .get_event_room_receipt_events(self.room_id(), ReceiptType::Read, thread, event_id)
+            .get_event_room_receipt_events(self.room_id(), receipt_type, thread, event_id)
             .await
     }
 }

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -28,6 +28,7 @@ use ruma::{
     assign,
     events::{
         direct::DirectEventContent,
+        receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
             encryption::RoomEncryptionEventContent, history_visibility::HistoryVisibility,
             server_acl::RoomServerAclEventContent, MediaSource,
@@ -39,7 +40,8 @@ use ruma::{
         SyncStateEvent,
     },
     serde::Raw,
-    uint, EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedServerName, RoomId, UInt, UserId,
+    uint, EventId, MatrixToUri, MatrixUri, OwnedEventId, OwnedServerName, OwnedUserId, RoomId,
+    UInt, UserId,
 };
 use serde::de::DeserializeOwned;
 
@@ -972,6 +974,48 @@ impl Common {
         // alias might point to another room, e.g. after a room upgrade.
         let via = self.route().await?;
         Ok(self.room_id().matrix_event_uri_via(event_id, via))
+    }
+
+    /// Get the latest receipt of a user in this room.
+    ///
+    /// # Arguments
+    ///
+    /// * `receipt_type` - The type of receipt to get.
+    ///
+    /// * `thread` - The thread containing the event of the receipt, if any.
+    ///
+    /// * `user_id` - The ID of the user.
+    ///
+    /// Returns the ID of the event on which the receipt applies and the
+    /// receipt.
+    pub async fn user_receipt(
+        &self,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        user_id: &UserId,
+    ) -> Result<Option<(OwnedEventId, Receipt)>> {
+        self.inner.user_receipt(receipt_type, thread, user_id).await.map_err(Into::into)
+    }
+
+    /// Get the receipts for an event in this room.
+    ///
+    /// # Arguments
+    ///
+    /// * `receipt_type` - The type of receipt to get.
+    ///
+    /// * `thread` - The thread containing the event of the receipt, if any.
+    ///
+    /// * `event_id` - The ID of the event.
+    ///
+    /// Returns a list of IDs of users who have sent a receipt for the event and
+    /// the corresponding receipts.
+    pub async fn event_receipts(
+        &self,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        event_id: &EventId,
+    ) -> Result<Vec<(OwnedUserId, Receipt)>> {
+        self.inner.event_receipts(receipt_type, thread, event_id).await.map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -15,7 +15,7 @@ pub mod timeline;
 pub use self::{
     common::{Common, Messages, MessagesOptions},
     invited::Invited,
-    joined::Joined,
+    joined::{Joined, Receipts},
     left::Left,
     member::RoomMember,
 };


### PR DESCRIPTION
This includes breaking changes beyond adding parameters, as the methods for sending receipts/markers where renamed for the following reasons:
- With the old names one could assume at first glance that they are getters, due to the Rust naming conventions, but they are not.
- The primary use cases of the receipts/read marker endpoints have been lost a bit since they now both allow to set any receipt/marker. The new names reflect more why someone would call one method instead of the other.

This is a big change so maybe we should just deprecate the old methods for now.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
