### PR TITLE
add binding for compute_all_signatures

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1361,15 +1361,19 @@ impl OlmMachine {
     ///     }
     /// }
     /// ```
+    /// 
+    /// * `compute_all_signatures` - If true will check all signatures, if 
+    /// false will stop as soon as a valid and trusted signature is found
     pub fn verify_backup(
         &self,
         backup_info: String,
+        compute_all_signatures: bool,
     ) -> Result<SignatureVerification, CryptoStoreError> {
         let backup_info = serde_json::from_str(&backup_info)?;
 
         Ok(self
             .runtime
-            .block_on(self.inner.backup_machine().verify_backup(backup_info, false))?
+            .block_on(self.inner.backup_machine().verify_backup(backup_info, compute_all_signatures))?
             .into())
     }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Add ffi bindings for `compute_all_signatures` when checking backup signatures

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
