### PR TITLE
Remove its own user id when updating the account data

### DIFF
--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -802,7 +802,7 @@ impl Common {
         if is_direct {
             let mut room_members = self.active_members().await?;
             room_members.retain(|member| member.user_id() != self.own_user_id());
-            
+
             for member in room_members {
                 let entry = content.entry(member.user_id().to_owned()).or_default();
                 if !entry.iter().any(|room_id| room_id == this_room_id) {

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -800,7 +800,9 @@ impl Common {
         let this_room_id = self.inner.room_id();
 
         if is_direct {
-            let room_members = self.active_members().await?;
+            let mut room_members = self.active_members().await?;
+            room_members.retain(|member| member.user_id() != self.own_user_id());
+            
             for member in room_members {
                 let entry = content.entry(member.user_id().to_owned()).or_default();
                 if !entry.iter().any(|room_id| room_id == this_room_id) {


### PR DESCRIPTION
For direct rooms a client is interested to store for each user, the set of direct room it has with him.
It doesn't make much sense to store the same information for its own user id.
Doing so the account data would collect duplicate information without apparently any benefit.

**Example**
If `U1` is marking direct a room `R1` with `U2` and `U3`:

_Before this PR the result would be_
```json
{
    "U1": [ "R1" ],
    "U2": [ "R1" ],
    "U3": [ "R1" ]
}
```

_After this PR_
```json
{
    "U2": [ "R1" ],
    "U3": [ "R1" ]
}
```