### PR TITLE
Broadcast UnknownToken errors

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -27,6 +27,7 @@ use ruma::{
     OwnedServerName, ServerName,
 };
 use thiserror::Error;
+use tokio::sync::broadcast;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::sync::OnceCell;
 use tracing::{
@@ -419,6 +420,8 @@ impl ClientBuilder {
         #[cfg(feature = "experimental-sliding-sync")]
         let sliding_sync_proxy = sliding_sync_proxy.map(RwLock::new);
 
+        let (unknown_token_error_sender, _) = broadcast::channel(1);
+
         let inner = Arc::new(ClientInner {
             homeserver,
             authentication_issuer,
@@ -441,6 +444,7 @@ impl ClientBuilder {
             sync_beat: event_listener::Event::new(),
             handle_refresh_tokens: self.handle_refresh_tokens,
             refresh_token_lock: Mutex::new(Ok(())),
+            unknown_token_error_sender,
         });
 
         debug!("Done building the Client");

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -49,7 +49,7 @@ mod events;
 pub use account::Account;
 #[cfg(feature = "sso-login")]
 pub use client::SsoLoginBuilder;
-pub use client::{Client, ClientBuildError, ClientBuilder, LoginBuilder, LoopCtrl};
+pub use client::{Client, ClientBuildError, ClientBuilder, LoginBuilder, LoopCtrl, UnknownToken};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;
 pub use error::{Error, HttpError, HttpResult, RefreshTokenError, Result, RumaApiError};


### PR DESCRIPTION
Fixes vector-im/element-x-ios/issues/297 - Broadcast all UnknownToken errors, handle them on the FFI client side and send a `did_receive_auth_error` delegate call. 

The second step of this PR will be to get rid of the `is_soft_logout` flag from the Session and ClientState, I see no reason why we need to persist those anymore
