### PR TITLE
fix+chore(sdk): Few fixes and cleans up of `SlidingSync` itself

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -298,7 +298,7 @@ impl SlidingSyncBuilder {
 
             extensions: Mutex::new(self.extensions).into(),
             sent_extensions: Mutex::new(None).into(),
-            failure_count: Default::default(),
+            reset_counter: Default::default(),
 
             pos: Arc::new(StdRwLock::new(Observable::new(None))),
             delta_token: Arc::new(StdRwLock::new(Observable::new(delta_token_inner))),

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1072,11 +1072,10 @@ impl SlidingSync {
                 }
             }
 
-            // Update the `to-device` next-batch if found.
-            sliding_sync_response
-                .extensions
-                .to_device
-                .map(|to_device| self.update_to_device_since(to_device.next_batch));
+            // Update the `to-device` next-batch if any.
+            if let Some(to_device) = sliding_sync_response.extensions.to_device {
+                self.update_to_device_since(to_device.next_batch);
+            }
 
             // Track the most recently successfully sent extensions (needed for sticky
             // semantics).

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1077,18 +1077,21 @@ impl SlidingSync {
         views: &mut BTreeMap<String, SlidingSyncViewRequestGenerator>,
     ) -> Result<Option<UpdateSummary>> {
         let mut requests = BTreeMap::new();
-        let mut to_remove = Vec::new();
 
-        for (name, generator) in views.iter_mut() {
-            if let Some(request) = generator.next() {
-                requests.insert(name.clone(), request);
-            } else {
-                to_remove.push(name.clone());
+        {
+            let mut views_to_remove = Vec::new();
+
+            for (name, generator) in views.iter_mut() {
+                if let Some(request) = generator.next() {
+                    requests.insert(name.clone(), request);
+                } else {
+                    views_to_remove.push(name.clone());
+                }
             }
-        }
 
-        for n in to_remove {
-            views.remove(&n);
+            for view_name in views_to_remove {
+                views.remove(&view_name);
+            }
         }
 
         if views.is_empty() {


### PR DESCRIPTION
I suggest to read this PR commit by commit. It's a collection of small clean ups to make the code easier to understand and easier to maintain. It also fixes one compilation error.