### PR TITLE
sdk: Simplify return type of fetch_in_reply_to_details

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -308,8 +308,7 @@ impl Timeline {
     /// before all requests are handled.
     #[instrument(skip(self), fields(room_id = ?self.room().room_id()))]
     pub async fn fetch_event_details(&self, event_id: &EventId) -> Result<()> {
-        self.inner.fetch_in_reply_to_details(event_id).await?;
-        Ok(())
+        self.inner.fetch_in_reply_to_details(event_id).await
     }
 
     /// Fetch all member events for the room this timeline is displaying.


### PR DESCRIPTION
I talked to Kévin who added this function, the `Ok()` return value was supposed to be used later but it's no longer clear that we actually need it for anything.