### PR TITLE
Disable automatic-key-forwarding for the matrix-sdk-ffi bindings

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -46,7 +46,7 @@ version = "0.6.0"
 [dependencies.matrix-sdk-crypto]
 path = "../../crates/matrix-sdk-crypto"
 version = "0.6.0"
-features = ["qrcode", "backups_v1"]
+features = ["qrcode", "backups_v1", "automatic-room-key-forwarding"]
 
 [dependencies.matrix-sdk-sqlite]
 path = "../../crates/matrix-sdk-sqlite"

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -41,7 +41,7 @@ futures-util = "0.3.27"
 http = { workspace = true }
 js-sys = "0.3.49"
 matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
-matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto", features = ["js"] }
+matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto", features = ["js", "automatic-room-key-forwarding"] }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../../crates/matrix-sdk-indexeddb" }
 matrix-sdk-qrcode = { version = "0.4.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
 ruma = { workspace = true, features = ["js", "rand", "unstable-msc2677"] }

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -24,7 +24,7 @@ qrcode = ["matrix-sdk-crypto/qrcode"]
 tracing = ["dep:tracing-subscriber"]
 
 [dependencies]
-matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto", features = ["js"] }
+matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto", features = ["js", "automatic-room-key-forwarding"] }
 matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
 matrix-sdk-sled = { version = "0.2.0", path = "../../crates/matrix-sdk-sled", default-features = false, features = ["crypto-store"] }
 matrix-sdk-sqlite = { version = "0.1.0", path = "../../crates/matrix-sdk-sqlite", features = ["crypto-store"] }

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v0.7.0
 
+- Disable the automatic-key-forwarding feature by default.
+
 - Add a new variant to the `VerificationRequestState` enum called
   `Transitioned`. This enum variant is used when a `VerificationRequest`
   transitions into a concrete `Verification` object. The concrete `Verification`

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.6.0"
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["automatic-room-key-forwarding"]
+default = []
 automatic-room-key-forwarding = []
 js = ["ruma/js", "vodozemac/js"]
 qrcode = ["dep:matrix-sdk-qrcode"]

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -26,7 +26,6 @@ testing = []
 
 e2e-encryption = [
     "matrix-sdk-base/e2e-encryption",
-    "matrix-sdk-base/automatic-room-key-forwarding",
     "matrix-sdk-sqlite?/crypto-store",        # activate crypto-store on sqlite if given
     "matrix-sdk-indexeddb?/e2e-encryption",   # activate on indexeddb if given
 ]


### PR DESCRIPTION
Not completely sure why disabling this didn't work the first time. The feature is now disabled by default in the matrix-sdk-crypto crate.

- [x] Public API changes documented in changelogs (optional)
