### PR TITLE
JS Bindings: make `unused_fallback_keys` as optional in `machine.rs/receive_sync_changes`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.0-alpha.8
+
+-  Make `unused_fallback_keys` as optional in `Machine.receive_sync_changes`
+
 # v0.1.0-alpha.7
 
 -   Add new accessors `Device.algorithms` and `Device.isSignedByOwner`

--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.1.0-alpha.8
 
--  Make `unused_fallback_keys` as optional in `Machine.receive_sync_changes`
+-   Make `unused_fallback_keys` as optional in `Machine.receive_sync_changes`
 
 # v0.1.0-alpha.7
 

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -222,7 +222,7 @@ impl OlmMachine {
         to_device_events: &str,
         changed_devices: &sync_events::DeviceLists,
         one_time_key_counts: &Map,
-        unused_fallback_keys: &Set,
+        unused_fallback_keys: Option<Set>,
     ) -> Result<Promise, JsError> {
         let to_device_events = serde_json::from_str(to_device_events)?;
         let changed_devices = changed_devices.inner.clone();
@@ -239,13 +239,18 @@ impl OlmMachine {
                 Some((key, value))
             })
             .collect();
-        let unused_fallback_keys: Option<Vec<DeviceKeyAlgorithm>> = Some(
-            unused_fallback_keys
-                .values()
-                .into_iter()
-                .filter_map(|js_value| Some(DeviceKeyAlgorithm::from(js_value.ok()?.as_string()?)))
-                .collect(),
-        );
+
+        // Convert the unused_fallback_keys JS Set to a `Vec<DeviceKeyAlgorithm>`
+        let unused_fallback_keys: Option<Vec<DeviceKeyAlgorithm>> =  match unused_fallback_keys {
+            Some(fallback_keys) => {
+                Some(fallback_keys
+                    .values()
+                    .into_iter()
+                    .filter_map(|js_value| Some(DeviceKeyAlgorithm::from(js_value.ok()?.as_string()?)))
+                    .collect())
+            },
+            _ => None,
+        };
 
         let me = self.inner.clone();
 

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -241,14 +241,16 @@ impl OlmMachine {
             .collect();
 
         // Convert the unused_fallback_keys JS Set to a `Vec<DeviceKeyAlgorithm>`
-        let unused_fallback_keys: Option<Vec<DeviceKeyAlgorithm>> =  match unused_fallback_keys {
-            Some(fallback_keys) => {
-                Some(fallback_keys
+        let unused_fallback_keys: Option<Vec<DeviceKeyAlgorithm>> = match unused_fallback_keys {
+            Some(fallback_keys) => Some(
+                fallback_keys
                     .values()
                     .into_iter()
-                    .filter_map(|js_value| Some(DeviceKeyAlgorithm::from(js_value.ok()?.as_string()?)))
-                    .collect())
-            },
+                    .filter_map(|js_value| {
+                        Some(DeviceKeyAlgorithm::from(js_value.ok()?.as_string()?))
+                    })
+                    .collect(),
+            ),
             _ => None,
         };
 

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -241,18 +241,16 @@ impl OlmMachine {
             .collect();
 
         // Convert the unused_fallback_keys JS Set to a `Vec<DeviceKeyAlgorithm>`
-        let unused_fallback_keys: Option<Vec<DeviceKeyAlgorithm>> = match unused_fallback_keys {
-            Some(fallback_keys) => Some(
+        let unused_fallback_keys: Option<Vec<DeviceKeyAlgorithm>> =
+            unused_fallback_keys.map(|fallback_keys| {
                 fallback_keys
                     .values()
                     .into_iter()
                     .filter_map(|js_value| {
                         Some(DeviceKeyAlgorithm::from(js_value.ok()?.as_string()?))
                     })
-                    .collect(),
-            ),
-            _ => None,
-        };
+                    .collect()
+            });
 
         let me = self.inner.clone();
 

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -220,6 +220,19 @@ describe(OlmMachine.name, () => {
         expect(receiveSyncChanges).toEqual([]);
     });
 
+    test("can receive sync changes with unusedFallbackKeys as undefined", async () => {
+        const m = await machine();
+        const toDeviceEvents = JSON.stringify([]);
+        const changedDevices = new DeviceLists();
+        const oneTimeKeyCounts = new Map();
+
+        const receiveSyncChanges = JSON.parse(
+            await m.receiveSyncChanges(toDeviceEvents, changedDevices, oneTimeKeyCounts, undefined),
+        );
+
+        expect(receiveSyncChanges).toEqual([]);
+    });
+
     test("can get the outgoing requests that need to be send out", async () => {
         const m = await machine();
         const toDeviceEvents = JSON.stringify([]);


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->

Needed in https://github.com/vector-im/element-web/issues/25215
