### PR TITLE
feat(sdk): `SlidingSync::stream` can match expected responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2920,7 +2920,7 @@ dependencies = [
  "byteorder",
  "image 0.23.14",
  "qrcode",
- "ruma-common 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruma-common",
  "thiserror",
  "vodozemac",
 ]
@@ -4292,24 +4292,24 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
+source = "git+https://github.com/ruma/ruma?rev=2edfe5bc5f3ee88014e57230c50a5e005119344a#2edfe5bc5f3ee88014e57230c50a5e005119344a"
 dependencies = [
  "assign",
  "js_int",
  "js_option",
  "ruma-appservice-api",
  "ruma-client-api",
- "ruma-common 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
+ "ruma-common",
  "ruma-federation-api",
 ]
 
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
+source = "git+https://github.com/ruma/ruma?rev=2edfe5bc5f3ee88014e57230c50a5e005119344a#2edfe5bc5f3ee88014e57230c50a5e005119344a"
 dependencies = [
  "js_int",
- "ruma-common 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
+ "ruma-common",
  "serde",
  "serde_json",
 ]
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
+source = "git+https://github.com/ruma/ruma?rev=2edfe5bc5f3ee88014e57230c50a5e005119344a#2edfe5bc5f3ee88014e57230c50a5e005119344a"
 dependencies = [
  "assign",
  "bytes",
@@ -4325,7 +4325,7 @@ dependencies = [
  "js_int",
  "js_option",
  "maplit",
- "ruma-common 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
+ "ruma-common",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -4334,33 +4334,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b4ec3f70ea9afeae96a6c1e5eb86ed02760d5c28a167b5d9a433cefaaf815c"
-dependencies = [
- "base64 0.21.0",
- "bytes",
- "form_urlencoded",
- "indexmap",
- "js_int",
- "js_option",
- "konst",
- "percent-encoding",
- "regex",
- "ruma-identifiers-validation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ruma-macros 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_html_form",
- "serde_json",
- "thiserror",
- "tracing",
- "url",
- "wildmatch",
-]
-
-[[package]]
-name = "ruma-common"
-version = "0.11.3"
-source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
+source = "git+https://github.com/ruma/ruma?rev=2edfe5bc5f3ee88014e57230c50a5e005119344a#2edfe5bc5f3ee88014e57230c50a5e005119344a"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4378,8 +4352,8 @@ dependencies = [
  "pulldown-cmark",
  "rand 0.8.5",
  "regex",
- "ruma-identifiers-validation 0.9.1 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
- "ruma-macros 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
+ "ruma-identifiers-validation",
+ "ruma-macros",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -4393,10 +4367,10 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
+source = "git+https://github.com/ruma/ruma?rev=2edfe5bc5f3ee88014e57230c50a5e005119344a#2edfe5bc5f3ee88014e57230c50a5e005119344a"
 dependencies = [
  "js_int",
- "ruma-common 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
+ "ruma-common",
  "serde",
  "serde_json",
 ]
@@ -4404,17 +4378,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebefdab34311af44d07cd2cd91c36cfe6a8c770647c6b00f6ab47f1186b2bb72"
-dependencies = [
- "js_int",
- "thiserror",
-]
-
-[[package]]
-name = "ruma-identifiers-validation"
-version = "0.9.1"
-source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
+source = "git+https://github.com/ruma/ruma?rev=2edfe5bc5f3ee88014e57230c50a5e005119344a#2edfe5bc5f3ee88014e57230c50a5e005119344a"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4423,29 +4387,13 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e883799456b6213da90fe065d4234f282b89afe161af3e5fcc854e44e8f582"
+source = "git+https://github.com/ruma/ruma?rev=2edfe5bc5f3ee88014e57230c50a5e005119344a#2edfe5bc5f3ee88014e57230c50a5e005119344a"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "ruma-identifiers-validation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "syn",
- "toml 0.7.2",
-]
-
-[[package]]
-name = "ruma-macros"
-version = "0.11.3"
-source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "ruma-identifiers-validation 0.9.1 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
+ "ruma-identifiers-validation",
  "serde",
  "syn",
  "toml 0.7.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,6 +2642,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "wasm-bindgen-test",
  "wiremock",
  "zeroize",
@@ -2919,7 +2920,7 @@ dependencies = [
  "byteorder",
  "image 0.23.14",
  "qrcode",
- "ruma-common",
+ "ruma-common 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "vodozemac",
 ]
@@ -4291,26 +4292,24 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6429e3fae5d6ab07742bcf9a1705f68f97d082801cc5afe9290579bf7abcf053"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
 dependencies = [
  "assign",
  "js_int",
  "js_option",
  "ruma-appservice-api",
  "ruma-client-api",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
  "ruma-federation-api",
 ]
 
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed16a943a44ba290481f2284f71cac31757fabaee8ca2d059afd20ff8b33c31"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
 dependencies = [
  "js_int",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
  "serde",
  "serde_json",
 ]
@@ -4318,8 +4317,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67b35700529224d167697ce575c71ca26c489af5774756843e335af767f6fdf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
 dependencies = [
  "assign",
  "bytes",
@@ -4327,7 +4325,7 @@ dependencies = [
  "js_int",
  "js_option",
  "maplit",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -4338,6 +4336,31 @@ name = "ruma-common"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3b4ec3f70ea9afeae96a6c1e5eb86ed02760d5c28a167b5d9a433cefaaf815c"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "form_urlencoded",
+ "indexmap",
+ "js_int",
+ "js_option",
+ "konst",
+ "percent-encoding",
+ "regex",
+ "ruma-identifiers-validation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruma-macros 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "wildmatch",
+]
+
+[[package]]
+name = "ruma-common"
+version = "0.11.3"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4355,8 +4378,8 @@ dependencies = [
  "pulldown-cmark",
  "rand 0.8.5",
  "regex",
- "ruma-identifiers-validation",
- "ruma-macros",
+ "ruma-identifiers-validation 0.9.1 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
+ "ruma-macros 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -4370,11 +4393,10 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d05ebbed580138816c3d564f9191e576acf96441e1faca9dcefe7092db6979"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
 dependencies = [
  "js_int",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
  "serde",
  "serde_json",
 ]
@@ -4390,6 +4412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruma-identifiers-validation"
+version = "0.9.1"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
+dependencies = [
+ "js_int",
+ "thiserror",
+]
+
+[[package]]
 name = "ruma-macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,7 +4430,22 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "ruma-identifiers-validation",
+ "ruma-identifiers-validation 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "syn",
+ "toml 0.7.2",
+]
+
+[[package]]
+name = "ruma-macros"
+version = "0.11.3"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id#7a78869de4ec920ea770ffd2a27eafcc1b3619b0"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "ruma-identifiers-validation 0.9.1 (git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-response-txn-id)",
  "serde",
  "syn",
  "toml 0.7.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ uniffi_bindgen = "0.23.0"
 vodozemac = { git = "https://github.com/matrix-org/vodozemac", rev = "fb609ca1e4df5a7a818490ae86ac694119e41e71" }
 zeroize = "1.3.0"
 
+[patch.crates-io]
+ruma = { git = "https://github.com/Hywan/ruma", branch = "feat-sliding-sync-response-txn-id" }
+
 # Default release profile, select with `--release`
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ dashmap = "5.2.0"
 eyeball = "0.1.4"
 eyeball-im = "0.1.0"
 http = "0.2.6"
-ruma = { version = "0.8.0", features = ["client-api-c"] }
-ruma-common = "0.11.2"
+ruma = { git = "https://github.com/ruma/ruma", rev = "2edfe5bc5f3ee88014e57230c50a5e005119344a", features = ["client-api-c"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "2edfe5bc5f3ee88014e57230c50a5e005119344a" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"
@@ -42,9 +42,6 @@ uniffi = "0.23.0"
 uniffi_bindgen = "0.23.0"
 vodozemac = { git = "https://github.com/matrix-org/vodozemac", rev = "fb609ca1e4df5a7a818490ae86ac694119e41e71" }
 zeroize = "1.3.0"
-
-[patch.crates-io]
-ruma = { git = "https://github.com/Hywan/ruma", branch = "feat-sliding-sync-response-txn-id" }
 
 # Default release profile, select with `--release`
 [profile.release]

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -87,7 +87,7 @@ mime = "0.3.16"
 pin-project-lite = "0.2.9"
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.11.10", default_features = false }
-ruma = { workspace = true, features = ["compat", "rand", "unstable-msc2448", "unstable-msc2965"] }
+ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc2965"] }
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -49,6 +49,7 @@ experimental-sliding-sync = [
     "matrix-sdk-base/experimental-sliding-sync",
     "experimental-timeline",
     "reqwest/gzip",
+    "dep:uuid",
 ]
 
 docsrs = [
@@ -94,6 +95,7 @@ thiserror = { workspace = true }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 url = "2.2.2"
+uuid = { version = "1.3.0", optional = true }
 zeroize = { workspace = true }
 
 [dependencies.image]

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1059,6 +1059,8 @@ impl SlidingSync {
             assign!(v4::Request::new(), {
                 pos,
                 delta_token,
+                // We want to track whether the incoming response maps to this
+                // request. We use the (optional) `txn_id` field for that.
                 txn_id: Some(stream_id.to_owned()),
                 timeout: Some(timeout),
                 lists,


### PR DESCRIPTION
This patch adds a new feature.

Each call to `SlidingSync::stream` generates a unique `stream_id`. This `stream_id` is passed to requests as a `txn_id` field. Returned responses must hold the same `txn_id`, otherwise it means `stream` has received unexpected responses from another `stream` or something else.

So far, when the `txn_id` field of the response and the `stream_id` don't match, a log with the `ERROR` level is raised. Should we do more, like ignoring the response entirely? Not sure yet.