### PR TITLE
feat(sdk): Remove clones of large responses in Sliding Sync

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1,12 +1,16 @@
+use std::collections::BTreeMap;
 #[cfg(feature = "e2e-encryption")]
 use std::ops::Deref;
 
-use ruma::api::client::sync::sync_events::{
-    v3::{self, Ephemeral},
-    v4,
-};
 #[cfg(feature = "e2e-encryption")]
 use ruma::UserId;
+use ruma::{
+    api::client::sync::sync_events::{
+        v3::{self, Ephemeral},
+        v4, DeviceLists,
+    },
+    DeviceKeyAlgorithm, UInt,
+};
 use tracing::{debug, info, instrument};
 
 use super::BaseClient;
@@ -60,8 +64,8 @@ impl BaseClient {
         // We declare default values that can be referenced hereinbelow. When we try to
         // extract values from `e2ee`, that would be unfortunate to clone the
         // value just to pass them (to remove them `e2ee`) as a reference later.
-        let device_one_time_keys_count = Default::default();
-        let device_unused_fallback_key_types = Default::default();
+        let device_one_time_keys_count = BTreeMap::<DeviceKeyAlgorithm, UInt>::default();
+        let device_unused_fallback_key_types = None;
 
         let (device_lists, device_one_time_keys_count, device_unused_fallback_key_types) = e2ee
             .as_ref()
@@ -73,7 +77,11 @@ impl BaseClient {
                 )
             })
             .unwrap_or_else(|| {
-                (Default::default(), &device_one_time_keys_count, &device_unused_fallback_key_types)
+                (
+                    DeviceLists::default(),
+                    &device_one_time_keys_count,
+                    &device_unused_fallback_key_types,
+                )
             });
 
         info!(

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -14,11 +14,12 @@ impl Client {
     #[instrument(skip(self, response))]
     pub(crate) async fn process_sliding_sync(
         &self,
-        response: v4::Response,
+        response: &v4::Response,
     ) -> Result<SyncResponse> {
         let response = self.base_client().process_sliding_sync(response).await?;
         debug!("done processing on base_client");
         self.handle_sync_response(&response).await?;
+
         Ok(response)
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -976,10 +976,6 @@ impl SlidingSync {
     }
 
     /// Handle the HTTP response.
-    ///
-    /// But which response? `v4::Response`, aka the Sliding Sync response, or
-    /// `SyncResponse`? We have both because `SyncResponse` doesn't support
-    /// Sliding Sync yet.
     #[instrument(skip_all, fields(views = views.len()))]
     async fn handle_response(
         &self,
@@ -987,6 +983,8 @@ impl SlidingSync {
         extensions: Option<ExtensionsConfig>,
         views: &mut BTreeMap<String, SlidingSyncViewRequestGenerator>,
     ) -> Result<UpdateSummary, crate::Error> {
+        // Handle and transform a Sliding Sync Response to a `SyncResponse`.
+        //
         // We may not need the `sync_response` in the future (once `SyncResponse` will
         // move to Sliding Sync, i.e. to `v4::Response`), but processing the
         // `sliding_sync_response` is vital, so it must be done somewhere; for now it

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -978,12 +978,8 @@ impl SlidingSync {
     /// Handle the HTTP response.
     ///
     /// But which response? `v4::Response`, aka the Sliding Sync response, or
-    /// `SyncResponse` which still relies on `v3`?
-    /// Well that's tricky. We have both here, because this Sliding Sync
-    /// implementation is still experimental, and we didn't want to be too
-    /// invasive. Thus, `SyncResponse` doesn't support Sliding Sync yet. Hence
-    /// the fact this method handles both at the same time. It's not super
-    /// annoying but it was important to clarify that.
+    /// `SyncResponse`? We have both because `SyncResponse` doesn't support
+    /// Sliding Sync yet.
     #[instrument(skip_all, fields(views = views.len()))]
     async fn handle_response(
         &self,

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -44,9 +44,6 @@ impl SlidingSyncRoom {
         mut inner: v4::SlidingSyncRoom,
         timeline: Vec<SyncTimelineEvent>,
     ) -> Self {
-        // we overwrite to only keep one copy
-        inner.timeline = vec![];
-
         let mut timeline_queue = ObservableVector::new();
         timeline_queue.append(timeline.into_iter().collect());
 

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -41,7 +41,7 @@ impl SlidingSyncRoom {
     pub(super) fn new(
         client: Client,
         room_id: OwnedRoomId,
-        mut inner: v4::SlidingSyncRoom,
+        inner: v4::SlidingSyncRoom,
         timeline: Vec<SyncTimelineEvent>,
     ) -> Self {
         let mut timeline_queue = ObservableVector::new();


### PR DESCRIPTION
I admit this patch is quite tricky. Please try to follow me.

So, first off, in `SlidingSyncRoom::new`, we were clearing the timeline, because somehow it exists twice in memory at this step.

Which led me to understand how `SlidingSync::handle_response` was working. I've clarified how this part of the code works. We are dealing with 2 kind of responses for a specific reason: `SyncResponse` and `v4::Response`, now it's documented and I hope it's clearer.

Then, I notice that we were passing a clone of the entire sliding sync response (`v4::Response`) to `Client::process_sliding_sync`. I thought it was suboptimal, so I've updated the code to take a reference. It led me to update `BaseClient::process_sliding_sync`. It was a little bit tricky, but I reckon we have less clones now than before.

And now, back to `SlidingSync::handle_response`, I was able to compute the `timeline` correctly by draining it from the `v4::Response`, or by moving it from `SyncResponse`. So it's no longer necessary to have this clearing code inside `SlidingSyncRoom::new`. Honestly it has nothing to do at this place before.

To conclude: We have cleaner code, and less clones.

What thing I reckon could be optimized, is that the entire `timeline` (`Vec<TimelineEvent>`) is cloned to be passed to `Client::handle_timeline`. So this timeline exists in 2 places: in Sliding Sync, and somewhere else. I don't believe it's a problem now, that's how it works, but we must be aware of that.
