### PR TITLE
fix(bindings) Withheld code mapping

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -65,3 +65,4 @@ uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"
+assert_matches = { workspace = true }

--- a/bindings/matrix-sdk-crypto-ffi/src/error.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/error.rs
@@ -69,7 +69,7 @@ impl From<MegolmError> for DecryptionError {
         match value {
             MegolmError::MissingRoomKey(withheld_code) => Self::MissingRoomKey {
                 error: "Withheld Inbound group session".to_owned(),
-                withheld_code: withheld_code.map(|w| w.to_string()),
+                withheld_code: withheld_code.map(|w| w.as_str().to_owned()),
             },
             _ => Self::Megolm { error: value.to_string() },
         }
@@ -91,5 +91,27 @@ impl From<IdParseError> for DecryptionError {
 impl From<InnerStoreError> for DecryptionError {
     fn from(err: InnerStoreError) -> Self {
         Self::Store { error: err.to_string() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_withheld_error_mapping() {
+        use matrix_sdk_crypto::types::events::room_key_withheld::WithheldCode;
+
+        let inner_error = MegolmError::MissingRoomKey(Some(WithheldCode::Unverified));
+
+        let binding_error: DecryptionError = inner_error.into();
+
+        match binding_error {
+            DecryptionError::MissingRoomKey { error: _, withheld_code } => {
+                assert_eq!("m.unverified", withheld_code.unwrap())
+            }
+            _ => panic!("Unexpected mapping"),
+        }
     }
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/error.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/error.rs
@@ -97,6 +97,8 @@ impl From<InnerStoreError> for DecryptionError {
 #[cfg(test)]
 mod tests {
 
+    use assert_matches::assert_matches;
+
     use super::*;
 
     #[test]
@@ -107,11 +109,10 @@ mod tests {
 
         let binding_error: DecryptionError = inner_error.into();
 
-        match binding_error {
-            DecryptionError::MissingRoomKey { error: _, withheld_code } => {
-                assert_eq!("m.unverified", withheld_code.unwrap())
-            }
-            _ => panic!("Unexpected mapping"),
-        }
+        let code = assert_matches!(
+            binding_error,
+            DecryptionError::MissingRoomKey { error: _, withheld_code: Some(withheld_code) } => withheld_code
+        );
+        assert_eq!("m.unverified", code)
     }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes #1806

Withheld error binding was exposing human readable error instead of withheld vcode

