### PR TITLE
Some refactoring around the sync response types

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[cfg(feature = "e2e-encryption")]
 use std::ops::Deref;
 

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -23,11 +23,13 @@ use ruma::{
     api::client::{
         push::get_notifications::v3::Notification,
         sync::sync_events::{
-            v3::{Ephemeral, InvitedRoom, Presence, RoomAccountData, State},
-            DeviceLists, UnreadNotificationsCount as RumaUnreadNotificationsCount,
+            v3::InvitedRoom, DeviceLists, UnreadNotificationsCount as RumaUnreadNotificationsCount,
         },
     },
-    events::{AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyToDeviceEvent},
+    events::{
+        presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
+        AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnyToDeviceEvent,
+    },
     serde::Raw,
     DeviceKeyAlgorithm, OwnedRoomId,
 };
@@ -44,11 +46,11 @@ pub struct SyncResponse {
     /// Updates to rooms.
     pub rooms: Rooms,
     /// Updates to the presence status of other users.
-    pub presence: Presence,
+    pub presence: Vec<Raw<PresenceEvent>>,
     /// The global private data created by this user.
     pub account_data: Vec<Raw<AnyGlobalAccountDataEvent>>,
     /// Messages sent directly between devices.
-    pub to_device_events: Vec<Raw<AnyToDeviceEvent>>,
+    pub to_device: Vec<Raw<AnyToDeviceEvent>>,
     /// Information on E2E device updates.
     ///
     /// Only present on an incremental sync.
@@ -68,7 +70,7 @@ impl fmt::Debug for SyncResponse {
         f.debug_struct("SyncResponse")
             .field("rooms", &self.rooms)
             .field("account_data", &DebugListOfRawEventsNoId(&self.account_data))
-            .field("to_device_events", &DebugListOfRawEventsNoId(&self.to_device_events))
+            .field("to_device", &DebugListOfRawEventsNoId(&self.to_device))
             .field("device_lists", &self.device_lists)
             .field("device_one_time_keys_count", &self.device_one_time_keys_count)
             .field("ambiguity_changes", &self.ambiguity_changes)
@@ -99,20 +101,20 @@ pub struct JoinedRoom {
     /// parameter, and the start of the `timeline` (or all state up to the
     /// start of the `timeline`, if `since` is not given, or `full_state` is
     /// true).
-    pub state: State,
+    pub state: Vec<Raw<AnySyncStateEvent>>,
     /// The private data that this user has attached to this room.
     pub account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
     /// The ephemeral events in the room that aren't recorded in the timeline or
     /// state of the room. e.g. typing.
-    pub ephemeral: Ephemeral,
+    pub ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
 }
 
 impl JoinedRoom {
     pub(crate) fn new(
         timeline: Timeline,
-        state: State,
+        state: Vec<Raw<AnySyncStateEvent>>,
         account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
-        ephemeral: Ephemeral,
+        ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         unread_notifications: UnreadNotificationsCount,
     ) -> Self {
         Self { unread_notifications, timeline, state, account_data, ephemeral }
@@ -148,13 +150,17 @@ pub struct LeftRoom {
     /// parameter, and the start of the `timeline` (or all state up to the
     /// start of the `timeline`, if `since` is not given, or `full_state` is
     /// true).
-    pub state: State,
+    pub state: Vec<Raw<AnySyncStateEvent>>,
     /// The private data that this user has attached to this room.
-    pub account_data: RoomAccountData,
+    pub account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
 }
 
 impl LeftRoom {
-    pub(crate) fn new(timeline: Timeline, state: State, account_data: RoomAccountData) -> Self {
+    pub(crate) fn new(
+        timeline: Timeline,
+        state: Vec<Raw<AnySyncStateEvent>>,
+        account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
+    ) -> Self {
         Self { timeline, state, account_data }
     }
 }

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -67,14 +67,13 @@ impl fmt::Debug for SyncResponse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SyncResponse")
             .field("rooms", &self.rooms)
-            .field("presence", &self.presence)
             .field("account_data", &DebugListOfRawEventsNoId(&self.account_data))
             .field("to_device_events", &DebugListOfRawEventsNoId(&self.to_device_events))
             .field("device_lists", &self.device_lists)
             .field("device_one_time_keys_count", &self.device_one_time_keys_count)
             .field("ambiguity_changes", &self.ambiguity_changes)
             .field("notifications", &self.notifications)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -79,7 +79,7 @@ impl fmt::Debug for SyncResponse {
 }
 
 /// Updates to rooms in a [`SyncResponse`].
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct Rooms {
     /// The rooms that the user has left or been banned from.
     pub leave: BTreeMap<OwnedRoomId, LeftRoom>,
@@ -90,7 +90,7 @@ pub struct Rooms {
 }
 
 /// Updates to joined rooms.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub struct JoinedRoom {
     /// Counts of unread notifications for this room.
     pub unread_notifications: UnreadNotificationsCount,
@@ -140,7 +140,7 @@ impl From<RumaUnreadNotificationsCount> for UnreadNotificationsCount {
 }
 
 /// Updates to left rooms.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub struct LeftRoom {
     /// The timeline of messages and state changes in the room up to the point
     /// when the user left.
@@ -161,7 +161,7 @@ impl LeftRoom {
 }
 
 /// Events in the room.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default)]
 pub struct Timeline {
     /// True if the number of events returned was limited by the `limit` on the
     /// filter.

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -72,7 +72,7 @@ impl fmt::Debug for SyncResponse {
             .field("device_lists", &self.device_lists)
             .field("device_one_time_keys_count", &self.device_one_time_keys_count)
             .field("ambiguity_changes", &self.ambiguity_changes)
-            .field("notifications", &self.notifications)
+            .field("notifications", &DebugNotificationMap(&self.notifications))
             .finish_non_exhaustive()
     }
 }

--- a/crates/matrix-sdk-common/src/debug.rs
+++ b/crates/matrix-sdk-common/src/debug.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fmt;
 
 use ruma::{serde::Raw, OwnedEventId};

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{collections::BTreeMap, fmt};
 
 use ruma::{

--- a/crates/matrix-sdk-common/src/executor.rs
+++ b/crates/matrix-sdk-common/src/executor.rs
@@ -1,5 +1,20 @@
+// Copyright 2021 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Abstraction over an executor so we can spawn tasks under WASM the same way
 //! we do usually.
+
 #[cfg(target_arch = "wasm32")]
 use std::{
     future::Future,

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations)]
 

--- a/crates/matrix-sdk-common/src/timeout.rs
+++ b/crates/matrix-sdk-common/src/timeout.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{error::Error, fmt, time::Duration};
 
 use futures_core::Future;

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! The SDK's representation of the result of a `/sync` request.
 
 use std::{collections::BTreeMap, time::Duration};

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -25,9 +25,9 @@ use matrix_sdk_base::{
 use ruma::{
     api::client::{
         push::get_notifications::v3::Notification,
-        sync::sync_events::{self, v3::Presence, DeviceLists},
+        sync::sync_events::{self, DeviceLists},
     },
-    events::{AnyGlobalAccountDataEvent, AnyToDeviceEvent},
+    events::{presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyToDeviceEvent},
     serde::Raw,
     DeviceKeyAlgorithm, OwnedRoomId, RoomId,
 };
@@ -44,11 +44,11 @@ pub struct SyncResponse {
     /// Updates to rooms.
     pub rooms: Rooms,
     /// Updates to the presence status of other users.
-    pub presence: Presence,
+    pub presence: Vec<Raw<PresenceEvent>>,
     /// The global private data created by this user.
     pub account_data: Vec<Raw<AnyGlobalAccountDataEvent>>,
     /// Messages sent directly between devices.
-    pub to_device_events: Vec<Raw<AnyToDeviceEvent>>,
+    pub to_device: Vec<Raw<AnyToDeviceEvent>>,
     /// Information on E2E device updates.
     ///
     /// Only present on an incremental sync.
@@ -68,7 +68,7 @@ impl SyncResponse {
             rooms,
             presence,
             account_data,
-            to_device_events,
+            to_device,
             device_lists,
             device_one_time_keys_count,
             ambiguity_changes,
@@ -80,7 +80,7 @@ impl SyncResponse {
             rooms,
             presence,
             account_data,
-            to_device_events,
+            to_device,
             device_lists,
             device_one_time_keys_count,
             ambiguity_changes,
@@ -107,7 +107,7 @@ impl Client {
             rooms,
             presence,
             account_data,
-            to_device_events,
+            to_device,
             device_lists: _,
             device_one_time_keys_count: _,
             ambiguity_changes: _,
@@ -116,8 +116,8 @@ impl Client {
 
         let now = Instant::now();
         self.handle_sync_events(HandlerKind::GlobalAccountData, &None, account_data).await?;
-        self.handle_sync_events(HandlerKind::Presence, &None, &presence.events).await?;
-        self.handle_sync_events(HandlerKind::ToDevice, &None, to_device_events).await?;
+        self.handle_sync_events(HandlerKind::Presence, &None, presence).await?;
+        self.handle_sync_events(HandlerKind::ToDevice, &None, to_device).await?;
 
         for (room_id, room_info) in &rooms.join {
             if room_info.timeline.limited {
@@ -134,12 +134,11 @@ impl Client {
                 room_info;
 
             self.handle_sync_events(HandlerKind::RoomAccountData, &room, account_data).await?;
-            self.handle_sync_state_events(&room, &state.events).await?;
+            self.handle_sync_state_events(&room, state).await?;
             self.handle_sync_timeline_events(&room, &timeline.events).await?;
             // Handle ephemeral events after timeline, read receipts in here
             // could refer to timeline events from the same response.
-            self.handle_sync_events(HandlerKind::EphemeralRoomData, &room, &ephemeral.events)
-                .await?;
+            self.handle_sync_events(HandlerKind::EphemeralRoomData, &room, ephemeral).await?;
         }
 
         for (room_id, room_info) in &rooms.leave {
@@ -155,9 +154,8 @@ impl Client {
 
             let LeftRoom { timeline, state, account_data } = room_info;
 
-            self.handle_sync_events(HandlerKind::RoomAccountData, &room, &account_data.events)
-                .await?;
-            self.handle_sync_state_events(&room, &state.events).await?;
+            self.handle_sync_events(HandlerKind::RoomAccountData, &room, account_data).await?;
+            self.handle_sync_state_events(&room, state).await?;
             self.handle_sync_timeline_events(&room, &timeline.events).await?;
         }
 


### PR DESCRIPTION
Regarding the last commit, I want to note that my main goal there was consistency, which we didn't have between the room event lists (state, account data, ephemeral events). The solution I chose also shrinks the `Debug` output and makes customizing it a little easier, which is why I did it this way rather than updating account data to be like the other fields. I'm happy to revert that and change the account data field instead though.