### PR TITLE
Upgrade to eyeball 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,14 +1484,12 @@ dependencies = [
 
 [[package]]
 name = "eyeball"
-version = "0.1.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3609348664c9c1b07d9ff3933a466beaa4d197fb393b5d41ffda349458867626"
+checksum = "3c7be1d67275032c662cadf525a79aef6909469579c5d81c69c148f7257257af"
 dependencies = [
  "futures-core",
  "readlock",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -4133,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "readlock"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8f0cb425ba44d6bde0d063097aae68a2ce31e1d5359e96427704f33f4f73d9"
+checksum = "35c8a22130504d1f661d1bc373b424f2d45910fa5319132d903a4074e1527b2e"
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,12 +700,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
- "clap_derive 4.1.0",
+ "clap_derive 4.1.8",
  "clap_lex 0.3.1",
  "is-terminal",
  "once_cell",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1391,7 +1391,7 @@ name = "example-emoji-verification"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.1.6",
+ "clap 4.1.8",
  "futures",
  "matrix-sdk",
  "tokio",
@@ -1463,7 +1463,7 @@ name = "example-timeline"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.1.6",
+ "clap 4.1.8",
  "futures",
  "matrix-sdk",
  "tokio",
@@ -2286,7 +2286,7 @@ version = "0.2.0"
 dependencies = [
  "app_dirs2",
  "chrono",
- "clap 4.1.6",
+ "clap 4.1.8",
  "dialoguer",
  "eyeball",
  "eyeball-im",
@@ -6254,7 +6254,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "camino",
- "clap 4.1.6",
+ "clap 4.1.8",
  "fs_extra",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ base64 = "0.21.0"
 byteorder = "1.4.3"
 ctor = "0.1.26"
 dashmap = "5.2.0"
-eyeball = "0.1.4"
+eyeball = "0.4.0"
 eyeball-im = "0.1.0"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -147,7 +147,7 @@ impl AuthenticationService {
             })
             .map_err(AuthenticationError::from)?;
 
-        let details = RUNTIME.block_on(async { self.details_from_client(&client).await })?;
+        let details = RUNTIME.block_on(self.details_from_client(&client))?;
 
         // Now we've verified that it's a valid homeserver, make sure
         // there's a sliding sync proxy available one way or another.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -377,7 +377,8 @@ impl Client {
 impl Client {
     /// The homeserver this client is configured to use.
     pub fn homeserver(&self) -> String {
-        RUNTIME.block_on(async move { self.async_homeserver().await })
+        #[allow(unknown_lints, clippy::redundant_async_block)] // false positive
+        RUNTIME.block_on(self.async_homeserver())
     }
 
     pub fn rooms(&self) -> Vec<Arc<Room>> {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -250,7 +250,8 @@ impl Room {
             .unwrap()
             .get_or_insert_with(|| {
                 let room = self.room.clone();
-                let timeline = RUNTIME.block_on(async move { room.timeline().await });
+                #[allow(unknown_lints, clippy::redundant_async_block)] // false positive
+                let timeline = RUNTIME.block_on(room.timeline());
                 Arc::new(timeline)
             })
             .clone();

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -194,8 +194,8 @@ impl SlidingSyncRoom {
             }
         };
 
-        let (timeline_items, timeline_stream) =
-            RUNTIME.block_on(async { timeline.subscribe().await });
+        #[allow(unknown_lints, clippy::redundant_async_block)] // false positive
+        let (timeline_items, timeline_stream) = RUNTIME.block_on(timeline.subscribe());
 
         let handle_events = async move {
             let listener: Arc<dyn TimelineListener> = listener.into();

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, RwLock};
 
 use anyhow::Context;
-use eyeball::Observable;
+use eyeball::unique::Observable;
 use eyeball_im::VectorDiff;
 use futures_util::{future::join, pin_mut, StreamExt};
 use matrix_sdk::ruma::{

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -134,7 +134,7 @@ impl BaseClient {
     /// Get the session tokens.
     ///
     /// This returns a subscriber object that you can use both to
-    /// [`get`](SharedSubscriber::get) the current value as well as to react to
+    /// [`get`](Subscriber::get) the current value as well as to react to
     /// changes to the tokens.
     ///
     /// If the client is currently logged in, the inner value is a

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -17,12 +17,11 @@ use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
     fmt,
-    sync::RwLockReadGuard as StdRwLockReadGuard,
 };
 #[cfg(feature = "e2e-encryption")]
 use std::{ops::Deref, sync::Arc};
 
-use eyeball::Observable;
+use eyeball::Subscriber;
 use matrix_sdk_common::{instant::Instant, locks::RwLock};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_crypto::{
@@ -134,10 +133,14 @@ impl BaseClient {
 
     /// Get the session tokens.
     ///
-    /// If the client is currently logged in, this will return a
+    /// This returns a subscriber object that you can use both to
+    /// [`get`](SharedSubscriber::get) the current value as well as to react to
+    /// changes to the tokens.
+    ///
+    /// If the client is currently logged in, the inner value is a
     /// [`SessionTokens`] object which contains the access token and optional
-    /// refresh token. Otherwise it returns `None`.
-    pub fn session_tokens(&self) -> StdRwLockReadGuard<'_, Observable<Option<SessionTokens>>> {
+    /// refresh token. Otherwise it is `None`.
+    pub fn session_tokens(&self) -> Subscriber<Option<SessionTokens>> {
         self.store.session_tokens()
     }
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -27,10 +27,10 @@ use std::{
     pin::Pin,
     result::Result as StdResult,
     str::Utf8Error,
-    sync::{Arc, RwLockReadGuard as StdRwLockReadGuard},
+    sync::Arc,
 };
 
-use eyeball::{Observable, SharedObservable};
+use eyeball::{shared::Observable as SharedObservable, Subscriber};
 use once_cell::sync::OnceCell;
 
 #[cfg(any(test, feature = "testing"))]
@@ -210,8 +210,8 @@ impl Store {
 
     /// The [`SessionTokens`] containing our access token and optional refresh
     /// token.
-    pub fn session_tokens(&self) -> StdRwLockReadGuard<'_, Observable<Option<SessionTokens>>> {
-        self.session_tokens.read()
+    pub fn session_tokens(&self) -> Subscriber<Option<SessionTokens>> {
+        self.session_tokens.subscribe()
     }
 
     /// Set the current [`SessionTokens`].
@@ -223,7 +223,7 @@ impl Store {
     /// token and optional refresh token.
     pub fn session(&self) -> Option<Session> {
         let meta = self.session_meta.get()?;
-        let tokens = self.session_tokens().clone()?;
+        let tokens = self.session_tokens().get()?;
         Some(Session::from_parts(meta.to_owned(), tokens))
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1066,6 +1066,7 @@ pub(crate) mod tests {
 
         let listener = manager.listen_for_received_queries();
 
+        #[allow(unknown_lints, clippy::redundant_async_block)] // false positive
         let task = tokio::task::spawn(async move { listener.wait(Duration::from_secs(10)).await });
 
         manager

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -14,7 +14,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use eyeball::{Observable, SharedObservable};
+use eyeball::shared::{Observable as SharedObservable, ObservableWriteGuard};
 use futures_core::Stream;
 use futures_util::StreamExt;
 use matrix_sdk_common::instant::Instant;
@@ -159,7 +159,7 @@ impl RequestHandle {
     pub fn cancel_with_code(&self, cancel_code: &CancelCode) {
         let mut guard = self.inner.write();
         if let Some(updated) = guard.cancel(true, cancel_code) {
-            Observable::set(&mut guard, updated);
+            ObservableWriteGuard::set(&mut guard, updated);
         }
     }
 }
@@ -207,7 +207,7 @@ impl VerificationRequest {
     pub(crate) fn request_to_device(&self) -> ToDeviceRequest {
         let inner = self.inner.read();
 
-        let methods = if let InnerRequest::Created(c) = &**inner {
+        let methods = if let InnerRequest::Created(c) = &*inner {
             c.state.our_methods.clone()
         } else {
             SUPPORTED_METHODS.to_vec()
@@ -263,7 +263,7 @@ impl VerificationRequest {
 
     /// The id of the other device that is participating in this verification.
     pub fn other_device_id(&self) -> Option<OwnedDeviceId> {
-        match &**self.inner.read() {
+        match &*self.inner.read() {
             InnerRequest::Requested(r) => Some(r.state.other_device_id.clone()),
             InnerRequest::Ready(r) => Some(r.state.other_device_id.clone()),
             InnerRequest::Created(_)
@@ -284,7 +284,7 @@ impl VerificationRequest {
     /// Get info about the cancellation if the verification request has been
     /// cancelled.
     pub fn cancel_info(&self) -> Option<CancelInfo> {
-        if let InnerRequest::Cancelled(c) = &**self.inner.read() {
+        if let InnerRequest::Cancelled(c) = &*self.inner.read() {
             Some(c.state.clone().into())
         } else {
             None
@@ -293,12 +293,12 @@ impl VerificationRequest {
 
     /// Has the verification request been answered by another device.
     pub fn is_passive(&self) -> bool {
-        matches!(**self.inner.read(), InnerRequest::Passive(_))
+        matches!(*self.inner.read(), InnerRequest::Passive(_))
     }
 
     /// Is the verification request ready to start a verification flow.
     pub fn is_ready(&self) -> bool {
-        matches!(**self.inner.read(), InnerRequest::Ready(_))
+        matches!(*self.inner.read(), InnerRequest::Ready(_))
     }
 
     /// Has the verification flow timed out.
@@ -311,7 +311,7 @@ impl VerificationRequest {
     /// Will be present only if the other side requested the verification or if
     /// we're in the ready state.
     pub fn their_supported_methods(&self) -> Option<Vec<VerificationMethod>> {
-        match &**self.inner.read() {
+        match &*self.inner.read() {
             InnerRequest::Requested(r) => Some(r.state.their_methods.clone()),
             InnerRequest::Ready(r) => Some(r.state.their_methods.clone()),
             InnerRequest::Created(_)
@@ -326,7 +326,7 @@ impl VerificationRequest {
     /// Will be present only we requested the verification or if we're in the
     /// ready state.
     pub fn our_supported_methods(&self) -> Option<Vec<VerificationMethod>> {
-        match &**self.inner.read() {
+        match &*self.inner.read() {
             InnerRequest::Created(r) => Some(r.state.our_methods.clone()),
             InnerRequest::Ready(r) => Some(r.state.our_methods.clone()),
             InnerRequest::Requested(_)
@@ -353,20 +353,20 @@ impl VerificationRequest {
 
     /// Has the verification flow that was started with this request finished.
     pub fn is_done(&self) -> bool {
-        matches!(**self.inner.read(), InnerRequest::Done(_))
+        matches!(*self.inner.read(), InnerRequest::Done(_))
     }
 
     /// Has the verification flow that was started with this request been
     /// cancelled.
     pub fn is_cancelled(&self) -> bool {
-        matches!(**self.inner.read(), InnerRequest::Cancelled(_))
+        matches!(*self.inner.read(), InnerRequest::Cancelled(_))
     }
 
     /// Generate a QR code that can be used by another client to start a QR code
     /// based verification.
     #[cfg(feature = "qrcode")]
     pub async fn generate_qr_code(&self) -> Result<Option<QrVerification>, CryptoStoreError> {
-        let inner = self.inner.get();
+        let inner = self.inner.read();
 
         inner.generate_qr_code(self.we_started, self.inner.clone().into()).await
     }
@@ -383,7 +383,7 @@ impl VerificationRequest {
         &self,
         data: QrVerificationData,
     ) -> Result<Option<QrVerification>, ScanError> {
-        let future = if let InnerRequest::Ready(r) = &**self.inner.read() {
+        let future = if let InnerRequest::Ready(r) = &*self.inner.read() {
             QrVerification::from_scan(
                 r.store.clone(),
                 r.other_user_id.clone(),
@@ -465,7 +465,7 @@ impl VerificationRequest {
             return None;
         };
 
-        Observable::set(&mut guard, updated);
+        ObservableWriteGuard::set(&mut guard, updated);
 
         let request = match content {
             OutgoingContent::ToDevice(content) => ToDeviceRequest::with_id(
@@ -507,14 +507,14 @@ impl VerificationRequest {
     fn cancel_with_code(&self, cancel_code: CancelCode) -> Option<OutgoingVerificationRequest> {
         let mut guard = self.inner.write();
 
-        let send_to_everyone = self.we_started() && matches!(**guard, InnerRequest::Created(_));
+        let send_to_everyone = self.we_started() && matches!(*guard, InnerRequest::Created(_));
         let other_device = guard.other_device_id();
 
         if let Some(updated) = guard.cancel(true, &cancel_code) {
-            Observable::set(&mut guard, updated);
+            ObservableWriteGuard::set(&mut guard, updated);
         }
 
-        let content = if let InnerRequest::Cancelled(c) = &**guard {
+        let content = if let InnerRequest::Cancelled(c) = &*guard {
             Some(c.state.as_content(self.flow_id()))
         } else {
             None
@@ -632,10 +632,10 @@ impl VerificationRequest {
     pub(crate) fn receive_ready(&self, sender: &UserId, content: &ReadyContent<'_>) {
         let mut guard = self.inner.write();
 
-        match &**guard {
+        match &*guard {
             InnerRequest::Created(s) => {
                 let new_value = InnerRequest::Ready(s.clone().into_ready(sender, content));
-                Observable::set(&mut guard, new_value);
+                ObservableWriteGuard::set(&mut guard, new_value);
 
                 if let Some(request) =
                     self.cancel_for_other_devices(CancelCode::Accepted, Some(content.from_device()))
@@ -647,7 +647,7 @@ impl VerificationRequest {
                 if sender == self.own_user_id() && content.from_device() != self.account.device_id()
                 {
                     let new_value = InnerRequest::Passive(s.clone().into_passive(content));
-                    Observable::set(&mut guard, new_value);
+                    ObservableWriteGuard::set(&mut guard, new_value);
                 }
             }
             InnerRequest::Ready(_)
@@ -686,7 +686,7 @@ impl VerificationRequest {
 
             let mut guard = self.inner.write();
             if let Some(updated) = guard.receive_done(content) {
-                Observable::set(&mut guard, updated);
+                ObservableWriteGuard::set(&mut guard, updated);
             }
         }
     }
@@ -703,7 +703,7 @@ impl VerificationRequest {
         );
         let mut guard = self.inner.write();
         if let Some(updated) = guard.cancel(false, content.cancel_code()) {
-            Observable::set(&mut guard, updated);
+            ObservableWriteGuard::set(&mut guard, updated);
         }
 
         if self.we_started() {
@@ -781,7 +781,7 @@ impl VerificationRequest {
     /// To listen to changes to the [`VerificationRequestState`] use the
     /// [`VerificationRequest::changes`] method.
     pub fn state(&self) -> VerificationRequestState {
-        (&**self.inner.read()).into()
+        (&*self.inner.read()).into()
     }
 }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -25,7 +25,6 @@ use std::{
 #[cfg(target_arch = "wasm32")]
 use async_once_cell::OnceCell;
 use dashmap::DashMap;
-use eyeball::Observable;
 use futures_core::Stream;
 use futures_util::StreamExt;
 use matrix_sdk_base::{
@@ -367,7 +366,7 @@ impl Client {
     ///
     /// [refreshing access tokens]: https://spec.matrix.org/v1.3/client-server-api/#refreshing-access-tokens
     pub fn session_tokens(&self) -> Option<SessionTokens> {
-        self.base_client().session_tokens().clone()
+        self.base_client().session_tokens().get()
     }
 
     /// Get the current access token for this session.
@@ -502,7 +501,7 @@ impl Client {
     ///
     /// [refreshing access tokens]: https://spec.matrix.org/v1.3/client-server-api/#refreshing-access-tokens
     pub fn session_tokens_stream(&self) -> impl Stream<Item = Option<SessionTokens>> {
-        Observable::subscribe(&self.base_client().session_tokens())
+        self.base_client().session_tokens()
     }
 
     /// Get the whole session info of this client.
@@ -2431,6 +2430,7 @@ impl Client {
     ///
     /// # anyhow::Ok(()) });
     /// ```
+    #[allow(unknown_lints, clippy::let_with_type_underscore)] // triggered by instrument macro
     #[instrument(skip(self), parent = &self.inner.root_span)]
     pub async fn sync_stream(
         &self,

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Mutex, RwLock as StdRwLock},
 };
 
-use eyeball::Observable;
+use eyeball::unique::Observable;
 use ruma::{
     api::client::sync::sync_events::v4::{
         self, AccountDataConfig, E2EEConfig, ExtensionsConfig, ReceiptsConfig, ToDeviceConfig,

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{atomic::AtomicBool, Arc, RwLock as StdRwLock},
 };
 
-use eyeball::Observable;
+use eyeball::unique::Observable;
 use eyeball_im::ObservableVector;
 use im::Vector;
 use ruma::{api::client::sync::sync_events::v4, events::StateEventType, UInt};

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 pub use builder::*;
-use eyeball::Observable;
+use eyeball::unique::Observable;
 use eyeball_im::{ObservableVector, VectorDiff};
 use futures_core::Stream;
 use im::Vector;

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
 
-use eyeball::Observable;
+use eyeball::unique::Observable;
 use ruma::{api::client::sync::sync_events::v4, assign, OwnedRoomId, UInt};
 use tracing::{error, instrument, trace};
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -611,7 +611,7 @@ use std::{
 pub use builder::*;
 pub use client::*;
 pub use error::*;
-use eyeball::Observable;
+use eyeball::unique::Observable;
 use futures_core::stream::Stream;
 pub use list::*;
 use matrix_sdk_base::sync::SyncResponse;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1141,8 +1141,9 @@ impl SlidingSync {
     ///
     /// This stream will send requests and will handle responses automatically,
     /// hence updating the lists.
+    #[allow(unknown_lints, clippy::let_with_type_underscore)] // triggered by instrument macro
     #[instrument(name = "sync_stream", skip_all, parent = &self.inner.client.inner.root_span)]
-    pub fn stream(&self) -> impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_ {
+    pub fn stream<'a>(&'a self) -> impl Stream<Item = Result<UpdateSummary, crate::Error>> + 'a {
         // Collect all the lists that need to be updated.
         let list_generators = {
             let mut list_generators = BTreeMap::new();

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -7,7 +7,7 @@ use std::{
     },
 };
 
-use eyeball::Observable;
+use eyeball::unique::Observable;
 use eyeball_im::ObservableVector;
 use im::Vector;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -543,6 +543,7 @@ async fn fetch_members_deduplication() {
 
     // Create N tasks that try to fetch the members.
     for _ in 0..5 {
+        #[allow(unknown_lints, clippy::redundant_async_block)] // false positive
         let task = tokio::spawn({
             let room = room.clone();
             async move { room.sync_members().await }

--- a/crates/matrix-sdk/tests/integration/room/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline.rs
@@ -180,6 +180,7 @@ async fn echo() {
 
     // Don't move the original timeline, it must live until the end of the test
     let timeline = timeline.clone();
+    #[allow(unknown_lints, clippy::redundant_async_block)] // false positive
     let send_hdl = spawn(async move {
         timeline
             .send(RoomMessageEventContent::text_plain("Hello, World!").into(), Some(txn_id))

--- a/labs/jack-in/src/app/model.rs
+++ b/labs/jack-in/src/app/model.rs
@@ -212,7 +212,7 @@ impl Update<Msg> for Model {
                     None
                 }
                 Msg::SendMessage(m) => {
-                    if let Some(tl) = &**self.sliding_sync.room_timeline.read() {
+                    if let Some(tl) = &*self.sliding_sync.room_timeline.read() {
                         block_on(async move {
                             // fire and forget
                             tl.send(RoomMessageEventContent::text_plain(m).into(), None).await;

--- a/labs/jack-in/src/client/state.rs
+++ b/labs/jack-in/src/client/state.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use eyeball::SharedObservable;
+use eyeball::shared::Observable as SharedObservable;
 use eyeball_im::{ObservableVector, VectorDiff};
 use futures::{pin_mut, StreamExt};
 use matrix_sdk::{

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -73,7 +73,7 @@ mod tests {
 
     use anyhow::{bail, Context};
     use assert_matches::assert_matches;
-    use eyeball::Observable;
+    use eyeball::unique::Observable;
     use eyeball_im::VectorDiff;
     use futures::{pin_mut, stream::StreamExt};
     use matrix_sdk::{


### PR DESCRIPTION
Hope the reduction in `*`s is appreciated 😄

I think we should use the `Subscriber` type in more places. We probably don't need three distinct session token accessors in the client if we just return a `Subscriber`.