### PR TITLE
fix(sdk): `SlidingSyncList.room_list` emits updates for non-moving rooms

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -403,7 +403,7 @@ impl SlidingSync {
                 };
 
                 let maximum_number_of_rooms: u32 =
-                    updates.count.try_into().expect("the list total count convertible into u32");
+                    updates.count.try_into().expect("failed to convert `count` to `u32`");
 
                 if list.handle_response(maximum_number_of_rooms, &updates.ops)? {
                     updated_lists.push(name.clone());

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -405,7 +405,7 @@ impl SlidingSync {
                 let maximum_number_of_rooms: u32 =
                     updates.count.try_into().expect("failed to convert `count` to `u32`");
 
-                if list.handle_response(maximum_number_of_rooms, &updates.ops)? {
+                if list.update(maximum_number_of_rooms, &updates.ops, &updated_rooms)? {
                     updated_lists.push(name.clone());
                 }
             }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -354,8 +354,10 @@ impl SlidingSync {
         }
 
         let update_summary = {
-            let mut updated_rooms = Vec::new();
             let mut rooms_map = self.inner.rooms.write().unwrap();
+
+            // Update the rooms.
+            let mut updated_rooms = Vec::with_capacity(sliding_sync_response.rooms.len());
 
             for (room_id, mut room_data) in sliding_sync_response.rooms.into_iter() {
                 // `sync_response` contains the rooms with decrypted events if any, so look at
@@ -390,7 +392,8 @@ impl SlidingSync {
                 updated_rooms.push(room_id);
             }
 
-            let mut updated_lists = Vec::new();
+            // Update the lists.
+            let mut updated_lists = Vec::with_capacity(sliding_sync_response.lists.len());
 
             for (name, updates) in sliding_sync_response.lists {
                 let Some(list) = lists.get_mut(&name) else {


### PR DESCRIPTION
The `SlidingSyncList.room_list` field is used to store the list of rooms
for a particular Sliding Sync list. It's used by the user to receive
“diff”s when a room sees its position modified. For example when a new
room receives a message, it “climbs back up” the entire room list to
be at the top place. Another example is when a new room is created,
some rooms will move around to give the new room a space. All those
moves will create “diff”.

However, the user also expects to receive a “diff” when a room has
received some updates, even if it's position doesn't change. For
example, when a room is already at the top of the list but receives a
new message: It has received an update, but its position stays the same.

This specific latter feature was implemented before, but it has been
removed by accident in https://github.com/matrix-org/matrix-rust-sdk/pull/1699 (more specifically in https://github.com/matrix-org/matrix-rust-sdk/pull/1699/commits/861a05be69a566d9a4ad125dc6ecb418d2b3210f).
At that time, it was not clear why the code was filtering for specific
filled room entries, to set the filled room entries at the same position.
Zero comment, zero test. I didn't consider this as a feature but as a bug.

So this patch re-introduces this feature. Hopefully in a more optimal
way. If a room has already triggered a first “diff” because of a
position change, it won't trigger a second “diff” because it has
received an update (which was the case before).

The `SlidingSyncList::handle_response` method has also been renamed
`update`, as it does update, whenever it comes from.

The code has been commented and documented to explain this feature.

Existing tests have been updated, especially for `apply_sync_operations`
which now ensure the `rooms_that_have_received_an_update` collections is
updated accordingly. Another test has been updated specifically to test
the “diff”s received by `room_list`.