### PR TITLE
Replace the libolm backup encryption code with a native Rust version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,6 +2741,7 @@ dependencies = [
  "base64 0.21.0",
  "bs58",
  "byteorder",
+ "cbc",
  "cfg-if",
  "ctor 0.2.0",
  "ctr",
@@ -2749,6 +2750,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
+ "hkdf",
  "hmac",
  "http",
  "indoc",
@@ -5760,7 +5762,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vodozemac"
 version = "0.3.0"
-source = "git+https://github.com/matrix-org/vodozemac?rev=03f87573f704caf00273be6a77b017ccb5f3de75#03f87573f704caf00273be6a77b017ccb5f3de75"
+source = "git+https://github.com/matrix-org/vodozemac?rev=195ae1c9112fd602358b3373dc662573707e57e5#195ae1c9112fd602358b3373dc662573707e57e5"
 dependencies = [
  "aes",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-core = "0.1.30"
 uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "75b9df455d1b67d25291c09634ff22160e4abcbf" }
 uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "75b9df455d1b67d25291c09634ff22160e4abcbf" }
-vodozemac = { git = "https://github.com/matrix-org/vodozemac", rev = "03f87573f704caf00273be6a77b017ccb5f3de75" }
+vodozemac = { git = "https://github.com/matrix-org/vodozemac", rev = "195ae1c9112fd602358b3373dc662573707e57e5" }
 zeroize = "1.3.0"
 
 # Default release profile, select with `--release`

--- a/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, iter, ops::DerefMut, sync::Arc};
 
 use hmac::Hmac;
 use matrix_sdk_crypto::{
-    backups::OlmPkDecryptionError,
+    backups::DecryptionError,
     store::{CryptoStoreError as InnerStoreError, RecoveryKey},
 };
 use pbkdf2::pbkdf2;
