### PR TITLE
Add powerlevel updates

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/members.rs
+++ b/crates/matrix-sdk-base/src/rooms/members.rs
@@ -17,7 +17,10 @@ use std::sync::Arc;
 use ruma::{
     events::{
         presence::PresenceEvent,
-        room::{member::MembershipState, power_levels::SyncRoomPowerLevelsEvent},
+        room::{
+            member::MembershipState,
+            power_levels::{PowerLevelAction, SyncRoomPowerLevelsEvent},
+        },
     },
     MxcUri, UserId,
 };
@@ -99,6 +102,15 @@ impl RoomMember {
             .as_ref()
             .map(|e| e.power_levels().for_user(self.user_id()).into())
             .unwrap_or_else(|| if self.is_room_creator { 100 } else { 0 })
+    }
+
+    /// Whether the given user can do the given action based on the power
+    /// levels.
+    pub fn can_do(&self, action: PowerLevelAction) -> bool {
+        (*self.power_levels)
+            .as_ref()
+            .map(|e| e.power_levels().user_can_do(self.user_id(), action))
+            .unwrap_or_else(|| self.is_room_creator)
     }
 
     /// Is the name that the member uses ambiguous in the room.

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -171,6 +171,10 @@ pub enum Error {
     #[error("the queried endpoint requires authentication but was called before logging in")]
     AuthenticationRequired,
 
+    /// This request failed because the local data wasn't sufficient.
+    #[error("Local cache doesn't contain all necessary data to perform the action.")]
+    InsufficientData,
+
     /// Attempting to restore a session after the olm-machine has already been
     /// set up fails
     #[cfg(feature = "e2e-encryption")]


### PR DESCRIPTION
Two small helper functions on Room and RoomMember around power_levels:

- `RoomMember.can_do` exposes the `ruma::PowerLevel::user_can_do`-helper function to check whether a user has the permissions to perform certain actions in the given room.
- `Joined.update_power_levels` is a handy function to update user power levels 

Signed-off-by: Benjamin Kampmann <ben.kampmann@gmail.com>
