### PR TITLE
chore: Fix cargo xtask doc

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -41,7 +46,7 @@ jobs:
           CARGO_TARGET_APPLIES_TO_HOST: "true"
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options --cfg docsrs -Dwarnings"
         run:
-          cargo doc --no-deps --features docsrs
+          cargo doc --no-deps --workspace --features docsrs
 
       - name: Build `matrix-sdk-crypto-nodejs` doc
         run: |

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -391,7 +391,7 @@ impl OlmMachine {
     ///
     /// After the request was sent out and a successful response was received
     /// the response body should be passed back to the state machine using the
-    /// [mark_request_as_sent()](#method.mark_request_as_sent) method.
+    /// [mark_request_as_sent()](Self::mark_request_as_sent) method.
     ///
     /// **Note**: This method call should be locked per call.
     pub fn outgoing_requests(&self) -> Result<Vec<Request>, CryptoStoreError> {
@@ -540,10 +540,10 @@ impl OlmMachine {
     ///
     /// After the request was sent out and a successful response was received
     /// the response body should be passed back to the state machine using the
-    /// [mark_request_as_sent()](#method.mark_request_as_sent) method.
+    /// [mark_request_as_sent()](Self::mark_request_as_sent) method.
     ///
     /// This method should be called every time before a call to
-    /// [`share_room_key()`](#method.share_room_key) is made.
+    /// [`share_room_key()`](Self::share_room_key) is made.
     ///
     /// # Arguments
     ///
@@ -566,9 +566,9 @@ impl OlmMachine {
     /// whether to encrypt only for trusted devices.
     ///
     /// These settings can be modified via
-    /// [set_room_algorithm()](#method.set_room_algorithm) and
-    /// [set_room_only_allow_trusted_devices()](#method.
-    /// set_room_only_allow_trusted_devices) methods.
+    /// [set_room_algorithm()](Self::set_room_algorithm) and
+    /// [set_room_only_allow_trusted_devices()](Self::set_room_only_allow_trusted_devices)
+    /// methods.
     pub fn get_room_settings(
         &self,
         room_id: String,
@@ -609,8 +609,8 @@ impl OlmMachine {
     /// devices, or whether they should be excluded from the conversation.
     ///
     /// Note that per-room setting may be overridden by a global
-    /// [set_only_allow_trusted_devices()](#method.
-    /// set_only_allow_trusted_devices) method.
+    /// [set_only_allow_trusted_devices()](Self::set_only_allow_trusted_devices)
+    /// method.
     pub fn set_room_only_allow_trusted_devices(
         &self,
         room_id: String,
@@ -661,10 +661,10 @@ impl OlmMachine {
     ///
     /// After the request was sent out and a successful response was received
     /// the response body should be passed back to the state machine using the
-    /// [mark_request_as_sent()](#method.mark_request_as_sent) method.
+    /// [mark_request_as_sent()](Self::mark_request_as_sent) method.
     ///
     /// This method should be called every time before a call to
-    /// [`encrypt()`](#method.encrypt) with the given `room_id` is made.
+    /// [`encrypt()`](Self::encrypt) with the given `room_id` is made.
     ///
     /// # Arguments
     ///
@@ -706,11 +706,11 @@ impl OlmMachine {
     ///
     /// 1. Get the one-time key claim request to establish 1:1 Olm sessions for
     ///    the room members of the room we wish to participate in. This is done
-    ///    using the [`get_missing_sessions()`](#method.get_missing_sessions)
+    ///    using the [`get_missing_sessions()`](Self::get_missing_sessions)
     ///    method. This method call should be locked per call.
     ///
     /// 2. Share a room key with all the room members using the
-    ///    [`share_room_key()`](#method.share_room_key). This method
+    ///    [`share_room_key()`](Self::share_room_key). This method
     ///    call should be locked per room.
     ///
     /// 3. Encrypt the event using this method.
@@ -1048,7 +1048,7 @@ impl OlmMachine {
     /// * `methods` - The list of verification methods we advertised as
     /// supported in the `m.key.verification.request` event.
     ///
-    /// [verification_request_content()]: #method.verification_request_content
+    /// [verification_request_content()]: Self::verification_request_content
     pub fn request_verification(
         &self,
         user_id: String,
@@ -1184,7 +1184,7 @@ impl OlmMachine {
     ///
     /// * `device_id` - The ID of device we would like to verify.
     ///
-    /// [request_verification_with_device()]: #method.request_verification_with_device
+    /// [request_verification_with_device()]: Self::request_verification_with_device
     pub fn start_sas_with_device(
         &self,
         user_id: String,

--- a/bindings/matrix-sdk-crypto-js/README.md
+++ b/bindings/matrix-sdk-crypto-js/README.md
@@ -16,7 +16,7 @@ Encryption](https://en.wikipedia.org/wiki/End-to-end_encryption)) for
 These WebAssembly bindings are written in [Rust]. To build them, you
 need to install the Rust compiler, see [the Install Rust
 Page](https://www.rust-lang.org/tools/install). Then, the workflow is
-pretty classical by using [yarn], see [the Downloading and installing
+pretty classical by using [yarn](https://yarnpkg.com/), see [the Downloading and installing
 Node.js and npm
 Page](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) and [installing yarn](https://classic.yarnpkg.com/lang/en/docs/install).
 

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -332,9 +332,9 @@ impl Timeline {
 
     /// Fetch unavailable details about the event with the given ID.
     ///
-    /// This method only works for IDs of [`RemoteEventTimelineItem`]s, to
-    /// prevent losing details when a local echo is replaced by its remote
-    /// echo.
+    /// This method only works for IDs of remote [`EventTimelineItem`]s,
+    /// to prevent losing details when a local echo is replaced by its
+    /// remote echo.
     ///
     /// This method tries to make all the requests it can. If an error is
     /// encountered for a given request, it is forwarded with the

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -121,16 +121,16 @@ background though. For that, the client implementation offers to run lists
 in two additional full-sync-modes, which require additional configuration:
 
 - [`SlidingSyncMode::Paging`]: Pages through the entire list of
-  rooms one request at a time asking for the next `batch_size` number of
-  rooms up to the end or `limit` if configured
-- [`SlidingSyncMode::Growing`]: Grows the window by `batch_size` on
-  every request till all rooms or until `limit` of rooms are in list.
+  rooms one request at a time asking for the next `full_sync_batch_size` number of
+  rooms up to the end or `full_sync_maximum_number_of_rooms_to_fetch` if configured
+- [`SlidingSyncMode::Growing`]: Grows the window by `full_sync_batch_size` on
+  every request till all rooms or until `full_sync_maximum_number_of_rooms_to_fetch` of rooms are in list.
 
 For both, one should configure
-[`batch_size`](SlidingSyncListBuilder::batch_size) and optionally
-[`limit`](SlidingSyncListBuilder::limit) on the [`SlidingSyncListBuilder`].
-Both full-sync lists will notice if the number of rooms increased at runtime
-and will attempt to catch up to that (barring the `limit`).
+[`full_sync_batch_size`](SlidingSyncListBuilder::full_sync_batch_size) and optionally
+[`full_sync_maximum_number_of_rooms_to_fetch`](SlidingSyncListBuilder::full_sync_maximum_number_of_rooms_to_fetch)
+on the [`SlidingSyncListBuilder`]. Both full-sync lists will notice if the number of rooms
+increased at runtime and will attempt to catch up to that (barring the `limit`).
 
 ## Rooms
 
@@ -140,7 +140,7 @@ of the room at the given position. The details (`required_state`s and
 timeline items) requested by all lists are bundled, together with the common
 details (e.g. whether it is a `dm` or its calculated name) and made
 available on the Sliding Sync session struct as a [reactive](#reactive-api)
-through [`.rooms`](SlidingSync::rooms), [`get_room`](SlidingSync::get_room)
+through [`.get_all_rooms`](SlidingSync::get_all_rooms), [`get_room`](SlidingSync::get_room)
 and [`get_rooms`](SlidingSync::get_rooms) APIs.
 
 Notably, this map only knows about the rooms that have come down [Sliding


### PR DESCRIPTION
This fixes the documentation so running `cargo xtask doc` locally keeps on working. Second commit also adds a CI task to make sure we don't regress this in the future, and that we can keep on using `cargo xtask ci` on local machines.