### PR TITLE
sdk: Log redactions of already-redacted events

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -541,6 +541,11 @@ impl<'a> TimelineEventHandler<'a> {
                 return None;
             };
 
+            if let TimelineItemContent::RedactedMessage = &event_item.content {
+                debug!("event item is already redacted");
+                return None;
+            }
+
             let mut event_item = event_item.to_owned();
             event_item.content = TimelineItemContent::RedactedMessage;
             event_item.kind = remote_event_item.without_reactions().into();


### PR DESCRIPTION
Logs I got from EX are puzzling, add another log for a thing where I'm not sure if we're hitting it (redacting an event we already consider redacted), and avoid some unnecessary work for that same thing.
