### PR TITLE
Add a guide for contributing to UniFFI bindings

### DIFF
--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -7,18 +7,20 @@ The process requires to developers to write a `.udl` (UniFFI Definition Language
 Rust code related with bindings live in the [matrix-rust-sdk/bindings](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings) folder.
 
 Each Rust crate can expose definitions to UniFFI using two different approaches:
-- Using an `.udl` file. When a crate has one, you find it under the `src` folder (an example is [here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)). In this case most of the Rust definitions can be found in the file.
-- Add UniFFI directivies as Rust attributes. In this case Rust source files (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`). 
+- Using an `.udl` file. When a crate has one, you find it under the `src` folder (an example is [here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)).
+- Add UniFFI directivies as Rust attributes. In this case Rust source files (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`). Attributes are preferred, where applicable.
  
 
 ## Expose Rust methods/types to UniFFI
 
 ### Check if the API is already on UniFFI
 
-First of all check if the API / type you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
+First of all check if the API / type you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
 This crate contains mainly small Rust wrappers around the actual Rust SDK (e.g. the crate [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
 
-If the API is on UniFFI already, you can probably see it also in the file [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl) where most of the matrix definitions are declared.
+If the Rust definition is on UniFFI already, you either:
+- find it in a `.udl` file like [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)
+- see it marked with a proper UniFFI Rust attribute like this `#[uniffi::export]`. This method should be preferred where applicable
 
 
 ### Adding a missing matrix API
@@ -37,5 +39,4 @@ If the API is on UniFFI already, you can probably see it also in the file [matri
 **A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The compiler will complain if the Rust code and/or the `.udl` is wrong.
 
 
-**Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?\
-**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.
+**Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?<br/>**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -27,11 +27,11 @@ If the Rust definition is on UniFFI already, you either:
 
 1. Unless you want to contribute on the crypto side, you probably need to add some code in the [matrix-rust-sdk/bindings/matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi) crate. After you find the crate you need to understand which file is best to contain the new Rust definition. When exposing new matrix API often (but not always) you need to touch the file [client.rs](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/client.rs).
 
-2. Identify the API to expose in the the target Rust crate (typically in [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk). If you can’t find your definition. If you can’t find it, you probably need to touch the actual Rust sdk as well. In this case you typically just need to write some around [ruma](https://github.com/ruma/ruma) (a rust sdk’s dependency) which already implements most of the matrix protocol. 
+2. Identify the API to expose in the target Rust crate (typically in [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk). If you can’t find it, you probably need to touch the actual Rust SDK as well. In this case you typically just need to write some code around [ruma](https://github.com/ruma/ruma) (a Rust SDK’s dependency) which already implements most of the matrix protocol. 
 
-3. When you got the Rust code you need to expose to UniFFI, just write a small Rust wrapper in the related UniFFI crate (most of the time is **matrix-sdk-ffi**).
+3. After you got (by finding or writing) the required Rust code, you need to expose to UniFFI. To do that just write a small Rust wrapper in the related UniFFI crate (most of the time is **matrix-sdk-ffi**).
 
-4. When your new definition is ready, remember to expose it in the related `.udl` file (or add an appropriate UniFFI export Rust attribute). For the **matrix-sdk-ffi** crate the definition file is [api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl). Remember: the language inside a `.udl` file isn’t Rust. To learn more about how map Rust into UDL read [here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html).
+4. When your new (wrapping) Rust definition is ready, remember to expose it in the related `.udl` file (or add an appropriate UniFFI export Rust attribute). For the **matrix-sdk-ffi** crate the definition file is [api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl). Remember: the language inside a `.udl` file isn’t Rust. To learn more about how map Rust into UDL read [here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html).
 
 ## FAQ
 
@@ -39,4 +39,5 @@ If the Rust definition is on UniFFI already, you either:
 **A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The compiler will complain if the Rust code and/or the `.udl` is wrong.
 
 
-**Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?<br/>**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.
+**Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?\
+**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong and fix it accordingly.

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Each Rust crate can expose definitions to UniFFI using two different approaches:
 
 ### Check if the API is already on UniFFI
 
-First of all check if the API/type you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
+First of all check if the API / type you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
 This crate contains mainly small Rust wrappers around the actual Rust sdk (e.g. the crate [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
 
 If the API is on UniFFI already, you can probably see it also in the file [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl) where most of the matrix definitions are declared.

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -1,37 +1,35 @@
 ## Introduction
 **matrix-rust-sdk** leverages [UniFFI](https://mozilla.github.io/uniffi-rs/) to generate bindings for host languages (eg. Swift and Kotlin).
 
-The process requires to developers to write a `.udl` (UniFFI Definition Language) file, where Rust definitions to be exposed are collected.
-
-
 Rust code related with bindings live in the [matrix-rust-sdk/bindings](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings) folder.
 
-Each Rust crate can expose definitions to UniFFI using two different approaches:
+Developers can expose Rust code to UniFFI using two different approaches:
 - Using an `.udl` file. When a crate has one, you find it under the `src` folder (an example is [here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)).
 - Add UniFFI directivies as Rust attributes. In this case Rust source files (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`). Attributes are preferred, where applicable.
  
 
-## Expose Rust methods/types to UniFFI
+## Expose Rust definitions to UniFFI
 
 ### Check if the API is already on UniFFI
 
-First of all check if the API / type you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
+First of all check if the Rust definition you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
 This crate contains mainly small Rust wrappers around the actual Rust SDK (e.g. the crate [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
 
 If the Rust definition is on UniFFI already, you either:
 - find it in a `.udl` file like [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)
-- see it marked with a proper UniFFI Rust attribute like this `#[uniffi::export]`. This method should be preferred where applicable
+- see it marked with a proper UniFFI Rust attribute like this `#[uniffi::export]`
 
 
 ### Adding a missing matrix API
 
-1. Unless you want to contribute on the crypto side, you probably need to add some code in the [matrix-rust-sdk/bindings/matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi) crate. After you find the crate you need to understand which file is best to contain the new Rust definition. When exposing new matrix API often (but not always) you need to touch the file [client.rs](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/client.rs).
+1. Unless you want to contribute on the crypto side, you probably need to add some code in the [matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi) crate. After you find the crate you need to understand which file is best to contain the new Rust definition. When exposing new matrix API often (but not always) you need to touch the file [client.rs](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/client.rs)
 
-2. Identify the API to expose in the target Rust crate (typically in [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk). If you can’t find it, you probably need to touch the actual Rust SDK as well. In this case you typically just need to write some code around [ruma](https://github.com/ruma/ruma) (a Rust SDK’s dependency) which already implements most of the matrix protocol. 
+2. Identify the API to expose in the target Rust crate (typically in [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk). If you can’t find it, you probably need to touch the actual Rust SDK as well. In this case you typically just need to write some code around [ruma](https://github.com/ruma/ruma) (a Rust SDK’s dependency) which already implements most of the matrix protocol
 
-3. After you got (by finding or writing) the required Rust code, you need to expose to UniFFI. To do that just write a small Rust wrapper in the related UniFFI crate (most of the time is **matrix-sdk-ffi**).
+3. After you got (by finding or writing) the required Rust code, you need to expose to UniFFI. To do that just write a small Rust wrapper in the related UniFFI crate (most of the time is **matrix-sdk-ffi**) you found on step 1.
 
-4. When your new (wrapping) Rust definition is ready, remember to expose it in the related `.udl` file (or add an appropriate UniFFI export Rust attribute). For the **matrix-sdk-ffi** crate the definition file is [api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl). Remember: the language inside a `.udl` file isn’t Rust. To learn more about how map Rust into UDL read [here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html).
+4. When your new (wrapping) Rust definition is ready, remember to expose it to UniFFI.
+It’s best to do it using UniFFI Rust attributes (e.g. `#[uniffi::export]`). Otherwise add the new definition in the crate’s `.udl` file. For the **matrix-sdk-ffi** crate the definition file is [api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl). **Remember**: the language inside a `.udl` file isn’t Rust. To learn more about how map Rust into UDL read [here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html)
 
 ## FAQ
 

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -33,7 +33,8 @@ If the API is on UniFFI already, you can probably see it also in the file [matri
 
 ## FAQ
 
-**Q**: I wrote my Rust code and exposed it to UniFFI. How can I check if the compiler is happy?<br/>**A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The compiler will complain if the Rust code and/or the `.udl` is wrong.
+**Q**: I wrote my Rust code and exposed it to UniFFI. How can I check if the compiler is happy?\
+**A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The compiler will complain if the Rust code and/or the `.udl` is wrong.
 
 
 **Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?<br/>**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Each Rust crate can expose definitions to UniFFI using two different approaches:
 ### Check if the API is already on UniFFI
 
 First of all check if the API / type you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
-This crate contains mainly small Rust wrappers around the actual Rust sdk (e.g. the crate [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
+This crate contains mainly small Rust wrappers around the actual Rust SDK (e.g. the crate [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
 
 If the API is on UniFFI already, you can probably see it also in the file [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl) where most of the matrix definitions are declared.
 

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Rust code related with bindings live in the [matrix-rust-sdk/bindings](https://g
 
 Each Rust crate can expose definitions to UniFFI using two different approaches:
 - Using an `.udl` file. When a crate has one, you find it under the `src` folder (an example is [here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)). In this case most of the Rust definitions can be found in the file.
-- Add UniFFI directivies as Rust attirbutes. In this case Rust source files (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`). 
+- Add UniFFI directivies as Rust attributes. In this case Rust source files (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`). 
  
 
 ## Expose Rust methods/types to UniFFI
@@ -18,12 +18,12 @@ Each Rust crate can expose definitions to UniFFI using two different approaches:
 First of all check if the API/type you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
 This crate contains mainly small Rust wrappers around the actual Rust sdk (e.g. the crate [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
 
-If the API is alreadu on UniFFI, you can probably see it also in the file [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl) where most of the matrix definitons are declared.
+If the API is on UniFFI already, you can probably see it also in the file [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl) where most of the matrix definitions are declared.
 
 
 ### Adding a missing matrix API
 
-1. Unless you want to contribute on the crypto side, you problably need to add some code in the [matrix-rust-sdk/bindings/matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi) crate. After you find the crate you need to undesrtand which file is best to contain the new Rust definition. When exposing new matrix API often (but not always) you need to touch the file [client.rs](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/client.rs).
+1. Unless you want to contribute on the crypto side, you probably need to add some code in the [matrix-rust-sdk/bindings/matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi) crate. After you find the crate you need to understand which file is best to contain the new Rust definition. When exposing new matrix API often (but not always) you need to touch the file [client.rs](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/client.rs).
 
 2. Identify the API to expose in the the target Rust crate (typically in [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk). If you can’t find your definition. If you can’t find it, you probably need to touch the actual Rust sdk as well. In this case you typically just need to write some around [ruma](https://github.com/ruma/ruma) (a rust sdk’s dependency) which already implements most of the matrix protocol. 
 
@@ -36,4 +36,4 @@ If the API is alreadu on UniFFI, you can probably see it also in the file [matri
 **Q**: I wrote my Rust code and exposed it to UniFFI. How can I check if the compiler is happy?<br/>**A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The compiler will complain if the Rust code and/or the `.udl` is wrong.
 
 
-**Q**: The complier is happy with my code but the CI is failing on GitHub. How can I fix it?<br/>**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.
+**Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?<br/>**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -37,4 +37,5 @@ If the API is on UniFFI already, you can probably see it also in the file [matri
 **A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The compiler will complain if the Rust code and/or the `.udl` is wrong.
 
 
-**Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?<br/>**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.
+**Q**: The compiler is happy with my code but the CI is failing on GitHub. How can I fix it?\
+**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.

--- a/bindings/CONTRIBUTING.md
+++ b/bindings/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+## Introduction
+**matrix-rust-sdk** leverages [UniFFI](https://mozilla.github.io/uniffi-rs/) to generate bindings for host languages (eg. Swift and Kotlin).
+
+The process requires to developers to write a `.udl` (UniFFI Definition Language) file, where Rust definitions to be exposed are collected.
+
+
+Rust code related with bindings live in the [matrix-rust-sdk/bindings](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings) folder.
+
+Each Rust crate can expose definitions to UniFFI using two different approaches:
+- Using an `.udl` file. When a crate has one, you find it under the `src` folder (an example is [here](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl)). In this case most of the Rust definitions can be found in the file.
+- Add UniFFI directivies as Rust attirbutes. In this case Rust source files (`.rs`) contain attributes related to UniFFI (e.g. `#[uniffi::export]`). 
+ 
+
+## Expose Rust methods/types to UniFFI
+
+### Check if the API is already on UniFFI
+
+First of all check if the API/type you are looking for exists on UniFFI already. Most of exposed matrix definitions are collected in the crate [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi).
+This crate contains mainly small Rust wrappers around the actual Rust sdk (e.g. the crate [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk))
+
+If the API is alreadu on UniFFI, you can probably see it also in the file [matrix-sdk-ffi/src/api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl) where most of the matrix definitons are declared.
+
+
+### Adding a missing matrix API
+
+1. Unless you want to contribute on the crypto side, you problably need to add some code in the [matrix-rust-sdk/bindings/matrix-sdk-ffi](https://github.com/matrix-org/matrix-rust-sdk/tree/main/bindings/matrix-sdk-ffi) crate. After you find the crate you need to undesrtand which file is best to contain the new Rust definition. When exposing new matrix API often (but not always) you need to touch the file [client.rs](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/client.rs).
+
+2. Identify the API to expose in the the target Rust crate (typically in [matrix-sdk](https://github.com/matrix-org/matrix-rust-sdk/tree/main/crates/matrix-sdk). If you can’t find your definition. If you can’t find it, you probably need to touch the actual Rust sdk as well. In this case you typically just need to write some around [ruma](https://github.com/ruma/ruma) (a rust sdk’s dependency) which already implements most of the matrix protocol. 
+
+3. When you got the Rust code you need to expose to UniFFI, just write a small Rust wrapper in the related UniFFI crate (most of the time is **matrix-sdk-ffi**).
+
+4. When your new definition is ready, remember to expose it in the related `.udl` file (or add an appropriate UniFFI export Rust attribute). For the **matrix-sdk-ffi** crate the definition file is [api.udl](https://github.com/matrix-org/matrix-rust-sdk/blob/main/bindings/matrix-sdk-ffi/src/api.udl). Remember: the language inside a `.udl` file isn’t Rust. To learn more about how map Rust into UDL read [here](https://mozilla.github.io/uniffi-rs/udl_file_spec.html).
+
+## FAQ
+
+**Q**: I wrote my Rust code and exposed it to UniFFI. How can I check if the compiler is happy?<br/>**A**: Run `cargo build` in the crate you touched (e.g. matrix-sdk-ffi). The compiler will complain if the Rust code and/or the `.udl` is wrong.
+
+
+**Q**: The complier is happy with my code but the CI is failing on GitHub. How can I fix it?<br/>**A**: The CI may fail for different reasons, you need to have a look on the failing GitHub workflow. One common reason though, is that the linter ([Clippy](https://github.com/rust-lang/rust-clippy)) isn’t happy with your code. If this is the case, you can run `cargo clippy` in the crate you touched to see what’s wrong.

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -20,3 +20,6 @@ maintained by the owners of the Matrix Rust SDK project.
 [`matrix-sdk-crypto`]: ../crates/matrix-sdk-crypto
 [`matrix-sdk-ffi`]: ./matrix-sdk-ffi
 [`matrix-sdk`]: ../crates/matrix-sdk
+
+# Contributing
+To contribute read this [guide](./CONTRIBUTING.md).


### PR DESCRIPTION
This PR adds a guide for people that don't know Rust well, but they still want to contributed to UniFFI bindings.