### PR TITLE
Consistently use Ruma's Owned*Id types

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -33,8 +33,8 @@ use ruma::{
         RoomAccountDataEventType,
     },
     room::RoomType,
-    EventId, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedUserId, RoomAliasId, RoomId,
-    RoomVersionId, UserId,
+    EventId, OwnedEventId, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, RoomAliasId,
+    RoomId, RoomVersionId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, instrument, warn};
@@ -51,8 +51,8 @@ use crate::{
 /// invited rooms.
 #[derive(Debug, Clone)]
 pub struct Room {
-    room_id: Arc<RoomId>,
-    own_user_id: Arc<UserId>,
+    room_id: OwnedRoomId,
+    own_user_id: OwnedUserId,
     inner: Arc<SyncRwLock<RoomInfo>>,
     store: Arc<DynStateStore>,
 }
@@ -540,7 +540,7 @@ impl Room {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RoomInfo {
     /// The unique room id of the room.
-    pub(crate) room_id: Arc<RoomId>,
+    pub(crate) room_id: OwnedRoomId,
     /// The state of the room.
     #[serde(rename = "room_type")] // for backwards compatibility
     room_state: RoomState,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -371,12 +371,12 @@ impl StateChanges {
 
     /// Update the `StateChanges` struct with the given `RoomInfo`.
     pub fn add_room(&mut self, room: RoomInfo) {
-        self.room_infos.insert(room.room_id.as_ref().to_owned(), room);
+        self.room_infos.insert(room.room_id.clone(), room);
     }
 
     /// Update the `StateChanges` struct with the given `RoomInfo`.
     pub fn add_stripped_room(&mut self, room: RoomInfo) {
-        self.stripped_room_infos.insert(room.room_id.as_ref().to_owned(), room);
+        self.stripped_room_infos.insert(room.room_id.clone(), room);
     }
 
     /// Update the `StateChanges` struct with the given `AnyBasicEvent`.

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -25,7 +25,7 @@ use ruma::{
     events::{
         key::verification::VerificationMethod, room::message::KeyVerificationRequestEventContent,
     },
-    EventId, OwnedDeviceId, RoomId, UserId,
+    EventId, OwnedDeviceId, OwnedUserId, RoomId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -363,7 +363,7 @@ impl PartialEq for ReadOnlyUserIdentities {
 /// signatures can be checked with this identity.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ReadOnlyUserIdentity {
-    user_id: Arc<UserId>,
+    user_id: OwnedUserId,
     pub(crate) master_key: MasterPubkey,
     self_signing_key: SelfSigningPubkey,
 }
@@ -464,7 +464,7 @@ impl ReadOnlyUserIdentity {
 /// the identity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadOnlyOwnUserIdentity {
-    user_id: Arc<UserId>,
+    user_id: OwnedUserId,
     master_key: MasterPubkey,
     self_signing_key: SelfSigningPubkey,
     user_signing_key: UserSigningPubkey,

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -95,9 +95,9 @@ use crate::{
 #[derive(Clone)]
 pub struct OlmMachine {
     /// The unique user id that owns this account.
-    user_id: Arc<UserId>,
+    user_id: OwnedUserId,
     /// The unique device ID of the device that holds this account.
-    device_id: Arc<DeviceId>,
+    device_id: OwnedDeviceId,
     /// Our underlying Olm Account holding our identity keys.
     account: Account,
     /// The private part of our cross signing identity.
@@ -161,14 +161,14 @@ impl OlmMachine {
         account: ReadOnlyAccount,
         user_identity: PrivateCrossSigningIdentity,
     ) -> Self {
-        let user_id: Arc<UserId> = user_id.into();
+        let user_id: OwnedUserId = user_id.into();
         let user_identity = Arc::new(Mutex::new(user_identity));
 
         let verification_machine =
             VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
         let store =
             Store::new(user_id.clone(), user_identity.clone(), store, verification_machine.clone());
-        let device_id: Arc<DeviceId> = device_id.into();
+        let device_id: OwnedDeviceId = device_id.into();
         let users_for_key_claim = Arc::new(DashMap::new());
 
         let account = Account { inner: account, store: store.clone() };

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -478,9 +478,9 @@ impl Account {
 #[derive(Clone)]
 pub struct ReadOnlyAccount {
     /// The user_id this account belongs to
-    pub user_id: Arc<UserId>,
+    pub user_id: OwnedUserId,
     /// The device_id of this entry
-    pub device_id: Arc<DeviceId>,
+    pub device_id: OwnedDeviceId,
     inner: Arc<Mutex<InnerAccount>>,
     /// The associated identity keys
     pub identity_keys: Arc<IdentityKeys>,

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -124,7 +124,7 @@ pub struct InboundGroupSession {
     pub(crate) creator_info: SessionCreatorInfo,
 
     /// The Room this GroupSession belongs to
-    pub room_id: Arc<RoomId>,
+    pub room_id: OwnedRoomId,
 
     /// A flag recording whether the `InboundGroupSession` was received directly
     /// as a `m.room_key` event or indirectly via a forward or file import.
@@ -531,7 +531,7 @@ impl TryFrom<&ExportedRoomKey> for InboundGroupSession {
             },
             history_visibility: None.into(),
             first_known_index,
-            room_id: key.room_id.to_owned().into(),
+            room_id: key.room_id.to_owned(),
             imported: true,
             algorithm: key.algorithm.to_owned().into(),
             backed_up: AtomicBool::from(false).into(),
@@ -558,7 +558,7 @@ impl From<&ForwardedMegolmV1AesSha2Content> for InboundGroupSession {
             },
             history_visibility: None.into(),
             first_known_index,
-            room_id: value.room_id.to_owned().into(),
+            room_id: value.room_id.to_owned(),
             imported: true,
             algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2.into(),
             backed_up: AtomicBool::from(false).into(),
@@ -581,7 +581,7 @@ impl From<&ForwardedMegolmV2AesSha2Content> for InboundGroupSession {
             },
             history_visibility: None.into(),
             first_known_index,
-            room_id: value.room_id.to_owned().into(),
+            room_id: value.room_id.to_owned(),
             imported: true,
             algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2.into(),
             backed_up: AtomicBool::from(false).into(),

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -27,8 +27,8 @@ use dashmap::DashMap;
 use ruma::{
     events::room::{encryption::RoomEncryptionEventContent, history_visibility::HistoryVisibility},
     serde::Raw,
-    DeviceId, OwnedDeviceId, OwnedTransactionId, OwnedUserId, RoomId, SecondsSinceUnixEpoch,
-    TransactionId, UserId,
+    DeviceId, OwnedDeviceId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId,
+    SecondsSinceUnixEpoch, TransactionId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -131,10 +131,10 @@ impl EncryptionSettings {
 #[derive(Clone)]
 pub struct OutboundGroupSession {
     inner: Arc<RwLock<GroupSession>>,
-    device_id: Arc<DeviceId>,
+    device_id: OwnedDeviceId,
     account_identity_keys: Arc<IdentityKeys>,
     session_id: Arc<str>,
-    room_id: Arc<RoomId>,
+    room_id: OwnedRoomId,
     pub(crate) creation_time: SecondsSinceUnixEpoch,
     message_count: Arc<AtomicU64>,
     shared: Arc<AtomicBool>,
@@ -207,7 +207,7 @@ impl OutboundGroupSession {
     /// * `settings` - Settings determining the algorithm and rotation period of
     /// the outbound group session.
     pub fn new(
-        device_id: Arc<DeviceId>,
+        device_id: OwnedDeviceId,
         identity_keys: Arc<IdentityKeys>,
         room_id: &RoomId,
         settings: EncryptionSettings,
@@ -623,7 +623,7 @@ impl OutboundGroupSession {
     /// * `pickle_mode` - The mode that was used to pickle the session, either
     /// an unencrypted mode or an encrypted using passphrase.
     pub fn from_pickle(
-        device_id: Arc<DeviceId>,
+        device_id: OwnedDeviceId,
         identity_keys: Arc<IdentityKeys>,
         pickle: PickledOutboundGroupSession,
     ) -> Result<Self, PickleError> {
@@ -723,7 +723,7 @@ pub struct PickledOutboundGroupSession {
     /// The settings this session adheres to.
     pub settings: Arc<EncryptionSettings>,
     /// The room id this session is used for.
-    pub room_id: Arc<RoomId>,
+    pub room_id: OwnedRoomId,
     /// The timestamp when this session was created.
     pub creation_time: SecondsSinceUnixEpoch,
     /// The number of messages this session has already encrypted.

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -14,7 +14,7 @@
 
 use std::{fmt, sync::Arc};
 
-use ruma::{serde::Raw, DeviceId, SecondsSinceUnixEpoch, UserId};
+use ruma::{serde::Raw, OwnedDeviceId, OwnedUserId, SecondsSinceUnixEpoch};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
@@ -40,9 +40,9 @@ use crate::{
 #[derive(Clone)]
 pub struct Session {
     /// The `UserId` associated with this session
-    pub user_id: Arc<UserId>,
+    pub user_id: OwnedUserId,
     /// The specific `DeviceId` associated with this session
-    pub device_id: Arc<DeviceId>,
+    pub device_id: OwnedDeviceId,
     /// The `IdentityKeys` associated with this session
     pub our_identity_keys: Arc<IdentityKeys>,
     /// The OlmSession
@@ -143,8 +143,8 @@ impl Session {
             recipient_device.ed25519_key().ok_or(EventError::MissingSigningKey)?;
 
         let payload = json!({
-            "sender": self.user_id.as_str(),
-            "sender_device": self.device_id.as_ref(),
+            "sender": &self.user_id,
+            "sender_device": &self.device_id,
             "keys": {
                 "ed25519": self.our_identity_keys.ed25519.to_base64(),
             },
@@ -221,8 +221,8 @@ impl Session {
     /// * `pickle_mode` - The mode that was used to pickle the session, either
     /// an unencrypted mode or an encrypted using passphrase.
     pub fn from_pickle(
-        user_id: Arc<UserId>,
-        device_id: Arc<DeviceId>,
+        user_id: OwnedUserId,
+        device_id: OwnedDeviceId,
         our_identity_keys: Arc<IdentityKeys>,
         pickle: PickledSession,
     ) -> Self {

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -50,7 +50,7 @@ use crate::{
 /// It can be used to sign devices or other identities.
 #[derive(Clone, Debug)]
 pub struct PrivateCrossSigningIdentity {
-    user_id: Arc<UserId>,
+    user_id: OwnedUserId,
     shared: Arc<AtomicBool>,
     pub(crate) master_key: Arc<Mutex<Option<MasterSigning>>>,
     pub(crate) user_signing_key: Arc<Mutex<Option<UserSigning>>>,
@@ -617,11 +617,7 @@ impl PrivateCrossSigningIdentity {
 
         let keys = PickledSignings { master_key, user_signing_key, self_signing_key };
 
-        PickledCrossSigningIdentity {
-            user_id: self.user_id.as_ref().to_owned(),
-            shared: self.shared(),
-            keys,
-        }
+        PickledCrossSigningIdentity { user_id: self.user_id.clone(), shared: self.shared(), keys }
     }
 
     /// Restore the private cross signing identity from a pickle.

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -473,7 +473,7 @@ mod tests {
         let verification =
             VerificationMachine::new(account.clone(), identity.clone(), store.clone());
 
-        let user_id: Arc<UserId> = user_id.into();
+        let user_id = user_id.to_owned();
         let device_id = device_id.into();
 
         let store = Store::new(user_id.clone(), identity, store, verification);

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -103,7 +103,7 @@ pub use crate::gossiping::{GossipRequest, SecretInfo};
 /// adds the generic interface on top.
 #[derive(Debug, Clone)]
 pub struct Store {
-    user_id: Arc<UserId>,
+    user_id: OwnedUserId,
     identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
     inner: Arc<DynCryptoStore>,
     verification_machine: VerificationMachine,
@@ -366,7 +366,7 @@ impl From<&InboundGroupSession> for RoomKeyInfo {
 impl Store {
     /// Create a new Store
     pub(crate) fn new(
-        user_id: Arc<UserId>,
+        user_id: OwnedUserId,
         identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
         store: Arc<DynCryptoStore>,
         verification_machine: VerificationMachine,

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -135,7 +135,7 @@ pub struct VerificationRequest {
     verification_cache: VerificationCache,
     account: ReadOnlyAccount,
     flow_id: Arc<FlowId>,
-    other_user_id: Arc<UserId>,
+    other_user_id: OwnedUserId,
     inner: SharedObservable<InnerRequest>,
     creation_time: Arc<Instant>,
     we_started: bool,

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -34,7 +34,7 @@ use matrix_sdk_crypto::{
     TrackedUser,
 };
 use matrix_sdk_store_encryption::StoreCipher;
-use ruma::{DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId};
+use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId, UserId};
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::Mutex;
 use wasm_bindgen::JsValue;
@@ -134,8 +134,8 @@ type Result<A, E = IndexeddbCryptoStoreError> = std::result::Result<A, E>;
 
 #[derive(Clone, Debug)]
 pub struct AccountInfo {
-    user_id: Arc<UserId>,
-    device_id: Arc<DeviceId>,
+    user_id: OwnedUserId,
+    device_id: OwnedDeviceId,
     identity_keys: Arc<IdentityKeys>,
 }
 

--- a/crates/matrix-sdk-sled/src/crypto_store.rs
+++ b/crates/matrix-sdk-sled/src/crypto_store.rs
@@ -37,7 +37,7 @@ use matrix_sdk_crypto::{
     TrackedUser,
 };
 use matrix_sdk_store_encryption::StoreCipher;
-use ruma::{DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId};
+use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId, UserId};
 use serde::{de::DeserializeOwned, Serialize};
 use sled::{
     transaction::{ConflictableTransactionError, TransactionError},
@@ -157,8 +157,8 @@ impl EncodeKey for ReadOnlyDevice {
 
 #[derive(Clone, Debug)]
 pub struct AccountInfo {
-    user_id: Arc<UserId>,
-    device_id: Arc<DeviceId>,
+    user_id: OwnedUserId,
+    device_id: OwnedDeviceId,
     identity_keys: Arc<IdentityKeys>,
 }
 

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -33,7 +33,7 @@ use matrix_sdk_crypto::{
     TrackedUser,
 };
 use matrix_sdk_store_encryption::StoreCipher;
-use ruma::{DeviceId, OwnedDeviceId, RoomId, TransactionId, UserId};
+use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId, UserId};
 use rusqlite::OptionalExtension;
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::{fs, sync::Mutex};
@@ -48,8 +48,8 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub struct AccountInfo {
-    user_id: Arc<UserId>,
-    device_id: Arc<DeviceId>,
+    user_id: OwnedUserId,
+    device_id: OwnedDeviceId,
     identity_keys: Arc<IdentityKeys>,
 }
 


### PR DESCRIPTION
… instead of `Arc<*Id>`.
