### PR TITLE
Compile for Mac Catalyst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,16 +1116,6 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ctor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
@@ -2463,11 +2453,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 dependencies = [
- "cfg-if",
  "value-bag",
 ]
 
@@ -2557,7 +2546,7 @@ dependencies = [
  "backoff",
  "bytes",
  "bytesize",
- "ctor 0.2.0",
+ "ctor",
  "dashmap",
  "dirs",
  "event-listener",
@@ -2631,7 +2620,7 @@ dependencies = [
  "assign",
  "async-trait",
  "bitflags 2.3.0",
- "ctor 0.2.0",
+ "ctor",
  "dashmap",
  "eyeball",
  "futures-executor",
@@ -2684,7 +2673,7 @@ dependencies = [
  "byteorder",
  "cbc",
  "cfg-if",
- "ctor 0.2.0",
+ "ctor",
  "ctr",
  "dashmap",
  "eyeball",
@@ -2861,7 +2850,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assign",
- "ctor 0.2.0",
+ "ctor",
  "matrix-sdk",
  "once_cell",
  "tempfile",
@@ -2913,7 +2902,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "ctor 0.2.0",
+ "ctor",
  "deadpool-sqlite",
  "glob",
  "matrix-sdk-base",
@@ -2984,7 +2973,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "chrono",
- "ctor 0.2.0",
+ "ctor",
  "eyeball-im",
  "futures-core",
  "futures-util",
@@ -3120,7 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49ac8112fe5998579b22e29903c7b277fc7f91c7860c0236f35792caf8156e18"
 dependencies = [
  "bitflags 2.3.0",
- "ctor 0.2.0",
+ "ctor",
  "napi-derive",
  "napi-sys",
  "once_cell",
@@ -5685,13 +5674,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor 0.1.26",
- "version_check",
-]
+checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 
 [[package]]
 name = "vcpkg"


### PR DESCRIPTION
Hello!
Trying to port Element X to Mac Catalyst. The Rust SDK is of course a prerequisite.

Unfortunately, there is a problem with rustc, so I wrote up a pull request to fix it there first:
https://github.com/rust-lang/rust/pull/111384

After it gets merged, the changes I made here to `build_crypto_xcframework.sh` will make it compile for Catalyst and bundle all four platforms (iOS, macOS, Catalyst and simulator) into one .xcframework.

It will use nightly rustc for catalyst, but stable for the other platforms. 