### PR TITLE
chore(comment): fix the comment for `Error::CannotModifyRanges`

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -19,9 +19,9 @@ pub enum Error {
     #[error("The sliding sync list `{0}` is handling a response, but its request generator has not been initialized")]
     RequestGeneratorHasNotBeenInitialized(String),
 
-    /// Someone has tried to modify a sliding sync list's ranges, but the
-    /// selected sync mode doesn't allow that.
-    #[error("The chosen sync mode for the list `{0}` doesn't allow to modify the ranges")]
+    /// Someone has tried to modify a sliding sync list's ranges, but only the
+    /// `Selective` sync mode does allow that.
+    #[error("The chosen sync mode for the list `{0}` doesn't allow to modify the ranges; only `Selective` allows that")]
     CannotModifyRanges(String),
 
     /// Ranges have a `start` bound greater than `end`.

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -912,6 +912,8 @@ pub enum SlidingSyncMode {
 impl SlidingSyncMode {
     /// Return whether an external caller can modify the sync mode's ranges.
     fn ranges_can_be_modified_by_user(&self) -> bool {
+        // If this gets modified, don't forget to update the `Error::CannotModifyRanges`
+        // error message.
         matches!(self, Self::Selective)
     }
 }


### PR DESCRIPTION
The comment and the check in the code were contradicting each other; the comment was wrong, and the code was right, so there's that.