### PR TITLE
Remove LocalEventTimelineItem, RemoteEventTimelineItem from public API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -243,11 +243,11 @@ pub struct EventTimelineItem(pub(crate) matrix_sdk::room::timeline::EventTimelin
 #[uniffi::export]
 impl EventTimelineItem {
     pub fn is_local(&self) -> bool {
-        self.0.as_local().is_some()
+        self.0.is_local_echo()
     }
 
     pub fn is_remote(&self) -> bool {
-        self.0.as_remote().is_some()
+        !self.0.is_local_echo()
     }
 
     pub fn unique_identifier(&self) -> String {

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -88,6 +88,7 @@ matrix-sdk-indexeddb = { version = "0.2.0", path = "../matrix-sdk-indexeddb", de
 matrix-sdk-sled = { version = "0.2.0", path = "../matrix-sdk-sled", default-features = false, optional = true }
 mime = "0.3.16"
 mime_guess = "2.0.4"
+once_cell = { workspace = true }
 pin-project-lite = "0.2.9"
 rand = { version = "0.8.5", optional = true }
 reqwest = { version = "0.11.10", default_features = false }

--- a/crates/matrix-sdk/src/room/timeline/event_item/local.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/local.rs
@@ -1,8 +1,6 @@
-use ruma::{
-    EventId, MilliSecondsSinceUnixEpoch, OwnedTransactionId, OwnedUserId, TransactionId, UserId,
-};
+use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedTransactionId, TransactionId};
 
-use super::{EventSendState, Profile, TimelineDetails, TimelineItemContent};
+use super::EventSendState;
 
 /// An item for an event that was created locally and not yet echoed back by
 /// the homeserver.
@@ -12,26 +10,17 @@ pub struct LocalEventTimelineItem {
     send_state: EventSendState,
     /// The transaction ID.
     transaction_id: OwnedTransactionId,
-    /// The sender of the event.
-    sender: OwnedUserId,
-    /// The sender's profile of the event.
-    sender_profile: TimelineDetails<Profile>,
     /// The timestamp of the event.
     timestamp: MilliSecondsSinceUnixEpoch,
-    /// The content of the event.
-    content: TimelineItemContent,
 }
 
 impl LocalEventTimelineItem {
     pub(in crate::room::timeline) fn new(
         send_state: EventSendState,
         transaction_id: OwnedTransactionId,
-        sender: OwnedUserId,
-        sender_profile: TimelineDetails<Profile>,
         timestamp: MilliSecondsSinceUnixEpoch,
-        content: TimelineItemContent,
     ) -> Self {
-        Self { send_state, transaction_id, sender, sender_profile, timestamp, content }
+        Self { send_state, transaction_id, timestamp }
     }
 
     /// Get the event's send state.
@@ -55,47 +44,13 @@ impl LocalEventTimelineItem {
         &self.transaction_id
     }
 
-    /// Get the sender of the event.
-    ///
-    /// This is always the user's own user ID.
-    pub(crate) fn sender(&self) -> &UserId {
-        &self.sender
-    }
-
-    /// Get the profile of the event's sender.
-    ///
-    /// Since `LocalEventTimelineItem`s are always sent by the user that is
-    /// logged in with the client that created the timeline, this effectively
-    /// gives the sender's own (possibly room-specific) profile.
-    pub fn sender_profile(&self) -> &TimelineDetails<Profile> {
-        &self.sender_profile
-    }
-
     /// Get the timestamp when the event was created locally.
     pub fn timestamp(&self) -> MilliSecondsSinceUnixEpoch {
         self.timestamp
     }
 
-    /// Get the content of the event.
-    pub fn content(&self) -> &TimelineItemContent {
-        &self.content
-    }
-
     /// Clone the current event item, and update its `send_state`.
     pub(in crate::room::timeline) fn with_send_state(&self, send_state: EventSendState) -> Self {
         Self { send_state, ..self.clone() }
-    }
-
-    /// Clone the current event item, and update its `sender_profile`.
-    pub(in crate::room::timeline) fn with_sender_profile(
-        &self,
-        sender_profile: TimelineDetails<Profile>,
-    ) -> Self {
-        Self { sender_profile, ..self.clone() }
-    }
-
-    /// Clone the current event item, and update its `content`.
-    pub(in crate::room::timeline) fn with_content(&self, content: TimelineItemContent) -> Self {
-        Self { content, ..self.clone() }
     }
 }

--- a/crates/matrix-sdk/src/room/timeline/event_item/local.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/local.rs
@@ -5,7 +5,7 @@ use super::EventSendState;
 /// An item for an event that was created locally and not yet echoed back by
 /// the homeserver.
 #[derive(Debug, Clone)]
-pub struct LocalEventTimelineItem {
+pub(in crate::room::timeline) struct LocalEventTimelineItem {
     /// The send state of this local event.
     send_state: EventSendState,
     /// The transaction ID.
@@ -15,7 +15,7 @@ pub struct LocalEventTimelineItem {
 }
 
 impl LocalEventTimelineItem {
-    pub(in crate::room::timeline) fn new(
+    pub fn new(
         send_state: EventSendState,
         transaction_id: OwnedTransactionId,
         timestamp: MilliSecondsSinceUnixEpoch,
@@ -50,7 +50,7 @@ impl LocalEventTimelineItem {
     }
 
     /// Clone the current event item, and update its `send_state`.
-    pub(in crate::room::timeline) fn with_send_state(&self, send_state: EventSendState) -> Self {
+    pub fn with_send_state(&self, send_state: EventSendState) -> Self {
         Self { send_state, ..self.clone() }
     }
 }

--- a/crates/matrix-sdk/src/room/timeline/event_item/local.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/local.rs
@@ -1,4 +1,4 @@
-use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedTransactionId};
+use ruma::{EventId, OwnedTransactionId};
 
 use super::EventSendState;
 
@@ -10,8 +10,6 @@ pub(in crate::room::timeline) struct LocalEventTimelineItem {
     pub send_state: EventSendState,
     /// The transaction ID.
     pub transaction_id: OwnedTransactionId,
-    /// The timestamp of the event.
-    pub timestamp: MilliSecondsSinceUnixEpoch,
 }
 
 impl LocalEventTimelineItem {

--- a/crates/matrix-sdk/src/room/timeline/event_item/local.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/local.rs
@@ -1,4 +1,4 @@
-use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedTransactionId, TransactionId};
+use ruma::{EventId, MilliSecondsSinceUnixEpoch, OwnedTransactionId};
 
 use super::EventSendState;
 
@@ -7,27 +7,14 @@ use super::EventSendState;
 #[derive(Debug, Clone)]
 pub(in crate::room::timeline) struct LocalEventTimelineItem {
     /// The send state of this local event.
-    send_state: EventSendState,
+    pub send_state: EventSendState,
     /// The transaction ID.
-    transaction_id: OwnedTransactionId,
+    pub transaction_id: OwnedTransactionId,
     /// The timestamp of the event.
-    timestamp: MilliSecondsSinceUnixEpoch,
+    pub timestamp: MilliSecondsSinceUnixEpoch,
 }
 
 impl LocalEventTimelineItem {
-    pub fn new(
-        send_state: EventSendState,
-        transaction_id: OwnedTransactionId,
-        timestamp: MilliSecondsSinceUnixEpoch,
-    ) -> Self {
-        Self { send_state, transaction_id, timestamp }
-    }
-
-    /// Get the event's send state.
-    pub fn send_state(&self) -> &EventSendState {
-        &self.send_state
-    }
-
     /// Get the event ID of this item.
     ///
     /// Will be `Some` if and only if `send_state` is
@@ -37,16 +24,6 @@ impl LocalEventTimelineItem {
             EventSendState::Sent { event_id } => Some(event_id),
             _ => None,
         }
-    }
-
-    /// Get the transaction ID of the event.
-    pub fn transaction_id(&self) -> &TransactionId {
-        &self.transaction_id
-    }
-
-    /// Get the timestamp when the event was created locally.
-    pub fn timestamp(&self) -> MilliSecondsSinceUnixEpoch {
-        self.timestamp
     }
 
     /// Clone the current event item, and update its `send_state`.

--- a/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
@@ -45,15 +45,15 @@ pub(super) use self::{local::LocalEventTimelineItem, remote::RemoteEventTimeline
 #[derive(Clone, Debug)]
 pub struct EventTimelineItem {
     /// The sender of the event.
-    sender: OwnedUserId,
+    pub(super) sender: OwnedUserId,
     /// The sender's profile of the event.
-    sender_profile: TimelineDetails<Profile>,
+    pub(super) sender_profile: TimelineDetails<Profile>,
     /// The timestamp of the event.
-    timestamp: MilliSecondsSinceUnixEpoch,
+    pub(super) timestamp: MilliSecondsSinceUnixEpoch,
     /// The content of the event.
-    content: TimelineItemContent,
+    pub(super) content: TimelineItemContent,
     /// The kind of event timeline item, local or remote.
-    kind: EventTimelineItemKind,
+    pub(super) kind: EventTimelineItemKind,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
@@ -48,6 +48,8 @@ pub struct EventTimelineItem {
     sender: OwnedUserId,
     /// The sender's profile of the event.
     sender_profile: TimelineDetails<Profile>,
+    /// The timestamp of the event.
+    timestamp: MilliSecondsSinceUnixEpoch,
     /// The content of the event.
     content: TimelineItemContent,
     /// The kind of event timeline item, local or remote.
@@ -66,10 +68,11 @@ impl EventTimelineItem {
     pub(super) fn new(
         sender: OwnedUserId,
         sender_profile: TimelineDetails<Profile>,
+        timestamp: MilliSecondsSinceUnixEpoch,
         content: TimelineItemContent,
         kind: EventTimelineItemKind,
     ) -> Self {
-        Self { sender, sender_profile, content, kind }
+        Self { sender, sender_profile, timestamp, content, kind }
     }
 
     /// Check whether this item is a local echo.
@@ -195,10 +198,7 @@ impl EventTimelineItem {
     /// time the local event was created. Otherwise, returns the origin
     /// server timestamp.
     pub fn timestamp(&self) -> MilliSecondsSinceUnixEpoch {
-        match &self.kind {
-            EventTimelineItemKind::Local(local_event) => local_event.timestamp,
-            EventTimelineItemKind::Remote(remote_event) => remote_event.timestamp,
-        }
+        self.timestamp
     }
 
     /// Whether this timeline item was sent by the logged-in user themselves.

--- a/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
@@ -108,18 +108,18 @@ impl EventTimelineItem {
     /// case of a remote event.
     pub fn unique_identifier(&self) -> String {
         match &self.kind {
-            EventTimelineItemKind::Local(item) => match item.send_state() {
+            EventTimelineItemKind::Local(item) => match &item.send_state {
                 EventSendState::Sent { event_id } => event_id.to_string(),
-                _ => item.transaction_id().to_string(),
+                _ => item.transaction_id.to_string(),
             },
-            EventTimelineItemKind::Remote(item) => item.event_id().to_string(),
+            EventTimelineItemKind::Remote(item) => item.event_id.to_string(),
         }
     }
 
     /// Get the event's send state, if it is a local echo.
     pub fn send_state(&self) -> Option<&EventSendState> {
         match &self.kind {
-            EventTimelineItemKind::Local(local) => Some(local.send_state()),
+            EventTimelineItemKind::Local(local) => Some(&local.send_state),
             EventTimelineItemKind::Remote(_) => None,
         }
     }
@@ -130,7 +130,7 @@ impl EventTimelineItem {
     /// local event is received.
     pub fn transaction_id(&self) -> Option<&TransactionId> {
         match &self.kind {
-            EventTimelineItemKind::Local(local) => Some(local.transaction_id()),
+            EventTimelineItemKind::Local(local) => Some(&local.transaction_id),
             EventTimelineItemKind::Remote(_) => None,
         }
     }
@@ -146,7 +146,7 @@ impl EventTimelineItem {
     pub fn event_id(&self) -> Option<&EventId> {
         match &self.kind {
             EventTimelineItemKind::Local(local_event) => local_event.event_id(),
-            EventTimelineItemKind::Remote(remote_event) => Some(remote_event.event_id()),
+            EventTimelineItemKind::Remote(remote_event) => Some(&remote_event.event_id),
         }
     }
 
@@ -171,7 +171,7 @@ impl EventTimelineItem {
         static EMPTY_REACTIONS: Lazy<BundledReactions> = Lazy::new(Default::default);
         match &self.kind {
             EventTimelineItemKind::Local(_) => &EMPTY_REACTIONS,
-            EventTimelineItemKind::Remote(remote_event) => remote_event.reactions(),
+            EventTimelineItemKind::Remote(remote_event) => &remote_event.reactions,
         }
     }
 
@@ -185,7 +185,7 @@ impl EventTimelineItem {
         static EMPTY_RECEIPTS: Lazy<IndexMap<OwnedUserId, Receipt>> = Lazy::new(Default::default);
         match &self.kind {
             EventTimelineItemKind::Local(_) => &EMPTY_RECEIPTS,
-            EventTimelineItemKind::Remote(remote_event) => remote_event.read_receipts(),
+            EventTimelineItemKind::Remote(remote_event) => &remote_event.read_receipts,
         }
     }
 
@@ -196,8 +196,8 @@ impl EventTimelineItem {
     /// server timestamp.
     pub fn timestamp(&self) -> MilliSecondsSinceUnixEpoch {
         match &self.kind {
-            EventTimelineItemKind::Local(local_event) => local_event.timestamp(),
-            EventTimelineItemKind::Remote(remote_event) => remote_event.timestamp(),
+            EventTimelineItemKind::Local(local_event) => local_event.timestamp,
+            EventTimelineItemKind::Remote(remote_event) => remote_event.timestamp,
         }
     }
 
@@ -205,7 +205,7 @@ impl EventTimelineItem {
     pub fn is_own(&self) -> bool {
         match &self.kind {
             EventTimelineItemKind::Local(_) => true,
-            EventTimelineItemKind::Remote(remote_event) => remote_event.is_own(),
+            EventTimelineItemKind::Remote(remote_event) => remote_event.is_own,
         }
     }
 
@@ -224,7 +224,7 @@ impl EventTimelineItem {
     pub fn is_highlighted(&self) -> bool {
         match &self.kind {
             EventTimelineItemKind::Local(_) => false,
-            EventTimelineItemKind::Remote(remote_event) => remote_event.is_highlighted(),
+            EventTimelineItemKind::Remote(remote_event) => remote_event.is_highlighted,
         }
     }
 
@@ -232,7 +232,7 @@ impl EventTimelineItem {
     pub fn encryption_info(&self) -> Option<&EncryptionInfo> {
         match &self.kind {
             EventTimelineItemKind::Local(_) => None,
-            EventTimelineItemKind::Remote(remote_event) => remote_event.encryption_info(),
+            EventTimelineItemKind::Remote(remote_event) => remote_event.encryption_info.as_ref(),
         }
     }
 
@@ -244,7 +244,7 @@ impl EventTimelineItem {
     pub fn original_json(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
         match &self.kind {
             EventTimelineItemKind::Local(_local_event) => None,
-            EventTimelineItemKind::Remote(remote_event) => Some(remote_event.original_json()),
+            EventTimelineItemKind::Remote(remote_event) => Some(&remote_event.original_json),
         }
     }
 
@@ -252,7 +252,7 @@ impl EventTimelineItem {
     pub fn latest_edit_json(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
         match &self.kind {
             EventTimelineItemKind::Local(_local_event) => None,
-            EventTimelineItemKind::Remote(remote_event) => remote_event.latest_edit_json(),
+            EventTimelineItemKind::Remote(remote_event) => remote_event.latest_edit_json.as_ref(),
         }
     }
 
@@ -274,7 +274,7 @@ impl EventTimelineItem {
         let mut new = self.clone();
         new.content = new_content;
         if let EventTimelineItemKind::Remote(r) = &mut new.kind {
-            r.set_edit_json(edit_json);
+            r.latest_edit_json = edit_json;
         }
 
         new

--- a/crates/matrix-sdk/src/room/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/remote.rs
@@ -12,7 +12,7 @@ use super::BundledReactions;
 
 /// An item for an event that was received from the homeserver.
 #[derive(Clone)]
-pub struct RemoteEventTimelineItem {
+pub(in crate::room::timeline) struct RemoteEventTimelineItem {
     /// The event ID.
     event_id: OwnedEventId,
     /// The timestamp of the event.
@@ -43,7 +43,7 @@ pub struct RemoteEventTimelineItem {
 
 impl RemoteEventTimelineItem {
     #[allow(clippy::too_many_arguments)] // Would be nice to fix, but unclear how
-    pub(in crate::room::timeline) fn new(
+    pub fn new(
         event_id: OwnedEventId,
         timestamp: MilliSecondsSinceUnixEpoch,
         reactions: BundledReactions,
@@ -118,29 +118,25 @@ impl RemoteEventTimelineItem {
         self.is_highlighted
     }
 
-    pub(in crate::room::timeline) fn add_read_receipt(
-        &mut self,
-        user_id: OwnedUserId,
-        receipt: Receipt,
-    ) {
+    pub fn add_read_receipt(&mut self, user_id: OwnedUserId, receipt: Receipt) {
         self.read_receipts.insert(user_id, receipt);
     }
 
     /// Remove the read receipt for the given user.
     ///
     /// Returns `true` if there was one, `false` if not.
-    pub(in crate::room::timeline) fn remove_read_receipt(&mut self, user_id: &UserId) -> bool {
+    pub fn remove_read_receipt(&mut self, user_id: &UserId) -> bool {
         self.read_receipts.remove(user_id).is_some()
     }
 
     /// Clone the current event item, and update its `reactions`.
-    pub(in crate::room::timeline) fn with_reactions(&self, reactions: BundledReactions) -> Self {
+    pub fn with_reactions(&self, reactions: BundledReactions) -> Self {
         Self { reactions, ..self.clone() }
     }
 
     /// Clone the current event item, change its `content` to
     /// [`TimelineItemContent::RedactedMessage`], and reset its `reactions`.
-    pub(in crate::room::timeline) fn to_redacted(&self) -> Self {
+    pub fn to_redacted(&self) -> Self {
         Self { reactions: BundledReactions::default(), ..self.clone() }
     }
 

--- a/crates/matrix-sdk/src/room/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/remote.rs
@@ -5,7 +5,7 @@ use matrix_sdk_base::deserialized_responses::EncryptionInfo;
 use ruma::{
     events::{receipt::Receipt, AnySyncTimelineEvent},
     serde::Raw,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
+    OwnedEventId, OwnedUserId, UserId,
 };
 
 use super::BundledReactions;
@@ -15,8 +15,6 @@ use super::BundledReactions;
 pub(in crate::room::timeline) struct RemoteEventTimelineItem {
     /// The event ID.
     pub event_id: OwnedEventId,
-    /// The timestamp of the event.
-    pub timestamp: MilliSecondsSinceUnixEpoch,
     /// All bundled reactions about the event.
     pub reactions: BundledReactions,
     /// All read receipts for the event.
@@ -70,7 +68,6 @@ impl fmt::Debug for RemoteEventTimelineItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RemoteEventTimelineItem")
             .field("event_id", &self.event_id)
-            .field("timestamp", &self.timestamp)
             .field("reactions", &self.reactions)
             .field("is_own", &self.is_own)
             .field("encryption_info", &self.encryption_info)

--- a/crates/matrix-sdk/src/room/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/remote.rs
@@ -5,7 +5,7 @@ use matrix_sdk_base::deserialized_responses::EncryptionInfo;
 use ruma::{
     events::{receipt::Receipt, AnySyncTimelineEvent},
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
 };
 
 use super::BundledReactions;
@@ -14,110 +14,34 @@ use super::BundledReactions;
 #[derive(Clone)]
 pub(in crate::room::timeline) struct RemoteEventTimelineItem {
     /// The event ID.
-    event_id: OwnedEventId,
+    pub event_id: OwnedEventId,
     /// The timestamp of the event.
-    timestamp: MilliSecondsSinceUnixEpoch,
+    pub timestamp: MilliSecondsSinceUnixEpoch,
     /// All bundled reactions about the event.
-    reactions: BundledReactions,
+    pub reactions: BundledReactions,
     /// All read receipts for the event.
     ///
     /// The key is the ID of a room member and the value are details about the
     /// read receipt.
     ///
     /// Note that currently this ignores threads.
-    read_receipts: IndexMap<OwnedUserId, Receipt>,
+    pub read_receipts: IndexMap<OwnedUserId, Receipt>,
     /// Whether the event has been sent by the the logged-in user themselves.
-    is_own: bool,
+    pub is_own: bool,
     /// Encryption information.
-    encryption_info: Option<EncryptionInfo>,
+    pub encryption_info: Option<EncryptionInfo>,
     /// JSON of the original event.
     ///
     /// If the message is edited, this *won't* change, instead
     /// `latest_edit_json` will be updated.
-    original_json: Raw<AnySyncTimelineEvent>,
+    pub original_json: Raw<AnySyncTimelineEvent>,
     /// JSON of the latest edit to this item.
-    latest_edit_json: Option<Raw<AnySyncTimelineEvent>>,
+    pub latest_edit_json: Option<Raw<AnySyncTimelineEvent>>,
     /// Whether the item should be highlighted in the timeline.
-    is_highlighted: bool,
+    pub is_highlighted: bool,
 }
 
 impl RemoteEventTimelineItem {
-    #[allow(clippy::too_many_arguments)] // Would be nice to fix, but unclear how
-    pub fn new(
-        event_id: OwnedEventId,
-        timestamp: MilliSecondsSinceUnixEpoch,
-        reactions: BundledReactions,
-        read_receipts: IndexMap<OwnedUserId, Receipt>,
-        is_own: bool,
-        encryption_info: Option<EncryptionInfo>,
-        original_json: Raw<AnySyncTimelineEvent>,
-        is_highlighted: bool,
-    ) -> Self {
-        Self {
-            event_id,
-            timestamp,
-            reactions,
-            read_receipts,
-            is_own,
-            encryption_info,
-            original_json,
-            latest_edit_json: None,
-            is_highlighted,
-        }
-    }
-
-    /// Get the ID of the event.
-    pub fn event_id(&self) -> &EventId {
-        &self.event_id
-    }
-
-    /// Get the event timestamp as set by the homeserver that created the event.
-    pub fn timestamp(&self) -> MilliSecondsSinceUnixEpoch {
-        self.timestamp
-    }
-
-    /// Get the reactions of this item.
-    pub fn reactions(&self) -> &BundledReactions {
-        // FIXME: Find out the state of incomplete bundled reactions, adjust
-        //        Ruma if necessary, return the whole BundledReactions field
-        &self.reactions
-    }
-
-    /// Get the read receipts of this item.
-    ///
-    /// The key is the ID of a room member and the value are details about the
-    /// read receipt.
-    ///
-    /// Note that currently this ignores threads.
-    pub fn read_receipts(&self) -> &IndexMap<OwnedUserId, Receipt> {
-        &self.read_receipts
-    }
-
-    /// Whether the event has been sent by the the logged-in user themselves.
-    pub fn is_own(&self) -> bool {
-        self.is_own
-    }
-
-    /// Get the encryption information for the event, if any.
-    pub fn encryption_info(&self) -> Option<&EncryptionInfo> {
-        self.encryption_info.as_ref()
-    }
-
-    /// Get the raw JSON representation of the primary event.
-    pub fn original_json(&self) -> &Raw<AnySyncTimelineEvent> {
-        &self.original_json
-    }
-
-    /// Get the raw JSON representation of the latest edit, if any.
-    pub fn latest_edit_json(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
-        self.latest_edit_json.as_ref()
-    }
-
-    /// Whether the event should be highlighted in the timeline.
-    pub fn is_highlighted(&self) -> bool {
-        self.is_highlighted
-    }
-
     pub fn add_read_receipt(&mut self, user_id: OwnedUserId, receipt: Receipt) {
         self.read_receipts.insert(user_id, receipt);
     }
@@ -138,10 +62,6 @@ impl RemoteEventTimelineItem {
     /// [`TimelineItemContent::RedactedMessage`], and reset its `reactions`.
     pub fn to_redacted(&self) -> Self {
         Self { reactions: BundledReactions::default(), ..self.clone() }
-    }
-
-    pub(super) fn set_edit_json(&mut self, edit_json: Option<Raw<AnySyncTimelineEvent>>) {
-        self.latest_edit_json = edit_json;
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -254,7 +254,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
         // The event was already marked as sent, that's a broken state, let's
         // emit an error but also override to the given sent state.
-        if let EventSendState::Sent { event_id: existing_event_id } = local_item.send_state() {
+        if let EventSendState::Sent { event_id: existing_event_id } = &local_item.send_state {
             let new_event_id = new_event_id.map(debug);
             error!(?existing_event_id, ?new_event_id, "Local echo already marked as sent");
         }
@@ -388,9 +388,9 @@ impl<P: RoomDataProvider> TimelineInner<P> {
                     return None;
                 };
 
-                tracing::Span::current().record("event_id", debug(remote_event.event_id()));
+                tracing::Span::current().record("event_id", debug(&remote_event.event_id));
 
-                let raw = remote_event.original_json().cast_ref();
+                let raw = remote_event.original_json.cast_ref();
                 match olm_machine.decrypt_room_event(raw, room_id).await {
                     Ok(event) => {
                         trace!("Successfully decrypted event that previously failed to decrypt");
@@ -568,7 +568,7 @@ impl TimelineInner {
         // We need to be sure to have the latest position of the event as it might have
         // changed while waiting for the request.
         let mut state = self.state.lock().await;
-        let (index, item) = rfind_event_by_id(&state.items, remote_item.event_id())
+        let (index, item) = rfind_event_by_id(&state.items, &remote_item.event_id)
             .ok_or(super::Error::RemoteEventNotInTimeline)?;
 
         // Check the state of the event again, it might have been redacted while

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -53,9 +53,8 @@ use super::{
         handle_explicit_read_receipts, latest_user_read_receipt, load_read_receipts_for_event,
         user_receipt,
     },
-    rfind_event_by_id, rfind_event_item, EventSendState, EventTimelineItem, InReplyToDetails,
-    Message, Profile, RelativePosition, RepliedToEvent, TimelineDetails, TimelineItem,
-    TimelineItemContent,
+    rfind_event_by_id, rfind_event_item, EventSendState, InReplyToDetails, Message, Profile,
+    RelativePosition, RepliedToEvent, TimelineDetails, TimelineItem, TimelineItemContent,
 };
 use crate::{
     events::SyncTimelineEventWithoutContent,
@@ -250,7 +249,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             return;
         };
 
-        let EventTimelineItem::Local(item) = item else {
+        let Some(item) = item.as_local() else {
             // Remote echo already received. This is very unlikely.
             trace!("Remote echo received before send-event response");
             return;
@@ -387,7 +386,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
                 tracing::Span::current().record("session_id", session_id);
 
-                let EventTimelineItem::Remote(remote_event) = event_item else {
+                let Some(remote_event) = event_item.as_remote() else {
                     error!("Key for unable-to-decrypt timeline item is not an event ID");
                     return None;
                 };

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -59,9 +59,9 @@ use self::inner::{TimelineInner, TimelineInnerState};
 pub use self::{
     event_item::{
         AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, EventSendState,
-        EventTimelineItem, InReplyToDetails, LocalEventTimelineItem, MemberProfileChange,
-        MembershipChange, Message, OtherState, Profile, ReactionGroup, RemoteEventTimelineItem,
-        RepliedToEvent, RoomMembershipChange, Sticker, TimelineDetails, TimelineItemContent,
+        EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange, Message,
+        OtherState, Profile, ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker,
+        TimelineDetails, TimelineItemContent,
     },
     pagination::{PaginationOptions, PaginationOutcome},
     virtual_item::VirtualTimelineItem,

--- a/crates/matrix-sdk/src/room/timeline/read_receipts.rs
+++ b/crates/matrix-sdk/src/room/timeline/read_receipts.rs
@@ -112,9 +112,9 @@ pub(super) fn maybe_add_implicit_read_receipt(
         return;
     };
 
-    let receipt = Receipt::new(remote_event_item.timestamp());
+    let receipt = Receipt::new(remote_event_item.timestamp);
     let new_receipt = FullReceipt {
-        event_id: remote_event_item.event_id(),
+        event_id: &remote_event_item.event_id,
         user_id: &sender,
         receipt_type: ReceiptType::Read,
         receipt: &receipt,

--- a/crates/matrix-sdk/src/room/timeline/read_receipts.rs
+++ b/crates/matrix-sdk/src/room/timeline/read_receipts.rs
@@ -108,7 +108,7 @@ pub(super) fn maybe_add_implicit_read_receipt(
     timeline_items: &mut ObservableVector<Arc<TimelineItem>>,
     users_read_receipts: &mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
 ) {
-    let EventTimelineItem::Remote(remote_event_item) = event_item else {
+    let Some(remote_event_item) = event_item.as_remote_mut() else {
         return;
     };
 

--- a/crates/matrix-sdk/src/room/timeline/read_receipts.rs
+++ b/crates/matrix-sdk/src/room/timeline/read_receipts.rs
@@ -108,11 +108,12 @@ pub(super) fn maybe_add_implicit_read_receipt(
     users_read_receipts: &mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
 ) {
     let sender = event_item.sender().to_owned();
+    let timestamp = event_item.timestamp();
     let Some(remote_event_item) = event_item.as_remote_mut() else {
         return;
     };
 
-    let receipt = Receipt::new(remote_event_item.timestamp);
+    let receipt = Receipt::new(timestamp);
     let new_receipt = FullReceipt {
         event_id: &remote_event_item.event_id,
         user_id: &sender,

--- a/crates/matrix-sdk/src/room/timeline/tests/basic.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/basic.rs
@@ -67,26 +67,26 @@ async fn reaction_redaction() {
     let _day_divider =
         assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event = item.as_event().unwrap().as_remote().unwrap();
+    let event = item.as_event().unwrap();
     assert_eq!(event.reactions().len(), 0);
 
-    let msg_event_id = event.event_id();
+    let msg_event_id = event.event_id().unwrap();
 
     let rel = Annotation::new(msg_event_id.to_owned(), "+1".to_owned());
     timeline.handle_live_message_event(&BOB, ReactionEventContent::new(rel)).await;
     let item =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    let event = item.as_event().unwrap().as_remote().unwrap();
+    let event = item.as_event().unwrap();
     assert_eq!(event.reactions().len(), 1);
 
     // TODO: After adding raw timeline items, check for one here
 
-    let reaction_event_id = event.event_id();
+    let reaction_event_id = event.event_id().unwrap();
 
     timeline.handle_live_redaction(&BOB, reaction_event_id).await;
     let item =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    let event = item.as_event().unwrap().as_remote().unwrap();
+    let event = item.as_event().unwrap();
     assert_eq!(event.reactions().len(), 0);
 }
 

--- a/crates/matrix-sdk/src/room/timeline/tests/echo.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/echo.rs
@@ -96,7 +96,7 @@ async fn remote_echo_full_trip() {
     // The local echo is replaced with the remote echo
     let item =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    assert!(item.as_event().unwrap().as_remote().is_some());
+    assert!(!item.as_event().unwrap().is_local_echo());
 }
 
 #[async_test]
@@ -150,5 +150,5 @@ async fn remote_echo_new_position() {
     // … and the remote echo added (no new day divider because both bob's and
     // alice's message are from the same day according to server timestamps)
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    assert!(item.as_event().unwrap().as_remote().is_some());
+    assert!(!item.as_event().unwrap().is_local_echo());
 }

--- a/crates/matrix-sdk/src/room/timeline/tests/echo.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/echo.rs
@@ -32,8 +32,8 @@ async fn remote_echo_full_trip() {
     {
         let item =
             assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-        let event = item.as_event().unwrap().as_local().unwrap();
-        assert_matches!(event.send_state(), EventSendState::NotSentYet);
+        let event = item.as_event().unwrap();
+        assert_matches!(event.send_state(), Some(EventSendState::NotSentYet));
     }
 
     // Scenario 2: The local event has not been sent to the server successfully, it
@@ -52,8 +52,8 @@ async fn remote_echo_full_trip() {
             stream.next().await,
             Some(VectorDiff::Set { value, index: 1 }) => value
         );
-        let event = item.as_event().unwrap().as_local().unwrap();
-        assert_matches!(event.send_state(), EventSendState::SendingFailed { .. });
+        let event = item.as_event().unwrap();
+        assert_matches!(event.send_state(), Some(EventSendState::SendingFailed { .. }));
     }
 
     // Scenario 3: The local event has been sent successfully to the server and an
@@ -72,8 +72,8 @@ async fn remote_echo_full_trip() {
             stream.next().await,
             Some(VectorDiff::Set { value, index: 1 }) => value
         );
-        let event_item = item.as_event().unwrap().as_local().unwrap();
-        assert_matches!(event_item.send_state(), EventSendState::Sent { .. });
+        let event_item = item.as_event().unwrap();
+        assert_matches!(event_item.send_state(), Some(EventSendState::Sent { .. }));
 
         event_item.timestamp()
     };
@@ -115,8 +115,8 @@ async fn remote_echo_new_position() {
         assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
 
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let txn_id_from_event = item.as_event().unwrap().as_local().unwrap();
-    assert_eq!(txn_id, *txn_id_from_event.transaction_id());
+    let txn_id_from_event = item.as_event().unwrap();
+    assert_eq!(txn_id, txn_id_from_event.transaction_id().unwrap());
 
     // … and another event that comes back before the remote echo
     timeline.handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("test")).await;

--- a/crates/matrix-sdk/src/room/timeline/tests/echo.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/echo.rs
@@ -11,10 +11,7 @@ use ruma::{
 use serde_json::json;
 
 use super::{TestTimeline, ALICE, BOB};
-use crate::{
-    room::timeline::{event_item::EventSendState, EventTimelineItem},
-    Error,
-};
+use crate::{room::timeline::event_item::EventSendState, Error};
 
 #[async_test]
 async fn remote_echo_full_trip() {
@@ -99,7 +96,7 @@ async fn remote_echo_full_trip() {
     // The local echo is replaced with the remote echo
     let item =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    assert_matches!(item.as_event().unwrap(), EventTimelineItem::Remote(_));
+    assert!(item.as_event().unwrap().as_remote().is_some());
 }
 
 #[async_test]
@@ -153,5 +150,5 @@ async fn remote_echo_new_position() {
     // … and the remote echo added (no new day divider because both bob's and
     // alice's message are from the same day according to server timestamps)
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    assert_matches!(item.as_event().unwrap(), EventTimelineItem::Remote(_));
+    assert!(item.as_event().unwrap().as_remote().is_some());
 }

--- a/crates/matrix-sdk/src/room/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/encryption.rs
@@ -97,7 +97,7 @@ async fn retry_message_decryption() {
 
     let item =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    let event = item.as_event().unwrap().as_remote().unwrap();
+    let event = item.as_event().unwrap();
     assert_matches!(event.encryption_info(), Some(_));
     let text = assert_matches!(event.content(), TimelineItemContent::Message(msg) => msg.body());
     assert_eq!(text, "It's a secret to everybody");
@@ -199,7 +199,7 @@ async fn retry_edit_decryption() {
     let items = timeline.inner.items().await;
     assert_eq!(items.len(), 2);
 
-    let item = items[1].as_event().unwrap().as_remote().unwrap();
+    let item = items[1].as_event().unwrap();
 
     assert_matches!(item.encryption_info(), Some(_));
     let msg = assert_matches!(item.content(), TimelineItemContent::Message(msg) => msg);
@@ -389,7 +389,7 @@ async fn retry_message_decryption_highlighted() {
 
     let item =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    let event = item.as_event().unwrap().as_remote().unwrap();
+    let event = item.as_event().unwrap();
     assert_matches!(event.encryption_info(), Some(_));
     let text = assert_matches!(event.content(), TimelineItemContent::Message(msg) => msg.body());
     assert_eq!(text, "A secret to everybody but Alice");

--- a/crates/matrix-sdk/src/room/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/invalid.rs
@@ -3,7 +3,7 @@ use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk_test::async_test;
 use ruma::{
-    assign, event_id,
+    assign,
     events::{
         relation::Replacement,
         room::message::{self, MessageType, RoomMessageEventContent},
@@ -25,11 +25,11 @@ async fn invalid_edit() {
     let _day_divider =
         assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event = item.as_event().unwrap().as_remote().unwrap();
+    let event = item.as_event().unwrap();
     let msg = event.content().as_message().unwrap();
     assert_eq!(msg.body(), "test");
 
-    let msg_event_id = event.event_id();
+    let msg_event_id = event.event_id().unwrap();
 
     let edit = assign!(RoomMessageEventContent::text_plain(" * fake"), {
         relates_to: Some(message::Relation::Replacement(Replacement::new(
@@ -65,9 +65,9 @@ async fn invalid_event_content() {
     let _day_divider =
         assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event_item = item.as_event().unwrap().as_remote().unwrap();
+    let event_item = item.as_event().unwrap();
     assert_eq!(event_item.sender(), "@alice:example.org");
-    assert_eq!(event_item.event_id(), event_id!("$eeG0HA0FAZ37wP8kXlNkxx3I").to_owned());
+    assert_eq!(event_item.event_id().unwrap(), "$eeG0HA0FAZ37wP8kXlNkxx3I");
     assert_eq!(event_item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(10)));
     let event_type = assert_matches!(
         event_item.content(),
@@ -89,9 +89,9 @@ async fn invalid_event_content() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event_item = item.as_event().unwrap().as_remote().unwrap();
+    let event_item = item.as_event().unwrap();
     assert_eq!(event_item.sender(), "@alice:example.org");
-    assert_eq!(event_item.event_id(), event_id!("$d5G0HA0FAZ37wP8kXlNkxx3I").to_owned());
+    assert_eq!(event_item.event_id().unwrap(), "$d5G0HA0FAZ37wP8kXlNkxx3I");
     assert_eq!(event_item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(2179)));
     let (event_type, state_key) = assert_matches!(
         event_item.content(),

--- a/crates/matrix-sdk/src/room/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/read_receipts.rs
@@ -37,13 +37,13 @@ async fn read_receipts_updates() {
     // No read receipt for our own user.
     let item_a =
         assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event_a = item_a.as_event().unwrap().as_remote().unwrap();
+    let event_a = item_a.as_event().unwrap();
     assert!(event_a.read_receipts().is_empty());
 
     // Implicit read receipt of Bob.
     let item_b =
         assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event_b = item_b.as_event().unwrap().as_remote().unwrap();
+    let event_b = item_b.as_event().unwrap();
     assert_eq!(event_b.read_receipts().len(), 1);
     assert!(event_b.read_receipts().get(*BOB).is_some());
 
@@ -52,12 +52,12 @@ async fn read_receipts_updates() {
 
     let item_a =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 2, value }) => value);
-    let event_a = item_a.as_event().unwrap().as_remote().unwrap();
+    let event_a = item_a.as_event().unwrap();
     assert!(event_a.read_receipts().is_empty());
 
     let item_c =
         assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event_c = item_c.as_event().unwrap().as_remote().unwrap();
+    let event_c = item_c.as_event().unwrap();
     assert_eq!(event_c.read_receipts().len(), 1);
     assert!(event_c.read_receipts().get(*BOB).is_some());
 
@@ -65,13 +65,13 @@ async fn read_receipts_updates() {
 
     let item_d =
         assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event_d = item_d.as_event().unwrap().as_remote().unwrap();
+    let event_d = item_d.as_event().unwrap();
     assert!(event_d.read_receipts().is_empty());
 
     // Explicit read receipt is updated.
     timeline
         .handle_read_receipts([(
-            event_d.event_id().to_owned(),
+            event_d.event_id().unwrap().to_owned(),
             ReceiptType::Read,
             BOB.to_owned(),
             ReceiptThread::Unthreaded,
@@ -80,12 +80,12 @@ async fn read_receipts_updates() {
 
     let item_c =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 3, value }) => value);
-    let event_c = item_c.as_event().unwrap().as_remote().unwrap();
+    let event_c = item_c.as_event().unwrap();
     assert!(event_c.read_receipts().is_empty());
 
     let item_d =
         assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 4, value }) => value);
-    let event_d = item_d.as_event().unwrap().as_remote().unwrap();
+    let event_d = item_d.as_event().unwrap();
     assert_eq!(event_d.read_receipts().len(), 1);
     assert!(event_d.read_receipts().get(*BOB).is_some());
 }

--- a/crates/matrix-sdk/tests/integration/room/timeline/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline/mod.rs
@@ -191,8 +191,8 @@ async fn echo() {
 
     let _day_divider = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let local_echo = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let item = local_echo.as_event().unwrap().as_local().unwrap();
-    assert_matches!(item.send_state(), EventSendState::NotSentYet);
+    let item = local_echo.as_event().unwrap();
+    assert_matches!(item.as_local().unwrap().send_state(), EventSendState::NotSentYet);
 
     let msg = assert_matches!(item.content(), TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(msg.msgtype(), MessageType::Text(text) => text);
@@ -423,7 +423,7 @@ async fn reaction() {
         timeline_stream.next().await,
         Some(VectorDiff::Set { index: 1, value }) => value
     );
-    let event_item = updated_message.as_event().unwrap().as_remote().unwrap();
+    let event_item = updated_message.as_event().unwrap();
     let msg = assert_matches!(event_item.content(), TimelineItemContent::Message(msg) => msg);
     assert!(!msg.is_edited());
     assert_eq!(event_item.reactions().len(), 1);
@@ -453,7 +453,7 @@ async fn reaction() {
         timeline_stream.next().await,
         Some(VectorDiff::Set { index: 1, value }) => value
     );
-    let event_item = updated_message.as_event().unwrap().as_remote().unwrap();
+    let event_item = updated_message.as_event().unwrap();
     let msg = assert_matches!(event_item.content(), TimelineItemContent::Message(msg) => msg);
     assert!(!msg.is_edited());
     assert_eq!(event_item.reactions().len(), 0);
@@ -657,7 +657,7 @@ async fn in_reply_to_details() {
     let first = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     assert_matches!(first.as_event().unwrap().content(), TimelineItemContent::Message(_));
     let second = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let second_event = second.as_event().unwrap().as_remote().unwrap();
+    let second_event = second.as_event().unwrap();
     let message =
         assert_matches!(second_event.content(), TimelineItemContent::Message(message) => message);
     let in_reply_to = message.in_reply_to().unwrap();
@@ -665,7 +665,7 @@ async fn in_reply_to_details() {
     assert_matches!(in_reply_to.event, TimelineDetails::Unavailable);
 
     // Fetch details locally first.
-    timeline.fetch_event_details(second_event.event_id()).await.unwrap();
+    timeline.fetch_event_details(second_event.event_id().unwrap()).await.unwrap();
 
     let second = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 2, value }) => value);
     let message = assert_matches!(second.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);
@@ -696,8 +696,11 @@ async fn in_reply_to_details() {
     let _read_receipt_update =
         assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { value, .. }) => value);
 
-    let third = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let third_event = third.as_event().unwrap().as_remote().unwrap();
+    let third = assert_matches!(
+        timeline_stream.next().await,
+        Some(VectorDiff::PushBack { value }) => value
+    );
+    let third_event = third.as_event().unwrap();
     let message =
         assert_matches!(third_event.content(), TimelineItemContent::Message(message) => message);
     let in_reply_to = message.in_reply_to().unwrap();
@@ -716,7 +719,7 @@ async fn in_reply_to_details() {
         .await;
 
     // Fetch details remotely if we can't find them locally.
-    timeline.fetch_event_details(third_event.event_id()).await.unwrap();
+    timeline.fetch_event_details(third_event.event_id().unwrap()).await.unwrap();
     server.reset().await;
 
     let third = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 3, value }) => value);
@@ -745,7 +748,7 @@ async fn in_reply_to_details() {
         .mount(&server)
         .await;
 
-    timeline.fetch_event_details(third_event.event_id()).await.unwrap();
+    timeline.fetch_event_details(third_event.event_id().unwrap()).await.unwrap();
 
     let third = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 3, value }) => value);
     let message = assert_matches!(third.as_event().unwrap().content(), TimelineItemContent::Message(message) => message);

--- a/crates/matrix-sdk/tests/integration/room/timeline/mod.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline/mod.rs
@@ -192,7 +192,7 @@ async fn echo() {
     let _day_divider = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let local_echo = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let item = local_echo.as_event().unwrap();
-    assert_matches!(item.as_local().unwrap().send_state(), EventSendState::NotSentYet);
+    assert_matches!(item.send_state(), Some(EventSendState::NotSentYet));
 
     let msg = assert_matches!(item.content(), TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(msg.msgtype(), MessageType::Text(text) => text);
@@ -205,8 +205,8 @@ async fn echo() {
         timeline_stream.next().await,
         Some(VectorDiff::Set { index: 1, value }) => value
     );
-    let item = sent_confirmation.as_event().unwrap().as_local().unwrap();
-    assert_matches!(item.send_state(), EventSendState::Sent { .. });
+    let item = sent_confirmation.as_event().unwrap();
+    assert_matches!(item.send_state(), Some(EventSendState::Sent { .. }));
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
@@ -243,7 +243,7 @@ async fn echo() {
         timeline_stream.next().await,
         Some(VectorDiff::PushBack { value }) => value
     );
-    let item = remote_echo.as_event().unwrap().as_remote().unwrap();
+    let item = remote_echo.as_event().unwrap();
     assert!(item.is_own());
     assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(152038280)));
 }
@@ -807,7 +807,7 @@ async fn sync_highlighted() {
         timeline_stream.next().await,
         Some(VectorDiff::PushBack { value }) => value
     );
-    let remote_event = first.as_event().unwrap().as_remote().unwrap();
+    let remote_event = first.as_event().unwrap();
     // Own events don't trigger push rules.
     assert!(!remote_event.is_highlighted());
 
@@ -833,7 +833,7 @@ async fn sync_highlighted() {
         timeline_stream.next().await,
         Some(VectorDiff::PushBack { value }) => value
     );
-    let remote_event = second.as_event().unwrap().as_remote().unwrap();
+    let remote_event = second.as_event().unwrap();
     // `m.room.tombstone` should be highlighted by default.
     assert!(remote_event.is_highlighted());
 }
@@ -918,7 +918,7 @@ async fn back_pagination_highlighted() {
         timeline_stream.next().await,
         Some(VectorDiff::Insert { index: 2, value }) => value
     );
-    let remote_event = first.as_event().unwrap().as_remote().unwrap();
+    let remote_event = first.as_event().unwrap();
     // Own events don't trigger push rules.
     assert!(!remote_event.is_highlighted());
 
@@ -926,7 +926,7 @@ async fn back_pagination_highlighted() {
         timeline_stream.next().await,
         Some(VectorDiff::Insert { index: 2, value }) => value
     );
-    let remote_event = second.as_event().unwrap().as_remote().unwrap();
+    let remote_event = second.as_event().unwrap();
     // `m.room.tombstone` should be highlighted by default.
     assert!(remote_event.is_highlighted());
 

--- a/crates/matrix-sdk/tests/integration/room/timeline/read_receipts.rs
+++ b/crates/matrix-sdk/tests/integration/room/timeline/read_receipts.rs
@@ -86,24 +86,24 @@ async fn read_receipts_updates() {
 
     // We don't list the read receipt of our own user on events.
     let first_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let first_event = first_item.as_event().unwrap().as_remote().unwrap();
+    let first_event = first_item.as_event().unwrap();
     assert!(first_event.read_receipts().is_empty());
 
     let (own_receipt_event_id, _) = timeline.latest_user_read_receipt(own_user_id).await.unwrap();
-    assert_eq!(own_receipt_event_id, first_event.event_id());
+    assert_eq!(own_receipt_event_id, first_event.event_id().unwrap());
 
     // Implicit read receipt of @alice:localhost.
     let second_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let second_event = second_item.as_event().unwrap().as_remote().unwrap();
+    let second_event = second_item.as_event().unwrap();
     assert_eq!(second_event.read_receipts().len(), 1);
 
     // Read receipt of @alice:localhost is moved to third event.
     let second_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 2, value }) => value);
-    let second_event = second_item.as_event().unwrap().as_remote().unwrap();
+    let second_event = second_item.as_event().unwrap();
     assert!(second_event.read_receipts().is_empty());
 
     let third_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let third_event = third_item.as_event().unwrap().as_remote().unwrap();
+    let third_event = third_item.as_event().unwrap();
     assert_eq!(third_event.read_receipts().len(), 1);
 
     let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
@@ -130,7 +130,7 @@ async fn read_receipts_updates() {
     server.reset().await;
 
     let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
-    assert_eq!(alice_receipt_event_id, third_event.event_id());
+    assert_eq!(alice_receipt_event_id, third_event.event_id().unwrap());
 
     // Read receipt on older event is ignored.
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
@@ -191,7 +191,7 @@ async fn read_receipts_updates() {
     server.reset().await;
 
     let third_item = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 3, value }) => value);
-    let third_event = third_item.as_event().unwrap().as_remote().unwrap();
+    let third_event = third_item.as_event().unwrap();
     assert_eq!(third_event.read_receipts().len(), 2);
 
     let (bob_receipt_event_id, _) = timeline.latest_user_read_receipt(bob).await.unwrap();

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -865,7 +865,7 @@ async fn fast_unfreeze() -> anyhow::Result<()> {
         let (sliding_window_list, growing_sync) = build_lists()?;
         let sync_proxy = sync_proxy_builder
             .clone()
-            .storage_key(Some("sliding_sync".to_string()))
+            .storage_key(Some("sliding_sync".to_owned()))
             .add_list(sliding_window_list)
             .add_list(growing_sync)
             .build()
@@ -891,7 +891,7 @@ async fn fast_unfreeze() -> anyhow::Result<()> {
     let start = Instant::now();
     let _sync_proxy = sync_proxy_builder
         .clone()
-        .storage_key(Some("sliding_sync".to_string()))
+        .storage_key(Some("sliding_sync".to_owned()))
         .add_list(sliding_window_list)
         .add_list(growing_sync)
         .build()
@@ -962,7 +962,7 @@ async fn continue_on_reset() -> anyhow::Result<()> {
     println!("starting the sliding sync setup");
     let sync_proxy = sync_proxy_builder
         .clone()
-        .storage_key(Some("sliding_sync".to_string()))
+        .storage_key(Some("sliding_sync".to_owned()))
         .add_list(growing_sync)
         .build()
         .await?;
@@ -1047,7 +1047,7 @@ async fn noticing_new_rooms_in_growing() -> anyhow::Result<()> {
     println!("starting the sliding sync setup");
     let sync_proxy = sync_proxy_builder
         .clone()
-        .storage_key(Some("sliding_sync".to_string()))
+        .storage_key(Some("sliding_sync".to_owned()))
         .add_list(growing_sync)
         .build()
         .await?;

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -223,14 +223,14 @@ async fn modifying_timeline_limit() -> anyhow::Result<()> {
         assert_matches!(timeline_items[0].as_virtual(), Some(_));
 
         // Second timeline item.
-        let latest_remote_event = timeline_items[1].as_event().unwrap().as_remote().unwrap();
-        all_event_ids.push(latest_remote_event.event_id().to_owned());
+        let latest_remote_event = timeline_items[1].as_event().unwrap();
+        all_event_ids.push(latest_remote_event.event_id().unwrap().to_owned());
 
         // Test the room to see the last event.
         let latest_event = room.latest_event().await.unwrap();
         assert_eq!(
             latest_event.event_id(),
-            Some(latest_remote_event.event_id()),
+            latest_remote_event.event_id(),
             "Unexpected latest event"
         );
         assert_eq!(latest_event.content().as_message().unwrap().body(), "Message #19");


### PR DESCRIPTION
Remove `LocalTimelineItem` and `RemoteTimelineItem` from public API since it isn't really needed and we have more flexibility with how to lay out the types without that.

Also make fields of `EventTimelineItem`, `LocalTimelineItem` and `RemoteTimelineItem` public within the `timeline` module so we don't need as many one-line functions.