### PR TITLE
feat(bindings): Add is_read field on NotificationItem

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -23,6 +23,7 @@ dictionary NotificationItem {
     boolean is_noisy;
     boolean is_direct;
     boolean is_encrypted;
+    boolean is_read;
 };
 
 interface TimelineEvent {};

--- a/bindings/matrix-sdk-ffi/src/notification_service.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_service.rs
@@ -18,6 +18,7 @@ pub struct NotificationItem {
     pub is_noisy: bool,
     pub is_direct: bool,
     pub is_encrypted: bool,
+    pub is_read: bool,
 }
 
 impl NotificationItem {
@@ -45,6 +46,7 @@ impl NotificationItem {
             is_noisy,
             is_direct: room.is_direct().await?,
             is_encrypted: room.is_encrypted().await?,
+            is_read: notification.read,
         };
         Ok(item)
     }


### PR DESCRIPTION
This is to allow clients to decide if they want to discard notifications that are already read or not.