### PR TITLE
feat(bindings): exposed `set_name` in `Room`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -578,6 +578,21 @@ impl Room {
         })
     }
 
+    /// Sets a new name to the room.
+    pub fn set_name(&self, name: Option<String>) -> Result<(), ClientError> {
+        let room = match &self.room {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => {
+                return Err(anyhow!("Can't set a name in a room that isn't in joined state").into())
+            }
+        };
+
+        RUNTIME.block_on(async move {
+            room.set_name(name).await?;
+            Ok(())
+        })
+    }
+
     /// Sets a new topic in the room.
     pub fn set_topic(&self, topic: String) -> Result<(), ClientError> {
         let room = match &self.room {


### PR DESCRIPTION
Exposed `set_name` function for changing the name of a room

Note: I didn't test this change because I fail to build the rust sdk...