### PR TITLE
Lock timeline state once for decryption retrying

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -733,6 +733,7 @@ impl<'a> TimelineEventHandler<'a> {
 
             #[cfg(feature = "e2e-encryption")]
             Flow::Remote { position: TimelineItemPosition::Update(idx), .. } => {
+                trace!("Updating timeline item at position {idx}");
                 self.items.set(*idx, item);
             }
         }


### PR DESCRIPTION
I was saying so far that I don't think that a race condition is what we're getting but it actually seems very likely – this is the one obvious way we can get mismatched indices here.