### PR TITLE
refactor(crypto): get_or_load never returns crypto error

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -586,9 +586,7 @@ impl GossipMachine {
         let outbound_session = self
             .outbound_group_sessions
             .get_with_id(session.room_id(), session.session_id())
-            .await
-            .ok()
-            .flatten();
+            .await;
 
         // If this is our own, verified device, we share the entire session from the
         // earliest known index.

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -583,10 +583,8 @@ impl GossipMachine {
         use super::KeyForwardDecision;
         use crate::olm::ShareState;
 
-        let outbound_session = self
-            .outbound_group_sessions
-            .get_with_id(session.room_id(), session.session_id())
-            .await;
+        let outbound_session =
+            self.outbound_group_sessions.get_with_id(session.room_id(), session.session_id()).await;
 
         // If this is our own, verified device, we share the entire session from the
         // earliest known index.


### PR DESCRIPTION
<!-- description of the changes in this PR -->

GroupSessions#get_or_load() was changed to catch CryptoStore errors and return None, but the `fn` was still returning a Result

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
