### PR TITLE
matrix-sdk-crypto-js: prepare v0.1.0-alpha.5

### DIFF
--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-js",
-    "version": "0.1.0-alpha.4",
+    "version": "0.1.0-alpha.5",
     "homepage": "https://github.com/matrix-org/matrix-rust-sdk",
     "description": "Matrix encryption library, for JavaScript",
     "license": "Apache-2.0",


### PR DESCRIPTION
I'd like to cut a new release of the crypto-js bindings, in particular to include #1619 and #1633.