### PR TITLE
fix(bindings): `SlidingSync.sync` returns an immediately cancellable `TaskHandle`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -1,7 +1,4 @@
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, RwLock,
-};
+use std::sync::{Arc, RwLock};
 
 use anyhow::Context;
 use eyeball::Observable;
@@ -20,7 +17,7 @@ pub use matrix_sdk::{
     SlidingSyncBuilder as MatrixSlidingSyncBuilder, SlidingSyncMode, SlidingSyncState,
 };
 use tokio::{sync::broadcast::error::RecvError, task::JoinHandle};
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, warn};
 use url::Url;
 
 use super::{Client, Room, RUNTIME};
@@ -41,6 +38,7 @@ impl TaskHandle {
         Self { handle: Some(handle), callback: Default::default() }
     }
 
+    #[allow(dead_code)]
     fn with_callback(callback: TaskHandleCallback) -> Self {
         Self { handle: Default::default(), callback: RwLock::new(Some(callback)) }
     }

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeMap,
     fmt::Debug,
-    sync::{Arc, Mutex, RwLock as StdRwLock},
+    sync::{Mutex, RwLock as StdRwLock},
 };
 
 use eyeball::Observable;
@@ -289,23 +289,21 @@ impl SlidingSyncBuilder {
         let rooms = StdRwLock::new(rooms_found);
         let lists = StdRwLock::new(self.lists);
 
-        Ok(SlidingSync {
-            inner: Arc::new(SlidingSyncInner {
-                homeserver: self.homeserver,
-                client,
-                storage_key: self.storage_key,
+        Ok(SlidingSync::new(SlidingSyncInner {
+            homeserver: self.homeserver,
+            client,
+            storage_key: self.storage_key,
 
-                lists,
-                rooms,
+            lists,
+            rooms,
 
-                extensions: Mutex::new(self.extensions).into(),
-                reset_counter: Default::default(),
+            extensions: Mutex::new(self.extensions),
+            reset_counter: Default::default(),
 
-                pos: StdRwLock::new(Observable::new(None)),
-                delta_token: StdRwLock::new(Observable::new(delta_token_inner)),
-                subscriptions: StdRwLock::new(self.subscriptions),
-                unsubscribe: Default::default(),
-            }),
-        })
+            pos: StdRwLock::new(Observable::new(None)),
+            delta_token: StdRwLock::new(Observable::new(delta_token_inner)),
+            subscriptions: StdRwLock::new(self.subscriptions),
+            unsubscribe: Default::default(),
+        }))
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -653,7 +653,7 @@ pub struct SlidingSync {
 
     /// A lock to ensure that responses are handled one at a time.
     /// [The lock][AsyncMutex] is fair, and this fairness property is important
-    /// to ensure responses are handled in the correct order.
+    /// to ensure responses are handled by their arrival order.
     response_handling_lock: Arc<AsyncMutex<()>>,
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -652,6 +652,8 @@ pub struct SlidingSync {
     inner: Arc<SlidingSyncInner>,
 
     /// A lock to ensure that responses are handled one at a time.
+    /// [The lock][AsyncMutex] is fair, and this fairness property is important
+    /// to ensure responses are handled in the correct order.
     response_handling_lock: Arc<AsyncMutex<()>>,
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -652,8 +652,6 @@ pub struct SlidingSync {
     inner: Arc<SlidingSyncInner>,
 
     /// A lock to ensure that responses are handled one at a time.
-    /// [The lock][AsyncMutex] is fair, and this fairness property is important
-    /// to ensure responses are handled by their arrival order.
     response_handling_lock: Arc<AsyncMutex<()>>,
 }
 


### PR DESCRIPTION
Before this patch, `SlidingSync::sync` was returning a callback-based `TaskHandle`. It was waiting on the “stream loop” to finish (since it's a long- poll, it means waiting 2*30s, cf. our code), before checking an atomic flag has some value to decide whether it was time to leave the loop or not. So when the user is cancelling this `TaskHandle`, a response (if any) was always handled. But in the meantime, it was possible to start a new `sync`, and it seems like it creates bugs. It's not easy to reproduce but it's kind of easy to understand: **Responses are applied on the same `SlidingSync` instance in no particular order concurrently**.

After this patch, `SlidingSync::sync` now returns a handle-based `TaskHandle`. It means that cancelling it will cancel the “stream loop” immediately. If no response was in-flight from the server, that's perfect, no problem. If a response was in-flight, the inner `pos` of the `SlidingSync` instance won't be updated as the response won't be handled. So the server will re-send the same response with the next sync request.

But, as @gnunicorn has found, we have a problem. Basically, cancelling a `Future` happen on any `.await` point. Where do we have such `.await` points? Well: when sending the request and waiting on the response, or in several places when handling the received response. So it becomes possible to fully break the states of Sliding Sync if the `Future` cancellation happens… after a response is received in `sync_once`, and… before `sync_once` ultimately returns. That's why, prior to this PR, the code waits entirely on `stream`, then `sync_once`, to fully finish its iteration before cancelling the flow.

What's the solution then? The part 1 of the solution proposed by this PR is the following:

* In `sync_once`, the code is as usual, until a response is received. If waiting on the response is cancelled, that's fine, no problem here. If a response has been received, we have passed the `.await` point, and now…
* handling the response happens in a new `Future` passed to `tokio::spawn`, and `sync_once` awaits on this task to finish. The code _inside_ the “response handling `Future`” runs, whatever we do. Cancelling the `sync_once` method/future won't cancel the “response handling `Future`”.

So now, we are ensuring that —if a response is received— handling it cannot be cancelled. Great! No more broken/corrupted state \o/.

But wait, if the `sync_once` method/future is cancelled, then the “response handling `Future`” is now running in detached mode. Many things can happen in this scenario. This is already what's happening now (like multiple responses can be apply concurrently on the same `SlidingStream` instance). We don't want this.

So, the part 2 of the solution proposed by this PR is the following:

* `SlidingSync` has a `response_handling_lock` lock, it's an `Arc<tokio::sync::Mutex<()>>`,
* The “response handling `Future`” will start by locking this `response_handling_lock`, and will release it once the response is fully handled.

Since `tokio::sync::Mutex` is fair, we are sure that responses are handled in the correct order.

And I believe, this solves the way we can **safely** cancel `SlidingSync::stream`.

I proppose to review this patch commit-by-commit as some refactoring was necessary. Most notably, all `SlidingSync`'s fields have been moved into a `SlidingSyncInner` type, and the new type is `SlidingSync { inner: Arc<SlidingSyncInner>, … }`. It results in a cleaner code with clearer intent, and much less `Arc`; it also helps to have a “global lock” (`response_handling_lock`).