### PR TITLE
Add custom login method

### DIFF
--- a/crates/matrix-sdk/src/client/login_builder.rs
+++ b/crates/matrix-sdk/src/client/login_builder.rs
@@ -22,6 +22,7 @@ use std::{
 use ruma::{
     api::client::{session::login, uiaa::UserIdentifier},
     assign,
+    serde::JsonObject,
 };
 use tracing::{info, instrument};
 
@@ -35,16 +36,20 @@ use crate::{config::RequestConfig, Result};
 /// [the spec]: https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3login
 enum LoginMethod {
     /// Login type `m.login.password`
-    UserPassword { id: UserIdentifier, password: String },
+    UserPassword {
+        id: UserIdentifier,
+        password: String,
+    },
     /// Login type `m.token`
     Token(String),
+    Custom(login::v3::LoginInfo),
 }
 
 impl LoginMethod {
     fn id(&self) -> Option<&UserIdentifier> {
         match self {
             LoginMethod::UserPassword { id, .. } => Some(id),
-            LoginMethod::Token(_) => None,
+            LoginMethod::Token(_) | LoginMethod::Custom(_) => None,
         }
     }
 
@@ -52,6 +57,7 @@ impl LoginMethod {
         match self {
             LoginMethod::UserPassword { .. } => "identifier and password",
             LoginMethod::Token(_) => "token",
+            LoginMethod::Custom(_) => "custom",
         }
     }
 
@@ -61,6 +67,7 @@ impl LoginMethod {
                 login::v3::LoginInfo::Password(login::v3::Password::new(id, password))
             }
             LoginMethod::Token(token) => login::v3::LoginInfo::Token(login::v3::Token::new(token)),
+            LoginMethod::Custom(login_info) => login_info,
         }
     }
 }
@@ -96,6 +103,15 @@ impl LoginBuilder {
 
     pub(super) fn new_token(client: Client, token: String) -> Self {
         Self::new(client, LoginMethod::Token(token))
+    }
+
+    pub(super) fn new_custom(
+        client: Client,
+        login_type: &str,
+        data: JsonObject,
+    ) -> serde_json::Result<Self> {
+        let login_info = login::v3::LoginInfo::new(login_type, data)?;
+        Ok(Self::new(client, LoginMethod::Custom(login_info)))
     }
 
     /// Set the device ID.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1023,9 +1023,11 @@ impl Client {
     ///
     /// # Arguments
     ///
-    /// * `login_type` - Identifier of the custom login type, e.g. `org.matrix.login.jwt`
+    /// * `login_type` - Identifier of the custom login type, e.g.
+    ///   `org.matrix.login.jwt`
     ///
-    /// * `data` - The additional data which should be attached to the login request.
+    /// * `data` - The additional data which should be attached to the login
+    ///   request.
     ///
     /// ```no_run
     /// # use futures::executor::block_on;
@@ -1040,7 +1042,9 @@ impl Client {
     /// let response = client
     ///     .login_custom(
     ///         "org.matrix.login.jwt",
-    ///         [("token".to_owned(), "jwt_token_content".into())].into_iter().collect(),
+    ///         [("token".to_owned(), "jwt_token_content".into())]
+    ///             .into_iter()
+    ///             .collect(),
     ///     )?
     ///     .initial_device_display_name("My bot")
     ///     .await?;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1041,7 +1041,7 @@ impl Client {
     /// let response = client
     ///     .login_custom(
     ///         "org.matrix.login.jwt",
-    ///         [("token".to_string(), json!("jwt_token_content"))].into_iter().collect(),
+    ///         [("token".to_owned(), "jwt_token_content".into())].into_iter().collect(),
     ///     )?
     ///     .initial_device_display_name("My bot")
     ///     .await?;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1030,7 +1030,6 @@ impl Client {
     /// ```no_run
     /// # use futures::executor::block_on;
     /// # use url::Url;
-    /// # use serde_json::json;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
     /// # block_on(async {
     /// use matrix_sdk::Client;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -61,8 +61,10 @@ use ruma::{
         error::FromHttpResponseError,
         MatrixVersion, OutgoingRequest, SendAccessToken,
     },
-    assign, DeviceId, OwnedDeviceId, OwnedRoomId, OwnedServerName, RoomAliasId, RoomId,
-    RoomOrAliasId, ServerName, UInt, UserId,
+    assign,
+    serde::JsonObject,
+    DeviceId, OwnedDeviceId, OwnedRoomId, OwnedServerName, RoomAliasId, RoomId, RoomOrAliasId,
+    ServerName, UInt, UserId,
 };
 use serde::de::DeserializeOwned;
 #[cfg(not(target_arch = "wasm32"))]
@@ -1015,6 +1017,47 @@ impl Client {
     /// its localpart.
     pub fn login_identifier(&self, id: UserIdentifier, password: &str) -> LoginBuilder {
         LoginBuilder::new_password(self.clone(), id, password.to_owned())
+    }
+
+    /// Login to the server with a custom login type
+    ///
+    /// # Arguments
+    ///
+    /// * `login_type` - Identifier of the custom login type, e.g. `org.matrix.login.jwt`
+    ///
+    /// * `data` - The additional data which should be attached to the login request.
+    ///
+    /// ```no_run
+    /// # use futures::executor::block_on;
+    /// # use url::Url;
+    /// # use serde_json::json;
+    /// # let homeserver = Url::parse("http://example.com").unwrap();
+    /// # block_on(async {
+    /// use matrix_sdk::Client;
+    ///
+    /// let client = Client::new(homeserver).await?;
+    /// let user = "example";
+    ///
+    /// let response = client
+    ///     .login_custom(
+    ///         "org.matrix.login.jwt",
+    ///         [("token".to_string(), json!("jwt_token_content"))].into_iter().collect(),
+    ///     )?
+    ///     .initial_device_display_name("My bot")
+    ///     .await?;
+    ///
+    /// println!(
+    ///     "Logged in as {user}, got device_id {} and access_token {}",
+    ///     response.device_id, response.access_token,
+    /// );
+    /// # anyhow::Ok(()) });
+    /// ```
+    pub fn login_custom(
+        &self,
+        login_type: &str,
+        data: JsonObject,
+    ) -> serde_json::Result<LoginBuilder> {
+        LoginBuilder::new_custom(self.clone(), login_type, data)
     }
 
     /// Login to the server with a token.


### PR DESCRIPTION
The `Client::login_custom` allows to login by using a custom login method. In particular, it is possible to login to Synapse which supports JWT authentication.

Signed-off-by: boxdot <d@zerovolt.org>