### PR TITLE
fix(sliding_sync): Prevent PagingFullSync and GrowingFullSync from go…

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/view.rs
+++ b/crates/matrix-sdk/src/sliding_sync/view.rs
@@ -631,10 +631,17 @@ impl SlidingSyncViewRequestGenerator {
         limit: Option<u32>,
     ) -> v4::SyncRequestList {
         let calc_end = start + batch_size;
-        let end = match limit {
+
+        let mut end = match limit {
             Some(l) => std::cmp::min(l, calc_end),
             _ => calc_end,
         };
+
+        end = match self.view.rooms_count() {
+            Some(total_room_count) => std::cmp::min(end, total_room_count - 1),
+            _ => end,
+        };
+
         self.make_request_for_ranges(vec![(start.into(), end.into())])
     }
 


### PR DESCRIPTION
…ing over the total room count

We noticed that the GrowingFullSync we use in ElementX often goes over the total number of rooms actually available for a particular view. This PR fixes that.