### PR TITLE
chore(crypto): Add support for encrypted m.dummy events

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -822,6 +822,9 @@ impl OlmMachine {
                     decrypted.result.raw_event = Raw::from_json(to_raw_value(&e)?);
                 }
             }
+            AnyDecryptedOlmEvent::Dummy(_) => {
+                debug!("Received a `m.dummy` event");
+            }
             AnyDecryptedOlmEvent::Custom(_) => {
                 warn!("Received an unexpected encrypted to-device event");
             }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -823,7 +823,7 @@ impl OlmMachine {
                 }
             }
             AnyDecryptedOlmEvent::Dummy(_) => {
-                debug!("Received a `m.dummy` event");
+                debug!("Received an `m.dummy` event");
             }
             AnyDecryptedOlmEvent::Custom(_) => {
                 warn!("Received an unexpected encrypted to-device event");

--- a/crates/matrix-sdk-crypto/src/types/events/dummy.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/dummy.rs
@@ -1,0 +1,66 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types for `m.dummy` to-device events.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::{EventType, ToDeviceEvent};
+
+/// The `m.dummy` to-device event.
+pub type DummyEvent = ToDeviceEvent<DummyEventContent>;
+
+/// The content of an `m.dummy` event.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DummyEventContent {
+    /// Any other, custom and non-specced fields of the content.
+    #[serde(flatten)]
+    other: BTreeMap<String, Value>,
+}
+
+impl EventType for DummyEventContent {
+    const EVENT_TYPE: &'static str = "m.dummy";
+}
+
+#[cfg(test)]
+pub(super) mod test {
+    use serde_json::{json, Value};
+
+    use super::DummyEvent;
+
+    pub fn json() -> Value {
+        json!({
+            "sender": "@alice:example.org",
+            "content": {
+                "m.custom": "something custom",
+            },
+            "type": "m.dummy",
+            "m.custom.top": "something custom in the top",
+        })
+    }
+
+    #[test]
+    fn deserialization() -> Result<(), serde_json::Error> {
+        let json = json();
+        let event: DummyEvent = serde_json::from_value(json.clone())?;
+
+        let serialized = serde_json::to_value(event)?;
+        assert_eq!(json, serialized);
+
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk-crypto/src/types/events/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/mod.rs
@@ -18,6 +18,7 @@
 //! types. Once deserialized they aim to zeroize all the secret material once
 //! the type is dropped.
 
+pub mod dummy;
 pub mod forwarded_room_key;
 pub mod olm_v1;
 pub mod room;

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -145,7 +145,7 @@ impl AnyDecryptedOlmEvent {
             AnyDecryptedOlmEvent::RoomKey(e) => e.content.event_type(),
             AnyDecryptedOlmEvent::ForwardedRoomKey(e) => e.content.event_type(),
             AnyDecryptedOlmEvent::SecretSend(e) => e.content.event_type(),
-            AnyDecryptedOlmEvent::Dummy(e) => &e.content.event_type(),
+            AnyDecryptedOlmEvent::Dummy(e) => e.content.event_type(),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -23,6 +23,7 @@ use serde_json::value::RawValue;
 use vodozemac::Ed25519PublicKey;
 
 use super::{
+    dummy::DummyEventContent,
     forwarded_room_key::ForwardedRoomKeyContent,
     room_key::RoomKeyContent,
     room_key_request::{self, SupportedKeyInfo},
@@ -30,6 +31,10 @@ use super::{
     EventType,
 };
 use crate::types::{deserialize_ed25519_key, events::from_str, serialize_ed25519_key};
+
+/// An `m.dummy` event that was decrypted using the
+/// `m.olm.v1.curve25519-aes-sha2` algorithm
+pub type DecryptedDummyEvent = DecryptedOlmV1Event<DummyEventContent>;
 
 /// An `m.room_key` event that was decrypted using the
 /// `m.olm.v1.curve25519-aes-sha2` algorithm
@@ -82,6 +87,8 @@ pub enum AnyDecryptedOlmEvent {
     ForwardedRoomKey(DecryptedForwardedRoomKeyEvent),
     /// The `m.secret.send` decrypted to-device event.
     SecretSend(DecryptedSecretSendEvent),
+    /// The `m.dummy` decrypted to-device event.
+    Dummy(DecryptedDummyEvent),
     /// A decrypted to-device event of an unknown or custom type.
     Custom(Box<ToDeviceCustomEvent>),
 }
@@ -94,6 +101,7 @@ impl AnyDecryptedOlmEvent {
             AnyDecryptedOlmEvent::ForwardedRoomKey(e) => &e.sender,
             AnyDecryptedOlmEvent::SecretSend(e) => &e.sender,
             AnyDecryptedOlmEvent::Custom(e) => &e.sender,
+            AnyDecryptedOlmEvent::Dummy(e) => &e.sender,
         }
     }
 
@@ -104,6 +112,7 @@ impl AnyDecryptedOlmEvent {
             AnyDecryptedOlmEvent::ForwardedRoomKey(e) => &e.recipient,
             AnyDecryptedOlmEvent::SecretSend(e) => &e.recipient,
             AnyDecryptedOlmEvent::Custom(e) => &e.recipient,
+            AnyDecryptedOlmEvent::Dummy(e) => &e.recipient,
         }
     }
 
@@ -114,6 +123,7 @@ impl AnyDecryptedOlmEvent {
             AnyDecryptedOlmEvent::ForwardedRoomKey(e) => &e.keys,
             AnyDecryptedOlmEvent::SecretSend(e) => &e.keys,
             AnyDecryptedOlmEvent::Custom(e) => &e.keys,
+            AnyDecryptedOlmEvent::Dummy(e) => &e.keys,
         }
     }
 
@@ -124,6 +134,7 @@ impl AnyDecryptedOlmEvent {
             AnyDecryptedOlmEvent::ForwardedRoomKey(e) => &e.recipient_keys,
             AnyDecryptedOlmEvent::SecretSend(e) => &e.recipient_keys,
             AnyDecryptedOlmEvent::Custom(e) => &e.recipient_keys,
+            AnyDecryptedOlmEvent::Dummy(e) => &e.recipient_keys,
         }
     }
 
