### PR TITLE
feat(crypto): exposing the version of vodozemac

### DIFF
--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -103,6 +103,6 @@ pub mod vodozemac {
         olm::{
             DecryptionError as OlmDecryptionError, SessionCreationError as OlmSessionCreationError,
         },
-        DecodeError, KeyError, PickleError, SignatureError,
+        DecodeError, KeyError, PickleError, SignatureError, VERSION,
     };
 }


### PR DESCRIPTION
Resolves #1227 by exposing the `VERSION` from the vodozemac crate.

Signed-off-by: Archit Bhonsle <abhonsle2000@gmail.com>
