### PR TITLE
Respect new server ordering when receiving duplicate events

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -651,17 +651,10 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
 
                 if let Some((idx, old_item)) = result {
                     if let EventTimelineItem::Remote(old_item) = old_item {
-                        // Item was previously received by the server. Until we
-                        // implement forwards pagination, this indicates a bug
-                        // somewhere.
-                        warn!(?item, ?old_item, "Received duplicate event");
-
-                        // With /messages and /sync sometimes disagreeing on
-                        // order of messages, we might want to change the
-                        // position in some circumstances, but for now this
-                        // should be good enough.
-                        self.timeline_items.set_cloned(idx, item);
-                        return;
+                        // Item was previously received from the server. This
+                        // should be very rare normally, but with the sliding-
+                        // sync proxy, it is actually very common.
+                        trace!(?item, ?old_item, "Received duplicate event");
                     };
 
                     if txn_id.is_none() {

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -700,12 +700,12 @@ impl<'a, 'i> TimelineEventHandler<'a, 'i> {
                         // Pre-requisites for removing the day divider:
                         // 1. there is one preceding the old item at all
                         if self.timeline_items[idx - 1].is_day_divider()
-                            // 2. the next item after the old one being removed
+                            // 2. the item after the old one that was removed
                             //    is virtual (it should be impossible for this
                             //    to be a read marker)
                             && self
                                 .timeline_items
-                                .get(idx + 1)
+                                .get(idx)
                                 .map_or(true, |item| item.is_virtual())
                         {
                             trace!("Removing day divider");

--- a/crates/matrix-sdk/src/room/timeline/tests/echo.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/echo.rs
@@ -136,8 +136,11 @@ async fn remote_echo_new_position() {
 
     // … the local echo should be removed
     assert_matches!(stream.next().await, Some(VecDiff::RemoveAt { index: 1 }));
+    // … along with its day divider
+    assert_matches!(stream.next().await, Some(VecDiff::RemoveAt { index: 0 }));
 
-    // … and the remote echo added
+    // … and the remote echo added (no new day divider because both bob's and
+    // alice's message are from the same day according to server timestamps)
     let item = assert_matches!(stream.next().await, Some(VecDiff::Push { value }) => value);
     assert_matches!(item.as_event().unwrap(), EventTimelineItem::Remote(_));
 }

--- a/crates/matrix-sdk/src/room/timeline/tests/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/mod.rs
@@ -22,7 +22,7 @@ use std::sync::{
 use async_trait::async_trait;
 use futures_core::Stream;
 use futures_signals::signal_vec::{SignalVecExt, VecDiff};
-use matrix_sdk_base::deserialized_responses::{SyncTimelineEvent, TimelineEvent};
+use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use once_cell::sync::Lazy;
 use ruma::{
     events::{
@@ -55,29 +55,6 @@ struct TestTimeline {
 impl TestTimeline {
     fn new() -> Self {
         Self { inner: TimelineInner::new(TestProfileProvider), next_ts: AtomicU64::new(0) }
-    }
-
-    async fn with_initial_events<'a>(
-        events: impl IntoIterator<Item = (&'a UserId, AnyMessageLikeEventContent)>,
-    ) -> Self {
-        let mut this =
-            Self { inner: TimelineInner::new(TestProfileProvider), next_ts: AtomicU64::new(0) };
-
-        this.inner
-            .add_initial_events(
-                events
-                    .into_iter()
-                    .map(|(sender, content)| {
-                        let event =
-                            serde_json::from_value(this.make_message_event(sender, content))
-                                .unwrap();
-                        SyncTimelineEvent { event, encryption_info: None }
-                    })
-                    .collect(),
-            )
-            .await;
-
-        this
     }
 
     fn stream(&self) -> impl Stream<Item = VecDiff<Arc<TimelineItem>>> {


### PR DESCRIPTION
Previously, the server ordering was only respected for remote echoes, now events newly received from syncing are always added at the back and if they already exist at an earlier position in the timeline, they're removed from there.

Also fixes an off-by-one index error when removing the day divider for an item that is removed to be re-inserted somewhere else.