### PR TITLE
sliding sync: Use `RangeInclusive<u32>` instead of raw start/end `UInt` values

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -654,7 +654,7 @@ impl SlidingSyncList {
 
     /// The current timeline limit
     pub fn get_timeline_limit(&self) -> Option<u32> {
-        self.inner.timeline_limit().map(|limit| u32::try_from(limit).unwrap_or_default())
+        self.inner.timeline_limit()
     }
 
     /// The current timeline limit

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -8,7 +8,7 @@ use matrix_sdk::ruma::{
         v4::RoomSubscription as RumaRoomSubscription,
         UnreadNotificationsCount as RumaUnreadNotificationsCount,
     },
-    assign, IdParseError, OwnedRoomId, RoomId, UInt,
+    assign, IdParseError, OwnedRoomId, RoomId,
 };
 pub use matrix_sdk::{
     room::timeline::Timeline, ruma::api::client::sync::sync_events::v4::SyncRequestListFilters,
@@ -664,7 +664,7 @@ impl SlidingSyncList {
 
     /// Unset the current timeline limit
     pub fn unset_timeline_limit(&self) {
-        self.inner.set_timeline_limit::<UInt>(None)
+        self.inner.set_timeline_limit::<u32>(None)
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -533,9 +533,9 @@ impl SlidingSyncListBuilder {
         Arc::new(builder)
     }
 
-    pub fn add_range(self: Arc<Self>, from: u32, to: u32) -> Arc<Self> {
+    pub fn add_range(self: Arc<Self>, from: u32, to_included: u32) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.add_range(from, to);
+        builder.inner = builder.inner.add_range(from..=to_included);
         Arc::new(builder)
     }
 
@@ -631,7 +631,7 @@ impl SlidingSyncList {
     /// Remember to cancel the existing stream and fetch a new one as this will
     /// only be applied on the next request.
     pub fn set_range(&self, start: u32, end: u32) -> Result<(), SlidingSyncError> {
-        self.inner.set_range(start, end).map_err(Into::into)
+        self.inner.set_range(start..=end).map_err(Into::into)
     }
 
     /// Set the ranges to fetch
@@ -639,7 +639,7 @@ impl SlidingSyncList {
     /// Remember to cancel the existing stream and fetch a new one as this will
     /// only be applied on the next request.
     pub fn add_range(&self, start: u32, end: u32) -> Result<(), SlidingSyncError> {
-        self.inner.add_range((start, end)).map_err(Into::into)
+        self.inner.add_range(start..=end).map_err(Into::into)
     }
 
     /// Reset the ranges

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -664,7 +664,7 @@ impl SlidingSyncList {
 
     /// Unset the current timeline limit
     pub fn unset_timeline_limit(&self) {
-        self.inner.set_timeline_limit::<u32>(None)
+        self.inner.set_timeline_limit(None)
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -79,7 +79,7 @@ let list_builder = SlidingSyncList::builder("main_list")
         v4::SyncRequestListFilters::default(), { is_dm: Some(true)}
     )))
     .sort(vec!["by_recency".to_owned()])
-    .set_range(0u32, 9u32);
+    .set_range(0u32..=9);
 ```
 
 Please refer to the [specification][MSC], the [Ruma types][ruma-types],
@@ -438,7 +438,7 @@ let full_sync_list = SlidingSyncList::builder(&full_sync_list_name)
 
 let active_list = SlidingSyncList::builder(&active_list_name) // the active window
     .sync_mode(SlidingSyncMode::Selective)  // sync up the specific range only
-    .set_range(0u32, 9u32) // only the top 10 items
+    .set_range(0u32..=9) // only the top 10 items
     .sort(vec!["by_recency".to_owned()]) // last active
     .timeline_limit(5u32) // add the last 5 timeline items for room preview and faster timeline loading
     .required_state(vec![ // we want to know immediately:

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -13,7 +13,7 @@ use ruma::{api::client::sync::sync_events::v4, events::StateEventType};
 use tokio::sync::mpsc::Sender;
 
 use super::{
-    super::SlidingSyncInternalMessage, SlidingSyncList, SlidingSyncListInner,
+    super::SlidingSyncInternalMessage, Bound, SlidingSyncList, SlidingSyncListInner,
     SlidingSyncListRequestGenerator, SlidingSyncMode, SlidingSyncState,
 };
 
@@ -29,9 +29,9 @@ pub struct SlidingSyncListBuilder {
     full_sync_batch_size: u32,
     full_sync_maximum_number_of_rooms_to_fetch: Option<u32>,
     filters: Option<v4::SyncRequestListFilters>,
-    timeline_limit: Option<u32>,
+    timeline_limit: Option<Bound>,
     name: String,
-    ranges: Vec<RangeInclusive<u32>>,
+    ranges: Vec<RangeInclusive<Bound>>,
     once_built: Arc<Box<dyn Fn(SlidingSyncList) -> SlidingSyncList + Send + Sync>>,
 }
 
@@ -131,7 +131,7 @@ impl SlidingSyncListBuilder {
     }
 
     /// Set the limit of regular events to fetch for the timeline.
-    pub fn timeline_limit(mut self, timeline_limit: u32) -> Self {
+    pub fn timeline_limit(mut self, timeline_limit: Bound) -> Self {
         self.timeline_limit = Some(timeline_limit);
         self
     }
@@ -144,24 +144,24 @@ impl SlidingSyncListBuilder {
     }
 
     /// Set the ranges to fetch.
-    pub fn ranges(mut self, ranges: Vec<RangeInclusive<u32>>) -> Self {
+    pub fn ranges(mut self, ranges: Vec<RangeInclusive<Bound>>) -> Self {
         self.ranges = ranges;
         self
     }
 
-    /// Set a single range fetch.
-    pub fn set_range(mut self, range: RangeInclusive<u32>) -> Self {
+    /// Set a single range to fetch.
+    pub fn set_range(mut self, range: RangeInclusive<Bound>) -> Self {
         self.ranges = vec![range];
         self
     }
 
     /// Set the ranges to fetch.
-    pub fn add_range(mut self, range: RangeInclusive<u32>) -> Self {
+    pub fn add_range(mut self, range: RangeInclusive<Bound>) -> Self {
         self.ranges.push(range);
         self
     }
 
-    /// Set the ranges to fetch.
+    /// Reset the ranges to fetch.
     pub fn reset_ranges(mut self) -> Self {
         self.ranges.clear();
         self

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -9,7 +9,7 @@ use std::{
 
 use eyeball::unique::Observable;
 use eyeball_im::ObservableVector;
-use ruma::{api::client::sync::sync_events::v4, events::StateEventType, UInt};
+use ruma::{api::client::sync::sync_events::v4, events::StateEventType};
 use tokio::sync::mpsc::Sender;
 
 use super::{
@@ -29,7 +29,7 @@ pub struct SlidingSyncListBuilder {
     full_sync_batch_size: u32,
     full_sync_maximum_number_of_rooms_to_fetch: Option<u32>,
     filters: Option<v4::SyncRequestListFilters>,
-    timeline_limit: Option<UInt>,
+    timeline_limit: Option<u32>,
     name: String,
     ranges: Vec<RangeInclusive<u32>>,
     once_built: Arc<Box<dyn Fn(SlidingSyncList) -> SlidingSyncList + Send + Sync>>,
@@ -131,7 +131,7 @@ impl SlidingSyncListBuilder {
     }
 
     /// Set the limit of regular events to fetch for the timeline.
-    pub fn timeline_limit<U: Into<UInt>>(mut self, timeline_limit: U) -> Self {
+    pub fn timeline_limit<U: Into<u32>>(mut self, timeline_limit: U) -> Self {
         self.timeline_limit = Some(timeline_limit.into());
         self
     }

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -131,8 +131,8 @@ impl SlidingSyncListBuilder {
     }
 
     /// Set the limit of regular events to fetch for the timeline.
-    pub fn timeline_limit<U: Into<u32>>(mut self, timeline_limit: U) -> Self {
-        self.timeline_limit = Some(timeline_limit.into());
+    pub fn timeline_limit(mut self, timeline_limit: u32) -> Self {
+        self.timeline_limit = Some(timeline_limit);
         self
     }
 
@@ -144,23 +144,20 @@ impl SlidingSyncListBuilder {
     }
 
     /// Set the ranges to fetch.
-    pub fn ranges<U: Into<u32> + Copy>(mut self, range: Vec<RangeInclusive<U>>) -> Self {
-        self.ranges = range
-            .into_iter()
-            .map(|r| RangeInclusive::new((*r.start()).into(), (*r.end()).into()))
-            .collect();
+    pub fn ranges(mut self, ranges: Vec<RangeInclusive<u32>>) -> Self {
+        self.ranges = ranges;
         self
     }
 
     /// Set a single range fetch.
-    pub fn set_range<U: Into<u32> + Copy>(mut self, range: RangeInclusive<U>) -> Self {
-        self.ranges = vec![RangeInclusive::new((*range.start()).into(), (*range.end()).into())];
+    pub fn set_range(mut self, range: RangeInclusive<u32>) -> Self {
+        self.ranges = vec![range];
         self
     }
 
     /// Set the ranges to fetch.
-    pub fn add_range<U: Into<u32> + Copy>(mut self, range: RangeInclusive<U>) -> Self {
-        self.ranges.push(RangeInclusive::new((*range.start()).into(), (*range.end()).into()));
+    pub fn add_range(mut self, range: RangeInclusive<u32>) -> Self {
+        self.ranges.push(range);
         self
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -64,10 +64,7 @@ impl SlidingSyncList {
     }
 
     /// Set the ranges to fetch.
-    pub fn set_ranges<U>(&self, ranges: &[RangeInclusive<U>]) -> Result<(), Error>
-    where
-        U: Into<u32> + Copy,
-    {
+    pub fn set_ranges(&self, ranges: &[RangeInclusive<u32>]) -> Result<(), Error> {
         if self.inner.sync_mode.ranges_can_be_modified_by_user().not() {
             return Err(Error::CannotModifyRanges(self.name().to_owned()));
         }
@@ -79,10 +76,7 @@ impl SlidingSyncList {
     }
 
     /// Reset the ranges to a particular set.
-    pub fn set_range<U>(&self, range: RangeInclusive<U>) -> Result<(), Error>
-    where
-        U: Into<u32> + Copy,
-    {
+    pub fn set_range(&self, range: RangeInclusive<u32>) -> Result<(), Error> {
         if self.inner.sync_mode.ranges_can_be_modified_by_user().not() {
             return Err(Error::CannotModifyRanges(self.name().to_owned()));
         }
@@ -94,10 +88,7 @@ impl SlidingSyncList {
     }
 
     /// Set the ranges to fetch.
-    pub fn add_range<U>(&self, range: RangeInclusive<U>) -> Result<(), Error>
-    where
-        U: Into<u32> + Copy,
-    {
+    pub fn add_range(&self, range: RangeInclusive<u32>) -> Result<(), Error> {
         if self.inner.sync_mode.ranges_can_be_modified_by_user().not() {
             return Err(Error::CannotModifyRanges(self.name().to_owned()));
         }
@@ -119,7 +110,7 @@ impl SlidingSyncList {
             return Err(Error::CannotModifyRanges(self.name().to_owned()));
         }
 
-        self.inner.set_ranges::<u32>(&[]);
+        self.inner.set_ranges(&[]);
         self.reset()?;
 
         Ok(())
@@ -141,12 +132,7 @@ impl SlidingSyncList {
     }
 
     /// Set timeline limit.
-    pub fn set_timeline_limit<U>(&self, timeline: Option<U>)
-    where
-        U: Into<u32>,
-    {
-        let timeline = timeline.map(Into::into);
-
+    pub fn set_timeline_limit(&self, timeline: Option<u32>) {
         Observable::set(&mut self.inner.timeline_limit.write().unwrap(), timeline);
     }
 
@@ -290,24 +276,14 @@ pub(super) struct SlidingSyncListInner {
 
 impl SlidingSyncListInner {
     /// Reset and add new ranges.
-    fn set_ranges<U>(&self, ranges: &[RangeInclusive<U>])
-    where
-        U: Into<u32> + Copy,
-    {
-        let ranges = ranges
-            .iter()
-            .map(|r| RangeInclusive::new((*r.start()).into(), (*r.end()).into()))
-            .collect();
-        Observable::set(&mut self.ranges.write().unwrap(), ranges);
+    fn set_ranges(&self, ranges: &[RangeInclusive<u32>]) {
+        Observable::set(&mut self.ranges.write().unwrap(), ranges.to_vec());
     }
 
     /// Add a new range.
-    fn add_range<U>(&self, range: RangeInclusive<U>)
-    where
-        U: Into<u32> + Copy,
-    {
+    fn add_range(&self, range: RangeInclusive<u32>) {
         Observable::update(&mut self.ranges.write().unwrap(), |ranges| {
-            ranges.push(RangeInclusive::new((*range.start()).into(), (*range.end()).into()));
+            ranges.push(RangeInclusive::new(*range.start(), *range.end()));
         });
     }
 
@@ -1122,7 +1098,7 @@ mod tests {
             assert_eq!(timeline_limit, &Some(42));
         }
 
-        list.set_timeline_limit::<u32>(None);
+        list.set_timeline_limit(None);
 
         {
             let lock = list.inner.timeline_limit.read().unwrap();

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -534,9 +534,9 @@ impl SlidingSyncListInner {
         let mut request_generator = self.request_generator.write().unwrap();
 
         let range_end: u32 =
-            request_generator.ranges.first().map(|r| u32::try_from(*r.end()).unwrap()).ok_or_else(
-                || Error::RequestGeneratorHasNotBeenInitialized(self.name.to_owned()),
-            )?;
+            request_generator.ranges.first().map(|r| *r.end()).ok_or_else(|| {
+                Error::RequestGeneratorHasNotBeenInitialized(self.name.to_owned())
+            })?;
 
         match &mut request_generator.kind {
             SlidingSyncListRequestGeneratorKind::Paging {
@@ -945,16 +945,16 @@ mod tests {
             let lock = list.inner.ranges.read().unwrap();
             let ranges = Observable::get(&lock);
 
-            assert_eq!(ranges, &vec![0..=1, 2..=3]);
+            assert_eq!(ranges, &[0..=1, 2..=3]);
         }
 
-        list.set_ranges(&vec![4u32..=5, 6..=7]).unwrap();
+        list.set_ranges(&[4u32..=5, 6..=7]).unwrap();
 
         {
             let lock = list.inner.ranges.read().unwrap();
             let ranges = Observable::get(&lock);
 
-            assert_eq!(ranges, &vec![4..=5, 6..=7]);
+            assert_eq!(ranges, &[4..=5, 6..=7]);
         }
     }
 
@@ -973,7 +973,7 @@ mod tests {
                 let lock = list.inner.ranges.read().unwrap();
                 let ranges = Observable::get(&lock);
 
-                assert_eq!(ranges, &vec![0..=1, 2..=3]);
+                assert_eq!(ranges, &[0..=1, 2..=3]);
             }
 
             list.set_range(4u32..=5).unwrap();
@@ -982,7 +982,7 @@ mod tests {
                 let lock = list.inner.ranges.read().unwrap();
                 let ranges = Observable::get(&lock);
 
-                assert_eq!(ranges, &vec![4..=5]);
+                assert_eq!(ranges, &[4..=5]);
             }
         }
 
@@ -1019,7 +1019,7 @@ mod tests {
                 let lock = list.inner.ranges.read().unwrap();
                 let ranges = Observable::get(&lock);
 
-                assert_eq!(ranges, &vec![0..=1]);
+                assert_eq!(ranges, &[0..=1]);
             }
 
             list.add_range(2u32..=3).unwrap();
@@ -1028,7 +1028,7 @@ mod tests {
                 let lock = list.inner.ranges.read().unwrap();
                 let ranges = Observable::get(&lock);
 
-                assert_eq!(ranges, &vec![0..=1, 2..=3]);
+                assert_eq!(ranges, &[0..=1, 2..=3]);
             }
         }
 
@@ -1065,7 +1065,7 @@ mod tests {
                 let lock = list.inner.ranges.read().unwrap();
                 let ranges = Observable::get(&lock);
 
-                assert_eq!(ranges, &vec![0..=1]);
+                assert_eq!(ranges, &[0..=1]);
             }
 
             list.reset_ranges().unwrap();

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -386,8 +386,7 @@ impl SlidingSyncListInner {
             .collect();
         let sort = self.sort.clone();
         let required_state = self.required_state.clone();
-        let timeline_limit =
-            self.timeline_limit.read().unwrap().map(|v| UInt::new(v as u64).unwrap());
+        let timeline_limit = self.timeline_limit.read().unwrap().map(UInt::from);
         let filters = self.filters.clone();
 
         assign!(v4::SyncRequestList::default(), {

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -29,9 +29,7 @@
 //! user-specified limit representing the maximum number of rooms the user
 //! actually wants to load.
 
-use std::cmp::min;
-
-use ruma::UInt;
+use std::{cmp::min, ops::RangeInclusive};
 
 use crate::sliding_sync::Error;
 
@@ -72,7 +70,7 @@ pub(super) enum SlidingSyncListRequestGeneratorKind {
 #[derive(Debug)]
 pub(in super::super) struct SlidingSyncListRequestGenerator {
     /// The current ranges used by this request generator.
-    pub(super) ranges: Vec<(UInt, UInt)>,
+    pub(super) ranges: Vec<RangeInclusive<u32>>,
     /// The kind of request generator.
     pub(super) kind: SlidingSyncListRequestGeneratorKind,
 }
@@ -154,7 +152,7 @@ pub(super) fn create_range(
     desired_size: u32,
     maximum_number_of_rooms_to_fetch: Option<u32>,
     maximum_number_of_rooms: Option<u32>,
-) -> Result<(UInt, UInt), Error> {
+) -> Result<RangeInclusive<u32>, Error> {
     // Calculate the range.
     // The `start` bound is given. Let's calculate the `end` bound.
 
@@ -185,30 +183,28 @@ pub(super) fn create_range(
         return Err(Error::InvalidRange { start, end });
     }
 
-    Ok((start.into(), end.into()))
+    Ok(RangeInclusive::new(start.into(), end.into()))
 }
 
 #[cfg(test)]
 mod tests {
-    use ruma::uint;
-
     use super::*;
 
     #[test]
     fn test_create_range_from() {
         // From 0, we want 100 items.
-        assert_eq!(create_range(0, 100, None, None), Ok((uint!(0), uint!(99))));
+        assert_eq!(create_range(0, 100, None, None), Ok(0..=99));
 
         // From 100, we want 100 items.
-        assert_eq!(create_range(100, 100, None, None), Ok((uint!(100), uint!(199))));
+        assert_eq!(create_range(100, 100, None, None), Ok(100..=199));
 
         // From 0, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 50.
-        assert_eq!(create_range(0, 100, Some(50), None), Ok((uint!(0), uint!(49))));
+        assert_eq!(create_range(0, 100, Some(50), None), Ok(0..=49));
 
         // From 49, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 50. There is 1 item to load.
-        assert_eq!(create_range(49, 100, Some(50), None), Ok((uint!(49), uint!(49))));
+        assert_eq!(create_range(49, 100, Some(50), None), Ok(49..=49));
 
         // From 50, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 50.
@@ -219,11 +215,11 @@ mod tests {
 
         // From 0, we want 100 items, but there is a maximum number of rooms defined at
         // 50.
-        assert_eq!(create_range(0, 100, None, Some(50)), Ok((uint!(0), uint!(49))));
+        assert_eq!(create_range(0, 100, None, Some(50)), Ok(0..=49));
 
         // From 49, we want 100 items, but there is a maximum number of rooms defined at
         // 50. There is 1 item to load.
-        assert_eq!(create_range(49, 100, None, Some(50)), Ok((uint!(49), uint!(49))));
+        assert_eq!(create_range(49, 100, None, Some(50)), Ok(49..=49));
 
         // From 50, we want 100 items, but there is a maximum number of rooms defined at
         // 50.
@@ -234,10 +230,10 @@ mod tests {
 
         // From 0, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 75, and a maximum number of rooms defined at 50.
-        assert_eq!(create_range(0, 100, Some(75), Some(50)), Ok((uint!(0), uint!(49))));
+        assert_eq!(create_range(0, 100, Some(75), Some(50)), Ok(0..=49));
 
         // From 0, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 50, and a maximum number of rooms defined at 75.
-        assert_eq!(create_range(0, 100, Some(50), Some(75)), Ok((uint!(0), uint!(49))));
+        assert_eq!(create_range(0, 100, Some(50), Some(75)), Ok(0..=49));
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -183,7 +183,7 @@ pub(super) fn create_range(
         return Err(Error::InvalidRange { start, end });
     }
 
-    Ok(RangeInclusive::new(start.into(), end.into()))
+    Ok(RangeInclusive::new(start, end))
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -31,6 +31,7 @@
 
 use std::{cmp::min, ops::RangeInclusive};
 
+use super::Bound;
 use crate::sliding_sync::Error;
 
 /// The kind of request generator.
@@ -152,7 +153,7 @@ pub(super) fn create_range(
     desired_size: u32,
     maximum_number_of_rooms_to_fetch: Option<u32>,
     maximum_number_of_rooms: Option<u32>,
-) -> Result<RangeInclusive<u32>, Error> {
+) -> Result<RangeInclusive<Bound>, Error> {
     // Calculate the range.
     // The `start` bound is given. Let's calculate the `end` bound.
 

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -44,7 +44,7 @@ async fn it_works_smoke_test() -> anyhow::Result<()> {
         .add_list(
             SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::Selective)
-                .add_range(0u32, 10)
+                .add_range(0u32..=10)
                 .timeline_limit(0u32),
         )
         .build()
@@ -70,7 +70,7 @@ async fn modifying_timeline_limit() -> anyhow::Result<()> {
             .add_list(
                 SlidingSyncList::builder("init_list")
                     .sync_mode(SlidingSyncMode::Selective)
-                    .add_range(0u32, 1)
+                    .add_range(0u32..=1)
                     .timeline_limit(0u32)
                     .build(),
             )
@@ -127,7 +127,7 @@ async fn modifying_timeline_limit() -> anyhow::Result<()> {
         .add_list(
             SlidingSyncList::builder("visible_room_list")
                 .sync_mode(SlidingSyncMode::Selective)
-                .add_range(0u32, 1)
+                .add_range(0u32..=1)
                 .timeline_limit(1u32)
                 .build(),
         )
@@ -282,7 +282,7 @@ async fn adding_list_later() -> anyhow::Result<()> {
     let build_list = |name| {
         SlidingSyncList::builder(name)
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(0u32, 10u32)
+            .set_range(0u32..=10u32)
             .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
             .build()
     };
@@ -367,7 +367,7 @@ async fn live_lists() -> anyhow::Result<()> {
     let build_list = |name| {
         SlidingSyncList::builder(name)
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(0u32, 10u32)
+            .set_range(0u32..=10u32)
             .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
             .build()
     };
@@ -477,7 +477,7 @@ async fn list_goes_live() -> anyhow::Result<()> {
     let (_client, sync_proxy_builder) = random_setup_with_rooms(21).await?;
     let sliding_window_list = SlidingSyncList::builder("sliding")
         .sync_mode(SlidingSyncMode::Selective)
-        .set_range(0u32, 10u32)
+        .set_range(0u32..=10u32)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
 
@@ -540,7 +540,7 @@ async fn resizing_sliding_window() -> anyhow::Result<()> {
     let (_client, sync_proxy_builder) = random_setup_with_rooms(20).await?;
     let sliding_window_list = SlidingSyncList::builder("sliding")
         .sync_mode(SlidingSyncMode::Selective)
-        .set_range(0u32, 10u32)
+        .set_range(0u32..=10u32)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
     let sync_proxy = sync_proxy_builder.add_list(sliding_window_list).build().await?;
@@ -567,7 +567,7 @@ async fn resizing_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window
 
-    list.set_range(1u32, 10).unwrap();
+    list.set_range(1u32..=10).unwrap();
     // Ensure 0-0 invalidation ranges work.
 
     for _n in 0..2 {
@@ -590,7 +590,7 @@ async fn resizing_sliding_window() -> anyhow::Result<()> {
             .collect::<Vec<_>>()
     );
 
-    list.set_range(5u32, 10).unwrap();
+    list.set_range(5u32..=10).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -614,7 +614,7 @@ async fn resizing_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window
 
-    list.set_range(5u32, 15).unwrap();
+    list.set_range(5u32..=15).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -643,7 +643,7 @@ async fn moving_out_of_sliding_window() -> anyhow::Result<()> {
     let (client, sync_proxy_builder) = random_setup_with_rooms(20).await?;
     let sliding_window_list = SlidingSyncList::builder("sliding")
         .sync_mode(SlidingSyncMode::Selective)
-        .set_range(1u32, 10u32)
+        .set_range(1u32..=10u32)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
     let sync_proxy = sync_proxy_builder.add_list(sliding_window_list).build().await?;
@@ -670,7 +670,7 @@ async fn moving_out_of_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window
 
-    list.set_range(0u32, 10).unwrap();
+    list.set_range(0u32..=10).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -693,7 +693,7 @@ async fn moving_out_of_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window again
 
-    list.set_range(2u32, 12).unwrap();
+    list.set_range(2u32..=12).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -751,7 +751,7 @@ async fn moving_out_of_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window again
 
-    list.set_range(0u32, 10).unwrap();
+    list.set_range(0u32..=10).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -787,7 +787,7 @@ async fn fast_unfreeze() -> anyhow::Result<()> {
     let build_lists = || {
         let sliding_window_list = SlidingSyncList::builder("sliding")
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(1u32, 10u32)
+            .set_range(1u32..=10u32)
             .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
             .build();
         let growing_sync = SlidingSyncList::builder("growing")
@@ -1053,7 +1053,7 @@ async fn restart_room_resubscription() -> anyhow::Result<()> {
         .add_list(
             SlidingSyncList::builder("sliding_list")
                 .sync_mode(SlidingSyncMode::Selective)
-                .set_range(0u32, 2u32)
+                .set_range(0u32..=2u32)
                 .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
                 .build(),
         )
@@ -1079,7 +1079,7 @@ async fn restart_room_resubscription() -> anyhow::Result<()> {
 
     // let's move the window
 
-    list.set_range(1u32, 2).unwrap();
+    list.set_range(1u32..=2).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")??;
@@ -1211,7 +1211,7 @@ async fn receipts_extension_works() -> anyhow::Result<()> {
     let (client, sync_proxy_builder) = random_setup_with_rooms(1).await?;
     let list = SlidingSyncList::builder("a")
         .sync_mode(SlidingSyncMode::Selective)
-        .ranges(vec![(0u32, 1u32)])
+        .ranges(vec![(0u32..=1u32)])
         .sort(vec!["by_recency".to_owned()])
         .build();
 

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -191,7 +191,7 @@ async fn modifying_timeline_limit() -> anyhow::Result<()> {
 
     // Sync to receive messages with a `timeline_limit` set to 20.
     {
-        list.set_timeline_limit(Some(uint!(20)));
+        list.set_timeline_limit(Some(20u32));
 
         let mut update_summary;
 

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -44,8 +44,8 @@ async fn it_works_smoke_test() -> anyhow::Result<()> {
         .add_list(
             SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::Selective)
-                .add_range(0u32..=10)
-                .timeline_limit(0u32),
+                .add_range(0..=10)
+                .timeline_limit(0),
         )
         .build()
         .await?;
@@ -70,8 +70,8 @@ async fn modifying_timeline_limit() -> anyhow::Result<()> {
             .add_list(
                 SlidingSyncList::builder("init_list")
                     .sync_mode(SlidingSyncMode::Selective)
-                    .add_range(0u32..=1)
-                    .timeline_limit(0u32)
+                    .add_range(0..=1)
+                    .timeline_limit(0)
                     .build(),
             )
             .build()
@@ -127,8 +127,8 @@ async fn modifying_timeline_limit() -> anyhow::Result<()> {
         .add_list(
             SlidingSyncList::builder("visible_room_list")
                 .sync_mode(SlidingSyncMode::Selective)
-                .add_range(0u32..=1)
-                .timeline_limit(1u32)
+                .add_range(0..=1)
+                .timeline_limit(1)
                 .build(),
         )
         .build()
@@ -191,7 +191,7 @@ async fn modifying_timeline_limit() -> anyhow::Result<()> {
 
     // Sync to receive messages with a `timeline_limit` set to 20.
     {
-        list.set_timeline_limit(Some(20u32));
+        list.set_timeline_limit(Some(20));
 
         let mut update_summary;
 
@@ -282,7 +282,7 @@ async fn adding_list_later() -> anyhow::Result<()> {
     let build_list = |name| {
         SlidingSyncList::builder(name)
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(0u32..=10u32)
+            .set_range(0..=10)
             .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
             .build()
     };
@@ -367,7 +367,7 @@ async fn live_lists() -> anyhow::Result<()> {
     let build_list = |name| {
         SlidingSyncList::builder(name)
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(0u32..=10u32)
+            .set_range(0..=10)
             .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
             .build()
     };
@@ -477,13 +477,13 @@ async fn list_goes_live() -> anyhow::Result<()> {
     let (_client, sync_proxy_builder) = random_setup_with_rooms(21).await?;
     let sliding_window_list = SlidingSyncList::builder("sliding")
         .sync_mode(SlidingSyncMode::Selective)
-        .set_range(0u32..=10u32)
+        .set_range(0..=10)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
 
     let full = SlidingSyncList::builder("full")
         .sync_mode(SlidingSyncMode::Growing)
-        .full_sync_batch_size(10u32)
+        .full_sync_batch_size(10)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
     let sync_proxy =
@@ -540,7 +540,7 @@ async fn resizing_sliding_window() -> anyhow::Result<()> {
     let (_client, sync_proxy_builder) = random_setup_with_rooms(20).await?;
     let sliding_window_list = SlidingSyncList::builder("sliding")
         .sync_mode(SlidingSyncMode::Selective)
-        .set_range(0u32..=10u32)
+        .set_range(0..=10)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
     let sync_proxy = sync_proxy_builder.add_list(sliding_window_list).build().await?;
@@ -567,7 +567,7 @@ async fn resizing_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window
 
-    list.set_range(1u32..=10).unwrap();
+    list.set_range(1..=10).unwrap();
     // Ensure 0-0 invalidation ranges work.
 
     for _n in 0..2 {
@@ -590,7 +590,7 @@ async fn resizing_sliding_window() -> anyhow::Result<()> {
             .collect::<Vec<_>>()
     );
 
-    list.set_range(5u32..=10).unwrap();
+    list.set_range(5..=10).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -614,7 +614,7 @@ async fn resizing_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window
 
-    list.set_range(5u32..=15).unwrap();
+    list.set_range(5..=15).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -643,7 +643,7 @@ async fn moving_out_of_sliding_window() -> anyhow::Result<()> {
     let (client, sync_proxy_builder) = random_setup_with_rooms(20).await?;
     let sliding_window_list = SlidingSyncList::builder("sliding")
         .sync_mode(SlidingSyncMode::Selective)
-        .set_range(1u32..=10u32)
+        .set_range(1..=10)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
     let sync_proxy = sync_proxy_builder.add_list(sliding_window_list).build().await?;
@@ -670,7 +670,7 @@ async fn moving_out_of_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window
 
-    list.set_range(0u32..=10).unwrap();
+    list.set_range(0..=10).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -693,7 +693,7 @@ async fn moving_out_of_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window again
 
-    list.set_range(2u32..=12).unwrap();
+    list.set_range(2..=12).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -751,7 +751,7 @@ async fn moving_out_of_sliding_window() -> anyhow::Result<()> {
 
     // let's move the window again
 
-    list.set_range(0u32..=10).unwrap();
+    list.set_range(0..=10).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")?;
@@ -787,7 +787,7 @@ async fn fast_unfreeze() -> anyhow::Result<()> {
     let build_lists = || {
         let sliding_window_list = SlidingSyncList::builder("sliding")
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(1u32..=10u32)
+            .set_range(1..=10)
             .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
             .build();
         let growing_sync = SlidingSyncList::builder("growing")
@@ -848,7 +848,7 @@ async fn growing_sync_keeps_going() -> anyhow::Result<()> {
     let (_client, sync_proxy_builder) = random_setup_with_rooms(20).await?;
     let growing_sync = SlidingSyncList::builder("growing")
         .sync_mode(SlidingSyncMode::Growing)
-        .full_sync_batch_size(5u32)
+        .full_sync_batch_size(5)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
 
@@ -892,7 +892,7 @@ async fn continue_on_reset() -> anyhow::Result<()> {
     print!("setup took its time");
     let growing_sync = SlidingSyncList::builder("growing")
         .sync_mode(SlidingSyncMode::Growing)
-        .full_sync_batch_size(5u32)
+        .full_sync_batch_size(5)
         .full_sync_maximum_number_of_rooms_to_fetch(100)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
@@ -976,7 +976,7 @@ async fn noticing_new_rooms_in_growing() -> anyhow::Result<()> {
     print!("setup took its time");
     let growing_sync = SlidingSyncList::builder("growing")
         .sync_mode(SlidingSyncMode::Growing)
-        .full_sync_batch_size(10u32)
+        .full_sync_batch_size(10)
         .full_sync_maximum_number_of_rooms_to_fetch(100)
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
         .build();
@@ -1053,7 +1053,7 @@ async fn restart_room_resubscription() -> anyhow::Result<()> {
         .add_list(
             SlidingSyncList::builder("sliding_list")
                 .sync_mode(SlidingSyncMode::Selective)
-                .set_range(0u32..=2u32)
+                .set_range(0..=2)
                 .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
                 .build(),
         )
@@ -1079,7 +1079,7 @@ async fn restart_room_resubscription() -> anyhow::Result<()> {
 
     // let's move the window
 
-    list.set_range(1u32..=2).unwrap();
+    list.set_range(1..=2).unwrap();
 
     for _n in 0..2 {
         let room_summary = stream.next().await.context("sync has closed unexpectedly")??;
@@ -1211,7 +1211,7 @@ async fn receipts_extension_works() -> anyhow::Result<()> {
     let (client, sync_proxy_builder) = random_setup_with_rooms(1).await?;
     let list = SlidingSyncList::builder("a")
         .sync_mode(SlidingSyncMode::Selective)
-        .ranges(vec![(0u32..=1u32)])
+        .ranges(vec![(0..=1)])
         .sort(vec!["by_recency".to_owned()])
         .build();
 


### PR DESCRIPTION
Replaces usage of `UInt` in the internal code and public interfaces with `RangeInclusive`, which clarify that the end value is included in the range, and is generally more idiomatic in Rust.

I've gone ahead and also replaced the one other use of `UInt` for `timeline_limit` with a `u32`. Requesting 2**31-1 last events should be enough for anyone!

Fixes #1739.