@@ -24,7 +24,7 @@ pub struct BackupRecoveryKey {
 pub enum PkDecryptionError {
     /// An internal libolm error happened during decryption.
     #[error("Error decryption a PkMessage {0}")]
-    Olm(#[from] OlmPkDecryptionError),
+    Olm(#[from] DecryptionError),
 }
 
 /// Error type for the decoding and storing of the backup key.
@@ -164,6 +164,6 @@ impl BackupRecoveryKey {
         mac: String,
         ciphertext: String,
     ) -> Result<String, PkDecryptionError> {
-        self.inner.decrypt_v1(ephemeral_key, mac, ciphertext).map_err(|e| e.into())
+        self.inner.decrypt_v1(&ephemeral_key, &mac, &ciphertext).map_err(|e| e.into())
     }
 }

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,4 +1,7 @@
 # v0.7.0
 
+- Replace the libolm backup encryption code with a native Rust version. This
+  adds WASM support to the backups_v1 feature.
+
 - Add new API `store::Store::room_keys_received_stream` to provide
   updates of room keys being received.

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -19,7 +19,7 @@ default = ["automatic-room-key-forwarding"]
 automatic-room-key-forwarding = []
 js = ["ruma/js", "vodozemac/js"]
 qrcode = ["dep:matrix-sdk-qrcode"]
-backups_v1 = ["dep:olm-rs", "dep:bs58"]
+backups_v1 = ["dep:bs58", "dep:cbc", "dep:hkdf"]
 experimental-algorithms = []
 
 # Testing helpers for implementations based upon this
@@ -33,17 +33,19 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 bs58 = { version = "0.4.0", optional = true }
 byteorder = { workspace = true }
+cbc = { version = "0.1.2", features = ["std"], optional = true }
+cfg-if = "1.0"
 ctr = "0.9.1"
 dashmap = { workspace = true }
 eyeball = { workspace = true }
 futures-core = "0.3.24"
 futures-util = { workspace = true }
+hkdf = { version = "0.12.3", optional = true }
 hmac = "0.12.1"
 http = { workspace = true, optional = true } # feature = testing only
 itertools = "0.10.5"
 matrix-sdk-qrcode = { version = "0.4.0", path = "../matrix-sdk-qrcode", optional = true }
 matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
-olm-rs = { version = "2.2.0", features = ["serde"], optional = true }
 pbkdf2 = { version = "0.11.0", default-features = false }
 rand = "0.8.5"
 ruma = { workspace = true, features = ["rand", "canonical-json", "unstable-msc2677"] }
@@ -51,13 +53,12 @@ serde = { workspace = true, features = ["derive", "rc"] }
 rmp-serde = "1.1.1"
 serde_json = { workspace = true }
 sha2 = "0.10.2"
+tokio-stream = { version = "0.1.12", features = ["sync"] }
+tokio = { workspace = true, default-features = false, features = ["sync"] }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 vodozemac = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
-cfg-if = "1.0"
-tokio-stream = { version = "0.1.12", features = ["sync"] }
-tokio = { workspace = true, default-features = false, features = ["sync"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { workspace = true }
@@ -73,6 +74,7 @@ futures = { version = "0.3.21", features = ["executor"] }
 http = { workspace = true }
 indoc = "1.0.4"
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
+olm-rs = { version = "2.2.0", features = ["serde"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 # required for async_test macro
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -17,20 +17,20 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use olm_rs::pk::OlmPkEncryption;
 use ruma::{
     api::client::backup::{KeyBackupData, KeyBackupDataInit, SessionDataInit},
     serde::Base64,
     OwnedDeviceKeyId, OwnedUserId,
 };
+use vodozemac::Curve25519PublicKey;
 use zeroize::Zeroizing;
 
-use super::recovery::DecodeError;
+use super::{compat::PkEncryption, recovery::DecodeError};
 use crate::olm::InboundGroupSession;
 
 #[derive(Debug)]
 struct InnerBackupKey {
-    key: [u8; MegolmV1BackupKey::KEY_SIZE],
+    key: Curve25519PublicKey,
     signatures: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>,
     version: Mutex<Option<String>>,
 }
@@ -52,16 +52,15 @@ impl std::fmt::Debug for MegolmV1BackupKey {
 }
 
 impl MegolmV1BackupKey {
-    const KEY_SIZE: usize = 32;
-
-    pub(super) fn new(public_key: &str, version: Option<String>) -> Self {
-        let key = Self::from_base64(public_key).expect("Invalid backup key");
-
-        if let Some(version) = version {
-            key.set_version(version)
+    pub(super) fn new(key: Curve25519PublicKey, version: Option<String>) -> Self {
+        Self {
+            inner: InnerBackupKey {
+                key,
+                signatures: Default::default(),
+                version: Mutex::new(version),
+            }
+            .into(),
         }
-
-        key
     }
 
     /// Get the full name of the backup algorithm this backup key supports.
@@ -76,24 +75,17 @@ impl MegolmV1BackupKey {
 
     /// Try to create a new `MegolmV1BackupKey` from a base 64 encoded string.
     pub fn from_base64(public_key: &str) -> Result<Self, DecodeError> {
-        let mut key = [0u8; Self::KEY_SIZE];
-        let decoded_key = crate::utilities::decode(public_key)?;
+        let key = Curve25519PublicKey::from_base64(public_key)?;
 
-        if decoded_key.len() != Self::KEY_SIZE {
-            Err(DecodeError::Length(Self::KEY_SIZE, decoded_key.len()))
-        } else {
-            key.copy_from_slice(&decoded_key);
+        let inner =
+            InnerBackupKey { key, signatures: Default::default(), version: Mutex::new(None) };
 
-            let inner =
-                InnerBackupKey { key, signatures: Default::default(), version: Mutex::new(None) };
-
-            Ok(MegolmV1BackupKey { inner: inner.into() })
-        }
+        Ok(MegolmV1BackupKey { inner: inner.into() })
     }
 
     /// Convert the [`MegolmV1BackupKey`] to a base 64 encoded string.
     pub fn to_base64(&self) -> String {
-        crate::utilities::encode(self.inner.key)
+        self.inner.key.to_base64()
     }
 
     /// Get the backup version that this key is used with, if any.
@@ -110,7 +102,7 @@ impl MegolmV1BackupKey {
     }
 
     pub(crate) async fn encrypt(&self, session: InboundGroupSession) -> KeyBackupData {
-        let pk = OlmPkEncryption::new(&self.to_base64());
+        let pk = PkEncryption::from_key(self.inner.key);
 
         // The forwarding chains don't mean much, we only care whether we received the
         // session directly from the creator of the session or not.
@@ -123,23 +115,21 @@ impl MegolmV1BackupKey {
         // The key gets zeroized in `BackedUpRoomKey` but we're creating a copy
         // here that won't, so let's wrap it up in a `Zeroizing` struct.
         let key =
-            Zeroizing::new(serde_json::to_string(&key).expect("Can't serialize exported room key"));
+            Zeroizing::new(serde_json::to_vec(&key).expect("Can't serialize exported room key"));
 
         let message = pk.encrypt(&key);
 
         let session_data = SessionDataInit {
-            ephemeral: Base64::parse(message.ephemeral_key)
-                .expect("Can't decode the base64 encoded ephemeral backup key"),
-            ciphertext: Base64::parse(message.ciphertext)
-                .expect("Can't decode a base64 encoded libolm ciphertext"),
-            mac: Base64::parse(message.mac).expect("Can't decode a base64 encoded MAC"),
+            ephemeral: Base64::new(message.ephemeral_key.to_vec()),
+            ciphertext: Base64::new(message.ciphertext),
+            mac: Base64::new(message.mac),
         }
         .into();
 
         KeyBackupDataInit {
             first_message_index,
             forwarded_count,
-            // TODO is this actually used anywhere? seems to be completely
+            // TODO: is this actually used anywhere? seems to be completely
             // useless and requires us to get the Device out of the store?
             // Also should this be checked at the time of the backup or at the
             // time of the room key receival?

--- a/crates/matrix-sdk-crypto/src/backups/keys/compat.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/compat.rs
@@ -1,0 +1,283 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! ☣️  Compat support for Olm's PkEncryption and PkDecryption
+use aes::{
+    cipher::{
+        block_padding::{Pkcs7, UnpadError},
+        generic_array::GenericArray,
+        BlockDecryptMut, BlockEncryptMut, IvSizeUser, KeyIvInit, KeySizeUser,
+    },
+    Aes256,
+};
+use hkdf::Hkdf;
+use hmac::{digest::MacError, Hmac, Mac as MacT};
+use sha2::Sha256;
+use thiserror::Error;
+use vodozemac::{Curve25519PublicKey, Curve25519SecretKey, KeyError, SharedSecret};
+
+use crate::utilities::decode;
+
+type Aes256CbcEnc = cbc::Encryptor<Aes256>;
+type Aes256CbcDec = cbc::Decryptor<Aes256>;
+type HmacSha256 = Hmac<Sha256>;
+
+type Aes256Key = GenericArray<u8, <Aes256 as KeySizeUser>::KeySize>;
+type Aes256Iv = GenericArray<u8, <Aes256CbcEnc as IvSizeUser>::IvSize>;
+type HmacSha256Key<'a> = &'a [u8; 32];
+
+const MAC_LENGTH: usize = 8;
+
+pub struct PkDecryption {
+    key: Curve25519SecretKey,
+    public_key: Curve25519PublicKey,
+}
+
+struct Keys {
+    aes_key: Box<[u8; 32]>,
+    mac_key: Box<[u8; 32]>,
+    iv: Box<[u8; 16]>,
+}
+
+impl Keys {
+    fn new(shared_secret: SharedSecret) -> Self {
+        let mut expanded_keys = Box::new([0u8; 80]);
+
+        let salt = [0u8; 32];
+        let hkdf: Hkdf<Sha256> = Hkdf::new(Some(&salt), shared_secret.as_bytes());
+
+        hkdf.expand(b"", &mut *expanded_keys)
+            .expect("We should be able to expand the shared secret into 80 bytes");
+
+        let mut aes_key = Box::new([0u8; 32]);
+        let mut mac_key = Box::new([0u8; 32]);
+        let mut iv = Box::new([0u8; 16]);
+
+        aes_key.copy_from_slice(&expanded_keys[0..32]);
+        mac_key.copy_from_slice(&expanded_keys[32..64]);
+        iv.copy_from_slice(&expanded_keys[64..80]);
+
+        Self { aes_key, mac_key, iv }
+    }
+
+    fn aes_key(&self) -> &Aes256Key {
+        Aes256Key::from_slice(self.aes_key.as_slice())
+    }
+
+    fn iv(&self) -> &Aes256Iv {
+        Aes256Iv::from_slice(self.iv.as_slice())
+    }
+
+    fn mac_key(&self) -> HmacSha256Key<'_> {
+        &self.mac_key
+    }
+
+    fn hmac(&self) -> HmacSha256 {
+        let hmac = HmacSha256::new_from_slice(self.mac_key())
+            .expect("We should be able to create a Hmac object from a 32 byte key");
+
+        hmac
+    }
+}
+
+impl PkDecryption {
+    pub fn new() -> Self {
+        let key = Curve25519SecretKey::new();
+        let public_key = Curve25519PublicKey::from(&key);
+
+        Self { key, public_key }
+    }
+
+    pub fn public_key(&self) -> Curve25519PublicKey {
+        self.public_key
+    }
+
+    pub fn decrypt(&self, message: &Message) -> Result<Vec<u8>, Error> {
+        let shared_secret = self.key.diffie_hellman(&message.ephemeral_key);
+
+        let keys = Keys::new(shared_secret);
+
+        let cipher = Aes256CbcDec::new(keys.aes_key(), keys.iv());
+        let decrypted = cipher.decrypt_padded_vec_mut::<Pkcs7>(&message.ciphertext)?;
+
+        let hmac = keys.hmac();
+        hmac.verify_truncated_left(&message.mac)?;
+
+        Ok(decrypted)
+    }
+
+    pub fn from_bytes(bytes: &[u8; 32]) -> Self {
+        let key = Curve25519SecretKey::from_slice(bytes);
+        let public_key = Curve25519PublicKey::from(&key);
+
+        Self { key, public_key }
+    }
+}
+
+impl Default for PkDecryption {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct PkEncryption {
+    public_key: Curve25519PublicKey,
+}
+
+impl From<&PkDecryption> for PkEncryption {
+    fn from(value: &PkDecryption) -> Self {
+        Self::from(value.public_key())
+    }
+}
+
+impl From<Curve25519PublicKey> for PkEncryption {
+    fn from(public_key: Curve25519PublicKey) -> Self {
+        Self { public_key }
+    }
+}
+
+impl PkEncryption {
+    pub fn from_key(public_key: Curve25519PublicKey) -> Self {
+        Self { public_key }
+    }
+
+    pub fn encrypt(&self, message: &[u8]) -> Message {
+        let ephemeral_key = Curve25519SecretKey::new();
+        let shared_secret = ephemeral_key.diffie_hellman(&self.public_key);
+        let keys = Keys::new(shared_secret);
+
+        let cipher = Aes256CbcEnc::new(keys.aes_key(), keys.iv());
+        let ciphertext = cipher.encrypt_padded_vec_mut::<Pkcs7>(message);
+
+        let hmac = keys.hmac();
+        let mut mac = hmac.finalize().into_bytes().to_vec();
+        mac.truncate(MAC_LENGTH);
+
+        Message { ciphertext, mac, ephemeral_key: Curve25519PublicKey::from(&ephemeral_key) }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum MessageDecodeError {
+    #[error(transparent)]
+    Base64(#[from] base64::DecodeError),
+    #[error(transparent)]
+    Key(#[from] KeyError),
+}
+
+pub struct Message {
+    pub ciphertext: Vec<u8>,
+    pub mac: Vec<u8>,
+    pub ephemeral_key: Curve25519PublicKey,
+}
+
+impl Message {
+    pub fn from_base64(
+        ciphertext: &str,
+        mac: &str,
+        ephemeral_key: &str,
+    ) -> Result<Self, MessageDecodeError> {
+        Ok(Self {
+            ciphertext: decode(ciphertext)?,
+            mac: decode(mac)?,
+            ephemeral_key: Curve25519PublicKey::from_base64(ephemeral_key)?,
+        })
+    }
+}
+
+/// Error type describing the failure cases the Pk decryption step can have.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The message has invalid PKCS7 padding.
+    #[error("Failed decrypting, invalid padding: {0}")]
+    InvalidPadding(#[from] UnpadError),
+    /// The message failed to be authenticated.
+    #[error("The MAC of the ciphertext didn't pass validation {0}")]
+    Mac(#[from] MacError),
+    /// The message failed to be decoded.
+    #[error("The message could not been decoded: {0}")]
+    Decoding(#[from] MessageDecodeError),
+}
+
+#[cfg(test)]
+mod test {
+    use olm_rs::pk::{OlmPkDecryption, OlmPkEncryption, PkMessage};
+
+    use super::*;
+    use crate::utilities::encode;
+
+    impl TryFrom<PkMessage> for Message {
+        type Error = MessageDecodeError;
+
+        fn try_from(value: PkMessage) -> Result<Self, Self::Error> {
+            Self::from_base64(&value.ciphertext, &value.mac, &value.ephemeral_key)
+        }
+    }
+
+    impl Into<PkMessage> for Message {
+        fn into(self) -> PkMessage {
+            PkMessage {
+                ciphertext: encode(self.ciphertext),
+                mac: encode(self.mac),
+                ephemeral_key: self.ephemeral_key.to_base64(),
+            }
+        }
+    }
+
+    #[test]
+    fn decrypt() {
+        let decryptor = PkDecryption::new();
+        let public_key = decryptor.public_key();
+        let encryptor = OlmPkEncryption::new(&public_key.to_base64());
+
+        let message = "It's a secret to everybody";
+
+        let encrypted = encryptor.encrypt(message);
+        let encrypted = encrypted.try_into().unwrap();
+
+        let decrypted = decryptor.decrypt(&encrypted).unwrap();
+
+        assert_eq!(message.as_bytes(), decrypted);
+    }
+
+    #[test]
+    fn encrypt() {
+        let decryptor = OlmPkDecryption::new();
+        let public_key = Curve25519PublicKey::from_base64(decryptor.public_key()).unwrap();
+        let encryptor = PkEncryption::from_key(public_key);
+
+        let message = "It's a secret to everybody";
+
+        let encrypted = encryptor.encrypt(message.as_ref());
+        let encrypted = encrypted.into();
+
+        let decrypted = decryptor.decrypt(encrypted).unwrap();
+
+        assert_eq!(message, decrypted);
+    }
+
+    #[test]
+    fn encrypt_native() {
+        let decryptor = PkDecryption::new();
+        let public_key = decryptor.public_key();
+        let encryptor = PkEncryption::from_key(public_key);
+
+        let message = "It's a secret to everybody";
+
+        let encrypted = encryptor.encrypt(message.as_ref());
+        let decrypted = decryptor.decrypt(&encrypted).unwrap();
+
+        assert_eq!(message.as_ref(), decrypted);
+    }
+}

--- a/crates/matrix-sdk-crypto/src/backups/keys/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/mod.rs
@@ -48,7 +48,9 @@
 //! the `/room_keys/version` API endpoint.
 
 mod backup;
+mod compat;
 mod recovery;
 
 pub use backup::MegolmV1BackupKey;
+pub use compat::{Error as DecryptionError, MessageDecodeError};
 pub use recovery::DecodeError;

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -44,8 +44,7 @@ use crate::{
 
 mod keys;
 
-pub use keys::{DecodeError, MegolmV1BackupKey};
-pub use olm_rs::errors::OlmPkDecryptionError;
+pub use keys::{DecodeError, DecryptionError, MegolmV1BackupKey};
 
 /// A state machine that handles backing up room keys.
 ///


### PR DESCRIPTION
This patch removes our dependency to libolm completely. This should allow WASM targets to use the backups_v1 feature of the matrix-sdk-crypto crate as well.

- [x] Public API changes documented in changelogs (optional)
