### PR TITLE
feat(sdk): Keep Timeline event handlers around longer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,6 +2705,7 @@ dependencies = [
  "matrix-sdk-test",
  "mime",
  "once_cell",
+ "pin-project-lite",
  "rand 0.8.5",
  "reqwest",
  "ruma",

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -83,6 +83,7 @@ matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../matrix-sdk-indexeddb", default-features = false, optional = true }
 matrix-sdk-sled = { version = "0.2.0", path = "../matrix-sdk-sled", default-features = false, optional = true }
 mime = "0.3.16"
+pin-project-lite = "0.2.9"
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.11.10", default_features = false }
 ruma = { workspace = true, features = ["compat", "rand", "unstable-msc2448", "unstable-msc2965"] }

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use futures_signals::signal_vec::{MutableVec, MutableVecLockRef, SignalVec};
+use futures_signals::signal_vec::{MutableSignalVec, MutableVec, MutableVecLockRef};
 use indexmap::IndexSet;
 use matrix_sdk_base::{
     crypto::OlmMachine,
@@ -83,7 +83,7 @@ impl<P: ProfileProvider> TimelineInner<P> {
         self.items.lock_ref()
     }
 
-    pub(super) fn items_signal(&self) -> impl SignalVec<Item = Arc<TimelineItem>> {
+    pub(super) fn items_signal(&self) -> MutableSignalVec<Arc<TimelineItem>> {
         trace!("Creating timeline items signal");
         self.items.signal_vec_cloned()
     }


### PR DESCRIPTION
… if the Timeline object itself is dropped, but something is still subscribed to its changes.