### PR TITLE
Update supported Node.js versions

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -93,16 +93,16 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        node-version: [14.0, 16.0, 18.0, 19.0]
+        node-version: [16.0, 18.0, 19.0, 20.0]
         include:
           - os: ubuntu-latest
             os-name: 🐧
 
           - os: macos-latest
             os-name: 🍏
-            node-version: 18.0
+            node-version: 20.0
 
-          - node-version: 18.0
+          - node-version: 20.0
             build-doc: true
 
     steps:
@@ -174,7 +174,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.0
+          node-version: 20.0
 
       - name: Install NPM dependencies
         working-directory: ${{ env.MATRIX_SDK_CRYPTO_JS_PATH }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Load cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release_crypto_js.yml
+++ b/.github/workflows/release_crypto_js.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.0
+          node-version: 20.0
 
       - name: Install NPM dependencies
         working-directory: ${{ env.PKG_PATH }}

--- a/bindings/matrix-sdk-crypto-nodejs/README.md
+++ b/bindings/matrix-sdk-crypto-nodejs/README.md
@@ -96,8 +96,8 @@ according to [the Node.js Releases
 Page](https://nodejs.org/en/about/releases/), _and_ which are
 compatible with [NAPI v6 (Node.js
 API)](https://nodejs.org/api/n-api.html#node-api-version-matrix). It
-means that this binding will work with the following versions: 14.0.0,
-16.0.0 and 18.0.0.
+means that this binding will work with the following versions: 16.0.0,
+18.0.0, 19.0.0 and 20.0.0.
 
 Once the Rust compiler, Node.js and npm are installed, you can run the
 following commands:

--- a/bindings/matrix-sdk-crypto-nodejs/package.json
+++ b/bindings/matrix-sdk-crypto-nodejs/package.json
@@ -20,7 +20,7 @@
         "yargs-parser": "~21.0.1"
     },
     "engines": {
-        "node": ">= 14"
+        "node": ">= 16"
     },
     "scripts": {
         "lint": "prettier --check .",


### PR DESCRIPTION
This updates the supported Node.js versions to cover the current/active/maintenance release states as of the end of April 2023.