### PR TITLE
Fix #1751 - Adds & exposes `avatar_url` for SlidingSyncRoom

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -200,7 +200,9 @@ impl SlidingSyncRoom {
     }
 
     pub fn avatar_url(&self) -> Option<String> {
-        self.client.get_room(self.inner.room_id()).and_then(|room| room.avatar_url_string())
+        self.client
+            .get_room(self.inner.room_id())
+            .and_then(|room| room.avatar_url().map(|url| url.into()))
     }
 
     #[allow(clippy::significant_drop_in_scrutinee)]

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -200,7 +200,7 @@ impl SlidingSyncRoom {
     }
 
     pub fn avatar_url(&self) -> Option<String> {
-        Some(self.client.get_room(self.inner.room_id())?.into())
+        Some(self.client.get_room(self.inner.room_id())?.avatar_url()?.into())
     }
 
     #[allow(clippy::significant_drop_in_scrutinee)]

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -199,6 +199,10 @@ impl SlidingSyncRoom {
             .map(|room| Arc::new(Room::with_timeline(room, self.timeline.clone())))
     }
 
+    pub fn avatar_url(&self) -> Option<String> {
+        self.client.get_room(self.inner.room_id()).and_then(|room| room.avatar_url_string())
+    }
+
     #[allow(clippy::significant_drop_in_scrutinee)]
     pub fn latest_room_message(&self) -> Option<Arc<EventTimelineItem>> {
         let item = RUNTIME.block_on(self.inner.latest_event())?;

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -200,9 +200,7 @@ impl SlidingSyncRoom {
     }
 
     pub fn avatar_url(&self) -> Option<String> {
-        self.client
-            .get_room(self.inner.room_id())
-            .and_then(|room| room.avatar_url().map(|url| url.into()))
+        Some(self.client.get_room(self.inner.room_id())?.into())
     }
 
     #[allow(clippy::significant_drop_in_scrutinee)]

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -178,13 +178,6 @@ impl Room {
             .and_then(|e| e.as_original().and_then(|e| e.content.url.clone()))
     }
 
-    /// Get the avatar url of this room directly as string
-    pub fn avatar_url_string(&self) -> Option<String> {
-        self.inner.read().unwrap().base_info.avatar.as_ref().and_then(|e| {
-            e.as_original().and_then(|e| e.content.url.as_ref().map(OwnedMxcUri::to_string))
-        })
-    }
-
     /// Get the canonical alias of this room.
     pub fn canonical_alias(&self) -> Option<OwnedRoomAliasId> {
         self.inner.read().unwrap().canonical_alias().map(ToOwned::to_owned)

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -178,6 +178,13 @@ impl Room {
             .and_then(|e| e.as_original().and_then(|e| e.content.url.clone()))
     }
 
+    /// Get the avatar url of this room directly as string
+    pub fn avatar_url_string(&self) -> Option<String> {
+        self.inner.read().unwrap().base_info.avatar.as_ref().and_then(|e| {
+            e.as_original().and_then(|e| e.content.url.as_ref().map(OwnedMxcUri::to_string))
+        })
+    }
+
     /// Get the canonical alias of this room.
     pub fn canonical_alias(&self) -> Option<OwnedRoomAliasId> {
         self.inner.read().unwrap().canonical_alias().map(ToOwned::to_owned)


### PR DESCRIPTION
Fixes #1751 

This PR also adds `avatar_url_string` on Room in normal.rs.

The reason for doing this, is because the regular `avatar_url` on Room (the non-sliding sync FFI-exposed version) calls `avatar_url` on Room in normal.rs, which first clones the `OwnedMcxUri`.

`avatar_url_string` instead of doing an (unnecessary) deep copy, creates a string directly from the underlying data type as this is to be returned across the FFI boundary anyhow.

Signed-off-by:  Simon Farre <simon.farre.cx@gmail.com>