### PR TITLE
sdk: Handle ephemeral events after timeline events

### DIFF
--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -119,11 +119,13 @@ impl Client {
             let JoinedRoom { unread_notifications: _, timeline, state, account_data, ephemeral } =
                 room_info;
 
-            self.handle_sync_events(HandlerKind::EphemeralRoomData, &room, &ephemeral.events)
-                .await?;
             self.handle_sync_events(HandlerKind::RoomAccountData, &room, account_data).await?;
             self.handle_sync_state_events(&room, &state.events).await?;
             self.handle_sync_timeline_events(&room, &timeline.events).await?;
+            // Handle ephemeral events after timeline, read receipts in here
+            // could refer to timeline events from the same response.
+            self.handle_sync_events(HandlerKind::EphemeralRoomData, &room, &ephemeral.events)
+                .await?;
         }
 
         for (room_id, room_info) in &rooms.leave {


### PR DESCRIPTION
While refactoring some read receipt code I was wondering if it was possible for the read receipt of a local echo to be handled before the event itself. I think it was, but only due to the weird order we handled events in. This should fix that.
