### PR TITLE
feat(room): `set_avatar_url` `remove_avatar_url` `upload_avatar` `set_topic`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -291,6 +291,12 @@ interface Room {
 
     [Throws=ClientError]
     void set_topic(string topic);
+
+    [Throws=ClientError]
+    void upload_avatar(string mime_type, sequence<u8> data);
+
+    [Throws=ClientError]
+    void remove_avatar();
 };
 
 callback interface TimelineListener {

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -288,6 +288,9 @@ interface Room {
 
     [Throws=ClientError]
     void reject_invitation();
+
+    [Throws=ClientError]
+    void set_topic(string topic);
 };
 
 callback interface TimelineListener {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -26,8 +26,6 @@ use tracing::error;
 use super::RUNTIME;
 use crate::{TimelineDiff, TimelineItem, TimelineListener};
 
-pub struct ImageInfo {}
-
 #[derive(uniffi::Enum)]
 pub enum Membership {
     Invited,
@@ -573,6 +571,7 @@ impl Room {
 
         RUNTIME.block_on(async move {
             let mime: Mime = mime_type.parse()?;
+            // TODO: We could add an FFI ImageInfo struct in the future
             room.upload_avatar(&mime, data, None).await?;
             Ok(())
         })

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -20,10 +20,13 @@ use matrix_sdk::{
         EventId, UserId,
     },
 };
+use mime::Mime;
 use tracing::error;
 
 use super::RUNTIME;
 use crate::{TimelineDiff, TimelineItem, TimelineListener};
+
+pub struct ImageInfo {}
 
 #[derive(uniffi::Enum)]
 pub enum Membership {
@@ -546,6 +549,44 @@ impl Room {
 
         RUNTIME.block_on(async move {
             room.set_room_topic(&topic).await?;
+            Ok(())
+        })
+    }
+
+    /// Upload and set the room's avatar.
+    ///
+    /// This will upload the data produced by the reader to the homeserver's
+    /// content repository, and set the room's avatar to the MXC URI for the
+    /// uploaded file.
+    ///
+    /// # Arguments
+    ///
+    /// * `mime_type` - The mime description of the avatar, for example
+    ///   image/jpeg
+    /// * `data` - The raw data that will be uploaded to the homeserver's
+    ///   content repository
+    pub fn upload_avatar(&self, mime_type: String, data: Vec<u8>) -> Result<()> {
+        let room = match &self.room {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => bail!("Can't set a avatar in a room that isn't in joined state"),
+        };
+
+        RUNTIME.block_on(async move {
+            let mime: Mime = mime_type.parse()?;
+            room.upload_avatar(&mime, data, None).await?;
+            Ok(())
+        })
+    }
+
+    /// Removes the current room avatar
+    pub fn remove_avatar(&self) -> Result<()> {
+        let room = match &self.room {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => bail!("Can't remove a avatar in a room that isn't in joined state"),
+        };
+
+        RUNTIME.block_on(async move {
+            room.remove_avatar().await?;
             Ok(())
         })
     }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -533,6 +533,11 @@ impl Room {
         })
     }
 
+    /// Sets a new topic in the room.
+    ///
+    /// # Arguments
+    ///
+    /// * `topic` - The new topic text that will be set for the room
     pub fn set_topic(&self, topic: String) -> Result<()> {
         let room = match &self.room {
             SdkRoom::Joined(j) => j.clone(),

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -532,6 +532,18 @@ impl Room {
             Ok(())
         })
     }
+
+    pub fn set_topic(&self, topic: String) -> Result<()> {
+        let room = match &self.room {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => bail!("Can't set a topic in a room that isn't in joined state"),
+        };
+
+        RUNTIME.block_on(async move {
+            room.set_room_topic(&topic).await?;
+            Ok(())
+        })
+    }
 }
 
 impl std::ops::Deref for Room {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -535,10 +535,6 @@ impl Room {
     }
 
     /// Sets a new topic in the room.
-    ///
-    /// # Arguments
-    ///
-    /// * `topic` - The new topic text that will be set for the room
     pub fn set_topic(&self, topic: String) -> Result<()> {
         let room = match &self.room {
             SdkRoom::Joined(j) => j.clone(),

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -25,7 +25,10 @@ use ruma::{
     assign,
     events::{
         receipt::ReceiptThread,
-        room::{message::RoomMessageEventContent, power_levels::RoomPowerLevelsEventContent},
+        room::{
+            message::RoomMessageEventContent, power_levels::RoomPowerLevelsEventContent,
+            topic::RoomTopicEventContent,
+        },
         EmptyStateKey, MessageLikeEventContent, StateEventContent,
     },
     serde::Raw,
@@ -856,6 +859,16 @@ impl Joined {
         }
 
         self.send_state_event(RoomPowerLevelsEventContent::from(power_levels)).await
+    }
+
+    /// Sets the new topic for this room.
+    ///
+    /// # Arguments
+    /// * `topic` - The new topic for the room
+    pub async fn set_room_topic(&self, topic: &str) -> Result<send_state_event::v3::Response> {
+        let topic_event = RoomTopicEventContent::new(topic.into());
+
+        self.send_state_event(topic_event).await
     }
 
     /// Send a state event with an empty state key to the homeserver.

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -863,7 +863,7 @@ impl Joined {
         self.send_state_event(RoomPowerLevelsEventContent::from(power_levels)).await
     }
 
-    /// Sets the new topic for this room.
+    /// Sets a new topic for this room.
     ///
     /// # Arguments
     /// * `topic` - The new topic for the room

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -878,7 +878,7 @@ impl Joined {
     /// # Arguments
     /// * `avatar_url` - The owned matrix uri that represents the avatar
     /// * `info` - The optional image info that can be provided for the avatar
-    pub async fn set_avatar(
+    pub async fn set_avatar_url(
         &self,
         url: &MxcUri,
         info: Option<ImageInfo>,
@@ -915,7 +915,7 @@ impl Joined {
         info.blurhash = upload_response.blurhash;
         info.mimetype = Some(mime.to_string());
 
-        self.set_avatar(&upload_response.content_uri, Some(info)).await
+        self.set_avatar_url(&upload_response.content_uri, Some(info)).await
     }
 
     /// Send a state event with an empty state key to the homeserver.

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -864,9 +864,6 @@ impl Joined {
     }
 
     /// Sets a new topic for this room.
-    ///
-    /// # Arguments
-    /// * `topic` - The new topic for the room
     pub async fn set_room_topic(&self, topic: &str) -> Result<send_state_event::v3::Response> {
         let topic_event = RoomTopicEventContent::new(topic.into());
 


### PR DESCRIPTION
Created the functions in the title, and exposed a binding for `upload_avatar` and `set_topic` in FFI
