### PR TITLE
crypto-js: log trace messages at debug

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/tracing.rs
+++ b/bindings/matrix-sdk-crypto-js/src/tracing.rs
@@ -213,7 +213,7 @@ mod inner {
             let message = format!("{level} {origin}{recorder}");
 
             match *level {
-                Level::TRACE => log_trace(message),
+                Level::TRACE => log_debug(message),
                 Level::DEBUG => log_debug(message),
                 Level::INFO => log_info(message),
                 Level::WARN => log_warn(message),

--- a/bindings/matrix-sdk-crypto-js/src/tracing.rs
+++ b/bindings/matrix-sdk-crypto-js/src/tracing.rs
@@ -145,9 +145,6 @@ mod inner {
 
     #[wasm_bindgen]
     extern "C" {
-        #[wasm_bindgen(js_namespace = console, js_name = "trace")]
-        fn log_trace(message: String);
-
         #[wasm_bindgen(js_namespace = console, js_name = "debug")]
         fn log_debug(message: String);
 


### PR DESCRIPTION
Javascript's `console.trace` is not a good equivalent for Rust's `Level::TRACE`.

In particular:
 * `console.trace` causes a stacktrace to be written with each message
 * Under nodejs, `console.trace` writes the message to `stderr`, while `console.debug` writes to `stdout`

`console.trace` is therefore somewhat analogous to `console.error`.

Since we already include the log level in the message, we might as well just send trace messages to `console.debug` rather than `console.trace`.