### PR TITLE
Add createRoom UniFFI binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=543c03f8f2d0f5a357b6be41cc0e166aa58cce63#543c03f8f2d0f5a357b6be41cc0e166aa58cce63"
+source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
 dependencies = [
  "assign",
  "js_int",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=543c03f8f2d0f5a357b6be41cc0e166aa58cce63#543c03f8f2d0f5a357b6be41cc0e166aa58cce63"
+source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=543c03f8f2d0f5a357b6be41cc0e166aa58cce63#543c03f8f2d0f5a357b6be41cc0e166aa58cce63"
+source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
 dependencies = [
  "assign",
  "bytes",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=543c03f8f2d0f5a357b6be41cc0e166aa58cce63#543c03f8f2d0f5a357b6be41cc0e166aa58cce63"
+source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=543c03f8f2d0f5a357b6be41cc0e166aa58cce63#543c03f8f2d0f5a357b6be41cc0e166aa58cce63"
+source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4378,7 +4378,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=543c03f8f2d0f5a357b6be41cc0e166aa58cce63#543c03f8f2d0f5a357b6be41cc0e166aa58cce63"
+source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=543c03f8f2d0f5a357b6be41cc0e166aa58cce63#543c03f8f2d0f5a357b6be41cc0e166aa58cce63"
+source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
 dependencies = [
  "once_cell",
  "proc-macro-crate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
+source = "git+https://github.com/ruma/ruma?rev=03a58bcd883f2830c77aeafc95da789513f748b3#03a58bcd883f2830c77aeafc95da789513f748b3"
 dependencies = [
  "assign",
  "js_int",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
+source = "git+https://github.com/ruma/ruma?rev=03a58bcd883f2830c77aeafc95da789513f748b3#03a58bcd883f2830c77aeafc95da789513f748b3"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
+source = "git+https://github.com/ruma/ruma?rev=03a58bcd883f2830c77aeafc95da789513f748b3#03a58bcd883f2830c77aeafc95da789513f748b3"
 dependencies = [
  "assign",
  "bytes",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
+source = "git+https://github.com/ruma/ruma?rev=03a58bcd883f2830c77aeafc95da789513f748b3#03a58bcd883f2830c77aeafc95da789513f748b3"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
+source = "git+https://github.com/ruma/ruma?rev=03a58bcd883f2830c77aeafc95da789513f748b3#03a58bcd883f2830c77aeafc95da789513f748b3"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4378,7 +4378,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
+source = "git+https://github.com/ruma/ruma?rev=03a58bcd883f2830c77aeafc95da789513f748b3#03a58bcd883f2830c77aeafc95da789513f748b3"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=4eb5033dd0d7c5c6e751fd858bc6763519dbd021#4eb5033dd0d7c5c6e751fd858bc6763519dbd021"
+source = "git+https://github.com/ruma/ruma?rev=03a58bcd883f2830c77aeafc95da789513f748b3#03a58bcd883f2830c77aeafc95da789513f748b3"
 dependencies = [
  "once_cell",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ eyeball = "0.1.4"
 eyeball-im = "0.1.0"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
-ruma = { git = "https://github.com/ruma/ruma", rev = "4eb5033dd0d7c5c6e751fd858bc6763519dbd021", features = ["client-api-c"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "4eb5033dd0d7c5c6e751fd858bc6763519dbd021" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "03a58bcd883f2830c77aeafc95da789513f748b3", features = ["client-api-c"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "03a58bcd883f2830c77aeafc95da789513f748b3" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ eyeball = "0.1.4"
 eyeball-im = "0.1.0"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
-ruma = { git = "https://github.com/ruma/ruma", rev = "543c03f8f2d0f5a357b6be41cc0e166aa58cce63", features = ["client-api-c"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "543c03f8f2d0f5a357b6be41cc0e166aa58cce63" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "4eb5033dd0d7c5c6e751fd858bc6763519dbd021", features = ["client-api-c"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "4eb5033dd0d7c5c6e751fd858bc6763519dbd021" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -169,14 +169,16 @@ enum RoomVisibility {
 };
 
 enum RoomPreset {
-    /// `join_rules` is set to `invite` and `history_visibility` is set to `shared`.
+    /// `join_rules` is set to `invite` and `history_visibility` is set to
+    /// `shared`.
     "PrivateChat",
 
-    /// `join_rules` is set to `public` and `history_visibility` is set to `shared`.
+    /// `join_rules` is set to `public` and `history_visibility` is set to
+    /// `shared`.
     "PublicChat",
 
-    /// Same as `PrivateChat`, but all initial invitees get the same power level as the
-    /// creator.
+    /// Same as `PrivateChat`, but all initial invitees get the same power level
+    /// as the creator.
     "TrustedPrivateChat",
 };
 

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -152,6 +152,7 @@ interface SlidingSyncBuilder {
 dictionary CreateRoomParameters {
     string name;
     string? topic;
+    boolean is_encrypted;
     boolean is_direct;
     RoomVisibility visibility;
     RoomPreset preset;

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -151,13 +151,13 @@ interface SlidingSyncBuilder {
 
 dictionary CreateRoomParameters {
     string name;
-    string? topic;
+    string? topic = null;
     boolean is_encrypted;
-    boolean is_direct;
+    boolean is_direct = false;
     RoomVisibility visibility;
     RoomPreset preset;
-    sequence<string>? invite;
-    string? avatar;
+    sequence<string>? invite = null;
+    string? avatar = null;
 };
 
 enum RoomVisibility {

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -153,10 +153,26 @@ dictionary CreateRoomParameters {
     string name;
     string? topic;
     boolean is_direct;
-    Visibility visibility;
-    Preset preset;
+    RoomVisibility visibility;
+    RoomPreset preset;
     sequence<string>? invite;
     string? avatar;
+};
+
+enum RoomVisibility {
+    /// Indicates that the room will be shown in the published room list.
+    "Public",
+
+    /// Indicates that the room will not be shown in the published room list.
+    "Private",
+};
+
+enum RoomPreset {
+    /// `join_rules` is set to `invite` and `history_visibility` is set to `shared`.
+    "PrivateChat",
+
+    /// `join_rules` is set to `public` and `history_visibility` is set to `shared`.
+    "PublicChat",
 };
 
 interface Client {

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -173,6 +173,10 @@ enum RoomPreset {
 
     /// `join_rules` is set to `public` and `history_visibility` is set to `shared`.
     "PublicChat",
+
+    /// Same as `PrivateChat`, but all initial invitees get the same power level as the
+    /// creator.
+    "TrustedPrivateChat",
 };
 
 interface Client {

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -213,6 +213,9 @@ interface Client {
     string device_id();
 
     [Throws=ClientError]
+    string create_room(CreateRoomParameters request);
+
+    [Throws=ClientError]
     string? account_data(string event_type);
 
     [Throws=ClientError]

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -149,6 +149,16 @@ interface SlidingSyncBuilder {
     SlidingSync build();
 };
 
+dictionary CreateRoomParameters {
+    string name;
+    string? topic;
+    boolean is_direct;
+    Visibility visibility;
+    Preset preset;
+    sequence<string>? invite;
+    string? avatar;
+};
+
 interface Client {
     void set_delegate(ClientDelegate? delegate);
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -406,7 +406,8 @@ pub struct CreateRoomParameters {
     pub is_direct: bool,
     pub visibility: Visibility,
     pub preset: create_room::v3::RoomPreset,
-    pub invite: Option<Vec<String>>
+    pub invite: Option<Vec<String>>,
+    pub avatar: Option<String>
 }
 
 impl From<CreateRoomParameters> for create_room::v3::Request  {
@@ -427,6 +428,11 @@ impl From<CreateRoomParameters> for create_room::v3::Request  {
             },
             None => vec![]
         };
+        
+        // need a way to inject the avatar url in the request
+        // let avatar = AnyInitialStateEvent::RoomAvatar(...);
+        // request.initial_state.push(avatar);
+
         request
     }
 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -401,8 +401,8 @@ pub struct CreateRoomParameters {
     pub name: String,
     pub topic: Option<String>,
     pub is_direct: bool,
-    pub visibility: Visibility,
-    pub preset: create_room::v3::RoomPreset,
+    pub visibility: RoomVisibility,
+    pub preset: RoomPreset,
     pub invite: Option<Vec<String>>,
     pub avatar: Option<String>,
 }
@@ -413,8 +413,8 @@ impl From<CreateRoomParameters> for create_room::v3::Request {
         request.name = Some(value.name);
         request.topic = value.topic;
         request.is_direct = value.is_direct;
-        request.visibility = value.visibility;
-        request.preset = Some(value.preset);
+        request.visibility = value.visibility.into();
+        request.preset = Some(value.preset.into());
         request.invite = match value.invite {
             Some(invite) => invite.iter().filter_map(|user_id| 
                 match UserId::parse(user_id) {
@@ -433,6 +433,40 @@ impl From<CreateRoomParameters> for create_room::v3::Request {
         // request.initial_state.push(avatar);
 
         request
+    }
+}
+
+pub enum RoomVisibility {
+    /// Indicates that the room will be shown in the published room list.
+    Public,
+
+    /// Indicates that the room will not be shown in the published room list.
+    Private,
+}
+
+impl From<RoomVisibility> for Visibility {
+    fn from(value: RoomVisibility) -> Self {
+        match value {
+            RoomVisibility::Public => Self::Public,
+            RoomVisibility::Private => Self::Private,
+        }
+    }
+}
+
+pub enum RoomPreset {
+    /// `join_rules` is set to `invite` and `history_visibility` is set to `shared`.
+    PrivateChat,
+
+    /// `join_rules` is set to `public` and `history_visibility` is set to `shared`.
+    PublicChat,
+}
+
+impl From<RoomPreset> for create_room::v3::RoomPreset {
+    fn from(value: RoomPreset) -> Self {
+        match value {
+            RoomPreset::PrivateChat => Self::PrivateChat,
+            RoomPreset::PublicChat => Self::PublicChat,
+        }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -473,14 +473,16 @@ impl From<RoomVisibility> for Visibility {
 }
 
 pub enum RoomPreset {
-    /// `join_rules` is set to `invite` and `history_visibility` is set to `shared`.
+    /// `join_rules` is set to `invite` and `history_visibility` is set to
+    /// `shared`.
     PrivateChat,
 
-    /// `join_rules` is set to `public` and `history_visibility` is set to `shared`.
+    /// `join_rules` is set to `public` and `history_visibility` is set to
+    /// `shared`.
     PublicChat,
 
-    /// Same as `PrivateChat`, but all initial invitees get the same power level as the
-    /// creator.
+    /// Same as `PrivateChat`, but all initial invitees get the same power level
+    /// as the creator.
     TrustedPrivateChat,
 }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -11,7 +11,7 @@ use matrix_sdk::{
             room::{create_room, Visibility},
             session::get_login_types,
         },
-        events::{room::MediaSource, AnyToDeviceEvent},
+        events::{room::MediaSource, AnyToDeviceEvent, AnyInitialStateEvent, room::avatar::RoomAvatarEventContent, InitialStateEvent},
         serde::Raw,
         TransactionId, UInt, UserId,
     },
@@ -428,9 +428,15 @@ impl From<CreateRoomParameters> for create_room::v3::Request {
             None => vec![],
         };
 
-        // need a way to inject the avatar url in the request
-        // let avatar = AnyInitialStateEvent::RoomAvatar(...);
-        // request.initial_state.push(avatar);
+
+        let mut initial_state: Vec<Raw<AnyInitialStateEvent>> = vec![];
+
+        if let Some(url) = value.avatar {
+            let mut content = RoomAvatarEventContent::new();
+            let mut avatar = InitialStateEvent::new(content);
+        }
+
+        request.initial_state = initial_state;
 
         request
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{
         },
         events::{room::MediaSource, AnyToDeviceEvent},
         serde::Raw,
-        TransactionId, UInt,
+        OwnedUserId, TransactionId, UInt,
     },
     Client as MatrixClient, Error, LoopCtrl,
 };
@@ -243,6 +243,20 @@ impl Client {
     pub fn device_id(&self) -> anyhow::Result<String> {
         let device_id = self.client.device_id().context("No Device ID found")?;
         Ok(device_id.to_string())
+    }
+
+    pub fn create_room(&self, invite: Vec<OwnedUserId>) -> anyhow::Result<()> {
+        let client = self.client.clone();
+
+        RUNTIME.block_on(async move {
+            let mut request = ruma::api::client::room::create_room::v3::Request::new();
+            request.invite = invite;
+
+            let response = client.create_room(request).await?;
+            let _id = response.room_id();
+
+            Ok(())
+        })
     }
 
     /// Get the content of the event of the given type out of the account data

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -7,6 +7,7 @@ use matrix_sdk::{
         api::client::{
             account::whoami, error::ErrorKind, media::get_content_thumbnail::v3::Method,
             session::get_login_types,
+            room::Visibility
         },
         events::{room::MediaSource, AnyToDeviceEvent},
         serde::Raw,
@@ -245,11 +246,12 @@ impl Client {
         Ok(device_id.to_string())
     }
 
-    pub fn create_room(&self, invite: Vec<OwnedUserId>) -> anyhow::Result<()> {
+    pub fn create_room(&self, visibility: Visibility, invite: Vec<OwnedUserId>) -> anyhow::Result<()> {
         let client = self.client.clone();
 
         RUNTIME.block_on(async move {
             let mut request = ruma::api::client::room::create_room::v3::Request::new();
+            request.visibility = visibility;
             request.invite = invite;
 
             let response = client.create_room(request).await?;


### PR DESCRIPTION
This PR adds the [createRoom](https://matrix.org/docs/spec/client_server/r0.6.1#post-matrix-client-r0-createroom) UniFFI binding.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1615