### PR TITLE
chore(base): Remove unused futures-channel dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2760,7 +2760,6 @@ dependencies = [
  "ctor",
  "dashmap",
  "futures",
- "futures-channel",
  "futures-core",
  "futures-signals",
  "futures-util",

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -29,7 +29,6 @@ testing = ["dep:http"]
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
-futures-channel = "0.3.21"
 futures-core = "0.3.21"
 futures-signals = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.21", default-features = false }


### PR DESCRIPTION
Not sure when it was last used, but it doesn't seem to be anymore.