### PR TITLE
Fix Wasm conversion into base64

### DIFF
--- a/bindings/matrix-sdk-crypto-js/scripts/build.sh
+++ b/bindings/matrix-sdk-crypto-js/scripts/build.sh
@@ -19,7 +19,11 @@ cd $(dirname "$0")/..
 RUSTFLAGS='-C opt-level=z' WASM_BINDGEN_WEAKREF=1 wasm-pack build --target nodejs --scope matrix-org --out-dir pkg "${WASM_PACK_ARGS[@]}"
 
 # Convert the Wasm into a JS file that exports the base64'ed Wasm.
-echo "module.exports = \`$(base64 pkg/matrix_sdk_crypto_js_bg.wasm)\`;" > pkg/matrix_sdk_crypto_js_bg.wasm.js
+{
+  printf 'module.exports = `'
+  base64 < pkg/matrix_sdk_crypto_js_bg.wasm
+  printf '`;'
+} > pkg/matrix_sdk_crypto_js_bg.wasm.js
 
 # In the JavaScript:
 #  1. Strip out the lines that load the WASM, and our new epilogue.


### PR DESCRIPTION
<!-- description of the changes in this PR -->

When running:

`yarn build`

This error is happening: 

```
Usage:  base64 [-hDd] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -Dd, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
  ````

[Room discussion](https://matrix.to/#/!lKmPiFsblczTEuHjWH:matrix.org/$Pcz75mtp3bv0SuINM0twMO2xAV9aJwaQiKD8K6lH_rQ?via=matrix.org&via=element.io&via=t2l.io)