### PR TITLE
Add missing const to make epilogue.js work in ECMAScript Module compatibility mode

### DIFF
--- a/bindings/matrix-sdk-crypto-js/scripts/epilogue.js
+++ b/bindings/matrix-sdk-crypto-js/scripts/epilogue.js
@@ -10,7 +10,7 @@ wasm = new Proxy(
 );
 
 let inited = false;
-__initSync = function () {
+const __initSync = function () {
     if (inited) {
         return;
     }


### PR DESCRIPTION
The `const` is needed for the module to be loaded in browser if you use ESModules. It seems like in commonjs this works fine, but ESM is stricter on variable declaration. Without this, it fails with `Uncaught ReferenceError: __initSync is not defined ` when it tries to import the package. This should have no impact on commonjs.

- [ ] Public API changes documented in changelogs (optional)