### PR TITLE
Some sliding sync refactoring

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/config.rs
+++ b/crates/matrix-sdk/src/sliding_sync/config.rs
@@ -1,11 +1,11 @@
 use std::{
     collections::BTreeMap,
     fmt::Debug,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock as StdRwLock},
 };
 
 use derive_builder::Builder;
-use futures_signals::{signal::Mutable, signal_map::MutableBTreeMap};
+use futures_signals::signal::Mutable;
 use ruma::{
     api::client::sync::sync_events::v4::{
         self, AccountDataConfig, E2EEConfig, ExtensionsConfig, ReceiptConfig, ToDeviceConfig,
@@ -110,9 +110,8 @@ impl SlidingSyncConfig {
         };
 
         trace!(len = rooms_found.len(), "rooms unfrozen");
-        let rooms = Arc::new(MutableBTreeMap::with_values(rooms_found));
-
-        let views = Arc::new(MutableBTreeMap::with_values(views));
+        let rooms = Arc::new(StdRwLock::new(rooms_found));
+        let views = Arc::new(StdRwLock::new(views));
 
         Ok(SlidingSync {
             homeserver,
@@ -128,7 +127,7 @@ impl SlidingSyncConfig {
 
             pos: Mutable::new(None),
             delta_token: Mutable::new(delta_token_inner),
-            subscriptions: Arc::new(MutableBTreeMap::with_values(subscriptions)),
+            subscriptions: Arc::new(StdRwLock::new(subscriptions)),
             unsubscribe: Default::default(),
         })
     }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -634,7 +634,7 @@ use std::{
 pub use client::*;
 pub use config::*;
 use futures_core::stream::Stream;
-use futures_signals::{signal::Mutable, signal_vec::MutableVec};
+use futures_signals::signal::Mutable;
 pub use room::*;
 use ruma::{
     api::client::{
@@ -643,7 +643,7 @@ use ruma::{
             self, AccountDataConfig, E2EEConfig, ExtensionsConfig, ToDeviceConfig,
         },
     },
-    assign, OwnedRoomId, RoomId, UInt,
+    assign, OwnedRoomId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -740,13 +740,6 @@ impl RoomListEntry {
     }
 }
 
-type ViewState = Mutable<SlidingSyncState>;
-type SyncMode = Mutable<SlidingSyncMode>;
-type StringState = Mutable<Option<String>>;
-type RangeState = Mutable<Vec<(UInt, UInt)>>;
-type RoomsCount = Mutable<Option<u32>>;
-type RoomsList = Arc<MutableVec<RoomListEntry>>;
-
 /// The Summary of a new SlidingSync Update received
 #[derive(Debug, Clone)]
 pub struct UpdateSummary {
@@ -768,8 +761,8 @@ pub struct SlidingSync {
     storage_key: Option<String>,
 
     // ------ Internal state
-    pub(crate) pos: StringState,
-    delta_token: StringState,
+    pub(crate) pos: Mutable<Option<String>>,
+    delta_token: Mutable<Option<String>>,
 
     /// The views of this sliding sync instance
     views: Arc<StdRwLock<BTreeMap<String, SlidingSyncView>>>,

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -623,10 +623,10 @@ mod view;
 use std::{
     collections::BTreeMap,
     fmt::Debug,
-    ops::Deref,
+    mem,
     sync::{
         atomic::{AtomicU8, Ordering},
-        Arc, Mutex,
+        Arc, Mutex, RwLock as StdRwLock,
     },
     time::Duration,
 };
@@ -634,7 +634,7 @@ use std::{
 pub use client::*;
 pub use config::*;
 use futures_core::stream::Stream;
-use futures_signals::{signal::Mutable, signal_map::MutableBTreeMap, signal_vec::MutableVec};
+use futures_signals::{signal::Mutable, signal_vec::MutableVec};
 pub use room::*;
 use ruma::{
     api::client::{
@@ -746,10 +746,6 @@ type StringState = Mutable<Option<String>>;
 type RangeState = Mutable<Vec<(UInt, UInt)>>;
 type RoomsCount = Mutable<Option<u32>>;
 type RoomsList = Arc<MutableVec<RoomListEntry>>;
-type RoomsMap = Arc<MutableBTreeMap<OwnedRoomId, SlidingSyncRoom>>;
-type RoomsSubscriptions = Arc<MutableBTreeMap<OwnedRoomId, v4::RoomSubscription>>;
-type RoomUnsubscribe = Arc<MutableVec<OwnedRoomId>>;
-type Views = Arc<MutableBTreeMap<String, SlidingSyncView>>;
 
 /// The Summary of a new SlidingSync Update received
 #[derive(Debug, Clone)]
@@ -776,13 +772,13 @@ pub struct SlidingSync {
     delta_token: StringState,
 
     /// The views of this sliding sync instance
-    views: Views,
+    views: Arc<StdRwLock<BTreeMap<String, SlidingSyncView>>>,
 
     /// The rooms details
-    rooms: RoomsMap,
+    rooms: Arc<StdRwLock<BTreeMap<OwnedRoomId, SlidingSyncRoom>>>,
 
-    subscriptions: RoomsSubscriptions,
-    unsubscribe: RoomUnsubscribe,
+    subscriptions: Arc<StdRwLock<BTreeMap<OwnedRoomId, v4::RoomSubscription>>>,
+    unsubscribe: Arc<StdRwLock<Vec<OwnedRoomId>>>,
 
     /// keeping track of retries and failure counts
     failure_count: Arc<AtomicU8>,
@@ -825,9 +821,10 @@ impl SlidingSync {
         let v = serde_json::to_vec(&FrozenSlidingSync::from(self))?;
         self.client.store().set_custom_value(storage_key.as_bytes(), v).await?;
         let frozen_views = {
-            let rooms_lock = self.rooms.lock_ref();
+            let rooms_lock = self.rooms.read().unwrap();
             self.views
-                .lock_ref()
+                .read()
+                .unwrap()
                 .iter()
                 .map(|(name, view)| {
                     (name.clone(), FrozenSlidingSyncView::freeze(view, &rooms_lock))
@@ -852,10 +849,11 @@ impl SlidingSync {
     pub fn new_builder_copy(&self) -> SlidingSyncBuilder {
         let mut builder = SlidingSyncBuilder::default()
             .client(self.client.clone())
-            .subscriptions(self.subscriptions.lock_ref().to_owned());
+            .subscriptions(self.subscriptions.read().unwrap().to_owned());
         for view in self
             .views
-            .lock_ref()
+            .read()
+            .unwrap()
             .values()
             .map(|v| v.new_builder().build().expect("builder worked before, builder works now"))
         {
@@ -875,7 +873,7 @@ impl SlidingSync {
     /// poll the stream after you've altered this. If you do that during, it
     /// might take one round trip to take effect.
     pub fn subscribe(&self, room_id: OwnedRoomId, settings: Option<v4::RoomSubscription>) {
-        self.subscriptions.lock_mut().insert_cloned(room_id, settings.unwrap_or_default());
+        self.subscriptions.write().unwrap().insert(room_id, settings.unwrap_or_default());
     }
 
     /// Unsubscribe from a given room.
@@ -884,8 +882,8 @@ impl SlidingSync {
     /// poll the stream after you've altered this. If you do that during, it
     /// might take one round trip to take effect.
     pub fn unsubscribe(&self, room_id: OwnedRoomId) {
-        if self.subscriptions.lock_mut().remove(&room_id).is_some() {
-            self.unsubscribe.lock_mut().push_cloned(room_id);
+        if self.subscriptions.write().unwrap().remove(&room_id).is_some() {
+            self.unsubscribe.write().unwrap().push(room_id);
         }
     }
 
@@ -908,12 +906,12 @@ impl SlidingSync {
 
     /// Lookup a specific room
     pub fn get_room(&self, room_id: &RoomId) -> Option<SlidingSyncRoom> {
-        self.rooms.lock_ref().get(room_id).cloned()
+        self.rooms.read().unwrap().get(room_id).cloned()
     }
 
     /// Check the number of rooms.
     pub fn get_number_of_rooms(&self) -> usize {
-        self.rooms.lock_ref().len()
+        self.rooms.read().unwrap().len()
     }
 
     fn update_to_device_since(&self, since: String) {
@@ -932,7 +930,7 @@ impl SlidingSync {
     /// listening to the stream and is therefor not necessarily up to date
     /// with the views used for the stream.
     pub fn view(&self, view_name: &str) -> Option<SlidingSyncView> {
-        self.views.lock_ref().get(view_name).cloned()
+        self.views.read().unwrap().get(view_name).cloned()
     }
 
     /// Remove the SlidingSyncView named `view_name` from the views list if
@@ -942,7 +940,7 @@ impl SlidingSync {
     /// stream created after this. The old stream will still continue to use the
     /// previous set of views
     pub fn pop_view(&self, view_name: &String) -> Option<SlidingSyncView> {
-        self.views.lock_mut().remove(view_name)
+        self.views.write().unwrap().remove(view_name)
     }
 
     /// Add the view to the list of views
@@ -955,7 +953,7 @@ impl SlidingSync {
     /// stream created after this. The old stream will still continue to use the
     /// previous set of views
     pub fn add_view(&self, view: SlidingSyncView) -> Option<SlidingSyncView> {
-        self.views.lock_mut().insert_cloned(view.name.clone(), view)
+        self.views.write().unwrap().insert(view.name.clone(), view)
     }
 
     /// Lookup a set of rooms
@@ -963,13 +961,13 @@ impl SlidingSync {
         &self,
         room_ids: I,
     ) -> Vec<Option<SlidingSyncRoom>> {
-        let rooms = self.rooms.lock_ref();
+        let rooms = self.rooms.read().unwrap();
         room_ids.map(|room_id| rooms.get(&room_id).cloned()).collect()
     }
 
     /// Get all rooms.
     pub fn get_all_rooms(&self) -> Vec<SlidingSyncRoom> {
-        self.rooms.lock_ref().iter().map(|(_, room)| room.clone()).collect()
+        self.rooms.read().unwrap().values().cloned().collect()
     }
 
     #[instrument(skip_all, fields(views = views.len()))]
@@ -985,7 +983,7 @@ impl SlidingSync {
         self.delta_token.replace(resp.delta_token);
         let update = {
             let mut rooms = Vec::new();
-            let mut rooms_map = self.rooms.lock_mut();
+            let mut rooms_map = self.rooms.write().unwrap();
             for (id, mut room_data) in resp.rooms.into_iter() {
                 let timeline = if let Some(joined_room) = processed.rooms.join.remove(&id) {
                     joined_room.timeline.events
@@ -999,17 +997,17 @@ impl SlidingSync {
                     // The room existed before, let's update it.
 
                     room.update(&room_data, timeline);
-                    rooms_map.insert_cloned(id.clone(), room);
-                    rooms.push(id.clone());
+                    rooms_map.insert(id.clone(), room);
                 } else {
                     // First time we need this room, let's create it.
 
-                    rooms_map.insert_cloned(
+                    rooms_map.insert(
                         id.clone(),
                         SlidingSyncRoom::from(self.client.clone(), id.clone(), room_data, timeline),
                     );
-                    rooms.push(id);
                 }
+
+                rooms.push(id);
             }
 
             let mut updated_views = Vec::new();
@@ -1070,14 +1068,8 @@ impl SlidingSync {
 
         let pos = self.pos.get_cloned();
         let delta_token = self.delta_token.get_cloned();
-        let room_subscriptions = self.subscriptions.lock_ref().clone();
-        let unsubscribe_rooms = {
-            let unsubs = self.unsubscribe.lock_ref().to_vec();
-            if !unsubs.is_empty() {
-                self.unsubscribe.lock_mut().clear();
-            }
-            unsubs
-        };
+        let room_subscriptions = self.subscriptions.read().unwrap().clone();
+        let unsubscribe_rooms = mem::take(&mut *self.unsubscribe.write().unwrap());
         let timeout = Duration::from_secs(30);
 
         // implement stickiness by only sending extensions if they have
@@ -1136,8 +1128,8 @@ impl SlidingSync {
     pub fn stream(&self) -> impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_ {
         let mut views = {
             let mut views = BTreeMap::new();
-            let views_lock = self.views.lock_ref();
-            for (name, view) in views_lock.deref().iter() {
+            let views_lock = self.views.read().unwrap();
+            for (name, view) in views_lock.iter() {
                 views.insert(name.clone(), view.request_generator());
             }
             views

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -425,25 +425,6 @@
 //! be a bit tedious though, so views and rooms have an additional way of
 //! subscribing to updates via [`futures_signals`][].
 //!
-//! As already touched on in
-//! description of [views](#views), their `state`, `rooms_list` and
-//! `rooms_count` are all various forms of `futures_signals::Mutable`, a
-//! low-cost, thread-safe futures based reactive API implementation.
-//! [`SlidingSync.rooms`][], too, are of a mutable implementation, namely the
-//! [`MutableBTreeMap`](`futures_signals::signal_map::MutableBTreeMap`) updated
-//! in real time (even before the summary comes around) allowing you to
-//! subscribe to their changes with a straight forward async API through the
-//! [`SignalExt`](`futures_signals::signal::SignalExt`) you can get from each by
-//! just calling `signal_cloned()` on it. For the most common use-cases you just
-//! want to have a stream of updates of the value you can poll for changes,
-//! which you then get by calling
-//! [`to_stream()`](`futures_signals::signal::SignalExt::to_stream`). You can do
-//! a lot more on the signal itself already, like
-//! [`map`](`futures_signals::signal::SignalExt::map`),
-//! [`for_each`](`futures_signals::signal::SignalExt::for_each`) or convert it
-//! into a [`Broadcaster`](futures_signals::signal::SignalExt::broadcast)
-//! depending on your needs.
-//!
 //! The `rooms_list` is of the more specialized
 //! [`MutableVec`](`futures_signals::signal_vec::MutableVec`) type. Rather than
 //! just signaling the latest state (which can be very inefficient, especially
@@ -795,10 +776,10 @@ pub struct SlidingSync {
     delta_token: StringState,
 
     /// The views of this sliding sync instance
-    pub views: Views,
+    views: Views,
 
     /// The rooms details
-    pub rooms: RoomsMap,
+    rooms: RoomsMap,
 
     subscriptions: RoomsSubscriptions,
     unsubscribe: RoomUnsubscribe,

--- a/crates/matrix-sdk/src/sliding_sync/view.rs
+++ b/crates/matrix-sdk/src/sliding_sync/view.rs
@@ -10,7 +10,6 @@ use std::{
 use derive_builder::Builder;
 use futures_signals::{
     signal::Mutable,
-    signal_map::MutableBTreeMapLockRef,
     signal_vec::{MutableVec, MutableVecLockMut},
 };
 use ruma::{
@@ -128,7 +127,7 @@ pub(super) struct FrozenSlidingSyncView {
 impl FrozenSlidingSyncView {
     pub(super) fn freeze(
         source_view: &SlidingSyncView,
-        rooms_map: &MutableBTreeMapLockRef<'_, OwnedRoomId, SlidingSyncRoom>,
+        rooms_map: &BTreeMap<OwnedRoomId, SlidingSyncRoom>,
     ) -> Self {
         let mut rooms = BTreeMap::new();
         let mut rooms_list = Vec::new();

--- a/crates/matrix-sdk/src/sliding_sync/view.rs
+++ b/crates/matrix-sdk/src/sliding_sync/view.rs
@@ -45,7 +45,7 @@ use crate::Result;
 pub struct SlidingSyncView {
     /// Which SlidingSyncMode to start this view under
     #[builder(setter(custom), default)]
-    sync_mode: Mutable<SlidingSyncMode>,
+    sync_mode: SlidingSyncMode,
 
     /// Sort the rooms list by this
     #[builder(default = "SlidingSyncViewBuilder::default_sort()")]
@@ -192,7 +192,7 @@ impl SlidingSyncViewBuilder {
 
     /// Set the Syncing mode
     pub fn sync_mode(mut self, sync_mode: SlidingSyncMode) -> Self {
-        self.sync_mode = Some(Mutable::new(sync_mode));
+        self.sync_mode = Some(sync_mode);
         self
     }
 
@@ -586,7 +586,7 @@ impl SlidingSyncView {
     pub fn new_builder(&self) -> SlidingSyncViewBuilder {
         SlidingSyncViewBuilder::default()
             .name(&self.name)
-            .sync_mode(self.sync_mode.lock_ref().clone())
+            .sync_mode(self.sync_mode.clone())
             .sort(self.sort.clone())
             .required_state(self.required_state.clone())
             .batch_size(self.batch_size)
@@ -774,7 +774,7 @@ impl SlidingSyncView {
     }
 
     pub(super) fn request_generator(&self) -> SlidingSyncViewRequestGenerator {
-        match self.sync_mode.read_only().get_cloned() {
+        match &self.sync_mode {
             SlidingSyncMode::PagingFullSync => {
                 SlidingSyncViewRequestGenerator::new_with_paging_syncup(self.clone())
             }


### PR DESCRIPTION
Try to minimize `futures-signals` usage / at least make it more obvious (the type aliases made things a bit opaque, especially now after they were partially in a different module from their usage).