### PR TITLE
refactor(base): Add an Error type to StateStore trait

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -63,11 +63,11 @@ use crate::{
     error::Result,
     rooms::{Room, RoomInfo, RoomType},
     store::{
-        ambiguity_map::AmbiguityCache, Result as StoreResult, StateChanges, StateStoreExt, Store,
-        StoreConfig,
+        ambiguity_map::AmbiguityCache, DynStateStore, Result as StoreResult, StateChanges,
+        StateStoreExt, Store, StoreConfig,
     },
     sync::{JoinedRoom, LeftRoom, Rooms, SyncResponse, Timeline},
-    Session, SessionMeta, SessionTokens, StateStore,
+    Session, SessionMeta, SessionTokens,
 };
 
 /// A no IO Client implementation.
@@ -175,7 +175,7 @@ impl BaseClient {
 
     /// Get a reference to the store.
     #[allow(unknown_lints, clippy::explicit_auto_deref)]
-    pub fn store(&self) -> &dyn StateStore {
+    pub fn store(&self) -> &DynStateStore {
         &*self.store
     }
 

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -40,7 +40,7 @@ use tracing::debug;
 
 use super::{BaseRoomInfo, DisplayName, RoomMember};
 use crate::{
-    store::{Result as StoreResult, StateStore, StateStoreExt},
+    store::{DynStateStore, Result as StoreResult, StateStoreExt},
     sync::UnreadNotificationsCount,
     MinimalStateEvent,
 };
@@ -52,7 +52,7 @@ pub struct Room {
     room_id: Arc<RoomId>,
     own_user_id: Arc<UserId>,
     inner: Arc<SyncRwLock<RoomInfo>>,
-    store: Arc<dyn StateStore>,
+    store: Arc<DynStateStore>,
 }
 
 /// The room summary containing member counts and members that should be used to
@@ -83,7 +83,7 @@ pub enum RoomType {
 impl Room {
     pub(crate) fn new(
         own_user_id: &UserId,
-        store: Arc<dyn StateStore>,
+        store: Arc<DynStateStore>,
         room_id: &RoomId,
         room_type: RoomType,
     ) -> Self {
@@ -93,7 +93,7 @@ impl Room {
 
     pub(crate) fn restore(
         own_user_id: &UserId,
-        store: Arc<dyn StateStore>,
+        store: Arc<DynStateStore>,
         room_info: RoomInfo,
     ) -> Self {
         Self {
@@ -811,7 +811,7 @@ mod test {
 
     use super::*;
     use crate::{
-        store::{MemoryStore, StateChanges},
+        store::{MemoryStore, StateChanges, StateStore},
         MinimalStateEvent, OriginalMinimalStateEvent,
     };
 

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -23,15 +23,12 @@ use ruma::{
 };
 use tracing::trace;
 
-use super::{Result, StateChanges};
-use crate::{
-    deserialized_responses::{AmbiguityChange, RawMemberEvent},
-    StateStore,
-};
+use super::{DynStateStore, Result, StateChanges};
+use crate::deserialized_responses::{AmbiguityChange, RawMemberEvent};
 
 #[derive(Debug)]
 pub(crate) struct AmbiguityCache {
-    pub store: Arc<dyn StateStore>,
+    pub store: Arc<DynStateStore>,
     pub cache: BTreeMap<OwnedRoomId, BTreeMap<String, BTreeSet<OwnedUserId>>>,
     pub changes: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, AmbiguityChange>>,
 }
@@ -72,7 +69,7 @@ impl AmbiguityMap {
 }
 
 impl AmbiguityCache {
-    pub fn new(store: Arc<dyn StateStore>) -> Self {
+    pub fn new(store: Arc<DynStateStore>) -> Self {
         Self { store, cache: BTreeMap::new(), changes: BTreeMap::new() }
     }
 

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -594,6 +594,8 @@ impl MemoryStore {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl StateStore for MemoryStore {
+    type Error = StoreError;
+
     async fn save_filter(&self, filter_name: &str, filter_id: &str) -> Result<()> {
         self.save_filter(filter_name, filter_id).await
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -21,7 +21,6 @@
 //! store.
 
 use std::{
-    borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
     fmt,
     ops::Deref,
@@ -37,10 +36,10 @@ use once_cell::sync::OnceCell;
 #[cfg(any(test, feature = "testing"))]
 #[macro_use]
 pub mod integration_tests;
+mod traits;
 
-use async_trait::async_trait;
 use dashmap::DashMap;
-use matrix_sdk_common::{locks::RwLock, AsyncTraitDeps};
+use matrix_sdk_common::locks::RwLock;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_crypto::store::{DynCryptoStore, IntoCryptoStore};
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
@@ -48,27 +47,22 @@ use ruma::{
     api::client::push::get_notifications::v3::Notification,
     events::{
         presence::PresenceEvent,
-        receipt::{Receipt, ReceiptEventContent, ReceiptThread, ReceiptType},
+        receipt::ReceiptEventContent,
         room::{
             member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
             redaction::OriginalSyncRoomRedactionEvent,
         },
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, EmptyStateKey, GlobalAccountDataEvent, GlobalAccountDataEventContent,
-        GlobalAccountDataEventType, RedactContent, RedactedStateEventContent, RoomAccountDataEvent,
-        RoomAccountDataEventContent, RoomAccountDataEventType, StateEventType, StaticEventContent,
-        StaticStateEventContent, SyncStateEvent,
+        AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
     },
     serde::Raw,
-    EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
+    EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
 };
 
 /// BoxStream of owned Types
 pub type BoxStream<T> = Pin<Box<dyn futures_util::Stream<Item = T> + Send>>;
 
 use crate::{
-    deserialized_responses::RawMemberEvent,
-    media::MediaRequest,
     rooms::{RoomInfo, RoomType},
     MinimalRoomMemberEvent, Room, Session, SessionMeta, SessionTokens,
 };
@@ -76,7 +70,10 @@ use crate::{
 pub(crate) mod ambiguity_map;
 mod memory_store;
 
-pub use self::memory_store::MemoryStore;
+pub use self::{
+    memory_store::MemoryStore,
+    traits::{DynStateStore, IntoStateStore, StateStore, StateStoreExt},
+};
 
 /// State store specific error type.
 #[derive(Debug, thiserror::Error)]
@@ -135,375 +132,13 @@ impl StoreError {
 /// A `StateStore` specific result type.
 pub type Result<T, E = StoreError> = std::result::Result<T, E>;
 
-/// An abstract state store trait that can be used to implement different stores
-/// for the SDK.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait StateStore: AsyncTraitDeps {
-    /// Save the given filter id under the given name.
-    ///
-    /// # Arguments
-    ///
-    /// * `filter_name` - The name that should be used to store the filter id.
-    ///
-    /// * `filter_id` - The filter id that should be stored in the state store.
-    async fn save_filter(&self, filter_name: &str, filter_id: &str) -> Result<()>;
-
-    /// Save the set of state changes in the store.
-    async fn save_changes(&self, changes: &StateChanges) -> Result<()>;
-
-    /// Get the filter id that was stored under the given filter name.
-    ///
-    /// # Arguments
-    ///
-    /// * `filter_name` - The name that was used to store the filter id.
-    async fn get_filter(&self, filter_name: &str) -> Result<Option<String>>;
-
-    /// Get the last stored sync token.
-    async fn get_sync_token(&self) -> Result<Option<String>>;
-
-    /// Get the stored presence event for the given user.
-    ///
-    /// # Arguments
-    ///
-    /// * `user_id` - The id of the user for which we wish to fetch the presence
-    /// event for.
-    async fn get_presence_event(&self, user_id: &UserId) -> Result<Option<Raw<PresenceEvent>>>;
-
-    /// Get a state event out of the state store.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room the state event was received for.
-    ///
-    /// * `event_type` - The event type of the state event.
-    async fn get_state_event(
-        &self,
-        room_id: &RoomId,
-        event_type: StateEventType,
-        state_key: &str,
-    ) -> Result<Option<Raw<AnySyncStateEvent>>>;
-
-    /// Get a list of state events for a given room and `StateEventType`.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room to find events for.
-    ///
-    /// * `event_type` - The event type.
-    async fn get_state_events(
-        &self,
-        room_id: &RoomId,
-        event_type: StateEventType,
-    ) -> Result<Vec<Raw<AnySyncStateEvent>>>;
-
-    /// Get the current profile for the given user in the given room.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The room id the profile is used in.
-    ///
-    /// * `user_id` - The id of the user the profile belongs to.
-    async fn get_profile(
-        &self,
-        room_id: &RoomId,
-        user_id: &UserId,
-    ) -> Result<Option<MinimalRoomMemberEvent>>;
-
-    /// Get the `MemberEvent` for the given state key in the given room id.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The room id the member event belongs to.
-    ///
-    /// * `state_key` - The user id that the member event defines the state for.
-    async fn get_member_event(
-        &self,
-        room_id: &RoomId,
-        state_key: &UserId,
-    ) -> Result<Option<RawMemberEvent>>;
-
-    /// Get all the user ids of members for a given room, for stripped and
-    /// regular rooms alike.
-    async fn get_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>>;
-
-    /// Get all the user ids of members that are in the invited state for a
-    /// given room, for stripped and regular rooms alike.
-    async fn get_invited_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>>;
-
-    /// Get all the user ids of members that are in the joined state for a
-    /// given room, for stripped and regular rooms alike.
-    async fn get_joined_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>>;
-
-    /// Get all the pure `RoomInfo`s the store knows about.
-    async fn get_room_infos(&self) -> Result<Vec<RoomInfo>>;
-
-    /// Get all the pure `RoomInfo`s the store knows about.
-    async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>>;
-
-    /// Get all the users that use the given display name in the given room.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room for which the display name users should
-    /// be fetched for.
-    ///
-    /// * `display_name` - The display name that the users use.
-    async fn get_users_with_display_name(
-        &self,
-        room_id: &RoomId,
-        display_name: &str,
-    ) -> Result<BTreeSet<OwnedUserId>>;
-
-    /// Get an event out of the account data store.
-    ///
-    /// # Arguments
-    ///
-    /// * `event_type` - The event type of the account data event.
-    async fn get_account_data_event(
-        &self,
-        event_type: GlobalAccountDataEventType,
-    ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>>;
-
-    /// Get an event out of the room account data store.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room for which the room account data event
-    ///   should
-    /// be fetched.
-    ///
-    /// * `event_type` - The event type of the room account data event.
-    async fn get_room_account_data_event(
-        &self,
-        room_id: &RoomId,
-        event_type: RoomAccountDataEventType,
-    ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>>;
-
-    /// Get an event out of the user room receipt store.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room for which the receipt should be
-    ///   fetched.
-    ///
-    /// * `receipt_type` - The type of the receipt.
-    ///
-    /// * `thread` - The thread containing this receipt.
-    ///
-    /// * `user_id` - The id of the user for who the receipt should be fetched.
-    async fn get_user_room_receipt_event(
-        &self,
-        room_id: &RoomId,
-        receipt_type: ReceiptType,
-        thread: ReceiptThread,
-        user_id: &UserId,
-    ) -> Result<Option<(OwnedEventId, Receipt)>>;
-
-    /// Get events out of the event room receipt store.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room for which the receipts should be
-    ///   fetched.
-    ///
-    /// * `receipt_type` - The type of the receipts.
-    ///
-    /// * `thread` - The thread containing this receipt.
-    ///
-    /// * `event_id` - The id of the event for which the receipts should be
-    ///   fetched.
-    async fn get_event_room_receipt_events(
-        &self,
-        room_id: &RoomId,
-        receipt_type: ReceiptType,
-        thread: ReceiptThread,
-        event_id: &EventId,
-    ) -> Result<Vec<(OwnedUserId, Receipt)>>;
-
-    /// Get arbitrary data from the custom store
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The key to fetch data for
-    async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
-
-    /// Put arbitrary data into the custom store
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The key to insert data into
-    ///
-    /// * `value` - The value to insert
-    async fn set_custom_value(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>>;
-
-    /// Add a media file's content in the media store.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The `MediaRequest` of the file.
-    ///
-    /// * `content` - The content of the file.
-    async fn add_media_content(&self, request: &MediaRequest, content: Vec<u8>) -> Result<()>;
-
-    /// Get a media file's content out of the media store.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The `MediaRequest` of the file.
-    async fn get_media_content(&self, request: &MediaRequest) -> Result<Option<Vec<u8>>>;
-
-    /// Removes a media file's content from the media store.
-    ///
-    /// # Arguments
-    ///
-    /// * `request` - The `MediaRequest` of the file.
-    async fn remove_media_content(&self, request: &MediaRequest) -> Result<()>;
-
-    /// Removes all the media files' content associated to an `MxcUri` from the
-    /// media store.
-    ///
-    /// # Arguments
-    ///
-    /// * `uri` - The `MxcUri` of the media files.
-    async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<()>;
-
-    /// Removes a room and all elements associated from the state store.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The `RoomId` of the room to delete.
-    async fn remove_room(&self, room_id: &RoomId) -> Result<()>;
-}
-
-/// Convenience functionality for state stores.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait StateStoreExt: StateStore {
-    /// Get a specific state event of statically-known type.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room the state event was received for.
-    async fn get_state_event_static<C>(
-        &self,
-        room_id: &RoomId,
-    ) -> Result<Option<Raw<SyncStateEvent<C>>>>
-    where
-        C: StaticEventContent + StaticStateEventContent<StateKey = EmptyStateKey> + RedactContent,
-        C::Redacted: RedactedStateEventContent,
-    {
-        Ok(self.get_state_event(room_id, C::TYPE.into(), "").await?.map(Raw::cast))
-    }
-
-    /// Get a specific state event of statically-known type.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room the state event was received for.
-    async fn get_state_event_static_for_key<C, K>(
-        &self,
-        room_id: &RoomId,
-        state_key: &K,
-    ) -> Result<Option<Raw<SyncStateEvent<C>>>>
-    where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
-        C::StateKey: Borrow<K>,
-        C::Redacted: RedactedStateEventContent,
-        K: AsRef<str> + ?Sized + Sync,
-    {
-        Ok(self.get_state_event(room_id, C::TYPE.into(), state_key.as_ref()).await?.map(Raw::cast))
-    }
-
-    /// Get a list of state events of a statically-known type for a given room.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room to find events for.
-    async fn get_state_events_static<C>(
-        &self,
-        room_id: &RoomId,
-    ) -> Result<Vec<Raw<SyncStateEvent<C>>>>
-    where
-        C: StaticEventContent + StaticStateEventContent + RedactContent,
-        C::Redacted: RedactedStateEventContent,
-    {
-        // FIXME: Could be more efficient, if we had streaming store accessor functions
-        Ok(self
-            .get_state_events(room_id, C::TYPE.into())
-            .await?
-            .into_iter()
-            .map(Raw::cast)
-            .collect())
-    }
-
-    /// Get an event of a statically-known type from the account data store.
-    async fn get_account_data_event_static<C>(
-        &self,
-    ) -> Result<Option<Raw<GlobalAccountDataEvent<C>>>>
-    where
-        C: StaticEventContent + GlobalAccountDataEventContent,
-    {
-        Ok(self.get_account_data_event(C::TYPE.into()).await?.map(Raw::cast))
-    }
-
-    /// Get an event of a statically-known type from the room account data
-    /// store.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The id of the room for which the room account data event
-    ///   should be fetched.
-    async fn get_room_account_data_event_static<C>(
-        &self,
-        room_id: &RoomId,
-    ) -> Result<Option<Raw<RoomAccountDataEvent<C>>>>
-    where
-        C: StaticEventContent + RoomAccountDataEventContent,
-    {
-        Ok(self.get_room_account_data_event(room_id, C::TYPE.into()).await?.map(Raw::cast))
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-impl<T: StateStore + ?Sized> StateStoreExt for T {}
-
-/// A type that can be type-erased into `Arc<dyn StateStore>`.
-///
-/// This trait is not meant to be implemented directly outside
-/// `matrix-sdk-crypto`, but it is automatically implemented for everything that
-/// implements `StateStore`.
-pub trait IntoStateStore {
-    #[doc(hidden)]
-    fn into_state_store(self) -> Arc<dyn StateStore>;
-}
-
-impl<T> IntoStateStore for T
-where
-    T: StateStore + Sized + 'static,
-{
-    fn into_state_store(self) -> Arc<dyn StateStore> {
-        Arc::new(self)
-    }
-}
-
-impl<T> IntoStateStore for Arc<T>
-where
-    T: StateStore + 'static,
-{
-    fn into_state_store(self) -> Arc<dyn StateStore> {
-        self
-    }
-}
-
 /// A state store wrapper for the SDK.
 ///
 /// This adds additional higher level store functionality on top of a
 /// `StateStore` implementation.
 #[derive(Clone)]
 pub(crate) struct Store {
-    pub(super) inner: Arc<dyn StateStore>,
+    pub(super) inner: Arc<DynStateStore>,
     session_meta: Arc<OnceCell<SessionMeta>>,
     pub(super) session_tokens: SharedObservable<Option<SessionTokens>>,
     /// The current sync token that should be used for the next sync call.
@@ -520,7 +155,7 @@ pub(crate) struct Store {
 
 impl Store {
     /// Create a new store, wrapping the given `StateStore`
-    pub fn new(inner: Arc<dyn StateStore>) -> Self {
+    pub fn new(inner: Arc<DynStateStore>) -> Self {
         Self {
             inner,
             session_meta: Default::default(),
@@ -662,7 +297,7 @@ impl fmt::Debug for Store {
 }
 
 impl Deref for Store {
-    type Target = dyn StateStore;
+    type Target = DynStateStore;
 
     fn deref(&self) -> &Self::Target {
         self.inner.deref()
@@ -840,7 +475,7 @@ impl StateChanges {
 pub struct StoreConfig {
     #[cfg(feature = "e2e-encryption")]
     pub(crate) crypto_store: Arc<DynCryptoStore>,
-    pub(crate) state_store: Arc<dyn StateStore>,
+    pub(crate) state_store: Arc<DynStateStore>,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1,0 +1,607 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{borrow::Borrow, collections::BTreeSet, fmt, sync::Arc};
+
+use async_trait::async_trait;
+use matrix_sdk_common::AsyncTraitDeps;
+use ruma::{
+    events::{
+        presence::PresenceEvent,
+        receipt::{Receipt, ReceiptThread, ReceiptType},
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent, EmptyStateKey,
+        GlobalAccountDataEvent, GlobalAccountDataEventContent, GlobalAccountDataEventType,
+        RedactContent, RedactedStateEventContent, RoomAccountDataEvent,
+        RoomAccountDataEventContent, RoomAccountDataEventType, StateEventType, StaticEventContent,
+        StaticStateEventContent, SyncStateEvent,
+    },
+    serde::Raw,
+    EventId, MxcUri, OwnedEventId, OwnedUserId, RoomId, UserId,
+};
+
+use super::{StateChanges, StoreError};
+use crate::{
+    deserialized_responses::RawMemberEvent, media::MediaRequest, MinimalRoomMemberEvent, RoomInfo,
+};
+
+/// An abstract state store trait that can be used to implement different stores
+/// for the SDK.
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait StateStore: AsyncTraitDeps {
+    /// The error type used by this state store.
+    type Error: fmt::Debug + Into<StoreError>;
+
+    /// Save the given filter id under the given name.
+    ///
+    /// # Arguments
+    ///
+    /// * `filter_name` - The name that should be used to store the filter id.
+    ///
+    /// * `filter_id` - The filter id that should be stored in the state store.
+    async fn save_filter(&self, filter_name: &str, filter_id: &str) -> Result<(), Self::Error>;
+
+    /// Save the set of state changes in the store.
+    async fn save_changes(&self, changes: &StateChanges) -> Result<(), Self::Error>;
+
+    /// Get the filter id that was stored under the given filter name.
+    ///
+    /// # Arguments
+    ///
+    /// * `filter_name` - The name that was used to store the filter id.
+    async fn get_filter(&self, filter_name: &str) -> Result<Option<String>, Self::Error>;
+
+    /// Get the last stored sync token.
+    async fn get_sync_token(&self) -> Result<Option<String>, Self::Error>;
+
+    /// Get the stored presence event for the given user.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - The id of the user for which we wish to fetch the presence
+    /// event for.
+    async fn get_presence_event(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<Raw<PresenceEvent>>, Self::Error>;
+
+    /// Get a state event out of the state store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room the state event was received for.
+    ///
+    /// * `event_type` - The event type of the state event.
+    async fn get_state_event(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+        state_key: &str,
+    ) -> Result<Option<Raw<AnySyncStateEvent>>, Self::Error>;
+
+    /// Get a list of state events for a given room and `StateEventType`.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room to find events for.
+    ///
+    /// * `event_type` - The event type.
+    async fn get_state_events(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+    ) -> Result<Vec<Raw<AnySyncStateEvent>>, Self::Error>;
+
+    /// Get the current profile for the given user in the given room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The room id the profile is used in.
+    ///
+    /// * `user_id` - The id of the user the profile belongs to.
+    async fn get_profile(
+        &self,
+        room_id: &RoomId,
+        user_id: &UserId,
+    ) -> Result<Option<MinimalRoomMemberEvent>, Self::Error>;
+
+    /// Get the `MemberEvent` for the given state key in the given room id.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The room id the member event belongs to.
+    ///
+    /// * `state_key` - The user id that the member event defines the state for.
+    async fn get_member_event(
+        &self,
+        room_id: &RoomId,
+        state_key: &UserId,
+    ) -> Result<Option<RawMemberEvent>, Self::Error>;
+
+    /// Get all the user ids of members for a given room, for stripped and
+    /// regular rooms alike.
+    async fn get_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error>;
+
+    /// Get all the user ids of members that are in the invited state for a
+    /// given room, for stripped and regular rooms alike.
+    async fn get_invited_user_ids(&self, room_id: &RoomId)
+        -> Result<Vec<OwnedUserId>, Self::Error>;
+
+    /// Get all the user ids of members that are in the joined state for a
+    /// given room, for stripped and regular rooms alike.
+    async fn get_joined_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error>;
+
+    /// Get all the pure `RoomInfo`s the store knows about.
+    async fn get_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error>;
+
+    /// Get all the pure `RoomInfo`s the store knows about.
+    async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error>;
+
+    /// Get all the users that use the given display name in the given room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which the display name users should
+    /// be fetched for.
+    ///
+    /// * `display_name` - The display name that the users use.
+    async fn get_users_with_display_name(
+        &self,
+        room_id: &RoomId,
+        display_name: &str,
+    ) -> Result<BTreeSet<OwnedUserId>, Self::Error>;
+
+    /// Get an event out of the account data store.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_type` - The event type of the account data event.
+    async fn get_account_data_event(
+        &self,
+        event_type: GlobalAccountDataEventType,
+    ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>, Self::Error>;
+
+    /// Get an event out of the room account data store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which the room account data event
+    ///   should
+    /// be fetched.
+    ///
+    /// * `event_type` - The event type of the room account data event.
+    async fn get_room_account_data_event(
+        &self,
+        room_id: &RoomId,
+        event_type: RoomAccountDataEventType,
+    ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>, Self::Error>;
+
+    /// Get an event out of the user room receipt store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which the receipt should be
+    ///   fetched.
+    ///
+    /// * `receipt_type` - The type of the receipt.
+    ///
+    /// * `thread` - The thread containing this receipt.
+    ///
+    /// * `user_id` - The id of the user for who the receipt should be fetched.
+    async fn get_user_room_receipt_event(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        user_id: &UserId,
+    ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error>;
+
+    /// Get events out of the event room receipt store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which the receipts should be
+    ///   fetched.
+    ///
+    /// * `receipt_type` - The type of the receipts.
+    ///
+    /// * `thread` - The thread containing this receipt.
+    ///
+    /// * `event_id` - The id of the event for which the receipts should be
+    ///   fetched.
+    async fn get_event_room_receipt_events(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        event_id: &EventId,
+    ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error>;
+
+    /// Get arbitrary data from the custom store
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to fetch data for
+    async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Put arbitrary data into the custom store
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert data into
+    ///
+    /// * `value` - The value to insert
+    async fn set_custom_value(
+        &self,
+        key: &[u8],
+        value: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Add a media file's content in the media store.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The `MediaRequest` of the file.
+    ///
+    /// * `content` - The content of the file.
+    async fn add_media_content(
+        &self,
+        request: &MediaRequest,
+        content: Vec<u8>,
+    ) -> Result<(), Self::Error>;
+
+    /// Get a media file's content out of the media store.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The `MediaRequest` of the file.
+    async fn get_media_content(
+        &self,
+        request: &MediaRequest,
+    ) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Removes a media file's content from the media store.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The `MediaRequest` of the file.
+    async fn remove_media_content(&self, request: &MediaRequest) -> Result<(), Self::Error>;
+
+    /// Removes all the media files' content associated to an `MxcUri` from the
+    /// media store.
+    ///
+    /// # Arguments
+    ///
+    /// * `uri` - The `MxcUri` of the media files.
+    async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<(), Self::Error>;
+
+    /// Removes a room and all elements associated from the state store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The `RoomId` of the room to delete.
+    async fn remove_room(&self, room_id: &RoomId) -> Result<(), Self::Error>;
+}
+
+#[repr(transparent)]
+struct EraseStateStoreError<T>(T);
+
+impl<T: fmt::Debug> fmt::Debug for EraseStateStoreError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<T: StateStore> StateStore for EraseStateStoreError<T> {
+    type Error = StoreError;
+
+    async fn save_filter(&self, filter_name: &str, filter_id: &str) -> Result<(), Self::Error> {
+        self.0.save_filter(filter_name, filter_id).await.map_err(Into::into)
+    }
+
+    async fn save_changes(&self, changes: &StateChanges) -> Result<(), Self::Error> {
+        self.0.save_changes(changes).await.map_err(Into::into)
+    }
+
+    async fn get_filter(&self, filter_name: &str) -> Result<Option<String>, Self::Error> {
+        self.0.get_filter(filter_name).await.map_err(Into::into)
+    }
+
+    async fn get_sync_token(&self) -> Result<Option<String>, Self::Error> {
+        self.0.get_sync_token().await.map_err(Into::into)
+    }
+
+    async fn get_presence_event(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<Raw<PresenceEvent>>, Self::Error> {
+        self.0.get_presence_event(user_id).await.map_err(Into::into)
+    }
+
+    async fn get_state_event(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+        state_key: &str,
+    ) -> Result<Option<Raw<AnySyncStateEvent>>, Self::Error> {
+        self.0.get_state_event(room_id, event_type, state_key).await.map_err(Into::into)
+    }
+
+    async fn get_state_events(
+        &self,
+        room_id: &RoomId,
+        event_type: StateEventType,
+    ) -> Result<Vec<Raw<AnySyncStateEvent>>, Self::Error> {
+        self.0.get_state_events(room_id, event_type).await.map_err(Into::into)
+    }
+
+    async fn get_profile(
+        &self,
+        room_id: &RoomId,
+        user_id: &UserId,
+    ) -> Result<Option<MinimalRoomMemberEvent>, Self::Error> {
+        self.0.get_profile(room_id, user_id).await.map_err(Into::into)
+    }
+
+    async fn get_member_event(
+        &self,
+        room_id: &RoomId,
+        state_key: &UserId,
+    ) -> Result<Option<RawMemberEvent>, Self::Error> {
+        self.0.get_member_event(room_id, state_key).await.map_err(Into::into)
+    }
+
+    async fn get_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error> {
+        self.0.get_user_ids(room_id).await.map_err(Into::into)
+    }
+
+    async fn get_invited_user_ids(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<OwnedUserId>, Self::Error> {
+        self.0.get_invited_user_ids(room_id).await.map_err(Into::into)
+    }
+
+    async fn get_joined_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error> {
+        self.0.get_joined_user_ids(room_id).await.map_err(Into::into)
+    }
+
+    async fn get_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error> {
+        self.0.get_room_infos().await.map_err(Into::into)
+    }
+
+    async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error> {
+        self.0.get_stripped_room_infos().await.map_err(Into::into)
+    }
+
+    async fn get_users_with_display_name(
+        &self,
+        room_id: &RoomId,
+        display_name: &str,
+    ) -> Result<BTreeSet<OwnedUserId>, Self::Error> {
+        self.0.get_users_with_display_name(room_id, display_name).await.map_err(Into::into)
+    }
+
+    async fn get_account_data_event(
+        &self,
+        event_type: GlobalAccountDataEventType,
+    ) -> Result<Option<Raw<AnyGlobalAccountDataEvent>>, Self::Error> {
+        self.0.get_account_data_event(event_type).await.map_err(Into::into)
+    }
+
+    async fn get_room_account_data_event(
+        &self,
+        room_id: &RoomId,
+        event_type: RoomAccountDataEventType,
+    ) -> Result<Option<Raw<AnyRoomAccountDataEvent>>, Self::Error> {
+        self.0.get_room_account_data_event(room_id, event_type).await.map_err(Into::into)
+    }
+
+    async fn get_user_room_receipt_event(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        user_id: &UserId,
+    ) -> Result<Option<(OwnedEventId, Receipt)>, Self::Error> {
+        self.0
+            .get_user_room_receipt_event(room_id, receipt_type, thread, user_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn get_event_room_receipt_events(
+        &self,
+        room_id: &RoomId,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+        event_id: &EventId,
+    ) -> Result<Vec<(OwnedUserId, Receipt)>, Self::Error> {
+        self.0
+            .get_event_room_receipt_events(room_id, receipt_type, thread, event_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.get_custom_value(key).await.map_err(Into::into)
+    }
+
+    async fn set_custom_value(
+        &self,
+        key: &[u8],
+        value: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.set_custom_value(key, value).await.map_err(Into::into)
+    }
+
+    async fn add_media_content(
+        &self,
+        request: &MediaRequest,
+        content: Vec<u8>,
+    ) -> Result<(), Self::Error> {
+        self.0.add_media_content(request, content).await.map_err(Into::into)
+    }
+
+    async fn get_media_content(
+        &self,
+        request: &MediaRequest,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.0.get_media_content(request).await.map_err(Into::into)
+    }
+
+    async fn remove_media_content(&self, request: &MediaRequest) -> Result<(), Self::Error> {
+        self.0.remove_media_content(request).await.map_err(Into::into)
+    }
+
+    async fn remove_media_content_for_uri(&self, uri: &MxcUri) -> Result<(), Self::Error> {
+        self.0.remove_media_content_for_uri(uri).await.map_err(Into::into)
+    }
+
+    async fn remove_room(&self, room_id: &RoomId) -> Result<(), Self::Error> {
+        self.0.remove_room(room_id).await.map_err(Into::into)
+    }
+}
+
+/// Convenience functionality for state stores.
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait StateStoreExt: StateStore {
+    /// Get a specific state event of statically-known type.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room the state event was received for.
+    async fn get_state_event_static<C>(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Option<Raw<SyncStateEvent<C>>>, Self::Error>
+    where
+        C: StaticEventContent + StaticStateEventContent<StateKey = EmptyStateKey> + RedactContent,
+        C::Redacted: RedactedStateEventContent,
+    {
+        Ok(self.get_state_event(room_id, C::TYPE.into(), "").await?.map(Raw::cast))
+    }
+
+    /// Get a specific state event of statically-known type.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room the state event was received for.
+    async fn get_state_event_static_for_key<C, K>(
+        &self,
+        room_id: &RoomId,
+        state_key: &K,
+    ) -> Result<Option<Raw<SyncStateEvent<C>>>, Self::Error>
+    where
+        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C::StateKey: Borrow<K>,
+        C::Redacted: RedactedStateEventContent,
+        K: AsRef<str> + ?Sized + Sync,
+    {
+        Ok(self.get_state_event(room_id, C::TYPE.into(), state_key.as_ref()).await?.map(Raw::cast))
+    }
+
+    /// Get a list of state events of a statically-known type for a given room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room to find events for.
+    async fn get_state_events_static<C>(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<Raw<SyncStateEvent<C>>>, Self::Error>
+    where
+        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C::Redacted: RedactedStateEventContent,
+    {
+        // FIXME: Could be more efficient, if we had streaming store accessor functions
+        Ok(self
+            .get_state_events(room_id, C::TYPE.into())
+            .await?
+            .into_iter()
+            .map(Raw::cast)
+            .collect())
+    }
+
+    /// Get an event of a statically-known type from the account data store.
+    async fn get_account_data_event_static<C>(
+        &self,
+    ) -> Result<Option<Raw<GlobalAccountDataEvent<C>>>, Self::Error>
+    where
+        C: StaticEventContent + GlobalAccountDataEventContent,
+    {
+        Ok(self.get_account_data_event(C::TYPE.into()).await?.map(Raw::cast))
+    }
+
+    /// Get an event of a statically-known type from the room account data
+    /// store.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The id of the room for which the room account data event
+    ///   should be fetched.
+    async fn get_room_account_data_event_static<C>(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Option<Raw<RoomAccountDataEvent<C>>>, Self::Error>
+    where
+        C: StaticEventContent + RoomAccountDataEventContent,
+    {
+        Ok(self.get_room_account_data_event(room_id, C::TYPE.into()).await?.map(Raw::cast))
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<T: StateStore + ?Sized> StateStoreExt for T {}
+
+/// A type-erased [`StateStore`].
+pub type DynStateStore = dyn StateStore<Error = StoreError>;
+
+/// A type that can be type-erased into `Arc<dyn StateStore>`.
+///
+/// This trait is not meant to be implemented directly outside
+/// `matrix-sdk-crypto`, but it is automatically implemented for everything that
+/// implements `StateStore`.
+pub trait IntoStateStore {
+    #[doc(hidden)]
+    fn into_state_store(self) -> Arc<DynStateStore>;
+}
+
+impl<T> IntoStateStore for T
+where
+    T: StateStore + Sized + 'static,
+{
+    fn into_state_store(self) -> Arc<DynStateStore> {
+        Arc::new(EraseStateStoreError(self))
+    }
+}
+
+// Turns a given `Arc<T>` into `Arc<DynStateStore>` by attaching the
+// StateStore impl vtable of `EraseStateStoreError<T>`.
+impl<T> IntoStateStore for Arc<T>
+where
+    T: StateStore + 'static,
+{
+    fn into_state_store(self) -> Arc<DynStateStore> {
+        let ptr: *const T = Arc::into_raw(self);
+        let ptr_erased = ptr as *const EraseStateStoreError<T>;
+        // SAFETY: EraseStateStoreError is repr(transparent) so T and
+        //         EraseStateStoreError<T> have the same layout and ABI
+        unsafe { Arc::from_raw(ptr_erased) }
+    }
+}

--- a/crates/matrix-sdk-indexeddb/src/state_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store.rs
@@ -1366,6 +1366,8 @@ impl IndexeddbStateStore {
 #[cfg(target_arch = "wasm32")]
 #[async_trait(?Send)]
 impl StateStore for IndexeddbStateStore {
+    type Error = StoreError;
+
     async fn save_filter(&self, filter_name: &str, filter_id: &str) -> StoreResult<()> {
         self.save_filter(filter_name, filter_id).await.map_err(|e| e.into())
     }

--- a/crates/matrix-sdk-sled/src/state_store.rs
+++ b/crates/matrix-sdk-sled/src/state_store.rs
@@ -1442,6 +1442,8 @@ impl SledStateStore {
 
 #[async_trait]
 impl StateStore for SledStateStore {
+    type Error = StoreError;
+
     async fn save_filter(&self, filter_name: &str, filter_id: &str) -> StoreResult<()> {
         self.save_filter(filter_name, filter_id).await.map_err(Into::into)
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -28,8 +28,8 @@ use eyeball::Observable;
 use futures_core::Stream;
 use futures_util::StreamExt;
 use matrix_sdk_base::{
-    BaseClient, RoomType, SendOutsideWasm, Session, SessionMeta, SessionTokens, StateStore,
-    SyncOutsideWasm,
+    store::DynStateStore, BaseClient, RoomType, SendOutsideWasm, Session, SessionMeta,
+    SessionTokens, SyncOutsideWasm,
 };
 use matrix_sdk_common::{
     instant::Instant,
@@ -503,7 +503,7 @@ impl Client {
     }
 
     /// Get a reference to the state store.
-    pub fn store(&self) -> &dyn StateStore {
+    pub fn store(&self) -> &DynStateStore {
         self.base_client().store()
     }
 


### PR DESCRIPTION
Same as for the crypto store, this makes store implementations easier. We might also be able to merge the error types of the indexeddb crypto and state store based on this, haven't tried that yet.