### PR TITLE
crypto-js: Expose more data on `Device`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -63,6 +63,12 @@ impl Device {
         self.inner.is_cross_signing_trusted()
     }
 
+    /// Is this device cross-signed by its owner?
+    #[wasm_bindgen(js_name = "isCrossSignedByOwner")]
+    pub fn is_cross_signed_by_owner(&self) -> bool {
+        self.inner.is_cross_signed_by_owner()
+    }
+
     /// Set the local trust state of the device to the given state.
     ///
     /// This won’t affect any cross signing trust state, this only

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -4,6 +4,7 @@ use js_sys::{Array, Map, Promise};
 use wasm_bindgen::prelude::*;
 
 use crate::{
+    encryption::EncryptionAlgorithm,
     future::future_to_promise,
     identifiers::{self, DeviceId, UserId},
     impl_from_to_inner,
@@ -139,6 +140,19 @@ impl Device {
         }
 
         map
+    }
+
+    /// Get the list of algorithms this device supports.
+    ///
+    /// Returns `Array<EncryptionAlgorithm>`.
+    #[wasm_bindgen(getter)]
+    pub fn algorithms(&self) -> Array {
+        self.inner
+            .algorithms()
+            .iter()
+            .map(|alg| EncryptionAlgorithm::from(alg.clone()))
+            .map(JsValue::from)
+            .collect()
     }
 
     /// Get a map containing all the device signatures.

--- a/bindings/matrix-sdk-crypto-js/src/encryption.rs
+++ b/bindings/matrix-sdk-crypto-js/src/encryption.rs
@@ -86,6 +86,17 @@ pub enum EncryptionAlgorithm {
     MegolmV1AesSha2,
 }
 
+impl From<EncryptionAlgorithm> for JsValue {
+    fn from(value: EncryptionAlgorithm) -> Self {
+        use EncryptionAlgorithm::*;
+
+        match value {
+            OlmV1Curve25519AesSha2 => JsValue::from(0),
+            MegolmV1AesSha2 => JsValue::from(1),
+        }
+    }
+}
+
 impl From<EncryptionAlgorithm> for matrix_sdk_crypto::types::EventEncryptionAlgorithm {
     fn from(value: EncryptionAlgorithm) -> Self {
         use EncryptionAlgorithm::*;

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -11,6 +11,7 @@ const {
     DeviceKeyName,
     DeviceKeyAlgorithmName,
     Ed25519PublicKey,
+    EncryptionAlgorithm,
     Curve25519PublicKey,
     Signatures,
     VerificationMethod,
@@ -115,6 +116,10 @@ describe(OlmMachine.name, () => {
         expect(dev.userId.toString()).toStrictEqual(user.toString());
         expect(dev.deviceId.toString()).toStrictEqual(secondDeviceId.toString());
         expect(dev.deviceName).toBeUndefined();
+        expect(dev.algorithms).toEqual([
+            EncryptionAlgorithm.OlmV1Curve25519AesSha2,
+            EncryptionAlgorithm.MegolmV1AesSha2,
+        ]);
 
         const deviceKey = dev.getKey(DeviceKeyAlgorithmName.Ed25519);
 

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -104,6 +104,7 @@ describe(OlmMachine.name, () => {
         expect(dev).toBeInstanceOf(Device);
         expect(dev.isVerified()).toStrictEqual(false);
         expect(dev.isCrossSigningTrusted()).toStrictEqual(false);
+        expect(dev.isCrossSignedByOwner()).toStrictEqual(false);
 
         expect(dev.localTrustState).toStrictEqual(LocalTrust.Unset);
         expect(dev.isLocallyTrusted()).toStrictEqual(false);


### PR DESCRIPTION
Implement `Device.algorithms` and `Device.isSignedByOwner` for the js bindings.