### PR TITLE
feat(sdk): `SlidingSync::add_list` has an immediate effect

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -189,10 +189,10 @@ impl SlidingSyncRoom {
     pub fn add_timeline_listener(
         &self,
         listener: Box<dyn TimelineListener>,
-    ) -> Result<SlidingSyncSubscribeResult, ClientError> {
+    ) -> Result<SlidingSyncAddTimelineListenerResult, ClientError> {
         let (items, stoppable_spawn) = self.add_timeline_listener_inner(listener)?;
 
-        Ok(SlidingSyncSubscribeResult { items, task_handle: Arc::new(stoppable_spawn) })
+        Ok(SlidingSyncAddTimelineListenerResult { items, task_handle: Arc::new(stoppable_spawn) })
     }
 
     pub fn subscribe_to_room(&self, settings: Option<RoomSubscription>) -> Arc<TaskHandle> {
@@ -294,7 +294,7 @@ impl SlidingSyncRoom {
 }
 
 #[derive(uniffi::Record)]
-pub struct SlidingSyncSubscribeResult {
+pub struct SlidingSyncAddTimelineListenerResult {
     pub items: Vec<Arc<TimelineItem>>,
     pub task_handle: Arc<TaskHandle>,
 }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -159,6 +159,7 @@ impl SlidingSync {
     pub async fn unsubscribe_from_room(&self, room_id: OwnedRoomId) -> Result<()> {
         // If removing the subscription was successful…
         if self.inner.room_subscriptions.write().unwrap().remove(&room_id).is_some() {
+            // … then keep the unsubscription for the next request.
             self.inner.room_unsubscriptions.write().unwrap().insert(room_id);
             self.inner.internal_channel_send(SlidingSyncInternalMessage::ContinueSyncLoop).await?;
         }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -750,7 +750,7 @@ mod test {
         api::client::sync::sync_events::v4::{E2EEConfig, ToDeviceConfig},
         room_id,
     };
-    use wiremock::{http::Method, Match, MockServer, Request};
+    use wiremock::MockServer;
 
     use super::*;
     use crate::test_utils::logged_in_client;
@@ -793,15 +793,6 @@ mod test {
         );
 
         Ok(())
-    }
-
-    struct SlidingSyncMatcher;
-
-    impl Match for SlidingSyncMatcher {
-        fn matches(&self, request: &Request) -> bool {
-            request.url.path() == "/_matrix/client/unstable/org.matrix.msc3575/sync"
-                && request.method == Method::Post
-        }
     }
 
     async fn new_sliding_sync(


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1926, https://github.com/matrix-org/matrix-rust-sdk/pull/1936.

`SlidingSync::add_list` now sends `SlidingSyncInternalMessage::ContinueSyncLoop` once the list is added.

To make this work correctly, `add_list`, along with `subscribe_to_room` and `unsubscribe_to_room` become async.

New tests are added to ensure Tokio doesn't emit a panic.

On the FFI side:

* `SlidingSync::add_list` now returns an `Arc<TaskHandle>`
* `SlidingSync::subscribe` is renamed to `::subscribe_to_room`, and returns an `Arc<TaskHandle>`
* `SlidingSync::unsubscribe` is renamed to `::unsubscribe_to_room`, and returns an `Arc<TaskHandle>`
* `SlidingSyncRoom::subscribe_and_add_timeline_listener` is replaced by new methods: `SlidingSyncRoom::subscribe_to_room` and `SlidingSyncRoom::unsubscribe_to_room`, the `::add_timeline_listener` method already exists

Finally, a small clean up, the `SlidingSyncSubscribeResult` type is renamed `SlidingSyncAddTimelineListenerResult` as… it was… never used for subscription results, but always for `add_timeline_listener` result.
