### PR TITLE
Update account_data when creating a new dm room

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -928,6 +928,7 @@ pub(crate) mod tests {
     }
 
     #[test]
+    #[allow(clippy::redundant_clone)]
     fn delete_a_device() {
         let device = get_device();
         assert!(!device.is_deleted());

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -757,8 +757,8 @@ impl Account {
     /// # Arguments
     ///
     /// * `room_id` - The room id of the DM room.
-    /// * `user_id` - The user id of the invitee for the DM room.
-    pub async fn mark_as_dm(&self, room_id: &RoomId, user_id: &OwnedUserId) -> Result<()> {
+    /// * `user_ids` - The user ids of the invitees for the DM room.
+    pub(crate) async fn mark_as_dm(&self, room_id: &RoomId, user_ids: &[OwnedUserId]) -> Result<()> {
         use ruma::events::direct::DirectEventContent;
 
         // Now we need to mark the room as a DM for ourselves, we fetch the
@@ -771,8 +771,10 @@ impl Account {
             .transpose()?
             .unwrap_or_default();
 
-        content.entry(user_id.to_owned()).or_default().push(room_id.to_owned());
-
+        for user_id in user_ids {
+            content.entry(user_id.to_owned()).or_default().push(room_id.to_owned());
+        }
+        
         // TODO We should probably save the fact that we need to send this out
         // because otherwise we might end up in a state where we have a DM that
         // isn't marked as one.

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -748,11 +748,11 @@ impl Account {
         Ok(self.client.send(request, None).await?)
     }
 
-    /// Marks the given room with `room_id` as "direct chat" with the given
-    /// `user_id`.
+    /// Marks the given room with `room_id` as "direct chat" with with any
+    /// user in `user_ids`.
     ///
     /// This is done adding new the `room_id` to the list of DM
-    /// chats with the user having id `user_id`.
+    /// chats for any user id in `user_ids`.
     ///
     /// # Arguments
     ///

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -748,9 +748,12 @@ impl Account {
         Ok(self.client.send(request, None).await?)
     }
 
-    /// Marks the given room with `room_id` as "direct chat" with the given `user_id`.
-    /// This is done adding new the `room_id` to the list of DM chats with the user having id `user_id`.
-    /// 
+    /// Marks the given room with `room_id` as "direct chat" with the given
+    /// `user_id`.
+    ///
+    /// This is done adding new the `room_id` to the list of DM
+    /// chats with the user having id `user_id`.
+    ///
     /// # Arguments
     ///
     /// * `room_id` - The room id of the DM room.

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -758,7 +758,11 @@ impl Account {
     ///
     /// * `room_id` - The room id of the DM room.
     /// * `user_ids` - The user ids of the invitees for the DM room.
-    pub(crate) async fn mark_as_dm(&self, room_id: &RoomId, user_ids: &[OwnedUserId]) -> Result<()> {
+    pub(crate) async fn mark_as_dm(
+        &self,
+        room_id: &RoomId,
+        user_ids: &[OwnedUserId],
+    ) -> Result<()> {
         use ruma::events::direct::DirectEventContent;
 
         // Now we need to mark the room as a DM for ourselves, we fetch the
@@ -774,7 +778,7 @@ impl Account {
         for user_id in user_ids {
             content.entry(user_id.to_owned()).or_default().push(room_id.to_owned());
         }
-        
+
         // TODO We should probably save the fact that we need to send this out
         // because otherwise we might end up in a state where we have a DM that
         // isn't marked as one.

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -39,7 +39,7 @@ use ruma::{
     },
     serde::Raw,
     thirdparty::Medium,
-    ClientSecret, MxcUri, OwnedMxcUri, SessionId, UInt, RoomId, OwnedUserId,
+    ClientSecret, MxcUri, OwnedMxcUri, OwnedUserId, RoomId, SessionId, UInt,
 };
 use serde::Deserialize;
 
@@ -758,11 +758,7 @@ impl Account {
     ///
     /// * `room_id` - The room id of the DM room.
     /// * `user_id` - The user id of the invitee for the DM room.
-    pub async fn mark_as_dm(
-        &self,
-        room_id: &RoomId,
-        user_id: &OwnedUserId,
-    ) -> Result<()> {
+    pub async fn mark_as_dm(&self, room_id: &RoomId, user_id: &OwnedUserId) -> Result<()> {
         use ruma::events::direct::DirectEventContent;
 
         // Now we need to mark the room as a DM for ourselves, we fetch the

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1704,7 +1704,10 @@ impl Client {
         // supporting just the DM chat with another person (no group dm chat)
         if is_direct_room && invite.len() == 1 {
             if let Some(user) = invite.first() {
-                self.account().mark_as_dm(joined_room.room_id(), user).await?;
+                if let Err(error) = self.account().mark_as_dm(joined_room.room_id(), user).await {
+                    // FIXME: Retry in the background
+                    error!("Failed to mark room as DM: {error}");
+                }
             }
         }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1704,7 +1704,7 @@ impl Client {
         // supporting just the DM chat with another person (no group dm chat)
         if is_direct_room && invite.len() == 1 {
             if let Some(user) = invite.first() {
-                self.update_m_direct_account_data(joined_room.room_id(), user).await?;
+                self.account().mark_as_dm(joined_room.room_id(), user).await?;
             }
         }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1699,14 +1699,12 @@ impl Client {
 
         let joined_room = room::Joined::new(self, base_room).unwrap();
 
-        if is_direct_room {
-            if let Some(user) = invite.first() {
-                if let Err(error) =
-                    self.account().mark_as_dm(joined_room.room_id(), &[user.to_owned()]).await
-                {
-                    // FIXME: Retry in the background
-                    error!("Failed to mark room as DM: {error}");
-                }
+        if is_direct_room && !invite.is_empty() {
+            if let Err(error) =
+                self.account().mark_as_dm(joined_room.room_id(), invite.as_slice()).await
+            {
+                // FIXME: Retry in the background
+                error!("Failed to mark room as DM: {error}");
             }
         }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -71,9 +71,7 @@ use serde::de::DeserializeOwned;
 use tokio::sync::broadcast;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::sync::OnceCell;
-#[cfg(feature = "e2e-encryption")]
-use tracing::error;
-use tracing::{debug, field::display, info, instrument, trace, Instrument, Span};
+use tracing::{debug, error, field::display, info, instrument, trace, Instrument, Span};
 use url::Url;
 
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1701,10 +1701,11 @@ impl Client {
 
         let joined_room = room::Joined::new(self, base_room).unwrap();
 
-        // supporting just the DM chat with another person (no group dm chat)
-        if is_direct_room && invite.len() == 1 {
+        if is_direct_room {
             if let Some(user) = invite.first() {
-                if let Err(error) = self.account().mark_as_dm(joined_room.room_id(), user).await {
+                if let Err(error) =
+                    self.account().mark_as_dm(joined_room.room_id(), &[user.to_owned()]).await
+                {
                     // FIXME: Retry in the background
                     error!("Failed to mark room as DM: {error}");
                 }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -52,7 +52,7 @@ use ruma::{
         },
         uiaa::AuthData,
     },
-    assign, DeviceId, OwnedUserId, TransactionId, UserId, RoomId,
+    assign, DeviceId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use tracing::{debug, instrument, trace, warn};
 
@@ -279,7 +279,11 @@ impl Client {
     ///
     /// * `room_id` - The room id of the DM room.
     /// * `user_id` - The user id of the invitee for the DM room.
-    pub(crate) async fn update_m_direct_account_data(&self, room_id: &RoomId, user_id: &OwnedUserId) -> Result<()> {
+    pub(crate) async fn update_m_direct_account_data(
+        &self,
+        room_id: &RoomId,
+        user_id: &OwnedUserId,
+    ) -> Result<()> {
         use ruma::events::direct::DirectEventContent;
 
         // Now we need to mark the room as a DM for ourselves, we fetch the

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -268,7 +268,7 @@ impl Client {
 
         let room = self.create_room(request).await?;
 
-        self.account().mark_as_dm(room.room_id(), &user_id).await?;
+        self.account().mark_as_dm(room.room_id(), &[user_id]).await?;
 
         Ok(room)
     }


### PR DESCRIPTION
This PR put some logic in the Client type to update the `m.direct` account_data when creating a new dm room.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1674