### PR TITLE
Fix redaction regression

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -544,9 +544,9 @@ impl<'a> TimelineEventHandler<'a> {
             Some(event_item.with_kind(remote_event_item.to_redacted()))
         });
 
-        if self.result.items_updated > 0 {
+        if self.result.items_updated == 0 {
             // We will want to know this when debugging redaction issues.
-            debug!(redaction_key = ?redacts, "redaction affected no event");
+            debug!("redaction affected no event");
         }
     }
 

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -537,11 +537,15 @@ impl<'a> TimelineEventHandler<'a> {
         // directly with the raw event timeline feature (not yet implemented).
         update_timeline_item!(self, &redacts, "redaction", |event_item| {
             let Some(remote_event_item) = event_item.as_remote() else {
-                error!("inconsistent state: reaction received on a non-remote event item");
+                error!("inconsistent state: redaction received on a non-remote event item");
                 return None;
             };
 
-            Some(event_item.with_kind(remote_event_item.to_redacted()))
+            let mut event_item = event_item.to_owned();
+            event_item.content = TimelineItemContent::RedactedMessage;
+            event_item.kind = remote_event_item.without_reactions().into();
+
+            Some(event_item)
         });
 
         if self.result.items_updated == 0 {

--- a/crates/matrix-sdk/src/room/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_item/remote.rs
@@ -58,9 +58,8 @@ impl RemoteEventTimelineItem {
         Self { reactions, ..self.clone() }
     }
 
-    /// Clone the current event item, change its `content` to
-    /// [`TimelineItemContent::RedactedMessage`], and reset its `reactions`.
-    pub fn to_redacted(&self) -> Self {
+    /// Clone the current event item, and reset its `reactions`.
+    pub fn without_reactions(&self) -> Self {
         Self { reactions: BundledReactions::default(), ..self.clone() }
     }
 }

--- a/crates/matrix-sdk/src/room/timeline/tests/basic.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/basic.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;

--- a/crates/matrix-sdk/src/room/timeline/tests/basic.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/basic.rs
@@ -7,8 +7,7 @@ use matrix_sdk_test::async_test;
 use ruma::{
     assign,
     events::{
-        reaction::ReactionEventContent,
-        relation::{Annotation, InReplyTo},
+        relation::InReplyTo,
         room::{
             member::{MembershipState, RedactedRoomMemberEventContent, RoomMemberEventContent},
             message::{MessageType, Relation, RoomMessageEventContent},
@@ -54,38 +53,6 @@ async fn initial_events() {
     assert_eq!(item.as_event().unwrap().sender(), *ALICE);
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     assert_eq!(item.as_event().unwrap().sender(), *BOB);
-}
-
-#[async_test]
-async fn reaction_redaction() {
-    let timeline = TestTimeline::new();
-    let mut stream = timeline.subscribe().await;
-
-    timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("hi!")).await;
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event = item.as_event().unwrap();
-    assert_eq!(event.reactions().len(), 0);
-
-    let msg_event_id = event.event_id().unwrap();
-
-    let rel = Annotation::new(msg_event_id.to_owned(), "+1".to_owned());
-    timeline.handle_live_message_event(&BOB, ReactionEventContent::new(rel)).await;
-    let item =
-        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    let event = item.as_event().unwrap();
-    assert_eq!(event.reactions().len(), 1);
-
-    // TODO: After adding raw timeline items, check for one here
-
-    let reaction_event_id = event.event_id().unwrap();
-
-    timeline.handle_live_redaction(&BOB, reaction_event_id).await;
-    let item =
-        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    let event = item.as_event().unwrap();
-    assert_eq!(event.reactions().len(), 0);
 }
 
 #[async_test]

--- a/crates/matrix-sdk/src/room/timeline/tests/echo.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/echo.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{io, sync::Arc};
 
 use assert_matches::assert_matches;

--- a/crates/matrix-sdk/src/room/timeline/tests/edit.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/edit.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;

--- a/crates/matrix-sdk/src/room/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/encryption.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![cfg(not(target_arch = "wasm32"))]
 
 use std::{collections::BTreeSet, io::Cursor, iter};

--- a/crates/matrix-sdk/src/room/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/invalid.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;

--- a/crates/matrix-sdk/src/room/timeline/tests/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/mod.rs
@@ -54,6 +54,7 @@ mod edit;
 mod encryption;
 mod invalid;
 mod read_receipts;
+mod redaction;
 mod virt;
 
 static ALICE: Lazy<&UserId> = Lazy::new(|| user_id!("@alice:server.name"));

--- a/crates/matrix-sdk/src/room/timeline/tests/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 The Matrix.org Foundation C.I.C.
+// Copyright 2023 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/matrix-sdk/src/room/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/redaction.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;

--- a/crates/matrix-sdk/src/room/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/redaction.rs
@@ -1,0 +1,41 @@
+use assert_matches::assert_matches;
+use eyeball_im::VectorDiff;
+use futures_util::StreamExt;
+use matrix_sdk_test::async_test;
+use ruma::events::{
+    reaction::ReactionEventContent, relation::Annotation, room::message::RoomMessageEventContent,
+};
+
+use super::{TestTimeline, ALICE, BOB};
+
+#[async_test]
+async fn reaction_redaction() {
+    let timeline = TestTimeline::new();
+    let mut stream = timeline.subscribe().await;
+
+    timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("hi!")).await;
+    let _day_divider =
+        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let event = item.as_event().unwrap();
+    assert_eq!(event.reactions().len(), 0);
+
+    let msg_event_id = event.event_id().unwrap();
+
+    let rel = Annotation::new(msg_event_id.to_owned(), "+1".to_owned());
+    timeline.handle_live_message_event(&BOB, ReactionEventContent::new(rel)).await;
+    let item =
+        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+    let event = item.as_event().unwrap();
+    assert_eq!(event.reactions().len(), 1);
+
+    // TODO: After adding raw timeline items, check for one here
+
+    let reaction_event_id = event.event_id().unwrap();
+
+    timeline.handle_live_redaction(&BOB, reaction_event_id).await;
+    let item =
+        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+    let event = item.as_event().unwrap();
+    assert_eq!(event.reactions().len(), 0);
+}

--- a/crates/matrix-sdk/src/room/timeline/tests/virt.rs
+++ b/crates/matrix-sdk/src/room/timeline/tests/virt.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use assert_matches::assert_matches;
 use chrono::{Datelike, Local, TimeZone};
 use eyeball_im::VectorDiff;


### PR DESCRIPTION
Regression almost certainly introduced in #1791. I'm a bit puzzled that we only had a redaction test for reactions, not for the main content. I thought I had written one way back. Should be the proper fix for #1864.