### PR TITLE
feat(sdk): `SlidingSyncMode` has richer variants

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -46,15 +46,6 @@ enum SlidingSyncState {
     "FullyLoaded",
 };
 
-enum SlidingSyncMode {
-    /// Sync up the entire room list first, page by page
-    "Paging",
-    /// Sync up the entire room list first through a growing window
-    "Growing",
-    /// Only ever sync the currently selected window
-    "Selective",
-};
-
 callback interface SlidingSyncListStateObserver {
     void did_receive_update(SlidingSyncState new_state);
 };

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -469,9 +469,33 @@ impl SlidingSyncListBuilder {
         Arc::new(Self { inner: matrix_sdk::SlidingSyncList::builder(name) })
     }
 
-    pub fn sync_mode(self: Arc<Self>, mode: SlidingSyncMode) -> Arc<Self> {
+    pub fn sync_mode_selective(self: Arc<Self>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.sync_mode(mode);
+        builder.inner = builder.inner.sync_mode(SlidingSyncMode::new_selective());
+        Arc::new(builder)
+    }
+
+    pub fn sync_mode_paging(
+        self: Arc<Self>,
+        batch_size: u32,
+        maximum_number_of_rooms_to_fetch: Option<u32>,
+    ) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder
+            .inner
+            .sync_mode(SlidingSyncMode::new_paging(batch_size, maximum_number_of_rooms_to_fetch));
+        Arc::new(builder)
+    }
+
+    pub fn sync_mode_growing(
+        self: Arc<Self>,
+        batch_size: u32,
+        maximum_number_of_rooms_to_fetch: Option<u32>,
+    ) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder
+            .inner
+            .sync_mode(SlidingSyncMode::new_growing(batch_size, maximum_number_of_rooms_to_fetch));
         Arc::new(builder)
     }
 
@@ -498,24 +522,6 @@ impl SlidingSyncListBuilder {
     pub fn no_filters(self: Arc<Self>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.filters(None);
-        Arc::new(builder)
-    }
-
-    pub fn batch_size(self: Arc<Self>, batch_size: u32) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.full_sync_batch_size(batch_size);
-        Arc::new(builder)
-    }
-
-    pub fn room_limit(self: Arc<Self>, limit: u32) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.full_sync_maximum_number_of_rooms_to_fetch(limit);
-        Arc::new(builder)
-    }
-
-    pub fn no_room_limit(self: Arc<Self>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.full_sync_maximum_number_of_rooms_to_fetch(None);
         Arc::new(builder)
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -74,7 +74,7 @@ are **inclusive**) like so:
 use ruma::{assign, api::client::sync::sync_events::v4};
 
 let list_builder = SlidingSyncList::builder("main_list")
-    .sync_mode(SlidingSyncMode::new_selective())
+    .sync_mode(SlidingSyncMode::Selective)
     .filters(Some(assign!(
         v4::SyncRequestListFilters::default(), { is_dm: Some(true)}
     )))
@@ -423,14 +423,14 @@ let sliding_sync_builder = client
     .storage_key(Some("example-cache".to_owned())); // we want these to be loaded from and stored into the persistent storage
 
 let full_sync_list = SlidingSyncList::builder(&full_sync_list_name)
-    .sync_mode(SlidingSyncMode::new_growing(50, Some(500)))  // sync up by growing the window of 50 rooms, up to 500 rooms
+    .sync_mode(SlidingSyncMode::Growing { batch_size: 50, maximum_number_of_rooms_to_fetch: Some(500) }) // sync up by growing the window
     .sort(vec!["by_recency".to_owned()]) // ordered by most recent
     .required_state(vec![
         (StateEventType::RoomEncryption, "".to_owned())
      ]); // only want to know if the room is encrypted
 
 let active_list = SlidingSyncList::builder(&active_list_name) // the active window
