### PR TITLE
Update iOS Crypto SDK docs

### DIFF
--- a/bindings/apple/MatrixSDKCrypto-Local.podspec
+++ b/bindings/apple/MatrixSDKCrypto-Local.podspec
@@ -1,0 +1,21 @@
+# Podspec file for local-development only, which points to local version of generated framework instead of github release
+# To use this, the file needs to be copied to the root of `matrix-rust-sdk` in order to have access to the source files.`
+Pod::Spec.new do |s|
+
+    s.name                  = "MatrixSDKCrypto"
+    s.version               = "0.0.1"
+    s.summary               = "Uniffi based bindings for the Rust SDK crypto crate."
+    s.homepage              = "https://github.com/matrix-org/matrix-rust-sdk"
+    s.license               = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
+    s.author                = { "matrix.org" => "support@matrix.org" }
+
+    s.ios.deployment_target = "11.0"
+    s.osx.deployment_target = "10.10"
+
+    s.swift_versions = ['5.1', '5.2']
+
+    s.source                = { :git => "Not Published", :tag => "Cocoapods/#{s.name}/#{s.version}" }
+    s.vendored_frameworks   = "generated/MatrixSDKCryptoFFI.xcframework"
+    s.source_files          = "generated/Sources/**/*.{swift}"
+    s.resources             = ["bindings/matrix-sdk-crypto-ffi/src/**/*.rs", "crates/matrix-sdk-crypto/src/**/*.rs"]
+end

--- a/bindings/apple/MatrixSDKCrypto.podspec
+++ b/bindings/apple/MatrixSDKCrypto.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name                  = "MatrixSDKCrypto"
-    s.version               = "0.1.5"
+    s.version               = "0.0.1" # Version is only incremented manually and locally before pushing to CocoaPods
     s.summary               = "Uniffi based bindings for the Rust SDK crypto crate."
     s.homepage              = "https://github.com/matrix-org/matrix-rust-sdk"
     s.license               = { :type => "Apache License, Version 2.0", :file => "LICENSE" }

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -55,12 +55,19 @@ The generated framework and Swift code can be distributed and integrated directl
 
 ### Publishing MatrixSDKCrypto
 
