### PR TITLE
sdk: Allow to filter members and user IDs store results by membership

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -19,6 +19,7 @@ use matrix_sdk::{
         },
         EventId, UserId,
     },
+    RoomMemberships,
 };
 use mime::Mime;
 use tracing::error;
@@ -168,7 +169,7 @@ impl Room {
         let room = self.room.clone();
         RUNTIME.block_on(async move {
             let members = room
-                .members()
+                .members(RoomMemberships::empty())
                 .await?
                 .iter()
                 .map(|m| Arc::new(RoomMember::new(m.clone())))

--- a/crates/matrix-sdk-appservice/src/lib.rs
+++ b/crates/matrix-sdk-appservice/src/lib.rs
@@ -550,7 +550,7 @@ mod tests {
     use matrix_sdk::{
         config::RequestConfig,
         ruma::{api::appservice::Registration, events::room::member::OriginalSyncRoomMemberEvent},
-        Client,
+        Client, RoomMemberships,
     };
     use matrix_sdk_test::{appservice::TransactionBuilder, async_test, TimelineTestEvent};
     use ruma::{
@@ -888,7 +888,7 @@ mod tests {
             .await?
             .get_room(room_id)
             .expect("Expected room to be available")
-            .members_no_sync()
+            .members_no_sync(RoomMemberships::empty())
             .await?;
 
         assert_eq!(members[0].display_name().unwrap(), "changed");

--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -8,6 +8,7 @@
   other state events in `state` and `stripped_state`.
 - `StateStore::get_user_ids` takes a `RoomMemberships` to be able to filter the results by any
   membership state.
+  - `StateStore::get_joined_user_ids` and `StateStore::get_invited_user_ids` are deprecated.
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -10,7 +10,8 @@
   membership state.
   - `StateStore::get_joined_user_ids` and `StateStore::get_invited_user_ids` are deprecated.
 - `Room::members` takes a `RoomMemberships` to be able to filter the results by any membership
-  state. 
+  state.
+  - `Room::active_members` and `Room::joined_members` are deprecated.
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -6,6 +6,8 @@
 - Add `RoomInfo::state` accessor
 - Remove `members` and `stripped_members` fields in `StateChanges`. Room member events are now with
   other state events in `state` and `stripped_state`.
+- `StateStore::get_user_ids` takes a `RoomMemberships` to be able to filter the results by any
+  membership state.
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -9,6 +9,8 @@
 - `StateStore::get_user_ids` takes a `RoomMemberships` to be able to filter the results by any
   membership state.
   - `StateStore::get_joined_user_ids` and `StateStore::get_invited_user_ids` are deprecated.
+- `Room::members` takes a `RoomMemberships` to be able to filter the results by any membership
+  state. 
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -340,12 +340,14 @@ impl Room {
 
     /// Get the list of `RoomMember`s that are considered to be joined members
     /// of this room.
+    #[deprecated = "Use members with RoomMemberships::JOIN instead"]
     pub async fn joined_members(&self) -> StoreResult<Vec<RoomMember>> {
         self.members(RoomMemberships::JOIN).await
     }
 
     /// Get the list of `RoomMember`s that are considered to be joined or
     /// invited members of this room.
+    #[deprecated = "Use members with RoomMemberships::ACTIVE instead"]
     pub async fn active_members(&self) -> StoreResult<Vec<RoomMember>> {
         self.members(RoomMemberships::ACTIVE).await
     }
@@ -368,7 +370,12 @@ impl Room {
         let is_own_user_id = |u: &str| u == self.own_user_id().as_str();
 
         let members: Vec<RoomMember> = if summary.heroes.is_empty() {
-            self.active_members().await?.into_iter().filter(|u| !is_own_member(u)).take(5).collect()
+            self.members(RoomMemberships::ACTIVE)
+                .await?
+                .into_iter()
+                .filter(|u| !is_own_member(u))
+                .take(5)
+                .collect()
         } else {
             let members: Vec<_> =
                 stream::iter(summary.heroes.iter().filter(|u| !is_own_user_id(u)))

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -318,7 +318,7 @@ impl Room {
     /// Get the list of users ids that are considered to be joined members of
     /// this room.
     pub async fn joined_user_ids(&self) -> StoreResult<Vec<OwnedUserId>> {
-        self.store.get_joined_user_ids(self.room_id()).await
+        self.store.get_user_ids(self.room_id(), RoomMemberships::JOIN).await
     }
 
     /// Get the all `RoomMember`s of this room that are known to the store.
@@ -340,7 +340,7 @@ impl Room {
     /// Get the list of `RoomMember`s that are considered to be joined members
     /// of this room.
     pub async fn joined_members(&self) -> StoreResult<Vec<RoomMember>> {
-        let joined = self.store.get_joined_user_ids(self.room_id()).await?;
+        let joined = self.store.get_user_ids(self.room_id(), RoomMemberships::JOIN).await?;
         let mut members = Vec::new();
 
         for u in joined {
@@ -357,13 +357,12 @@ impl Room {
     /// Get the list of `RoomMember`s that are considered to be joined or
     /// invited members of this room.
     pub async fn active_members(&self) -> StoreResult<Vec<RoomMember>> {
-        let joined = self.store.get_joined_user_ids(self.room_id()).await?;
-        let invited = self.store.get_invited_user_ids(self.room_id()).await?;
+        let active = self.store.get_user_ids(self.room_id(), RoomMemberships::ACTIVE).await?;
 
         let mut members = Vec::new();
 
-        for u in joined.iter().chain(&invited) {
-            let m = self.get_member(u).await?;
+        for u in active {
+            let m = self.get_member(&u).await?;
 
             if let Some(member) = m {
                 members.push(member);

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -341,36 +341,13 @@ impl Room {
     /// Get the list of `RoomMember`s that are considered to be joined members
     /// of this room.
     pub async fn joined_members(&self) -> StoreResult<Vec<RoomMember>> {
-        let joined = self.store.get_user_ids(self.room_id(), RoomMemberships::JOIN).await?;
-        let mut members = Vec::new();
-
-        for u in joined {
-            let m = self.get_member(&u).await?;
-
-            if let Some(member) = m {
-                members.push(member);
-            }
-        }
-
-        Ok(members)
+        self.members(RoomMemberships::JOIN).await
     }
 
     /// Get the list of `RoomMember`s that are considered to be joined or
     /// invited members of this room.
     pub async fn active_members(&self) -> StoreResult<Vec<RoomMember>> {
-        let active = self.store.get_user_ids(self.room_id(), RoomMemberships::ACTIVE).await?;
-
-        let mut members = Vec::new();
-
-        for u in active {
-            let m = self.get_member(&u).await?;
-
-            if let Some(member) = m {
-                members.push(member);
-            }
-        }
-
-        Ok(members)
+        self.members(RoomMemberships::ACTIVE).await
     }
 
     async fn calculate_name(&self) -> StoreResult<DisplayName> {

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -321,9 +321,10 @@ impl Room {
         self.store.get_user_ids(self.room_id(), RoomMemberships::JOIN).await
     }
 
-    /// Get the all `RoomMember`s of this room that are known to the store.
-    pub async fn members(&self) -> StoreResult<Vec<RoomMember>> {
-        let user_ids = self.store.get_user_ids(self.room_id(), RoomMemberships::empty()).await?;
+    /// Get the `RoomMember`s of this room that are known to the store, with the
+    /// given memberships.
+    pub async fn members(&self, memberships: RoomMemberships) -> StoreResult<Vec<RoomMember>> {
+        let user_ids = self.store.get_user_ids(self.room_id(), memberships).await?;
         let mut members = Vec::new();
 
         for u in user_ids {

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -44,7 +44,7 @@ use crate::{
     deserialized_responses::MemberEvent,
     store::{DynStateStore, Result as StoreResult, StateStoreExt},
     sync::UnreadNotificationsCount,
-    MinimalStateEvent,
+    MinimalStateEvent, RoomMemberships,
 };
 
 /// The underlying room data structure collecting state for joined, left and
@@ -323,7 +323,7 @@ impl Room {
 
     /// Get the all `RoomMember`s of this room that are known to the store.
     pub async fn members(&self) -> StoreResult<Vec<RoomMember>> {
-        let user_ids = self.store.get_user_ids(self.room_id()).await?;
+        let user_ids = self.store.get_user_ids(self.room_id(), RoomMemberships::empty()).await?;
         let mut members = Vec::new();
 
         for u in user_ids {

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -335,12 +335,12 @@ impl StateStoreIntegrationTests for DynStateStore {
             "Expected to find 2 members for room"
         );
         assert_eq!(
-            self.get_invited_user_ids(room_id).await?.len(),
+            self.get_user_ids(room_id, RoomMemberships::INVITE).await?.len(),
             1,
             "Expected to find 1 invited user ids"
         );
         assert_eq!(
-            self.get_joined_user_ids(room_id).await?.len(),
+            self.get_user_ids(room_id, RoomMemberships::JOIN).await?.len(),
             1,
             "Expected to find 1 joined user ids"
         );
@@ -818,10 +818,13 @@ impl StateStoreIntegrationTests for DynStateStore {
             "still user ids found"
         );
         assert!(
-            self.get_invited_user_ids(room_id).await?.is_empty(),
+            self.get_user_ids(room_id, RoomMemberships::INVITE).await?.is_empty(),
             "still invited user ids found"
         );
-        assert!(self.get_joined_user_ids(room_id).await?.is_empty(), "still joined users found");
+        assert!(
+            self.get_user_ids(room_id, RoomMemberships::JOIN).await?.is_empty(),
+            "still joined users found"
+        );
         assert!(
             self.get_users_with_display_name(room_id, "example").await?.is_empty(),
             "still display names found"

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -18,14 +18,14 @@ use std::{
 };
 
 use async_trait::async_trait;
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
 use matrix_sdk_common::instant::Instant;
 use ruma::{
     canonical_json::redact,
     events::{
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
-        room::member::{MembershipState, StrippedRoomMemberEvent, SyncRoomMemberEvent},
+        room::member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
     },
@@ -38,7 +38,7 @@ use tracing::{debug, warn};
 use super::{Result, RoomInfo, StateChanges, StateStore, StoreError};
 use crate::{
     deserialized_responses::RawMemberEvent, media::MediaRequest, MinimalRoomMemberEvent,
-    StateStoreDataKey, StateStoreDataValue,
+    RoomMemberships, StateStoreDataKey, StateStoreDataValue,
 };
 
 /// In-Memory, non-persistent implementation of the `StateStore`
@@ -51,11 +51,9 @@ pub struct MemoryStore {
     sync_token: Arc<RwLock<Option<String>>>,
     filters: Arc<DashMap<String, String>>,
     account_data: Arc<DashMap<GlobalAccountDataEventType, Raw<AnyGlobalAccountDataEvent>>>,
-    members: Arc<DashMap<OwnedRoomId, DashSet<OwnedUserId>>>,
     profiles: Arc<DashMap<OwnedRoomId, DashMap<OwnedUserId, MinimalRoomMemberEvent>>>,
     display_names: Arc<DashMap<OwnedRoomId, DashMap<String, BTreeSet<OwnedUserId>>>>,
-    joined_user_ids: Arc<DashMap<OwnedRoomId, DashSet<OwnedUserId>>>,
-    invited_user_ids: Arc<DashMap<OwnedRoomId, DashSet<OwnedUserId>>>,
+    members: Arc<DashMap<OwnedRoomId, DashMap<OwnedUserId, RoomMemberships>>>,
     room_info: Arc<DashMap<OwnedRoomId, RoomInfo>>,
     room_state:
         Arc<DashMap<OwnedRoomId, DashMap<StateEventType, DashMap<String, Raw<AnySyncStateEvent>>>>>,
@@ -65,9 +63,7 @@ pub struct MemoryStore {
     stripped_room_state: Arc<
         DashMap<OwnedRoomId, DashMap<StateEventType, DashMap<String, Raw<AnyStrippedStateEvent>>>>,
     >,
-    stripped_members: Arc<DashMap<OwnedRoomId, DashSet<OwnedUserId>>>,
-    stripped_joined_user_ids: Arc<DashMap<OwnedRoomId, DashSet<OwnedUserId>>>,
-    stripped_invited_user_ids: Arc<DashMap<OwnedRoomId, DashSet<OwnedUserId>>>,
+    stripped_members: Arc<DashMap<OwnedRoomId, DashMap<OwnedUserId, RoomMemberships>>>,
     presence: Arc<DashMap<OwnedUserId, Raw<PresenceEvent>>>,
     room_user_receipts: Arc<
         DashMap<
@@ -99,19 +95,15 @@ impl MemoryStore {
             sync_token: Default::default(),
             filters: Default::default(),
             account_data: Default::default(),
-            members: Default::default(),
             profiles: Default::default(),
             display_names: Default::default(),
-            joined_user_ids: Default::default(),
-            invited_user_ids: Default::default(),
+            members: Default::default(),
             room_info: Default::default(),
             room_state: Default::default(),
             room_account_data: Default::default(),
             stripped_room_infos: Default::default(),
             stripped_room_state: Default::default(),
             stripped_members: Default::default(),
-            stripped_joined_user_ids: Default::default(),
-            stripped_invited_user_ids: Default::default(),
             presence: Default::default(),
             room_user_receipts: Default::default(),
             room_event_receipts: Default::default(),
@@ -240,47 +232,12 @@ impl MemoryStore {
                             }
                         };
 
-                        self.stripped_joined_user_ids.remove(room);
-                        self.stripped_invited_user_ids.remove(room);
-
-                        match event.membership() {
-                            MembershipState::Join => {
-                                self.joined_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .insert(event.state_key().to_owned());
-                                self.invited_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .remove(event.state_key());
-                            }
-                            MembershipState::Invite => {
-                                self.invited_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .insert(event.state_key().to_owned());
-                                self.joined_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .remove(event.state_key());
-                            }
-                            _ => {
-                                self.joined_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .remove(event.state_key());
-                                self.invited_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .remove(event.state_key());
-                            }
-                        }
+                        self.stripped_members.remove(room);
 
                         self.members
                             .entry(room.clone())
                             .or_default()
-                            .insert(event.state_key().to_owned());
-                        self.stripped_members.remove(room);
+                            .insert(event.state_key().to_owned(), event.membership().into());
                     }
                 }
             }
@@ -324,43 +281,10 @@ impl MemoryStore {
                             }
                         };
 
-                        match event.content.membership {
-                            MembershipState::Join => {
-                                self.stripped_joined_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .insert(event.state_key.clone());
-                                self.stripped_invited_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .remove(&event.state_key);
-                            }
-                            MembershipState::Invite => {
-                                self.stripped_invited_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .insert(event.state_key.clone());
-                                self.stripped_joined_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .remove(&event.state_key);
-                            }
-                            _ => {
-                                self.stripped_joined_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .remove(&event.state_key);
-                                self.stripped_invited_user_ids
-                                    .entry(room.clone())
-                                    .or_default()
-                                    .remove(&event.state_key);
-                            }
-                        }
-
                         self.stripped_members
                             .entry(room.clone())
                             .or_default()
-                            .insert(event.state_key.clone());
+                            .insert(event.state_key, (&event.content.membership).into());
                     }
                 }
             }
@@ -507,43 +431,53 @@ impl MemoryStore {
         }
     }
 
+    /// Get the user IDs for the given room with the given memberships and
+    /// stripped state.
+    ///
+    /// If `memberships` is empty, returns all user IDs in the room with the
+    /// given stripped state.
+    fn get_user_ids_inner(
+        &self,
+        room_id: &RoomId,
+        memberships: RoomMemberships,
+        stripped: bool,
+    ) -> Vec<OwnedUserId> {
+        let map = if stripped { &self.stripped_members } else { &self.members };
+
+        map.get(room_id)
+            .map(|u| {
+                u.iter()
+                    .filter_map(|u| {
+                        (memberships.is_empty() || memberships.contains(*u.value()))
+                            .then(|| u.key().clone())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     fn get_user_ids(&self, room_id: &RoomId) -> Vec<OwnedUserId> {
-        if let Some(u) = self.stripped_members.get(room_id) {
-            u.iter().map(|u| u.key().clone()).collect()
-        } else {
-            self.members
-                .get(room_id)
-                .map(|u| u.iter().map(|u| u.key().clone()).collect())
-                .unwrap_or_default()
+        let v = self.get_user_ids_inner(room_id, RoomMemberships::empty(), true);
+        if !v.is_empty() {
+            return v;
         }
+        self.get_user_ids_inner(room_id, RoomMemberships::empty(), false)
     }
 
     fn get_invited_user_ids(&self, room_id: &RoomId) -> Vec<OwnedUserId> {
-        self.invited_user_ids
-            .get(room_id)
-            .map(|u| u.iter().map(|u| u.clone()).collect())
-            .unwrap_or_default()
+        self.get_user_ids_inner(room_id, RoomMemberships::INVITE, false)
     }
 
     fn get_joined_user_ids(&self, room_id: &RoomId) -> Vec<OwnedUserId> {
-        self.joined_user_ids
-            .get(room_id)
-            .map(|u| u.iter().map(|u| u.clone()).collect())
-            .unwrap_or_default()
+        self.get_user_ids_inner(room_id, RoomMemberships::JOIN, false)
     }
 
     fn get_stripped_invited_user_ids(&self, room_id: &RoomId) -> Vec<OwnedUserId> {
-        self.stripped_invited_user_ids
-            .get(room_id)
-            .map(|u| u.iter().map(|u| u.clone()).collect())
-            .unwrap_or_default()
+        self.get_user_ids_inner(room_id, RoomMemberships::INVITE, true)
     }
 
     fn get_stripped_joined_user_ids(&self, room_id: &RoomId) -> Vec<OwnedUserId> {
-        self.stripped_joined_user_ids
-            .get(room_id)
-            .map(|u| u.iter().map(|u| u.clone()).collect())
-            .unwrap_or_default()
+        self.get_user_ids_inner(room_id, RoomMemberships::JOIN, true)
     }
 
     fn get_room_infos(&self) -> Vec<RoomInfo> {
@@ -631,11 +565,9 @@ impl MemoryStore {
     }
 
     async fn remove_room(&self, room_id: &RoomId) -> Result<()> {
-        self.members.remove(room_id);
         self.profiles.remove(room_id);
         self.display_names.remove(room_id);
-        self.joined_user_ids.remove(room_id);
-        self.invited_user_ids.remove(room_id);
+        self.members.remove(room_id);
         self.room_info.remove(room_id);
         self.room_state.remove(room_id);
         self.room_account_data.remove(room_id);

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -33,6 +33,7 @@ use ruma::{
 use super::{StateChanges, StoreError};
 use crate::{
     deserialized_responses::RawMemberEvent, media::MediaRequest, MinimalRoomMemberEvent, RoomInfo,
+    RoomMemberships,
 };
 
 /// An abstract state store trait that can be used to implement different stores
@@ -142,9 +143,13 @@ pub trait StateStore: AsyncTraitDeps {
         state_key: &UserId,
     ) -> Result<Option<RawMemberEvent>, Self::Error>;
 
-    /// Get all the user ids of members for a given room, for stripped and
-    /// regular rooms alike.
-    async fn get_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error>;
+    /// Get the user ids of members for a given room with the given memberships,
+    /// for stripped and regular rooms alike.
+    async fn get_user_ids(
+        &self,
+        room_id: &RoomId,
+        memberships: RoomMemberships,
+    ) -> Result<Vec<OwnedUserId>, Self::Error>;
 
     /// Get all the user ids of members that are in the invited state for a
     /// given room, for stripped and regular rooms alike.
@@ -391,8 +396,12 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         self.0.get_member_event(room_id, state_key).await.map_err(Into::into)
     }
 
-    async fn get_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error> {
-        self.0.get_user_ids(room_id).await.map_err(Into::into)
+    async fn get_user_ids(
+        &self,
+        room_id: &RoomId,
+        memberships: RoomMemberships,
+    ) -> Result<Vec<OwnedUserId>, Self::Error> {
+        self.0.get_user_ids(room_id, memberships).await.map_err(Into::into)
     }
 
     async fn get_invited_user_ids(

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -153,11 +153,13 @@ pub trait StateStore: AsyncTraitDeps {
 
     /// Get all the user ids of members that are in the invited state for a
     /// given room, for stripped and regular rooms alike.
+    #[deprecated = "Use get_user_ids with RoomMemberships::INVITE instead."]
     async fn get_invited_user_ids(&self, room_id: &RoomId)
         -> Result<Vec<OwnedUserId>, Self::Error>;
 
     /// Get all the user ids of members that are in the joined state for a
     /// given room, for stripped and regular rooms alike.
+    #[deprecated = "Use get_user_ids with RoomMemberships::JOIN instead."]
     async fn get_joined_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error>;
 
     /// Get all the pure `RoomInfo`s the store knows about.
@@ -408,11 +410,11 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         &self,
         room_id: &RoomId,
     ) -> Result<Vec<OwnedUserId>, Self::Error> {
-        self.0.get_invited_user_ids(room_id).await.map_err(Into::into)
+        self.0.get_user_ids(room_id, RoomMemberships::INVITE).await.map_err(Into::into)
     }
 
     async fn get_joined_user_ids(&self, room_id: &RoomId) -> Result<Vec<OwnedUserId>, Self::Error> {
-        self.0.get_joined_user_ids(room_id).await.map_err(Into::into)
+        self.0.get_user_ids(room_id, RoomMemberships::JOIN).await.map_err(Into::into)
     }
 
     async fn get_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error> {

--- a/crates/matrix-sdk-sled/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-sled/src/state_store/migrations.rs
@@ -390,7 +390,8 @@ pub const V1_DB_STORES: &[&str] = &[
 mod test {
     use assert_matches::assert_matches;
     use matrix_sdk_base::{
-        deserialized_responses::RawMemberEvent, RoomInfo, RoomState, StateStoreDataKey,
+        deserialized_responses::RawMemberEvent, RoomInfo, RoomMemberships, RoomState,
+        StateStoreDataKey,
     };
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{
@@ -774,23 +775,41 @@ mod test {
             .build()
             .unwrap();
 
-        assert_eq!(store.get_joined_user_ids(room_id).await.unwrap().len(), 0);
         assert_eq!(
-            store.get_invited_user_ids(room_id).await.unwrap().as_slice(),
+            store.get_user_ids(room_id, RoomMemberships::JOIN, false).await.unwrap().len(),
+            0
+        );
+        assert_eq!(
+            store.get_user_ids(room_id, RoomMemberships::INVITE, false).await.unwrap().as_slice(),
             [invite_user_id.to_owned()]
         );
-        let user_ids = store.get_user_ids(room_id).await.unwrap();
+        let user_ids = store.get_user_ids(room_id, RoomMemberships::empty(), false).await.unwrap();
         assert_eq!(user_ids.len(), 2);
         assert!(user_ids.contains(&invite_user_id.to_owned()));
         assert!(user_ids.contains(&ban_user_id.to_owned()));
 
         assert_eq!(
-            store.get_stripped_joined_user_ids(stripped_room_id).await.unwrap().as_slice(),
+            store
+                .get_user_ids(stripped_room_id, RoomMemberships::JOIN, true)
+                .await
+                .unwrap()
+                .as_slice(),
             [stripped_user_id.to_owned()]
         );
-        assert_eq!(store.get_stripped_invited_user_ids(stripped_room_id).await.unwrap().len(), 0);
         assert_eq!(
-            store.get_stripped_user_ids(stripped_room_id).await.unwrap().as_slice(),
+            store
+                .get_user_ids(stripped_room_id, RoomMemberships::INVITE, true)
+                .await
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            store
+                .get_user_ids(stripped_room_id, RoomMemberships::empty(), true)
+                .await
+                .unwrap()
+                .as_slice(),
             [stripped_user_id.to_owned()]
         );
     }

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -1,3 +1,8 @@
+# unreleased
+
+- `Common::members` and `Common::members_no_sync` take a `RoomMemberships` to be able to filter the
+  results by any membership state.
+
 # 0.6.2
 
 - Fix the access token being printed in tracing span fields.

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `Common::members` and `Common::members_no_sync` take a `RoomMemberships` to be able to filter the
   results by any membership state.
+  - `Common::active_members(_no_sync)` and `Common::joined_members(_no_sync)` are deprecated.
 
 # 0.6.2
 

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -14,8 +14,12 @@
 
 use std::sync::Arc;
 
-use matrix_sdk_base::crypto::{
-    types::MasterPubkey, OwnUserIdentity as InnerOwnUserIdentity, UserIdentity as InnerUserIdentity,
+use matrix_sdk_base::{
+    crypto::{
+        types::MasterPubkey, OwnUserIdentity as InnerOwnUserIdentity,
+        UserIdentity as InnerUserIdentity,
+    },
+    RoomMemberships,
 };
 use ruma::{
     events::{
@@ -465,7 +469,7 @@ impl OtherUserIdentity {
         let room = if let Some(room) = self.direct_message_room.read().await.as_ref() {
             // Make sure that the user, to be verified, is still in the room
             if !room
-                .active_members()
+                .members(RoomMemberships::ACTIVE)
                 .await?
                 .iter()
                 .any(|member| member.user_id() == self.inner.user_id())

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -20,7 +20,7 @@ pub use async_trait::async_trait;
 pub use bytes;
 pub use matrix_sdk_base::{
     deserialized_responses, DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember,
-    RoomState, Session, StateChanges, StoreError,
+    RoomMemberships, RoomState, Session, StateChanges, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -445,13 +445,7 @@ impl Common {
     /// Use [active_members()](#method.active_members) if you want to ensure to
     /// always get the full member list.
     pub async fn active_members_no_sync(&self) -> Result<Vec<RoomMember>> {
-        Ok(self
-            .inner
-            .active_members()
-            .await?
-            .into_iter()
-            .map(|member| RoomMember::new(self.client.clone(), member))
-            .collect())
+        self.members_no_sync(MembershipFilter::ACTIVE).await
     }
 
     /// Get all the joined members of this room.
@@ -476,13 +470,7 @@ impl Common {
     /// Use [joined_members()](#method.joined_members) if you want to ensure to
     /// always get the full member list.
     pub async fn joined_members_no_sync(&self) -> Result<Vec<RoomMember>> {
-        Ok(self
-            .inner
-            .joined_members()
-            .await?
-            .into_iter()
-            .map(|member| RoomMember::new(self.client.clone(), member))
-            .collect())
+        self.members_no_sync(MembershipFilter::JOIN).await
     }
 
     /// Get a specific member of this room.

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -524,8 +524,7 @@ impl Common {
             .map(|member| RoomMember::new(self.client.clone(), member)))
     }
 
-    /// Get all members for this room, includes invited, joined and left
-    /// members.
+    /// Get members for this room, with the given memberships.
     ///
     /// *Note*: This method will fetch the members from the homeserver if the
     /// member list isn't synchronized due to member lazy loading. Because of
@@ -533,13 +532,12 @@ impl Common {
     ///
     /// Use [members_no_sync()](#method.members_no_sync) if you want a
     /// method that doesn't do any requests.
-    pub async fn members(&self) -> Result<Vec<RoomMember>> {
+    pub async fn members(&self, memberships: RoomMemberships) -> Result<Vec<RoomMember>> {
         self.ensure_members().await?;
-        self.members_no_sync().await
+        self.members_no_sync(memberships).await
     }
 
-    /// Get all members for this room, includes invited, joined and left
-    /// members.
+    /// Get members for this room, with the given memberships.
     ///
     /// *Note*: This method will not fetch the members from the homeserver if
     /// the member list isn't synchronized due to member lazy loading. Thus,
@@ -547,10 +545,10 @@ impl Common {
     ///
     /// Use [members()](#method.members) if you want to ensure to always get
     /// the full member list.
-    pub async fn members_no_sync(&self) -> Result<Vec<RoomMember>> {
+    pub async fn members_no_sync(&self, memberships: RoomMemberships) -> Result<Vec<RoomMember>> {
         Ok(self
             .inner
-            .members(RoomMemberships::empty())
+            .members(memberships)
             .await?
             .into_iter()
             .map(|member| RoomMember::new(self.client.clone(), member))

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, collections::BTreeMap, ops::Deref, sync::Arc};
 use matrix_sdk_base::{
     deserialized_responses::{MembersResponse, TimelineEvent},
     store::StateStoreExt,
-    StateChanges,
+    RoomMemberships, StateChanges,
 };
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::{
@@ -550,7 +550,7 @@ impl Common {
     pub async fn members_no_sync(&self) -> Result<Vec<RoomMember>> {
         Ok(self
             .inner
-            .members()
+            .members(RoomMemberships::empty())
             .await?
             .into_iter()
             .map(|member| RoomMember::new(self.client.clone(), member))
@@ -701,8 +701,6 @@ impl Common {
     /// Returns true if all devices in the room are verified, otherwise false.
     #[cfg(feature = "e2e-encryption")]
     pub async fn contains_only_verified_devices(&self) -> Result<bool> {
-        use matrix_sdk_base::RoomMemberships;
-
         let user_ids =
             self.client.store().get_user_ids(self.room_id(), RoomMemberships::empty()).await?;
 

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -431,9 +431,10 @@ impl Common {
     ///
     /// Use [active_members_no_sync()](#method.active_members_no_sync) if you
     /// want a method that doesn't do any requests.
+    #[deprecated = "Use members with RoomMemberships::ACTIVE instead"]
     pub async fn active_members(&self) -> Result<Vec<RoomMember>> {
         self.ensure_members().await?;
-        self.active_members_no_sync().await
+        self.members_no_sync(RoomMemberships::ACTIVE).await
     }
 
     /// Get active members for this room, includes invited, joined members.
@@ -444,8 +445,9 @@ impl Common {
     ///
     /// Use [active_members()](#method.active_members) if you want to ensure to
     /// always get the full member list.
+    #[deprecated = "Use members_no_sync with RoomMemberships::ACTIVE instead"]
     pub async fn active_members_no_sync(&self) -> Result<Vec<RoomMember>> {
-        self.members_no_sync(MembershipFilter::ACTIVE).await
+        self.members_no_sync(RoomMemberships::ACTIVE).await
     }
 
     /// Get all the joined members of this room.
@@ -456,9 +458,10 @@ impl Common {
     ///
     /// Use [joined_members_no_sync()](#method.joined_members_no_sync) if you
     /// want a method that doesn't do any requests.
+    #[deprecated = "Use members with RoomMemberships::JOIN instead"]
     pub async fn joined_members(&self) -> Result<Vec<RoomMember>> {
         self.ensure_members().await?;
-        self.joined_members_no_sync().await
+        self.members_no_sync(RoomMemberships::JOIN).await
     }
 
     /// Get all the joined members of this room.
@@ -469,8 +472,9 @@ impl Common {
     ///
     /// Use [joined_members()](#method.joined_members) if you want to ensure to
     /// always get the full member list.
+    #[deprecated = "Use members_no_sync with RoomMemberships::JOIN instead"]
     pub async fn joined_members_no_sync(&self) -> Result<Vec<RoomMember>> {
-        self.members_no_sync(MembershipFilter::JOIN).await
+        self.members_no_sync(RoomMemberships::JOIN).await
     }
 
     /// Get a specific member of this room.
@@ -787,7 +791,7 @@ impl Common {
         let this_room_id = self.inner.room_id();
 
         if is_direct {
-            let mut room_members = self.active_members().await?;
+            let mut room_members = self.members(RoomMemberships::ACTIVE).await?;
             room_members.retain(|member| member.user_id() != self.own_user_id());
 
             for member in room_members {
@@ -853,7 +857,7 @@ impl Common {
         // - Are blocked due to server ACLs
         // - Are IP addresses
         let members: Vec<_> = self
-            .joined_members_no_sync()
+            .members_no_sync(RoomMemberships::JOIN)
             .await?
             .into_iter()
             .filter(|member| {

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -701,7 +701,10 @@ impl Common {
     /// Returns true if all devices in the room are verified, otherwise false.
     #[cfg(feature = "e2e-encryption")]
     pub async fn contains_only_verified_devices(&self) -> Result<bool> {
-        let user_ids = self.client.store().get_user_ids(self.room_id()).await?;
+        use matrix_sdk_base::RoomMemberships;
+
+        let user_ids =
+            self.client.store().get_user_ids(self.room_id(), RoomMemberships::empty()).await?;
 
         for user_id in user_ids {
             let devices = self.client.encryption().get_user_devices(&user_id).await?;

--- a/crates/matrix-sdk/src/room/member.rs
+++ b/crates/matrix-sdk/src/room/member.rs
@@ -41,9 +41,10 @@ impl RoomMember {
     ///
     /// ```no_run
     /// # use futures::executor::block_on;
-    /// # use matrix_sdk::{
-    /// #     media::MediaFormat, room::RoomMember, ruma::room_id, Client,
-    /// # };
+    /// use matrix_sdk::{
+    ///     media::MediaFormat, room::RoomMember, ruma::room_id, Client,
+    ///     RoomMemberships,
+    /// };
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://example.com").unwrap();
     /// # block_on(async {
@@ -52,7 +53,7 @@ impl RoomMember {
     /// client.login_username(user, "password").send().await.unwrap();
     /// let room_id = room_id!("!roomid:example.com");
     /// let room = client.get_joined_room(&room_id).unwrap();
-    /// let members = room.members().await.unwrap();
+    /// let members = room.members(RoomMemberships::empty()).await.unwrap();
     /// let member = members.first().unwrap();
     /// if let Some(avatar) = member.avatar(MediaFormat::File).await.unwrap() {
     ///     std::fs::write("avatar.png", avatar);

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use assert_matches::assert_matches;
-use matrix_sdk::{config::SyncSettings, room::RoomMember, DisplayName};
+use matrix_sdk::{config::SyncSettings, room::RoomMember, DisplayName, RoomMemberships};
 use matrix_sdk_test::{
     async_test, bulk_room_members, test_json, EventBuilder, JoinedRoomBuilder, StateTestEvent,
     TimelineTestEvent,
@@ -40,7 +40,7 @@ async fn user_presence() {
     let _response = client.sync_once(sync_settings).await.unwrap();
 
     let room = client.get_joined_room(&test_json::DEFAULT_SYNC_ROOM_ID).unwrap();
-    let members: Vec<RoomMember> = room.active_members().await.unwrap();
+    let members: Vec<RoomMember> = room.members(RoomMemberships::ACTIVE).await.unwrap();
 
     assert_eq!(2, members.len());
     // assert!(room.power_levels.is_some())

--- a/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
@@ -9,7 +9,7 @@ use matrix_sdk::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         events::room::member::{MembershipState, StrippedRoomMemberEvent},
     },
-    Client, RoomState,
+    Client, RoomMemberships, RoomState,
 };
 use tokio::sync::Notify;
 
@@ -105,11 +105,11 @@ async fn test_repeated_join_leave() -> Result<()> {
 
     // Now check the underlying state store that it also has the correct information
     // (for when the client restarts).
-    let invited = karl.store().get_invited_user_ids(room_id).await?;
+    let invited = karl.store().get_user_ids(room_id, RoomMemberships::INVITE).await?;
     assert_eq!(invited.len(), 1);
     assert_eq!(invited[0], karl_id);
 
-    let joined = karl.store().get_joined_user_ids(room_id).await?;
+    let joined = karl.store().get_user_ids(room_id, RoomMemberships::JOIN).await?;
     assert!(!joined.contains(&karl_id));
 
     let event = karl


### PR DESCRIPTION
Introduce flags to filter results at the store level, which should allow to benefit from optimizations in the backend (in the future SQLite state store for example).

Reduces also the number of methods in the API by exposing only one method for all memberships. Other methods are deprecated.

Based on #1794.\
Fixes #930.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
