### PR TITLE
A little bit of cleanup

### DIFF
--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -82,7 +82,6 @@ impl RawMemberEvent {
 }
 
 /// Wrapper around both MemberEvent-Types
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum MemberEvent {
     /// A member event from a room in joined or left state.

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -25,7 +25,7 @@ use ruma::{
     serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, UserId,
 };
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// A change in ambiguity of room members that an `m.room.member` event
 /// triggers.
@@ -83,7 +83,7 @@ impl RawMemberEvent {
 
 /// Wrapper around both MemberEvent-Types
 #[allow(clippy::large_enum_variant)]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug)]
 pub enum MemberEvent {
     /// A member event from a room in joined or left state.
     Sync(SyncRoomMemberEvent),

--- a/xtask/src/kotlin.rs
+++ b/xtask/src/kotlin.rs
@@ -160,7 +160,7 @@ fn build_for_android_target(
     // The builtin dev profile has its files stored under target/debug, all
     // other targets have matching directory names
     let profile_dir_name = if profile == "dev" { "debug" } else { profile };
-    let package_camel = package_name.replace("-", "_");
+    let package_camel = package_name.replace('-', "_");
     let lib_name = format!("lib{package_camel}.so");
     Ok(workspace::target_path()?.join(target).join(profile_dir_name).join(lib_name))
 }


### PR DESCRIPTION
This is an event type that was deserializing from serde's weird default `{ "Tag": { /* enum fields */ } }` enum representation. Hopefully nobody is using this impl, but since `Serialize` was already not implemented either, chances are very low this was used.