### PR TITLE
Only send verifications requests to devices that are cross-signed

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    collections::HashMap,
     ops::Deref,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -25,7 +26,7 @@ use ruma::{
     events::{
         key::verification::VerificationMethod, room::message::KeyVerificationRequestEventContent,
     },
-    EventId, OwnedDeviceId, OwnedUserId, RoomId, UserId,
+    DeviceId, EventId, OwnedDeviceId, OwnedUserId, RoomId, UserId,
 };
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -161,14 +162,10 @@ impl OwnUserIdentity {
         &self,
         methods: Option<Vec<VerificationMethod>>,
     ) -> Result<(VerificationRequest, OutgoingVerificationRequest), CryptoStoreError> {
-        let devices: Vec<OwnedDeviceId> = self
-            .verification_machine
-            .store
-            .get_user_devices(self.user_id())
-            .await?
-            .into_keys()
-            .filter(|d| &**d != self.verification_machine.own_device_id())
-            .collect();
+        let all_devices = self.verification_machine.store.get_user_devices(self.user_id()).await?;
+        let devices = self
+            .inner
+            .filter_devices_to_request(all_devices, self.verification_machine.own_device_id());
 
         Ok(self
             .verification_machine
@@ -622,6 +619,19 @@ impl ReadOnlyOwnUserIdentity {
 
         Ok(())
     }
+
+    fn filter_devices_to_request(
+        &self,
+        devices: HashMap<OwnedDeviceId, ReadOnlyDevice>,
+        own_device_id: &DeviceId,
+    ) -> Vec<OwnedDeviceId> {
+        devices
+            .into_iter()
+            .filter_map(|(d_id, d)| {
+                (d_id != own_device_id && self.is_device_signed(&d).is_ok()).then_some(d_id)
+            })
+            .collect()
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -699,11 +709,11 @@ pub(crate) mod testing {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
+    use std::{collections::HashMap, sync::Arc};
 
     use assert_matches::assert_matches;
     use matrix_sdk_test::async_test;
-    use ruma::user_id;
+    use ruma::{device_id, user_id};
     use serde_json::{json, Value};
     use tokio::sync::Mutex;
 
@@ -873,6 +883,29 @@ pub(crate) mod tests {
         assert_matches!(
             serde_json::from_value::<UserSigningPubkey>(user_signing_key_json.clone()),
             Err(_)
+        );
+    }
+
+    #[test]
+    fn filter_devices_to_request() {
+        let response = own_key_query();
+        let identity = get_own_identity();
+        let (first, second) = device(&response);
+
+        let second_device_id = second.device_id().to_owned();
+        let unknown_device_id = device_id!("UNKNOWN");
+
+        let devices = HashMap::from([
+            (first.device_id().to_owned(), first),
+            (second.device_id().to_owned(), second),
+        ]);
+
+        // Own device and devices not verified are filtered out.
+        assert_eq!(identity.filter_devices_to_request(devices.clone(), &second_device_id).len(), 0);
+        // Signed devices that are not our own are kept.
+        assert_eq!(
+            identity.filter_devices_to_request(devices, unknown_device_id),
+            [second_device_id]
         );
     }
 }

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -627,8 +627,9 @@ impl ReadOnlyOwnUserIdentity {
     ) -> Vec<OwnedDeviceId> {
         devices
             .into_iter()
-            .filter_map(|(d_id, d)| {
-                (d_id != own_device_id && self.is_device_signed(&d).is_ok()).then_some(d_id)
+            .filter_map(|(device_id, device)| {
+                (device_id != own_device_id && self.is_device_signed(&device).is_ok())
+                    .then_some(device_id)
             })
             .collect()
     }

--- a/crates/matrix-sdk/src/encryption/identities/devices.rs
+++ b/crates/matrix-sdk/src/encryption/identities/devices.rs
@@ -513,6 +513,11 @@ impl Device {
     pub async fn set_local_trust(&self, trust_state: LocalTrust) -> Result<(), CryptoStoreError> {
         self.inner.set_local_trust(trust_state).await
     }
+
+    /// Is the device cross-signed by its own user.
+    pub fn is_cross_signed_by_owner(&self) -> bool {
+        self.inner.is_cross_signed_by_owner()
+    }
 }
 
 /// The collection of all the [`Device`]s a user has.


### PR DESCRIPTION
The commit adds a method that allows to check first if any device is cross-signed.

cc @poljar.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
