### PR TITLE
Upgrade UniFFI, use proc-macros more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5658,8 +5658,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "uniffi"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71cc01459bc34cfe43fabf32b39f1228709bc6db1b3a664a92940af3d062376"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "anyhow",
  "camino",
@@ -5680,8 +5679,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbba5103051c18f10b22f80a74439ddf7100273f217a547005d2735b2498994"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "anyhow",
  "askama",
@@ -5704,8 +5702,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1a28368ff3d83717e3d3e2e15a66269c43488c3f036914131bb68892f29fb"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "anyhow",
  "camino",
@@ -5715,8 +5712,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03de61393a42b4ad4984a3763c0600594ac3e57e5aaa1d05cede933958987c03"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "quote",
  "syn",
@@ -5725,8 +5721,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2b4852d638d74ca2d70e450475efb6d91fe6d54a7cd8d6bd80ad2ee6cd7daa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5741,8 +5736,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa03394de21e759e0022f1ea8d992d2e39290d735b9ed52b1f74b20a684f794e"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "bincode",
  "camino",
@@ -5760,8 +5754,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fdab2c436aed7a6391bec64204ec33948bfed9b11b303235740771f85c4ea6"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "serde",
  "siphasher",
@@ -5771,8 +5764,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b0570953ec41d97ce23e3b92161ac18231670a1f97523258a6d2ab76d7f76c"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "anyhow",
  "camino",
@@ -6056,8 +6048,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4#58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ serde_html_form = "0.2.0"
 serde_json = "1.0.91"
 thiserror = "1.0.38"
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
-uniffi = "0.23.0"
-uniffi_bindgen = "0.23.0"
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "58758341b72e9e8ff51ecd57a3eb22d6cc41a4b4" }
 vodozemac = { git = "https://github.com/matrix-org/vodozemac", rev = "fb609ca1e4df5a7a818490ae86ac694119e41e71" }
 zeroize = "1.3.0"
 

--- a/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
@@ -27,8 +27,7 @@ pub enum PkDecryptionError {
 }
 
 /// Error type for the decoding and storing of the backup key.
