### PR TITLE
feat(sdk): Move `Client.root_span` inside `ClientInner`

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -450,12 +450,6 @@ impl ClientBuilder {
 
         debug!("Done building the Client");
 
-        // We drop the root span here so it gets pushed to the subscribers, i.e. it gets
-        // only uploaded to a OpenTelemetry collector if the span gets dropped.
-        // We still want it around so other methods that get called by this
-        // client instance are connected to it, so we clone.
-        // drop(self.root_span.clone());
-
         Ok(Client { inner })
     }
 }

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -445,6 +445,7 @@ impl ClientBuilder {
             handle_refresh_tokens: self.handle_refresh_tokens,
             refresh_token_lock: Mutex::new(Ok(())),
             unknown_token_error_sender,
+            root_span: self.root_span,
         });
 
         debug!("Done building the Client");
@@ -453,9 +454,9 @@ impl ClientBuilder {
         // only uploaded to a OpenTelemetry collector if the span gets dropped.
         // We still want it around so other methods that get called by this
         // client instance are connected to it, so we clone.
-        drop(self.root_span.clone());
+        // drop(self.root_span.clone());
 
-        Ok(Client { inner, root_span: self.root_span })
+        Ok(Client { inner })
     }
 }
 

--- a/crates/matrix-sdk/src/client/login_builder.rs
+++ b/crates/matrix-sdk/src/client/login_builder.rs
@@ -158,7 +158,7 @@ impl LoginBuilder {
     /// Instead of calling this function and `.await`ing its return value, you
     /// can also `.await` the `LoginBuilder` directly.
     #[instrument(
-        parent = &self.client.root_span,
+        parent = &self.client.inner.root_span,
         target = "matrix_sdk::client",
         name = "login",
         skip_all,
@@ -296,7 +296,7 @@ where
     /// Instead of calling this function and `.await`ing its return value, you
     /// can also `.await` the `SsoLoginBuilder` directly.
     #[instrument(
-        parent = &self.client.root_span,
+        parent = &self.client.inner.root_span,
         target = "matrix_sdk::client",
         name = "login",
         skip_all,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -140,7 +140,6 @@ pub struct UnknownToken {
 #[derive(Clone)]
 pub struct Client {
     pub(crate) inner: Arc<ClientInner>,
-    pub(crate) root_span: Span,
 }
 
 pub(crate) struct ClientInner {
@@ -193,6 +192,8 @@ pub(crate) struct ClientInner {
     /// Client API UnknownToken error publisher. Allows the subscriber logout
     /// the user when any request fails because of an invalid access token
     pub(crate) unknown_token_error_sender: broadcast::Sender<UnknownToken>,
+    /// Root span for `tracing`.
+    pub(crate) root_span: Span,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -1208,13 +1209,14 @@ impl Client {
             }
         }
 
-        self.root_span
+        self.inner
+            .root_span
             .record("user_id", display(&response.user_id))
             .record("device_id", display(&response.device_id));
 
         #[cfg(feature = "e2e-encryption")]
         if let Some(key) = self.encryption().ed25519_key().await {
-            self.root_span.record("ed25519_key", key);
+            self.inner.root_span.record("ed25519_key", key);
         }
 
         self.inner.base_client.receive_login_response(response).await?;
@@ -1281,13 +1283,14 @@ impl Client {
     /// ```
     ///
     /// [`login`]: #method.login
-    #[instrument(skip_all, parent = &self.root_span)]
+    #[instrument(skip_all, parent = &self.inner.root_span)]
     pub async fn restore_session(&self, session: Session) -> Result<()> {
         debug!("Restoring session");
 
         let (meta, tokens) = session.into_parts();
 
-        self.root_span
+        self.inner
+            .root_span
             .record("user_id", display(&meta.user_id))
             .record("device_id", display(&meta.device_id));
 
@@ -1296,7 +1299,7 @@ impl Client {
 
         #[cfg(feature = "e2e-encryption")]
         if let Some(key) = self.encryption().ed25519_key().await {
-            self.root_span.record("ed25519_key", key);
+            self.inner.root_span.record("ed25519_key", key);
         }
 
         debug!("Done restoring session");
@@ -1483,7 +1486,7 @@ impl Client {
     /// client.register(request).await;
     /// # })
     /// ```
-    #[instrument(skip_all, parent = &self.root_span)]
+    #[instrument(skip_all, parent = &self.inner.root_span)]
     pub async fn register(
         &self,
         request: register::v3::Request,
@@ -1546,7 +1549,7 @@ impl Client {
     ///
     /// let response = client.sync_once(sync_settings).await.unwrap();
     /// # });
-    #[instrument(skip(self, definition), parent = &self.root_span)]
+    #[instrument(skip(self, definition), parent = &self.inner.root_span)]
     pub async fn get_or_upload_filter(
         &self,
         filter_name: &str,
@@ -2273,7 +2276,7 @@ impl Client {
     ///     .await;
     /// })
     /// ```
-    #[instrument(skip_all, parent = &self.root_span)]
+    #[instrument(skip_all, parent = &self.inner.root_span)]
     pub async fn sync_with_callback<C>(
         &self,
         sync_settings: crate::config::SyncSettings,
@@ -2428,7 +2431,7 @@ impl Client {
     ///
     /// # anyhow::Ok(()) });
     /// ```
-    #[instrument(skip(self), parent = &self.root_span)]
+    #[instrument(skip(self), parent = &self.inner.root_span)]
     pub async fn sync_stream(
         &self,
         mut sync_settings: crate::config::SyncSettings,

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -85,7 +85,7 @@ impl Joined {
     }
 
     /// Leave this room.
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn leave(&self) -> Result<Left> {
         self.inner.leave().await
     }
@@ -97,7 +97,7 @@ impl Joined {
     /// * `user_id` - The user to ban with `UserId`.
     ///
     /// * `reason` - The reason for banning this user.
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn ban_user(&self, user_id: &UserId, reason: Option<&str>) -> Result<()> {
         let request = assign!(
             ban_user::v3::Request::new(self.inner.room_id().to_owned(), user_id.to_owned()),
@@ -115,7 +115,7 @@ impl Joined {
     ///   room.
     ///
     /// * `reason` - Optional reason why the room member is being kicked out.
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn kick_user(&self, user_id: &UserId, reason: Option<&str>) -> Result<()> {
         let request = assign!(
             kick_user::v3::Request::new(self.inner.room_id().to_owned(), user_id.to_owned()),
@@ -130,7 +130,7 @@ impl Joined {
     /// # Arguments
     ///
     /// * `user_id` - The `UserId` of the user to invite to the room.
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn invite_user_by_id(&self, user_id: &UserId) -> Result<()> {
         let recipient = InvitationRecipient::UserId { user_id: user_id.to_owned() };
 
@@ -145,7 +145,7 @@ impl Joined {
     /// # Arguments
     ///
     /// * `invite_id` - A third party id of a user to invite to the room.
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn invite_user_by_3pid(&self, invite_id: Invite3pid) -> Result<()> {
         let recipient = InvitationRecipient::ThirdPartyId(invite_id);
         let request = invite_user::v3::Request::new(self.inner.room_id().to_owned(), recipient);
@@ -219,7 +219,7 @@ impl Joined {
         Ok(())
     }
 
-    #[instrument(name = "typing_notice", skip(self), parent = &self.client.root_span)]
+    #[instrument(name = "typing_notice", skip(self), parent = &self.client.inner.root_span)]
     async fn send_typing_notice(&self, typing: bool) -> Result<()> {
         let typing = if typing {
             self.client
@@ -256,7 +256,7 @@ impl Joined {
     ///   [`ReceiptType::FullyRead`].
     ///
     /// * `event_id` - The `EventId` of the event to set the receipt on.
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn send_single_receipt(
         &self,
         receipt_type: ReceiptType,
@@ -281,7 +281,7 @@ impl Joined {
     /// * `receipts` - The `Receipts` to send.
     ///
     /// If `receipts` is empty, this is a no-op.
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn send_multiple_receipts(&self, receipts: Receipts) -> Result<()> {
         if receipts.is_empty() {
             return Ok(());
@@ -329,7 +329,7 @@ impl Joined {
     /// }
     /// # anyhow::Ok(()) });
     /// ```
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn enable_encryption(&self) -> Result<()> {
         use ruma::{
             events::room::encryption::RoomEncryptionEventContent, EventEncryptionAlgorithm,
@@ -430,7 +430,7 @@ impl Joined {
     /// Warning: This waits until a sync happens and does not return if no sync
     /// is happening! It can also return early when the room is not a joined
     /// room anymore!
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn sync_up(&self) {
         while !self.is_synced() && self.room_type() == RoomType::Joined {
             self.client.inner.sync_beat.listen().wait_timeout(Duration::from_secs(1));
@@ -701,7 +701,7 @@ impl Joined {
     /// }
     /// # anyhow::Ok(()) });
     /// ```
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn send_attachment(
         &self,
         body: &str,
@@ -901,7 +901,7 @@ impl Joined {
     /// joined_room.send_state_event(content).await?;
     /// # anyhow::Ok(()) };
     /// ```
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn send_state_event(
         &self,
         content: impl StateEventContent<StateKey = EmptyStateKey>,
@@ -1001,7 +1001,7 @@ impl Joined {
     /// }
     /// # anyhow::Ok(()) });
     /// ```
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn send_state_event_raw(
         &self,
         content: Value,
@@ -1052,7 +1052,7 @@ impl Joined {
     /// }
     /// # anyhow::Ok(()) });
     /// ```
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn redact(
         &self,
         event_id: &EventId,

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -263,7 +263,7 @@ impl Timeline {
     ///
     /// [`MessageLikeUnsigned`]: ruma::events::MessageLikeUnsigned
     /// [`SyncMessageLikeEvent`]: ruma::events::SyncMessageLikeEvent
-    #[instrument(skip(self, content), parent = &self.inner.room().client.root_span, fields(room_id = ?self.room().room_id()))]
+    #[instrument(skip(self, content), parent = &self.inner.room().client.inner.root_span, fields(room_id = ?self.room().room_id()))]
     pub async fn send(&self, content: AnyMessageLikeEventContent, txn_id: Option<&TransactionId>) {
         let txn_id = txn_id.map_or_else(TransactionId::new, ToOwned::to_owned);
         self.inner.handle_local_event(txn_id.clone(), content.clone()).await;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1139,7 +1139,7 @@ impl SlidingSync {
     ///
     /// This stream will send requests and will handle responses automatically,
     /// hence updating the lists.
-    #[instrument(name = "sync_stream", skip_all, parent = &self.inner.client.root_span)]
+    #[instrument(name = "sync_stream", skip_all, parent = &self.inner.client.inner.root_span)]
     pub fn stream(&self) -> impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_ {
         // Collect all the lists that need to be updated.
         let list_generators = {

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -100,7 +100,7 @@ impl SlidingSyncRoom {
     ///
     /// Use `Timeline::latest_event` instead if you already have a timeline for
     /// this `SlidingSyncRoom`.
-    #[instrument(skip_all, parent = &self.client.root_span)]
+    #[instrument(skip_all, parent = &self.client.inner.root_span)]
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
         self.timeline_builder()?.build().await.latest_event().await
     }


### PR DESCRIPTION
This patch moves `Client.root_span` inside `ClientInner`. That way, when cloning `Client`, we don't clone the `root_span: Span` everytime.

Try to fix https://github.com/matrix-org/matrix-rust-sdk/pull/1587 one commit at a time.