### PR TITLE
feat(bindings): Add report_content_and_ignore.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -258,7 +258,7 @@ interface Room {
     void report_content(string event_id, i32? score, string? reason);
     
     [Throws=ClientError]
-    void report_content_and_ignore(string event_id, i32? score, string? reason, string sender_id);
+    void ignore_user(string user_id);
 
     [Throws=ClientError]
     void send_reaction(string event_id, string key);

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -256,6 +256,9 @@ interface Room {
 
     [Throws=ClientError]
     void report_content(string event_id, i32? score, string? reason);
+    
+    [Throws=ClientError]
+    void report_content_and_ignore(string event_id, i32? score, string? reason, string sender_id);
 
     [Throws=ClientError]
     void send_reaction(string event_id, string key);

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -446,6 +446,34 @@ impl Room {
         })
     }
 
+    /// Reports an event from the room whilst also ignoring the sender.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - The ID of the event to report
+    ///
+    /// * `reason` - The reason for the event being reported (optional).
+    ///
+    /// * `score` - The score to rate this content as where -100 is most
+    ///   offensive and 0 is inoffensive (optional).
+    ///
+    /// * `sender_id` - The ID of the event's sender who should be ignored.
+    pub fn report_content_and_ignore(
+        &self,
+        event_id: String,
+        score: Option<i32>,
+        reason: Option<String>,
+        sender_id: String,
+    ) -> Result<()> {
+        self.report_content(event_id, score, reason)?;
+        let user_id = UserId::parse(sender_id)?;
+
+        RUNTIME.block_on(async move {
+            self.client().account().ignore_user(&user_id).await?;
+            Ok(())
+        })
+    }
+
     /// Leaves the joined room.
     ///
     /// Will throw an error if used on an room that isn't in a joined state

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -446,29 +446,14 @@ impl Room {
         })
     }
 
-    /// Reports an event from the room whilst also ignoring the sender.
+    /// Ignores a user.
     ///
     /// # Arguments
     ///
-    /// * `event_id` - The ID of the event to report
-    ///
-    /// * `reason` - The reason for the event being reported (optional).
-    ///
-    /// * `score` - The score to rate this content as where -100 is most
-    ///   offensive and 0 is inoffensive (optional).
-    ///
-    /// * `sender_id` - The ID of the event's sender who should be ignored.
-    pub fn report_content_and_ignore(
-        &self,
-        event_id: String,
-        score: Option<i32>,
-        reason: Option<String>,
-        sender_id: String,
-    ) -> Result<()> {
-        self.report_content(event_id, score, reason)?;
-        let user_id = UserId::parse(sender_id)?;
-
+    /// * `event_id` - The ID of the user to ignore.
+    pub fn ignore_user(&self, user_id: String) -> Result<()> {
         RUNTIME.block_on(async move {
+            let user_id = UserId::parse(user_id)?;
             self.client().account().ignore_user(&user_id).await?;
             Ok(())
         })


### PR DESCRIPTION
This PR adds `report_content_and_ignore` that is like `report_content` but with an additional step to ignore the user. I considered adding `sender_id` as an optional string to `report_content` but decided it wasn't clear enough that supplying this would ignore the user, hence the specific method.