### PR TITLE
Ensure correct Olm session selection for encrypted messages

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -335,6 +335,11 @@ impl Device {
         self.verification_machine.store.get_sessions(&k.to_base64()).await
     }
 
+    #[cfg(test)]
+    pub(crate) async fn get_most_recent_session(&self) -> OlmResult<Option<Session>> {
+        self.inner.get_most_recent_session(self.verification_machine.store.inner()).await
+    }
+
     /// Is this device considered to be verified.
     ///
     /// This method returns true if either [`is_locally_trusted()`] returns true
@@ -612,6 +617,34 @@ impl ReadOnlyDevice {
         }
     }
 
+    /// Find and return the most recently created Olm [`Session`] we are sharing
+    /// with this device.
+    pub(crate) async fn get_most_recent_session(
+        &self,
+        store: &DynCryptoStore,
+    ) -> OlmResult<Option<Session>> {
+        if let Some(sender_key) = self.curve25519_key() {
+            if let Some(s) = store.get_sessions(&sender_key.to_base64()).await? {
+                let mut sessions = s.lock().await;
+
+                sessions.sort_by_key(|s| s.creation_time);
+
+                Ok(sessions.last().cloned())
+            } else {
+                Ok(None)
+            }
+        } else {
+            warn!(
+                user_id = ?self.user_id(),
+                device_id = ?self.device_id(),
+                "Trying to find a Olm session of a device, but the device doesn't have a \
+                Curve25519 key",
+            );
+
+            Err(EventError::MissingSenderKey.into())
+        }
+    }
+
     /// Does this device support the olm.v2.curve25519-aes-sha2 encryption
     /// algorithm.
     #[cfg(feature = "experimental-algorithms")]
@@ -680,44 +713,29 @@ impl ReadOnlyDevice {
         event_type: &str,
         content: Value,
     ) -> OlmResult<(Session, Raw<ToDeviceEncryptedEventContent>)> {
-        let Some(sender_key) = self.curve25519_key() else {
-            warn!(
+        let session = self.get_most_recent_session(store).await?;
+
+        if let Some(mut session) = session {
+            let message = session.encrypt(self, event_type, content).await?;
+
+            trace!(
                 user_id = ?self.user_id(),
                 device_id = ?self.device_id(),
-                "Trying to encrypt a Megolm session, but the device doesn't \
-                have a curve25519 key",
+                session_id = session.session_id(),
+                "Successfully encrypted a Megolm session",
             );
-            return Err(EventError::MissingSenderKey.into());
-        };
 
-        let session = if let Some(s) = store.get_sessions(&sender_key.to_base64()).await? {
-            let mut sessions = s.lock().await;
-            sessions.sort_by_key(|s| s.last_use_time);
-            sessions.get(0).cloned()
+            Ok((session, message))
         } else {
-            None
-        };
-
-        let Some(mut session) = session else {
             warn!(
                 "Trying to encrypt a Megolm session for user {} on device {}, \
                 but no Olm session is found",
                 self.user_id(),
                 self.device_id()
             );
-            return Err(OlmError::MissingSession);
-        };
 
-        let message = session.encrypt(self, event_type, content).await?;
-
-        trace!(
-            user_id = ?self.user_id(),
-            device_id = ?self.device_id(),
-            session_id = session.session_id(),
-            "Successfully encrypted a Megolm session",
-        );
-
-        Ok((session, message))
+            Err(OlmError::MissingSession)
+        }
     }
 
     /// Update a device with a new device keys struct.


### PR DESCRIPTION
In some cases, restoring client state from backups may cause Olm sessions to become corrupted, resulting in a backward ratchet. As a consequence, the receiving side is unable to decrypt messages. To address this issue, the failed side initiates a new Olm session and sends a dummy encrypted message.

However, this dummy message also creates a new Olm session on the sender's side. To ensure that both sides use the same new session, we must sort sessions by their creation timestamp before encrypting new messages.

Although the session list was sorted correctly previously, we selected the wrong side of the list, resulting in an outdated session being selected instead of the newest one. This patch resolves the issue by selecting the newest Olm session and adds a test to the session getter logic to prevent reintroduction of this bug.

This closes: #1727.