### PR TITLE
Fix a race condition around some methods that get deduplicated

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -515,21 +515,21 @@ pub struct RoomInfo {
     /// The unique room id of the room.
     pub(crate) room_id: Arc<RoomId>,
     /// The type of the room.
-    pub(crate) room_type: RoomType,
+    room_type: RoomType,
     /// The unread notifications counts.
-    pub(crate) notification_counts: UnreadNotificationsCount,
+    notification_counts: UnreadNotificationsCount,
     /// The summary of this room.
-    pub(crate) summary: RoomSummary,
+    summary: RoomSummary,
     /// Flag remembering if the room members are synced.
-    pub(crate) members_synced: bool,
+    members_synced: bool,
     /// The prev batch of this room we received during the last sync.
     pub(crate) last_prev_batch: Option<String>,
     /// How much we know about this room.
     #[serde(default = "SyncInfo::complete")] // see fn docs for why we use this default
-    pub(crate) sync_info: SyncInfo,
+    sync_info: SyncInfo,
     /// Whether or not the encryption info was been synced.
     #[serde(default = "encryption_state_default")] // see fn docs for why we use this default
-    pub(crate) encryption_state_synced: bool,
+    encryption_state_synced: bool,
     /// Base room info which holds some basic event contents important for the
     /// room state.
     pub(crate) base_info: BaseRoomInfo,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 use std::{
+    collections::BTreeMap,
     fmt::{self, Debug},
     future::Future,
     pin::Pin,
@@ -159,11 +160,11 @@ pub(crate) struct ClientInner {
     /// Locks making sure we only have one group session sharing request in
     /// flight per room.
     #[cfg(feature = "e2e-encryption")]
-    pub(crate) group_session_locks: DashMap<OwnedRoomId, Arc<Mutex<()>>>,
+    pub(crate) group_session_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
     /// Lock making sure we're only doing one key claim request at a time.
     #[cfg(feature = "e2e-encryption")]
     pub(crate) key_claim_lock: Mutex<()>,
-    pub(crate) members_request_locks: DashMap<OwnedRoomId, Arc<Mutex<()>>>,
+    pub(crate) members_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
     /// Locks for requests on the encryption state of rooms.
     pub(crate) encryption_state_request_locks: DashMap<OwnedRoomId, Arc<Mutex<()>>>,
     pub(crate) typing_notice_times: DashMap<OwnedRoomId, Instant>,

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -391,16 +391,16 @@ impl Common {
         }
     }
 
-    pub(crate) async fn ensure_members(&self) -> Result<()> {
+    pub(crate) async fn ensure_members(&self) -> Result<Option<MembersResponse>> {
         if !self.are_events_visible() {
-            return Ok(());
+            return Ok(None);
         }
 
         if !self.are_members_synced() {
-            self.request_members().await?;
+            self.request_members().await
+        } else {
+            Ok(None)
         }
-
-        Ok(())
     }
 
     fn are_events_visible(&self) -> bool {
@@ -417,9 +417,10 @@ impl Common {
     /// Sync the member list with the server.
     ///
     /// This method will de-duplicate requests if it is called multiple times in
-    /// quick succession, in that case the return value will be `None`.
+    /// quick succession, in that case the return value will be `None`. This
+    /// method does nothing if the members are already synced.
     pub async fn sync_members(&self) -> Result<Option<MembersResponse>> {
-        self.request_members().await
+        self.ensure_members().await
     }
 
     /// Get active members for this room, includes invited, joined members.

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -621,7 +621,7 @@ impl Joined {
                 );
 
                 if !self.are_members_synced() {
-                    self.request_members().await?;
+                    self.ensure_members().await?;
                     // TODO query keys here?
                 }
 

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -1,7 +1,10 @@
 // The http mocking library is not supported for wasm32
 #![cfg(not(target_arch = "wasm32"))]
 
-use matrix_sdk::{config::RequestConfig, Client, ClientBuilder, Session};
+use matrix_sdk::{
+    config::{RequestConfig, SyncSettings},
+    Client, ClientBuilder, Session,
+};
 use matrix_sdk_test::test_json;
 use ruma::{api::MatrixVersion, device_id, user_id};
 use serde::Serialize;
@@ -47,6 +50,17 @@ async fn logged_in_client() -> (Client, MockServer) {
     };
     let (client, server) = no_retry_test_client().await;
     client.restore_session(session).await.unwrap();
+
+    (client, server)
+}
+
+async fn synced_client() -> (Client, MockServer) {
+    let (client, server) = logged_in_client().await;
+    mock_sync(&server, &*test_json::SYNC, None).await;
+
+    let sync_settings = SyncSettings::new();
+
+    let _response = client.sync_once(sync_settings).await.unwrap();
 
     (client, server)
 }

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use futures::future::join_all;
 use matrix_sdk::{
     attachment::{
         AttachmentConfig, AttachmentInfo, BaseImageInfo, BaseThumbnailInfo, BaseVideoInfo,
@@ -21,7 +22,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_encryption_state, mock_sync};
+use crate::{logged_in_client, mock_encryption_state, mock_sync, synced_client};
 
 #[async_test]
 async fn invite_user_by_id() {
@@ -496,7 +497,7 @@ async fn room_attachment_send_info_thumbnail() {
 
 #[async_test]
 async fn room_redact() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = synced_client().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/redact/.*?/.*?"))
@@ -504,12 +505,6 @@ async fn room_redact() {
         .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
         .mount(&server)
         .await;
-
-    mock_sync(&server, &*test_json::SYNC, None).await;
-
-    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
-
-    let _response = client.sync_once(sync_settings).await.unwrap();
 
     let room = client.get_joined_room(&test_json::DEFAULT_SYNC_ROOM_ID).unwrap();
 
@@ -520,4 +515,47 @@ async fn room_redact() {
     let response = room.redact(event_id, reason, Some(txn_id)).await.unwrap();
 
     assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fetch_members_deduplication() {
+    let (client, server) = synced_client().await;
+
+    // We don't need any members, we're just checking if we're correctly
+    // deduplicating calls to the method.
+    let response_body = json!({
+        "chunk": [],
+    });
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/members"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_body))
+        // Expect that we're only going to send the request out once.
+        .expect(1..=1)
+        .mount(&server)
+        .await;
+
+    let room = client.get_joined_room(&test_json::DEFAULT_SYNC_ROOM_ID).unwrap();
+
+    let mut tasks = Vec::new();
+
+    // Create N tasks that try to fetch the members.
+    for _ in 0..5 {
+        let task = tokio::spawn({
+            let room = room.clone();
+            async move { room.sync_members().await }
+        });
+
+        tasks.push(task);
+    }
+
+    // Wait on all of them at once.
+    let results = join_all(tasks).await;
+
+    // See how many of them sent a request and thus have a response.
+    let response_count =
+        results.iter().filter(|r| r.as_ref().unwrap().as_ref().unwrap().is_some()).count();
+    assert_eq!(response_count, 1);
 }


### PR DESCRIPTION
The first patch is the meat of the PR, i suggest this to be reviewed commit by commit.

The second patch makes it easier to ensure that some fields, i.e. the `members_synced` field, are only modified in one place of the codebase.

The third patch makes sure that syncing members only happens if it isn't already done so.