-    .sync_mode(SlidingSyncMode::new_selective())  // sync up the specific range only
+    .sync_mode(SlidingSyncMode::Selective)  // sync up the specific range only
     .set_range(0u32..=9) // only the top 10 items
     .sort(vec!["by_recency".to_owned()]) // last active
     .timeline_limit(5u32) // add the last 5 timeline items for room preview and faster timeline loading

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -427,7 +427,7 @@ let full_sync_list = SlidingSyncList::builder(&full_sync_list_name)
     .sort(vec!["by_recency".to_owned()]) // ordered by most recent
     .required_state(vec![
         (StateEventType::RoomEncryption, "".to_owned())
-     ]) // only want to know if the room is encrypted
+     ]); // only want to know if the room is encrypted
 
 let active_list = SlidingSyncList::builder(&active_list_name) // the active window
     .sync_mode(SlidingSyncMode::new_selective())  // sync up the specific range only

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::Sender;
 
 use super::{
     super::SlidingSyncInternalMessage, Bound, SlidingSyncList, SlidingSyncListCachePolicy,
-    SlidingSyncListInner, SlidingSyncMode, SlidingSyncState,
+    SlidingSyncListInner, SlidingSyncListRequestGenerator, SlidingSyncMode, SlidingSyncState,
 };
 use crate::{
     sliding_sync::{cache::restore_sliding_sync_list, FrozenSlidingSyncRoom},
@@ -212,7 +212,9 @@ impl SlidingSyncListBuilder {
                 cache_policy: self.cache_policy,
 
                 // Computed from the builder.
-                request_generator: StdRwLock::new(self.sync_mode.into()),
+                request_generator: StdRwLock::new(SlidingSyncListRequestGenerator::new(
+                    self.sync_mode,
+                )),
 
                 // Values read from deserialization, or that are still equal to the default values
                 // otherwise.

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -912,10 +912,7 @@ pub enum SlidingSyncMode {
 impl SlidingSyncMode {
     /// Return whether an external caller can modify the sync mode's ranges.
     fn ranges_can_be_modified_by_user(&self) -> bool {
-        match self {
-            Self::Selective => true,
-            Self::Paging { .. } | Self::Growing { .. } => false,
-        }
+        matches!(self, Self::Selective)
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -77,6 +77,34 @@ pub(in super::super) struct SlidingSyncListRequestGenerator {
 }
 
 impl SlidingSyncListRequestGenerator {
+    pub(super) fn new(sync_mode: SlidingSyncMode) -> Self {
+        match sync_mode {
+            SlidingSyncMode::Paging { batch_size, maximum_number_of_rooms_to_fetch } => Self {
+                ranges: Vec::new(),
+                kind: SlidingSyncListRequestGeneratorKind::Paging {
+                    batch_size,
+                    maximum_number_of_rooms_to_fetch,
+                    number_of_fetched_rooms: 0,
+                    fully_loaded: false,
+                },
+            },
+
+            SlidingSyncMode::Growing { batch_size, maximum_number_of_rooms_to_fetch } => Self {
+                ranges: Vec::new(),
+                kind: SlidingSyncListRequestGeneratorKind::Growing {
+                    batch_size,
+                    maximum_number_of_rooms_to_fetch,
+                    number_of_fetched_rooms: 0,
+                    fully_loaded: false,
+                },
+            },
+
+            SlidingSyncMode::Selective => {
+                Self { ranges: Vec::new(), kind: SlidingSyncListRequestGeneratorKind::Selective }
+            }
+        }
+    }
+
     pub(super) fn reset(&mut self) {
         // Reset the ranges.
         self.ranges.clear();
@@ -107,36 +135,6 @@ impl SlidingSyncListRequestGenerator {
             SlidingSyncListRequestGeneratorKind::Paging { fully_loaded, .. }
             | SlidingSyncListRequestGeneratorKind::Growing { fully_loaded, .. } => fully_loaded,
             SlidingSyncListRequestGeneratorKind::Selective => true,
-        }
-    }
-}
-
-impl From<SlidingSyncMode> for SlidingSyncListRequestGenerator {
-    fn from(sync_mode: SlidingSyncMode) -> Self {
-        match sync_mode {
-            SlidingSyncMode::Paging { batch_size, maximum_number_of_rooms_to_fetch } => Self {
-                ranges: Vec::new(),
-                kind: SlidingSyncListRequestGeneratorKind::Paging {
-                    batch_size,
-                    maximum_number_of_rooms_to_fetch,
-                    number_of_fetched_rooms: 0,
-                    fully_loaded: false,
-                },
-            },
-
-            SlidingSyncMode::Growing { batch_size, maximum_number_of_rooms_to_fetch } => Self {
-                ranges: Vec::new(),
-                kind: SlidingSyncListRequestGeneratorKind::Growing {
-                    batch_size,
-                    maximum_number_of_rooms_to_fetch,
-                    number_of_fetched_rooms: 0,
-                    fully_loaded: false,
-                },
-            },
-
-            SlidingSyncMode::Selective => {
-                Self { ranges: Vec::new(), kind: SlidingSyncListRequestGeneratorKind::Selective }
-            }
         }
     }
 }
@@ -234,7 +232,7 @@ mod tests {
     #[test]
     fn test_request_generator_selective_from_sync_mode() {
         let sync_mode = SlidingSyncMode::new_selective();
-        let request_generator = SlidingSyncListRequestGenerator::from(sync_mode);
+        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode);
 
         assert!(request_generator.ranges.is_empty());
         assert_eq!(request_generator.kind, SlidingSyncListRequestGeneratorKind::Selective);
@@ -243,7 +241,7 @@ mod tests {
     #[test]
     fn test_request_generator_paging_from_sync_mode() {
         let sync_mode = SlidingSyncMode::new_paging(1, Some(2));
-        let request_generator = SlidingSyncListRequestGenerator::from(sync_mode);
+        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode);
 
         assert!(request_generator.ranges.is_empty());
         assert_eq!(
@@ -260,7 +258,7 @@ mod tests {
     #[test]
     fn test_request_generator_growing_from_sync_mode() {
         let sync_mode = SlidingSyncMode::new_growing(1, Some(2));
-        let request_generator = SlidingSyncListRequestGenerator::from(sync_mode);
+        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode);
 
         assert!(request_generator.ranges.is_empty());
         assert_eq!(

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -31,7 +31,7 @@
 
 use std::{cmp::min, ops::RangeInclusive};
 
-use super::Bound;
+use super::{Bound, SlidingSyncMode};
 use crate::sliding_sync::Error;
 
 /// The kind of request generator.
@@ -77,43 +77,6 @@ pub(in super::super) struct SlidingSyncListRequestGenerator {
 }
 
 impl SlidingSyncListRequestGenerator {
-    /// Create a new request generator configured for paging-mode.
-    pub(super) fn new_paging(
-        batch_size: u32,
-        maximum_number_of_rooms_to_fetch: Option<u32>,
-    ) -> Self {
-        Self {
-            ranges: Vec::new(),
-            kind: SlidingSyncListRequestGeneratorKind::Paging {
-                batch_size,
-                maximum_number_of_rooms_to_fetch,
-                number_of_fetched_rooms: 0,
-                fully_loaded: false,
-            },
-        }
-    }
-
-    /// Create a new request generator configured for growing-mode.
-    pub(super) fn new_growing(
-        batch_size: u32,
-        maximum_number_of_rooms_to_fetch: Option<u32>,
-    ) -> Self {
-        Self {
-            ranges: Vec::new(),
-            kind: SlidingSyncListRequestGeneratorKind::Growing {
-                batch_size,
-                maximum_number_of_rooms_to_fetch,
-                number_of_fetched_rooms: 0,
-                fully_loaded: false,
-            },
-        }
-    }
-
-    /// Create a new request generator configured for selective-mode.
-    pub(super) fn new_selective() -> Self {
-        Self { ranges: Vec::new(), kind: SlidingSyncListRequestGeneratorKind::Selective }
-    }
-
     pub(super) fn reset(&mut self) {
         // Reset the ranges.
         self.ranges.clear();
@@ -144,6 +107,36 @@ impl SlidingSyncListRequestGenerator {
             SlidingSyncListRequestGeneratorKind::Paging { fully_loaded, .. }
             | SlidingSyncListRequestGeneratorKind::Growing { fully_loaded, .. } => fully_loaded,
             SlidingSyncListRequestGeneratorKind::Selective => true,
+        }
+    }
+}
+
+impl From<SlidingSyncMode> for SlidingSyncListRequestGenerator {
+    fn from(sync_mode: SlidingSyncMode) -> Self {
+        match sync_mode {
+            SlidingSyncMode::Paging { batch_size, maximum_number_of_rooms_to_fetch } => Self {
+                ranges: Vec::new(),
+                kind: SlidingSyncListRequestGeneratorKind::Paging {
+                    batch_size,
+                    maximum_number_of_rooms_to_fetch,
+                    number_of_fetched_rooms: 0,
+                    fully_loaded: false,
+                },
+            },
+
+            SlidingSyncMode::Growing { batch_size, maximum_number_of_rooms_to_fetch } => Self {
+                ranges: Vec::new(),
+                kind: SlidingSyncListRequestGeneratorKind::Growing {
+                    batch_size,
+                    maximum_number_of_rooms_to_fetch,
+                    number_of_fetched_rooms: 0,
+                    fully_loaded: false,
+                },
+            },
+
+            SlidingSyncMode::Selective => {
+                Self { ranges: Vec::new(), kind: SlidingSyncListRequestGeneratorKind::Selective }
+            }
         }
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -121,6 +121,8 @@ pub(super) struct SlidingSyncInner {
     /// calls. May contain the latest next_batch for to_devices, etc.
     extensions: Mutex<Option<ExtensionsConfig>>,
 
+    /// Internal channel used to pass messages between Sliding Sync and other
+    /// types.
     internal_channel:
         (Sender<SlidingSyncInternalMessage>, AsyncRwLock<Receiver<SlidingSyncInternalMessage>>),
 }


### PR DESCRIPTION
Address https://github.com/matrix-org/matrix-rust-sdk/issues/1911.

`SlidingSyncMode` was previously declared as:

```rust
enum SlidingSyncMode {
    Selective,
    Paging,
    Growing,
}
```

Now, the new declaration is:

```rust
enum SlidingSyncMode {
    Selective,
    Paging {
        batch_size: u32,
        maximum_number_of_rooms_to_fetch: Option<u32>,
    },
    Growing {
        batch_size: u32,
        maximum_number_of_rooms_to_fetch: Option<u32>,
    }
}
```

First off, it helps to remove the `full_sync_batch_size` and
`full_sync_maximum_number_of_rooms_to_fetch` methods and fields from
`SlidingSyncListBuilder`. It was containing default values in case of.
That was useless and needed to be fixed. Also, calling a `full_sync_*`
method with the `Selective` mode had no effect, which could disturb
the user. Well, now everything is clean on that front.

Second, `SlidingSyncListRequestGenerator` no longer has constructors,
but a `From<SlidingSyncMode>` implementation. However, the constructors
now live in `SlidingSyncMode` with `new_selective`, `new_paging` and
`new_growing` methods which are helpers. All in all, it makes creating a
`SlidingSyncListRequestGeneator` simpler: just call `sync_mode.into()`
and boom.

Finally, this patch removes the `default_with_fullsync` list builder
helper, which makes no sense at all.

On the FFI side, this patch replaces `sync_mode` on `SlidingSyncListBuilder` by
`sync_mode_selective`, `sync_mode_paging` and `sync_mode_growing`, which
removes the need to use `SlidingSyncMode` directly.

This patch also removes `batch_size`, `room_limit` and `no_room_limit`
as it's now arguments of `sync_mode_paging` and `sync_mode_growing`.