### PR TITLE
sled & indexeddb: Store memberships as strings

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -309,30 +309,25 @@ fn calculate_room_name(
 }
 
 bitflags! {
-    /// Room memberships as a bitset.
+    /// Room membership filter as a bitset.
     ///
-    /// Note that, when used as a filter, [`RoomMemberships::empty()`] doesn't
-    /// filter the results and is equivalent to [`RoomMemberships::all()`].
+    /// Note that [`RoomMemberships::empty()`] doesn't filter the results and
+    /// [`RoomMemberships::all()`] filters out unknown memberships.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub struct RoomMemberships: u16 {
-        /// An unknown (i.e. unspecced) membership.
-        const UNKNOWN = 0b00000001;
         /// The member joined the room.
-        const JOIN    = 0b00000010;
+        const JOIN    = 0b00000001;
         /// The member was invited to the room.
-        const INVITE  = 0b00000100;
+        const INVITE  = 0b00000010;
         /// The member requested to join the room.
-        const KNOCK   = 0b00001000;
+        const KNOCK   = 0b00000100;
         /// The member left the room.
-        const LEAVE   = 0b00010000;
+        const LEAVE   = 0b00001000;
         /// The member was banned.
-        const BAN     = 0b00100000;
+        const BAN     = 0b00010000;
 
         /// The member is active in the room (i.e. joined or invited).
         const ACTIVE = Self::JOIN.bits() | Self::INVITE.bits();
-
-        /// The member has a known (i.e. specced) membership.
-        const KNOWN = Self::JOIN.bits() | Self::INVITE.bits() | Self::KNOCK.bits() | Self::LEAVE.bits() | Self::BAN.bits();
     }
 }
 
@@ -343,21 +338,16 @@ impl RoomMemberships {
             return true;
         }
 
-        let membership = Self::from(membership);
-        self.contains(membership)
-    }
-}
-
-impl From<&MembershipState> for RoomMemberships {
-    fn from(value: &MembershipState) -> Self {
-        match value {
+        let membership = match membership {
             MembershipState::Ban => Self::BAN,
             MembershipState::Invite => Self::INVITE,
             MembershipState::Join => Self::JOIN,
             MembershipState::Knock => Self::KNOCK,
             MembershipState::Leave => Self::LEAVE,
-            _ => Self::UNKNOWN,
-        }
+            _ => return false,
+        };
+
+        self.contains(membership)
     }
 }
 

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -336,6 +336,18 @@ bitflags! {
     }
 }
 
+impl RoomMemberships {
+    /// Whether the given membership matches this `RoomMemberships`.
+    pub fn matches(&self, membership: &MembershipState) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        let membership = Self::from(membership);
+        self.contains(membership)
+    }
+}
+
 impl From<&MembershipState> for RoomMemberships {
     fn from(value: &MembershipState) -> Self {
         match value {


### PR DESCRIPTION
Storing as bitset is not future-proof: the `UNKNOWN` bit will always be unsupported while a string can become supported in a future version.

This also removes the `UNKNOWN` filter as it can be complicated to match against strings and should not be very used.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
