### PR TITLE
feat(sdk): restart the sync loop when adding a new list to an existing SS instance

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -186,7 +186,7 @@ impl SlidingSyncList {
     }
 
     /// Calculate the next request and return it.
-    pub(super) fn next_request(&mut self) -> Result<v4::SyncRequestList, Error> {
+    pub(super) fn next_request(&self) -> Result<v4::SyncRequestList, Error> {
         self.inner.next_request()
     }
 
@@ -225,7 +225,7 @@ impl SlidingSyncList {
         Ok(new_changes)
     }
 
-    // Reset `Self`.
+    /// Reset `Self`.
     pub(super) fn reset(&self) -> Result<(), Error> {
         self.inner.reset();
 


### PR DESCRIPTION
As noticed by @stefanceriu (thanks!), we don't cancel a long-polling request when we add a new list to the sliding sync. It would make sense to do so, in case the long-polling request was blocked and just waiting for new data to arrive; the new list added could contain more data that could be immediately available.

This also contains a small fix: if the request was cancelled, we could forget about an `unsubscribe` request. Now the unsubscription effectively happens only *after* the response has been received.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1926.