### PR TITLE
crypto-js: extend `mark_request_as_sent` to accept SigningKeysUploadResponses

### DIFF
--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v0.1.0-alpha.7
+# v0.1.0-alpha.8
 
 -   Extend `OlmDevice.markRequestAsSent` to accept respinses to
     `SigningKeysUploadRequest`s.

--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,7 +1,9 @@
-# v0.1.0-alpha.8
+# v0.1.0-alpha.9
 
 -   Extend `OlmDevice.markRequestAsSent` to accept responses to
     `SigningKeysUploadRequest`s.
+
+# v0.1.0-alpha.8
 -   `importCrossSigningKeys`: change the parameters to be individual keys
     rather than a `CrossSigningKeyExport` object.
 -   Make `unused_fallback_keys` optional in `Machine.receive_sync_changes`

--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v0.1.0-alpha.7
 
+-   Extend `OlmDevice.markRequestAsSent` to accept respinses to
+    `SigningKeysUploadRequest`s.
+
+# v0.1.0-alpha.7
+
 -   Add new accessors `Device.algorithms` and `Device.isSignedByOwner`
 -   In `OlmMachine.getUserDevices`, wait a limited time for any in-flight
     device-list updates to complete.

--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -4,6 +4,7 @@
     `SigningKeysUploadRequest`s.
 
 # v0.1.0-alpha.8
+
 -   `importCrossSigningKeys`: change the parameters to be individual keys
     rather than a `CrossSigningKeyExport` object.
 -   Make `unused_fallback_keys` optional in `Machine.receive_sync_changes`

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -428,6 +428,8 @@ impl OlmMachine {
     /// between all the devices.
     ///
     /// Uploading these keys will require user interactive auth.
+    ///
+    /// Returns an `Array` of `OutgoingRequest`s
     #[wasm_bindgen(js_name = "bootstrapCrossSigning")]
     pub fn bootstrap_cross_signing(&self, reset: bool) -> Promise {
         let me = self.inner.clone();

--- a/bindings/matrix-sdk-crypto-js/src/requests.rs
+++ b/bindings/matrix-sdk-crypto-js/src/requests.rs
@@ -322,6 +322,15 @@ pub struct SigningKeysUploadRequest {
     pub body: JsString,
 }
 
+#[wasm_bindgen]
+impl SigningKeysUploadRequest {
+    /// Get its request type.
+    #[wasm_bindgen(getter, js_name = "type")]
+    pub fn request_type(&self) -> RequestType {
+        RequestType::SigningKeysUpload
+    }
+}
+
 macro_rules! request {
     (
         $destination_request:ident from $source_request:ident
@@ -482,4 +491,7 @@ pub enum RequestType {
 
     /// Represents a `KeysBackupRequest`.
     KeysBackup,
+
+    /// Represents a `SigningKeysUploadRequest`
+    SigningKeysUpload,
 }

--- a/bindings/matrix-sdk-crypto-js/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-js/src/responses.rs
@@ -87,7 +87,7 @@ impl From<SigningKeysUploadResponse> for OwnedResponse {
 impl TryFrom<(RequestType, http::Response<Vec<u8>>)> for OwnedResponse {
     type Error = JsError;
 
-    /// Convert an http response object into the underlying ruma model of the
+    /// Convert an HTTP response object into the underlying ruma model of the
     /// response, and wrap as an OwnedResponse.
     ///
     /// (This is used in
@@ -132,10 +132,10 @@ impl TryFrom<(RequestType, http::Response<Vec<u8>>)> for OwnedResponse {
             RequestType::SigningKeysUpload => {
                 // SigningKeysUploadResponse::try_from_http_response returns a
                 // FromHttpResponseError<UiaaResponse> instead of a
-                // ruma_client_api::error::Error, so we have to hande it
+                // ruma_client_api::error::Error, so we have to handle it
                 // separately. In practice, the application is supposed to
                 // have dealt with UIA before we get here, so we just map it straight into a
-                // regular JsError anyway.
+                // regular `JsError` anyway.
                 return SigningKeysUploadResponse::try_from_http_response(response)
                     .map(Into::into)
                     .map_err(JsError::from);

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -441,7 +441,15 @@ impl OlmMachine {
     /// exist on the server and thus will reset the trust between all the
     /// devices.
     ///
-    /// Uploading these keys will require user interactive auth.
+    /// # Returns
+    ///
+    /// A pair of requests which should be sent out to the server. Once
+    /// sent, the responses should be passed back to the state machine using
+    /// [`mark_request_as_sent`].
+    ///
+    /// These requests may require user interactive auth.
+    ///
+    /// [`mark_request_as_sent`]: #method.mark_request_as_sent`mark_request_
     pub async fn bootstrap_cross_signing(
         &self,
         reset: bool,


### PR DESCRIPTION
Currently, we can't pass the response to a `SigningKeysUploadRequest` into `mark_request_as_sent`, which apparently we should be able to do.

So, we need to make `SigningKeysUploadRequest` have a `type` like the other `OutgoingRequest`s, and  add support for `SigningKeysUploadResponse` to `OwnedResponse`.