### PR TITLE
sdk: Add more data to RemoteEventTimelineItem Debug string

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
@@ -35,7 +35,10 @@ pub use self::content::{
     MemberProfileChange, MembershipChange, Message, OtherState, ReactionGroup, RepliedToEvent,
     RoomMembershipChange, Sticker, TimelineItemContent,
 };
-pub(super) use self::{local::LocalEventTimelineItem, remote::RemoteEventTimelineItem};
+pub(super) use self::{
+    local::LocalEventTimelineItem,
+    remote::{RemoteEventOrigin, RemoteEventTimelineItem},
+};
 
 /// An item in the timeline that represents at least one event.
 ///


### PR DESCRIPTION
It would have been useful to know where a remote event came from in previous debugging sessions.