### PR TITLE
feat(sdk): Keep track of events read receipts in the timeline API

### DIFF
--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -272,7 +272,7 @@ impl Common {
     /// independent events.
     #[cfg(feature = "experimental-timeline")]
     pub async fn timeline(&self) -> Timeline {
-        Timeline::builder(self).track_fully_read().build().await
+        Timeline::builder(self).track_read_marker_and_receipts().build().await
     }
 
     /// Fetch the event with the given `EventId` in this room.

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -21,6 +21,7 @@ use matrix_sdk_base::deserialized_responses::EncryptionInfo;
 use ruma::{
     events::{
         reaction::ReactionEventContent,
+        receipt::{Receipt, ReceiptType},
         relation::{Annotation, Replacement},
         room::{
             encrypted::RoomEncryptedEventContent,
@@ -46,8 +47,10 @@ use super::{
         MemberProfileChange, OtherState, Profile, RemoteEventTimelineItem, RoomMembershipChange,
         Sticker,
     },
-    find_read_marker, rfind_event_by_id, rfind_event_item, EventTimelineItem, InReplyToDetails,
-    Message, ReactionGroup, TimelineDetails, TimelineInnerState, TimelineItem, TimelineItemContent,
+    find_read_marker,
+    read_receipts::maybe_add_implicit_read_receipt,
+    rfind_event_by_id, rfind_event_item, EventTimelineItem, InReplyToDetails, Message,
+    ReactionGroup, TimelineDetails, TimelineInnerState, TimelineItem, TimelineItemContent,
     VirtualTimelineItem,
 };
 use crate::{events::SyncTimelineEventWithoutContent, room::timeline::MembershipChange};
@@ -72,6 +75,7 @@ pub(super) struct TimelineEventMetadata {
     pub(super) is_own_event: bool,
     pub(super) relations: BundledRelations,
     pub(super) encryption_info: Option<EncryptionInfo>,
+    pub(super) read_receipts: IndexMap<OwnedUserId, Receipt>,
 }
 
 #[derive(Clone)]
@@ -201,6 +205,9 @@ pub(super) struct TimelineEventHandler<'a> {
     pending_reactions: &'a mut HashMap<OwnedEventId, IndexSet<OwnedEventId>>,
     fully_read_event: &'a mut Option<OwnedEventId>,
     fully_read_event_in_timeline: &'a mut bool,
+    track_read_receipts: bool,
+    users_read_receipts:
+        &'a mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
     result: HandleEventResult,
 }
 
@@ -224,6 +231,7 @@ impl<'a> TimelineEventHandler<'a> {
         event_meta: TimelineEventMetadata,
         flow: Flow,
         state: &'a mut TimelineInnerState,
+        track_read_receipts: bool,
     ) -> Self {
         Self {
             meta: event_meta,
@@ -233,6 +241,8 @@ impl<'a> TimelineEventHandler<'a> {
             pending_reactions: &mut state.pending_reactions,
             fully_read_event: &mut state.fully_read_event,
             fully_read_event_in_timeline: &mut state.fully_read_event_in_timeline,
+            track_read_receipts,
+            users_read_receipts: &mut state.users_read_receipts,
             result: HandleEventResult::default(),
         }
     }
@@ -532,7 +542,7 @@ impl<'a> TimelineEventHandler<'a> {
         let sender_profile = TimelineDetails::from_initial_value(self.meta.sender_profile.clone());
         let mut reactions = self.pending_reactions().unwrap_or_default();
 
-        let item = match &self.flow {
+        let mut item = match &self.flow {
             Flow::Local { txn_id, timestamp } => EventTimelineItem::Local(LocalEventTimelineItem {
                 send_state: EventSendState::NotSentYet,
                 transaction_id: txn_id.to_owned(),
@@ -558,12 +568,11 @@ impl<'a> TimelineEventHandler<'a> {
                     reactions,
                     is_own: self.meta.is_own_event,
                     encryption_info: self.meta.encryption_info.clone(),
+                    read_receipts: self.meta.read_receipts.clone(),
                     raw: raw_event.clone(),
                 })
             }
         };
-
-        let item = Arc::new(TimelineItem::Event(item));
 
         match &self.flow {
             Flow::Local { timestamp, .. } => {
@@ -586,7 +595,7 @@ impl<'a> TimelineEventHandler<'a> {
                     self.items.push_back(Arc::new(TimelineItem::day_divider(*timestamp)));
                 }
 
-                self.items.push_back(item);
+                self.items.push_back(Arc::new(item.into()));
             }
 
             Flow::Remote {
@@ -631,7 +640,17 @@ impl<'a> TimelineEventHandler<'a> {
                         .insert(offset, Arc::new(TimelineItem::day_divider(*origin_server_ts)));
                 }
 
-                self.items.insert(offset + 1, item);
+                if self.track_read_receipts {
+                    maybe_add_implicit_read_receipt(
+                        offset,
+                        &mut item,
+                        self.meta.is_own_event,
+                        self.items,
+                        self.users_read_receipts,
+                    );
+                }
+
+                self.items.insert(offset + 1, Arc::new(item.into()));
             }
 
             Flow::Remote {
@@ -672,8 +691,19 @@ impl<'a> TimelineEventHandler<'a> {
                     {
                         // If the old item is the last one and no day divider
                         // changes need to happen, replace and return early.
+
+                        if self.track_read_receipts {
+                            maybe_add_implicit_read_receipt(
+                                idx,
+                                &mut item,
+                                self.meta.is_own_event,
+                                self.items,
+                                self.users_read_receipts,
+                            );
+                        }
+
                         trace!(idx, "Replacing existing event");
-                        self.items.set(idx, item);
+                        self.items.set(idx, Arc::new(item.into()));
                         return;
                     } else {
                         // In more complex cases, remove the item and day
@@ -729,14 +759,24 @@ impl<'a> TimelineEventHandler<'a> {
                     self.items.push_back(Arc::new(TimelineItem::day_divider(*origin_server_ts)));
                 }
 
+                if self.track_read_receipts {
+                    maybe_add_implicit_read_receipt(
+                        self.items.len(),
+                        &mut item,
+                        self.meta.is_own_event,
+                        self.items,
+                        self.users_read_receipts,
+                    );
+                }
+
                 trace!("Adding new remote timeline item at the end");
-                self.items.push_back(item);
+                self.items.push_back(Arc::new(item.into()));
             }
 
             #[cfg(feature = "e2e-encryption")]
             Flow::Remote { position: TimelineItemPosition::Update(idx), .. } => {
                 trace!("Updating timeline item at position {idx}");
-                self.items.set(*idx, item);
+                self.items.set(*idx, Arc::new(item.into()));
             }
         }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -52,7 +52,7 @@ use ruma::{
     OwnedTransactionId, OwnedUserId, TransactionId, UserId,
 };
 
-use super::inner::ProfileProvider;
+use super::inner::RoomDataProvider;
 use crate::{Error, Result};
 
 /// An item in the timeline that represents at least one event.
@@ -571,9 +571,9 @@ impl RepliedToEvent {
         &self.sender_profile
     }
 
-    pub(super) async fn try_from_timeline_event<P: ProfileProvider>(
+    pub(super) async fn try_from_timeline_event<P: RoomDataProvider>(
         timeline_event: TimelineEvent,
-        profile_provider: &P,
+        room_data_provider: &P,
     ) -> Result<Self> {
         let event = match timeline_event.event.deserialize() {
             Ok(AnyTimelineEvent::MessageLike(event)) => event,
@@ -593,7 +593,7 @@ impl RepliedToEvent {
         };
         let sender = event.sender().to_owned();
         let sender_profile =
-            TimelineDetails::from_initial_value(profile_provider.profile(&sender).await);
+            TimelineDetails::from_initial_value(room_data_provider.profile(&sender).await);
 
         Ok(Self { message, sender, sender_profile })
     }

--- a/crates/matrix-sdk/src/room/timeline/event_item.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item.rs
@@ -22,6 +22,7 @@ use ruma::{
             room::PolicyRuleRoomEventContent, server::PolicyRuleServerEventContent,
             user::PolicyRuleUserEventContent,
         },
+        receipt::Receipt,
         room::{
             aliases::RoomAliasesEventContent,
             avatar::RoomAvatarEventContent,
@@ -294,6 +295,13 @@ pub struct RemoteEventTimelineItem {
     pub content: TimelineItemContent,
     /// All bundled reactions about the event.
     pub reactions: BundledReactions,
+    /// All read receipts for the event.
+    ///
+    /// The key is the ID of a room member and the value are details about the
+    /// read receipt.
+    ///
+    /// Note that currently this ignores threads.
+    pub read_receipts: IndexMap<OwnedUserId, Receipt>,
     /// Whether the event has been sent by the the logged-in user themselves.
     pub is_own: bool,
     /// Encryption information.

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -41,6 +41,7 @@ mod event_handler;
 mod event_item;
 mod inner;
 mod pagination;
+mod read_receipts;
 #[cfg(test)]
 mod tests;
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/room/timeline/read_receipts.rs
+++ b/crates/matrix-sdk/src/room/timeline/read_receipts.rs
@@ -1,0 +1,228 @@
+// Copyright 2023 Kévin Commaille
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::HashMap, sync::Arc};
+
+use eyeball_im::ObservableVector;
+use indexmap::IndexMap;
+use ruma::{
+    events::receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
+    EventId, OwnedEventId, OwnedUserId, UserId,
+};
+use tracing::error;
+
+use super::{
+    inner::{RoomDataProvider, TimelineInnerState},
+    rfind_event_by_id, EventTimelineItem, TimelineItem,
+};
+
+struct FullReceipt<'a> {
+    event_id: &'a EventId,
+    user_id: &'a UserId,
+    receipt_type: ReceiptType,
+    receipt: &'a Receipt,
+}
+
+pub(super) fn handle_explicit_read_receipts(
+    receipt_event_content: ReceiptEventContent,
+    own_user_id: &UserId,
+    timeline_state: &mut TimelineInnerState,
+) {
+    for (event_id, receipt_types) in receipt_event_content.0 {
+        for (receipt_type, receipts) in receipt_types {
+            // We only care about read receipts here.
+            if !matches!(receipt_type, ReceiptType::Read | ReceiptType::ReadPrivate) {
+                continue;
+            }
+
+            for (user_id, receipt) in receipts {
+                if receipt.thread != ReceiptThread::Unthreaded {
+                    continue;
+                }
+
+                let receipt_item_pos =
+                    rfind_event_by_id(&timeline_state.items, &event_id).map(|(pos, _)| pos);
+                let is_own_user_id = user_id == own_user_id;
+                let full_receipt = FullReceipt {
+                    event_id: &event_id,
+                    user_id: &user_id,
+                    receipt_type: receipt_type.clone(),
+                    receipt: &receipt,
+                };
+
+                let read_receipt_updated = maybe_update_read_receipt(
+                    full_receipt,
+                    receipt_item_pos,
+                    is_own_user_id,
+                    &mut timeline_state.items,
+                    &mut timeline_state.users_read_receipts,
+                );
+
+                if read_receipt_updated && !is_own_user_id {
+                    // Update the new item pointed to by the user's read receipt.
+                    let new_receipt_event_item = receipt_item_pos.and_then(|pos| {
+                        let e = timeline_state.items[pos].as_event()?.as_remote()?;
+                        Some((pos, e.clone()))
+                    });
+
+                    if let Some((pos, mut remote_event_item)) = new_receipt_event_item {
+                        remote_event_item.read_receipts.insert(user_id, receipt);
+                        timeline_state
+                            .items
+                            .set(pos, Arc::new(TimelineItem::Event(remote_event_item.into())));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Add an implicit read receipt to the given event item, if it is more recent
+/// than the current read receipt for the sender of the event.
+///
+/// According to the spec, read receipts should not point to events sent by our
+/// own user, but these events are used to reset the notification count, so we
+/// need to handle them locally too. For that we create an "implicit" read
+/// receipt, compared to the "explicit" ones sent by the client.
+pub(super) fn maybe_add_implicit_read_receipt(
+    item_pos: usize,
+    event_item: &mut EventTimelineItem,
+    is_own_event: bool,
+    timeline_items: &mut ObservableVector<Arc<TimelineItem>>,
+    users_read_receipts: &mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
+) {
+    let EventTimelineItem::Remote(remote_event_item) = event_item else {
+        return;
+    };
+
+    let receipt = Receipt::new(remote_event_item.timestamp);
+    let new_receipt = FullReceipt {
+        event_id: &remote_event_item.event_id,
+        user_id: &remote_event_item.sender.clone(),
+        receipt_type: ReceiptType::Read,
+        receipt: &receipt,
+    };
+
+    let read_receipt_updated = maybe_update_read_receipt(
+        new_receipt,
+        Some(item_pos),
+        is_own_event,
+        timeline_items,
+        users_read_receipts,
+    );
+    if read_receipt_updated && !is_own_event {
+        remote_event_item.read_receipts.insert(remote_event_item.sender.clone(), receipt);
+    }
+}
+
+/// Update the timeline items with the given read receipt if it is more recent
+/// than the current one.
+///
+/// In the process, this method removes the corresponding receipt from its old
+/// item, if applicable, and updates the `users_read_receipts` map to use the
+/// new receipt.
+///
+/// Returns true if the read receipt was saved.
+///
+/// Currently this method only works reliably if the timeline was started from
+/// the end of the timeline.
+fn maybe_update_read_receipt(
+    receipt: FullReceipt<'_>,
+    new_item_pos: Option<usize>,
+    is_own_user_id: bool,
+    timeline_items: &mut ObservableVector<Arc<TimelineItem>>,
+    users_read_receipts: &mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
+) -> bool {
+    let old_event_id = users_read_receipts
+        .get(receipt.user_id)
+        .and_then(|receipts| receipts.get(&receipt.receipt_type))
+        .map(|(event_id, _)| event_id);
+    if old_event_id.map_or(false, |id| id == receipt.event_id) {
+        // Nothing to do.
+        return false;
+    }
+
+    let old_item = old_event_id.and_then(|e| {
+        let (pos, item) = rfind_event_by_id(timeline_items, e)?;
+        Some((pos, item.as_remote()?))
+    });
+
+    if let Some((old_receipt_pos, old_event_item)) = old_item {
+        let Some(new_receipt_pos) = new_item_pos else {
+            // The old receipt is likely more recent since we can't find the event of the
+            // new receipt in the timeline. Even if it isn't, we wouldn't know where to put
+            // it.
+            return false;
+        };
+
+        if old_receipt_pos > new_receipt_pos {
+            // The old receipt is more recent than the new one.
+            return false;
+        }
+
+        if !is_own_user_id {
+            // Remove the read receipt for this user from the old event.
+            let mut old_event_item = old_event_item.clone();
+            if old_event_item.read_receipts.remove(receipt.user_id).is_none() {
+                error!("inconsistent state: old event item for user's read receipt doesn't have a receipt for the user");
+            }
+            timeline_items
+                .set(old_receipt_pos, Arc::new(TimelineItem::Event(old_event_item.into())));
+        }
+    }
+
+    // The new receipt is deemed more recent from now on because:
+    // - If old_receipt_item is Some, we already checked all the cases where it
+    //   wouldn't be more recent.
+    // - If both old_receipt_item and new_receipt_item are None, they are both
+    //   explicit read receipts so the server should only send us a more recent
+    //   receipt.
+    // - If old_receipt_item is None and new_receipt_item is Some, the new receipt
+    //   is likely more recent because it has a place in the timeline.
+    users_read_receipts
+        .entry(receipt.user_id.to_owned())
+        .or_default()
+        .insert(receipt.receipt_type, (receipt.event_id.to_owned(), receipt.receipt.clone()));
+
+    true
+}
+
+/// Load the read receipts from the store for the given event ID.
+pub(super) async fn load_read_receipts_for_event<P: RoomDataProvider>(
+    event_id: &EventId,
+    timeline_state: &mut TimelineInnerState,
+    room_data_provider: &P,
+) -> IndexMap<OwnedUserId, Receipt> {
+    let read_receipts = room_data_provider.read_receipts_for_event(event_id).await;
+
+    // Filter out receipts for our own user.
+    let own_user_id = room_data_provider.own_user_id();
+    let read_receipts: IndexMap<OwnedUserId, Receipt> =
+        read_receipts.into_iter().filter(|(user_id, _)| user_id != own_user_id).collect();
+
+    // Keep track of the user's read receipt.
+    for (user_id, receipt) in read_receipts.clone() {
+        // Only insert the read receipt if the user is not known to avoid conflicts with
+        // `TimelineInner::handle_read_receipts`.
+        if !timeline_state.users_read_receipts.contains_key(&user_id) {
+            timeline_state
+                .users_read_receipts
+                .entry(user_id)
+                .or_default()
+                .insert(ReceiptType::Read, (event_id.to_owned(), receipt));
+        }
+    }
+
+    read_receipts
+}

--- a/crates/matrix-sdk/src/room/timeline/tests/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/mod.rs
@@ -14,25 +14,30 @@
 
 //! Unit tests (based on private methods) for the timeline API.
 
-use std::sync::{
-    atomic::{AtomicU64, Ordering::SeqCst},
-    Arc,
+use std::{
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicU64, Ordering::SeqCst},
+        Arc,
+    },
 };
 
 use async_trait::async_trait;
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
+use indexmap::IndexMap;
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 use once_cell::sync::Lazy;
 use ruma::{
     events::{
+        receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
         AnyMessageLikeEventContent, EmptyStateKey, MessageLikeEventContent,
         RedactedMessageLikeEventContent, RedactedStateEventContent, StateEventContent,
         StaticStateEventContent,
     },
     serde::Raw,
-    server_name, user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedTransactionId, TransactionId,
-    UserId,
+    server_name, user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId,
+    OwnedUserId, TransactionId, UserId,
 };
 use serde_json::{json, Value as JsonValue};
 
@@ -42,6 +47,7 @@ mod basic;
 mod echo;
 mod encryption;
 mod invalid;
+mod read_receipts;
 mod virt;
 
 static ALICE: Lazy<&UserId> = Lazy::new(|| user_id!("@alice:server.name"));
@@ -55,6 +61,11 @@ struct TestTimeline {
 impl TestTimeline {
     fn new() -> Self {
         Self { inner: TimelineInner::new(TestRoomDataProvider), next_ts: AtomicU64::new(0) }
+    }
+
+    fn with_read_receipt_tracking(mut self) -> Self {
+        self.inner = self.inner.with_read_receipt_tracking(true);
+        self
     }
 
     async fn subscribe(&self) -> impl Stream<Item = VectorDiff<Arc<TimelineItem>>> {
@@ -156,6 +167,14 @@ impl TestTimeline {
         self.inner.handle_back_paginated_event(timeline_event).await;
     }
 
+    async fn handle_read_receipts(
+        &self,
+        receipts: impl IntoIterator<Item = (OwnedEventId, ReceiptType, OwnedUserId, ReceiptThread)>,
+    ) {
+        let ev_content = self.make_receipt_event_content(receipts);
+        self.inner.handle_read_receipts(ev_content).await;
+    }
+
     /// Set the next server timestamp.
     ///
     /// Timestamps will continue to increase by 1 (millisecond) from that value.
@@ -245,6 +264,24 @@ impl TestTimeline {
         })
     }
 
+    fn make_receipt_event_content(
+        &self,
+        receipts: impl IntoIterator<Item = (OwnedEventId, ReceiptType, OwnedUserId, ReceiptThread)>,
+    ) -> ReceiptEventContent {
+        let mut ev_content = ReceiptEventContent(BTreeMap::new());
+        for (event_id, receipt_type, user_id, thread) in receipts {
+            let event_map = ev_content.entry(event_id).or_default();
+            let receipt_map = event_map.entry(receipt_type).or_default();
+
+            let mut receipt = Receipt::new(self.next_server_ts());
+            receipt.thread = thread;
+
+            receipt_map.insert(user_id, receipt);
+        }
+
+        ev_content
+    }
+
     fn next_server_ts(&self) -> MilliSecondsSinceUnixEpoch {
         MilliSecondsSinceUnixEpoch(
             self.next_ts
@@ -265,5 +302,9 @@ impl RoomDataProvider for TestRoomDataProvider {
 
     async fn profile(&self, _user_id: &UserId) -> Option<Profile> {
         None
+    }
+
+    async fn read_receipts_for_event(&self, _event_id: &EventId) -> IndexMap<OwnedUserId, Receipt> {
+        IndexMap::new()
     }
 }

--- a/crates/matrix-sdk/src/room/timeline/tests/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/mod.rs
@@ -36,7 +36,7 @@ use ruma::{
 };
 use serde_json::{json, Value as JsonValue};
 
-use super::{inner::ProfileProvider, Profile, TimelineInner, TimelineItem};
+use super::{inner::RoomDataProvider, Profile, TimelineInner, TimelineItem};
 
 mod basic;
 mod echo;
@@ -48,13 +48,13 @@ static ALICE: Lazy<&UserId> = Lazy::new(|| user_id!("@alice:server.name"));
 static BOB: Lazy<&UserId> = Lazy::new(|| user_id!("@bob:other.server"));
 
 struct TestTimeline {
-    inner: TimelineInner<TestProfileProvider>,
+    inner: TimelineInner<TestRoomDataProvider>,
     next_ts: AtomicU64,
 }
 
 impl TestTimeline {
     fn new() -> Self {
-        Self { inner: TimelineInner::new(TestProfileProvider), next_ts: AtomicU64::new(0) }
+        Self { inner: TimelineInner::new(TestRoomDataProvider), next_ts: AtomicU64::new(0) }
     }
 
     async fn subscribe(&self) -> impl Stream<Item = VectorDiff<Arc<TimelineItem>>> {
@@ -255,10 +255,10 @@ impl TestTimeline {
     }
 }
 
-struct TestProfileProvider;
+struct TestRoomDataProvider;
 
 #[async_trait]
-impl ProfileProvider for TestProfileProvider {
+impl RoomDataProvider for TestRoomDataProvider {
     fn own_user_id(&self) -> &UserId {
         &ALICE
     }

--- a/crates/matrix-sdk/src/room/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/read_receipts.rs
@@ -1,0 +1,91 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use assert_matches::assert_matches;
+use eyeball_im::VectorDiff;
+use futures_util::StreamExt;
+use matrix_sdk_test::async_test;
+use ruma::events::{
+    receipt::{ReceiptThread, ReceiptType},
+    room::message::RoomMessageEventContent,
+};
+
+use super::{TestTimeline, ALICE, BOB};
+
+#[async_test]
+async fn read_receipts_updates() {
+    let timeline = TestTimeline::new().with_read_receipt_tracking();
+    let mut stream = timeline.subscribe().await;
+
+    timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("A")).await;
+    timeline.handle_live_message_event(*BOB, RoomMessageEventContent::text_plain("B")).await;
+
+    let _day_divider =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+
+    // No read receipt for our own user.
+    let item_a =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let event_a = item_a.as_event().unwrap().as_remote().unwrap();
+    assert!(event_a.read_receipts.is_empty());
+
+    // Implicit read receipt of Bob.
+    let item_b =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let event_b = item_b.as_event().unwrap().as_remote().unwrap();
+    assert_eq!(event_b.read_receipts.len(), 1);
+    assert!(event_b.read_receipts.get(*BOB).is_some());
+
+    // Implicit read receipt of Bob is updated.
+    timeline.handle_live_message_event(*BOB, RoomMessageEventContent::text_plain("C")).await;
+
+    let item_a =
+        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 2, value }) => value);
+    let event_a = item_a.as_event().unwrap().as_remote().unwrap();
+    assert!(event_a.read_receipts.is_empty());
+
+    let item_c =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let event_c = item_c.as_event().unwrap().as_remote().unwrap();
+    assert_eq!(event_c.read_receipts.len(), 1);
+    assert!(event_c.read_receipts.get(*BOB).is_some());
+
+    timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("D")).await;
+
+    let item_d =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let event_d = item_d.as_event().unwrap().as_remote().unwrap();
+    assert!(event_d.read_receipts.is_empty());
+
+    // Explicit read receipt is updated.
+    timeline
+        .handle_read_receipts([(
+            event_d.event_id.clone(),
+            ReceiptType::Read,
+            BOB.to_owned(),
+            ReceiptThread::Unthreaded,
+        )])
+        .await;
+
+    let item_c =
+        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 3, value }) => value);
+    let event_c = item_c.as_event().unwrap().as_remote().unwrap();
+    assert!(event_c.read_receipts.is_empty());
+
+    let item_d =
+        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 4, value }) => value);
+    let event_d = item_d.as_event().unwrap().as_remote().unwrap();
+    assert_eq!(event_d.read_receipts.len(), 1);
+    assert!(event_d.read_receipts.get(*BOB).is_some());
+}

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -78,7 +78,7 @@ impl SlidingSyncRoom {
 
     /// `Timeline` of this room
     pub async fn timeline(&self) -> Option<Timeline> {
-        Some(self.timeline_builder()?.track_fully_read().build().await)
+        Some(self.timeline_builder()?.track_read_marker_and_receipts().build().await)
     }
 
     fn timeline_builder(&self) -> Option<TimelineBuilder> {


### PR DESCRIPTION
This adds a list of read receipts for each event in the timeline and keeps it updated.

It also adds a map to allow to keep track of implicit read receipts (a read receipt because a member sent an event).

This is limited because we can't keep track of read receipts on events that don't create `TimelineEventItem`s. We would need to have an ordered list of all events in the timeline to have more reliable tracking.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>