### PR TITLE
FFI client cleanup

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -10,7 +10,6 @@ interface ClientError {
 
 callback interface ClientDelegate {
     void did_receive_auth_error(boolean is_soft_logout);
-    void did_update_restore_token();
 };
 
 dictionary RequiredState {
@@ -208,7 +207,6 @@ dictionary Session {
     string user_id;
     string device_id;
     string homeserver_url;
-    boolean is_soft_logout;
     string? sliding_sync_proxy;
 };
 

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -9,7 +9,6 @@ interface ClientError {
 };
 
 callback interface ClientDelegate {
-    void did_receive_sync_update();
     void did_receive_auth_error(boolean is_soft_logout);
     void did_update_restore_token();
 };

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -11,7 +11,7 @@ use matrix_sdk::{
 use sanitize_filename_reader_friendly::sanitize;
 use zeroize::Zeroizing;
 
-use super::{client::Client, ClientState, RUNTIME};
+use super::{client::Client, RUNTIME};
 use crate::helpers::unwrap_or_clone_arc;
 
 #[derive(Clone)]
@@ -135,7 +135,7 @@ impl ClientBuilder {
 
         RUNTIME.block_on(async move {
             let client = inner_builder.build().await?;
-            let c = Client::new(client, ClientState::default());
+            let c = Client::new(client);
             c.set_sliding_sync_proxy(builder.sliding_sync_proxy);
             Ok(Arc::new(c))
         })

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -51,11 +51,6 @@ pub use self::{
     timeline::*,
 };
 
-#[derive(Default, Debug)]
-pub struct ClientState {
-    is_soft_logout: bool,
-}
-
 #[derive(thiserror::Error, Debug)]
 pub enum ClientError {
     #[error("client error: {msg}")]

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -53,9 +53,6 @@ pub use self::{
 
 #[derive(Default, Debug)]
 pub struct ClientState {
-    has_first_synced: bool,
-    is_syncing: bool,
-    should_stop_syncing: bool,
     is_soft_logout: bool,
 }
 


### PR DESCRIPTION
* remove now unused FFI Client `start_sync` method and related properties
* remove the `is_soft_logout` flag from the session, remove the `did_update_restore_token` ClientDelegate method and now empty `ClientState`. With the `UnkownToken` broadcast in place the `did_receive_auth_error(is_soft_logout)` delegate method will be invoked at all times. There's no need to store it in the session anymore and, if necessary, the final client can decide to store it next to the session instead of inside it