### PR TITLE
Fix timeline ordering regression

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -705,10 +705,12 @@ impl<'a> TimelineEventHandler<'a> {
                         trace!(?item, ?old_item, "Received duplicate event");
 
                         if old_item.content.is_redacted() && !item.content.is_redacted() {
-                            warn!(
-                                "Skipping original form of an event that was previously redacted"
-                            );
-                            return;
+                            warn!("Got original form of an event that was previously redacted");
+                            item.content = TimelineItemContent::RedactedMessage;
+                            item.as_remote_mut()
+                                .expect("Can't have a local item when flow == Remote")
+                                .reactions
+                                .clear();
                         }
                     };
 

--- a/crates/matrix-sdk/src/room/timeline/event_handler.rs
+++ b/crates/matrix-sdk/src/room/timeline/event_handler.rs
@@ -487,7 +487,7 @@ impl<'a> TimelineEventHandler<'a> {
         if let Some((_, rel)) = self.reaction_map.remove(&(None, Some(redacts.clone()))) {
             update_timeline_item!(self, &rel.event_id, "redaction", |event_item| {
                 let Some(remote_event_item) = event_item.as_remote() else {
-                    error!("inconsistent state: reaction received on a non-remote event item");
+                    error!("inconsistent state: redaction received on a non-remote event item");
                     return None;
                 };
 


### PR DESCRIPTION
It's a shame we need that branch at all, this reduces its specialness to fix a regression where it was interfering with timeline item ordering.