### PR TITLE
feat(sdk): Remove hacks for Sliding Sync ranges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,7 @@ jobs:
       # run sliding sync and point it at the postgres container and synapse container.
       # the postgres container needs to be above this to make sure it has started prior to this service.
       slidingsync:
-        image: "ghcr.io/matrix-org/sliding-sync:v0.99.0"
+        image: "ghcr.io/matrix-org/sliding-sync:main"
         env:
           SYNCV3_SERVER: "http://synapse:8008"
           SYNCV3_SECRET: "SUPER_CI_SECRET"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,7 +436,7 @@ jobs:
       # run sliding sync and point it at the postgres container and synapse container.
       # the postgres container needs to be above this to make sure it has started prior to this service.
       slidingsync:
-        image: "ghcr.io/matrix-org/sliding-sync:main"
+        image: "ghcr.io/matrix-org/sliding-sync:v0.99.2"
         env:
           SYNCV3_SERVER: "http://synapse:8008"
           SYNCV3_SECRET: "SUPER_CI_SECRET"

--- a/testing/sliding-sync-integration-test/assets/docker-compose.yml
+++ b/testing/sliding-sync-integration-test/assets/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ./data/db:/var/lib/postgresql/data
 
   sliding-sync-proxy:
-    image: ghcr.io/matrix-org/sliding-sync:v0.99.1
+    image: ghcr.io/matrix-org/sliding-sync:main
     depends_on:
       postgres:
         condition: service_healthy

--- a/testing/sliding-sync-integration-test/assets/docker-compose.yml
+++ b/testing/sliding-sync-integration-test/assets/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ./data/db:/var/lib/postgresql/data
 
   sliding-sync-proxy:
-    image: ghcr.io/matrix-org/sliding-sync:main
+    image: ghcr.io/matrix-org/sliding-sync:v0.99.2
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Now that https://github.com/matrix-org/sliding-sync/issues/52 is fixed, we can remove the hacks introduced in https://github.com/matrix-org/matrix-rust-sdk/pull/1699 to handle bad ranges.

It may fix some bugs we have now. The hacks were intended to work with a buggy proxy, not with a valid one (the behaviors were very different).

Let's try this.