### PR TITLE
Message ID support: The sending side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "vodozemac",
  "zeroize",
 ]
@@ -5426,6 +5427,15 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ulid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a3aaa69b04e5b66cc27309710a569ea23593612387d67daaf102e73aa974fd"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "unarray"

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -46,6 +46,7 @@ version = "0.6.0"
 [dependencies.matrix-sdk-crypto]
 path = "../../crates/matrix-sdk-crypto"
 version = "0.6.0"
+default_features = false
 features = ["qrcode", "backups_v1", "automatic-room-key-forwarding"]
 
 [dependencies.matrix-sdk-sqlite]

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -41,7 +41,6 @@ futures-util = "0.3.27"
 http = { workspace = true }
 js-sys = "0.3.49"
 matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
-matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto", features = ["js", "automatic-room-key-forwarding"] }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../../crates/matrix-sdk-indexeddb" }
 matrix-sdk-qrcode = { version = "0.4.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
 ruma = { workspace = true, features = ["js", "rand", "unstable-msc2677"] }
@@ -52,3 +51,9 @@ vodozemac = { workspace = true, features = ["js"] }
 wasm-bindgen = "0.2.83"
 wasm-bindgen-futures = "0.4.33"
 zeroize = { workspace = true }
+
+[dependencies.matrix-sdk-crypto]
+path = "../../crates/matrix-sdk-crypto"
+version = "0.6.0"
+default_features = false
+features = ["js", "automatic-room-key-forwarding"]

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -24,7 +24,6 @@ qrcode = ["matrix-sdk-crypto/qrcode"]
 tracing = ["dep:tracing-subscriber"]
 
 [dependencies]
-matrix-sdk-crypto = { version = "0.6.0", path = "../../crates/matrix-sdk-crypto", features = ["js", "automatic-room-key-forwarding"] }
 matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
 matrix-sdk-sled = { version = "0.2.0", path = "../../crates/matrix-sdk-sled", default-features = false, features = ["crypto-store"] }
 matrix-sdk-sqlite = { version = "0.1.0", path = "../../crates/matrix-sdk-sqlite", features = ["crypto-store"] }
@@ -36,6 +35,12 @@ http = { workspace = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["tracing-log", "time", "smallvec", "fmt", "env-filter"], optional = true }
 vodozemac = { workspace = true, features = ["js"] }
 zeroize = { workspace = true }
+
+[dependencies.matrix-sdk-crypto]
+path = "../../crates/matrix-sdk-crypto"
+version = "0.6.0"
+default_features = false
+features = ["js", "automatic-room-key-forwarding"]
 
 [build-dependencies]
 napi-build = "2.0.0"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -21,6 +21,7 @@ e2e-encryption = ["dep:matrix-sdk-crypto"]
 js = ["matrix-sdk-common/js", "matrix-sdk-crypto?/js", "ruma/js", "matrix-sdk-store-encryption/js"]
 qrcode = ["matrix-sdk-crypto?/qrcode"]
 automatic-room-key-forwarding = ["matrix-sdk-crypto?/automatic-room-key-forwarding"]
+message-ids = ["matrix-sdk-crypto?/message-ids"]
 experimental-sliding-sync = ["ruma/unstable-msc3575"]
 
 # helpers for testing features build upon this

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v0.7.0
 
+- Add a new optional `message-ids` feature which adds a unique ID to the content
+  of `m.room.encrypted` event contents which get sent out.
+
 - Disable the automatic-key-forwarding feature by default.
 
 - Add a new variant to the `VerificationRequestState` enum called

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -20,6 +20,7 @@ automatic-room-key-forwarding = []
 js = ["ruma/js", "vodozemac/js"]
 qrcode = ["dep:matrix-sdk-qrcode"]
 backups_v1 = ["dep:bs58", "dep:cbc", "dep:hkdf"]
+message-ids = ["dep:ulid"]
 experimental-algorithms = []
 
 # Testing helpers for implementations based upon this
@@ -48,15 +49,16 @@ matrix-sdk-qrcode = { version = "0.4.0", path = "../matrix-sdk-qrcode", optional
 matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 pbkdf2 = { version = "0.11.0", default-features = false }
 rand = "0.8.5"
+rmp-serde = "1.1.1"
 ruma = { workspace = true, features = ["rand", "canonical-json", "unstable-msc2677"] }
 serde = { workspace = true, features = ["derive", "rc"] }
-rmp-serde = "1.1.1"
 serde_json = { workspace = true }
 sha2 = "0.10.2"
 tokio-stream = { version = "0.1.12", features = ["sync"] }
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
+ulid = { version = "1.0.0", optional = true }
 vodozemac = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1204,6 +1204,7 @@ impl ReadOnlyAccount {
                 &device,
                 "m.dummy",
                 serde_json::to_value(ToDeviceDummyEventContent::new()).unwrap(),
+                None,
             )
             .await
             .unwrap()

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -14,7 +14,7 @@
 
 use std::{fmt, sync::Arc};
 
-use ruma::{serde::Raw, OwnedDeviceId, OwnedUserId, SecondsSinceUnixEpoch};
+use ruma::{serde::Raw, JsOption, OwnedDeviceId, OwnedUserId, SecondsSinceUnixEpoch};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
@@ -151,6 +151,7 @@ impl Session {
         recipient_device: &ReadOnlyDevice,
         event_type: &str,
         content: Value,
+        message_id: Option<String>,
     ) -> OlmResult<Raw<ToDeviceEncryptedEventContent>> {
         let plaintext = {
             let recipient_signing_key =
@@ -180,12 +181,14 @@ impl Session {
                 ciphertext,
                 recipient_key: self.sender_key,
                 sender_key: self.our_identity_keys.curve25519,
+                message_id: JsOption::from_implicit_option(message_id),
             }
             .into(),
             #[cfg(feature = "experimental-algorithms")]
             EventEncryptionAlgorithm::OlmV2Curve25519AesSha2 => OlmV2Curve25519AesSha2Content {
                 ciphertext,
                 sender_key: self.our_identity_keys.curve25519,
+                message_id: JsOption::from_implicit_option(message_id),
             }
             .into(),
             _ => unreachable!(),

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -26,6 +26,7 @@ testing = []
 
 e2e-encryption = [
     "matrix-sdk-base/e2e-encryption",
+    "matrix-sdk-base/message-ids",
     "matrix-sdk-sqlite?/crypto-store",        # activate crypto-store on sqlite if given
     "matrix-sdk-indexeddb?/e2e-encryption",   # activate on indexeddb if given
 ]


### PR DESCRIPTION
This closes: https://github.com/matrix-org/matrix-rust-sdk/issues/1266

The first patch cleans some logs up, secondly we add optional support to send
message IDs for our `m.room.encrypted` to-device events, and finally we log the
message ID when we encrypt room keys.

- [x] Public API changes documented in changelogs (optional)
