### PR TITLE
bench: fix running the crypto bench + add back sled to compare sled with sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ version = "1.0.0"
 dependencies = [
  "criterion",
  "matrix-sdk-crypto",
+ "matrix-sdk-sled",
  "matrix-sdk-sqlite",
  "matrix-sdk-test",
  "pprof",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 criterion = { version = "0.4.0", features = ["async", "async_tokio", "html_reports"] }
 matrix-sdk-crypto = { path = "../crates/matrix-sdk-crypto", version = "0.6.0"}
 matrix-sdk-sqlite = { path = "../crates/matrix-sdk-sqlite", version = "0.1.0", default-features = false, features = ["crypto-store"] }
+matrix-sdk-sled = { path = "../crates/matrix-sdk-sled", version = "0.2.0", default-features = false, features = ["crypto-store"] }
 matrix-sdk-test = { path = "../testing/matrix-sdk-test", version = "0.6.0"}
 ruma = { workspace = true }
 serde_json = { workspace = true }

--- a/benchmarks/benches/crypto_bench.rs
+++ b/benchmarks/benches/crypto_bench.rs
@@ -2,6 +2,7 @@ use std::{ops::Deref, sync::Arc};
 
 use criterion::*;
 use matrix_sdk_crypto::{EncryptionSettings, OlmMachine};
+use matrix_sdk_sled::SledCryptoStore;
 use matrix_sdk_sqlite::SqliteCryptoStore;
 use matrix_sdk_test::response_from_file;
 use ruma::{
@@ -65,10 +66,14 @@ pub fn keys_query(c: &mut Criterion) {
 
     let name = format!("{count} device and cross signing keys");
 
+    // Benchmark memory store.
+
     group.bench_with_input(BenchmarkId::new("memory store", &name), &response, |b, response| {
         b.to_async(&runtime)
             .iter(|| async { machine.mark_request_as_sent(&txn_id, response).await.unwrap() })
     });
+
+    // Benchmark sqlite store.
 
     let dir = tempfile::tempdir().unwrap();
     let store = Arc::new(runtime.block_on(SqliteCryptoStore::open(dir.path(), None)).unwrap());
@@ -84,6 +89,18 @@ pub fn keys_query(c: &mut Criterion) {
         let _guard = runtime.enter();
         drop(machine);
     }
+
+    // Benchmark (deprecated) sled store.
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(runtime.block_on(SledCryptoStore::open(dir.path(), None)).unwrap());
+    let machine =
+        runtime.block_on(OlmMachine::with_store(alice_id(), alice_device_id(), store)).unwrap();
+
+    group.bench_with_input(BenchmarkId::new("sled store", &name), &response, |b, response| {
+        b.to_async(&runtime)
+            .iter(|| async { machine.mark_request_as_sent(&txn_id, response).await.unwrap() })
+    });
 
     group.finish()
 }
@@ -147,6 +164,28 @@ pub fn keys_claiming(c: &mut Criterion) {
         )
     });
 
