### PR TITLE
Add workaround for building Android bindings with supported NDK versions (r23+)

### DIFF
--- a/bindings/matrix-sdk-ffi/build.rs
+++ b/bindings/matrix-sdk-ffi/build.rs
@@ -1,3 +1,34 @@
+use std::env;
+
+/// Adds a temporary workaround for an issue with the Rust compiler and Android in x86_64 devices:
+/// See https://github.com/rust-lang/rust/issues/109717.
+/// The workaround comes from: https://github.com/mozilla/application-services/pull/5442
+fn setup_x86_64_android_workaround() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    if target_arch == "x86_64" && target_os == "android" {
+        let android_ndk_home = env::var("ANDROID_NDK_HOME").expect("ANDROID_NDK_HOME not set");
+        let build_os = match env::consts::OS {
+            "linux" => "linux",
+            "macos" => "darwin",
+            "windows" => "windows",
+            _ => panic!(
+                "Unsupported OS. You must use either Linux, MacOS or Windows to build the crate."
+            ),
+        };
+        let default_clang_version = "14.0.7";
+        let clang_version =
+            env::var("NDK_CLANG_VERSION").unwrap_or(default_clang_version.to_string());
+        let linux_x86_64_lib_dir = format!(
+            "toolchains/llvm/prebuilt/{}-x86_64/lib64/clang/{}/lib/linux/",
+            build_os, clang_version
+        );
+        println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
+        println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
+    }
+}
+
 fn main() {
+    setup_x86_64_android_workaround();
     uniffi::generate_scaffolding("./src/api.udl").expect("Building the UDL file failed");
 }

--- a/bindings/matrix-sdk-ffi/build.rs
+++ b/bindings/matrix-sdk-ffi/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
-/// Adds a temporary workaround for an issue with the Rust compiler and Android in x86_64 devices:
-/// See https://github.com/rust-lang/rust/issues/109717.
+/// Adds a temporary workaround for an issue with the Rust compiler and Android
+/// in x86_64 devices: https://github.com/rust-lang/rust/issues/109717.
 /// The workaround comes from: https://github.com/mozilla/application-services/pull/5442
 fn setup_x86_64_android_workaround() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/bindings/matrix-sdk-ffi/build.rs
+++ b/bindings/matrix-sdk-ffi/build.rs
@@ -18,7 +18,7 @@ fn setup_x86_64_android_workaround() {
         };
         const DEFAULT_CLANG_VERSION: &str = "14.0.7";
         let clang_version =
-            env::var("NDK_CLANG_VERSION").unwrap_or_else(|| DEFAULT_CLANG_VERSION.to_owned());
+            env::var("NDK_CLANG_VERSION").unwrap_or_else(|_| DEFAULT_CLANG_VERSION.to_owned());
         let linux_x86_64_lib_dir = format!(
             "toolchains/llvm/prebuilt/{build_os}-x86_64/lib64/clang/{clang_version}/lib/linux/"
         );

--- a/bindings/matrix-sdk-ffi/build.rs
+++ b/bindings/matrix-sdk-ffi/build.rs
@@ -4,8 +4,8 @@ use std::env;
 /// in x86_64 devices: https://github.com/rust-lang/rust/issues/109717.
 /// The workaround comes from: https://github.com/mozilla/application-services/pull/5442
 fn setup_x86_64_android_workaround() {
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
     if target_arch == "x86_64" && target_os == "android" {
         let android_ndk_home = env::var("ANDROID_NDK_HOME").expect("ANDROID_NDK_HOME not set");
         let build_os = match env::consts::OS {
@@ -16,12 +16,11 @@ fn setup_x86_64_android_workaround() {
                 "Unsupported OS. You must use either Linux, MacOS or Windows to build the crate."
             ),
         };
-        let default_clang_version = "14.0.7";
+        const DEFAULT_CLANG_VERSION: &str = "14.0.7";
         let clang_version =
-            env::var("NDK_CLANG_VERSION").unwrap_or(default_clang_version.to_string());
+            env::var("NDK_CLANG_VERSION").unwrap_or_else(|| DEFAULT_CLANG_VERSION.to_owned());
         let linux_x86_64_lib_dir = format!(
-            "toolchains/llvm/prebuilt/{}-x86_64/lib64/clang/{}/lib/linux/",
-            build_os, clang_version
+            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib64/clang/{clang_version}/lib/linux/"
         );
         println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
         println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Adds a temporary workaround to `bindings/matrix-sdk-ffi/build.rs` where we replace a linked library with a version that works fine in Android devices with x86_64 arch. This should let us release working versions of the Rust SDK for Android even while [this bug](https://github.com/rust-lang/rust/issues/109717) still exists.

- [ ] Public API changes documented in changelogs (optional)
