### PR TITLE
chore(indexeddb): Update version of `uuid`

### DIFF
--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -45,5 +45,5 @@ matrix-sdk-base = { path = "../matrix-sdk-base", features = ["testing"] }
 matrix-sdk-common = { path = "../matrix-sdk-common", features = ["js"] }
 matrix-sdk-crypto = { path = "../matrix-sdk-crypto", features = ["js", "testing"] }
 matrix-sdk-test = { path = "../../testing/matrix-sdk-test" }
-uuid = "1.0.0"
+uuid = "1.3.0"
 wasm-bindgen-test = "0.3.33"


### PR DESCRIPTION
This patch updates the version of `uuid`. It doesn't bring any significant new features, just something I've found (I'm going to use `uuid` in another crate, that's why I was looking at `uuid` usage in our codebase already).