### PR TITLE
Remove outdated documentation

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -96,14 +96,6 @@ impl Timeline {
     }
 
     /// Add more events to the start of the timeline.
-    ///
-    /// # Arguments
-    ///
-    /// * `initial_pagination_size`: The number of events to fetch from the
-    ///   server in the first pagination request. The server may choose return
-    ///   fewer events, for example because the supplied number is too big or
-    ///   the beginning of the visible timeline was reached.
-    /// * `
     #[instrument(skip_all, fields(initial_pagination_size, room_id = ?self.room().room_id()))]
     pub async fn paginate_backwards(&self, mut opts: PaginationOptions<'_>) -> Result<()> {
         let mut start_lock = self.start_token.lock().await;


### PR DESCRIPTION
Since `PaginationOptions` has its own documentation, I don't think we need the `Arguments` section on the function where it's being passed, hence I just removed it altogether.