### PR TITLE
Install musl-gcc for linux-musl nodejs releases

### DIFF
--- a/.github/workflows/prep-crypto-nodejs-release.yml
+++ b/.github/workflows/prep-crypto-nodejs-release.yml
@@ -110,7 +110,7 @@ jobs:
 
   trigger-release:
     # and trigger the tagging release workflow
-    uses: matrix-org/matrix-rust-sdk/.github/workflows/release-crypto-nodejs.yml@main
+    uses: ./.github/workflows/release-crypto-nodejs.yml
     needs: ['prepare-release']
     name: "Trigger release Workflow"
     with:

--- a/.github/workflows/release-crypto-nodejs.yml
+++ b/.github/workflows/release-crypto-nodejs.yml
@@ -52,6 +52,7 @@ jobs:
             apt_install: gcc-arm-linux-gnueabihf
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            apt_install: musl-tools
           # ----------------------------------- macOS
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
Edit the `x86_64-unknown-linux-musl` release workflow to let it install `musl-gcc` before building `libsqlite3-sys`.

Without this, the workflow build fails (example: https://github.com/matrix-org/matrix-rust-sdk/actions/runs/4697562772/jobs/8329227545#step:8:217).

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>
