### PR TITLE
fix(ci): Fix path to `matrix-sdk-crypto-js` and allow `pushd` to return an error

### DIFF
--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -373,7 +373,7 @@ fn run_wasm_pack_tests(cmd: Option<WasmFeatureSet>) -> Result<()> {
     ]);
 
     let run = |(folder, arg_set): (&str, &str)| {
-        let _ = pushd(folder)?;
+        let _pwd = pushd(folder)?;
         cmd!("pwd").env(WASM_TIMEOUT_ENV_KEY, WASM_TIMEOUT_VALUE).run()?; // print dir so we know what might have failed
         cmd!("wasm-pack test --node -- ")
             .args(arg_set.split_whitespace())


### PR DESCRIPTION
First off, this patch changes `pushd(…)` to `pushd(…)?` so that errors are propagated.

Second, instead of assuming that all crates live in `crates/`, let's allow to precise a prefix, like `crates/` or `bindings/` directly in the “folder” path of `args`.