-1. Run [`build_crypto_xcframework.sh`](#building-only-the-crypto-sdk) script which generates a .zip file with the framework
-2. Increment the version in [`MatrixSDKCrypto.podspec`](./MatrixSDKCrypto.podspec)
+1. Navigate into `bindings/apple` and run [`build_crypto_xcframework.sh`](#building-only-the-crypto-sdk) script which generates a .zip file with the framework in `./generated` folder
+
+   Note that whilst you can run this command from any git branch, if you want to make a public release, ensure you are building from latest `main`
+
+2. Tag the commit you just used to build the release and push the tag to GitHub
+
+   Use `matrix-sdk-crypto-ffi-<major>.<minor>.<patch>` tag name
+
+3. Create a new [GitHub release](https://github.com/matrix-org/matrix-rust-sdk/releases) using this tag (see [example](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.3.4))
+4. Upload the previously generated .zip file to this release
+5. Increment the version in [`MatrixSDKCrypto.podspec`](./MatrixSDKCrypto.podspec)
 
    Note that this is not automated and is a local-only change. To determine the most recent published version, run `pod repo update && pod search MatrixSDKCrypto`
    or check git tags via `git tag | grep matrix-sdk-crypto-ffi`
 
-3. Create a new [GitHub release](https://github.com/matrix-org/matrix-rust-sdk/releases) and a tag with the same version (see [example](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.3.4) for naming)
-4. Upload the .zip file to this release
-5. Push new Podspec version to Cocoapods via `pod trunk push MatrixSDKCrypto.podspec --allow-warnings`
+6. Push new Podspec version to Cocoapods via `pod trunk push MatrixSDKCrypto.podspec --allow-warnings`

--- a/bindings/apple/README.md
+++ b/bindings/apple/README.md
@@ -2,14 +2,16 @@
 
 This project and build script demonstrate how to create an XCFramework that can be imported into an Xcode project and run on Apple platforms. It can compile and bundle an [entire SDK](#Building-the-SDK), or only a smaller [Crypto module](#Building-only-the-Crypto-SDK) that provides end-to-end encryption for clients that already depend on an SDK (e.g. [Matrix iOS SDK](https://github.com/matrix-org/matrix-ios-sdk))
 
-## Prerequisites for building universal frameworks
+## Building
 
-* the Rust toolchain
-* Apple targets (e.g. `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios aarch64-apple-darwin x86_64-apple-darwin`)
-* `xcodebuild` command line tool from [Apple](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
-* `lipo` for creating the fat static libs
+### Prerequisites for building universal frameworks
 
-## Building the SDK
+- the Rust toolchain
+- Apple targets (e.g. `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios aarch64-apple-darwin x86_64-apple-darwin`)
+- `xcodebuild` command line tool from [Apple](https://developer.apple.com/library/archive/technotes/tn2339/_index.html)
+- `lipo` for creating the fat static libs
+
+### Building the SDK
 
 ```
 cargo xtask swift build-framework
@@ -17,7 +19,7 @@ cargo xtask swift build-framework
 
 The `build-framework` task will go through all the steps required to generate a fully usable `.xcframework`:
 
-1. compile `matrix-sdk-ffi` libraries for iOS, the iOS simulator and macOS under `/target`. Some targets are not part of the standard library and they will be built using the nightly toolchain. 
+1. compile `matrix-sdk-ffi` libraries for iOS, the iOS simulator and macOS under `/target`. Some targets are not part of the standard library and they will be built using the nightly toolchain.
 2. `lipo` together the libraries for the same platform under `/generated`
 3. run `uniffi` and generate the C header, module map and swift files
 4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS one, and add the header and module map to it under `generated/MatrixSDKFFI.xcframework`
@@ -27,7 +29,7 @@ For development purposes, it will additionally generate a `Package.swift` file i
 
 When building the SDK for release you should pass the `--release` argument to the task, which will strip away any symbols and optimise the created binary.
 
-## Building only the Crypto SDK
+### Building only the Crypto SDK
 
 ```
 build_crypto_xcframework.sh
@@ -41,7 +43,7 @@ The `build_crypto_xcframework.sh` script will go through all the steps required 
 4. `xcodebuild` an `xcframework` from the fat static libs and the original iOS one, and add the header and module map to it under `generated/MatrixSDKCryptoFFI.xcframework`
 5. cleanup and delete the generated files except the .xcframework and the swift sources (that aren't part of the framework)
 
-## Building & testing the Swift package
+### Building & testing the Swift package
 
 The `Package.swift` file in this directory provides a simple example on how to integrate everything together but also a place to run unit and integration tests from.
 
@@ -52,8 +54,13 @@ It's pre-configured to link to the generated static lib and .swift files so succ
 The generated framework and Swift code can be distributed and integrated directly but in order to make things simpler we bundle them together as a [Swift package](https://github.com/matrix-org/matrix-rust-components-swift/) in the case of SDK, and as a CocoaPods podspec in the case of Crypto SDK.
 
 ### Publishing MatrixSDKCrypto
-1. Run `build_crypto_xcframework.sh` script which generates a .zip file with the framework
-2. Increment the version in `MatrixSDKCrypto.podspec`
-3. Create a new [GitHub release](https://github.com/matrix-org/matrix-rust-sdk/releases) with the same version (see [example](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.1.0) for naming)
+
+1. Run [`build_crypto_xcframework.sh`](#building-only-the-crypto-sdk) script which generates a .zip file with the framework
+2. Increment the version in [`MatrixSDKCrypto.podspec`](./MatrixSDKCrypto.podspec)
+
+   Note that this is not automated and is a local-only change. To determine the most recent published version, run `pod repo update && pod search MatrixSDKCrypto`
+   or check git tags via `git tag | grep matrix-sdk-crypto-ffi`
+
+3. Create a new [GitHub release](https://github.com/matrix-org/matrix-rust-sdk/releases) and a tag with the same version (see [example](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-ffi-0.3.4) for naming)
 4. Upload the .zip file to this release
 5. Push new Podspec version to Cocoapods via `pod trunk push MatrixSDKCrypto.podspec --allow-warnings`

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -19,6 +19,9 @@ TARGET_CRATE=matrix-sdk-crypto-ffi
 
 # Build static libs for all the different architectures
 
+# Required by olm-sys crate
+export IOS_SDK_PATH=`xcrun --show-sdk-path --sdk iphoneos`
+
 # iOS
 echo -e "Building for iOS [1/5]"
 cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios"

--- a/bindings/matrix-sdk-crypto-ffi/README.md
+++ b/bindings/matrix-sdk-crypto-ffi/README.md
@@ -5,6 +5,8 @@ README mainly describes how to build and integrate the bindings into a Kotlin
 based Android project, but the Android specific bits can be skipped if you are
 targeting an x86 Linux project.
 
+To build and distribute bindings for iOS projects, see a [dedicated page](../apple/README.md)
+
 ## Prerequisites
 
 ### Rust


### PR DESCRIPTION
Update a few details about the building / publishing of the iOS artifact for the crypto SDK. Note that this quite quite a manual process with several steps and a lot to be desired, the changes in this PR only make those steps as explicit as possible (thus providing a recipe for future automation).

Add also add second podspec file for local development that poinst to local source files