### PR TITLE
sdk: Store OIDC issuer as a `String` rather than a `Url`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -251,7 +251,7 @@ impl Client {
     /// The OIDC Provider that is trusted by the homeserver. `None` when
     /// not configured.
     pub async fn authentication_issuer(&self) -> Option<String> {
-        self.client.authentication_issuer().await.map(|server| server.to_string())
+        self.client.authentication_issuer().await
     }
 
     /// The sliding sync proxy that is trusted by the homeserver. `None` when

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -408,7 +408,10 @@ impl ClientBuilder {
                 if let Some(proxy) = well_known.sliding_sync_proxy.map(|p| p.url) {
                     sliding_sync_proxy = Url::parse(&proxy).ok();
                 }
-                debug!(homserver_url = well_known.homeserver.base_url, "Discovered the homeserver");
+                debug!(
+                    homeserver_url = well_known.homeserver.base_url,
+                    "Discovered the homeserver"
+                );
 
                 well_known.homeserver.base_url
             }

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -378,7 +378,7 @@ impl ClientBuilder {
         let base_client = BaseClient::with_store_config(store_config);
         let http_client = HttpClient::new(inner_http_client.clone(), self.request_config);
 
-        let mut authentication_issuer: Option<Url> = None;
+        let mut authentication_issuer = None;
         #[cfg(feature = "experimental-sliding-sync")]
         let mut sliding_sync_proxy: Option<Url> = None;
         let homeserver = match homeserver_cfg {
@@ -402,9 +402,8 @@ impl ClientBuilder {
                         err => ClientBuildError::Http(err),
                     })?;
 
-                if let Some(issuer) = well_known.authentication.map(|auth| auth.issuer) {
-                    authentication_issuer = Url::parse(&issuer).ok();
-                }
+                authentication_issuer = well_known.authentication.map(|auth| auth.issuer);
+
                 #[cfg(feature = "experimental-sliding-sync")]
                 if let Some(proxy) = well_known.sliding_sync_proxy.map(|p| p.url) {
                     sliding_sync_proxy = Url::parse(&proxy).ok();

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -145,7 +145,7 @@ pub(crate) struct ClientInner {
     /// The URL of the homeserver to connect to.
     homeserver: RwLock<Url>,
     /// The OIDC Provider that is trusted by the homeserver.
-    authentication_issuer: Option<RwLock<Url>>,
+    authentication_issuer: Option<RwLock<String>>,
     /// The sliding sync proxy that is trusted by the homeserver.
     #[cfg(feature = "experimental-sliding-sync")]
     sliding_sync_proxy: Option<RwLock<Url>>,
@@ -330,7 +330,7 @@ impl Client {
     }
 
     /// The OIDC Provider that is trusted by the homeserver.
-    pub async fn authentication_issuer(&self) -> Option<Url> {
+    pub async fn authentication_issuer(&self) -> Option<String> {
         let server = self.inner.authentication_issuer.as_ref()?;
         Some(server.read().await.clone())
     }


### PR DESCRIPTION
The url crate normalizes the string, but during OIDC verification steps, the issuer verification must be made against the exact string that was provided.

See https://github.com/matrix-org/matrix-authentication-service/pull/616.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>