### PR TITLE
Verify entered homeserver before proxy availability.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -147,8 +147,7 @@ impl AuthenticationService {
             })
             .map_err(AuthenticationError::from)?;
 
-        let details =
-            RUNTIME.block_on(async /*move*/ { self.details_from_client(&client).await })?;
+        let details = RUNTIME.block_on(async { self.details_from_client(&client).await })?;
 
         // Now we've verified that it's a valid homeserver, make sure
         // there's a sliding sync proxy available one way or another.

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, RwLock};
 
 use futures_util::future::join3;
 use matrix_sdk::{
-    ruma::{OwnedDeviceId, UserId},
+    ruma::{IdParseError, OwnedDeviceId, UserId},
     Session,
 };
 use zeroize::Zeroize;
@@ -28,6 +28,8 @@ impl Drop for AuthenticationService {
 pub enum AuthenticationError {
     #[error("A successful call to configure_homeserver must be made first.")]
     ClientMissing,
+    #[error("{message}")]
+    InvalidServerName { message: String },
     #[error("The homeserver doesn't provide a trusted a sliding sync proxy in its well-known configuration.")]
     SlidingSyncNotAvailable,
     #[error("Login was successful but is missing a valid Session to configure the file store.")]
@@ -39,6 +41,12 @@ pub enum AuthenticationError {
 impl From<anyhow::Error> for AuthenticationError {
     fn from(e: anyhow::Error) -> AuthenticationError {
         AuthenticationError::Generic { message: e.to_string() }
+    }
+}
+
+impl From<IdParseError> for AuthenticationError {
+    fn from(e: IdParseError) -> AuthenticationError {
+        AuthenticationError::InvalidServerName { message: e.to_string() }
     }
 }
 
@@ -112,29 +120,29 @@ impl AuthenticationService {
 
     /// Updates the service to authenticate with the homeserver for the
     /// specified address.
-    pub fn configure_homeserver(&self, server_name: String) -> Result<(), AuthenticationError> {
+    pub fn configure_homeserver(
+        &self,
+        server_name_or_homeserver_url: String,
+    ) -> Result<(), AuthenticationError> {
         let mut builder = Arc::new(ClientBuilder::new()).base_path(self.base_path.clone());
 
         // Remove any URL scheme from the name to attempt discovery first.
-        let (sanitized_name, is_url) = if server_name.starts_with("http://") {
-            (server_name.trim_start_matches("http://").to_string(), true)
-        } else if server_name.starts_with("https://") {
-            (server_name.trim_start_matches("https://").to_string(), true)
-        } else {
-            (server_name.clone(), false)
-        };
+        let server_name = matrix_sdk::sanitize_server_name(&server_name_or_homeserver_url)
+            .map_err(AuthenticationError::from)?;
 
-        builder = builder.server_name(sanitized_name);
+        builder = builder.server_name(server_name.to_string());
 
         let client = builder
             .build()
             .or_else(|e| {
-                if !is_url {
+                if !server_name_or_homeserver_url.starts_with("http://")
+                    && !server_name_or_homeserver_url.starts_with("http://")
+                {
                     return Err(e);
                 }
                 // When discovery fails, fallback to the homeserver URL if supplied.
                 let mut builder = Arc::new(ClientBuilder::new()).base_path(self.base_path.clone());
-                builder = builder.homeserver_url(server_name);
+                builder = builder.homeserver_url(server_name_or_homeserver_url);
                 builder.build()
             })
             .map_err(AuthenticationError::from)?;

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -55,6 +55,7 @@ pub use error::ImageError;
 pub use error::{Error, HttpError, HttpResult, RefreshTokenError, Result, RumaApiError};
 pub use http_client::HttpSend;
 pub use media::Media;
+pub use ruma::{IdParseError, OwnedServerName, ServerName};
 #[cfg(feature = "experimental-sliding-sync")]
 pub use sliding_sync::{
     RoomListEntry, SlidingSync, SlidingSyncBuilder, SlidingSyncMode, SlidingSyncRoom,
@@ -72,4 +73,10 @@ fn init_logging() {
         .with(tracing_subscriber::EnvFilter::from_default_env())
         .with(tracing_subscriber::fmt::layer().with_test_writer())
         .init();
+}
+
+/// Creates a server name from a user supplied string. The string is first
+/// sanitized by removing the http(s) scheme before being parsed.
+pub fn sanitize_server_name(s: &str) -> Result<OwnedServerName, IdParseError> {
+    ServerName::parse(s.trim_start_matches("http://").trim_start_matches("https://"))
 }


### PR DESCRIPTION
Passing a URL directly to the AuthenticationService would always fail as the well-known discovery doesn't take place. But it also doesn't report back to the user whether or not there is a valid homeserver at that URL, merely saying sliding sync isn't available which isn't helpful. This PR fixes https://github.com/vector-im/element-x-ios/issues/591 in 2 ways:
- When a URL is entered attempt discovery with a server name first before falling back to the URL directly.
- Check for homeserver details before the proxy so that entering "https://idontexist.com/" fails with the correct error.