### PR TITLE
ci: Work around frequent codecov upload errors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,6 +55,9 @@ jobs:
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v3
       with:
+        # Work around frequent upload errors, for runs inside the main repo (not PRs from forks).
+        # Otherwise not required for public repos.
+        token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
         # The upload sometimes fails due to https://github.com/codecov/codecov-action/issues/837.
         # To make sure that the failure gets flagged clearly in the UI, fail the action.
         fail_ci_if_error: true


### PR DESCRIPTION
Specify a token for codecov. According to codecov, this should fix the upload issues, which are related to rate limiting in GitHub's API. They might still happen for external contributors, but maybe if we just reduce our API usage this way, rate limiting isn't going to be a problem anymore.