@@ -134,6 +145,7 @@ impl AnyDecryptedOlmEvent {
             AnyDecryptedOlmEvent::RoomKey(e) => e.content.event_type(),
             AnyDecryptedOlmEvent::ForwardedRoomKey(e) => e.content.event_type(),
             AnyDecryptedOlmEvent::SecretSend(e) => e.content.event_type(),
+            AnyDecryptedOlmEvent::Dummy(e) => &e.content.event_type(),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/events/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/to_device.rs
@@ -16,7 +16,6 @@ use std::{collections::BTreeMap, fmt::Debug};
 
 use ruma::{
     events::{
-        dummy::ToDeviceDummyEvent,
         key::verification::{
             accept::ToDeviceKeyVerificationAcceptEvent, cancel::ToDeviceKeyVerificationCancelEvent,
             done::ToDeviceKeyVerificationDoneEvent, key::ToDeviceKeyVerificationKeyEvent,
@@ -37,6 +36,7 @@ use serde_json::{
 use zeroize::Zeroize;
 
 use super::{
+    dummy::DummyEvent,
     forwarded_room_key::{ForwardedRoomKeyContent, ForwardedRoomKeyEvent},
     room::encrypted::EncryptedToDeviceEvent,
     room_key::RoomKeyEvent,
@@ -52,7 +52,7 @@ pub enum ToDeviceEvents {
     /// A to-device event of an unknown or custom type.
     Custom(ToDeviceCustomEvent),
     /// The `m.dummy` to-device event.
-    Dummy(ToDeviceDummyEvent),
+    Dummy(DummyEvent),
 
     /// The `m.key.verification.accept` to-device event.
     KeyVerificationAccept(ToDeviceKeyVerificationAcceptEvent),
@@ -115,7 +115,7 @@ impl ToDeviceEvents {
     pub fn event_type(&self) -> ToDeviceEventType {
         match self {
             ToDeviceEvents::Custom(e) => ToDeviceEventType::from(e.event_type.to_owned()),
-            ToDeviceEvents::Dummy(e) => e.content.event_type(),
+            ToDeviceEvents::Dummy(_) => ToDeviceEventType::Dummy,
 
             ToDeviceEvents::KeyVerificationAccept(e) => e.content.event_type(),
             ToDeviceEvents::KeyVerificationCancel(e) => e.content.event_type(),


### PR DESCRIPTION
This mostly just silences an incorrect log warning that we received an unsupported event.

This supersedes https://github.com/matrix-org/matrix-rust-sdk/pull/1330.

This closes https://github.com/matrix-org/matrix-rust-sdk/issues/1230.