### PR TITLE
Switch the FFI bindings to use the SQLite cryptostore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,6 +2986,8 @@ dependencies = [
  "futures-util",
  "log-panics",
  "matrix-sdk",
+ "matrix-sdk-sled",
+ "matrix-sdk-sqlite",
  "mime",
  "once_cell",
  "opentelemetry",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -23,7 +23,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = "0.3.17"
 futures-util = { version = "0.3.17", default-features = false }
-matrix-sdk-sqlite = { path = "../../crates/matrix-sdk-sqlite" }
+matrix-sdk-sqlite = { path = "../../crates/matrix-sdk-sqlite", features = ["crypto-store"] }
 matrix-sdk-sled = { path = "../../crates/matrix-sdk-sled" }
 mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
@@ -61,7 +61,6 @@ features = [
     "experimental-timeline",
     "e2e-encryption",
     "markdown", 
-    "sled",
     "socks",
     "rustls-tls",
 ]
@@ -76,6 +75,5 @@ features = [
     "e2e-encryption",
     "markdown",
     "native-tls",
-    "sled",
     "socks",
 ]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -23,6 +23,8 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = "0.3.17"
 futures-util = { version = "0.3.17", default-features = false }
+matrix-sdk-sqlite = { path = "../../crates/matrix-sdk-sqlite" }
+matrix-sdk-sled = { path = "../../crates/matrix-sdk-sled" }
 mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014


### PR DESCRIPTION
Since we have no migration from Sled to SQLite we'll have to log our EX users out. cc @stefanceriu.