-#[derive(Debug, Error, uniffi::Error)]
-#[uniffi(flat_error)]
+#[derive(Debug, Error)]
 pub enum DecodeError {
     /// An error happened while decoding the recovery key.
     #[error(transparent)]
@@ -41,7 +40,7 @@ pub enum DecodeError {
 
 /// Struct containing info about the way the backup key got derived from a
 /// passphrase.
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Clone)]
 pub struct PassphraseInfo {
     /// The salt that was used during key derivation.
     pub private_key_salt: String,

--- a/bindings/matrix-sdk-crypto-ffi/src/error.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/error.rs
@@ -39,8 +39,7 @@ pub enum SignatureError {
     UnknownUserIdentity(String),
 }
 
-#[derive(Debug, thiserror::Error, uniffi::Error)]
-#[uniffi(flat_error)]
+#[derive(Debug, thiserror::Error)]
 pub enum CryptoStoreError {
     #[error("Failed to open the store")]
     OpenStore(#[from] OpenStoreError),

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -553,6 +553,7 @@ impl From<HistoryVisibility> for RustHistoryVisibility {
 /// These settings control which algorithm the room key should use, how long a
 /// room key should be used and some other important information that determines
 /// the lifetime of a room key.
+#[derive(uniffi::Record)]
 pub struct EncryptionSettings {
     /// The encryption algorithm that should be used in the room.
     pub algorithm: EventEncryptionAlgorithm,

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -717,10 +717,14 @@ mod uniffi_types {
         backup_recovery_key::{
             BackupRecoveryKey, DecodeError, MegolmV1BackupKey, PassphraseInfo, PkDecryptionError,
         },
-        error::CryptoStoreError,
-        machine::OlmMachine,
-        responses::Request,
-        BackupKeys, CrossSigningStatus, RoomKeyCounts,
+        error::{CryptoStoreError, DecryptionError, SecretImportError},
+        machine::{KeyRequestPair, OlmMachine},
+        responses::{BootstrapCrossSigningResult, DeviceLists, Request},
+        verification::{
+            RequestVerificationResult, StartSasResult, Verification, VerificationRequest,
+        },
+        BackupKeys, CrossSigningKeyExport, CrossSigningStatus, DecryptedEvent, EncryptionSettings,
+        RoomKeyCounts,
     };
 }
 

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -47,6 +47,7 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Runtime;
+use uniffi_api::*;
 pub use users::UserIdentity;
 pub use verification::{
     CancelInfo, ConfirmVerificationResult, QrCode, QrCodeListener, QrCodeState,

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -450,7 +450,10 @@ impl OlmMachine {
 
         Ok(())
     }
+}
 
+#[uniffi::export]
+impl OlmMachine {
     /// Let the state machine know about E2EE related sync changes that we
     /// received from the server.
     ///
@@ -468,12 +471,12 @@ impl OlmMachine {
     /// * `key_counts` - The map of uploaded one-time key types and counts.
     pub fn receive_sync_changes(
         &self,
-        events: &str,
+        events: String,
         device_changes: DeviceLists,
         key_counts: HashMap<String, i32>,
         unused_fallback_keys: Option<Vec<String>>,
     ) -> Result<String, CryptoStoreError> {
-        let to_device: ToDevice = serde_json::from_str(events)?;
+        let to_device: ToDevice = serde_json::from_str(&events)?;
         let device_changes: RumaDeviceLists = device_changes.into();
         let key_counts: BTreeMap<DeviceKeyAlgorithm, UInt> = key_counts
             .into_iter()
@@ -528,8 +531,8 @@ impl OlmMachine {
     ///
     /// A user can be marked for tracking using the
     /// [`OlmMachine::update_tracked_users()`] method.
-    pub fn is_user_tracked(&self, user_id: &str) -> Result<bool, CryptoStoreError> {
-        let user_id = parse_user_id(user_id)?;
+    pub fn is_user_tracked(&self, user_id: String) -> Result<bool, CryptoStoreError> {
+        let user_id = parse_user_id(&user_id)?;
         Ok(self.runtime.block_on(self.inner.tracked_users())?.contains(&user_id))
     }
 
@@ -581,7 +584,7 @@ impl OlmMachine {
     /// * `settings` - The settings that should be used for the room key.
     pub fn share_room_key(
         &self,
-        room_id: &str,
+        room_id: String,
         users: Vec<String>,
         settings: EncryptionSettings,
     ) -> Result<Vec<Request>, CryptoStoreError> {
@@ -633,16 +636,16 @@ impl OlmMachine {
     /// * `content` - The serialized content of the event.
     pub fn encrypt(
         &self,
-        room_id: &str,
-        event_type: &str,
-        content: &str,
+        room_id: String,
+        event_type: String,
+        content: String,
     ) -> Result<String, CryptoStoreError> {
         let room_id = RoomId::parse(room_id)?;
-        let content: Value = serde_json::from_str(content)?;
+        let content: Value = serde_json::from_str(&content)?;
 
         let encrypted_content = self
             .runtime
-            .block_on(self.inner.encrypt_room_event_raw(&room_id, content, event_type))
+            .block_on(self.inner.encrypt_room_event_raw(&room_id, content, &event_type))
             .expect("Encrypting an event produced an error");
 
         Ok(serde_json::to_string(&encrypted_content)?)
@@ -657,8 +660,8 @@ impl OlmMachine {
     /// * `room_id` - The unique id of the room where the event was sent to.
     pub fn decrypt_room_event(
         &self,
-        event: &str,
-        room_id: &str,
+        event: String,
+        room_id: String,
         handle_verification_events: bool,
     ) -> Result<DecryptedEvent, DecryptionError> {
         // Element Android wants only the content and the type and will create a
@@ -672,7 +675,7 @@ impl OlmMachine {
             content: &'a RawValue,
         }
 
-        let event: Raw<_> = serde_json::from_str(event)?;
+        let event: Raw<_> = serde_json::from_str(&event)?;
         let room_id = RoomId::parse(room_id)?;
 
         let decrypted = self.runtime.block_on(self.inner.decrypt_room_event(&event, &room_id))?;
@@ -727,10 +730,10 @@ impl OlmMachine {
     /// * `room_id` - The id of the room the event was sent to.
     pub fn request_room_key(
         &self,
-        event: &str,
-        room_id: &str,
+        event: String,
+        room_id: String,
     ) -> Result<KeyRequestPair, DecryptionError> {
-        let event: Raw<_> = serde_json::from_str(event)?;
+        let event: Raw<_> = serde_json::from_str(&event)?;
         let room_id = RoomId::parse(room_id)?;
 
         let (cancel, request) =
@@ -753,17 +756,19 @@ impl OlmMachine {
     /// passphrase into an key.
     pub fn export_room_keys(
         &self,
-        passphrase: &str,
+        passphrase: String,
         rounds: i32,
     ) -> Result<String, CryptoStoreError> {
         let keys = self.runtime.block_on(self.inner.export_room_keys(|_| true))?;
 
-        let encrypted = encrypt_room_key_export(&keys, passphrase, rounds as u32)
+        let encrypted = encrypt_room_key_export(&keys, &passphrase, rounds as u32)
             .map_err(CryptoStoreError::Serialization)?;
 
         Ok(encrypted)
     }
+}
 
+impl OlmMachine {
     fn import_room_keys_helper(
         &self,
         keys: Vec<ExportedRoomKey>,
@@ -838,10 +843,13 @@ impl OlmMachine {
 
         self.import_room_keys_helper(keys, true, progress_listener)
     }
+}
 
+#[uniffi::export]
+impl OlmMachine {
     /// Discard the currently active room key for the given room if there is
     /// one.
-    pub fn discard_room_key(&self, room_id: &str) -> Result<(), CryptoStoreError> {
+    pub fn discard_room_key(&self, room_id: String) -> Result<(), CryptoStoreError> {
         let room_id = RoomId::parse(room_id)?;
 
         self.runtime.block_on(self.inner.invalidate_group_session(&room_id))?;
@@ -857,8 +865,8 @@ impl OlmMachine {
     /// **Note**: This has been deprecated.
     pub fn receive_unencrypted_verification_event(
         &self,
-        event: &str,
-        room_id: &str,
+        event: String,
+        room_id: String,
     ) -> Result<(), CryptoStoreError> {
         self.receive_verification_event(event, room_id)
     }
@@ -869,11 +877,11 @@ impl OlmMachine {
     /// in rooms to the `OlmMachine`. The event should be in the decrypted form.
     pub fn receive_verification_event(
         &self,
-        event: &str,
-        room_id: &str,
+        event: String,
+        room_id: String,
     ) -> Result<(), CryptoStoreError> {
         let room_id = RoomId::parse(room_id)?;
-        let event: AnySyncMessageLikeEvent = serde_json::from_str(event)?;
+        let event: AnySyncMessageLikeEvent = serde_json::from_str(&event)?;
 
         let event = event.into_full_event(room_id);
 
@@ -888,7 +896,7 @@ impl OlmMachine {
     ///
     /// * `user_id` - The ID of the user for which we would like to fetch the
     /// verification requests.
-    pub fn get_verification_requests(&self, user_id: &str) -> Vec<Arc<VerificationRequest>> {
+    pub fn get_verification_requests(&self, user_id: String) -> Vec<Arc<VerificationRequest>> {
         let Ok(user_id) = UserId::parse(user_id) else {
             return vec![];
         };
@@ -913,8 +921,8 @@ impl OlmMachine {
     /// * `flow_id` - The ID that uniquely identifies the verification flow.
     pub fn get_verification_request(
         &self,
-        user_id: &str,
-        flow_id: &str,
+        user_id: String,
+        flow_id: String,
     ) -> Option<Arc<VerificationRequest>> {
         let user_id = UserId::parse(user_id).ok()?;
 
@@ -934,10 +942,10 @@ impl OlmMachine {
     /// support.
     pub fn verification_request_content(
         &self,
-        user_id: &str,
+        user_id: String,
         methods: Vec<String>,
     ) -> Result<Option<String>, CryptoStoreError> {
-        let user_id = parse_user_id(user_id)?;
+        let user_id = parse_user_id(&user_id)?;
 
         let identity = self.runtime.block_on(self.inner.get_identity(&user_id, None))?;
 
@@ -974,12 +982,12 @@ impl OlmMachine {
     /// [verification_request_content()]: #method.verification_request_content
     pub fn request_verification(
         &self,
-        user_id: &str,
-        room_id: &str,
-        event_id: &str,
+        user_id: String,
+        room_id: String,
+        event_id: String,
         methods: Vec<String>,
     ) -> Result<Option<Arc<VerificationRequest>>, CryptoStoreError> {
-        let user_id = parse_user_id(user_id)?;
+        let user_id = parse_user_id(&user_id)?;
         let event_id = EventId::parse(event_id)?;
         let room_id = RoomId::parse(room_id)?;
 
@@ -1016,17 +1024,18 @@ impl OlmMachine {
     /// supported in the `m.key.verification.request` event.
     pub fn request_verification_with_device(
         &self,
-        user_id: &str,
-        device_id: &str,
+        user_id: String,
+        device_id: String,
         methods: Vec<String>,
     ) -> Result<Option<RequestVerificationResult>, CryptoStoreError> {
-        let user_id = parse_user_id(user_id)?;
+        let user_id = parse_user_id(&user_id)?;
+        let device_id = device_id.as_str().into();
 
         let methods = methods.into_iter().map(VerificationMethod::from).collect();
 
         Ok(
             if let Some(device) =
-                self.runtime.block_on(self.inner.get_device(&user_id, device_id.into(), None))?
+                self.runtime.block_on(self.inner.get_device(&user_id, device_id, None))?
             {
                 let (verification, request) =
                     self.runtime.block_on(device.request_verification_with_methods(methods));
@@ -1085,11 +1094,11 @@ impl OlmMachine {
     /// verification.
     ///
     /// * `flow_id` - The ID that uniquely identifies the verification flow.
-    pub fn get_verification(&self, user_id: &str, flow_id: &str) -> Option<Arc<Verification>> {
+    pub fn get_verification(&self, user_id: String, flow_id: String) -> Option<Arc<Verification>> {
         let user_id = UserId::parse(user_id).ok()?;
 
         self.inner
-            .get_verification(&user_id, flow_id)
+            .get_verification(&user_id, &flow_id)
             .map(|v| Verification { inner: v, runtime: self.runtime.handle().to_owned() }.into())
     }
 
@@ -1109,14 +1118,15 @@ impl OlmMachine {
     /// [request_verification_with_device()]: #method.request_verification_with_device
     pub fn start_sas_with_device(
         &self,
-        user_id: &str,
-        device_id: &str,
+        user_id: String,
+        device_id: String,
     ) -> Result<Option<StartSasResult>, CryptoStoreError> {
-        let user_id = parse_user_id(user_id)?;
+        let user_id = parse_user_id(&user_id)?;
+        let device_id = device_id.as_str().into();
 
         Ok(
             if let Some(device) =
-                self.runtime.block_on(self.inner.get_device(&user_id, device_id.into(), None))?
+                self.runtime.block_on(self.inner.get_device(&user_id, device_id, None))?
             {
                 let (sas, request) = self.runtime.block_on(device.start_verification())?;
 
@@ -1159,10 +1169,7 @@ impl OlmMachine {
 
         Ok(())
     }
-}
 
-#[uniffi::export]
-impl OlmMachine {
     /// Activate the given backup key to be used with the given backup version.
     ///
     /// **Warning**: The caller needs to make sure that the given `BackupKey` is

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -71,11 +71,6 @@ enum DecryptionError {
     "Store",
 };
 
-dictionary DeviceLists {
-    sequence<string> changed;
-    sequence<string> left;
-};
-
 dictionary KeysImportResult {
     i64 imported;
     i64 total;
@@ -335,14 +330,6 @@ enum HistoryVisibility {
     "Joined",
     "Shared",
     "WorldReadable",
-};
-
-dictionary EncryptionSettings {
-    EventEncryptionAlgorithm algorithm;
-    u64 rotation_period;
-    u64 rotation_period_msgs;
-    HistoryVisibility history_visibility;
-    boolean only_allow_trusted_devices;
 };
 
 interface OlmMachine {

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -355,11 +355,6 @@ interface OlmMachine {
     );
 
     [Throws=CryptoStoreError]
-    string receive_sync_changes([ByRef] string events,
-                              DeviceLists device_changes,
-                              record<DOMString, i32> key_counts,
-                              sequence<string>? unused_fallback_keys);
-    [Throws=CryptoStoreError]
     sequence<Request> outgoing_requests();
     [Throws=CryptoStoreError]
     void mark_request_as_sent(
@@ -367,11 +362,6 @@ interface OlmMachine {
         RequestType request_type,
         [ByRef] string response
     );
-
-    [Throws=DecryptionError]
-    DecryptedEvent decrypt_room_event([ByRef] string event, [ByRef] string room_id, boolean handle_verificaton_events);
-    [Throws=CryptoStoreError]
-    string encrypt([ByRef] string room_id, [ByRef] string event_type, [ByRef] string content);
 
     [Throws=CryptoStoreError]
     UserIdentity? get_identity([ByRef] string user_id, u32 timeout);
@@ -386,56 +376,6 @@ interface OlmMachine {
     [Throws=CryptoStoreError]
     sequence<Device> get_user_devices([ByRef] string user_id, u32 timeout);
 
-    [Throws=CryptoStoreError]
-    boolean is_user_tracked([ByRef] string user_id);
-    [Throws=CryptoStoreError]
-    void update_tracked_users(sequence<string> users);
-    [Throws=CryptoStoreError]
-    Request? get_missing_sessions(sequence<string> users);
-    [Throws=CryptoStoreError]
-    sequence<Request> share_room_key(
-        [ByRef] string room_id,
-        sequence<string> users,
-        EncryptionSettings settings
-    );
-
-    [Throws=CryptoStoreError]
-    void receive_unencrypted_verification_event([ByRef] string event, [ByRef] string room_id);
-    [Throws=CryptoStoreError]
-    void receive_verification_event([ByRef] string event, [ByRef] string room_id);
-    sequence<VerificationRequest> get_verification_requests([ByRef] string user_id);
-    VerificationRequest? get_verification_request([ByRef] string user_id, [ByRef] string flow_id);
-    Verification? get_verification([ByRef] string user_id, [ByRef] string flow_id);
-
-    [Throws=CryptoStoreError]
-    VerificationRequest? request_verification(
-        [ByRef] string user_id,
-        [ByRef] string room_id,
-        [ByRef] string event_id,
-        sequence<string> methods
-    );
-    [Throws=CryptoStoreError]
-    string? verification_request_content(
-        [ByRef] string user_id,
-        sequence<string> methods
-    );
-    [Throws=CryptoStoreError]
-    RequestVerificationResult? request_self_verification(sequence<string> methods);
-    [Throws=CryptoStoreError]
-    RequestVerificationResult? request_verification_with_device(
-        [ByRef] string user_id,
-        [ByRef] string device_id,
-        sequence<string> methods
-    );
-
-    [Throws=CryptoStoreError]
-    StartSasResult? start_sas_with_device([ByRef] string user_id, [ByRef] string device_id);
-
-    [Throws=DecryptionError]
-    KeyRequestPair request_room_key([ByRef] string event, [ByRef] string room_id);
-
-    [Throws=CryptoStoreError]
-    string export_room_keys([ByRef] string passphrase, i32 rounds);
     [Throws=KeyImportError]
     KeysImportResult import_room_keys(
         [ByRef] string keys,
@@ -447,14 +387,7 @@ interface OlmMachine {
         [ByRef] string keys,
         ProgressListener progress_listener
     );
-    [Throws=CryptoStoreError]
-    void discard_room_key([ByRef] string room_id);
 
-    [Throws=CryptoStoreError]
-    BootstrapCrossSigningResult bootstrap_cross_signing();
-    CrossSigningKeyExport? export_cross_signing_keys();
-    [Throws=SecretImportError]
-    void import_cross_signing_keys(CrossSigningKeyExport export);
     [Throws=CryptoStoreError]
     boolean is_identity_verified([ByRef] string user_id);
 

--- a/bindings/matrix-sdk-crypto-ffi/src/olm.udl
+++ b/bindings/matrix-sdk-crypto-ffi/src/olm.udl
@@ -14,12 +14,11 @@ namespace matrix_sdk_crypto_ffi {
         string? passphrase,
         ProgressListener progress_listener
     );
-
 };
 
 [Error]
 interface MigrationError {
-  Generic(string error_message);
+    Generic(string error_message);
 };
 
 callback interface Logger {
@@ -168,12 +167,12 @@ interface Sas {
 
 [Enum]
 interface SasState {
-  Started();
-  Accepted();
-  KeysExchanged(sequence<i32>? emojis, sequence<i32> decimals);
-  Confirmed();
-  Done();
-  Cancelled(CancelInfo cancel_info);
+    Started();
+    Accepted();
+    KeysExchanged(sequence<i32>? emojis, sequence<i32> decimals);
+    Confirmed();
+    Done();
+    Cancelled(CancelInfo cancel_info);
 };
 
 callback interface SasListener {
@@ -208,12 +207,12 @@ interface QrCode {
 
 [Enum]
 interface QrCodeState {
-  Started();
-  Scanned();
-  Confirmed();
-  Reciprocated();
-  Done();
-  Cancelled(CancelInfo cancel_info);
+    Started();
+    Scanned();
+    Confirmed();
+    Reciprocated();
+    Done();
+    Cancelled(CancelInfo cancel_info);
 };
 
 callback interface QrCodeListener {
@@ -252,10 +251,10 @@ interface VerificationRequest {
 
 [Enum]
 interface VerificationRequestState {
-  Requested();
-  Ready(sequence<string> their_methods, sequence<string> our_methods);
-  Done();
-  Cancelled(CancelInfo cancel_info);
+    Requested();
+    Ready(sequence<string> their_methods, sequence<string> our_methods);
+    Done();
+    Cancelled(CancelInfo cancel_info);
 };
 
 callback interface VerificationRequestListener {

--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -112,7 +112,7 @@ impl From<ToDeviceRequest> for OutgoingVerificationRequest {
     }
 }
 
-#[derive(Debug, uniffi::Enum)]
+#[derive(Debug)]
 pub enum Request {
     ToDevice { request_id: String, event_type: String, body: String },
     KeysUpload { request_id: String, body: String },

--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -231,6 +231,7 @@ pub enum RequestType {
     RoomMessage,
 }
 
+#[derive(uniffi::Record)]
 pub struct DeviceLists {
     pub changed: Vec<String>,
     pub left: Vec<String>,

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -39,7 +39,7 @@ pub struct Room {
     timeline: TimelineLock,
 }
 
-#[derive(Clone, uniffi::Enum)]
+#[derive(Clone)]
 pub enum MembershipState {
     /// The user is banned.
     Ban,

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -254,7 +254,6 @@ pub struct UpdateSummary {
     pub rooms: Vec<String>,
 }
 
-#[derive(uniffi::Record)]
 pub struct RequiredState {
     pub key: String,
     pub value: String,
@@ -324,7 +323,7 @@ impl From<VectorDiff<MatrixRoomEntry>> for SlidingSyncListRoomsListDiff {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Enum)]
+#[derive(Clone, Debug)]
 pub enum RoomListEntry {
     Empty,
     Invalidated { room_id: String },


### PR DESCRIPTION
Taking the upgrade commit from #1587, and converting a fallible functions to prove it's possible and reduce UDL file size.

The `&str` to `String` change can be undone once the proc-macros support `&str`. AFAIK it doesn't make a difference for the generated bindings, right?