### PR TITLE
Add get_media_file function.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,6 +2755,7 @@ dependencies = [
  "matrix-sdk-sled",
  "matrix-sdk-test",
  "mime",
+ "mime_guess",
  "once_cell",
  "pin-project-lite",
  "rand 0.8.5",

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -176,6 +176,13 @@ interface Client {
 
     [Throws=ClientError]
     void login(string username, string password, string? initial_device_name, string? device_id);
+
+    [Throws=ClientError]
+    MediaFileHandle get_media_file(MediaSource source, string file_extension);
+};
+
+interface MediaFileHandle {
+    string path();
 };
 
 enum MembershipState {

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -178,7 +178,7 @@ interface Client {
     void login(string username, string password, string? initial_device_name, string? device_id);
 
     [Throws=ClientError]
-    MediaFileHandle get_media_file(MediaSource source, string file_extension);
+    MediaFileHandle get_media_file(MediaSource source, string mime_type);
 };
 
 interface MediaFileHandle {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -650,6 +650,6 @@ pub struct MediaFileHandle {
 impl MediaFileHandle {
     /// Get the media file's path.
     pub fn path(&self) -> String {
-        self.inner.path().to_str().unwrap().to_string()
+        self.inner.path().to_str().unwrap().to_owned()
     }
 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -185,17 +185,18 @@ impl Client {
     pub fn get_media_file(
         &self,
         media_source: Arc<MediaSource>,
-        file_extension: String,
+        mime_type: String,
     ) -> anyhow::Result<Arc<MediaFileHandle>> {
         let client = self.client.clone();
         let source = (*media_source).clone();
+        let mime_type: mime::Mime = mime_type.parse()?;
 
         RUNTIME.block_on(async move {
             let handle = client
                 .media()
                 .get_media_file(
                     &MediaRequest { source, format: MediaFormat::File },
-                    &file_extension,
+                    &mime_type,
                     true,
                 )
                 .await?;

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -589,6 +589,7 @@ pub struct AudioInfo {
     // for that
     pub duration: Option<u64>,
     pub size: Option<u64>,
+    pub mimetype: Option<String>,
 }
 
 #[derive(Clone, uniffi::Record)]
@@ -681,6 +682,7 @@ impl From<&matrix_sdk::ruma::events::room::message::AudioInfo> for AudioInfo {
         Self {
             duration: info.duration.map(|d| d.as_millis() as u64),
             size: info.size.map(Into::into),
+            mimetype: info.mimetype.clone(),
         }
     }
 }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -87,6 +87,7 @@ matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../matrix-sdk-indexeddb", default-features = false, optional = true }
 matrix-sdk-sled = { version = "0.2.0", path = "../matrix-sdk-sled", default-features = false, optional = true }
 mime = "0.3.16"
+mime_guess = "2.0.4"
 pin-project-lite = "0.2.9"
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.11.10", default_features = false }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -94,6 +94,7 @@ ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }
+tempfile = "3.3.0"
 thiserror = { workspace = true }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
@@ -137,7 +138,6 @@ dirs = "4.0.0"
 futures = { version = "0.3.21", default-features = false, features = ["executor"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 once_cell = { workspace = true }
-tempfile = "3.3.0"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -17,10 +17,13 @@
 
 #[cfg(feature = "e2e-encryption")]
 use std::io::Read;
-use std::{path::Path, time::Duration};
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::Path;
+use std::time::Duration;
 
 pub use matrix_sdk_base::media::*;
 use mime::Mime;
+#[cfg(not(target_arch = "wasm32"))]
 use mime_guess;
 use ruma::{
     api::client::media::{create_content, get_content, get_content_thumbnail},
@@ -28,7 +31,9 @@ use ruma::{
     events::room::MediaSource,
     MxcUri,
 };
+#[cfg(not(target_arch = "wasm32"))]
 use tempfile::{Builder as TempFileBuilder, NamedTempFile};
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::{fs::File as TokioFile, io::AsyncWriteExt};
 
 use crate::{
@@ -51,11 +56,13 @@ pub struct Media {
 /// A file handle that takes ownership of a media file on disk. When the handle
 /// is dropped, the file will be removed from the disk.
 #[derive(Debug)]
+#[cfg(not(target_arch = "wasm32"))]
 pub struct MediaFileHandle {
     /// The temporary file that contains the media.
     file: NamedTempFile,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl MediaFileHandle {
     /// Get the media file's path.
     pub fn path(&self) -> &Path {
@@ -129,6 +136,7 @@ impl Media {
     ///   temporary file's extension.
     ///
     /// * `use_cache` - If we should use the media cache for this request.
+    #[cfg(not(target_arch = "wasm32"))]
     pub async fn get_media_file(
         &self,
         request: &MediaRequest,


### PR DESCRIPTION
This PR adds a `get_media_file` that writes the decrypted media to disk and returns a `MediaFileHandle`. This handle maintains ownership of the file on disk and will delete it (via use of tempfile) when dropped.

What this PR doesn't do:
- De-duplicate requests of the same file (either for the potential HTTP requests or with shared handles over the same file).
- Expose a way for the app to tidy up the folder on launch if the app crashed with a file handle open. I'm unsure what would make most sense here e.g.
    - The app specifies the temp directory and tidies it up itself.
    - The app asks the SDK to tidy it up.
    - The SDK automatically tidies it up when creating a client.