### PR TITLE
Send custom encrypted to device

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -464,6 +464,20 @@ impl Device {
         }
     }
 
+    pub(crate) async fn maybe_encrypt_content(
+        &self,
+        event_type: &str,
+        content: &Value,
+    ) -> OlmResult<Option<(Session, Raw<ToDeviceEncryptedEventContent>)>> {
+        match self.encrypt(event_type, content.clone()).await {
+            Ok(ret) => Ok(Some(ret)),
+            Err(OlmError::MissingSession | OlmError::EventError(EventError::MissingSenderKey)) => {
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     /// Encrypt the given inbound group session as a forwarded room key for this
     /// device.
     pub async fn encrypt_room_key_for_forwarding(


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes #1816
Add a new crypto API to create:
OlmMachine.share_encrypted_to_device_event()


Remaining work:

- [x] Basic API for encrypting custom to_device
- [x] Basic unit test
- [ ] Error Handling? should it panic if a device is unknown? should it return the list of device with no olm session and continue to send to others?
- [ ] Persistence | Should persist the inflight custom to device (in ReadOnluDevice?) to provide proper reliability, like for room keys)
- [ ] Persistence | Impl all stores + migration + tests
- [ ] Add Bindings

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
