### PR TITLE
fix(bindings): correct timestamp value and removed `is_read`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -22,8 +22,6 @@ dictionary NotificationItem {
     boolean is_noisy;
     boolean is_direct;
     boolean is_encrypted;
-    boolean is_read;
-    u64 timestamp;
 };
 
 interface TimelineEvent {};

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -19,6 +19,10 @@ impl TimelineEvent {
         self.0.sender().to_string()
     }
 
+    pub fn timestamp(&self) -> u64 {
+        self.0.origin_server_ts().0.into()
+    }
+
     pub fn event_type(&self) -> Result<TimelineEventType, ClientError> {
         let event_type = match &self.0 {
             AnySyncTimelineEvent::MessageLike(event) => {

--- a/bindings/matrix-sdk-ffi/src/notification_service.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_service.rs
@@ -18,9 +18,6 @@ pub struct NotificationItem {
     pub is_noisy: bool,
     pub is_direct: bool,
     pub is_encrypted: bool,
-    pub is_read: bool,
-
-    pub timestamp: u64,
 }
 
 impl NotificationItem {
@@ -48,8 +45,6 @@ impl NotificationItem {
             is_noisy,
             is_direct: room.is_direct().await?,
             is_encrypted: room.is_encrypted().await?,
-            is_read: notification.read,
-            timestamp: notification.ts.0.into(),
         };
         Ok(item)
     }


### PR DESCRIPTION
The timestamp value of the Notification was not reliable since it was the timestamp in which it was generated internally, not the timestamp of when the event was sent (the doc said sent, but I feel the term is a bit ambiguous, maybe the intention was to say triggered? ), now I instead exposed on the TimelineEvent itself the timestamp, which is the actually timestamp of when the event was sent by the server.

Also for some reason the `is_read` field is always returning false... so doesn't seem very reliable and I decided to remove it entirely.