### PR TITLE
Upgrade UniFFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5461,7 +5461,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "uniffi"
 version = "0.23.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
  "anyhow",
  "camino",
@@ -5482,11 +5482,10 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.23.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
  "anyhow",
  "askama",
- "bincode",
  "camino",
  "fs-err",
  "glob",
@@ -5505,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.23.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
  "anyhow",
  "camino",
@@ -5515,7 +5514,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.23.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
  "quote",
  "syn",
@@ -5524,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.23.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5539,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.23.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
  "bincode",
  "camino",
@@ -5557,17 +5556,20 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.23.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
+ "anyhow",
+ "bytes",
  "serde",
  "siphasher",
  "uniffi_checksum_derive",
+ "uniffi_core",
 ]
 
 [[package]]
 name = "uniffi_testing"
 version = "0.23.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
  "anyhow",
  "camino",
@@ -5861,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41e94c0a4834137d8d359b829e2d4b334f5ab5b5#41e94c0a4834137d8d359b829e2d4b334f5ab5b5"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=aa91307b6ac27aae6d5c7ad971b762df952d2745#aa91307b6ac27aae6d5c7ad971b762df952d2745"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ thiserror = "1.0.38"
 tokio = { version = "1.24", default-features = false, features = ["sync"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-core = "0.1.30"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "41e94c0a4834137d8d359b829e2d4b334f5ab5b5" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "41e94c0a4834137d8d359b829e2d4b334f5ab5b5" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "aa91307b6ac27aae6d5c7ad971b762df952d2745" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "aa91307b6ac27aae6d5c7ad971b762df952d2745" }
 vodozemac = { git = "https://github.com/matrix-org/vodozemac", rev = "fb609ca1e4df5a7a818490ae86ac694119e41e71" }
 zeroize = "1.3.0"
 

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -853,22 +853,6 @@ fn vodozemac_version() -> String {
 
 uniffi::include_scaffolding!("olm");
 
-mod uniffi_types {
-    pub use crate::{
-        backup_recovery_key::{
-            BackupRecoveryKey, DecodeError, MegolmV1BackupKey, PassphraseInfo, PkDecryptionError,
-        },
-        error::{CryptoStoreError, DecryptionError, SecretImportError},
-        machine::{KeyRequestPair, OlmMachine},
-        responses::{BootstrapCrossSigningResult, DeviceLists, Request},
-        verification::{
-            RequestVerificationResult, StartSasResult, Verification, VerificationRequest,
-        },
-        BackupKeys, CrossSigningKeyExport, CrossSigningStatus, DecryptedEvent, EncryptionSettings,
-        EventEncryptionAlgorithm, RoomKeyCounts, RoomSettings, ShieldColor, ShieldState,
-    };
-}
-
 #[cfg(test)]
 mod test {
     use anyhow::Result;

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,0 +1,43 @@
+use matrix_sdk::{self, encryption::CryptoStoreError, HttpError, IdParseError};
+
+#[derive(thiserror::Error, Debug)]
+pub enum ClientError {
+    #[error("client error: {msg}")]
+    Generic { msg: String },
+}
+
+impl From<anyhow::Error> for ClientError {
+    fn from(e: anyhow::Error) -> ClientError {
+        ClientError::Generic { msg: e.to_string() }
+    }
+}
+
+impl From<matrix_sdk::Error> for ClientError {
+    fn from(e: matrix_sdk::Error) -> Self {
+        anyhow::Error::from(e).into()
+    }
+}
+
+impl From<CryptoStoreError> for ClientError {
+    fn from(e: CryptoStoreError) -> Self {
+        anyhow::Error::from(e).into()
+    }
+}
+
+impl From<HttpError> for ClientError {
+    fn from(e: HttpError) -> Self {
+        anyhow::Error::from(e).into()
+    }
+}
+
+impl From<IdParseError> for ClientError {
+    fn from(e: IdParseError) -> Self {
+        anyhow::Error::from(e).into()
+    }
+}
+
+impl From<serde_json::Error> for ClientError {
+    fn from(e: serde_json::Error) -> Self {
+        anyhow::Error::from(e).into()
+    }
+}

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -98,38 +98,3 @@ impl From<serde_json::Error> for ClientError {
 pub use platform::*;
 
 uniffi::include_scaffolding!("api");
-
-mod uniffi_types {
-    pub use matrix_sdk::ruma::events::room::{message::RoomMessageEventContent, MediaSource};
-
-    pub use crate::{
-        authentication_service::{
-            AuthenticationError, AuthenticationService, HomeserverLoginDetails,
-        },
-        client::{
-            Client, CreateRoomParameters, HttpPusherData, PushFormat, PusherIdentifiers,
-            PusherKind, SearchUsersResults, Session, UserProfile,
-        },
-        client_builder::ClientBuilder,
-        room::{Membership, Room},
-        room_member::{MembershipState, RoomMember},
-        session_verification::{SessionVerificationController, SessionVerificationEmoji},
-        sliding_sync::{
-            RequiredState, RoomListEntry, SlidingSync, SlidingSyncBuilder, SlidingSyncError,
-            SlidingSyncList, SlidingSyncListBuilder, SlidingSyncRequestListFilters,
-            SlidingSyncRoom, TaskHandle, UnreadNotificationsCount,
-        },
-        timeline::{
-            AudioInfo, AudioMessageContent, EmoteMessageContent, EncryptedMessage, EventSendState,
-            EventTimelineItem, EventTimelineItemDebugInfo, FileInfo, FileMessageContent,
-            FormattedBody, ImageInfo, ImageMessageContent, InReplyToDetails, InsertData,
-            MembershipChange, Message, MessageFormat, MessageType, NoticeMessageContent,
-            OtherState, ProfileDetails, Reaction, RepliedToEventDetails, SetData,
-            TextMessageContent, ThumbnailInfo, TimelineChange, TimelineDiff, TimelineItem,
-            TimelineItemContent, TimelineItemContentKind, VideoInfo, VideoMessageContent,
-            VirtualTimelineItem,
-        },
-        tracing::{LogLevel, Span},
-        ClientError,
-    };
-}


### PR DESCRIPTION
… and get rid of `uniffi_types` modules! 🎉 

We're also getting closer to proper error handling in FFI, removing `anyhow::Result<_>` in favor of more specific signatures although we don't yet have specific error variants in place (I wanted the diff to be small and only did what was necessary for the UniFFI upgrade in terms of error changes).