### PR TITLE
feat(sdk): Implement `SlidingSyncList::set_sync_mode`

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -202,7 +202,7 @@ impl SlidingSyncListBuilder {
         let list = SlidingSyncList {
             inner: Arc::new(SlidingSyncListInner {
                 // From the builder
-                sync_mode: self.sync_mode.clone(),
+                sync_mode: StdRwLock::new(self.sync_mode.clone()),
                 sort: self.sort,
                 required_state: self.required_state,
                 filters: self.filters,

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -1223,7 +1223,7 @@ mod tests {
             maximum_number_of_rooms = $maximum_number_of_rooms:expr,
             $(
                 next => {
-                    ranges = $( [ $range_start:literal ; $range_end:literal ] ),* ,
+                    ranges = $( $range_start:literal ..= $range_end:literal ),* ,
                     is_fully_loaded = $is_fully_loaded:expr,
                     list_state = $list_state:ident,
                 }
@@ -1276,29 +1276,29 @@ mod tests {
             list_state = NotLoaded,
             maximum_number_of_rooms = 25,
             next => {
-                ranges = [0; 9],
+                ranges = 0..=9,
                 is_fully_loaded = false,
                 list_state = PartiallyLoaded,
             },
             next => {
-                ranges = [10; 19],
+                ranges = 10..=19,
                 is_fully_loaded = false,
                 list_state = PartiallyLoaded,
             },
             // The maximum number of rooms is reached!
             next => {
-                ranges = [20; 24],
+                ranges = 20..=24,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             // Now it's fully loaded, so the same request must be produced everytime.
             next => {
-                ranges = [0; 24], // the range starts at 0 now!
+                ranges = 0..=24, // the range starts at 0 now!
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             next => {
-                ranges = [0; 24],
+                ranges = 0..=24,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
@@ -1318,29 +1318,29 @@ mod tests {
             list_state = NotLoaded,
             maximum_number_of_rooms = 25,
             next => {
-                ranges = [0; 9],
+                ranges = 0..=9,
                 is_fully_loaded = false,
                 list_state = PartiallyLoaded,
             },
             next => {
-                ranges = [10; 19],
+                ranges = 10..=19,
                 is_fully_loaded = false,
                 list_state = PartiallyLoaded,
             },
             // The maximum number of rooms to fetch is reached!
             next => {
-                ranges = [20; 21],
+                ranges = 20..=21,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             // Now it's fully loaded, so the same request must be produced everytime.
             next => {
-                ranges = [0; 21], // the range starts at 0 now!
+                ranges = 0..=21, // the range starts at 0 now!
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             next => {
-                ranges = [0; 21],
+                ranges = 0..=21,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
@@ -1360,29 +1360,29 @@ mod tests {
             list_state = NotLoaded,
             maximum_number_of_rooms = 25,
             next => {
-                ranges = [0; 9],
+                ranges = 0..=9,
                 is_fully_loaded = false,
                 list_state = PartiallyLoaded,
             },
             next => {
-                ranges = [0; 19],
+                ranges = 0..=19,
                 is_fully_loaded = false,
                 list_state = PartiallyLoaded,
             },
             // The maximum number of rooms is reached!
             next => {
-                ranges = [0; 24],
+                ranges = 0..=24,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             // Now it's fully loaded, so the same request must be produced everytime.
             next => {
-                ranges = [0; 24],
+                ranges = 0..=24,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             next => {
-                ranges = [0; 24],
+                ranges = 0..=24,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
@@ -1402,29 +1402,29 @@ mod tests {
             list_state = NotLoaded,
             maximum_number_of_rooms = 25,
             next => {
-                ranges = [0; 9],
+                ranges = 0..=9,
                 is_fully_loaded = false,
                 list_state = PartiallyLoaded,
             },
             next => {
-                ranges = [0; 19],
+                ranges = 0..=19,
                 is_fully_loaded = false,
                 list_state = PartiallyLoaded,
             },
             // The maximum number of rooms is reached!
             next => {
-                ranges = [0; 21],
+                ranges = 0..=21,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             // Now it's fully loaded, so the same request must be produced everytime.
             next => {
-                ranges = [0; 21],
+                ranges = 0..=21,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             next => {
-                ranges = [0; 21],
+                ranges = 0..=21,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
@@ -1446,18 +1446,18 @@ mod tests {
             maximum_number_of_rooms = 25,
             // The maximum number of rooms is reached directly!
             next => {
-                ranges = [0; 10], [42; 153],
+                ranges = 0..=10, 42..=153,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             // Now it's fully loaded, so the same request must be produced everytime.
             next => {
-                ranges = [0; 10], [42; 153],
+                ranges = 0..=10, 42..=153,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             next => {
-                ranges = [0; 10], [42; 153],
+                ranges = 0..=10, 42..=153,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             }
@@ -1479,18 +1479,18 @@ mod tests {
             maximum_number_of_rooms = 25,
             // The maximum number of rooms is reached directly!
             next => {
-                ranges = [0; 10], [42; 153],
+                ranges = 0..=10, 42..=153,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             // Now it's fully loaded, so the same request must be produced everytime.
             next => {
-                ranges = [0; 10], [42; 153],
+                ranges = 0..=10, 42..=153,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
             next => {
-                ranges = [0; 10], [42; 153],
+                ranges = 0..=10, 42..=153,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             }
@@ -1503,7 +1503,7 @@ mod tests {
             list_state = PartiallyLoaded,
             maximum_number_of_rooms = 25,
             next => {
-                ranges = [3; 7],
+                ranges = 3..=7,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
@@ -1516,7 +1516,7 @@ mod tests {
             list_state = PartiallyLoaded,
             maximum_number_of_rooms = 25,
             next => {
-                ranges = [3; 7], [10; 23],
+                ranges = 3..=7, 10..=23,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },
@@ -1529,7 +1529,7 @@ mod tests {
             list_state = PartiallyLoaded,
             maximum_number_of_rooms = 25,
             next => {
-                ranges = [42; 77],
+                ranges = 42..=77,
                 is_fully_loaded = true,
                 list_state = FullyLoaded,
             },

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -66,9 +66,9 @@ impl SlidingSyncList {
     ///
     /// This will change the sync-mode but also the request generator.
     ///
-    /// The ranges and the state will be updated when the next request will be sent
-    /// and a response will be received. The maximum number of rooms won't
-    /// change.
+    /// The ranges and the state will be updated when the next request will be
+    /// sent and a response will be received. The maximum number of rooms
+    /// won't change.
     pub fn set_sync_mode(&self, sync_mode: SlidingSyncMode) {
         self.inner.set_sync_mode(sync_mode);
     }

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -209,6 +209,9 @@ impl SlidingSyncList {
     }
 
     /// Calculate the next request and return it.
+    ///
+    /// The next request is entirely calculated based on the request generator
+    /// ([`SlidingSyncListRequestGenerator`]).
     pub(super) fn next_request(&mut self) -> Result<v4::SyncRequestList, Error> {
         self.inner.next_request()
     }

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -318,7 +318,7 @@ impl SlidingSyncListInner {
     /// This will change the sync-mode but also the request generator.
     ///
     /// [`Self::ranges`] and [`Self::state`] will be updated when the next
-    /// request will sent and a response will be received. The
+    /// request will be sent and a response will be received. The
     /// [`Self::maximum_number_of_rooms`] won't change.
     pub fn set_sync_mode(&self, sync_mode: SlidingSyncMode) {
         // Acquire both locks before modifying the values their hold.

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -66,7 +66,7 @@ impl SlidingSyncList {
     ///
     /// This will change the sync-mode but also the request generator.
     ///
-    /// The ranges and the state will be updated when the next request will sent
+    /// The ranges and the state will be updated when the next request will be sent
     /// and a response will be received. The maximum number of rooms won't
     /// change.
     pub fn set_sync_mode(&self, sync_mode: SlidingSyncMode) {

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -67,7 +67,7 @@ impl SlidingSyncList {
     /// This will change the sync-mode but also the request generator. A new
     /// request generator is generated. Since requests are calculated based on
     /// the request generator, changing the sync-mode is equivalent to
-    /// “resetting” the list. It's actually not calling [`Self::reset`], which
+    /// “resetting” the list. It's actually not calling `Self::reset`, which
     /// means that the state is not reset **purposely**. The ranges and the
     /// state will be updated when the next request will be sent and a
     /// response will be received. The maximum number of rooms won't change.

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -667,10 +667,9 @@ impl SlidingSyncListInner {
         &self,
         message: SlidingSyncInternalMessage,
     ) -> Result<(), Error> {
-        Ok(self
-            .sliding_sync_internal_channel_sender
+        self.sliding_sync_internal_channel_sender
             .blocking_send(message)
-            .map_err(|_| Error::InternalChannelIsBroken)?)
+            .map_err(|_| Error::InternalChannelIsBroken)
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -152,7 +152,9 @@ impl SlidingSync {
             .write()
             .unwrap()
             .insert(room_id, settings.unwrap_or_default());
-        self.inner.internal_channel_send(SlidingSyncInternalMessage::ContinueSyncLoop).await?;
+        self.inner
+            .internal_channel_send(SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration)
+            .await?;
 
         Ok(())
     }
@@ -163,7 +165,9 @@ impl SlidingSync {
         if self.inner.room_subscriptions.write().unwrap().remove(&room_id).is_some() {
             // … then keep the unsubscription for the next request.
             self.inner.room_unsubscriptions.write().unwrap().insert(room_id);
-            self.inner.internal_channel_send(SlidingSyncInternalMessage::ContinueSyncLoop).await?;
+            self.inner
+                .internal_channel_send(SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration)
+                .await?;
         }
 
         Ok(())
@@ -230,7 +234,9 @@ impl SlidingSync {
         list_builder: SlidingSyncListBuilder,
     ) -> Result<Option<SlidingSyncList>> {
         let list = list_builder.build(self.inner.internal_channel.0.clone());
-        self.inner.internal_channel_send(SlidingSyncInternalMessage::ContinueSyncLoop).await?;
+        self.inner
+            .internal_channel_send(SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration)
+            .await?;
 
         Ok(self.inner.lists.write().unwrap().insert(list.name().to_owned(), list))
     }
@@ -591,11 +597,11 @@ impl SlidingSync {
                         use SlidingSyncInternalMessage::*;
 
                         match internal_message {
-                            None | Some(BreakSyncLoop) => {
+                            None | Some(SyncLoopStop) => {
                                 break;
                             }
 
-                            Some(ContinueSyncLoop) => {
+                            Some(SyncLoopSkipOverCurrentIteration) => {
                                 continue;
                             }
                         }
@@ -683,9 +689,13 @@ impl SlidingSyncInner {
 
 #[derive(Debug)]
 enum SlidingSyncInternalMessage {
+    /// Instruct the sync loop to stop.
     #[allow(unused)] // temporary
-    BreakSyncLoop,
-    ContinueSyncLoop,
+    SyncLoopStop,
+
+    /// Instruct the sync loop to skip over any remaining work in its iteration,
+    /// and to jump to the next iteration.
+    SyncLoopSkipOverCurrentIteration,
 }
 
 #[cfg(any(test, feature = "testing"))]


### PR DESCRIPTION
Address #1911.

Changing the sync-mode of a list on-the-fly is necessary to optimise the
new `RoomList` API. For example, we can start with a list in a selective
mode, a range of `0..=50` and a `timeline_limit=0` to fetch the
beginning of the room list, and then _change_ the sync-mode to growing
to continue to sync the room list in the background.

Today, this is done with 2 lists and a merge of the lists, but
(i) this is error-prone, (ii) this is not optimal. Thanks to
`SlidingSyncList::set_sync_mode`, merging lists is no more necessary,
thus removing a class of bugs in client's code.

This patch then implements `SlidingSyncList::set_sync_mode` and adds
the necessary test. `set_sync_mode` will skip over the current iteration
of the sync loop automatically, but it won't reset the list.