### PR TITLE
fix(sdk): `SlidingSyncListInner::timeline_limit` and `ranges` are no longer observable

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -206,9 +206,9 @@ impl SlidingSyncListBuilder {
                 sort: self.sort,
                 required_state: self.required_state,
                 filters: self.filters,
-                timeline_limit: StdRwLock::new(Observable::new(self.timeline_limit)),
+                timeline_limit: StdRwLock::new(self.timeline_limit),
                 name: self.name,
-                ranges: StdRwLock::new(Observable::new(self.ranges)),
+                ranges: StdRwLock::new(self.ranges),
                 cache_policy: self.cache_policy,
 
                 // Computed from the builder.

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -131,7 +131,7 @@ impl SlidingSyncList {
 
     /// Get the timeline limit.
     pub fn timeline_limit(&self) -> Option<Bound> {
-        self.inner.timeline_limit.read().unwrap().clone()
+        *self.inner.timeline_limit.read().unwrap()
     }
 
     /// Set timeline limit.


### PR DESCRIPTION
The `SlidingSyncListInner::timeline_limit` and `::ranges` fields were observable (behind `eyeball::Observable`). It was actually useless as those fields were never exposed to the public API, thus it was impossible to subscribe to them.

This patch cleans up that. `timeline_limit` and `ranges` are no longer observable.
