### PR TITLE
Refactor event detail fetching

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -316,12 +316,7 @@ impl Timeline {
     /// before all requests are handled.
     #[instrument(skip(self), fields(room_id = ?self.room().room_id()))]
     pub async fn fetch_event_details(&self, event_id: &EventId) -> Result<()> {
-        let (index, item) = rfind_event_by_id(&self.inner.items(), event_id)
-            .and_then(|(pos, item)| item.as_remote().map(|item| (pos, item.clone())))
-            .ok_or(Error::RemoteEventNotInTimeline)?;
-
-        self.inner.fetch_in_reply_to_details(index, item).await?;
-
+        self.inner.fetch_in_reply_to_details(event_id).await?;
         Ok(())
     }
 


### PR DESCRIPTION
There wasn't a clear reason why part of the logic was inside `Timeline` an the rest in `TimelineInner`. Also we should honor parallel updates (for example redaction coming in via sync) to an item that we fetch details for.

cc @zecakeh 