### PR TITLE
matrix-sdk-crypto: enable tracing for in-crate tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,6 +2734,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "cfg-if",
+ "ctor",
  "ctr",
  "dashmap",
  "event-listener",
@@ -2758,6 +2759,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "vodozemac",
  "zeroize",
 ]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -60,6 +60,7 @@ tokio = { version = "1.24", default-features = false, features = ["time"] }
 [dev-dependencies]
 anyhow = { workspace = true }
 assert_matches = "1.5.0"
+ctor.workspace = true
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }
 http = { workspace = true }
 indoc = "1.0.4"
@@ -67,3 +68,4 @@ matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 # required for async_test macro
 tokio = { version = "1.24.2", default-features = false, features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -109,3 +109,14 @@ pub mod vodozemac {
 
 /// The version of the matrix-sdk-cypto crate being used
 pub static VERSION: &str = env!("CARGO_PKG_VERSION");
+
+// Enable tracing for tests in this crate
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[ctor::ctor]
+fn init_logging() {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(tracing_subscriber::fmt::layer().with_test_writer())
+        .init();
+}


### PR DESCRIPTION
Add a crate constructor, somewhat cargo-culted from the other crates, to enable tracing output from the tests.