### PR TITLE
Bump sliding sync receiver size

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -230,7 +230,7 @@ impl SlidingSyncBuilder {
 
         let mut delta_token = None;
 
-        let (internal_channel_sender, internal_channel_receiver) = channel(8);
+        let (internal_channel_sender, internal_channel_receiver) = channel(256);
 
         let mut lists = BTreeMap::new();
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -654,6 +654,8 @@ impl SlidingSync {
                     }
                 }
             }
+
+            debug!("Sync stream loop has exited.");
         }
     }
 


### PR DESCRIPTION
- Increase the size of the internal message receiver buffer, in case it's full before it can handle all the things. That's a blind attempt to fix a deadlock we've observed in ElementX iOS, when the app goes in the background.
- Also add log when exiting the stream loop, just to make sure it's properly exiting.