### PR TITLE
tests: add depends_on block for the sliding sync proxy

### DIFF
--- a/testing/sliding-sync-integration-test/assets/docker-compose.yml
+++ b/testing/sliding-sync-integration-test/assets/docker-compose.yml
@@ -29,6 +29,9 @@ services:
 
   sliding-sync-proxy:
     image: ghcr.io/matrix-org/sliding-sync:v0.99.0-rc1
+    depends_on:
+      postgres:
+        condition: service_healthy
     # image: ghcr.io/matrix-org/sliding-sync:latest
     links:
       - synapse


### PR DESCRIPTION
This prevents the proxy starting before postgres is ready, which causes the proxy to panic.