### PR TITLE
sdk: Add a method to change the room name

### DIFF
--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -28,6 +28,7 @@ use ruma::{
         room::{
             avatar::{ImageInfo, RoomAvatarEventContent},
             message::RoomMessageEventContent,
+            name::RoomNameEventContent,
             power_levels::RoomPowerLevelsEventContent,
             topic::RoomTopicEventContent,
         },
@@ -861,6 +862,11 @@ impl Joined {
         }
 
         self.send_state_event(RoomPowerLevelsEventContent::from(power_levels)).await
+    }
+
+    /// Sets the name of this room.
+    pub async fn set_name(&self, name: Option<String>) -> Result<send_state_event::v3::Response> {
+        self.send_state_event(RoomNameEventContent::new(name)).await
     }
 
     /// Sets a new topic for this room.

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -579,6 +579,7 @@ async fn set_name() {
             "name": name,
         })))
         .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .expect(1)
         .mount(&server)
         .await;
 

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -18,7 +18,7 @@ use ruma::{
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{body_partial_json, header, method, path, path_regex},
+    matchers::{body_json, body_partial_json, header, method, path, path_regex},
     Mock, ResponseTemplate,
 };
 
@@ -559,4 +559,28 @@ async fn fetch_members_deduplication() {
     let response_count =
         results.iter().filter(|r| r.as_ref().unwrap().as_ref().unwrap().is_some()).count();
     assert_eq!(response_count, 1);
+}
+
+#[async_test]
+async fn set_name() {
+    let (client, server) = synced_client().await;
+
+    mock_sync(&server, &*test_json::SYNC, None).await;
+    let sync_settings = SyncSettings::new();
+    client.sync_once(sync_settings).await.unwrap();
+
+    let room = client.get_joined_room(&test_json::DEFAULT_SYNC_ROOM_ID).unwrap();
+    let name = "The room name";
+
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.room.name/$"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(body_json(json!({
+            "name": name,
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EVENT_ID))
+        .mount(&server)
+        .await;
+
+    room.set_name(Some(name.to_owned())).await.unwrap();
 }


### PR DESCRIPTION
To go with the recent methods added to change the topic and avatar.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr> 
