### PR TITLE
Fix debug output for raw events

### DIFF
--- a/crates/matrix-sdk-common/src/debug.rs
+++ b/crates/matrix-sdk-common/src/debug.rs
@@ -16,7 +16,7 @@
 
 use std::fmt;
 
-use ruma::{serde::Raw, OwnedEventId};
+use ruma::serde::Raw;
 
 /// A wrapper around `Raw` that implements `Debug` in a way that only prints the
 /// event ID and event type.
@@ -26,8 +26,8 @@ pub struct DebugRawEvent<'a, T>(pub &'a Raw<T>);
 impl<T> fmt::Debug for DebugRawEvent<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEvent")
-            .field("event_id", &DebugEventId(self.0.get_field("event_id")))
-            .field("event_type", &DebugEventType(self.0.get_field("event_type")))
+            .field("event_id", &DebugStringField(self.0.get_field("event_id")))
+            .field("event_type", &DebugStringField(self.0.get_field("type")))
             .finish_non_exhaustive()
     }
 }
@@ -40,28 +40,15 @@ pub struct DebugRawEventNoId<'a, T>(pub &'a Raw<T>);
 impl<T> fmt::Debug for DebugRawEventNoId<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEvent")
-            .field("event_type", &DebugEventType(self.0.get_field("event_type")))
+            .field("event_type", &DebugStringField(self.0.get_field("type")))
             .finish_non_exhaustive()
     }
 }
 
-struct DebugEventId(serde_json::Result<Option<OwnedEventId>>);
+struct DebugStringField(serde_json::Result<Option<String>>);
 
 #[cfg(not(tarpaulin_include))]
-impl fmt::Debug for DebugEventId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            Ok(Some(id)) => id.fmt(f),
-            Ok(None) => f.write_str("Missing"),
-            Err(e) => f.debug_tuple("Invalid").field(&e).finish(),
-        }
-    }
-}
-
-struct DebugEventType(serde_json::Result<Option<String>>);
-
-#[cfg(not(tarpaulin_include))]
-impl fmt::Debug for DebugEventType {
+impl fmt::Debug for DebugStringField {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             Ok(Some(id)) => id.fmt(f),


### PR DESCRIPTION
It was looking for an "event_type" field rather than just "type". The code was also more complex than necessary.