### PR TITLE
Skip installing `protoc` where it is unneeded

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -198,11 +198,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,11 +147,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       # Can't use `${{ matrix.* }}` inside uses
       - name: Install Rust
         if: matrix.rust == 'stable'
@@ -335,11 +330,6 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v3
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       # Can't use `${{ matrix.* }}` inside uses
       - name: Install Rust
         if: matrix.rust == 'stable'

--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -62,12 +62,6 @@ jobs:
           key: |
             ${{ steps.cachekey.outputs[format('cachekey-{0}', matrix.cachekey-id)] }}
 
-      - name: Install Protoc
-        if: steps.xtask-cache.outputs.cache-hit != 'true'
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install rust stable toolchain
         if: steps.xtask-cache.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
This seems to have been cargo-culted to lots of places where it is redundant.