### PR TITLE
Fix #1623 - Expose `invite_user_by_id`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -277,6 +277,9 @@ interface Room {
 
     [Throws=ClientError]
     void remove_avatar();
+
+    [Throws=ClientError]
+    void invite_user_by_id(string user_id);
 };
 
 callback interface TimelineListener {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -540,6 +540,20 @@ impl Room {
             Ok(())
         })
     }
+
+    pub fn invite_user_by_id(&self, user_id: String) -> Result<()> {
+      let room = match &self.room {
+          SdkRoom::Joined(joined_room) => joined_room.clone(),
+          _ => bail!("Can't invite user to room that isn't in joined state"),
+      };
+
+      RUNTIME.block_on(async move {
+          let user =
+              <&UserId>::try_from(user_id.as_str()).context("Could not create user from string")?;
+          room.invite_user_by_id(&user).await?;
+          Ok(())
+      })
+  }
 }
 
 impl std::ops::Deref for Room {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -550,7 +550,7 @@ impl Room {
         RUNTIME.block_on(async move {
             let user = <&UserId>::try_from(user_id.as_str())
                 .context("Could not create user from string")?;
-            room.invite_user_by_id(&user).await?;
+            room.invite_user_by_id(user).await?;
             Ok(())
         })
     }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -542,18 +542,18 @@ impl Room {
     }
 
     pub fn invite_user_by_id(&self, user_id: String) -> Result<()> {
-      let room = match &self.room {
-          SdkRoom::Joined(joined_room) => joined_room.clone(),
-          _ => bail!("Can't invite user to room that isn't in joined state"),
-      };
+        let room = match &self.room {
+            SdkRoom::Joined(joined_room) => joined_room.clone(),
+            _ => bail!("Can't invite user to room that isn't in joined state"),
+        };
 
-      RUNTIME.block_on(async move {
-          let user =
-              <&UserId>::try_from(user_id.as_str()).context("Could not create user from string")?;
-          room.invite_user_by_id(&user).await?;
-          Ok(())
-      })
-  }
+        RUNTIME.block_on(async move {
+            let user = <&UserId>::try_from(user_id.as_str())
+                .context("Could not create user from string")?;
+            room.invite_user_by_id(&user).await?;
+            Ok(())
+        })
+    }
 }
 
 impl std::ops::Deref for Room {


### PR DESCRIPTION
This PR is self explanatory and fixes #1623 

Exposes said function to the FFI. Defined in the .adl file, and defined to throw `ClientError`

Signed-off-by: Simon Farre <simon.farre.cx@gmail.com>