### PR TITLE
chore(sdk): Remove unused methods in `sliding_sync`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, warn};
 use url::Url;
 
 use crate::{
-    helpers::unwrap_or_clone_arc, room::TimelineLock, Client, ClientError, EventTimelineItem, Room,
+    helpers::unwrap_or_clone_arc, room::TimelineLock, Client, EventTimelineItem, Room,
     TimelineDiff, TimelineItem, TimelineListener, RUNTIME,
 };
 
@@ -825,21 +825,9 @@ impl SlidingSyncBuilder {
 
 #[uniffi::export]
 impl SlidingSyncBuilder {
-    pub fn add_fullsync_list(self: Arc<Self>) -> Arc<Self> {
+    pub fn storage_key(self: Arc<Self>, name: Option<String>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.add_fullsync_list();
-        Arc::new(builder)
-    }
-
-    pub fn no_lists(self: Arc<Self>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.no_lists();
-        Arc::new(builder)
-    }
-
-    pub fn cold_cache(self: Arc<Self>, name: String) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.cold_cache(name);
+        builder.inner = builder.inner.storage_key(name);
         Arc::new(builder)
     }
 
@@ -890,17 +878,6 @@ impl SlidingSyncBuilder {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.with_all_extensions();
         Arc::new(builder)
-    }
-}
-
-#[uniffi::export]
-impl Client {
-    pub fn full_sliding_sync(&self) -> Result<Arc<SlidingSync>, ClientError> {
-        RUNTIME.block_on(async move {
-            let builder = self.client.sliding_sync().await;
-            let inner = builder.add_fullsync_list().build().await?;
-            Ok(Arc::new(SlidingSync::new(inner, self.clone())))
-        })
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -363,17 +363,12 @@ out).
 
 This is a purely in-memory cache layer though. If one wants Sliding Sync to
 persist and load from cold (storage) cache, one needs to set its key with
-[`cold_cache(name)`][`SlidingSyncBuilder::cold_cache`] and for each list
+[`storage_key(name)`][`SlidingSyncBuilder::storage_key`] and for each list
 present at `.build()`[`SlidingSyncBuilder::build`] sliding sync will attempt
 to load their latest cached version from storage, as well as some overall
 information of Sliding Sync. If that succeeded the lists `state` has been
 set to [`Preload`][SlidingSyncListState::Preload]. Only room data of rooms
 present in one of the lists is loaded from storage.
-
-Once [#1441](https://github.com/matrix-org/matrix-rust-sdk/pull/1441) is merged
-one can disable caching on a per-list basis by setting
-[`cold_cache(false)`][`SlidingSyncListBuilder::cold_cache`] when
-constructing the builder.
 
 Notice that lists added after Sliding Sync has been built **will not be
 loaded from cache** regardless of their settings (as this could lead to
@@ -431,7 +426,7 @@ let sliding_sync_builder = client
     .await
     .homeserver(Url::parse("http://sliding-sync.example.org")?) // our proxy server
     .with_common_extensions() // we want the e2ee and to-device enabled, please
-    .cold_cache("example-cache".to_owned()); // we want these to be loaded from and stored into the persistent storage
+    .storage_key(Some("example-cache".to_string())); // we want these to be loaded from and stored into the persistent storage
 
 let full_sync_list = SlidingSyncList::builder()
     .sync_mode(SlidingSyncMode::Growing)  // sync up by growing the window

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -426,7 +426,7 @@ let sliding_sync_builder = client
     .await
     .homeserver(Url::parse("http://sliding-sync.example.org")?) // our proxy server
     .with_common_extensions() // we want the e2ee and to-device enabled, please
-    .storage_key(Some("example-cache".to_string())); // we want these to be loaded from and stored into the persistent storage
+    .storage_key(Some("example-cache".to_owned())); // we want these to be loaded from and stored into the persistent storage
 
 let full_sync_list = SlidingSyncList::builder()
     .sync_mode(SlidingSyncMode::Growing)  // sync up by growing the window

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -16,7 +16,7 @@ use url::Url;
 
 use super::{
     cache::restore_sliding_sync_state, Error, SlidingSync, SlidingSyncInner, SlidingSyncList,
-    SlidingSyncListBuilder, SlidingSyncPositionMarkers, SlidingSyncRoom,
+    SlidingSyncPositionMarkers, SlidingSyncRoom,
 };
 use crate::{Client, Result};
 
@@ -61,41 +61,6 @@ impl SlidingSyncBuilder {
     /// Set the client this sliding sync will be using.
     pub fn client(mut self, value: Client) -> Self {
         self.client = Some(value);
-        self
-    }
-
-    pub(super) fn subscriptions(
-        mut self,
-        value: BTreeMap<OwnedRoomId, v4::RoomSubscription>,
-    ) -> Self {
-        self.subscriptions = value;
-        self
-    }
-
-    /// Convenience function to add a full-sync list to the builder
-    pub fn add_fullsync_list(self) -> Self {
-        self.add_list(
-            SlidingSyncListBuilder::default_with_fullsync()
-                .build()
-                .expect("Building default full sync list doesn't fail"),
-        )
-    }
-
-    /// The cold cache key to read from and store the frozen state at
-    pub fn cold_cache<T: ToString>(mut self, name: T) -> Self {
-        self.storage_key = Some(name.to_string());
-        self
-    }
-
-    /// Do not use the cold cache
-    pub fn no_cold_cache(mut self) -> Self {
-        self.storage_key = None;
-        self
-    }
-
-    /// Reset the lists to `None`
-    pub fn no_lists(mut self) -> Self {
-        self.lists.clear();
         self
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -125,26 +125,6 @@ impl SlidingSync {
         SlidingSyncBuilder::new()
     }
 
-    /// Generate a new [`SlidingSyncBuilder`] with the same inner settings and
-    /// lists but without the current state.
-    pub fn new_builder_copy(&self) -> SlidingSyncBuilder {
-        let mut builder = Self::builder()
-            .client(self.inner.client.clone())
-            .subscriptions(self.inner.subscriptions.read().unwrap().to_owned());
-
-        for list in self.inner.lists.read().unwrap().values().map(|list| {
-            list.new_builder().build().expect("builder worked before, builder works now")
-        }) {
-            builder = builder.add_list(list);
-        }
-
-        if let Some(homeserver) = &self.inner.homeserver {
-            builder.homeserver(homeserver.clone())
-        } else {
-            builder
-        }
-    }
-
     /// Subscribe to a given room.
     ///
     /// Note: this does not cancel any pending request, so make sure to only

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -86,8 +86,18 @@ impl From<&RoomListEntry> for RoomListEntryEasy {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn it_works_smoke_test() -> anyhow::Result<()> {
-    let (_client, sync_proxy_builder) = setup("odo".to_owned(), false).await?;
-    let sync_proxy = sync_proxy_builder.add_fullsync_list().build().await?;
+    let (_client, sync_builder) = setup("odo".to_owned(), false).await?;
+    let sync_proxy = sync_builder
+        .add_list(
+            SlidingSyncList::builder()
+                .sync_mode(SlidingSyncMode::Selective)
+                .add_range(0u32, 10)
+                .timeline_limit(0u32)
+                .name("foo")
+                .build()?,
+        )
+        .build()
+        .await?;
     let stream = sync_proxy.stream();
     pin_mut!(stream);
     let room_summary =
@@ -855,7 +865,7 @@ async fn fast_unfreeze() -> anyhow::Result<()> {
         let (sliding_window_list, growing_sync) = build_lists()?;
         let sync_proxy = sync_proxy_builder
             .clone()
-            .cold_cache("sliding_sync")
+            .storage_key(Some("sliding_sync".to_string()))
             .add_list(sliding_window_list)
             .add_list(growing_sync)
             .build()
@@ -881,7 +891,7 @@ async fn fast_unfreeze() -> anyhow::Result<()> {
     let start = Instant::now();
     let _sync_proxy = sync_proxy_builder
         .clone()
-        .cold_cache("sliding_sync")
+        .storage_key(Some("sliding_sync".to_string()))
         .add_list(sliding_window_list)
         .add_list(growing_sync)
         .build()
@@ -952,7 +962,7 @@ async fn continue_on_reset() -> anyhow::Result<()> {
     println!("starting the sliding sync setup");
     let sync_proxy = sync_proxy_builder
         .clone()
-        .cold_cache("sliding_sync")
+        .storage_key(Some("sliding_sync".to_string()))
         .add_list(growing_sync)
         .build()
         .await?;
@@ -1037,7 +1047,7 @@ async fn noticing_new_rooms_in_growing() -> anyhow::Result<()> {
     println!("starting the sliding sync setup");
     let sync_proxy = sync_proxy_builder
         .clone()
-        .cold_cache("sliding_sync")
+        .storage_key(Some("sliding_sync".to_string()))
         .add_list(growing_sync)
         .build()
         .await?;


### PR DESCRIPTION
Those methods are public, but never used by our current users.

Moreover, there is some big overlaps. For example, `storage_key`, `cold_cache` and `no_cache` do the same thing: They update the `storage_key` field. Or `add_fullsync_list` is just a helper that is never used except in the tests etc.