### PR TITLE
test: Remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4830,7 +4830,6 @@ name = "sliding-sync-integration-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ctor",
  "futures",
  "matrix-sdk",
  "matrix-sdk-integration-testing",

--- a/testing/sliding-sync-integration-test/Cargo.toml
+++ b/testing/sliding-sync-integration-test/Cargo.toml
@@ -6,7 +6,6 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-ctor = { workspace = true }
 matrix-sdk-integration-testing = { path = "../matrix-sdk-integration-testing", features = ["helpers"] }
 matrix-sdk = { path = "../../crates/matrix-sdk", features = ["experimental-sliding-sync", "testing"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
We activate logging through a ctor function in `matrix-sdk-test`, so no need to copy-paste it into this crate (maybe we can actually do this in other places).