### PR TITLE
refactor(bindings): Fix SlidingSyncRoom timeline listener return type

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -119,8 +119,10 @@ interface SlidingSyncView {
 };
 
 interface SlidingSyncRoom {
-    StoppableSpawn? subscribe_and_add_timeline_listener(TimelineListener listener, RoomSubscription? settings);
-    StoppableSpawn? add_timeline_listener(TimelineListener listener);
+    [Throws=ClientError]
+    StoppableSpawn subscribe_and_add_timeline_listener(TimelineListener listener, RoomSubscription? settings);
+    [Throws=ClientError]
+    StoppableSpawn add_timeline_listener(TimelineListener listener);
 };
 
 interface SlidingSync {


### PR DESCRIPTION
It's an error if the room was not found, so it should be surfaced as such.
