### PR TITLE
fix(sdk): `FrozenSlidingSyncRoom.timeline_queue` must serialize to `timeline`

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync.rs
+++ b/crates/matrix-sdk/src/sliding_sync.rs
@@ -783,7 +783,45 @@ struct FrozenSlidingSyncRoom {
     room_id: OwnedRoomId,
     inner: v4::SlidingSyncRoom,
     prev_batch: Option<String>,
+    #[serde(rename = "timeline")]
     timeline_queue: Vec<SyncTimelineEvent>,
+}
+
+#[cfg(test)]
+mod tests {
+    use matrix_sdk_base::deserialized_responses::TimelineEvent;
+    use ruma::events::room::message::RoomMessageEventContent;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_frozen_sliding_sync_room_serialize() {
+        let frozen_sliding_sync_room = FrozenSlidingSyncRoom {
+            room_id: <&RoomId>::try_from("!29fhd83h92h0:example.com").unwrap().to_owned(),
+            inner: v4::SlidingSyncRoom::default(),
+            prev_batch: Some("let it go!".to_owned()),
+            timeline_queue: vec![TimelineEvent {
+                event: Raw::new(&json! ({
+                    "content": RoomMessageEventContent::text_plain("let it gooo!"),
+                    "type": "m.room.message",
+                    "event_id": "$xxxxx:example.org",
+                    "room_id": "!someroom:example.com",
+                    "origin_server_ts": 2189,
+                    "sender": "@bob:example.com",
+                }))
+                .unwrap()
+                .cast(),
+                encryption_info: None,
+            }
+            .into()],
+        };
+
+        assert_eq!(
+            serde_json::to_string(&frozen_sliding_sync_room).unwrap(),
+            "{\"room_id\":\"!29fhd83h92h0:example.com\",\"inner\":{},\"prev_batch\":\"let it go!\",\"timeline\":[{\"event\":{\"content\":{\"body\":\"let it gooo!\",\"msgtype\":\"m.text\"},\"event_id\":\"$xxxxx:example.org\",\"origin_server_ts\":2189,\"room_id\":\"!someroom:example.com\",\"sender\":\"@bob:example.com\",\"type\":\"m.room.message\"},\"encryption_info\":null}]}",
+        );
+    }
 }
 
 impl From<&SlidingSyncRoom> for FrozenSlidingSyncRoom {


### PR DESCRIPTION
In https://github.com/matrix-org/matrix-rust-sdk/pull/1478, I've introduced a regression. The `FrozenSlidingSyncRoom.timeline` field has been renamed to `timeline_queue`.

I didn't notice that this type can be serialized and deserialized. That's actually a breaking change because this type is stored somewhere once serialized. So with #1478, it was impossible to deserialize them!

This patch fixes that. It also adds a test to ensure the serialization form of `FrozenSlidingSyncRoom` doesn't change.
