### PR TITLE
ffi: Add MediaSource::{from_json, to_json}

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -154,7 +154,15 @@ interface PaginationOptions {
 
 interface RoomMessageEventContent {};
 
+[Error]
+interface ClientError {
+    Generic(string msg);
+};
+
 interface MediaSource {
+    [Name=from_json, Throws=ClientError]
+    constructor(string json);
+    string to_json();
     string url();
 };
 

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,6 +1,6 @@
 use matrix_sdk::{self, encryption::CryptoStoreError, HttpError, IdParseError, StoreError};
 
-#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ClientError {
     #[error("client error: {msg}")]
     Generic { msg: String },

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -11,7 +11,10 @@ use matrix_sdk::{
 use ruma::UInt;
 use tracing::warn;
 
-use crate::{error::TimelineError, helpers::unwrap_or_clone_arc};
+use crate::{
+    error::{ClientError, TimelineError},
+    helpers::unwrap_or_clone_arc,
+};
 
 #[uniffi::export]
 pub fn media_source_from_url(url: String) -> Arc<MediaSource> {
@@ -934,6 +937,15 @@ pub enum VirtualTimelineItem {
 
 #[extension_trait]
 pub impl MediaSourceExt for MediaSource {
+    fn from_json(json: String) -> Result<MediaSource, ClientError> {
+        let res = serde_json::from_str(&json)?;
+        Ok(res)
+    }
+
+    fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+
     fn url(&self) -> String {
         match self {
             MediaSource::Plain(url) => url.to_string(),

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -943,7 +943,7 @@ pub impl MediaSourceExt for MediaSource {
     }
 
     fn to_json(&self) -> String {
-        serde_json::to_string(self).unwrap()
+        serde_json::to_string(self).expect("Media source should always be serializable ")
     }
 
     fn url(&self) -> String {


### PR DESCRIPTION
Useful for EX-Android until UniFFI gets GC integration for Kotlin.