### PR TITLE
Downgrade memory store 'Saved changes in <time>' log line to debug

### DIFF
--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -33,7 +33,7 @@ use ruma::{
     CanonicalJsonObject, EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId,
     RoomVersionId, UserId,
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use super::{Result, RoomInfo, StateChanges, StateStore, StoreError};
 use crate::{
@@ -439,7 +439,7 @@ impl MemoryStore {
             }
         }
 
-        info!("Saved changes in {:?}", now.elapsed());
+        debug!("Saved changes in {:?}", now.elapsed());
 
         Ok(())
     }


### PR DESCRIPTION
It doesn't seem very interesting since a memory store will be fast anyway. In practice, this fills the console quickly.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Olivier 'reivilibre' <oliverw@matrix.org>
