### PR TITLE
Update call_event_handlers span to default level of info

### DIFF
--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -438,7 +438,7 @@ impl Client {
         Ok(())
     }
 
-    #[instrument(level = "debug", skip_all, fields(?event_kind, ?event_type, room_id))]
+    #[instrument(skip_all, fields(?event_kind, ?event_type, room_id))]
     async fn call_event_handlers(
         &self,
         room: &Option<room::Room>,


### PR DESCRIPTION
I was wondering why recent logs didn't contain the room ID for event being handled, I think the answer is that we had this span on `level = "debug"`. Not sure why, honestly.