### PR TITLE
sdk: Re-export `CrossSigningStatus`

### DIFF
--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -31,13 +31,11 @@ pub use matrix_sdk_base::crypto::{
         SessionCreationError as MegolmSessionCreationError,
         SessionExportError as OlmSessionExportError,
     },
-    vodozemac, CryptoStoreError, DecryptorError, EventError, KeyExportError, LocalTrust,
-    MediaEncryptionInfo, MegolmError, OlmError, RoomKeyImportResult, SecretImportError,
+    vodozemac, CrossSigningStatus, CryptoStoreError, DecryptorError, EventError, KeyExportError,
+    LocalTrust, MediaEncryptionInfo, MegolmError, OlmError, RoomKeyImportResult, SecretImportError,
     SessionCreationError, SignatureError, VERSION,
 };
-use matrix_sdk_base::crypto::{
-    CrossSigningStatus, OutgoingRequest, RoomMessageRequest, ToDeviceRequest,
-};
+use matrix_sdk_base::crypto::{OutgoingRequest, RoomMessageRequest, ToDeviceRequest};
 use ruma::{
     api::client::{
         backup::add_backup_keys::v3::Response as KeysBackupResponse,


### PR DESCRIPTION
It's the output type of `Encryption::cross_signing_status()` but it's not re-exported in the main crate. 

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
