### PR TITLE
Upgrade eyeball-im

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,12 +540,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitmaps"
-version = "2.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
+checksum = "703642b98a00b3b90513279a8ede3fcfa479c126c5fb46e78f3051522f021403"
 
 [[package]]
 name = "blake3"
@@ -1614,12 +1611,12 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb8a6cfd1f5947d0426dcb753723318d5922c738e905be7af167547565f81d9"
+checksum = "29e6dff0ac9894dcc183064377dfeb4137bcffa9f9ec3dbc10f8e7fba34c0ac7"
 dependencies = [
  "futures-core",
- "im",
+ "imbl",
  "tokio",
  "tokio-stream",
 ]
@@ -2221,21 +2218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "serde",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "image"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,6 +2252,29 @@ dependencies = [
  "png 0.17.7",
  "scoped_threadpool",
  "tiff 0.8.1",
+]
+
+[[package]]
+name = "imbl"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2806b69cd9f4664844027b64465eacb444c67c1db9c778e341adff0c25cdb0d"
+dependencies = [
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.6.4",
+ "rand_xoshiro",
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6957ea0b2541c5ca561d3ef4538044af79f8a05a1eb3a3b148936aaceaa1076"
+dependencies = [
+ "bitmaps",
 ]
 
 [[package]]
@@ -2746,8 +2751,8 @@ dependencies = [
  "gloo-timers",
  "http",
  "hyper",
- "im",
  "image 0.24.5",
+ "imbl",
  "indexmap",
  "matrix-sdk-base",
  "matrix-sdk-common",
@@ -4924,16 +4929,6 @@ name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ byteorder = "1.4.3"
 ctor = "0.1.26"
 dashmap = "5.2.0"
 eyeball = "0.4.0"
-eyeball-im = "0.1.0"
+eyeball-im = "0.2.0"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 ruma = { git = "https://github.com/ruma/ruma", rev = "8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5", features = ["client-api-c"] }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -79,7 +79,7 @@ eyre = { version = "0.6.8", optional = true }
 futures-core = "0.3.21"
 futures-util = { workspace = true }
 http = { workspace = true }
-im = { version = "15.1.0", features = ["serde"] }
+imbl = { version = "2.0.0", features = ["serde"] }
 indexmap = "1.9.1"
 hyper = { version = "0.14.20", features = ["http1", "http2", "server"], optional = true }
 matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base", default_features = false }

--- a/crates/matrix-sdk/src/room/timeline/builder.rs
+++ b/crates/matrix-sdk/src/room/timeline/builder.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use im::Vector;
+use imbl::Vector;
 use matrix_sdk_base::{
     deserialized_responses::{EncryptionInfo, SyncTimelineEvent},
     locks::Mutex,

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -18,7 +18,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use eyeball_im::{ObservableVector, VectorSubscriber};
-use im::Vector;
+use imbl::Vector;
 use indexmap::{IndexMap, IndexSet};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::OlmMachine;

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -20,7 +20,7 @@ use std::{pin::Pin, sync::Arc, task::Poll};
 
 use eyeball_im::{VectorDiff, VectorSubscriber};
 use futures_core::Stream;
-use im::Vector;
+use imbl::Vector;
 use matrix_sdk_base::locks::Mutex;
 use pin_project_lite::pin_project;
 use ruma::{

--- a/crates/matrix-sdk/src/room/timeline/tests/basic.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/basic.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use im::vector;
+use imbl::vector;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::async_test;
 use ruma::{

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -7,7 +7,7 @@ use std::{
 
 use eyeball::unique::Observable;
 use eyeball_im::ObservableVector;
-use im::Vector;
+use imbl::Vector;
 use ruma::{api::client::sync::sync_events::v4, events::StateEventType, UInt};
 
 use super::{Error, RoomListEntry, SlidingSyncList, SlidingSyncMode, SlidingSyncState};

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -15,7 +15,7 @@ pub use builder::*;
 use eyeball::unique::Observable;
 use eyeball_im::{ObservableVector, VectorDiff};
 use futures_core::Stream;
-use im::Vector;
+use imbl::Vector;
 pub(super) use request_generator::*;
 use ruma::{api::client::sync::sync_events::v4, events::StateEventType, OwnedRoomId, RoomId, UInt};
 use serde::{Deserialize, Serialize};

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -9,7 +9,7 @@ use std::{
 
 use eyeball::unique::Observable;
 use eyeball_im::ObservableVector;
-use im::Vector;
+use imbl::Vector;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use ruma::{
     api::client::sync::sync_events::{v4, UnreadNotificationsCount},
@@ -355,7 +355,7 @@ impl From<&SlidingSyncRoom> for FrozenSlidingSyncRoom {
 
 #[cfg(test)]
 mod tests {
-    use im::vector;
+    use imbl::vector;
     use matrix_sdk_base::deserialized_responses::TimelineEvent;
     use ruma::{events::room::message::RoomMessageEventContent, RoomId};
     use serde_json::json;


### PR DESCRIPTION
… and adopt its change from `im` to `imbl`. We still need to pull that in explicitly because we use its `vector!` macro which is not re-exported, and because we want to enable its `serde` feature.
