### PR TITLE
Implement MSC3925 for the timeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5#8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5"
+source = "git+https://github.com/ruma/ruma?rev=89e398fd062b4e763a3341fc7067428285d51d09#89e398fd062b4e763a3341fc7067428285d51d09"
 dependencies = [
  "assign",
  "js_int",
@@ -4249,7 +4249,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5#8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5"
+source = "git+https://github.com/ruma/ruma?rev=89e398fd062b4e763a3341fc7067428285d51d09#89e398fd062b4e763a3341fc7067428285d51d09"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5#8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5"
+source = "git+https://github.com/ruma/ruma?rev=89e398fd062b4e763a3341fc7067428285d51d09#89e398fd062b4e763a3341fc7067428285d51d09"
 dependencies = [
  "assign",
  "bytes",
@@ -4277,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5#8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5"
+source = "git+https://github.com/ruma/ruma?rev=89e398fd062b4e763a3341fc7067428285d51d09#89e398fd062b4e763a3341fc7067428285d51d09"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4310,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5#8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5"
+source = "git+https://github.com/ruma/ruma?rev=89e398fd062b4e763a3341fc7067428285d51d09#89e398fd062b4e763a3341fc7067428285d51d09"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5#8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5"
+source = "git+https://github.com/ruma/ruma?rev=89e398fd062b4e763a3341fc7067428285d51d09#89e398fd062b4e763a3341fc7067428285d51d09"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4330,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5#8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5"
+source = "git+https://github.com/ruma/ruma?rev=89e398fd062b4e763a3341fc7067428285d51d09#89e398fd062b4e763a3341fc7067428285d51d09"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5#8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5"
+source = "git+https://github.com/ruma/ruma?rev=89e398fd062b4e763a3341fc7067428285d51d09#89e398fd062b4e763a3341fc7067428285d51d09"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ eyeball = "0.4.0"
 eyeball-im = "0.2.0"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
-ruma = { git = "https://github.com/ruma/ruma", rev = "8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5", features = ["client-api-c"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "8eea3e05490fa9a318f9ed66c3a75272e6ef0ee5" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "89e398fd062b4e763a3341fc7067428285d51d09", features = ["client-api-c"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "89e398fd062b4e763a3341fc7067428285d51d09" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/crates/matrix-sdk/src/events.rs
+++ b/crates/matrix-sdk/src/events.rs
@@ -1,10 +1,10 @@
 use ruma::{
     events::{
-        BundledRelations, EventContent, EventContentFromType, MessageLikeEventContent,
-        MessageLikeEventType, MessageLikeUnsigned, OriginalSyncMessageLikeEvent,
-        OriginalSyncStateEvent, PossiblyRedactedStateEventContent, RedactContent,
-        RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedSyncMessageLikeEvent,
-        RedactedSyncStateEvent, StateEventContent, StateEventType, StaticStateEventContent,
+        EventContent, EventContentFromType, MessageLikeEventContent, MessageLikeEventType,
+        MessageLikeUnsigned, OriginalSyncMessageLikeEvent, OriginalSyncStateEvent,
+        PossiblyRedactedStateEventContent, RedactContent, RedactedMessageLikeEventContent,
+        RedactedStateEventContent, RedactedSyncMessageLikeEvent, RedactedSyncStateEvent,
+        StateEventContent, StateEventType, StaticStateEventContent,
     },
     serde::from_raw_json_value,
     EventId, MilliSecondsSinceUnixEpoch, TransactionId, UserId,
@@ -36,16 +36,6 @@ impl SyncTimelineEventWithoutContent {
             SyncTimelineEventWithoutContent::RedactedMessageLike(ev) => ev.origin_server_ts,
             SyncTimelineEventWithoutContent::OriginalState(ev) => ev.origin_server_ts,
             SyncTimelineEventWithoutContent::RedactedState(ev) => ev.origin_server_ts,
-        }
-    }
-
-    pub(crate) fn relations(&self) -> &BundledRelations {
-        static DEFAULT_BUNDLED_RELATIONS: BundledRelations = BundledRelations::new();
-        match self {
-            SyncTimelineEventWithoutContent::OriginalMessageLike(ev) => &ev.unsigned.relations,
-            SyncTimelineEventWithoutContent::OriginalState(ev) => &ev.unsigned.relations,
-            SyncTimelineEventWithoutContent::RedactedMessageLike(_)
-            | SyncTimelineEventWithoutContent::RedactedState(_) => &DEFAULT_BUNDLED_RELATIONS,
         }
     }
 

--- a/crates/matrix-sdk/src/events.rs
+++ b/crates/matrix-sdk/src/events.rs
@@ -91,7 +91,7 @@ impl<'de> Deserialize<'de> for SyncTimelineEventWithoutContent {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) struct NoMessageLikeEventContent {
     #[serde(skip)]
     pub event_type: MessageLikeEventType,
@@ -144,7 +144,7 @@ impl StaticStateEventContent for NoStateEventContent {
     // We don't care about the `prev_content` since it wont deserialize with useful
     // data. Use this type which is `StateUnsigned` minus the `prev_content`
     // field.
-    type Unsigned = MessageLikeUnsigned;
+    type Unsigned = MessageLikeUnsigned<NoMessageLikeEventContent>;
     type PossiblyRedacted = Self;
 }
 impl RedactedStateEventContent for NoStateEventContent {


### PR DESCRIPTION
As of [Synapse v1.79.0](https://github.com/matrix-org/synapse/releases/tag/v1.79.0) (earlier if a homeserver admin opted in), Synapse no longer replaces the content of edited messages with the edit in the client-server API, as per MSC3925. This updates the timeline implementation to be able to handle both edited-message representations. (the heavy lifting is done in Ruma, of course)

I don't think this will work for encrypted rooms yet – we'd have to decrypt the edit inside the bundled edit relation, which I don't think we do.