### PR TITLE
Re-expose the vodozemac and matrix-sdk-crypto versions in the bindings

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -840,6 +840,9 @@ fn parse_user_id(user_id: &str) -> Result<OwnedUserId, CryptoStoreError> {
 }
 
 mod uniffi_types {
+    pub use matrix_sdk_crypto::VERSION;
+    pub use vodozemac::VERSION as VODOZEMAC_VERSION;
+
     pub use crate::{
         backup_recovery_key::{
             BackupRecoveryKey, DecodeError, MegolmV1BackupKey, PassphraseInfo, PkDecryptionError,

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -839,10 +839,17 @@ fn parse_user_id(user_id: &str) -> Result<OwnedUserId, CryptoStoreError> {
     ruma::UserId::parse(user_id).map_err(|e| CryptoStoreError::InvalidUserId(user_id.to_owned(), e))
 }
 
-mod uniffi_types {
-    pub use matrix_sdk_crypto::VERSION;
-    pub use vodozemac::VERSION as VODOZEMAC_VERSION;
+#[uniffi::export]
+fn version() -> String {
+    matrix_sdk_crypto::VERSION.to_owned()
+}
 
+#[uniffi::export]
+fn vodozemac_version() -> String {
+    vodozemac::VERSION.to_owned()
+}
+
+mod uniffi_types {
     pub use crate::{
         backup_recovery_key::{
             BackupRecoveryKey, DecodeError, MegolmV1BackupKey, PassphraseInfo, PkDecryptionError,

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -40,6 +40,27 @@ pub mod vodozemac;
 
 use wasm_bindgen::prelude::*;
 
+/// Object containing the versions of the Rust libraries we are using.
+#[wasm_bindgen(getter_with_clone)]
+#[derive(Debug)]
+pub struct Versions {
+    /// The version of the vodozemac crate.
+    #[wasm_bindgen(readonly)]
+    pub vodozemac: &'static str,
+    /// The version of the matrix-sdk-crypto crate.
+    #[wasm_bindgen(readonly)]
+    pub matrix_sdk_crypto: &'static str,
+}
+
+/// Get the versions of the Rust libraries we are using.
+#[wasm_bindgen(js_name = "getVersions")]
+pub fn get_versions() -> Versions {
+    Versions {
+        vodozemac: matrix_sdk_crypto::vodozemac::VERSION,
+        matrix_sdk_crypto: matrix_sdk_crypto::VERSION,
+    }
+}
+
 /// Run some stuff when the Wasm module is instantiated.
 ///
 /// Right now, it does the following:

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -38,6 +38,7 @@ pub mod types;
 pub mod verification;
 pub mod vodozemac;
 
+use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 /// Object containing the versions of the Rust libraries we are using.
@@ -46,18 +47,18 @@ use wasm_bindgen::prelude::*;
 pub struct Versions {
     /// The version of the vodozemac crate.
     #[wasm_bindgen(readonly)]
-    pub vodozemac: &'static str,
+    pub vodozemac: JsString,
     /// The version of the matrix-sdk-crypto crate.
     #[wasm_bindgen(readonly)]
-    pub matrix_sdk_crypto: &'static str,
+    pub matrix_sdk_crypto: JsString,
 }
 
 /// Get the versions of the Rust libraries we are using.
 #[wasm_bindgen(js_name = "getVersions")]
 pub fn get_versions() -> Versions {
     Versions {
-        vodozemac: matrix_sdk_crypto::vodozemac::VERSION,
-        matrix_sdk_crypto: matrix_sdk_crypto::VERSION,
+        vodozemac: matrix_sdk_crypto::vodozemac::VERSION.into(),
+        matrix_sdk_crypto: matrix_sdk_crypto::VERSION.into(),
     }
 }
 

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -7,7 +7,6 @@ const {
     EncryptionSettings,
     EventId,
     InboundGroupSession,
-    KeysClaimRequest,
     KeysQueryRequest,
     KeysUploadRequest,
     MaybeSignature,
@@ -16,15 +15,29 @@ const {
     RequestType,
     RoomId,
     RoomMessageRequest,
+    ShieldColor,
     SignatureUploadRequest,
     ToDeviceRequest,
     UserId,
     UserIdentity,
     VerificationRequest,
-    ShieldColor,
+    VerificationState,
+    Versions,
+    getVersions,
 } = require("../pkg/matrix_sdk_crypto_js");
 const { addMachineToMachine } = require("./helper");
 require("fake-indexeddb/auto");
+
+describe("Versions", () => {
+    test("can find out the crate versions", async () => {
+        const versions = getVersions();
+
+        expect(versions).toBeInstanceOf(Versions)
+        expect(versions.vodozemac).toBeDefined()
+        expect(versions.matrix_sdk_crypto).toBeDefined()
+    });
+
+});
 
 describe(OlmMachine.name, () => {
     test("can be instantiated with the async initializer", async () => {

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -32,11 +32,10 @@ describe("Versions", () => {
     test("can find out the crate versions", async () => {
         const versions = getVersions();
 
-        expect(versions).toBeInstanceOf(Versions)
-        expect(versions.vodozemac).toBeDefined()
-        expect(versions.matrix_sdk_crypto).toBeDefined()
+        expect(versions).toBeInstanceOf(Versions);
+        expect(versions.vodozemac).toBeDefined();
+        expect(versions.matrix_sdk_crypto).toBeDefined();
     });
-
 });
 
 describe(OlmMachine.name, () => {

--- a/bindings/matrix-sdk-crypto-nodejs/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/lib.rs
@@ -34,23 +34,23 @@ pub mod types;
 pub mod vodozemac;
 
 /// Object containing the versions of the Rust libraries we are using.
-#[napi(object)]
+#[napi]
 pub struct Versions {
     /// The version of the vodozemac crate.
     #[napi(getter)]
-    pub vodozemac: &'static str,
+    pub vodozemac: String,
 
     /// The version of the matrix-sdk-crypto crate.
     #[napi(getter)]
-    pub matrix_sdk_crypto: &'static str,
+    pub matrix_sdk_crypto: String,
 }
 
 /// Get the versions of the Rust libraries we are using.
 #[napi(js_name = "getVersions")]
 pub fn get_versions() -> Versions {
     Versions {
-        vodozemac: matrix_sdk_crypto::vodozemac::VERSION,
-        matrix_sdk_crypto: matrix_sdk_crypto::VERSION,
+        vodozemac: matrix_sdk_crypto::vodozemac::VERSION.to_owned(),
+        matrix_sdk_crypto: matrix_sdk_crypto::VERSION.to_owned(),
     }
 }
 

--- a/bindings/matrix-sdk-crypto-nodejs/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-nodejs/src/lib.rs
@@ -16,6 +16,8 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //#![warn(missing_docs, missing_debug_implementations)]
 
+use napi_derive::napi;
+
 pub mod attachment;
 pub mod encryption;
 mod errors;
@@ -30,5 +32,26 @@ pub mod sync_events;
 pub mod tracing;
 pub mod types;
 pub mod vodozemac;
+
+/// Object containing the versions of the Rust libraries we are using.
+#[napi(object)]
+pub struct Versions {
+    /// The version of the vodozemac crate.
+    #[napi(getter)]
+    pub vodozemac: &'static str,
+
+    /// The version of the matrix-sdk-crypto crate.
+    #[napi(getter)]
+    pub matrix_sdk_crypto: &'static str,
+}
+
+/// Get the versions of the Rust libraries we are using.
+#[napi(js_name = "getVersions")]
+pub fn get_versions() -> Versions {
+    Versions {
+        vodozemac: matrix_sdk_crypto::vodozemac::VERSION,
+        matrix_sdk_crypto: matrix_sdk_crypto::VERSION,
+    }
+}
 
 use crate::errors::into_err;

--- a/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -14,8 +14,10 @@ const {
     VerificationState,
     CrossSigningStatus,
     MaybeSignature,
-    StoreType,
     ShieldColor,
+    StoreType,
+    Versions,
+    getVersions,
 } = require("../");
 const path = require("path");
 const os = require("os");
@@ -26,6 +28,17 @@ describe("StoreType", () => {
         expect(StoreType.Sled).toStrictEqual(0);
         expect(StoreType.Sqlite).toStrictEqual(1);
     });
+});
+
+describe("Versions", () => {
+    test("can find out the crate versions", async () => {
+        const versions = getVersions();
+
+        expect(versions).toBeInstanceOf(Versions)
+        expect(versions.vodozemac).toBeDefined()
+        expect(versions.matrix_sdk_crypto).toBeDefined()
+    });
+
 });
 
 describe(OlmMachine.name, () => {

--- a/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -34,11 +34,10 @@ describe("Versions", () => {
     test("can find out the crate versions", async () => {
         const versions = getVersions();
 
-        expect(versions).toBeInstanceOf(Versions)
-        expect(versions.vodozemac).toBeDefined()
-        expect(versions.matrix_sdk_crypto).toBeDefined()
+        expect(versions).toBeInstanceOf(Versions);
+        expect(versions.vodozemac).toBeDefined();
+        expect(versions.matrix_sdk_crypto).toBeDefined();
     });
-
 });
 
 describe(OlmMachine.name, () => {

--- a/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -36,8 +36,9 @@ describe("Versions", () => {
 
         expect(versions).toBeInstanceOf(Versions);
         expect(versions.vodozemac).toBeDefined();
-        expect(versions.matrix_sdk_crypto).toBeDefined();
+        expect(versions.matrixSdkCrypto).toBeDefined();
     });
+
 });
 
 describe(OlmMachine.name, () => {

--- a/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js
@@ -38,7 +38,6 @@ describe("Versions", () => {
         expect(versions.vodozemac).toBeDefined();
         expect(versions.matrixSdkCrypto).toBeDefined();
     });
-
 });
 
 describe(OlmMachine.name, () => {


### PR DESCRIPTION
Edit from @Hywan:

This PR adds a `Versions` class in JS and NodeJS that expose the `matrix-sdk-crypto` and `vodozemac`'s versions.

It also adds a `version()` and `vodozemac_version()` functions in FFI.