### PR TITLE
Fix some rustdoc warnings

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_item/content.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/content.rs
@@ -42,7 +42,7 @@ use crate::{
     Result,
 };
 
-/// The content of an [`EventTimelineItem`].
+/// The content of an [`EventTimelineItem`][super::EventTimelineItem].
 #[derive(Clone, Debug)]
 pub enum TimelineItemContent {
     /// An `m.room.message` event or extensible event, including edits.
@@ -168,12 +168,10 @@ pub struct InReplyToDetails {
 
     /// The details of the event.
     ///
-    /// Use [`Timeline::fetch_item_details`] to fetch the data if it is
-    /// unavailable. The `replies_nesting_level` field in
-    /// [`TimelineDetailsSettings`] decides if this should be fetched.
+    /// Use [`Timeline::fetch_event_details`] to fetch the data if it is
+    /// unavailable.
     ///
-    /// [`Timeline::fetch_item_details`]: super::Timeline::fetch_item_details
-    /// [`TimelineDetailsSettings`]: super::TimelineDetailsSettings
+    /// [`Timeline::fetch_event_details`]: crate::room::timeline::Timeline::fetch_event_details
     pub event: TimelineDetails<Box<RepliedToEvent>>,
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -329,7 +329,7 @@ the [`SlidingSync`][] will only process new data and skip the processing
 even across restarts.
 
 To support this, in practice, one can spawn a `Future` that runs
-[`SlidingStream::stream`]. The spawned `Future` can be cancelled safely. If
+[`SlidingSync::stream`]. The spawned `Future` can be cancelled safely. If
 the client was waiting on a response, it's cancelled without any issue. If
 a response was just received, it
 will be fully handled by `SlidingSync`. This _response is always
@@ -367,7 +367,7 @@ persist and load from cold (storage) cache, one needs to set its key with
 present at `.build()`[`SlidingSyncBuilder::build`] sliding sync will attempt
 to load their latest cached version from storage, as well as some overall
 information of Sliding Sync. If that succeeded the lists `state` has been
-set to [`Preload`][SlidingSyncListState::Preload]. Only room data of rooms
+set to [`Preloaded`][SlidingSyncState::Preloaded]. Only room data of rooms
 present in one of the lists is loaded from storage.
 
 Notice that lists added after Sliding Sync has been built **will not be

--- a/crates/matrix-sdk/src/sliding_sync/list/room_list_entry.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/room_list_entry.rs
@@ -1,7 +1,7 @@
 use ruma::{OwnedRoomId, RoomId};
 use serde::{Deserialize, Serialize};
 
-/// Represent a room entry in the [`SlidingSyncList`].
+/// Represent a room entry in the [`SlidingSyncList`][super::SlidingSyncList].
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum RoomListEntry {

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -25,7 +25,7 @@ use crate::{
     Client,
 };
 
-/// Room details, provided by a [`SlidingSync`] instance.
+/// Room details, provided by a [`SlidingSync`][super::SlidingSync] instance.
 #[derive(Debug, Clone)]
 pub struct SlidingSyncRoom {
     client: Client,


### PR DESCRIPTION
We don't seem to be running the same checks in CI that `cargo xtask ci` does, since it fails while CI passes. We seem to have accumulated a number of broken intra-doc links, but for most (in sliding sync) I don't actually know how to rewrite them. This fixes the obvious ones.
