### PR TITLE
sdk: Sanitize timeline HTML input and remove reply fallbacks 

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -46,7 +46,7 @@ appservice = ["ruma/appservice-api-s"]
 image-proc = ["dep:image"]
 image-rayon = ["image-proc", "image?/jpeg_rayon"]
 
-experimental-timeline = ["ruma/unstable-msc2677", "dep:chrono"]
+experimental-timeline = ["ruma/unstable-msc2677", "ruma/unstable-sanitize", "dep:chrono"]
 
 experimental-sliding-sync = [
     "matrix-sdk-base/experimental-sliding-sync",

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -27,6 +27,7 @@ use ruma::{
     assign,
     events::{
         receipt::{Receipt, ReceiptThread},
+        room::message::sanitize::HtmlSanitizerMode,
         AnyMessageLikeEventContent,
     },
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, TransactionId, UserId,
@@ -66,6 +67,9 @@ pub use self::{
     pagination::{PaginationOptions, PaginationOutcome},
     virtual_item::VirtualTimelineItem,
 };
+
+/// The default sanitizer mode used when sanitizing HTML.
+const DEFAULT_SANITIZER_MODE: HtmlSanitizerMode = HtmlSanitizerMode::Compat;
 
 /// A high-level view into a regular¹ room's contents.
 ///

--- a/crates/matrix-sdk/src/room/timeline/tests/basic.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/basic.rs
@@ -4,23 +4,26 @@ use futures_util::StreamExt;
 use imbl::vector;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::async_test;
-use ruma::events::{
-    reaction::ReactionEventContent,
-    relation::Annotation,
-    room::{
-        member::{MembershipState, RedactedRoomMemberEventContent, RoomMemberEventContent},
-        message::RoomMessageEventContent,
-        name::RoomNameEventContent,
-        topic::RedactedRoomTopicEventContent,
+use ruma::{
+    assign,
+    events::{
+        reaction::ReactionEventContent,
+        relation::{Annotation, InReplyTo},
+        room::{
+            member::{MembershipState, RedactedRoomMemberEventContent, RoomMemberEventContent},
+            message::{MessageType, Relation, RoomMessageEventContent},
+            name::RoomNameEventContent,
+            topic::RedactedRoomTopicEventContent,
+        },
+        FullStateEventContent,
     },
-    FullStateEventContent,
 };
 use serde_json::{json, Value as JsonValue};
 
 use super::{TestTimeline, ALICE, BOB};
 use crate::room::timeline::{
-    event_item::AnyOtherFullStateEventContent, MembershipChange, TimelineItem, TimelineItemContent,
-    VirtualTimelineItem,
+    event_item::AnyOtherFullStateEventContent, MembershipChange, TimelineDetails, TimelineItem,
+    TimelineItemContent, VirtualTimelineItem,
 };
 
 fn sync_timeline_event(event: JsonValue) -> SyncTimelineEvent {
@@ -250,4 +253,101 @@ async fn dedup_initial() {
     assert_eq!(timeline_items.len(), 3);
     assert_eq!(timeline_items[1].as_event().unwrap().sender(), *BOB);
     assert_eq!(timeline_items[2].as_event().unwrap().sender(), *ALICE);
+}
+
+#[async_test]
+async fn sanitized() {
+    let timeline = TestTimeline::new();
+    let mut stream = timeline.subscribe().await;
+
+    timeline
+        .handle_live_message_event(
+            &ALICE,
+            RoomMessageEventContent::text_html(
+                "\
+                    @@Unknown text@@
+                    Some text\n\n\
+                    !!code```
+                        Some code
+                    ```
+                ",
+                "\
+                    <unknown>Unknown text</unknown>\
+                    <p>Some text</p>\
+                    <code unknown=\"code\">Some code</code>\
+                ",
+            ),
+        )
+        .await;
+
+    let _day_divider =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+
+    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let event = item.as_event().unwrap();
+    let message = assert_matches!(event.content(), TimelineItemContent::Message(msg) => msg);
+    let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
+    assert_eq!(
+        text.formatted.as_ref().unwrap().body,
+        "\
+            Unknown text\
+            <p>Some text</p>\
+            <code>Some code</code>\
+        "
+    );
+}
+
+#[async_test]
+async fn reply() {
+    let timeline = TestTimeline::new();
+    let mut stream = timeline.subscribe().await;
+
+    timeline
+        .handle_live_message_event(
+            &ALICE,
+            RoomMessageEventContent::text_plain("I want you to reply"),
+        )
+        .await;
+
+    let _day_divider =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+
+    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let first_event = item.as_event().unwrap();
+    let first_event_id = first_event.event_id().unwrap();
+    let first_event_sender = *ALICE;
+
+    let reply_formatted_body = format!("\
+        <mx-reply>\
+            <blockquote>\
+                <a href=\"https://matrix.to/#/!my_room:server.name/{first_event_id}\">In reply to</a> \
+                <a href=\"https://matrix.to/#/{first_event_sender}\">{first_event_sender}</a>\
+                <br>\
+                I want you to reply\
+            </blockquote>\
+        </mx-reply>\
+        <p>I'm replying!</p>\
+    ");
+    let reply_plain = format!(
+        "> <{first_event_sender}> I want you to reply\n\
+         I'm replying!"
+    );
+    let reply = assign!(RoomMessageEventContent::text_html(reply_plain, reply_formatted_body), {
+        relates_to: Some(Relation::Reply{
+            in_reply_to: InReplyTo::new(first_event_id.to_owned()),
+        }),
+    });
+
+    timeline.handle_live_message_event(&BOB, reply).await;
+
+    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let message = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::Message(msg) => msg);
+
+    let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
+    assert_eq!(text.body, "I'm replying!");
+    assert_eq!(text.formatted.as_ref().unwrap().body, "<p>I'm replying!</p>");
+
+    let in_reply_to = message.in_reply_to().unwrap();
+    assert_eq!(in_reply_to.event_id, first_event_id);
+    assert_matches!(in_reply_to.event, TimelineDetails::Unavailable);
 }

--- a/crates/matrix-sdk/src/room/timeline/tests/edit.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/edit.rs
@@ -10,12 +10,16 @@ use ruma::{
             self, MessageType, RedactedRoomMessageEventContent, RoomMessageEventContent,
         },
     },
+    serde::Raw,
+    server_name, EventId,
 };
+use serde_json::json;
 
 use super::{TestTimeline, ALICE};
+use crate::room::timeline::TimelineItemContent;
 
 #[async_test]
-async fn edit_redacted() {
+async fn live_redacted() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
@@ -37,4 +41,112 @@ async fn edit_redacted() {
     timeline.handle_live_message_event(&ALICE, edit).await;
 
     assert_eq!(timeline.inner.items().await.len(), 2);
+}
+
+#[async_test]
+async fn live_sanitized() {
+    let timeline = TestTimeline::new();
+    let mut stream = timeline.subscribe().await;
+
+    timeline
+        .handle_live_message_event(
+            &ALICE,
+            RoomMessageEventContent::text_html(
+                "**original** message",
+                "<strong>original</strong> message",
+            ),
+        )
+        .await;
+
+    let _day_divider =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+
+    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let first_event = item.as_event().unwrap();
+    let message = assert_matches!(first_event.content(), TimelineItemContent::Message(msg) => msg);
+    let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
+    assert_eq!(text.body, "**original** message");
+    assert_eq!(text.formatted.as_ref().unwrap().body, "<strong>original</strong> message");
+
+    let first_event_id = first_event.event_id().unwrap();
+
+    let new_plain_content = "!!edited!! **better** message";
+    let new_html_content = "<edited/> <strong>better</strong> message";
+    let edit = assign!(
+        RoomMessageEventContent::text_html(
+            format!("* {}", new_plain_content),
+            format!("* {}", new_html_content)
+        ),
+        {
+            relates_to: Some(message::Relation::Replacement(Replacement::new(
+                first_event_id.to_owned(),
+                MessageType::text_html(new_plain_content, new_html_content),
+            ))),
+        }
+    );
+    timeline.handle_live_message_event(&ALICE, edit).await;
+
+    let item =
+        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+    let first_event = item.as_event().unwrap();
+    let message = assert_matches!(first_event.content(), TimelineItemContent::Message(msg) => msg);
+    let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
+    assert_eq!(text.body, new_plain_content);
+    assert_eq!(text.formatted.as_ref().unwrap().body, " <strong>better</strong> message");
+}
+
+#[async_test]
+async fn aggregated_sanitized() {
+    let timeline = TestTimeline::new();
+    let mut stream = timeline.subscribe().await;
+
+    let original_event_id = EventId::new(server_name!("dummy.server"));
+    let ev = json!({
+        "content": {
+            "formatted_body": "<strong>original</strong> message",
+            "format": "org.matrix.custom.html",
+            "body": "**original** message",
+            "msgtype": "m.text"
+        },
+        "event_id": &original_event_id,
+        "origin_server_ts": timeline.next_server_ts(),
+        "sender": *ALICE,
+        "type": "m.room.message",
+        "unsigned": {
+            "m.relations": {
+                "m.replace": {
+                    "content": {
+                        "formatted_body": "* <edited/> <strong>better</strong> message",
+                        "format": "org.matrix.custom.html",
+                        "body": "* !!edited!! **better** message",
+                        "m.new_content": {
+                            "formatted_body": "<edited/> <strong>better</strong> message",
+                            "format": "org.matrix.custom.html",
+                            "body": "!!edited!! **better** message",
+                            "msgtype": "m.text"
+                        },
+                        "m.relates_to": {
+                            "event_id": original_event_id,
+                            "rel_type": "m.replace"
+                        },
+                        "msgtype": "m.text"
+                    },
+                    "event_id": EventId::new(server_name!("dummy.server")),
+                    "origin_server_ts": timeline.next_server_ts(),
+                    "sender": *ALICE,
+                    "type": "m.room.message",
+                }
+            }
+        }
+    });
+    timeline.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
+
+    let _day_divider =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let first_event = item.as_event().unwrap();
+    let message = assert_matches!(first_event.content(), TimelineItemContent::Message(msg) => msg);
+    let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
+    assert_eq!(text.body, "!!edited!! **better** message");
+    assert_eq!(text.formatted.as_ref().unwrap().body, " <strong>better</strong> message");
 }

--- a/crates/matrix-sdk/src/room/timeline/tests/edit.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/edit.rs
@@ -1,0 +1,40 @@
+use assert_matches::assert_matches;
+use eyeball_im::VectorDiff;
+use futures_util::StreamExt;
+use matrix_sdk_test::async_test;
+use ruma::{
+    assign,
+    events::{
+        relation::Replacement,
+        room::message::{
+            self, MessageType, RedactedRoomMessageEventContent, RoomMessageEventContent,
+        },
+    },
+};
+
+use super::{TestTimeline, ALICE};
+
+#[async_test]
+async fn edit_redacted() {
+    let timeline = TestTimeline::new();
+    let mut stream = timeline.subscribe().await;
+
+    timeline
+        .handle_live_redacted_message_event(*ALICE, RedactedRoomMessageEventContent::new())
+        .await;
+    let _day_divider =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+
+    let redacted_event_id = item.as_event().unwrap().event_id().unwrap();
+
+    let edit = assign!(RoomMessageEventContent::text_plain(" * test"), {
+        relates_to: Some(message::Relation::Replacement(Replacement::new(
+            redacted_event_id.to_owned(),
+            MessageType::text_plain("test"),
+        ))),
+    });
+    timeline.handle_live_message_event(&ALICE, edit).await;
+
+    assert_eq!(timeline.inner.items().await.len(), 2);
+}

--- a/crates/matrix-sdk/src/room/timeline/tests/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/mod.rs
@@ -49,6 +49,7 @@ use super::{inner::RoomDataProvider, Profile, TimelineInner, TimelineItem};
 
 mod basic;
 mod echo;
+mod edit;
 #[cfg(feature = "e2e-encryption")]
 mod encryption;
 mod invalid;


### PR DESCRIPTION
Based on #1845.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
