### PR TITLE
fix(bindings): More authentication service server name fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ emsdk-*
 .idea/
 .env
 .build
+.swiftpm
 /Package.swift
 
 ## User settings

--- a/bindings/apple/Tests/MatrixRustSDKTests/AuthenticationServiceTests.swift
+++ b/bindings/apple/Tests/MatrixRustSDKTests/AuthenticationServiceTests.swift
@@ -1,0 +1,64 @@
+@testable import MatrixRustSDK
+import XCTest
+
+class AuthenticationServiceTests: XCTestCase {
+    var service: AuthenticationService!
+    
+    override func setUp() {
+        service = AuthenticationService(basePath: FileManager.default.temporaryDirectory.path,
+                                        passphrase: nil,
+                                        customSlidingSyncProxy: nil)
+    }
+    
+    func testValidServers() {
+        XCTAssertNoThrow(try service.configureHomeserver(serverNameOrHomeserverUrl: "matrix.org"))
+        XCTAssertNoThrow(try service.configureHomeserver(serverNameOrHomeserverUrl: "https://matrix.org"))
+        XCTAssertNoThrow(try service.configureHomeserver(serverNameOrHomeserverUrl: "https://matrix.org/"))
+    }
+    
+    func testInvalidCharacters() {
+        XCTAssertThrowsError(try service.configureHomeserver(serverNameOrHomeserverUrl: "hello!@$£%^world"),
+                             "A server name with invalid characters should not succeed to build.") { error in
+            guard case AuthenticationError.InvalidServerName = error else { XCTFail("Expected invalid name error."); return }
+        }
+    }
+    
+    func textNonExistentDomain() {
+        XCTAssertThrowsError(try service.configureHomeserver(serverNameOrHomeserverUrl: "somesillylinkthatdoesntexist.com"),
+                             "A server name that doesn't exist should not succeed.") { error in
+            guard case AuthenticationError.Generic = error else { XCTFail("Expected generic error."); return }
+        }
+        XCTAssertThrowsError(try service.configureHomeserver(serverNameOrHomeserverUrl: "https://somesillylinkthatdoesntexist.com"),
+                             "A server URL that doesn't exist should not succeed.") { error in
+            guard case AuthenticationError.Generic = error else { XCTFail("Expected generic error."); return }
+        }
+    }
+    
+    func testValidDomainWithoutServer() {
+        XCTAssertThrowsError(try service.configureHomeserver(serverNameOrHomeserverUrl: "https://google.com"),
+                             "Google should not succeed as it doesn't host a homeserver.") { error in
+            guard case AuthenticationError.Generic = error else { XCTFail("Expected generic error."); return }
+        }
+    }
+    
+    func testServerWithoutSlidingSync() {
+        XCTAssertThrowsError(try service.configureHomeserver(serverNameOrHomeserverUrl: "envs.net"),
+                             "Envs should not succeed as it doesn't advertise a sliding sync proxy.") { error in
+            guard case AuthenticationError.SlidingSyncNotAvailable = error else { XCTFail("Expected sliding sync error."); return }
+        }
+    }
+    
+    func testHomeserverURL() {
+        XCTAssertThrowsError(try service.configureHomeserver(serverNameOrHomeserverUrl: "https://matrix-client.matrix.org"),
+                             "Directly using a homeserver should not succeed as a sliding sync proxy won't be found.") { error in
+            guard case AuthenticationError.SlidingSyncNotAvailable = error else { XCTFail("Expected sliding sync error."); return }
+        }
+    }
+    
+    func testHomeserverURLWithProxyOverride() {
+        service = AuthenticationService(basePath: FileManager.default.temporaryDirectory.path,
+                                        passphrase: nil, customSlidingSyncProxy: "https://slidingsync.proxy")
+        XCTAssertNoThrow(try service.configureHomeserver(serverNameOrHomeserverUrl: "https://matrix-client.matrix.org"),
+                         "Directly using a homeserver should succeed what a custom sliding sync proxy has been set.")
+    }
+}

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -76,7 +76,10 @@ fn init_logging() {
 }
 
 /// Creates a server name from a user supplied string. The string is first
