### PR TITLE
test(sdk): New Sliding Sync integration test suite for a mocked server

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -53,7 +53,6 @@ experimental-sliding-sync = [
     "matrix-sdk-base/experimental-sliding-sync",
     "experimental-timeline",
     "reqwest/gzip",
-    "dep:uuid",
 ]
 
 docsrs = [
@@ -102,7 +101,6 @@ thiserror = { workspace = true }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 url = "2.2.2"
-uuid = { version = "1.3.0", optional = true }
 zeroize = { workspace = true }
 
 [dependencies.image]

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -75,7 +75,7 @@ impl SlidingSyncListBuilder {
         }
     }
 
-    /// foo
+    /// Declare a callback that is called when a list is built.
     pub fn once_built<C>(mut self, callback: C) -> Self
     where
         C: Fn(SlidingSyncList) -> SlidingSyncList + Send + Sync + 'static,

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -60,7 +60,6 @@ use tokio::{
 };
 use tracing::{debug, error, instrument, warn, Instrument, Span};
 use url::Url;
-use uuid::Uuid;
 
 use crate::{config::RequestConfig, Client, Result};
 
@@ -396,7 +395,7 @@ impl SlidingSync {
     }
 
     #[instrument(skip_all, fields(pos))]
-    async fn sync_once(&self, stream_id: &str) -> Result<Option<UpdateSummary>> {
+    async fn sync_once(&self) -> Result<Option<UpdateSummary>> {
         let (request, request_config) = {
             // Collect requests for lists.
             let mut requests_lists = BTreeMap::new();
@@ -433,9 +432,6 @@ impl SlidingSync {
                 assign!(v4::Request::new(), {
                     pos,
                     delta_token,
-                    // We want to track whether the incoming response maps to this
-                    // request. We use the (optional) `txn_id` field for that.
-                    txn_id: Some(stream_id.to_owned()),
                     timeout: Some(timeout),
                     lists: requests_lists,
                     bump_event_types: self.inner.bump_event_types.clone(),
@@ -498,7 +494,6 @@ impl SlidingSync {
         // That's why we are running the handling of the response in a spawned
         // future that cannot be cancelled by anything.
         let this = self.clone();
-        let stream_id = stream_id.to_owned();
 
         // Spawn a new future to ensure that the code inside this future cannot be
         // cancelled if this method is cancelled.
@@ -509,22 +504,6 @@ impl SlidingSync {
             // ensure responses are handled one at a time, hence we lock the
             // `response_handling_lock`.
             let response_handling_lock = this.response_handling_lock.lock().await;
-
-            match &response.txn_id {
-                None => {
-                    error!(stream_id, "Sliding Sync has received an unexpected response: `txn_id` must match `stream_id`; it's missing");
-                }
-
-                Some(txn_id) if txn_id != &stream_id => {
-                    error!(
-                        stream_id,
-                        txn_id,
-                        "Sliding Sync has received an unexpected response: `txn_id` must match `stream_id`; they differ"
-                    );
-                }
-
-                _ => {}
-            }
 
             // Handle the response.
             let updates = this.handle_response(response).await?;
@@ -549,10 +528,7 @@ impl SlidingSync {
     #[allow(unknown_lints, clippy::let_with_type_underscore)] // triggered by instrument macro
     #[instrument(name = "sync_stream", skip_all)]
     pub fn stream(&self) -> impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_ {
-        // Define a stream ID.
-        let stream_id = Uuid::new_v4().to_string();
-
-        debug!(?self.inner.extensions, stream_id, "About to run the sync stream");
+        debug!(?self.inner.extensions, "About to run the sync stream");
 
         let sync_stream_span = Span::current();
 
@@ -581,7 +557,7 @@ impl SlidingSync {
                         }
                     }
 
-                    update_summary = self.sync_once(&stream_id).instrument(sync_stream_span.clone()) => {
+                    update_summary = self.sync_once().instrument(sync_stream_span.clone()) => {
                         match update_summary {
                             Ok(Some(updates)) => {
                                 self.inner.reset_counter.store(0, Ordering::SeqCst);

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -333,7 +333,10 @@ impl From<&SlidingSyncRoom> for FrozenSlidingSyncRoom {
 mod tests {
     use imbl::vector;
     use matrix_sdk_base::deserialized_responses::TimelineEvent;
-    use ruma::{events::room::message::RoomMessageEventContent, room_id, uint, RoomId};
+    use ruma::{
+        api::client::sync::sync_events::v4, events::room::message::RoomMessageEventContent,
+        room_id, uint, RoomId,
+    };
     use serde_json::json;
     use wiremock::MockServer;
 
@@ -598,7 +601,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_timeline_initially_empty() {
+    async fn test_timeline_queue_initially_empty() {
         let room = new_room(room_id!("!foo:bar.org"), room_response!({})).await;
 
         assert!(room.timeline_queue().is_empty());
@@ -951,18 +954,18 @@ mod tests {
             let timeline_events = (0..=max)
                 .map(|nth| {
                     TimelineEvent::new(
-                    Raw::new(&json!({
-                        "content": RoomMessageEventContent::text_plain(format!("message {nth}")),
-                        "type": "m.room.message",
-                        "event_id": format!("$x{nth}:baz.org"),
-                        "room_id": "!foo:bar.org",
-                        "origin_server_ts": nth,
-                        "sender": "@alice:baz.org",
-                    }))
-                    .unwrap()
-                    .cast(),
-                )
-                .into()
+                        Raw::new(&json!({
+                            "content": RoomMessageEventContent::text_plain(format!("message {nth}")),
+                            "type": "m.room.message",
+                            "event_id": format!("$x{nth}:baz.org"),
+                            "room_id": "!foo:bar.org",
+                            "origin_server_ts": nth,
+                            "sender": "@alice:baz.org",
+                        }))
+                        .unwrap()
+                        .cast(),
+                    )
+                    .into()
                 })
                 .collect::<Vec<_>>();
 

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -16,6 +16,7 @@ use wiremock::{
 mod client;
 mod refresh_token;
 mod room;
+mod sliding_sync;
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 #[ctor::ctor]

--- a/crates/matrix-sdk/tests/integration/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/tests/integration/sliding_sync/mod.rs
@@ -1,0 +1,1 @@
+mod timeline;

--- a/crates/matrix-sdk/tests/integration/sliding_sync/timeline.rs
+++ b/crates/matrix-sdk/tests/integration/sliding_sync/timeline.rs
@@ -1,0 +1,341 @@
+use std::{pin::Pin, sync::Arc};
+
+use anyhow::{Context, Result};
+use assert_matches::assert_matches;
+use eyeball_im::{Vector, VectorDiff};
+use futures::{pin_mut, Stream, StreamExt};
+use matrix_sdk::{
+    room::timeline::{TimelineItem, VirtualTimelineItem},
+    SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
+};
+use matrix_sdk_test::async_test;
+use ruma::{room_id, RoomId};
+use serde_json::json;
+use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
+
+use crate::logged_in_client;
+
+macro_rules! receive_response {
+    (
+        [$server:ident, $sliding_sync_stream:ident]
+        $( $json:tt )+
+    ) => {
+        {
+            let _mock_guard = Mock::given(SlidingSyncMatcher)
+                .respond_with(ResponseTemplate::new(200).set_body_json(
+                    json!( $( $json )+ )
+                ))
+                .mount_as_scoped(&$server)
+                .await;
+
+            let next = $sliding_sync_stream.next().await.context("`stream` trip")??;
+
+            next
+        }
+    };
+}
+
+macro_rules! timeline_event {
+    ($event_id:literal at $ts:literal sec) => {
+        json!({
+            "event_id": $event_id,
+            "sender": "@alice:bar.org",
+            "type": "m.room.message",
+            "content": {
+                "body": "foo",
+                "msgtype": "m.text",
+            },
+            "origin_server_ts": $ts,
+        })
+    }
+}
+
+macro_rules! assert_timeline_stream {
+    // `--- day divider ---`
+    ( @_ [ $stream:ident ] [ --- day divider --- ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $stream ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $stream.next().await,
+                        Some(VectorDiff::PushBack { value }) => {
+                            assert_matches!(value.as_ref(), TimelineItem::Virtual(VirtualTimelineItem::DayDivider(_)));
+                        }
+                    );
+                }
+            ]
+        )
+    };
+
+    // `append "$event_id"`
+    ( @_ [ $stream:ident ] [ append $event_id:literal ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $stream ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $stream.next().await,
+                        Some(VectorDiff::PushBack { value }) => {
+                            assert_matches!(
+                                value.as_ref(),
+                                TimelineItem::Event(event_timeline_item) => {
+                                    assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
+                                }
+                            );
+                        }
+                    );
+                }
+            ]
+        )
+    };
+
+    // `update [$nth] "$event_id"`
+    ( @_ [ $stream:ident ] [ update [$index:literal] $event_id:literal ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $stream ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $stream.next().await,
+                        Some(VectorDiff::Set { index: $index, value }) => {
+                            assert_matches!(
+                                value.as_ref(),
+                                TimelineItem::Event(event_timeline_item) => {
+                                    assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
+                                }
+                            );
+                        }
+                    );
+                }
+            ]
+        )
+    };
+
+    // `remove [$nth]`
+    ( @_ [ $stream:ident ] [ remove [$index:literal] ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $stream ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $stream.next().await,
+                        Some(VectorDiff::Remove { index: $index })
+                    );
+                }
+            ]
+        )
+    };
+
+    ( @_ [ $stream:ident ] [] [ $( $accumulator:tt )* ] ) => {
+        $( $accumulator )*
+    };
+
+    ( [ $stream:ident ] $( $all:tt )* ) => {
+        assert_timeline_stream!( @_ [ $stream ] [ $( $all )* ] [] )
+    };
+}
+
+async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockServer, SlidingSync)> {
+    let (client, server) = logged_in_client().await;
+
+    let mut sliding_sync_builder = client.sliding_sync().await;
+
+    for list in lists {
+        sliding_sync_builder = sliding_sync_builder.add_list(list);
+    }
+
+    let sliding_sync = sliding_sync_builder.build().await?;
+
+    Ok((server, sliding_sync))
+}
+
+async fn create_one_room(
+    server: &MockServer,
+    sliding_sync: &SlidingSync,
+    stream: &mut Pin<&mut impl Stream<Item = matrix_sdk::Result<UpdateSummary>>>,
+    room_id: &RoomId,
+    room_name: String,
+) -> Result<()> {
+    let update = receive_response!(
+        [server, stream]
+        {
+            "pos": "1",
+            "lists": {},
+            "rooms": {
+                room_id: {
+                    "name": room_name,
+                    "initial": true,
+                    "timeline": [],
+                }
+            },
+            "extensions": {},
+        }
+    );
+
+    assert!(update.rooms.contains(&room_id.to_owned()));
+
+    let room = sliding_sync.get_room(room_id).context("`get_room`")?;
+    assert_eq!(room.name(), Some(room_name.clone()));
+
+    Ok(())
+}
+
+async fn timeline(
+    sliding_sync: &SlidingSync,
+    room_id: &RoomId,
+) -> Result<(Vector<Arc<TimelineItem>>, impl Stream<Item = VectorDiff<Arc<TimelineItem>>>)> {
+    Ok(sliding_sync
+        .get_room(room_id)
+        .unwrap()
+        .timeline()
+        .await
+        .context("`timeline`")?
+        .subscribe()
+        .await)
+}
+
+struct SlidingSyncMatcher;
+
+impl Match for SlidingSyncMatcher {
+    fn matches(&self, request: &Request) -> bool {
+        request.url.path() == "/_matrix/client/unstable/org.matrix.msc3575/sync"
+            && request.method == Method::Post
+    }
+}
+
+#[async_test]
+async fn test_timeline_basic() -> Result<()> {
+    let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
+        .sync_mode(SlidingSyncMode::Selective)
+        .set_range(0..=10)])
+    .await?;
+
+    let stream = sliding_sync.stream();
+    pin_mut!(stream);
+
+    let room_id = room_id!("!foo:bar.org");
+
+    create_one_room(&server, &sliding_sync, &mut stream, room_id, "Room Name".to_string()).await?;
+
+    let (timeline_items, mut timeline_stream) = timeline(&sliding_sync, room_id).await?;
+    assert!(timeline_items.is_empty());
+
+    // Receiving a bunch of events.
+    {
+        receive_response! {
+            [server, stream]
+            {
+                "pos": "1",
+                "lists": {},
+                "rooms": {
+                    room_id: {
+                        "timeline": [
+                            timeline_event!("$x1:bar.org" at 1 sec),
+                            timeline_event!("$x2:bar.org" at 2 sec),
+                        ]
+                    }
+                }
+            }
+        };
+
+        assert_timeline_stream! {
+            [timeline_stream]
+            --- day divider ---;
+            append    "$x1:bar.org";
+            update[1] "$x1:bar.org";
+            append    "$x2:bar.org";
+        };
+    }
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_timeline_duplicated_events() -> Result<()> {
+    let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
+        .sync_mode(SlidingSyncMode::Selective)
+        .set_range(0..=10)])
+    .await?;
+
+    let stream = sliding_sync.stream();
+    pin_mut!(stream);
+
+    let room_id = room_id!("!foo:bar.org");
+
+    create_one_room(&server, &sliding_sync, &mut stream, room_id, "Room Name".to_string()).await?;
+
+    let (_, mut timeline_stream) = timeline(&sliding_sync, room_id).await?;
+
+    // Receiving events.
+    {
+        receive_response! {
+            [server, stream]
+            {
+                "pos": "1",
+                "lists": {},
+                "rooms": {
+                    room_id: {
+                        "timeline": [
+                            timeline_event!("$x1:bar.org" at 1 sec),
+                            timeline_event!("$x2:bar.org" at 2 sec),
+                            timeline_event!("$x3:bar.org" at 3 sec),
+                        ]
+                    }
+                }
+            }
+        };
+
+        assert_timeline_stream! {
+            [timeline_stream]
+            --- day divider ---;
+            append    "$x1:bar.org";
+            update[1] "$x1:bar.org";
+            append    "$x2:bar.org";
+            update[2] "$x2:bar.org";
+            append    "$x3:bar.org";
+        };
+    }
+
+    // Receiving new events, where the first has already been received.
+    {
+        receive_response! {
+            [server, stream]
+            {
+                "pos": "3",
+                "lists": {},
+                "rooms": {
+                    room_id: {
+                        "timeline": [
+                            timeline_event!("$x1:bar.org" at 4 sec),
+                            timeline_event!("$x4:bar.org" at 5 sec),
+                        ]
+                    }
+                }
+            }
+        };
+
+        assert_timeline_stream! {
+            [timeline_stream]
+            remove[1];
+            update[2] "$x3:bar.org";
+            append    "$x1:bar.org";
+            update[3] "$x1:bar.org";
+            append    "$x4:bar.org";
+        };
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Address ﻿https://github.com/matrix-org/matrix-rust-sdk/issues/1670.

That's the foundation to write SlidingSync integration tests for a mocked server. It contains 2 tests so far, but the idea of this PR is to create the tools to add more tests easily.

Yes, we are testing against a mocked server. The idea is to test SlidingSync + timeline mostly, so that if a problem happens, we can think about it without the SlidingSync server/proxy in the equation, which allows us to focus more easily on the problem and to find the culprit faster.

Some macros have been written to provide a better comprehension of the tests, for example:

```rust
// Receiving events.
{
    receive_response! {
        [server, stream]
        {
            "pos": "1",
            "lists": {},
            "rooms": {
                room_id: {
                    "timeline": [
                        timeline_event!("$x1:bar.org" at 1 sec),
                        timeline_event!("$x2:bar.org" at 2 sec),
                        timeline_event!("$x3:bar.org" at 3 sec),
                    ]
                }
            }
        }
    };

    assert_timeline_stream! {
        [timeline_stream]
        --- day divider ---;
        append    "$x1:bar.org";
        update[1] "$x1:bar.org";
        append    "$x2:bar.org";
        update[2] "$x2:bar.org";
        append    "$x3:bar.org";
    };
}

// Receiving new events, where the first has already been received.
{
    receive_response! {
        [server, stream]
        {
            "pos": "3",
            "lists": {},
            "rooms": {
                room_id: {
                    "timeline": [
                        timeline_event!("$x1:bar.org" at 4 sec),
                        timeline_event!("$x4:bar.org" at 5 sec),
                    ]
                }
            }
        }
    };

    assert_timeline_stream! {
        [timeline_stream]
        remove[1];
        update[2] "$x3:bar.org";
        append    "$x1:bar.org";
        update[3] "$x1:bar.org";
        append    "$x4:bar.org";
    };
}
```

This PR also contains some clean up, like removing the use of `txn_id` for every requests, stuff like that.

This PR must be reviewed commit by commit for more comfort.