### PR TITLE
feat(binding): added the timestamp field to NotificationItem

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -23,6 +23,7 @@ dictionary NotificationItem {
     boolean is_direct;
     boolean is_encrypted;
     boolean is_read;
+    u64 timestamp;
 };
 
 interface TimelineEvent {};

--- a/bindings/matrix-sdk-ffi/src/notification_service.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_service.rs
@@ -19,6 +19,8 @@ pub struct NotificationItem {
     pub is_direct: bool,
     pub is_encrypted: bool,
     pub is_read: bool,
+
+    pub timestamp: u64,
 }
 
 impl NotificationItem {
@@ -47,6 +49,7 @@ impl NotificationItem {
             is_direct: room.is_direct().await?,
             is_encrypted: room.is_encrypted().await?,
             is_read: notification.read,
+            timestamp: notification.ts.0.into(),
         };
         Ok(item)
     }

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -83,7 +83,7 @@ impl SlidingSyncBuilder {
     /// does not matter.
     pub fn with_common_extensions(mut self) -> Self {
         {
-            let mut cfg = self.extensions.get_or_insert_with(Default::default);
+            let cfg = self.extensions.get_or_insert_with(Default::default);
             if cfg.to_device.enabled.is_none() {
                 cfg.to_device.enabled = Some(true);
             }
@@ -106,7 +106,7 @@ impl SlidingSyncBuilder {
     /// does not matter.
     pub fn with_all_extensions(mut self) -> Self {
         {
-            let mut cfg = self.extensions.get_or_insert_with(Default::default);
+            let cfg = self.extensions.get_or_insert_with(Default::default);
             if cfg.to_device.enabled.is_none() {
                 cfg.to_device.enabled = Some(true);
             }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -152,7 +152,7 @@ impl SlidingSync {
     /// Add the common extensions if not already configured.
     pub fn add_common_extensions(&self) {
         let mut lock = self.inner.extensions.lock().unwrap();
-        let mut cfg = lock.get_or_insert_with(Default::default);
+        let cfg = lock.get_or_insert_with(Default::default);
 
         if cfg.to_device.enabled.is_none() {
             cfg.to_device.enabled = Some(true);


### PR DESCRIPTION
An useful field that could be used by client to discard or show notifications based on their sent timestamp