### PR TITLE
Fix races between `/sync` and `/keys/queries`

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -127,7 +127,7 @@ pub(crate) struct IdentityManager {
     failures: FailuresCache<OwnedServerName>,
     store: Store,
 
-    /// details of the current "in-flight" key query request, if any
+    /// Details of the current "in-flight" key query request, if any
     keys_query_request_details: Arc<Mutex<KeysQueryRequestDetails>>,
 }
 
@@ -1142,7 +1142,7 @@ pub(crate) mod tests {
         );
     }
 
-    /// if a user is invalidated while a /keys/query request is in flight, that
+    /// If a user is invalidated while a /keys/query request is in flight, that
     /// user is not removed from the list of outdated users when the
     /// response is received
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -196,7 +196,8 @@ impl IdentityManager {
         };
 
         self.store.save_changes(changes).await?;
-        self.mark_tracked_users_as_up_to_date(response.device_keys.keys().map(Deref::deref))
+        self.store
+            .mark_tracked_users_as_up_to_date(response.device_keys.keys().map(Deref::deref))
             .await?;
 
         let changed_devices = devices.changed.iter().fold(BTreeMap::new(), |mut acc, d| {
@@ -704,13 +705,6 @@ impl IdentityManager {
         users: impl IntoIterator<Item = &UserId>,
     ) -> StoreResult<()> {
         self.store.update_tracked_users(users.into_iter()).await
-    }
-
-    pub async fn mark_tracked_users_as_up_to_date(
-        &self,
-        users: impl Iterator<Item = &UserId>,
-    ) -> StoreResult<()> {
-        self.store.mark_tracked_users_as_up_to_date(users).await
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -719,7 +719,8 @@ impl IdentityManager {
         }
 
         let mut result: Vec<(OwnedTransactionId, KeysQueryRequest)> = Vec::new();
-        let mut kqrd = KeysQueryRequestDetails { sequence_number, request_ids: HashSet::new() };
+        let mut request_details =
+            KeysQueryRequestDetails { sequence_number, request_ids: HashSet::new() };
 
         let filtered_users: Vec<OwnedUserId> =
             users.into_iter().filter(|u| !self.failures.contains(u.server_name())).collect();
@@ -729,9 +730,9 @@ impl IdentityManager {
             let req = KeysQueryRequest::new(c.iter().map(|u| (u.clone(), Vec::new())).collect());
             debug!(?request_id, users = ?c, "Created keys query request");
             result.push((request_id.clone(), req));
-            kqrd.request_ids.insert(request_id);
+            request_details.request_ids.insert(request_id);
         }
-        *(self.keys_query_request_details.lock().await) = kqrd;
+        *(self.keys_query_request_details.lock().await) = request_details;
         Ok(result)
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -695,15 +695,7 @@ impl IdentityManager {
         &self,
         users: impl Iterator<Item = &UserId>,
     ) -> StoreResult<()> {
-        let mut changed_user: Vec<(&UserId, bool)> = Vec::new();
-
-        for user_id in users {
-            if self.store.is_user_tracked(user_id).await? {
-                changed_user.push((user_id, true))
-            }
-        }
-
-        self.store.save_tracked_users(&changed_user).await
+        self.store.mark_tracked_users_as_changed(users).await
     }
 
     /// See the docs for [`OlmMachine::update_tracked_users()`].
@@ -711,23 +703,14 @@ impl IdentityManager {
         &self,
         users: impl IntoIterator<Item = &UserId>,
     ) -> StoreResult<()> {
-        let mut tracked_users = Vec::new();
-
-        for user_id in users {
-            if !self.store.is_user_tracked(user_id).await? {
-                tracked_users.push((user_id, true));
-            }
-        }
-
-        self.store.save_tracked_users(&tracked_users).await
+        self.store.update_tracked_users(users.into_iter()).await
     }
 
     pub async fn mark_tracked_users_as_up_to_date(
         &self,
         users: impl Iterator<Item = &UserId>,
     ) -> StoreResult<()> {
-        let updated_users: Vec<(&UserId, bool)> = users.map(|u| (u, false)).collect();
-        self.store.save_tracked_users(&updated_users).await
+        self.store.mark_tracked_users_as_up_to_date(users).await
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1041,7 +1041,7 @@ pub(crate) mod tests {
         );
         manager.receive_device_changes([alice].iter().map(Deref::deref)).await.unwrap();
         assert!(
-            !manager.store.is_user_tracked(alice).await.unwrap(),
+            !manager.store.tracked_users().await.unwrap().contains(alice),
             "Receiving a device changes update for a user we don't track does nothing"
         );
         assert!(

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1203,7 +1203,6 @@ pub(crate) mod tests {
             .any(|(_, r)| r.device_keys.contains_key(alice)));
 
         // clearing the failure flag should make the user reappear in the query list.
-        // XXX: how is this meant to happen in the application?
         manager.failures.remove([alice.server_name().to_owned()].iter());
         assert!(manager
             .users_for_key_query()

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -692,10 +692,10 @@ impl Store {
     /// This means that the user will be considered for a `/keys/query` request
     /// next time [`Store::users_for_key_query()`] is called.
     pub async fn mark_user_as_changed(&self, user: &UserId) -> Result<()> {
-        (self.users_for_key_query.lock().await).insert_user(user);
+        self.users_for_key_query.lock().await.insert_user(user);
         self.tracked_users_cache.insert(user.to_owned());
-        self.inner.save_tracked_users(&[(user, true)]).await?;
-        Ok(())
+
+        self.inner.save_tracked_users(&[(user, true)]).await
     }
 
     /// Add entries to the list of users being tracked for device changes
@@ -704,9 +704,10 @@ impl Store {
     /// Users that were already in the list are unaffected.
     pub async fn update_tracked_users(&self, users: impl Iterator<Item = &UserId>) -> Result<()> {
         self.load_tracked_users().await?;
-        let mut store_updates: Vec<(&UserId, bool)> = Vec::new();
-
+        
+        let mut store_updates = Vec::new();
         let mut key_query_lock = self.users_for_key_query.lock().await;
+        
         for user_id in users {
             if !self.tracked_users_cache.contains(user_id) {
                 self.tracked_users_cache.insert(user_id.to_owned());
@@ -714,8 +715,8 @@ impl Store {
                 store_updates.push((user_id, true))
             }
         }
-        self.inner.save_tracked_users(&store_updates).await?;
-        Ok(())
+        
+        self.inner.save_tracked_users(&store_updates).await
     }
 
     /// Process notifications that users have changed devices.

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -613,12 +613,16 @@ impl Store {
         Ok(())
     }
 
-    /// Mark that the given user has an outdated device list.
+    /// Mark the given user as being tracked for device lists, and mark that it
+    /// has an outdated device list.
     ///
     /// This means that the user will be considered for a `/keys/query` request
     /// next time [`Store::users_for_key_query()`] is called.
     pub async fn mark_user_as_changed(&self, user: &UserId) -> Result<()> {
-        self.save_tracked_users(&[(user, true)]).await
+        self.users_for_key_query_cache.insert(user.to_owned());
+        self.tracked_users_cache.insert(user.to_owned());
+        self.inner.save_tracked_users(&[(user, true)]).await?;
+        Ok(())
     }
 
     /// Save the list of users and their outdated/dirty flags to the store.

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -120,8 +120,9 @@ struct UsersForKeyQuery {
     user_map: HashMap<OwnedUserId, InvalidationSequenceNumber>,
 }
 
-// We use a wrapping arithemetic for the sequence numbers, to make sure we never
-// run out of numbers.
+// We use wrapping arithmetic for the sequence numbers, to make sure we never
+// run out of numbers. (2**64 should be enough for anyone, but it's easy enough
+// just to make it wrap.)
 //
 // We use a *signed* counter so that we can compare values via a subtraction.
 // For example, suppose we've just overflowed from i64::MAX to i64::MIN.

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -112,10 +112,10 @@ pub(crate) struct Store {
 /// tell if any users have been invalidated more recently than that request.
 #[derive(Debug)]
 struct UsersForKeyQuery {
-    /// the sequence number we will assign to the next addition to user_map
+    /// The sequence number we will assign to the next addition to user_map
     next_sequence_number: InvalidationSequenceNumber,
 
-    /// the users pending a lookup, together with the sequence number at which
+    /// The users pending a lookup, together with the sequence number at which
     /// they were added to the list
     user_map: HashMap<OwnedUserId, InvalidationSequenceNumber>,
 }
@@ -125,12 +125,12 @@ struct UsersForKeyQuery {
 type InvalidationSequenceNumber = i64;
 
 impl UsersForKeyQuery {
-    /// create a new, empty, `UsersForKeyQueryCache`
+    /// Create a new, empty, `UsersForKeyQueryCache`
     fn new() -> Self {
         UsersForKeyQuery { next_sequence_number: 0, user_map: HashMap::new() }
     }
 
-    /// record a new user that requires a key query
+    /// Record a new user that requires a key query
     fn insert_user(&mut self, user: &UserId) {
         let seq = self.next_sequence_number;
         trace!(?user, sequence_number = seq, "Flagging user for key query");
@@ -138,7 +138,7 @@ impl UsersForKeyQuery {
         self.next_sequence_number += 1;
     }
 
-    /// record that a user has received an update with the given sequence
+    /// Record that a user has received an update with the given sequence
     /// number.
     ///
     /// If the sequence number is newer than the oldest invalidation for this
@@ -168,7 +168,7 @@ impl UsersForKeyQuery {
         }
     }
 
-    /// fetch the list of users waiting for a key query, and the current
+    /// Fetch the list of users waiting for a key query, and the current
     /// sequence number
     fn users_for_key_query(&self) -> (HashSet<OwnedUserId>, InvalidationSequenceNumber) {
         // we return the sequence number of the last invalidation

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -798,13 +798,6 @@ impl Store {
         Ok(())
     }
 
-    /// Are we tracking the list of devices this user has?
-    pub async fn is_user_tracked(&self, user_id: &UserId) -> Result<bool> {
-        self.load_tracked_users().await?;
-
-        Ok(self.tracked_users_cache.contains(user_id))
-    }
-
     /// Get the set of users that has the outdate/dirty flag set for their list
     /// of devices.
     ///

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -51,7 +51,7 @@ use matrix_sdk_common::locks::Mutex;
 use ruma::{events::secret::request::SecretName, DeviceId, OwnedDeviceId, OwnedUserId, UserId};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::{info, instrument, trace, warn};
+use tracing::{info, instrument, trace, warn, Span};
 use vodozemac::{megolm::SessionOrdering, Curve25519PublicKey};
 use zeroize::Zeroize;
 
@@ -160,6 +160,7 @@ impl UsersForKeyQuery {
         let last_invalidation = self.user_map.get(user);
 
         if let Some(invalidation_sequence) = last_invalidation {
+            Span::current().record("invalidation_sequence", invalidation_sequence);
             if invalidation_sequence.wrapping_sub(query_sequence) > 0 {
                 trace!("User invalidated since this query started: still not up-to-date");
                 false


### PR DESCRIPTION
This PR attempts to fix https://github.com/matrix-org/matrix-rust-sdk/issues/1386.

The comments in the code should explain the general approach, but to give an overview:

We assign a unique sequence number to each device-list-invalidation notice, and keep track of the sequence number at which each user was most recently invalidated. Then, when we build a `/keys/query` request, we take note of the current sequence number. Finally, when we get the response from that `/keys/query` request, we compare that sequence number with the most-recent-invalidation of each user that is now supposedly up-to-date. All of that means that we can see if the user has been invalidated *since* we built the `/keys/query` request, in which case our request may have raced against the new device, so we do not mark the user as up-to-date.

To make that work, we need to keep track of the sequence number for in-flight `/keys/query` requests; we do that in the `IdentityManager`. Since there should only ever be at most one batch of requests in flight, that is relatively easy; however, we also record the request ids just to check that the application isn't doing something weird.

There is no need to persist the sequence numbers to permanent storage: provided the `IdentityManager` and `Store` objects have a lifetime at least as long as an in-flight `/keys/query` request, it is sufficient just to retain the `dirty` bit in permanent storage, and then, when we reload the ephemeral `Store` cache, to treat everything with a `dirty` bit as a "new" invalidation.

I've attempted to break the PR down into coherent commits to help with review. It starts with a bit of light refactoring, before updating the `IdentityManager` to track the key requests, and finally the actual sequence number magic.

Fixes: #1386.