### PR TITLE
chore: add tracing spans for Timeline builder code suspected slow

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/builder.rs
+++ b/crates/matrix-sdk/src/room/timeline/builder.rs
@@ -69,6 +69,7 @@ impl TimelineBuilder {
     }
 
     /// Create a [`Timeline`] with the options set on this builder.
+    #[tracing::instrument(skip(self))]
     pub(crate) async fn build(self) -> Timeline {
         let Self { room, prev_token, events, track_read_marker_and_receipts } = self;
         let has_events = !events.is_empty();

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -136,6 +136,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             .insert(receipt_type, receipt);
     }
 
+    #[tracing::instrument(skip(self, events))]
     pub(super) async fn add_initial_events(&mut self, events: Vector<SyncTimelineEvent>) {
         if events.is_empty() {
             return;

--- a/crates/matrix-sdk/src/room/timeline/inner.rs
+++ b/crates/matrix-sdk/src/room/timeline/inner.rs
@@ -136,7 +136,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             .insert(receipt_type, receipt);
     }
 
-    #[tracing::instrument(skip(self, events))]
+    #[tracing::instrument(skip_all)]
     pub(super) async fn add_initial_events(&mut self, events: Vector<SyncTimelineEvent>) {
         if events.is_empty() {
             return;

--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -214,6 +214,7 @@ impl Timeline {
     }
 
     #[cfg(feature = "e2e-encryption")]
+    #[tracing::instrument(skip(self))]
     async fn retry_decryption_for_all_events(&self) {
         self.inner
             .retry_event_decryption(


### PR DESCRIPTION
I've added a few tracing spans here and there so we can know how long it took to build the `TimelineBuilder`: one on the `build()` method itself, and two extras on functions called in `build()` and that I suspect to be the slowest there.