### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,7 +1440,6 @@ dependencies = [
  "matrix-sdk",
  "tokio",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]
@@ -1459,7 +1458,6 @@ name = "example-custom-events"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dirs",
  "matrix-sdk",
  "serde",
  "tokio",
@@ -1495,7 +1493,6 @@ name = "example-getting-started"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dirs",
  "matrix-sdk",
  "tokio",
  "tracing-subscriber",
@@ -2668,7 +2665,6 @@ dependencies = [
  "axum",
  "dashmap",
  "http",
- "http-body",
  "hyper",
  "matrix-sdk",
  "matrix-sdk-test",
@@ -2693,14 +2689,12 @@ version = "0.6.1"
 dependencies = [
  "assert_matches",
  "assign",
- "async-stream",
  "async-trait",
  "bitflags 2.2.1",
  "ctor 0.2.0",
  "dashmap",
  "eyeball",
  "futures",
- "futures-core",
  "futures-util",
  "http",
  "matrix-sdk-common",
@@ -2716,7 +2710,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen-test",
- "zeroize",
 ]
 
 [[package]]
@@ -2753,7 +2746,6 @@ dependencies = [
  "ctor 0.2.0",
  "ctr",
  "dashmap",
- "event-listener",
  "eyeball",
  "futures",
  "futures-core",
@@ -2806,7 +2798,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tracing",
  "tracing-subscriber",
  "uniffi",
  "vodozemac",
@@ -2898,7 +2889,6 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "base64 0.21.0",
- "dashmap",
  "getrandom 0.2.9",
  "gloo-utils",
  "indexed_db_futures",
@@ -2939,7 +2929,6 @@ dependencies = [
 name = "matrix-sdk-qrcode"
 version = "0.4.0"
 dependencies = [
- "base64 0.21.0",
  "byteorder",
  "image 0.23.14",
  "qrcode",
@@ -2953,15 +2942,12 @@ name = "matrix-sdk-sled"
 version = "0.2.0"
 dependencies = [
  "assert_matches",
- "async-stream",
  "async-trait",
- "dashmap",
  "fs_extra",
  "futures-core",
  "futures-util",
  "glob",
  "matrix-sdk-base",
- "matrix-sdk-common",
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
  "matrix-sdk-test",
@@ -2981,17 +2967,11 @@ name = "matrix-sdk-sqlite"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
- "async-stream",
  "async-trait",
  "ctor 0.2.0",
- "dashmap",
  "deadpool-sqlite",
- "fs_extra",
- "futures-core",
- "futures-util",
  "glob",
  "matrix-sdk-base",
- "matrix-sdk-common",
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
  "matrix-sdk-test",
@@ -3047,7 +3027,6 @@ dependencies = [
 name = "matrix-sdk-test-macros"
 version = "0.3.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 1.0.109",
 ]
@@ -6227,7 +6206,6 @@ dependencies = [
  "fs_extra",
  "serde",
  "serde_json",
- "uniffi",
  "uniffi_bindgen",
  "xshell",
 ]

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -29,7 +29,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.2"
 thiserror = { workspace = true }
-tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
 uniffi = { workspace = true }

--- a/crates/matrix-sdk-appservice/Cargo.toml
+++ b/crates/matrix-sdk-appservice/Cargo.toml
@@ -33,7 +33,6 @@ docs = []
 axum = { version = "0.6.1", default-features = false, features = ["json"] }
 dashmap = { workspace = true }
 http = { workspace = true }
-http-body = "0.4.5"
 hyper = { version = "0.14.20", features = ["http1", "http2", "server"] }
 matrix-sdk = { version = "0.6.0", path = "../matrix-sdk", default-features = false, features = ["appservice"] }
 regex = "1.5.5"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -28,12 +28,10 @@ testing = ["dep:http", "dep:matrix-sdk-test", "dep:assert_matches"]
 
 [dependencies]
 assert_matches = { workspace = true, optional = true }
-async-stream = { workspace = true }
 async-trait = { workspace = true }
 bitflags = "2.1.0"
 dashmap = { workspace = true }
 eyeball = { workspace = true }
-futures-core = "0.3.21"
 futures-util = { workspace = true }
 http = { workspace = true, optional = true }
 matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
@@ -47,7 +45,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -35,7 +35,6 @@ bs58 = { version = "0.4.0", optional = true }
 byteorder = { workspace = true }
 ctr = "0.9.1"
 dashmap = { workspace = true }
-event-listener = "2.5.2"
 eyeball = { workspace = true }
 futures-core = "0.3.24"
 futures-util = { workspace = true }

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -15,13 +15,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["e2e-encryption"]
-e2e-encryption = ["matrix-sdk-base/e2e-encryption", "dep:matrix-sdk-crypto", "dashmap"]
+e2e-encryption = ["matrix-sdk-base/e2e-encryption", "dep:matrix-sdk-crypto"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
-dashmap = { workspace = true, optional = true }
 gloo-utils = { version = "0.1", features = ["serde"] }
 indexed_db_futures = "0.3.0"
 js-sys = { version = "0.3.58" }

--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -16,7 +16,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-base64 = { workspace = true }
 byteorder = { workspace = true }
 qrcode = { version = "0.12.0", default-features = false }
 ruma-common = { workspace = true }

--- a/crates/matrix-sdk-sled/Cargo.toml
+++ b/crates/matrix-sdk-sled/Cargo.toml
@@ -24,14 +24,11 @@ crypto-store = [
 ]
 
 [dependencies]
-async-stream = { workspace = true }
 async-trait = { workspace = true }
-dashmap = { workspace = true }
 fs_extra = "1.2.0"
 futures-core = "0.3.21"
 futures-util = { workspace = true }
 matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base", optional = true }
-matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto", optional = true }
 matrix-sdk-store-encryption = { version = "0.2.0", path = "../matrix-sdk-store-encryption" }
 ruma = { workspace = true }

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -18,15 +18,9 @@ crypto-store = [
 state-store = []
 
 [dependencies]
-async-stream = { workspace = true }
 async-trait = { workspace = true }
-dashmap = { workspace = true }
 deadpool-sqlite = "0.5.0"
-fs_extra = "1.2.0"
-futures-core = "0.3.21"
-futures-util = { workspace = true }
 matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base" }
-matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto", optional = true }
 matrix-sdk-store-encryption = { version = "0.2.0", path = "../matrix-sdk-store-encryption" }
 rmp-serde = "1.1.1"

--- a/examples/command_bot/Cargo.toml
+++ b/examples/command_bot/Cargo.toml
@@ -12,7 +12,6 @@ test = false
 anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
-url = "2.2.2"
 
 [dependencies.matrix-sdk]
 path = "../../crates/matrix-sdk"

--- a/examples/custom_events/Cargo.toml
+++ b/examples/custom_events/Cargo.toml
@@ -10,7 +10,6 @@ test = false
 
 [dependencies]
 anyhow = "1"
-dirs = "4.0.0"
 serde = "1.0"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -10,7 +10,6 @@ test = false
 
 [dependencies]
 anyhow = "1"
-dirs = "4.0.0"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = "0.3.15"
 

--- a/testing/matrix-sdk-test-macros/Cargo.toml
+++ b/testing/matrix-sdk-test-macros/Cargo.toml
@@ -17,6 +17,5 @@ test = false
 doctest = false
 
 [dependencies]
-proc-macro2 = "1.0.37"
 quote = "1.0.18"
 syn = { version = "1.0.91", features = ["full", "extra-traits"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -14,6 +14,5 @@ clap = { version = "4.0.18", features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 fs_extra = "1"
-uniffi = { workspace = true }
 uniffi_bindgen = { workspace = true }
 xshell = "0.1.17"


### PR DESCRIPTION
Removes some unused dependencies, automatically detected by [cargo-machete](https://github.com/bnjbvr/cargo-machete). There weren't any unused dependencies overall across the workspace, but a few dependencies might have moved from one crate to another during the course of development, so this could help with reducing compile times by shuffling the cargo build pipeline.

I'm a bit dubious about some of the dependencies flagged as unused, so there might be a few false positives (I could at least build all the native tests with those changes); let's see what CI says.