+    group.bench_with_input(BenchmarkId::new("sled store", &name), &response, |b, response| {
+        b.iter_batched(
+            || {
+                let dir = tempfile::tempdir().unwrap();
+                let store =
+                    Arc::new(runtime.block_on(SledCryptoStore::open(dir.path(), None)).unwrap());
+
+                let machine = runtime
+                    .block_on(OlmMachine::with_store(alice_id(), alice_device_id(), store))
+                    .unwrap();
+                runtime
+                    .block_on(machine.mark_request_as_sent(&txn_id, &keys_query_response))
+                    .unwrap();
+                (machine, &runtime, &txn_id)
+            },
+            move |(machine, runtime, txn_id)| {
+                runtime.block_on(machine.mark_request_as_sent(txn_id, response)).unwrap()
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
     group.finish()
 }
 
@@ -171,6 +210,8 @@ pub fn room_key_sharing(c: &mut Criterion) {
     group.throughput(Throughput::Elements(count as u64));
     let name = format!("{count} devices");
 
+    // Benchmark memory store.
+
     group.bench_function(BenchmarkId::new("memory store", &name), |b| {
         b.to_async(&runtime).iter(|| async {
             let requests = machine
@@ -191,6 +232,8 @@ pub fn room_key_sharing(c: &mut Criterion) {
             machine.invalidate_group_session(room_id).await.unwrap();
         })
     });
+
+    // Benchmark sqlite store.
 
     let dir = tempfile::tempdir().unwrap();
     let store = Arc::new(runtime.block_on(SqliteCryptoStore::open(dir.path(), None)).unwrap());
@@ -226,6 +269,37 @@ pub fn room_key_sharing(c: &mut Criterion) {
         drop(machine);
     }
 
+    // Benchmark (deprecated) sled store.
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(runtime.block_on(SledCryptoStore::open(dir.path(), None)).unwrap());
+
+    let machine =
+        runtime.block_on(OlmMachine::with_store(alice_id(), alice_device_id(), store)).unwrap();
+    runtime.block_on(machine.mark_request_as_sent(&txn_id, &keys_query_response)).unwrap();
+    runtime.block_on(machine.mark_request_as_sent(&txn_id, &response)).unwrap();
+
+    group.bench_function(BenchmarkId::new("sled store", &name), |b| {
+        b.to_async(&runtime).iter(|| async {
+            let requests = machine
+                .share_room_key(
+                    room_id,
+                    users.iter().map(Deref::deref),
+                    EncryptionSettings::default(),
+                )
+                .await
+                .unwrap();
+
+            assert!(!requests.is_empty());
+
+            for request in requests {
+                machine.mark_request_as_sent(&request.txn_id, &to_device_response).await.unwrap();
+            }
+
+            machine.invalidate_group_session(room_id).await.unwrap();
+        })
+    });
+
     group.finish()
 }
 
@@ -246,11 +320,15 @@ pub fn devices_missing_sessions_collecting(c: &mut Criterion) {
 
     runtime.block_on(machine.mark_request_as_sent(&txn_id, &response)).unwrap();
 
+    // Benchmark memory store.
+
     group.bench_function(BenchmarkId::new("memory store", &name), |b| {
         b.to_async(&runtime).iter_with_large_drop(|| async {
             machine.get_missing_sessions(users.iter().map(Deref::deref)).await.unwrap()
         })
     });
+
+    // Benchmark sqlite store.
 
     let dir = tempfile::tempdir().unwrap();
     let store = Arc::new(runtime.block_on(SqliteCryptoStore::open(dir.path(), None)).unwrap());
@@ -270,6 +348,22 @@ pub fn devices_missing_sessions_collecting(c: &mut Criterion) {
         let _guard = runtime.enter();
         drop(machine);
     }
+
+    // Benchmark (deprecated) sled store.
+
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(runtime.block_on(SledCryptoStore::open(dir.path(), None)).unwrap());
+
+    let machine =
+        runtime.block_on(OlmMachine::with_store(alice_id(), alice_device_id(), store)).unwrap();
+
+    runtime.block_on(machine.mark_request_as_sent(&txn_id, &response)).unwrap();
+
+    group.bench_function(BenchmarkId::new("sled store", &name), |b| {
+        b.to_async(&runtime).iter(|| async {
+            machine.get_missing_sessions(users.iter().map(Deref::deref)).await.unwrap()
+        })
+    });
 
     group.finish()
 }


### PR DESCRIPTION
- This fixes the crypto bench by ensuring a tokio runtime is active whenever a `OlmMachine` built with a `SqliteCryptoStore` is dropped. That's necessary because `deadpool` makes use of `block_on` in the `Drop` implementation of one of its managers.
- This also adds back sled to the crypto benchmarks, so we can compare the performance of the two backends.

Turns out that sled was faster than sqlite: full report temporarily hosted on https://benj.me/pub/criterion/report/

# TL;DR: median run times

| Benchmark | Mem | Sled | Sqlite |
| -- | -- | -- | -- |
| devices missing session collecting | 8.59 ms | 16.23 ms | 133.36 ms |
| keys quering |3.5 ms | 6.69 ms | 8.01 ms |
| olm session creation | 35.24 ms | 38.07 ms | 46.74 ms |
| room key sharing | 2 ms | 5.18 ms | 9.27 ms |