### PR TITLE
fix(sdk): Deal with missing data in Sliding Sync's responses

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -153,14 +153,33 @@ impl SlidingSyncRoom {
         } = room_data;
 
         self.inner.unread_notifications = unread_notifications;
-        self.inner.name = name;
-        self.inner.initial = initial;
-        self.inner.is_dm = is_dm;
-        self.inner.invite_state = invite_state;
-        self.inner.required_state = required_state;
 
-        if let Some(batch) = prev_batch {
-            Observable::set(&mut self.prev_batch.write().unwrap(), Some(batch));
+        // The server might not send some parts of the response, because they were sent
+        // before and the server wants to save bandwidth. So let's update the values
+        // only when they exist.
+
+        if name.is_some() {
+            self.inner.name = name;
+        }
+
+        if initial.is_some() {
+            self.inner.initial = initial;
+        }
+
+        if is_dm.is_some() {
+            self.inner.is_dm = is_dm;
+        }
+
+        if !invite_state.is_empty() {
+            self.inner.invite_state = invite_state;
+        }
+
+        if !required_state.is_empty() {
+            self.inner.required_state = required_state;
+        }
+
+        if prev_batch.is_some() {
+            Observable::set(&mut self.prev_batch.write().unwrap(), prev_batch);
         }
 
         // There is timeline updates.


### PR DESCRIPTION
The Sliding Sync server might not send some parts of the response, because they were sent before and the server wants to save bandwidth. So let's update values only when they exist.