### PR TITLE
fix(tests): look for the right list when waiting for updates

### DIFF
--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -1203,7 +1203,7 @@ mod tests {
             let room_summary = stream.next().await.context("sync has closed unexpectedly")??;
 
             // we only heard about the ones we had asked for
-            if room_summary.views.iter().any(|s| s == "sliding") {
+            if room_summary.views.iter().any(|s| s == "sliding_view") {
                 break;
             }
         }


### PR DESCRIPTION
Otherwise it will time out after 30s and then continue executing, causing a slow test.
