### PR TITLE
crypto: Enable decoding padded base64

### DIFF
--- a/crates/matrix-sdk-crypto/src/utilities.rs
+++ b/crates/matrix-sdk-crypto/src/utilities.rs
@@ -28,8 +28,11 @@ use base64::{
 };
 use matrix_sdk_common::instant::Instant;
 
-const STANDARD_NO_PAD: GeneralPurpose =
-    GeneralPurpose::new(&alphabet::STANDARD, general_purpose::NO_PAD);
+const STANDARD_NO_PAD: GeneralPurpose = GeneralPurpose::new(
+    &alphabet::STANDARD,
+    general_purpose::NO_PAD
+        .with_decode_padding_mode(base64::engine::DecodePaddingMode::Indifferent),
+);
 
 /// Decode the input as base64 with no padding.
 pub fn decode(input: impl AsRef<[u8]>) -> Result<Vec<u8>, DecodeError> {


### PR DESCRIPTION
The [spec](https://spec.matrix.org/v1.6/appendices/#unpadded-base64) says:

> When decoding Base64, implementations SHOULD accept input with or without padding characters wherever possible, to ensure maximum interoperability.

cc @jplatte @poljar 

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>