### PR TITLE
fix(ffi): Generate correct temporary file names for media attachments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,7 +2639,7 @@ dependencies = [
  "matrix-sdk-sled",
  "matrix-sdk-test",
  "mime",
- "mime_guess",
+ "mime2ext",
  "once_cell",
  "pin-project-lite",
  "rand 0.8.5",
@@ -3081,6 +3081,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime2ext"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a85a5069ebd40e64b1985773cc81addbe9d90d7ecf60e7b5475a57ad584c70"
 
 [[package]]
 name = "mime_guess"

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -195,6 +195,7 @@ impl Client {
     pub fn get_media_file(
         &self,
         media_source: Arc<MediaSource>,
+        body: Option<String>,
         mime_type: String,
     ) -> Result<Arc<MediaFileHandle>, ClientError> {
         let client = self.client.clone();
@@ -206,6 +207,7 @@ impl Client {
                 .media()
                 .get_media_file(
                     &MediaRequest { source, format: MediaFormat::File },
+                    body,
                     &mime_type,
                     true,
                 )

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -87,7 +87,7 @@ matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../matrix-sdk-indexeddb", default-features = false, optional = true }
 matrix-sdk-sled = { version = "0.2.0", path = "../matrix-sdk-sled", default-features = false, optional = true }
 mime = "0.3.16"
-mime_guess = "2.0.4"
+mime2ext = "0.1.52"
 once_cell = { workspace = true }
 pin-project-lite = "0.2.9"
 rand = { version = "0.8.5", optional = true }

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -19,12 +19,12 @@
 use std::io::Read;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
-use std::time::Duration;
+use std::{fs::File, time::Duration};
 
 pub use matrix_sdk_base::media::*;
 use mime::Mime;
 #[cfg(not(target_arch = "wasm32"))]
-use mime_guess;
+use mime2ext;
 use ruma::{
     api::client::media::{create_content, get_content, get_content_thumbnail},
     assign,
@@ -140,19 +140,55 @@ impl Media {
     pub async fn get_media_file(
         &self,
         request: &MediaRequest,
+        body: Option<String>,
         content_type: &Mime,
         use_cache: bool,
     ) -> Result<MediaFileHandle> {
         let data = self.get_media_content(request, use_cache).await?;
 
-        let mut suffix = String::from("");
-        if let Some(extension) =
-            mime_guess::get_mime_extensions(content_type).and_then(|a| a.first())
-        {
-            suffix = String::from(".") + extension;
-        }
+        let inferred_extension = mime2ext::mime2ext(content_type);
 
-        let file = TempFileBuilder::new().suffix(&suffix).tempfile()?;
+        let body_path = body.as_ref().map(Path::new);
+        let filename = body_path.and_then(|f| f.file_name().and_then(|f| f.to_str()));
+        let filename_with_extension = body_path.and_then(|f| {
+            if f.extension().is_some() {
+                f.file_name().and_then(|f| f.to_str())
+            } else {
+                None
+            }
+        });
+
+        let file = match (filename, filename_with_extension, inferred_extension) {
+            // If the body is a file name and has an extension use that
+            (Some(_), Some(filename_with_extension), Some(_)) => {
+                // We're potentially using the same file name multiple times
+                // which might lead to tempfile() failing. Use `make` instead
+                // to avoid that
+                TempFileBuilder::new()
+                    .prefix(filename_with_extension)
+                    .rand_bytes(0)
+                    .make(|path| File::create(path))?
+            }
+            // If the body is a file name but doesn't have an extension try inferring one for it
+            (Some(filename), None, Some(inferred_extension)) => {
+                // We're potentially using the same file name multiple times
+                // which might lead to tempfile() failing. Use `make` instead
+                // to avoid that
+                TempFileBuilder::new()
+                    .prefix(filename)
+                    .suffix(&(".".to_owned() + inferred_extension))
+                    .rand_bytes(0)
+                    .make(|path| File::create(path))?
+            }
+            // If the only thing we have is an inferred extension then use that together with a
+            // randomly generated file name
+            (None, None, Some(inferred_extension)) => {
+                TempFileBuilder::new().suffix(&&(".".to_owned() + inferred_extension)).tempfile()?
+            }
+            // Otherwise just use a completely random file name
+            _ => TempFileBuilder::new().tempfile()?,
+        };
+
         TokioFile::from_std(file.reopen()?).write_all(&data).await?;
 
         Ok(MediaFileHandle { file })


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-x-ios/issues/843

As the issue above describes, simple text files (and surely others) aren't currently renderable iOS side. This happens because we use `mime_guess` to infer an extension from the content type and that results in a list of extensions sorted in no particular order. In this case `text/plain` results in `asm` because it just happens to be the first match from [this list](https://github.com/abonander/mime_guess/blob/master/src/mime_types.rs#L92) which iOS doesn't know what to do with.

To fix that this PR switches over to [mime2ext](https://github.com/blyxxyz/mime2ext#see-also) (like [this comment](https://github.com/abonander/mime_guess/issues/59#issuecomment-1110023679) from `mime_guess` suggests) which does return more commonly used extensions.

Separately, the `body` of an attachment is usually its original filename which we are currently not using. This PR also addresses that by adding an optional `body` property and trying to use it as much as possible when generating the temporary file name. This will in turn show up in the iOS system dialogs when trying to save said file.