### PR TITLE
feat(sdk): Make SlidingSync.pos already private

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -690,11 +690,13 @@ pub enum SlidingSyncState {
 /// The mode by which the the [`SlidingSyncView`] is in fetching the data.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SlidingSyncMode {
-    /// fully sync all rooms in the background, page by page of `batch_size`
+    /// Fully sync all rooms in the background, page by page of `batch_size`,
+    /// like `0..20`, `21..40`, 41..60` etc. assuming the `batch_size` is 20.
     #[serde(alias = "FullSync")]
     PagingFullSync,
-    /// fully sync all rooms in the background, with a growing window of
-    /// `batch_size`,
+    /// Fully sync all rooms in the background, with a growing window of
+    /// `batch_size`, like `0..20`, `0..40`, `0..60` etc. assuming the
+    /// `batch_size` is 20.
     GrowingFullSync,
     /// Only sync the specific windows defined
     #[default]

--- a/crates/matrix-sdk/src/test_utils.rs
+++ b/crates/matrix-sdk/src/test_utils.rs
@@ -4,8 +4,6 @@
 use matrix_sdk_base::Session;
 use ruma::{api::MatrixVersion, device_id, user_id};
 
-#[cfg(feature = "experimental-sliding-sync")]
-use crate::sliding_sync::SlidingSync;
 use crate::{config::RequestConfig, Client, ClientBuilder};
 
 pub(crate) fn test_client_builder(homeserver_url: Option<String>) -> ClientBuilder {
@@ -32,10 +30,4 @@ pub(crate) async fn logged_in_client(homeserver_url: Option<String>) -> Client {
     client.restore_session(session).await.unwrap();
 
     client
-}
-
-/// Force a specific pos-value to be used for the given sliding-sync instance.
-#[cfg(feature = "experimental-sliding-sync")]
-pub fn force_sliding_sync_pos(sliding_sync: &SlidingSync, new_pos: String) {
-    sliding_sync.pos.set(Some(new_pos));
 }

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -81,7 +81,6 @@ mod tests {
             api::client::error::ErrorKind as RumaError,
             events::room::message::RoomMessageEventContent, UInt,
         },
-        test_utils::force_sliding_sync_pos,
         SlidingSyncMode, SlidingSyncState, SlidingSyncView,
     };
 
@@ -1042,7 +1041,7 @@ mod tests {
         );
 
         // force the pos to be invalid and thus this being reset internally
-        force_sliding_sync_pos(&sync_proxy, "100".to_owned());
+        sync_proxy.set_pos("100".to_string());
         let mut error_seen = false;
 
         for _n in 0..2 {
@@ -1249,7 +1248,7 @@ mod tests {
         assert!(room_updated, "Room update has not been seen");
 
         // force the pos to be invalid and thus this being reset internally
-        force_sliding_sync_pos(&sync_proxy, "100".to_owned());
+        sync_proxy.set_pos("100".to_owned());
 
         let mut error_seen = false;
         let mut room_updated = false;


### PR DESCRIPTION
So far, the `SlidingSync.pos` field was public to the crate. In order to avoid
breaking the internal state of this type, its visibility is now private.

However, we need to be able to change the value when testing the
`SlidingSync` type itself. To achieve that, this patch removes the old
`force_sliding_sync_pos` function, and implements 2 new functions: `set_pos`
and `pos` directly on `SlidingSync` only when `#[cfg(any(test, feature = "testing"))]`.