### PR TITLE
Improve logs for pagination

### DIFF
--- a/crates/matrix-sdk/src/room/timeline/mod.rs
+++ b/crates/matrix-sdk/src/room/timeline/mod.rs
@@ -109,8 +109,8 @@ impl Timeline {
     }
 
     /// Add more events to the start of the timeline.
-    #[instrument(skip_all, fields(initial_pagination_size, room_id = ?self.room().room_id()))]
-    pub async fn paginate_backwards(&self, mut opts: PaginationOptions<'_>) -> Result<()> {
+    #[instrument(skip_all, fields(room_id = ?self.room().room_id(), ?options))]
+    pub async fn paginate_backwards(&self, mut options: PaginationOptions<'_>) -> Result<()> {
         let mut start_lock = self.start_token.lock().await;
         if start_lock.is_none()
             && self.inner.items().await.front().map_or(false, |item| item.is_timeline_start())
@@ -124,7 +124,7 @@ impl Timeline {
         let mut from = start_lock.clone();
         let mut outcome = PaginationOutcome::new();
 
-        while let Some(limit) = opts.next_event_limit(outcome) {
+        while let Some(limit) = options.next_event_limit(outcome) {
             let messages = self
                 .room()
                 .messages(assign!(MessagesOptions::backward(), {

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -234,7 +234,7 @@ impl SlidingSyncRoom {
         *self.inner.state.write().unwrap() = state;
     }
 
-    fn timeline_queue(&self) -> std::sync::RwLockReadGuard<Vector<SyncTimelineEvent>> {
+    fn timeline_queue(&self) -> std::sync::RwLockReadGuard<'_, Vector<SyncTimelineEvent>> {
         self.inner.timeline_queue.read().unwrap()
     }
 }
@@ -452,9 +452,9 @@ mod tests {
         test_room_name {
             name() = None;
             receives room_response!({"name": "gordon"});
-            _ = Some("gordon".to_string());
+            _ = Some("gordon".to_owned());
             receives nothing;
-            _ = Some("gordon".to_string());
+            _ = Some("gordon".to_owned());
         }
 
         test_room_is_dm {
@@ -521,7 +521,7 @@ mod tests {
                 new_room(room_id!("!foo:bar.org"), room_response!({"prev_batch": "t111_222_333"}))
                     .await;
 
-            assert_eq!(room.inner.prev_batch(), Some("t111_222_333".to_string()));
+            assert_eq!(room.inner.prev_batch(), Some("t111_222_333".to_owned()));
         }
 
         // Some value when updating.
@@ -531,10 +531,10 @@ mod tests {
             assert_eq!(room.inner.prev_batch(), None);
 
             room.update(room_response!({"prev_batch": "t111_222_333"}), vec![]);
-            assert_eq!(room.inner.prev_batch(), Some("t111_222_333".to_string()));
+            assert_eq!(room.inner.prev_batch(), Some("t111_222_333".to_owned()));
 
             room.update(room_response!({}), vec![]);
-            assert_eq!(room.inner.prev_batch(), Some("t111_222_333".to_string()));
+            assert_eq!(room.inner.prev_batch(), Some("t111_222_333".to_owned()));
         }
     }
 


### PR DESCRIPTION
- Fix the options tracing span field for the high-level timeline pagination (looks like it was never working on `main` since it was using a wrong name that was used in a previous iteration)
- Add a tracing span that includes options for individual pagination requests (which can also be triggered from outside the timeline)