### PR TITLE
fix(sdk): Attempt to EX-android crash with more hacks

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -228,7 +228,11 @@ impl<P: ProfileProvider> TimelineInner<P> {
     }
 
     #[instrument(skip_all)]
-    pub(super) fn add_loading_indicator(&self) {
+    pub(super) async fn add_loading_indicator(&self) {
+        // hack: Ensure this can't run between loop iterations of
+        // update_sender_profiles. We badly need to replace futures-signals...
+        let _guard = self.metadata.lock().await;
+
         let mut lock = self.items.lock_mut();
         if lock.first().map_or(false, |item| item.is_loading_indicator()) {
             warn!("There is already a loading indicator");
@@ -239,7 +243,11 @@ impl<P: ProfileProvider> TimelineInner<P> {
     }
 
     #[instrument(skip(self))]
-    pub(super) fn remove_loading_indicator(&self, more_messages: bool) {
+    pub(super) async fn remove_loading_indicator(&self, more_messages: bool) {
+        // hack: Ensure this can't run between loop iterations of
+        // update_sender_profiles. We badly need to replace futures-signals...
+        let _guard = self.metadata.lock().await;
+
         let mut lock = self.items.lock_mut();
         if !lock.first().map_or(false, |item| item.is_loading_indicator()) {
             warn!("There is no loading indicator");

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -121,7 +121,7 @@ impl Timeline {
             return Ok(());
         }
 
-        self.inner.add_loading_indicator();
+        self.inner.add_loading_indicator().await;
 
         let mut from = start_lock.clone();
         let mut outcome = PaginationOutcome::new();
@@ -169,7 +169,7 @@ impl Timeline {
             }
         }
 
-        self.inner.remove_loading_indicator(from.is_some());
+        self.inner.remove_loading_indicator(from.is_some()).await;
         *start_lock = from;
 
         Ok(())


### PR DESCRIPTION
Seems like these were the only two uses of `items.lock_mut()` where the metadata wasn't also locked. Let's hope this fixes the crash.

Obviously being careful about when / how we write to the items is not viable in the long term, so we will need to find a better solution soon (possibly just forking futures-signals so we don't have to deal with sync locks).