### PR TITLE
Timeline integration tests

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -236,19 +236,11 @@ impl SlidingSyncRoom {
         self.prev_batch.lock_ref().clone()
     }
 
-    /// `AliveTimeline` of this room
-    #[cfg(not(feature = "experimental-timeline"))]
-    pub fn timeline(&self) -> AliveRoomTimeline {
-        self.timeline.clone()
-    }
-
     /// `Timeline` of this room
-    #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(&self) -> Option<Timeline> {
         Some(self.timeline_builder()?.track_fully_read().build().await)
     }
 
-    #[cfg(feature = "experimental-timeline")]
     fn timeline_builder(&self) -> Option<TimelineBuilder> {
         if let Some(room) = self.client.get_room(&self.room_id) {
             let current_timeline = self.timeline.lock_ref().to_vec();
@@ -269,7 +261,6 @@ impl SlidingSyncRoom {
     ///
     /// Use `Timeline::latest_event` instead if you already have a timeline for
     /// this `SlidingSyncRoom`.
-    #[cfg(feature = "experimental-timeline")]
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
         self.timeline_builder()?.build().await.latest_event()
     }


### PR DESCRIPTION
This PR builds on top of https://github.com/matrix-org/matrix-rust-sdk/pull/1478 to add
* `modifying_timeline_limit()` that reproduces the missing last message bug https://github.com/vector-im/element-x-ios/issues/528
* `timeline_duplicates()` that shows the same message appearing twice in the timeline https://github.com/vector-im/element-x-ios/issues/530

It's not particularly clear to me what the underlying issue is especially as rebuilding the `sync.stream()` doesn't seem to work as I expect it.