### PR TITLE
feat: resetting the timeline when an ignore user list event is received

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -229,6 +229,9 @@ impl SlidingSyncRoom {
             }
         };
 
+        // This in the future could be removed, and the rx handling could be moved
+        // inside handle_sliding_sync_reset since we want to reset the sliding
+        // sync for ignore user list events
         let handle_ignore_user_list_changes = {
             let ignore_user_list_change_rx = self.client.subscribe_to_ignore_user_list_changes();
             let timeline = timeline.to_owned();

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -47,9 +47,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.24.2", default-features = false, features = ["sync"] }
-
 [dev-dependencies]
 assert_matches = "1.5.0"
 assign = "1.1.1"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -47,6 +47,9 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.24.2", default-features = false, features = ["sync"] }
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 assign = "1.1.1"

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -88,7 +88,7 @@ pub struct BaseClient {
     /// [`BaseClient::set_session_meta`]
     #[cfg(feature = "e2e-encryption")]
     olm_machine: OnceCell<OlmMachine>,
-    pub(crate) ignore_user_list_broadcast_tx: Arc<eyeball::shared::Observable<()>>,
+    pub(crate) ignore_user_list_changes_tx: Arc<eyeball::shared::Observable<()>>,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -120,7 +120,7 @@ impl BaseClient {
             crypto_store: config.crypto_store,
             #[cfg(feature = "e2e-encryption")]
             olm_machine: Default::default(),
-            ignore_user_list_broadcast_tx: Default::default(),
+            ignore_user_list_changes_tx: Default::default(),
         }
     }
 
@@ -896,7 +896,7 @@ impl BaseClient {
 
     pub(crate) async fn apply_changes(&self, changes: &StateChanges) {
         if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
-            eyeball::shared::Observable::set(&self.ignore_user_list_broadcast_tx, ());
+            eyeball::shared::Observable::set(&self.ignore_user_list_changes_tx, ());
         }
         for (room_id, room_info) in &changes.room_infos {
             if let Some(room) = self.store.get_room(room_id) {
@@ -1232,9 +1232,10 @@ impl BaseClient {
         }
     }
 
-    /// Returns a subscriber that publishes an event every time the ignore user list changes
+    /// Returns a subscriber that publishes an event every time the ignore user
+    /// list changes
     pub fn subscribe_to_ignore_user_list_changes(&self) -> Subscriber<()> {
-        self.ignore_user_list_broadcast_tx.subscribe()
+        self.ignore_user_list_changes_tx.subscribe()
     }
 }
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -53,7 +53,6 @@ use ruma::{
     serde::Raw,
     MilliSecondsSinceUnixEpoch, OwnedUserId, RoomId, UInt, UserId,
 };
-use tokio::sync::broadcast;
 use tracing::{debug, info, trace, warn};
 
 #[cfg(feature = "e2e-encryption")]
@@ -89,7 +88,7 @@ pub struct BaseClient {
     /// [`BaseClient::set_session_meta`]
     #[cfg(feature = "e2e-encryption")]
     olm_machine: OnceCell<OlmMachine>,
-    pub(crate) ignore_user_list_broadcast_tx: broadcast::Sender<()>,
+    pub(crate) ignore_user_list_broadcast_tx: Arc<eyeball::shared::Observable<()>>,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -115,14 +114,13 @@ impl BaseClient {
     /// * `config` - An optional session if the user already has one from a
     /// previous login call.
     pub fn with_store_config(config: StoreConfig) -> Self {
-        let (ignore_user_list_broadcast_tx, _) = broadcast::channel(1);
         BaseClient {
             store: Store::new(config.state_store),
             #[cfg(feature = "e2e-encryption")]
             crypto_store: config.crypto_store,
             #[cfg(feature = "e2e-encryption")]
             olm_machine: Default::default(),
-            ignore_user_list_broadcast_tx,
+            ignore_user_list_broadcast_tx: Default::default(),
         }
     }
 
@@ -898,7 +896,7 @@ impl BaseClient {
 
     pub(crate) async fn apply_changes(&self, changes: &StateChanges) {
         if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
-            let _ = self.ignore_user_list_broadcast_tx.send(());
+            eyeball::shared::Observable::set(&self.ignore_user_list_broadcast_tx, ());
         }
         for (room_id, room_info) in &changes.room_infos {
             if let Some(room) = self.store.get_room(room_id) {
@@ -1234,8 +1232,9 @@ impl BaseClient {
         }
     }
 
-    pub fn get_ignore_user_list_broadcast_tx(&self) -> &broadcast::Sender<()> {
-        &self.ignore_user_list_broadcast_tx
+    /// Returns a subscriber that publishes an event every time the ignore user list changes
+    pub fn subscribe_to_ignore_user_list_changes(&self) -> Subscriber<()> {
+        self.ignore_user_list_broadcast_tx.subscribe()
     }
 }
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -21,7 +21,7 @@ use std::{
 #[cfg(feature = "e2e-encryption")]
 use std::{ops::Deref, sync::Arc};
 
-use eyeball::Subscriber;
+use eyeball::{shared::Observable as SharedObservable, Subscriber};
 use matrix_sdk_common::{instant::Instant, locks::RwLock};
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_crypto::{
@@ -88,7 +88,7 @@ pub struct BaseClient {
     /// [`BaseClient::set_session_meta`]
     #[cfg(feature = "e2e-encryption")]
     olm_machine: OnceCell<OlmMachine>,
-    pub(crate) ignore_user_list_changes_tx: Arc<eyeball::shared::Observable<()>>,
+    pub(crate) ignore_user_list_changes_tx: Arc<SharedObservable<()>>,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -896,7 +896,7 @@ impl BaseClient {
 
     pub(crate) async fn apply_changes(&self, changes: &StateChanges) {
         if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
-            eyeball::shared::Observable::set(&self.ignore_user_list_changes_tx, ());
+            self.ignore_user_list_changes_tx.set(());
         }
         for (room_id, room_info) in &changes.room_infos {
             if let Some(room) = self.store.get_room(room_id) {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -13,14 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "e2e-encryption")]
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
     fmt,
-    ops::Deref,
-    sync::Arc,
 };
+#[cfg(feature = "e2e-encryption")]
+use std::{ops::Deref, sync::Arc};
 
 use eyeball::{shared::Observable as SharedObservable, Subscriber};
 use matrix_sdk_common::instant::Instant;

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "e2e-encryption")]
+use std::ops::Deref;
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
     fmt,
+    sync::Arc,
 };
-#[cfg(feature = "e2e-encryption")]
-use std::{ops::Deref, sync::Arc};
 
 use eyeball::{shared::Observable as SharedObservable, Subscriber};
 use matrix_sdk_common::instant::Instant;

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -13,13 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "e2e-encryption")]
 use std::{
     borrow::Borrow,
     collections::{BTreeMap, BTreeSet},
     fmt,
+    ops::Deref,
+    sync::Arc,
 };
-#[cfg(feature = "e2e-encryption")]
-use std::{ops::Deref, sync::Arc};
 
 use eyeball::{shared::Observable as SharedObservable, Subscriber};
 use matrix_sdk_common::instant::Instant;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -25,6 +25,7 @@ use std::{
 #[cfg(target_arch = "wasm32")]
 use async_once_cell::OnceCell;
 use dashmap::DashMap;
+use eyeball::Subscriber;
 use futures_core::Stream;
 use futures_util::StreamExt;
 use matrix_sdk_base::{
@@ -215,8 +216,9 @@ impl Client {
             .map_err(ClientBuildError::assert_valid_builder_args)
     }
 
-    pub fn get_ignore_user_list_broadcast_tx(&self) -> &broadcast::Sender<()> {
-        self.inner.base_client.get_ignore_user_list_broadcast_tx()
+    /// Returns a subscriber that publishes an event every time the ignore user list changes
+    pub fn subscribe_to_ignore_user_list_changes(&self) -> Subscriber<()> {
+        self.inner.base_client.subscribe_to_ignore_user_list_changes()
     }
 
     /// Create a new [`ClientBuilder`].

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -210,7 +210,8 @@ impl Client {
             .map_err(ClientBuildError::assert_valid_builder_args)
     }
 
-    /// Returns a subscriber that publishes an event every time the ignore user list changes.
+    /// Returns a subscriber that publishes an event every time the ignore user
+    /// list changes.
     pub fn subscribe_to_ignore_user_list_changes(&self) -> Subscriber<()> {
         self.inner.base_client.subscribe_to_ignore_user_list_changes()
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -216,7 +216,7 @@ impl Client {
             .map_err(ClientBuildError::assert_valid_builder_args)
     }
 
-    /// Returns a subscriber that publishes an event every time the ignore user list changes
+    /// Returns a subscriber that publishes an event every time the ignore user list changes.
     pub fn subscribe_to_ignore_user_list_changes(&self) -> Subscriber<()> {
         self.inner.base_client.subscribe_to_ignore_user_list_changes()
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -215,6 +215,10 @@ impl Client {
             .map_err(ClientBuildError::assert_valid_builder_args)
     }
 
+    pub fn get_ignore_user_list_broadcast_tx(&self) -> &broadcast::Sender<()> {
+        self.inner.base_client.get_ignore_user_list_broadcast_tx()
+    }
+
     /// Create a new [`ClientBuilder`].
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new()


### PR DESCRIPTION
This will require also a restart of SS and the cache to be cleaned, which @Hywan is working on separately, otherwise in offline cases the cold cache could restore the old messages.