### PR TITLE
fix(bindings): Fix for notification item to get sender in invited rooms

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -18,7 +18,7 @@ dictionary NotificationItem {
     string? room_canonical_alias;
     boolean is_noisy;
     boolean is_direct;
-    boolean is_encrypted;
+    boolean? is_encrypted;
 };
 
 interface TimelineEvent {};


### PR DESCRIPTION
the `get_room_member function` used for Common was always giving me a 403 for rooms where the user is invited.

So I used instead the `invite_details()` available on `Room::Invited`

Also there is an issue with the `is_encrypted()` call failing for Invited rooms:
https://github.com/matrix-org/matrix-rust-sdk/issues/1901
So for now I made the `is_encrypted` `bool `an `Option`

If this issue is likely going to be fixed soon, we can wait for the fix before approving and merging this PR, to keep the `is_encrypted` bool not optional, which is for sure more consistent