### PR TITLE
Add invited and joined members counts

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -456,6 +456,14 @@ impl Room {
         self.room.active_members_count()
     }
 
+    pub fn invited_members_count(&self) -> u64 {
+        self.room.invited_members_count()
+    }
+
+    pub fn joined_members_count(&self) -> u64 {
+        self.room.joined_members_count()
+    }
+
     /// Reports an event from the room.
     ///
     /// # Arguments

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -358,6 +358,16 @@ impl Room {
         self.inner.read().unwrap().active_members_count()
     }
 
+    /// Returns the number of members who have been invited to the room.
+    pub fn invited_members_count(&self) -> u64 {
+        self.inner.read().unwrap().invited_members_count()
+    }
+
+    /// Returns the number of members who have joined the room.
+    pub fn joined_members_count(&self) -> u64 {
+        self.inner.read().unwrap().joined_members_count()
+    }
+
     async fn calculate_name(&self) -> StoreResult<DisplayName> {
         let summary = {
             let inner = self.inner.read().unwrap();
@@ -748,6 +758,16 @@ impl RoomInfo {
     /// The return value is saturated at `u64::MAX`.
     pub fn active_members_count(&self) -> u64 {
         self.summary.joined_member_count.saturating_add(self.summary.invited_member_count)
+    }
+
+    /// The number of invited members in the room
+    pub fn invited_members_count(&self) -> u64 {
+        self.summary.invited_member_count
+    }
+
+    /// The number of joined members in the room
+    pub fn joined_members_count(&self) -> u64 {
+        self.summary.joined_member_count
     }
 
     /// Get the canonical alias of this room.

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -437,12 +437,6 @@ impl Common {
         self.members_no_sync(RoomMemberships::ACTIVE).await
     }
 
-    /// Returns the number of members who have joined or been invited to the
-    /// room.
-    pub fn active_members_count(&self) -> u64 {
-        self.inner.active_members_count()
-    }
-
     /// Get active members for this room, includes invited, joined members.
     ///
     /// *Note*: This method will not fetch the members from the homeserver if


### PR DESCRIPTION
This PR adds `invited_members_count` and `joined_members_count` for the room type.