### PR TITLE
chore(sdk): Code reorganization of the `sliding_sync` module + doc improvement

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -1,0 +1,18 @@
+//! Sliding Sync errors.
+
+use thiserror::Error;
+
+/// Internal representation of errors in Sliding Sync.
+#[derive(Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// The response we've received from the server can't be parsed or doesn't
+    /// match up with the current expectations on the client side. A
+    /// `sync`-restart might be required.
+    #[error("The sliding sync response could not be handled: {0}")]
+    BadResponse(String),
+    /// Called `.build()` on a builder type, but the given required field was
+    /// missing.
+    #[error("Required field missing: `{0}`")]
+    BuildMissingField(&'static str),
+}

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -651,15 +651,6 @@ pub use view::*;
 
 use crate::{config::RequestConfig, Client, Result};
 
-/// The Summary of a new SlidingSync Update received
-#[derive(Debug, Clone)]
-pub struct UpdateSummary {
-    /// The views (according to their name), which have seen an update
-    pub views: Vec<String>,
-    /// The Rooms that have seen updates
-    pub rooms: Vec<OwnedRoomId>,
-}
-
 /// Number of times a Sliding Sync session can expire before raising an error.
 ///
 /// A Sliding Sync session can expire. In this case, it is reset. However, to
@@ -669,7 +660,7 @@ pub struct UpdateSummary {
 /// raising a proper error.
 const MAXIMUM_SLIDING_SYNC_SESSION_EXPIRATION: u8 = 3;
 
-/// The sliding sync instance
+/// The Sliding Sync instance.
 #[derive(Clone, Debug)]
 pub struct SlidingSync {
     /// Customize the homeserver for sliding sync only
@@ -1186,6 +1177,16 @@ impl SlidingSync {
     pub fn set_pos(&self, new_pos: String) {
         Observable::set(&mut self.pos.write().unwrap(), Some(new_pos));
     }
+}
+
+/// A summary of the updates received after a sync (like in
+/// [`SlidingSync::stream`]).
+#[derive(Debug, Clone)]
+pub struct UpdateSummary {
+    /// The names of the views that have seen an update.
+    pub views: Vec<String>,
+    /// The rooms that have seen updates
+    pub rooms: Vec<OwnedRoomId>,
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -614,6 +614,7 @@
 
 mod builder;
 mod client;
+mod error;
 mod room;
 mod view;
 
@@ -630,6 +631,7 @@ use std::{
 
 pub use builder::*;
 pub use client::*;
+pub use error::*;
 use eyeball::Observable;
 use futures_core::stream::Stream;
 pub use room::*;
@@ -643,27 +645,11 @@ use ruma::{
     assign, OwnedRoomId, RoomId,
 };
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use tracing::{debug, error, info_span, instrument, trace, warn, Instrument, Span};
 use url::Url;
 pub use view::*;
 
 use crate::{config::RequestConfig, Client, Result};
-
-/// Internal representation of errors in Sliding Sync
-#[derive(Error, Debug)]
-#[non_exhaustive]
-pub enum Error {
-    /// The response we've received from the server can't be parsed or doesn't
-    /// match up with the current expectations on the client side. A
-    /// `sync`-restart might be required.
-    #[error("The sliding sync response could not be handled: {0}")]
-    BadResponse(String),
-    /// Called `.build()` on a builder type, but the given required field was
-    /// missing.
-    #[error("Required field missing: `{0}`")]
-    BuildMissingField(&'static str),
-}
 
 /// The Entry in the sliding sync room list per sliding sync view
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -760,7 +760,7 @@ pub struct UpdateSummary {
 /// A Sliding Sync session can expire. In this case, it is reset. However, to
 /// avoid entering an infinite loop of “it's expired, let's reset, it's expired,
 /// let's reset…” (maybe if the network has an issue, or the server, or anything
-/// else), we defined a maximum times a session can expire before
+/// else), we define a maximum times a session can expire before
 /// raising a proper error.
 const MAXIMUM_SLIDING_SYNC_SESSION_EXPIRATION: u8 = 3;
 
@@ -770,6 +770,7 @@ pub struct SlidingSync {
     /// Customize the homeserver for sliding sync only
     homeserver: Option<Url>,
 
+    /// The HTTP Matrix client.
     client: Client,
 
     /// The storage key to keep this cache at and load it from
@@ -826,7 +827,7 @@ impl From<&SlidingSync> for FrozenSlidingSync {
 impl SlidingSync {
     async fn cache_to_storage(&self) -> Result<(), crate::Error> {
         let Some(storage_key) = self.storage_key.as_ref() else { return Ok(()) };
-        trace!(storage_key, "saving to storage for later use");
+        trace!(storage_key, "Saving to storage for later use");
 
         let store = self.client.store();
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -651,49 +651,6 @@ pub use view::*;
 
 use crate::{config::RequestConfig, Client, Result};
 
-/// The Entry in the sliding sync room list per sliding sync view
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub enum RoomListEntry {
-    /// This entry isn't known at this point and thus considered `Empty`
-    #[default]
-    Empty,
-    /// There was `OwnedRoomId` but since the server told us to invalid this
-    /// entry. it is considered stale
-    Invalidated(OwnedRoomId),
-    /// This Entry is followed with `OwnedRoomId`
-    Filled(OwnedRoomId),
-}
-
-impl RoomListEntry {
-    /// Is this entry empty or invalidated?
-    pub fn empty_or_invalidated(&self) -> bool {
-        matches!(self, RoomListEntry::Empty | RoomListEntry::Invalidated(_))
-    }
-
-    /// The inner room_id if given
-    pub fn as_room_id(&self) -> Option<&RoomId> {
-        match &self {
-            RoomListEntry::Empty => None,
-            RoomListEntry::Invalidated(b) | RoomListEntry::Filled(b) => Some(b.as_ref()),
-        }
-    }
-
-    fn freeze(&self) -> RoomListEntry {
-        match &self {
-            RoomListEntry::Empty => RoomListEntry::Empty,
-            RoomListEntry::Invalidated(b) | RoomListEntry::Filled(b) => {
-                RoomListEntry::Invalidated(b.clone())
-            }
-        }
-    }
-}
-
-impl<'a> From<&'a RoomListEntry> for RoomListEntry {
-    fn from(value: &'a RoomListEntry) -> Self {
-        value.clone()
-    }
-}
-
 /// The Summary of a new SlidingSync Update received
 #[derive(Debug, Clone)]
 pub struct UpdateSummary {

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -665,28 +665,6 @@ pub enum Error {
     BuildMissingField(&'static str),
 }
 
-/// The state the [`SlidingSyncView`] is in.
-///
-/// The lifetime of a SlidingSync usually starts at a `Preload`, getting a fast
-/// response for the first given number of Rooms, then switches into
-/// `CatchingUp` during which the view fetches the remaining rooms, usually in
-/// order, some times in batches. Once that is ready, it switches into `Live`.
-///
-/// If the client has been offline for a while, though, the SlidingSync might
-/// return back to `CatchingUp` at any point.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum SlidingSyncState {
-    /// Hasn't started yet
-    #[default]
-    Cold,
-    /// We are quickly preloading a preview of the most important rooms
-    Preload,
-    /// We are trying to load all remaining rooms, might be in batches
-    CatchingUp,
-    /// We are all caught up and now only sync the live responses.
-    Live,
-}
-
 /// The mode by which the the [`SlidingSyncView`] is in fetching the data.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SlidingSyncMode {

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -665,22 +665,6 @@ pub enum Error {
     BuildMissingField(&'static str),
 }
 
-/// The mode by which the the [`SlidingSyncView`] is in fetching the data.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum SlidingSyncMode {
-    /// Fully sync all rooms in the background, page by page of `batch_size`,
-    /// like `0..20`, `21..40`, 41..60` etc. assuming the `batch_size` is 20.
-    #[serde(alias = "FullSync")]
-    PagingFullSync,
-    /// Fully sync all rooms in the background, with a growing window of
-    /// `batch_size`, like `0..20`, `0..40`, `0..60` etc. assuming the
-    /// `batch_size` is 20.
-    GrowingFullSync,
-    /// Only sync the specific windows defined
-    #[default]
-    Selective,
-}
-
 /// The Entry in the sliding sync room list per sliding sync view
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum RoomListEntry {

--- a/crates/matrix-sdk/src/sliding_sync/view.rs
+++ b/crates/matrix-sdk/src/sliding_sync/view.rs
@@ -18,7 +18,7 @@ use ruma::{
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, instrument, trace, warn};
 
-use super::{Error, FrozenSlidingSyncRoom, RoomListEntry, SlidingSyncMode, SlidingSyncRoom};
+use super::{Error, FrozenSlidingSyncRoom, RoomListEntry, SlidingSyncRoom};
 use crate::Result;
 
 /// Holding a specific filtered view within the concept of sliding sync.
@@ -925,4 +925,20 @@ pub enum SlidingSyncState {
     CatchingUp,
     /// We are all caught up and now only sync the live responses.
     Live,
+}
+
+/// The mode by which the the [`SlidingSyncView`] is in fetching the data.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SlidingSyncMode {
+    /// Fully sync all rooms in the background, page by page of `batch_size`,
+    /// like `0..20`, `21..40`, 41..60` etc. assuming the `batch_size` is 20.
+    #[serde(alias = "FullSync")]
+    PagingFullSync,
+    /// Fully sync all rooms in the background, with a growing window of
+    /// `batch_size`, like `0..20`, `0..40`, `0..60` etc. assuming the
+    /// `batch_size` is 20.
+    GrowingFullSync,
+    /// Only sync the specific windows defined
+    #[default]
+    Selective,
 }

--- a/crates/matrix-sdk/src/sliding_sync/view.rs
+++ b/crates/matrix-sdk/src/sliding_sync/view.rs
@@ -18,9 +18,7 @@ use ruma::{
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, instrument, trace, warn};
 
-use super::{
-    Error, FrozenSlidingSyncRoom, RoomListEntry, SlidingSyncMode, SlidingSyncRoom, SlidingSyncState,
-};
+use super::{Error, FrozenSlidingSyncRoom, RoomListEntry, SlidingSyncMode, SlidingSyncRoom};
 use crate::Result;
 
 /// Holding a specific filtered view within the concept of sliding sync.
@@ -905,4 +903,26 @@ fn room_ops(
     }
 
     Ok(())
+}
+
+/// The state the [`SlidingSyncView`] is in.
+///
+/// The lifetime of a SlidingSync usually starts at a `Preload`, getting a fast
+/// response for the first given number of Rooms, then switches into
+/// `CatchingUp` during which the view fetches the remaining rooms, usually in
+/// order, some times in batches. Once that is ready, it switches into `Live`.
+///
+/// If the client has been offline for a while, though, the SlidingSync might
+/// return back to `CatchingUp` at any point.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SlidingSyncState {
+    /// Hasn't started yet
+    #[default]
+    Cold,
+    /// We are quickly preloading a preview of the most important rooms
+    Preload,
+    /// We are trying to load all remaining rooms, might be in batches
+    CatchingUp,
+    /// We are all caught up and now only sync the live responses.
+    Live,
 }

--- a/crates/matrix-sdk/src/sliding_sync/view.rs
+++ b/crates/matrix-sdk/src/sliding_sync/view.rs
@@ -943,38 +943,40 @@ pub enum SlidingSyncMode {
     Selective,
 }
 
-/// The Entry in the sliding sync room list per sliding sync view
+/// The Entry in the Sliding Sync room list per Sliding Sync view.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum RoomListEntry {
-    /// This entry isn't known at this point and thus considered `Empty`
+    /// This entry isn't known at this point and thus considered `Empty`.
     #[default]
     Empty,
     /// There was `OwnedRoomId` but since the server told us to invalid this
-    /// entry. it is considered stale
+    /// entry. it is considered stale.
     Invalidated(OwnedRoomId),
-    /// This Entry is followed with `OwnedRoomId`
+    /// This entry is followed with `OwnedRoomId`.
     Filled(OwnedRoomId),
 }
 
 impl RoomListEntry {
     /// Is this entry empty or invalidated?
     pub fn empty_or_invalidated(&self) -> bool {
-        matches!(self, RoomListEntry::Empty | RoomListEntry::Invalidated(_))
+        matches!(self, Self::Empty | Self::Invalidated(_))
     }
 
-    /// The inner room_id if given
+    /// Return the inner `room_id` if the entry' state is not empty.
     pub fn as_room_id(&self) -> Option<&RoomId> {
         match &self {
-            RoomListEntry::Empty => None,
-            RoomListEntry::Invalidated(b) | RoomListEntry::Filled(b) => Some(b.as_ref()),
+            Self::Empty => None,
+            Self::Invalidated(room_id) | Self::Filled(room_id) => Some(room_id.as_ref()),
         }
     }
 
-    fn freeze(&self) -> RoomListEntry {
+    /// Clone this entry, but freeze it, i.e. if the entry is empty, it remains
+    /// empty, otherwise it is invalidated.
+    fn freeze(&self) -> Self {
         match &self {
-            RoomListEntry::Empty => RoomListEntry::Empty,
-            RoomListEntry::Invalidated(b) | RoomListEntry::Filled(b) => {
-                RoomListEntry::Invalidated(b.clone())
+            Self::Empty => Self::Empty,
+            Self::Invalidated(room_id) | Self::Filled(room_id) => {
+                Self::Invalidated(room_id.clone())
             }
         }
     }


### PR DESCRIPTION
This PR is supposed to be reviewed commit by commit. It's mostly code reorganization (e.g. moving types in the correct module) from the `crates/matrix-sdk/src/sliding_sync/mod.rs` file, so that this file is finally cleaned up (cf. https://github.com/matrix-org/matrix-rust-sdk/issues/1579). This PR also updates the doctests and the doc in general. It's again a list of tiny patches.