### PR TITLE
Expose displaying of thread capabilities trough FFI

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -464,6 +464,10 @@ impl Message {
     pub fn is_edited(&self) -> bool {
         self.0.is_edited()
     }
+
+    pub fn in_thread(&self) -> Option<String> {
+        self.0.in_thread().map(|event_id| event_id.to_string())
+    }
 }
 
 #[derive(Clone, uniffi::Enum)]

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -465,8 +465,8 @@ impl Message {
         self.0.is_edited()
     }
 
-    pub fn in_thread(&self) -> Option<String> {
-        self.0.in_thread().map(|event_id| event_id.to_string())
+    pub fn in_thread(&self) -> Option<InThreadDetails> {
+        self.0.in_thread().map(InThreadDetails::from)
     }
 }
 
@@ -727,6 +727,18 @@ impl From<&matrix_sdk::ruma::events::room::message::FileInfo> for FileInfo {
             thumbnail_info,
             thumbnail_source: info.thumbnail_source.clone().map(Arc::new),
         }
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct InThreadDetails {
+    pub thread_id: String,
+    pub is_fallback: bool,
+}
+
+impl From<&matrix_sdk::room::timeline::InThreadDetails> for InThreadDetails {
+    fn from(inner: &matrix_sdk::room::timeline::InThreadDetails) -> Self {
+        InThreadDetails { thread_id: inner.thread_id.to_string(), is_fallback: inner.is_fallback }
     }
 }
 

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -49,7 +49,7 @@ use super::{
     },
     find_read_marker,
     read_receipts::maybe_add_implicit_read_receipt,
-    rfind_event_by_id, rfind_event_item, EventTimelineItem, InReplyToDetails, Message,
+    rfind_event_by_id, rfind_event_item, unpack_relates_to, EventTimelineItem, Message,
     ReactionGroup, TimelineDetails, TimelineInnerState, TimelineItem, TimelineItemContent,
     VirtualTimelineItem,
 };
@@ -387,6 +387,7 @@ impl<'a> TimelineEventHandler<'a> {
                 msgtype: replacement.new_content,
                 in_reply_to: msg.in_reply_to.clone(),
                 edited: true,
+                in_thread: msg.in_thread.clone(),
             });
 
             let edit_json = match &self.flow {
@@ -963,9 +964,12 @@ impl NewEventTimelineItem {
             }
         });
 
+        let (in_reply_to, in_thread) = c.relates_to.map(unpack_relates_to).unwrap_or((None, None));
+
         let content = TimelineItemContent::Message(Message {
             msgtype: edit.map_or(c.msgtype, |e| e.new_content),
-            in_reply_to: c.relates_to.and_then(InReplyToDetails::from_relation),
+            in_reply_to,
+            in_thread,
             edited,
         });
 

--- a/crates/matrix-sdk/src/room/timeline/event_item/content.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/content.rs
@@ -197,10 +197,10 @@ pub fn unpack_relates_to<C>(
             }),
             None,
         ),
-        message::Relation::Thread(Thread { event_id, in_reply_to: Some(in_reply_to_), .. }) => {
-            let reply_details = Some(InReplyToDetails {
-                event_id: in_reply_to_.event_id,
-                event: TimelineDetails::Unavailable,
+        message::Relation::Thread(Thread { event_id, in_reply_to, .. }) => {
+            let reply_details = in_reply_to.map(|rep| InReplyToDetails {
+              event_id: rep.event_id,
+              event: TimelineDetails::Unavailable,
             });
             let thread_details = Some(event_id);
             (reply_details, thread_details)

--- a/crates/matrix-sdk/src/room/timeline/event_item/content.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/content.rs
@@ -199,8 +199,8 @@ pub fn unpack_relates_to<C>(
         ),
         message::Relation::Thread(Thread { event_id, in_reply_to, .. }) => {
             let reply_details = in_reply_to.map(|rep| InReplyToDetails {
-              event_id: rep.event_id,
-              event: TimelineDetails::Unavailable,
+                event_id: rep.event_id,
+                event: TimelineDetails::Unavailable,
             });
             let thread_details = Some(event_id);
             (reply_details, thread_details)

--- a/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
@@ -31,9 +31,9 @@ mod local;
 mod remote;
 
 pub use self::content::{
-    AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, InReplyToDetails,
-    MemberProfileChange, MembershipChange, Message, OtherState, ReactionGroup, RepliedToEvent,
-    RoomMembershipChange, Sticker, TimelineItemContent,
+    unpack_relates_to, AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage,
+    InReplyToDetails, MemberProfileChange, MembershipChange, Message, OtherState, ReactionGroup,
+    RepliedToEvent, RoomMembershipChange, Sticker, TimelineItemContent,
 };
 pub(super) use self::{
     local::LocalEventTimelineItem,

--- a/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/mod.rs
@@ -32,8 +32,8 @@ mod remote;
 
 pub use self::content::{
     unpack_relates_to, AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage,
-    InReplyToDetails, MemberProfileChange, MembershipChange, Message, OtherState, ReactionGroup,
-    RepliedToEvent, RoomMembershipChange, Sticker, TimelineItemContent,
+    InReplyToDetails, InThreadDetails, MemberProfileChange, MembershipChange, Message, OtherState,
+    ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker, TimelineItemContent,
 };
 pub(super) use self::{
     local::LocalEventTimelineItem,

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -59,9 +59,9 @@ use self::inner::{TimelineInner, TimelineInnerState};
 pub use self::{
     event_item::{
         unpack_relates_to, AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage,
-        EventSendState, EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange,
-        Message, OtherState, Profile, ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker,
-        TimelineDetails, TimelineItemContent,
+        EventSendState, EventTimelineItem, InReplyToDetails, InThreadDetails, MemberProfileChange,
+        MembershipChange, Message, OtherState, Profile, ReactionGroup, RepliedToEvent,
+        RoomMembershipChange, Sticker, TimelineDetails, TimelineItemContent,
     },
     pagination::{PaginationOptions, PaginationOutcome},
     virtual_item::VirtualTimelineItem,

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -58,9 +58,9 @@ pub(crate) use self::builder::TimelineBuilder;
 use self::inner::{TimelineInner, TimelineInnerState};
 pub use self::{
     event_item::{
-        AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, EventSendState,
-        EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange, Message,
-        OtherState, Profile, ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker,
+        unpack_relates_to, AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage,
+        EventSendState, EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange,
+        Message, OtherState, Profile, ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker,
         TimelineDetails, TimelineItemContent,
     },
     pagination::{PaginationOptions, PaginationOutcome},


### PR DESCRIPTION
Removes the prior InReplyToDetails::from_relation as this is no longer necessary.

Instead of modelling ruma's relationship enum, I've decided to flatten that and turn it into 2 distinct fields on Message instead. The reasoning behind this, clients that don't/can't/won't handle threads, can just ignore the field.

It also reduces the amount of indirection forced onto the consumer of the FFI, since they don't have to check what "kind" of relationship type they're inspecting, they just look up the in_reply_to field or the in_thread field and see if there's anything there.

Another added benefit is that this patch becomes smaller, with that in mind.

FFI-consumer can now determine if an event is in a thread by doing
```kotlin
val threadRootId = message.inThread()
if(threadRootId != null) { /* do something with thread root id */ }
```

I'm not thrilled over the name I picked here, but I named the method the first thing that came to mind.

Signed-off-by: Simon Farre <simon.farre.cx@gmail.com>