-/// sanitized by removing the http(s) scheme before being parsed.
+/// sanitized by removing whitespace, the http(s) scheme and any trailing
+/// slashes before being parsed.
 pub fn sanitize_server_name(s: &str) -> Result<OwnedServerName, IdParseError> {
-    ServerName::parse(s.trim_start_matches("http://").trim_start_matches("https://"))
+    ServerName::parse(
+        s.trim().trim_start_matches("http://").trim_start_matches("https://").trim_end_matches('/'),
+    )
 }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -83,3 +83,30 @@ pub fn sanitize_server_name(s: &str) -> Result<OwnedServerName, IdParseError> {
         s.trim().trim_start_matches("http://").trim_start_matches("https://").trim_end_matches('/'),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use crate::sanitize_server_name;
+
+    #[test]
+    fn test_sanitize_server_name() {
+        assert_eq!(sanitize_server_name("matrix.org").unwrap().as_str(), "matrix.org");
+        assert_eq!(sanitize_server_name("https://matrix.org").unwrap().as_str(), "matrix.org");
+        assert_eq!(sanitize_server_name("http://matrix.org").unwrap().as_str(), "matrix.org");
+        assert_eq!(
+            sanitize_server_name("https://matrix.server.org").unwrap().as_str(),
+            "matrix.server.org"
+        );
+        assert_eq!(
+            sanitize_server_name("https://matrix.server.org/").unwrap().as_str(),
+            "matrix.server.org"
+        );
+        assert_eq!(
+            sanitize_server_name("  https://matrix.server.org// ").unwrap().as_str(),
+            "matrix.server.org"
+        );
+        assert_matches!(sanitize_server_name("https://matrix.server.org/something"), Err(_))
+    }
+}

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, str::FromStr, time::Duration};
 
+use assert_matches::assert_matches;
 use matrix_sdk::{
     config::SyncSettings,
     media::{MediaFormat, MediaRequest, MediaThumbnailSize},
@@ -629,4 +630,30 @@ fn serialize_session() {
             "device_id": "EFGHIJ",
         })
     );
+}
+
+#[test]
+fn sanitize_server_name() {
+    assert_eq!(matrix_sdk::sanitize_server_name("matrix.org").unwrap().as_str(), "matrix.org");
+    assert_eq!(
+        matrix_sdk::sanitize_server_name("https://matrix.org").unwrap().as_str(),
+        "matrix.org"
+    );
+    assert_eq!(
+        matrix_sdk::sanitize_server_name("http://matrix.org").unwrap().as_str(),
+        "matrix.org"
+    );
+    assert_eq!(
+        matrix_sdk::sanitize_server_name("https://matrix.server.org").unwrap().as_str(),
+        "matrix.server.org"
+    );
+    assert_eq!(
+        matrix_sdk::sanitize_server_name("https://matrix.server.org/").unwrap().as_str(),
+        "matrix.server.org"
+    );
+    assert_eq!(
+        matrix_sdk::sanitize_server_name("  https://matrix.server.org// ").unwrap().as_str(),
+        "matrix.server.org"
+    );
+    assert_matches!(matrix_sdk::sanitize_server_name("https://matrix.server.org/something"), Err(_))
 }

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeMap, str::FromStr, time::Duration};
 
-use assert_matches::assert_matches;
 use matrix_sdk::{
     config::SyncSettings,
     media::{MediaFormat, MediaRequest, MediaThumbnailSize},
@@ -630,30 +629,4 @@ fn serialize_session() {
             "device_id": "EFGHIJ",
         })
     );
-}
-
-#[test]
-fn sanitize_server_name() {
-    assert_eq!(matrix_sdk::sanitize_server_name("matrix.org").unwrap().as_str(), "matrix.org");
-    assert_eq!(
-        matrix_sdk::sanitize_server_name("https://matrix.org").unwrap().as_str(),
-        "matrix.org"
-    );
-    assert_eq!(
-        matrix_sdk::sanitize_server_name("http://matrix.org").unwrap().as_str(),
-        "matrix.org"
-    );
-    assert_eq!(
-        matrix_sdk::sanitize_server_name("https://matrix.server.org").unwrap().as_str(),
-        "matrix.server.org"
-    );
-    assert_eq!(
-        matrix_sdk::sanitize_server_name("https://matrix.server.org/").unwrap().as_str(),
-        "matrix.server.org"
-    );
-    assert_eq!(
-        matrix_sdk::sanitize_server_name("  https://matrix.server.org// ").unwrap().as_str(),
-        "matrix.server.org"
-    );
-    assert_matches!(matrix_sdk::sanitize_server_name("https://matrix.server.org/something"), Err(_))
 }


### PR DESCRIPTION
Entering `https://matrix-client.matrix.org/` failed with an error about being an invalid domain or IP address. This PR fixes that by
- Trimming any trailing slashes (and whitespace whilst we're here) when sanitising.
- Trying to build the client with a URL instead of throwing when server name fails (e.g. `https://company.com/matrix`).

Additionally it adds tests to both the sanitising (Rust) and the service (Swift).