### PR TITLE
Replace remaining usage of futures-signal with eyeball(-im)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,12 +1248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "displaydoc"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,7 +1451,6 @@ dependencies = [
  "anyhow",
  "clap 4.1.6",
  "futures",
- "futures-signals",
  "matrix-sdk",
  "tokio",
  "tracing-subscriber",
@@ -1682,21 +1675,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "futures-signals"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3acc659ba666cff13fdf65242d16428f2f11935b688f82e4024ad39667a5132"
-dependencies = [
- "discard",
- "futures-channel",
- "futures-core",
- "futures-util",
- "log",
- "pin-project",
- "serde",
 ]
 
 [[package]]
@@ -2095,6 +2073,7 @@ dependencies = [
  "bitmaps",
  "rand_core 0.6.4",
  "rand_xoshiro",
+ "serde",
  "sized-chunks",
  "typenum",
  "version_check",
@@ -2271,10 +2250,10 @@ dependencies = [
  "chrono",
  "clap 4.1.6",
  "dialoguer",
+ "eyeball",
  "eyeball-im",
  "eyre",
  "futures",
- "futures-signals",
  "log4rs",
  "matrix-sdk",
  "matrix-sdk-common",
@@ -2576,7 +2555,6 @@ dependencies = [
  "eyre",
  "futures",
  "futures-core",
- "futures-signals",
  "futures-util",
  "getrandom 0.2.8",
  "gloo-timers",
@@ -2803,9 +2781,9 @@ dependencies = [
  "anyhow",
  "base64 0.21.0",
  "extension-trait",
+ "eyeball",
  "eyeball-im",
  "futures-core",
- "futures-signals",
  "futures-util",
  "log-panics",
  "matrix-sdk",
@@ -4679,6 +4657,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "eyeball",
  "eyeball-im",
  "futures",
  "matrix-sdk",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -18,10 +18,10 @@ uniffi = { workspace = true, features = ["build"] }
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.21"
+eyeball = { workspace = true }
 eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = "0.3.17"
-futures-signals = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.17", default-features = false }
 mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -66,23 +66,16 @@ interface RoomListEntry {
 
 [Enum]
 interface SlidingSyncViewRoomsListDiff {
-    Replace(sequence<RoomListEntry> values);
-    InsertAt(
-        u32 index,
-        RoomListEntry value
-    );
-    UpdateAt(
-        u32 index,
-        RoomListEntry value
-    );
-    RemoveAt(u32 index);
-    Move(
-        u32 old_index,
-        u32 new_index
-    );
-    Push(RoomListEntry value);
-    Pop();
+    Append(sequence<RoomListEntry> values);
+    Insert(u32 index, RoomListEntry value);
+    Set(u32 index, RoomListEntry value);
+    Remove(u32 index);
+    PushBack(RoomListEntry value);
+    PushFront(RoomListEntry value);
+    PopBack();
+    PopFront();
     Clear();
+    Reset(sequence<RoomListEntry> values);
 };
 
 callback interface SlidingSyncViewRoomListObserver {

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -73,10 +73,9 @@ eyeball = { workspace = true }
 eyeball-im = { workspace = true }
 eyre = { version = "0.6.8", optional = true }
 futures-core = "0.3.21"
-futures-signals = { version = "0.3.30", default-features = false }
 futures-util = { version = "0.3.21", default-features = false }
 http = { workspace = true }
-im = "15.1.0"
+im = { version = "15.1.0", features = ["serde"] }
 indexmap = "1.9.1"
 hyper = { version = "0.14.20", features = ["http1", "http2", "server"], optional = true }
 matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base", default_features = false }
@@ -120,6 +119,7 @@ optional = true
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-once-cell = "0.4.2"
 gloo-timers = { version = "0.2.6", features = ["futures"] }
+tokio = { version = "1.24.2", default-features = false, features = ["sync"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }

--- a/crates/matrix-sdk/src/room/timeline/builder.rs
+++ b/crates/matrix-sdk/src/room/timeline/builder.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use im::Vector;
 use matrix_sdk_base::{
     deserialized_responses::{EncryptionInfo, SyncTimelineEvent},
     locks::Mutex,
@@ -35,7 +36,7 @@ use crate::room;
 pub(crate) struct TimelineBuilder {
     room: room::Common,
     prev_token: Option<String>,
-    events: Vec<SyncTimelineEvent>,
+    events: Vector<SyncTimelineEvent>,
     track_fully_read: bool,
 }
 
@@ -44,7 +45,7 @@ impl TimelineBuilder {
         Self {
             room: room.clone(),
             prev_token: None,
-            events: Vec::default(),
+            events: Vector::new(),
             track_fully_read: false,
         }
     }
@@ -54,7 +55,7 @@ impl TimelineBuilder {
     pub(crate) fn events(
         mut self,
         prev_token: Option<String>,
-        events: Vec<SyncTimelineEvent>,
+        events: Vector<SyncTimelineEvent>,
     ) -> Self {
         self.prev_token = prev_token;
         self.events = events;

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -108,7 +108,7 @@ impl<P: ProfileProvider> TimelineInner<P> {
         (items, stream)
     }
 
-    pub(super) async fn add_initial_events(&mut self, events: Vec<SyncTimelineEvent>) {
+    pub(super) async fn add_initial_events(&mut self, events: Vector<SyncTimelineEvent>) {
         if events.is_empty() {
             return;
         }

--- a/crates/matrix-sdk/src/room/timeline/tests/basic.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/basic.rs
@@ -1,6 +1,7 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
+use im::vector;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::async_test;
 use ruma::{
@@ -39,7 +40,7 @@ async fn initial_events() {
 
     timeline
         .inner
-        .add_initial_events(vec![
+        .add_initial_events(vector![
             sync_timeline_event(
                 timeline.make_message_event(*ALICE, RoomMessageEventContent::text_plain("A")),
             ),
@@ -273,7 +274,7 @@ async fn dedup_initial() {
         timeline.make_message_event(*BOB, RoomMessageEventContent::text_plain("B")),
     );
 
-    timeline.inner.add_initial_events(vec![event_a.clone(), event_b, event_a]).await;
+    timeline.inner.add_initial_events(vector![event_a.clone(), event_b, event_a]).await;
 
     let timeline_items = timeline.inner.items().await;
     assert_eq!(timeline_items.len(), 3);

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex, RwLock as StdRwLock},
 };
 
-use futures_signals::signal::Mutable;
+use eyeball::Observable;
 use ruma::{
     api::client::sync::sync_events::v4::{
         self, AccountDataConfig, E2EEConfig, ExtensionsConfig, ReceiptConfig, ToDeviceConfig,
@@ -300,8 +300,8 @@ impl SlidingSyncBuilder {
             sent_extensions: Mutex::new(None).into(),
             failure_count: Default::default(),
 
-            pos: Mutable::new(None),
-            delta_token: Mutable::new(delta_token_inner),
+            pos: Arc::new(StdRwLock::new(Observable::new(None))),
+            delta_token: Arc::new(StdRwLock::new(Observable::new(delta_token_inner))),
             subscriptions: Arc::new(StdRwLock::new(self.subscriptions)),
             unsubscribe: Default::default(),
         })

--- a/examples/timeline/Cargo.toml
+++ b/examples/timeline/Cargo.toml
@@ -12,7 +12,6 @@ test = false
 anyhow = "1"
 clap = "4.0.16"
 futures = "0.3"
-futures-signals = { version = "0.3.30", default-features = false }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 url = "2.2.2"

--- a/labs/jack-in/Cargo.toml
+++ b/labs/jack-in/Cargo.toml
@@ -13,10 +13,10 @@ app_dirs2 = "2"
 chrono = "0.4.23"
 clap = { version = "4.0.29", features = ["derive", "env"] }
 dialoguer = "0.10.2"
+eyeball = { workspace = true }
 eyeball-im = { workspace = true }
 eyre = "0.6"
 futures = { version = "0.3.1" }
-futures-signals = "0.3.24"
 matrix-sdk = { path = "../../crates/matrix-sdk", default-features = false, features  = ["e2e-encryption", "anyhow", "native-tls", "sled", "experimental-sliding-sync", "experimental-timeline"], version = "0.6.0" }
 matrix-sdk-common = { path = "../../crates/matrix-sdk-common", version = "0.6.0" }
 matrix-sdk-sled = { path = "../../crates/matrix-sdk-sled", features = ["state-store", "crypto-store"], version = "0.2.0" }

--- a/labs/jack-in/src/app/model.rs
+++ b/labs/jack-in/src/app/model.rs
@@ -2,7 +2,7 @@
 //!
 //! app model
 
-use std::{ops::Deref, time::Duration};
+use std::time::Duration;
 
 use futures::executor::block_on;
 use matrix_sdk::{ruma::events::room::message::RoomMessageEventContent, Client};
@@ -212,7 +212,7 @@ impl Update<Msg> for Model {
                     None
                 }
                 Msg::SendMessage(m) => {
-                    if let Some(tl) = self.sliding_sync.room_timeline.lock_ref().deref() {
+                    if let Some(tl) = &**self.sliding_sync.room_timeline.read().unwrap() {
                         block_on(async move {
                             // fire and forget
                             tl.send(RoomMessageEventContent::text_plain(m).into(), None).await;

--- a/labs/jack-in/src/client/mod.rs
+++ b/labs/jack-in/src/client/mod.rs
@@ -95,7 +95,7 @@ pub async fn run_client(
 
     while let Some(update) = stream.next().await {
         {
-            let selected_room = ssync_state.selected_room.lock_ref().clone();
+            let selected_room = ssync_state.selected_room.read().unwrap().clone();
             if let Some(room_id) = selected_room {
                 if let Some(prev) = &prev_selected_room {
                     if prev != &room_id {

--- a/labs/jack-in/src/components/details.rs
+++ b/labs/jack-in/src/components/details.rs
@@ -46,7 +46,7 @@ impl Details {
     }
 
     pub fn refresh_data(&mut self) {
-        let Some(room_id) = self.sstate.selected_room.lock_ref().clone() else { return };
+        let Some(room_id) = self.sstate.selected_room.read().unwrap().clone() else { return };
         let Some(room_data) = self.sstate.get_room(&room_id) else {
             return;
         };
@@ -72,7 +72,8 @@ impl Details {
         let timeline: Vec<String> = self
             .sstate
             .current_timeline
-            .lock_ref()
+            .read()
+            .unwrap()
             .iter()
             .filter_map(|t| t.as_event()) // we ignore virtual events
             .map(|e| match e.content() {

--- a/labs/jack-in/src/main.rs
+++ b/labs/jack-in/src/main.rs
@@ -7,8 +7,8 @@ use std::{path::Path, time::Duration};
 use app_dirs2::{app_root, AppDataType, AppInfo};
 use clap::Parser;
 use dialoguer::{theme::ColorfulTheme, Password};
+use eyeball_im::VectorDiff;
 use eyre::{eyre, Result};
-use futures_signals::signal_vec::VecDiff;
 use matrix_sdk::{
     config::RequestConfig,
     room::timeline::TimelineItem,
@@ -51,7 +51,7 @@ pub enum Msg {
 pub enum JackInEvent {
     Any, // match all
     SyncUpdate(client::state::SlidingSyncState),
-    RoomDataUpdate(VecDiff<TimelineItem>),
+    RoomDataUpdate(VectorDiff<TimelineItem>),
 }
 
 impl PartialOrd for JackInEvent {

--- a/testing/sliding-sync-integration-test/Cargo.toml
+++ b/testing/sliding-sync-integration-test/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+eyeball = { workspace = true }
 eyeball-im = { workspace = true }
 matrix-sdk-integration-testing = { path = "../matrix-sdk-integration-testing", features = ["helpers"] }
 matrix-sdk = { path = "../../crates/matrix-sdk", features = ["experimental-sliding-sync", "testing"] }

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -73,13 +73,14 @@ mod tests {
 
     use anyhow::{bail, Context};
     use assert_matches::assert_matches;
+    use eyeball::Observable;
     use eyeball_im::VectorDiff;
     use futures::{pin_mut, stream::StreamExt};
     use matrix_sdk::{
         room::timeline::EventTimelineItem,
         ruma::{
             api::client::error::ErrorKind as RumaError,
-            events::room::message::RoomMessageEventContent, UInt,
+            events::room::message::RoomMessageEventContent, uint,
         },
         SlidingSyncMode, SlidingSyncState, SlidingSyncView,
     };
@@ -237,7 +238,7 @@ mod tests {
 
         // Sync to receive messages with a `timeline_limit` set to 20.
         {
-            view.timeline_limit.set(Some(UInt::try_from(20u32).unwrap()));
+            Observable::set(&mut view.timeline_limit.write().unwrap(), Some(uint!(20)));
 
             let mut update_summary;
 
@@ -1041,7 +1042,7 @@ mod tests {
         );
 
         // force the pos to be invalid and thus this being reset internally
-        sync_proxy.set_pos("100".to_string());
+        sync_proxy.set_pos("100".to_owned());
         let mut error_seen = false;
 
         for _n in 0..2 {


### PR DESCRIPTION
Doesn't look great in places because `Observable` has associated functions / no methods, that is fixable with a new wrapper type but I didn't want to block this PR on that.