### PR TITLE
test: sliding sync list fields reloaded from the cache are observable in streams

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -75,7 +75,11 @@ impl SlidingSyncListBuilder {
         }
     }
 
-    /// foo
+    /// Runs a callback once the list has been built.
+    ///
+    /// If the list was cached, then the cached fields won't be available in
+    /// this callback. Use the streams to get published versions of the
+    /// cached fields, once they've been set.
     pub fn once_built<C>(mut self, callback: C) -> Self
     where
         C: Fn(SlidingSyncList) -> SlidingSyncList + Send + Sync + 'static,


### PR DESCRIPTION
A test that would have made my life easier for https://github.com/matrix-org/matrix-rust-sdk/pull/1876: if a sliding sync list has been reloaded from a cache, it's expected at least by the iOS client that the initial values are published in the streams of observable values.