### PR TITLE
Add more debug info for event timeline items

### DIFF
--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -120,12 +120,12 @@ mod uniffi_types {
         },
         timeline::{
             AudioInfo, AudioMessageContent, EmoteMessageContent, EncryptedMessage, EventSendState,
-            EventTimelineItem, FileInfo, FileMessageContent, FormattedBody, ImageInfo,
-            ImageMessageContent, InsertData, MembershipChange, Message, MessageFormat, MessageType,
-            NoticeMessageContent, OtherState, ProfileTimelineDetails, Reaction, SetData,
-            TextMessageContent, ThumbnailInfo, TimelineChange, TimelineDiff, TimelineItem,
-            TimelineItemContent, TimelineItemContentKind, VideoInfo, VideoMessageContent,
-            VirtualTimelineItem,
+            EventTimelineItem, EventTimelineItemDebugInfo, FileInfo, FileMessageContent,
+            FormattedBody, ImageInfo, ImageMessageContent, InsertData, MembershipChange, Message,
+            MessageFormat, MessageType, NoticeMessageContent, OtherState, ProfileTimelineDetails,
+            Reaction, SetData, TextMessageContent, ThumbnailInfo, TimelineChange, TimelineDiff,
+            TimelineItem, TimelineItemContent, TimelineItemContentKind, VideoInfo,
+            VideoMessageContent, VirtualTimelineItem,
         },
         ClientError,
     };

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -304,8 +304,22 @@ impl EventTimelineItem {
         }
     }
 
-    pub fn raw(&self) -> Option<String> {
-        self.0.original_json().map(|r| r.json().get().to_owned())
+    pub fn debug_info(&self) -> EventTimelineItemDebugInfo {
+        use matrix_sdk::room::timeline::EventTimelineItem::*;
+
+        let (original_json, latest_edit_json) = match &self.0 {
+            Local(_) => (None, None),
+            Remote(event) => (
+                Some(event.original_json().json().get().to_owned()),
+                event.latest_edit_json().map(|raw| raw.json().get().to_owned()),
+            ),
+        };
+
+        EventTimelineItemDebugInfo {
+            model: format!("{:#?}", self.0),
+            original_json,
+            latest_edit_json,
+        }
     }
 
     pub fn local_send_state(&self) -> Option<EventSendState> {
@@ -316,10 +330,13 @@ impl EventTimelineItem {
             Remote(_) => None,
         }
     }
+}
 
-    pub fn fmt_debug(&self) -> String {
-        format!("{:#?}", self.0)
-    }
+#[derive(uniffi::Record)]
+pub struct EventTimelineItemDebugInfo {
+    model: String,
+    original_json: Option<String>,
+    latest_edit_json: Option<String>,
 }
 
 #[derive(uniffi::Enum)]

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -305,7 +305,7 @@ impl EventTimelineItem {
     }
 
     pub fn raw(&self) -> Option<String> {
-        self.0.raw().map(|r| r.json().get().to_owned())
+        self.0.original_json().map(|r| r.json().get().to_owned())
     }
 
     pub fn local_send_state(&self) -> Option<EventSendState> {

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -381,14 +381,19 @@ impl<'a> TimelineEventHandler<'a> {
                 }
             };
 
-            let content = TimelineItemContent::Message(Message {
+            let new_content = TimelineItemContent::Message(Message {
                 msgtype: replacement.new_content,
                 in_reply_to: msg.in_reply_to.clone(),
                 edited: true,
             });
 
+            let edit_json = match &self.flow {
+                Flow::Local { .. } => None,
+                Flow::Remote { raw_event, .. } => Some(raw_event.clone()),
+            };
+
             trace!("Applying edit");
-            Some(event_item.with_content(content))
+            Some(event_item.apply_edit(new_content, edit_json))
         });
     }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
@@ -169,18 +169,24 @@ impl EventTimelineItem {
     ///
     /// Returns `None` if this event hasn't been echoed back by the server
     /// yet.
-    pub fn raw(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
+    pub fn original_json(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
         match self {
             Self::Local(_local_event) => None,
-            Self::Remote(remote_event) => Some(remote_event.raw()),
+            Self::Remote(remote_event) => Some(remote_event.original_json()),
         }
     }
 
-    /// Clone the current event item, and update its `content`.
-    pub(super) fn with_content(&self, content: TimelineItemContent) -> Self {
+    /// Clone the current event item, and apply an edit to it.
+    pub(super) fn apply_edit(
+        &self,
+        new_content: TimelineItemContent,
+        edit_json: Option<Raw<AnySyncTimelineEvent>>,
+    ) -> Self {
         match self {
-            Self::Local(local_event) => Self::Local(local_event.with_content(content)),
-            Self::Remote(remote_event) => Self::Remote(remote_event.with_content(content)),
+            Self::Local(local_event) => Self::Local(local_event.with_content(new_content)),
+            Self::Remote(remote_event) => {
+                Self::Remote(remote_event.apply_edit(new_content, edit_json))
+            }
         }
     }
 

--- a/crates/matrix-sdk/tests/integration/room/timeline/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline/mod.rs
@@ -130,7 +130,7 @@ async fn edit() {
     assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(152038280)));
     assert!(item.event_id().is_some());
     assert!(!item.is_own());
-    assert!(item.raw().is_some());
+    assert!(item.original_json().is_some());
 
     let msg = assert_matches!(item.content(), TimelineItemContent::Message(msg) => msg);
     assert_matches!(msg.msgtype(), MessageType::Text(_));


### PR DESCRIPTION
Yesterday, I was debugging reply edits with Stefan, this would have been very useful.