### PR TITLE
feat(sdk): Add methods to only send receipts newer than the current ones in the timeline

### DIFF
--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -1072,9 +1072,9 @@ impl Joined {
 /// Receipts to send all at once.
 #[derive(Debug, Clone, Default)]
 pub struct Receipts {
-    fully_read: Option<OwnedEventId>,
-    read_receipt: Option<OwnedEventId>,
-    private_read_receipt: Option<OwnedEventId>,
+    pub(super) fully_read: Option<OwnedEventId>,
+    pub(super) read_receipt: Option<OwnedEventId>,
+    pub(super) private_read_receipt: Option<OwnedEventId>,
 }
 
 impl Receipts {

--- a/crates/matrix-sdk/src/room/timeline/builder.rs
+++ b/crates/matrix-sdk/src/room/timeline/builder.rs
@@ -20,10 +20,7 @@ use matrix_sdk_base::{
     locks::Mutex,
 };
 use ruma::{
-    events::{
-        fully_read::FullyReadEventContent,
-        receipt::{ReceiptThread, ReceiptType, SyncReceiptEvent},
-    },
+    events::receipt::{ReceiptThread, ReceiptType, SyncReceiptEvent},
     push::Action,
 };
 use tracing::error;
@@ -155,20 +152,7 @@ impl TimelineBuilder {
         ];
 
         if track_read_marker_and_receipts {
-            match room.account_data_static::<FullyReadEventContent>().await {
-                Ok(Some(fully_read)) => match fully_read.deserialize() {
-                    Ok(fully_read) => {
-                        inner.set_fully_read_event(fully_read.content.event_id).await;
-                    }
-                    Err(e) => {
-                        error!("Failed to deserialize fully-read account data: {e}");
-                    }
-                },
-                Err(e) => {
-                    error!("Failed to get fully-read account data from the store: {e}");
-                }
-                _ => {}
-            }
+            inner.load_fully_read_event().await;
 
             let fully_read_handle = room.add_event_handler({
                 let inner = inner.clone();

--- a/crates/matrix-sdk/tests/integration/room/timeline/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline/mod.rs
@@ -16,8 +16,8 @@ use matrix_sdk::{
 };
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{
-    async_test, test_json, EphemeralTestEvent, EventBuilder, JoinedRoomBuilder,
-    RoomAccountDataTestEvent, TimelineTestEvent,
+    async_test, test_json, EventBuilder, JoinedRoomBuilder, RoomAccountDataTestEvent,
+    TimelineTestEvent,
 };
 use ruma::{
     event_id,
@@ -32,6 +32,8 @@ use wiremock::{
     matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
 };
+
+mod read_receipts;
 
 use crate::{logged_in_client, mock_encryption_state, mock_sync};
 
@@ -730,158 +732,6 @@ async fn in_reply_to_details() {
     let third = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 3, value }) => value);
     let message = assert_matches!(third.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);
     assert_matches!(message.in_reply_to().unwrap().details, TimelineDetails::Ready(_));
-}
-
-#[async_test]
-async fn read_receipts_updates() {
-    let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    let alice = user_id!("@alice:localhost");
-    let bob = user_id!("@bob:localhost");
-
-    let second_event_id = event_id!("$e32037280er453l:localhost");
-    let third_event_id = event_id!("$Sg2037280074GZr34:localhost");
-
-    let mut ev_builder = EventBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
-    let (items, mut timeline_stream) = timeline.subscribe().await;
-
-    assert!(items.is_empty());
-
-    ev_builder.add_joined_room(
-        JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(TimelineTestEvent::MessageText)
-            .add_timeline_event(TimelineTestEvent::Custom(json!({
-                "content": {
-                    "body": "I'm dancing too",
-                    "msgtype": "m.text"
-                },
-                "event_id": second_event_id,
-                "origin_server_ts": 152039280,
-                "sender": alice,
-                "type": "m.room.message",
-            })))
-            .add_timeline_event(TimelineTestEvent::Custom(json!({
-                "content": {
-                    "body": "Viva la macarena!",
-                    "msgtype": "m.text"
-                },
-                "event_id": third_event_id,
-                "origin_server_ts": 152045280,
-                "sender": alice,
-                "type": "m.room.message",
-            }))),
-    );
-
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    let _day_divider = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-
-    // We don't list the read receipt of our own user on events.
-    let first_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let first_event = first_item.as_event().unwrap().as_remote().unwrap();
-    assert!(first_event.read_receipts().is_empty());
-
-    // Implicit read receipt of @alice:localhost.
-    let second_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let second_event = second_item.as_event().unwrap().as_remote().unwrap();
-    assert_eq!(second_event.read_receipts().len(), 1);
-
-    // Read receipt of @alice:localhost is moved to third event.
-    let second_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 2, value }) => value);
-    let second_event = second_item.as_event().unwrap().as_remote().unwrap();
-    assert!(second_event.read_receipts().is_empty());
-
-    let third_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let third_event = third_item.as_event().unwrap().as_remote().unwrap();
-    assert_eq!(third_event.read_receipts().len(), 1);
-
-    // Read receipt on unknown event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
-        EphemeralTestEvent::Custom(json!({
-            "content": {
-                "$unknowneventid": {
-                    "m.read": {
-                        alice: {
-                            "ts": 1436453550,
-                        },
-                    },
-                },
-            },
-            "type": "m.receipt",
-        })),
-    ));
-
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    // Read receipt on older event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
-        EphemeralTestEvent::Custom(json!({
-            "content": {
-                second_event_id: {
-                    "m.read": {
-                        alice: {
-                            "ts": 1436451550,
-                        },
-                    },
-                },
-            },
-            "type": "m.receipt",
-        })),
-    ));
-
-    // Read receipt on same event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
-        EphemeralTestEvent::Custom(json!({
-            "content": {
-                third_event_id: {
-                    "m.read": {
-                        alice: {
-                            "ts": 1436451550,
-                        },
-                    },
-                },
-            },
-            "type": "m.receipt",
-        })),
-    ));
-
-    // New user with explicit read receipt.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
-        EphemeralTestEvent::Custom(json!({
-            "content": {
-                third_event_id: {
-                    "m.read": {
-                        bob: {
-                            "ts": 1436451550,
-                        },
-                    },
-                },
-            },
-            "type": "m.receipt",
-        })),
-    ));
-
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    let third_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 3, value }) => value);
-    let third_event = third_item.as_event().unwrap().as_remote().unwrap();
-    assert_eq!(third_event.read_receipts().len(), 2);
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/room/timeline/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline/read_receipts.rs
@@ -1,0 +1,778 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use eyeball_im::VectorDiff;
+use futures_util::StreamExt;
+use matrix_sdk::{config::SyncSettings, room::Receipts};
+use matrix_sdk_test::{
+    async_test, EphemeralTestEvent, EventBuilder, JoinedRoomBuilder, RoomAccountDataTestEvent,
+    TimelineTestEvent,
+};
+use ruma::{
+    api::client::receipt::create_receipt::v3::ReceiptType, event_id,
+    events::receipt::ReceiptThread, room_id, user_id,
+};
+use serde_json::json;
+use wiremock::{
+    matchers::{body_json, header, method, path_regex},
+    Mock, ResponseTemplate,
+};
+
+use crate::{logged_in_client, mock_sync};
+
+#[async_test]
+async fn read_receipts_updates() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let own_user_id = client.user_id().unwrap();
+    let alice = user_id!("@alice:localhost");
+    let bob = user_id!("@bob:localhost");
+
+    let second_event_id = event_id!("$e32037280er453l:localhost");
+    let third_event_id = event_id!("$Sg2037280074GZr34:localhost");
+
+    let mut ev_builder = EventBuilder::new();
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert!(items.is_empty());
+
+    let own_receipt = timeline.latest_user_read_receipt(own_user_id).await;
+    assert_matches!(own_receipt, None);
+    let alice_receipt = timeline.latest_user_read_receipt(alice).await;
+    assert_matches!(alice_receipt, None);
+    let bob_receipt = timeline.latest_user_read_receipt(bob).await;
+    assert_matches!(bob_receipt, None);
+
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_timeline_event(TimelineTestEvent::MessageText)
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "I'm dancing too",
+                    "msgtype": "m.text"
+                },
+                "event_id": second_event_id,
+                "origin_server_ts": 152039280,
+                "sender": alice,
+                "type": "m.room.message",
+            })))
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "Viva la macarena!",
+                    "msgtype": "m.text"
+                },
+                "event_id": third_event_id,
+                "origin_server_ts": 152045280,
+                "sender": alice,
+                "type": "m.room.message",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let _day_divider = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+
+    // We don't list the read receipt of our own user on events.
+    let first_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let first_event = first_item.as_event().unwrap().as_remote().unwrap();
+    assert!(first_event.read_receipts().is_empty());
+
+    let (own_receipt_event_id, _) = timeline.latest_user_read_receipt(own_user_id).await.unwrap();
+    assert_eq!(own_receipt_event_id, first_event.event_id());
+
+    // Implicit read receipt of @alice:localhost.
+    let second_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let second_event = second_item.as_event().unwrap().as_remote().unwrap();
+    assert_eq!(second_event.read_receipts().len(), 1);
+
+    // Read receipt of @alice:localhost is moved to third event.
+    let second_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 2, value }) => value);
+    let second_event = second_item.as_event().unwrap().as_remote().unwrap();
+    assert!(second_event.read_receipts().is_empty());
+
+    let third_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let third_event = third_item.as_event().unwrap().as_remote().unwrap();
+    assert_eq!(third_event.read_receipts().len(), 1);
+
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
+    assert_eq!(alice_receipt_event_id, third_event_id);
+
+    // Read receipt on unknown event is ignored.
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+        EphemeralTestEvent::Custom(json!({
+            "content": {
+                "$unknowneventid": {
+                    "m.read": {
+                        alice: {
+                            "ts": 1436453550,
+                        },
+                    },
+                },
+            },
+            "type": "m.receipt",
+        })),
+    ));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
+    assert_eq!(alice_receipt_event_id, third_event.event_id());
+
+    // Read receipt on older event is ignored.
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+        EphemeralTestEvent::Custom(json!({
+            "content": {
+                second_event_id: {
+                    "m.read": {
+                        alice: {
+                            "ts": 1436451550,
+                        },
+                    },
+                },
+            },
+            "type": "m.receipt",
+        })),
+    ));
+
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
+    assert_eq!(alice_receipt_event_id, third_event_id);
+
+    // Read receipt on same event is ignored.
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+        EphemeralTestEvent::Custom(json!({
+            "content": {
+                third_event_id: {
+                    "m.read": {
+                        alice: {
+                            "ts": 1436451550,
+                        },
+                    },
+                },
+            },
+            "type": "m.receipt",
+        })),
+    ));
+
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
+    assert_eq!(alice_receipt_event_id, third_event_id);
+
+    // New user with explicit read receipt.
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+        EphemeralTestEvent::Custom(json!({
+            "content": {
+                third_event_id: {
+                    "m.read": {
+                        bob: {
+                            "ts": 1436451550,
+                        },
+                    },
+                },
+            },
+            "type": "m.receipt",
+        })),
+    ));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let third_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 3, value }) => value);
+    let third_event = third_item.as_event().unwrap().as_remote().unwrap();
+    assert_eq!(third_event.read_receipts().len(), 2);
+
+    let (bob_receipt_event_id, _) = timeline.latest_user_read_receipt(bob).await.unwrap();
+    assert_eq!(bob_receipt_event_id, third_event_id);
+
+    // Private read receipt is updated.
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+        EphemeralTestEvent::Custom(json!({
+            "content": {
+                second_event_id: {
+                    "m.read.private": {
+                        own_user_id: {
+                            "ts": 1436453550,
+                        },
+                    },
+                },
+            },
+            "type": "m.receipt",
+        })),
+    ));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let (own_user_receipt_event_id, _) =
+        timeline.latest_user_read_receipt(own_user_id).await.unwrap();
+    assert_eq!(own_user_receipt_event_id, second_event_id);
+}
+
+#[async_test]
+async fn send_single_receipt() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let own_user_id = client.user_id().unwrap();
+
+    let mut ev_builder = EventBuilder::new();
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline().await;
+
+    // Unknown receipts are sent.
+    let first_receipts_event_id = event_id!("$first_receipts_event_id");
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.read/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Public read receipt")
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.read\.private/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Private read receipt")
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.fully_read/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Fully-read marker")
+        .mount(&server)
+        .await;
+
+    timeline
+        .send_single_receipt(
+            ReceiptType::Read,
+            ReceiptThread::Unthreaded,
+            first_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::ReadPrivate,
+            ReceiptThread::Unthreaded,
+            first_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::FullyRead,
+            ReceiptThread::Unthreaded,
+            first_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    server.reset().await;
+
+    // Unchanged receipts are not sent.
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
+                "content": {
+                    first_receipts_event_id: {
+                        "m.read.private": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                        "m.read": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                    },
+                },
+                "type": "m.receipt",
+            })))
+            .add_account_data(RoomAccountDataTestEvent::Custom(json!({
+                "content": {
+                    "event_id": first_receipts_event_id,
+                },
+                "type": "m.fully_read",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    timeline
+        .send_single_receipt(
+            ReceiptType::Read,
+            ReceiptThread::Unthreaded,
+            first_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::ReadPrivate,
+            ReceiptThread::Unthreaded,
+            first_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::FullyRead,
+            ReceiptThread::Unthreaded,
+            first_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    server.reset().await;
+
+    // Receipts with unknown previous receipts are always sent.
+    let second_receipts_event_id = event_id!("$second_receipts_event_id");
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.read/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Public read receipt")
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.read\.private/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Private read receipt")
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.fully_read/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Fully-read marker")
+        .mount(&server)
+        .await;
+
+    timeline
+        .send_single_receipt(
+            ReceiptType::Read,
+            ReceiptThread::Unthreaded,
+            second_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::ReadPrivate,
+            ReceiptThread::Unthreaded,
+            second_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::FullyRead,
+            ReceiptThread::Unthreaded,
+            second_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    server.reset().await;
+
+    // Newer receipts in the timeline are sent.
+    let third_receipts_event_id = event_id!("$third_receipts_event_id");
+
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "I'm User A",
+                    "msgtype": "m.text",
+                },
+                "event_id": second_receipts_event_id,
+                "origin_server_ts": 152046694,
+                "sender": "@user_a:example.org",
+                "type": "m.room.message",
+            })))
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "I'm User B",
+                    "msgtype": "m.text",
+                },
+                "event_id": third_receipts_event_id,
+                "origin_server_ts": 152049794,
+                "sender": "@user_b:example.org",
+                "type": "m.room.message",
+            })))
+            .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
+                "content": {
+                    second_receipts_event_id: {
+                        "m.read.private": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                        "m.read": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                    },
+                },
+                "type": "m.receipt",
+            })))
+            .add_account_data(RoomAccountDataTestEvent::Custom(json!({
+                "content": {
+                    "event_id": second_receipts_event_id,
+                },
+                "type": "m.fully_read",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.read/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Public read receipt")
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.read\.private/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Private read receipt")
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt/m\.fully_read/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Fully-read marker")
+        .mount(&server)
+        .await;
+
+    timeline
+        .send_single_receipt(
+            ReceiptType::Read,
+            ReceiptThread::Unthreaded,
+            third_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::ReadPrivate,
+            ReceiptThread::Unthreaded,
+            third_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::FullyRead,
+            ReceiptThread::Unthreaded,
+            third_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    server.reset().await;
+
+    // Older receipts in the timeline are not sent.
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
+                "content": {
+                    third_receipts_event_id: {
+                        "m.read.private": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                        "m.read": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                    },
+                },
+                "type": "m.receipt",
+            })))
+            .add_account_data(RoomAccountDataTestEvent::Custom(json!({
+                "content": {
+                    "event_id": third_receipts_event_id,
+                },
+                "type": "m.fully_read",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    timeline
+        .send_single_receipt(
+            ReceiptType::Read,
+            ReceiptThread::Unthreaded,
+            second_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::ReadPrivate,
+            ReceiptThread::Unthreaded,
+            second_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+    timeline
+        .send_single_receipt(
+            ReceiptType::FullyRead,
+            ReceiptThread::Unthreaded,
+            second_receipts_event_id.to_owned(),
+        )
+        .await
+        .unwrap();
+}
+
+#[async_test]
+async fn send_multiple_receipts() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let own_user_id = client.user_id().unwrap();
+
+    let mut ev_builder = EventBuilder::new();
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline().await;
+
+    // Unknown receipts are sent.
+    let first_receipts_event_id = event_id!("$first_receipts_event_id");
+    let first_receipts = Receipts::new()
+        .fully_read_marker(Some(first_receipts_event_id.to_owned()))
+        .public_read_receipt(Some(first_receipts_event_id.to_owned()))
+        .private_read_receipt(Some(first_receipts_event_id.to_owned()));
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/read_markers$"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_json(json!({
+            "m.fully_read": first_receipts_event_id,
+            "m.read": first_receipts_event_id,
+            "m.read.private": first_receipts_event_id,
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    timeline.send_multiple_receipts(first_receipts.clone()).await.unwrap();
+    server.reset().await;
+
+    // Unchanged receipts are not sent.
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
+                "content": {
+                    first_receipts_event_id: {
+                        "m.read.private": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                        "m.read": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                    },
+                },
+                "type": "m.receipt",
+            })))
+            .add_account_data(RoomAccountDataTestEvent::Custom(json!({
+                "content": {
+                    "event_id": first_receipts_event_id,
+                },
+                "type": "m.fully_read",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    timeline.send_multiple_receipts(first_receipts).await.unwrap();
+    server.reset().await;
+
+    // Receipts with unknown previous receipts are always sent.
+    let second_receipts_event_id = event_id!("$second_receipts_event_id");
+    let second_receipts = Receipts::new()
+        .fully_read_marker(Some(second_receipts_event_id.to_owned()))
+        .public_read_receipt(Some(second_receipts_event_id.to_owned()))
+        .private_read_receipt(Some(second_receipts_event_id.to_owned()));
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/read_markers$"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_json(json!({
+            "m.fully_read": second_receipts_event_id,
+            "m.read": second_receipts_event_id,
+            "m.read.private": second_receipts_event_id,
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    timeline.send_multiple_receipts(second_receipts.clone()).await.unwrap();
+    server.reset().await;
+
+    // Newer receipts in the timeline are sent.
+    let third_receipts_event_id = event_id!("$third_receipts_event_id");
+    let third_receipts = Receipts::new()
+        .fully_read_marker(Some(third_receipts_event_id.to_owned()))
+        .public_read_receipt(Some(third_receipts_event_id.to_owned()))
+        .private_read_receipt(Some(third_receipts_event_id.to_owned()));
+
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "I'm User A",
+                    "msgtype": "m.text",
+                },
+                "event_id": second_receipts_event_id,
+                "origin_server_ts": 152046694,
+                "sender": "@user_a:example.org",
+                "type": "m.room.message",
+            })))
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "I'm User B",
+                    "msgtype": "m.text",
+                },
+                "event_id": third_receipts_event_id,
+                "origin_server_ts": 152049794,
+                "sender": "@user_b:example.org",
+                "type": "m.room.message",
+            })))
+            .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
+                "content": {
+                    second_receipts_event_id: {
+                        "m.read.private": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                        "m.read": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                    },
+                },
+                "type": "m.receipt",
+            })))
+            .add_account_data(RoomAccountDataTestEvent::Custom(json!({
+                "content": {
+                    "event_id": second_receipts_event_id,
+                },
+                "type": "m.fully_read",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    Mock::given(method("POST"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/read_markers$"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_json(json!({
+            "m.fully_read": third_receipts_event_id,
+            "m.read": third_receipts_event_id,
+            "m.read.private": third_receipts_event_id,
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    timeline.send_multiple_receipts(third_receipts.clone()).await.unwrap();
+    server.reset().await;
+
+    // Older receipts in the timeline are not sent.
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
+                "content": {
+                    third_receipts_event_id: {
+                        "m.read.private": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                        "m.read": {
+                            own_user_id: {
+                                "ts": 1436453550,
+                            },
+                        },
+                    },
+                },
+                "type": "m.receipt",
+            })))
+            .add_account_data(RoomAccountDataTestEvent::Custom(json!({
+                "content": {
+                    "event_id": third_receipts_event_id,
+                },
+                "type": "m.fully_read",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    timeline.send_multiple_receipts(second_receipts.clone()).await.unwrap();
+}


### PR DESCRIPTION
This is to avoid unnecessary requests for clients. They can just call this method every time without having to check where they are in the timeline compared to the read receipts.

If we don't know where the receipts are in the timeline, we just make the request and let the server handle it.

Based on #1530.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
