### PR TITLE
Add platform versions for swift CI tests

### DIFF
--- a/bindings/apple/Package.swift
+++ b/bindings/apple/Package.swift
@@ -5,6 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "MatrixRustSDK",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12)
+    ],
     products: [
         .library(name: "MatrixRustSDK",
                  targets: ["MatrixRustSDK"]),


### PR DESCRIPTION
In order to hopefuly fix the CI for https://github.com/matrix-org/matrix-rust-sdk/pull/1587