### PR TITLE
sdk: Don't add original form of redacted events to the timeline

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -689,11 +689,18 @@ impl<'a> TimelineEventHandler<'a> {
                 });
 
                 if let Some((idx, old_item)) = result {
-                    if let Some(old_item) = old_item.as_remote() {
+                    if old_item.as_remote().is_some() {
                         // Item was previously received from the server. This
                         // should be very rare normally, but with the sliding-
                         // sync proxy, it is actually very common.
                         trace!(?item, ?old_item, "Received duplicate event");
+
+                        if old_item.content.is_redacted() && !item.content.is_redacted() {
+                            warn!(
+                                "Skipping original form of an event that was previously redacted"
+                            );
+                            return;
+                        }
                     };
 
                     if txn_id.is_none() {

--- a/crates/matrix-sdk/src/room/timeline/event_item/content.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/content.rs
@@ -111,6 +111,10 @@ impl TimelineItemContent {
             _ => None,
         }
     }
+
+    pub(crate) fn is_redacted(&self) -> bool {
+        matches!(self, Self::RedactedMessage)
+    }
 }
 
 /// An `m.room.message` event or extensible event, including edits.


### PR DESCRIPTION
If the redaction already happened server-side, it is a bug for the server to even still have access to the non-redacted form.
We don't accept the server data in this case, and also log a warning.
