### PR TITLE
matrix-sdk-crypto-js: drop `v` from release tags

### DIFF
--- a/bindings/matrix-sdk-crypto-js/.yarnrc
+++ b/bindings/matrix-sdk-crypto-js/.yarnrc
@@ -1,2 +1,2 @@
-version-tag-prefix "matrix-sdk-crypto-js-v"
+version-tag-prefix "matrix-sdk-crypto-js-"
 version-git-message "matrix-sdk-crypto-js v%s"


### PR DESCRIPTION
Currently, the tags used for releases of this binding have the format: "matrix-sdk-crypto-js-v0.1.0-alpha.5". This is inconsistent with tags used for other parts of the project, which omit the `v` prefix.