### PR TITLE
Add "opaque interface declarations"

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -8,6 +8,10 @@ callback interface NotificationDelegate {
     void did_receive_notification(NotificationItem notification);
 };
 
+interface AuthenticationService {};
+interface Span {};
+interface NotificationService {};
+
 dictionary NotificationItem {
     TimelineEvent event;
     string room_id;

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -11,7 +11,6 @@ use zeroize::Zeroize;
 use super::{client::Client, client_builder::ClientBuilder, RUNTIME};
 use crate::error::ClientError;
 
-#[derive(uniffi::Object)]
 pub struct AuthenticationService {
     base_path: String,
     passphrase: Option<String>,

--- a/bindings/matrix-sdk-ffi/src/notification_service.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_service.rs
@@ -51,7 +51,6 @@ impl NotificationItem {
 }
 
 #[allow(dead_code)]
-#[derive(uniffi::Object)]
 pub struct NotificationService {
     base_path: String,
     user_id: String,

--- a/bindings/matrix-sdk-ffi/src/tracing.rs
+++ b/bindings/matrix-sdk-ffi/src/tracing.rs
@@ -95,7 +95,6 @@ fn span_or_event_enabled(callsite: &'static DefaultCallsite) -> bool {
     }
 }
 
-#[derive(uniffi::Object)]
 pub struct Span(tracing::Span);
 
 #[uniffi::export]


### PR DESCRIPTION
Using the `#[derive(uniffi::Object)]` on certain types make them not show up in the `.aar` file when building for Android. Could not determine why that is, but removing the derive macro, and adding the empty interface declarations inside the UDL, makes them turn back up again in the final `.aar`

we can still use `#[uniffi::export]` and `#[uniffi::constructor]` as expected. Further research will have to be done to determine why the object derive macro is causing this issue, but the documentation on uniffi does say it's experimental, so maybe the opaque interface declarations should be the preferred approach, going forward?
