### PR TITLE
Drop outbound group sessions because of the withheld support

### DIFF
--- a/crates/matrix-sdk-sqlite/migrations/006_drop_outbound_group_sessions.sql
+++ b/crates/matrix-sdk-sqlite/migrations/006_drop_outbound_group_sessions.sql
@@ -1,0 +1,4 @@
+-- Outbound group sessions changed their format, now we remember which members
+-- received a withheld code. To not throw errors when trying to restore such
+-- sessions just drop them so they get rotated.
+DELETE FROM "outbound_group_session";

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -190,7 +190,7 @@ impl SqliteCryptoStore {
     }
 }
 
-const DATABASE_VERSION: u8 = 5;
+const DATABASE_VERSION: u8 = 6;
 
 async fn run_migrations(conn: &SqliteConn) -> rusqlite::Result<()> {
     let kv_exists = conn
@@ -256,6 +256,13 @@ async fn run_migrations(conn: &SqliteConn) -> rusqlite::Result<()> {
     if version < 5 {
         conn.with_transaction(|txn| {
             txn.execute_batch(include_str!("../migrations/005_withheld_code.sql"))
+        })
+        .await?;
+    }
+
+    if version < 6 {
+        conn.with_transaction(|txn| {
+            txn.execute_batch(include_str!("../migrations/006_drop_outbound_group_sessions.sql"))
         })
         .await?;
     }


### PR DESCRIPTION
This was forgotten as part of https://github.com/matrix-org/matrix-rust-sdk/pull/1483. The PR changed the format of the `OutboundGroupSession`, so any old sessions can't be restored anymore.