### PR TITLE
base-sdk: Don't separate member events from other state events

### DIFF
--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -4,6 +4,8 @@
 
 - Rename `RoomType` to `RoomState`
 - Add `RoomInfo::state` accessor
+- Remove `members` and `stripped_members` fields in `StateChanges`. Room member events are now with
+  other state events in `state` and `stripped_state`.
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -813,13 +813,16 @@ mod test {
     use assign::assign;
     use matrix_sdk_test::async_test;
     use ruma::{
-        events::room::{
-            canonical_alias::RoomCanonicalAliasEventContent,
-            member::{
-                MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent,
-                SyncRoomMemberEvent,
+        events::{
+            room::{
+                canonical_alias::RoomCanonicalAliasEventContent,
+                member::{
+                    MembershipState, RoomMemberEventContent, StrippedRoomMemberEvent,
+                    SyncRoomMemberEvent,
+                },
+                name::RoomNameEventContent,
             },
-            name::RoomNameEventContent,
+            StateEventType,
         },
         room_alias_id, room_id,
         serde::Raw,
@@ -1025,16 +1028,15 @@ mod test {
             heroes: vec![me.to_string(), matthew.to_string()],
         });
 
-        changes
-            .members
+        let members = changes
+            .state
             .entry(room_id.to_owned())
             .or_default()
-            .insert(matthew.to_owned(), make_member_event(matthew, "Matthew"));
-        changes
-            .members
-            .entry(room_id.to_owned())
-            .or_default()
-            .insert(me.to_owned(), make_member_event(me, "Me"));
+            .entry(StateEventType::RoomMember)
+            .or_default();
+        members.insert(matthew.into(), make_member_event(matthew, "Matthew").cast());
+        members.insert(me.into(), make_member_event(me, "Me").cast());
+
         store.save_changes(&changes).await.unwrap();
 
         room.inner.write().unwrap().update_summary(&summary);
@@ -1052,16 +1054,15 @@ mod test {
         let me = user_id!("@me:example.org");
         let mut changes = StateChanges::new("".to_owned());
 
-        changes
-            .members
+        let members = changes
+            .state
             .entry(room_id.to_owned())
             .or_default()
-            .insert(matthew.to_owned(), make_member_event(matthew, "Matthew"));
-        changes
-            .members
-            .entry(room_id.to_owned())
-            .or_default()
-            .insert(me.to_owned(), make_member_event(me, "Me"));
+            .entry(StateEventType::RoomMember)
+            .or_default();
+        members.insert(matthew.into(), make_member_event(matthew, "Matthew").cast());
+        members.insert(me.into(), make_member_event(me, "Me").cast());
+
         store.save_changes(&changes).await.unwrap();
 
         assert_eq!(
@@ -1082,16 +1083,15 @@ mod test {
             heroes: vec![me.to_string(), matthew.to_string()],
         });
 
-        changes
-            .members
+        let members = changes
+            .state
             .entry(room_id.to_owned())
             .or_default()
-            .insert(matthew.to_owned(), make_member_event(matthew, "Matthew"));
-        changes
-            .members
-            .entry(room_id.to_owned())
-            .or_default()
-            .insert(me.to_owned(), make_member_event(me, "Me"));
+            .entry(StateEventType::RoomMember)
+            .or_default();
+        members.insert(matthew.into(), make_member_event(matthew, "Matthew").cast());
+        members.insert(me.into(), make_member_event(me, "Me").cast());
+
         store.save_changes(&changes).await.unwrap();
 
         room.inner.write().unwrap().update_summary(&summary);

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -20,8 +20,15 @@ use std::{
 use gloo_utils::format::JsValueSerdeExt;
 use indexed_db_futures::{prelude::*, request::OpenDbRequest, IdbDatabase, IdbVersionChangeEvent};
 use js_sys::Date as JsDate;
-use matrix_sdk_base::StateStoreDataKey;
+use matrix_sdk_base::{RoomInfo, StateStoreDataKey};
 use matrix_sdk_store_encryption::StoreCipher;
+use ruma::{
+    events::{
+        room::member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
+        StateEventType,
+    },
+    serde::Raw,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 use wasm_bindgen::JsValue;
@@ -32,7 +39,7 @@ use super::{
 };
 use crate::IndexeddbStateStoreError;
 
-const CURRENT_DB_VERSION: u32 = 4;
+const CURRENT_DB_VERSION: u32 = 5;
 const CURRENT_META_DB_VERSION: u32 = 2;
 
 /// Sometimes Migrations can't proceed without having to drop existing
@@ -56,6 +63,8 @@ struct StoreKeyWrapper(Vec<u8>);
 mod old_keys {
     pub const SESSION: &str = "session";
     pub const SYNC_TOKEN: &str = "sync_token";
+    pub const MEMBERS: &str = "members";
+    pub const STRIPPED_MEMBERS: &str = "stripped_members";
 }
 
 pub async fn upgrade_meta_db(
@@ -199,6 +208,9 @@ pub async fn upgrade_inner_db(
             if old_version < 4 {
                 migration.merge(migrate_to_v4(&pre_db, store_cipher).await?);
             }
+            if old_version < 5 {
+                migration.merge(migrate_to_v5(&pre_db, store_cipher).await?);
+            }
         }
 
         pre_db.close();
@@ -240,7 +252,7 @@ pub async fn upgrade_inner_db(
 pub const V1_STORES: &[&str] = &[
     old_keys::SESSION,
     keys::ACCOUNT_DATA,
-    keys::MEMBERS,
+    old_keys::MEMBERS,
     keys::PROFILES,
     keys::DISPLAY_NAMES,
     keys::JOINED_USER_IDS,
@@ -250,7 +262,7 @@ pub const V1_STORES: &[&str] = &[
     keys::PRESENCE,
     keys::ROOM_ACCOUNT_DATA,
     keys::STRIPPED_ROOM_INFOS,
-    keys::STRIPPED_MEMBERS,
+    old_keys::STRIPPED_MEMBERS,
     keys::STRIPPED_ROOM_STATE,
     keys::STRIPPED_JOINED_USER_IDS,
     keys::STRIPPED_INVITED_USER_IDS,
@@ -407,17 +419,105 @@ async fn migrate_to_v4(
     })
 }
 
+/// Move the member events with other state events.
+async fn migrate_to_v5(
+    db: &IdbDatabase,
+    store_cipher: Option<&StoreCipher>,
+) -> Result<OngoingMigration> {
+    let tx = db.transaction_on_multi_with_mode(
+        &[
+            old_keys::MEMBERS,
+            old_keys::STRIPPED_MEMBERS,
+            keys::ROOM_STATE,
+            keys::STRIPPED_ROOM_STATE,
+            keys::ROOM_INFOS,
+            keys::STRIPPED_ROOM_INFOS,
+        ],
+        IdbTransactionMode::Readwrite,
+    )?;
+
+    let members_store = tx.object_store(old_keys::MEMBERS)?;
+    let state_store = tx.object_store(keys::ROOM_STATE)?;
+    let room_infos = tx
+        .object_store(keys::ROOM_INFOS)?
+        .get_all()?
+        .await?
+        .iter()
+        .filter_map(|f| deserialize_event::<RoomInfo>(store_cipher, f).ok())
+        .collect::<Vec<_>>();
+
+    for room_info in room_infos {
+        let room_id = room_info.room_id();
+        let range = encode_to_range(store_cipher, old_keys::MEMBERS, room_id)?;
+        for value in members_store.get_all_with_key(&range)?.await?.iter() {
+            let raw_member_event =
+                deserialize_event::<Raw<SyncRoomMemberEvent>>(store_cipher, value.clone())?;
+            let state_key = raw_member_event.get_field::<String>("state_key")?.unwrap_or_default();
+            let key = encode_key(
+                store_cipher,
+                keys::ROOM_STATE,
+                (room_id, StateEventType::RoomMember, state_key),
+            );
+
+            state_store.add_key_val(&key, &value)?;
+        }
+    }
+
+    let stripped_members_store = tx.object_store(old_keys::STRIPPED_MEMBERS)?;
+    let stripped_state_store = tx.object_store(keys::STRIPPED_ROOM_STATE)?;
+    let stripped_room_infos = tx
+        .object_store(keys::STRIPPED_ROOM_INFOS)?
+        .get_all()?
+        .await?
+        .iter()
+        .filter_map(|f| deserialize_event::<RoomInfo>(store_cipher, f).ok())
+        .collect::<Vec<_>>();
+
+    for room_info in stripped_room_infos {
+        let room_id = room_info.room_id();
+        let range = encode_to_range(store_cipher, old_keys::STRIPPED_MEMBERS, room_id)?;
+        for value in stripped_members_store.get_all_with_key(&range)?.await?.iter() {
+            let raw_member_event =
+                deserialize_event::<Raw<StrippedRoomMemberEvent>>(store_cipher, value.clone())?;
+            let state_key = raw_member_event.get_field::<String>("state_key")?.unwrap_or_default();
+            let key = encode_key(
+                store_cipher,
+                keys::STRIPPED_ROOM_STATE,
+                (room_id, StateEventType::RoomMember, state_key),
+            );
+
+            stripped_state_store.add_key_val(&key, &value)?;
+        }
+    }
+
+    tx.await.into_result()?;
+
+    Ok(OngoingMigration {
+        drop_stores: [old_keys::MEMBERS, old_keys::STRIPPED_MEMBERS].into_iter().collect(),
+        create_stores: Default::default(),
+        data: Default::default(),
+    })
+}
+
 #[cfg(all(test, target_arch = "wasm32"))]
 mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use assert_matches::assert_matches;
     use indexed_db_futures::prelude::*;
-    use matrix_sdk_base::{StateStore, StateStoreDataKey, StoreError};
-    use matrix_sdk_test::async_test;
+    use matrix_sdk_base::{
+        deserialized_responses::RawMemberEvent, RoomInfo, RoomState, StateStore, StateStoreDataKey,
+        StoreError,
+    };
+    use matrix_sdk_test::{async_test, test_json};
     use ruma::{
-        events::{AnySyncStateEvent, StateEventType},
+        events::{
+            room::member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
+            AnySyncStateEvent, StateEventType,
+        },
         room_id,
+        serde::Raw,
+        user_id,
     };
     use serde_json::json;
     use uuid::Uuid;
@@ -449,6 +549,12 @@ mod tests {
                 } else {
                     for name in ALL_STORES {
                         db.create_object_store(name)?;
+                    }
+
+                    if version < 5 {
+                        for name in [old_keys::MEMBERS, old_keys::STRIPPED_MEMBERS] {
+                            db.create_object_store(name)?;
+                        }
                     }
                 }
 
@@ -742,6 +848,79 @@ mod tests {
             .into_filter()
             .unwrap();
         assert_eq!(stored_filter_2_id, filter_2_id);
+
+        Ok(())
+    }
+
+    #[async_test]
+    pub async fn test_migrating_to_v5() -> Result<()> {
+        let name = format!("migrating-v5-{}", Uuid::new_v4().as_hyphenated().to_string());
+
+        let room_id = room_id!("!room:localhost");
+        let member_event =
+            Raw::new(&*test_json::MEMBER_INVITE).unwrap().cast::<SyncRoomMemberEvent>();
+        let user_id = user_id!("@invited:localhost");
+
+        let stripped_room_id = room_id!("!stripped_room:localhost");
+        let stripped_member_event =
+            Raw::new(&*test_json::MEMBER_STRIPPED).unwrap().cast::<StrippedRoomMemberEvent>();
+        let stripped_user_id = user_id!("@example:localhost");
+
+        // Populate DB with old table.
+        {
+            let db = create_fake_db(&name, 4).await?;
+            let tx = db.transaction_on_multi_with_mode(
+                &[
+                    old_keys::MEMBERS,
+                    keys::ROOM_INFOS,
+                    old_keys::STRIPPED_MEMBERS,
+                    keys::STRIPPED_ROOM_INFOS,
+                ],
+                IdbTransactionMode::Readwrite,
+            )?;
+
+            let members_store = tx.object_store(old_keys::MEMBERS)?;
+            members_store.put_key_val(
+                &encode_key(None, old_keys::MEMBERS, (room_id, user_id)),
+                &serialize_event(None, &member_event)?,
+            )?;
+            let room_infos_store = tx.object_store(keys::ROOM_INFOS)?;
+            let room_info = RoomInfo::new(room_id, RoomState::Joined);
+            room_infos_store.put_key_val(
+                &encode_key(None, keys::ROOM_INFOS, room_id),
+                &serialize_event(None, &room_info)?,
+            )?;
+
+            let stripped_members_store = tx.object_store(old_keys::STRIPPED_MEMBERS)?;
+            stripped_members_store.put_key_val(
+                &encode_key(None, old_keys::STRIPPED_MEMBERS, (stripped_room_id, stripped_user_id)),
+                &serialize_event(None, &stripped_member_event)?,
+            )?;
+            let stripped_room_infos_store = tx.object_store(keys::STRIPPED_ROOM_INFOS)?;
+            let stripped_room_info = RoomInfo::new(stripped_room_id, RoomState::Invited);
+            stripped_room_infos_store.put_key_val(
+                &encode_key(None, keys::STRIPPED_ROOM_INFOS, stripped_room_id),
+                &serialize_event(None, &stripped_room_info)?,
+            )?;
+
+            tx.await.into_result()?;
+            db.close();
+        }
+
+        // this transparently migrates to the latest version
+        let store = IndexeddbStateStore::builder().name(name).build().await?;
+
+        let stored_member_event = assert_matches!(
+            store.get_member_event(room_id, user_id).await,
+            Ok(Some(RawMemberEvent::Sync(e))) => e
+        );
+        assert_eq!(stored_member_event.json().get(), member_event.json().get());
+
+        let stored_stripped_member_event = assert_matches!(
+            store.get_member_event(stripped_room_id, stripped_user_id).await,
+            Ok(Some(RawMemberEvent::Stripped(e))) => e
+        );
+        assert_eq!(stored_stripped_member_event.json().get(), stripped_member_event.json().get());
 
         Ok(())
     }


### PR DESCRIPTION
Currently the member events are not stored with the other state events. This has the pitfall of room member events not being available via methods like `Common::get_state_event()` (the example of [`Common::get_state_events_static()`](https://matrix-org.github.io/matrix-rust-sdk/matrix_sdk/room/struct.Common.html#method.get_state_events_static) would even always return an empty `Vec`). I also don't see any benefit in putting them in a separate list because accessing them among other state events is quite easy (although slightly more verbose in places).

Sadly this is one big commit because changing one thing requires changing a lot of other things.

- [x] Public API changes documented in changelogs (optional)

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>