### PR TITLE
feat(crypto): exposing the version of sdk-crypto

### DIFF
--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -107,5 +107,5 @@ pub mod vodozemac {
     };
 }
 
-/// The version of matrix-sdk-cypto being used
+/// The version of the matrix-sdk-cypto crate being used
 pub static VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -106,3 +106,6 @@ pub mod vodozemac {
         DecodeError, KeyError, PickleError, SignatureError,
     };
 }
+
+/// The version of matrix-sdk-cypto being used
+pub static VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -33,7 +33,7 @@ pub use matrix_sdk_base::crypto::{
     },
     vodozemac, CryptoStoreError, DecryptorError, EventError, KeyExportError, LocalTrust,
     MediaEncryptionInfo, MegolmError, OlmError, RoomKeyImportResult, SecretImportError,
-    SessionCreationError, SignatureError,
+    SessionCreationError, SignatureError, VERSION,
 };
 use matrix_sdk_base::crypto::{
     CrossSigningStatus, OutgoingRequest, RoomMessageRequest, ToDeviceRequest,


### PR DESCRIPTION
Resolves #1227
Exporting the version of `matrix-sdk-crypto` and `matrix-sdk/encryption`.

Signed-off-by: Archit Bhonsle <abhonsle2000@gmail.com>
