### PR TITLE
sliding sync: Rejigger the range API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -418,7 +418,7 @@ pub struct SlidingSyncSelectiveModeBuilder {
 impl SlidingSyncSelectiveModeBuilder {
     #[uniffi::constructor]
     pub fn new() -> Arc<Self> {
-        Arc::new(Self { inner: MatrixSlidingSyncSelectiveModeBuilder::new() })
+        Arc::new(Self { inner: SlidingSyncMode::new_selective() })
     }
 
     pub fn add_range(self: Arc<Self>, start: u32, end_inclusive: u32) -> Arc<Self> {
@@ -482,8 +482,7 @@ impl SlidingSyncListBuilder {
     ) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         let selective_mode_builder = unwrap_or_clone_arc(selective_mode_builder);
-        builder.inner =
-            builder.inner.sync_mode(SlidingSyncMode::new_selective(selective_mode_builder.inner));
+        builder.inner = builder.inner.sync_mode(selective_mode_builder.inner.build());
         Arc::new(builder)
     }
 

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -482,7 +482,7 @@ impl SlidingSyncListBuilder {
     ) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         let selective_mode_builder = unwrap_or_clone_arc(selective_mode_builder);
-        builder.inner = builder.inner.sync_mode(selective_mode_builder.inner.build());
+        builder.inner = builder.inner.sync_mode(selective_mode_builder.inner);
         Arc::new(builder)
     }
 

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -549,12 +549,6 @@ impl SlidingSyncListBuilder {
         Arc::new(builder)
     }
 
-    pub fn add_range(self: Arc<Self>, from: u32, to_included: u32) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.add_range(from..=to_included);
-        Arc::new(builder)
-    }
-
     pub fn once_built(self: Arc<Self>, callback: Box<dyn SlidingSyncListOnceBuilt>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
 

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -107,9 +107,6 @@ pub enum SlidingSyncError {
     /// initialized. It happens when a response is handled before a request has
     /// been sent. It usually happens when testing.
     RequestGeneratorHasNotBeenInitialized { msg: String },
-    /// Someone has tried to modify a sliding sync list's ranges, but the
-    /// selected sync mode doesn't allow that.
-    CannotModifyRanges { msg: String },
     /// Ranges have a `start` bound greater than `end`.
     InvalidRange {
         /// Start bound.
@@ -132,7 +129,6 @@ impl From<matrix_sdk::sliding_sync::Error> for SlidingSyncError {
             E::RequestGeneratorHasNotBeenInitialized(msg) => {
                 Self::RequestGeneratorHasNotBeenInitialized { msg }
             }
-            E::CannotModifyRanges(msg) => Self::CannotModifyRanges { msg },
             E::InvalidRange { start, end } => Self::InvalidRange { start, end },
             E::InternalChannelIsBroken => Self::InternalChannelIsBroken,
             error => Self::Unknown { error: error.to_string() },

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -5,8 +5,7 @@ use assert_matches::assert_matches;
 use eyeball_im::{Vector, VectorDiff};
 use futures_util::{pin_mut, Stream, StreamExt};
 use matrix_sdk::{
-    sliding_sync::SlidingSyncSelectiveModeBuilder, SlidingSync, SlidingSyncList,
-    SlidingSyncListBuilder, UpdateSummary,
+    SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
 };
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::timeline::{SlidingSyncRoomExt, TimelineItem, VirtualTimelineItem};
@@ -220,7 +219,7 @@ impl Match for SlidingSyncMatcher {
 #[async_test]
 async fn test_timeline_basic() -> Result<()> {
     let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
+        .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
     .await?;
 
     let stream = sliding_sync.sync();
@@ -266,7 +265,7 @@ async fn test_timeline_basic() -> Result<()> {
 #[async_test]
 async fn test_timeline_duplicated_events() -> Result<()> {
     let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
+        .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
     .await?;
 
     let stream = sliding_sync.sync();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -5,7 +5,8 @@ use assert_matches::assert_matches;
 use eyeball_im::{Vector, VectorDiff};
 use futures_util::{pin_mut, Stream, StreamExt};
 use matrix_sdk::{
-    SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
+    sliding_sync::SlidingSyncSelectiveModeBuilder, SlidingSync, SlidingSyncList,
+    SlidingSyncListBuilder, UpdateSummary,
 };
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::timeline::{SlidingSyncRoomExt, TimelineItem, VirtualTimelineItem};
@@ -219,8 +220,7 @@ impl Match for SlidingSyncMatcher {
 #[async_test]
 async fn test_timeline_basic() -> Result<()> {
     let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncMode::Selective)
-        .add_range(0..=10)])
+        .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
     .await?;
 
     let stream = sliding_sync.sync();
@@ -266,8 +266,7 @@ async fn test_timeline_basic() -> Result<()> {
 #[async_test]
 async fn test_timeline_duplicated_events() -> Result<()> {
     let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-        .sync_mode(SlidingSyncMode::Selective)
-        .add_range(0..=10)])
+        .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
     .await?;
 
     let stream = sliding_sync.sync();

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -68,15 +68,15 @@ by recency and select to list the top 10 via `ranges: [ [0,9] ]` (indexes
 are **inclusive**) like so:
 
 ```rust
-# use matrix_sdk::sliding_sync::{SlidingSyncList, SlidingSyncSelectiveModeBuilder};
+# use matrix_sdk::sliding_sync::{SlidingSyncList, SlidingSyncMode};
 use ruma::{assign, api::client::sync::sync_events::v4};
 
 let list_builder = SlidingSyncList::builder("main_list")
-    .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=9).build())
+    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=9))
     .filters(Some(assign!(
         v4::SyncRequestListFilters::default(), { is_dm: Some(true)}
     )))
-    .sort(vec!["by_recency".to_owned()])
+    .sort(vec!["by_recency".to_owned()]);
 ```
 
 Please refer to the [specification][MSC], the [Ruma types][ruma-types],
@@ -399,7 +399,7 @@ start up and retrieve only the data needed to actually run.
 # Full example
 
 ```rust,no_run
-use matrix_sdk::{Client, sliding_sync::{SlidingSyncList, SlidingSyncMode, SlidingSyncSelectiveModeBuilder}};
+use matrix_sdk::{Client, sliding_sync::{SlidingSyncList, SlidingSyncMode}};
 use ruma::{assign, api::client::sync::sync_events::v4, events::StateEventType};
 use tracing::{warn, error, info, debug};
 use futures_util::{pin_mut, StreamExt};
@@ -423,7 +423,7 @@ let full_sync_list = SlidingSyncList::builder(&full_sync_list_name)
      ]); // only want to know if the room is encrypted
 
 let active_list = SlidingSyncList::builder(&active_list_name) // the active window
-    .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=9).build())  // sync up the specific range only, first 10 items
+    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=9))  // sync up the specific range only, first 10 items
     .sort(vec!["by_recency".to_owned()]) // last active
     .timeline_limit(5u32) // add the last 5 timeline items for room preview and faster timeline loading
     .required_state(vec![ // we want to know immediately:

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -68,16 +68,15 @@ by recency and select to list the top 10 via `ranges: [ [0,9] ]` (indexes
 are **inclusive**) like so:
 
 ```rust
-# use matrix_sdk::sliding_sync::{SlidingSyncList, SlidingSyncMode};
+# use matrix_sdk::sliding_sync::{SlidingSyncList, SlidingSyncSelectiveModeBuilder};
 use ruma::{assign, api::client::sync::sync_events::v4};
 
 let list_builder = SlidingSyncList::builder("main_list")
-    .sync_mode(SlidingSyncMode::Selective)
+    .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=9).build())
     .filters(Some(assign!(
         v4::SyncRequestListFilters::default(), { is_dm: Some(true)}
     )))
     .sort(vec!["by_recency".to_owned()])
-    .add_range(0u32..=9);
 ```
 
 Please refer to the [specification][MSC], the [Ruma types][ruma-types],
@@ -400,7 +399,7 @@ start up and retrieve only the data needed to actually run.
 # Full example
 
 ```rust,no_run
-use matrix_sdk::{Client, sliding_sync::{SlidingSyncList, SlidingSyncMode}};
+use matrix_sdk::{Client, sliding_sync::{SlidingSyncList, SlidingSyncMode, SlidingSyncSelectiveModeBuilder}};
 use ruma::{assign, api::client::sync::sync_events::v4, events::StateEventType};
 use tracing::{warn, error, info, debug};
 use futures_util::{pin_mut, StreamExt};
@@ -424,8 +423,7 @@ let full_sync_list = SlidingSyncList::builder(&full_sync_list_name)
      ]); // only want to know if the room is encrypted
 
 let active_list = SlidingSyncList::builder(&active_list_name) // the active window
-    .sync_mode(SlidingSyncMode::Selective)  // sync up the specific range only
-    .add_range(0u32..=9) // only the top 10 items
+    .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=9).build())  // sync up the specific range only, first 10 items
     .sort(vec!["by_recency".to_owned()]) // last active
     .timeline_limit(5u32) // add the last 5 timeline items for room preview and faster timeline loading
     .required_state(vec![ // we want to know immediately:

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -19,11 +19,6 @@ pub enum Error {
     #[error("The sliding sync list `{0}` is handling a response, but its request generator has not been initialized")]
     RequestGeneratorHasNotBeenInitialized(String),
 
-    /// Someone has tried to modify a sliding sync list's ranges, but only the
-    /// `Selective` sync mode does allow that.
-    #[error("The chosen sync mode for the list `{0}` doesn't allow to modify the ranges; only `Selective` allows that")]
-    CannotModifyRanges(String),
-
     /// Ranges have a `start` bound greater than `end`.
     #[error("Ranges have invalid bounds: `{start}..{end}`")]
     InvalidRange {

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -102,8 +102,8 @@ impl SlidingSyncListBuilder {
     }
 
     /// Which SlidingSyncMode to start this list under.
-    pub fn sync_mode(mut self, value: SlidingSyncMode) -> Self {
-        self.sync_mode = value;
+    pub fn sync_mode(mut self, value: impl Into<SlidingSyncMode>) -> Self {
+        self.sync_mode = value.into();
         self
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -729,16 +729,11 @@ impl SlidingSyncSelectiveModeBuilder {
         self.ranges.push(range);
         self
     }
-
-    /// Finish building the selective mode.
-    pub fn build(self) -> SlidingSyncMode {
-        SlidingSyncMode::Selective { ranges: self.ranges }
-    }
 }
 
-impl Into<SlidingSyncMode> for SlidingSyncSelectiveModeBuilder {
-    fn into(self) -> SlidingSyncMode {
-        self.build()
+impl From<SlidingSyncSelectiveModeBuilder> for SlidingSyncMode {
+    fn from(builder: SlidingSyncSelectiveModeBuilder) -> SlidingSyncMode {
+        SlidingSyncMode::Selective { ranges: builder.ranges }
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -908,22 +908,17 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         // Set range on `Selective`.
-        {
-            let list = SlidingSyncList::builder("foo")
-                .sync_mode(
-                    SlidingSyncSelectiveModeBuilder::new()
-                        .add_range(0..=1)
-                        .add_range(2..=3)
-                        .build(),
-                )
-                .build(sender.clone());
+        let list = SlidingSyncList::builder("foo")
+            .sync_mode(
+                SlidingSyncSelectiveModeBuilder::new().add_range(0..=1).add_range(2..=3).build(),
+            )
+            .build(sender.clone());
 
-            assert_eq!(list.inner.request_generator.read().unwrap().ranges(), &[0..=1, 2..=3]);
+        assert_eq!(list.inner.request_generator.read().unwrap().ranges(), &[0..=1, 2..=3]);
 
-            list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(4..=5).build())
-                .unwrap();
-            assert_eq!(list.inner.request_generator.read().unwrap().ranges(), &[4..=5]);
-        }
+        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(4..=5).build())
+            .unwrap();
+        assert_eq!(list.inner.request_generator.read().unwrap().ranges(), &[4..=5]);
     }
 
     #[test]

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -714,7 +714,7 @@ pub enum SlidingSyncState {
 /// Builder for a new sliding sync list in selective mode.
 ///
 /// Conveniently allows to add ranges.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SlidingSyncSelectiveModeBuilder {
     ranges: Vec<RangeInclusive<Bound>>,
 }
@@ -722,7 +722,7 @@ pub struct SlidingSyncSelectiveModeBuilder {
 impl SlidingSyncSelectiveModeBuilder {
     /// Create a new `SlidingSyncSelectiveModeBuilder`.
     pub fn new() -> Self {
-        Self { ranges: Vec::new() }
+        Self::default()
     }
 
     /// Select a range to fetch.
@@ -830,7 +830,7 @@ mod tests {
             .sync_mode(
                 SlidingSyncSelectiveModeBuilder::new().add_range(0..=1).add_range(2..=3).build(),
             )
-            .build(sender.clone());
+            .build(sender);
 
         assert_eq!(list.inner.request_generator.read().unwrap().ranges(), &[0..=1, 2..=3]);
 

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -841,8 +841,7 @@ mod tests {
         // There shouldn't be any internal request to restart the sync loop yet.
         assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
 
-        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(4..=5).build())
-            .unwrap();
+        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(4..=5)).unwrap();
 
         {
             let mut generator = list.inner.request_generator.write().unwrap();
@@ -862,7 +861,7 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         let list = SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=1).build())
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=1))
             .timeline_limit(7)
             .build(sender);
 
@@ -880,7 +879,7 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         let mut list = SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=1).build())
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=1))
             .build(sender);
 
         let room0 = room_id!("!room0:bar.org");
@@ -1124,12 +1123,7 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         let mut list = SlidingSyncList::builder("testing")
-            .sync_mode(
-                SlidingSyncSelectiveModeBuilder::new()
-                    .add_range(0..=10)
-                    .add_range(42..=153)
-                    .build(),
-            )
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).add_range(42..=153))
             .build(sender);
 
         assert_ranges! {
@@ -1161,12 +1155,7 @@ mod tests {
         let (sender, _receiver) = channel(4);
 
         let mut list = SlidingSyncList::builder("testing")
-            .sync_mode(
-                SlidingSyncSelectiveModeBuilder::new()
-                    .add_range(0..=10)
-                    .add_range(42..=153)
-                    .build(),
-            )
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).add_range(42..=153))
             .build(sender);
 
         assert_ranges! {
@@ -1192,8 +1181,7 @@ mod tests {
             }
         };
 
-        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(3..=7).build())
-            .unwrap();
+        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(3..=7)).unwrap();
 
         assert_ranges! {
             list = list,
@@ -1206,8 +1194,7 @@ mod tests {
             },
         };
 
-        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(42..=77).build())
-            .unwrap();
+        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(42..=77)).unwrap();
 
         assert_ranges! {
             list = list,
@@ -1220,7 +1207,7 @@ mod tests {
             },
         };
 
-        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().build()).unwrap();
+        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new()).unwrap();
 
         assert_ranges! {
             list = list,
@@ -1239,12 +1226,7 @@ mod tests {
         let (sender, _receiver) = channel(4);
 
         let mut list = SlidingSyncList::builder("testing")
-            .sync_mode(
-                SlidingSyncSelectiveModeBuilder::new()
-                    .add_range(0..=10)
-                    .add_range(42..=153)
-                    .build(),
-            )
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).add_range(42..=153))
             .build(sender);
 
         assert_ranges! {
@@ -1343,15 +1325,14 @@ mod tests {
         };
 
         // Changing from `Paging` to `Selective`.
-        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().build()).unwrap();
+        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new()).unwrap();
 
         assert_eq!(list.state(), SlidingSyncState::PartiallyLoaded); // we had some partial state, but we can't be sure it's fully loaded until the
                                                                      // next request
 
         // We need to update the ranges, of course, as they are not managed
         // automatically anymore.
-        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=100).build())
-            .unwrap();
+        list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=100)).unwrap();
 
         assert_ranges! {
             list = list,
@@ -1383,7 +1364,7 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         let mut list = SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=3).build())
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=3))
             .build(sender);
 
         assert_eq!(**list.inner.maximum_number_of_rooms.read().unwrap(), None);
@@ -1522,7 +1503,7 @@ mod tests {
                 }
             })
         );
-        assert_json_roundtrip!(from SlidingSyncMode: SlidingSyncMode::new_selective().build() => json!({
+        assert_json_roundtrip!(from SlidingSyncMode: SlidingSyncMode::from(SlidingSyncMode::new_selective()) => json!({
                 "Selective": {
                     "ranges": []
                 }

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -1211,7 +1211,7 @@ mod tests {
             next => {
                 ranges = ,
                 is_fully_loaded = true,
-                list_state = PartiallyLoaded,
+                list_state = FullyLoaded,
             },
         };
     }

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -433,7 +433,8 @@ impl SlidingSyncListInner {
         Ok(new_changes)
     }
 
-    /// Update the state of the [`SlidingSyncListRequestGenerator`] after receiving a response.
+    /// Update the state of the [`SlidingSyncListRequestGenerator`] after
+    /// receiving a response.
     fn update_request_generator_state(&self, maximum_number_of_rooms: u32) -> Result<(), Error> {
         let mut request_generator = self.request_generator.write().unwrap();
 
@@ -1413,7 +1414,8 @@ mod tests {
         // Changing from `Paging` to `Selective`.
         list.set_sync_mode(SlidingSyncSelectiveModeBuilder::new().build()).unwrap();
 
-        assert_eq!(list.state(), SlidingSyncState::PartiallyLoaded); // we had some partial state, but we can't be sure it's fully loaded until the next request
+        assert_eq!(list.state(), SlidingSyncState::PartiallyLoaded); // we had some partial state, but we can't be sure it's fully loaded until the
+                                                                     // next request
 
         // We need to update the ranges, of course, as they are not managed
         // automatically anymore.

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -120,7 +120,8 @@ impl SlidingSyncListRequestGenerator {
     /// Return a view on the ranges requested by this generator.
     ///
     /// For generators in the selective mode, this is the initial set of ranges.
-    /// For growing and paginated generators, this is the range committed in the latest response received from the server.
+    /// For growing and paginated generators, this is the range committed in the
+    /// latest response received from the server.
     pub(super) fn requested_ranges(&self) -> &[RangeInclusive<Bound>] {
         &self.ranges
     }
@@ -137,7 +138,8 @@ impl SlidingSyncListRequestGenerator {
             | SlidingSyncListRequestGeneratorKind::Growing { fully_loaded: true, .. }
             | SlidingSyncListRequestGeneratorKind::Selective => {
                 // Nothing to do: we already have the full ranges, return the existing ranges.
-                // For the growing and paging modes, keep the current value of `requested_end`, which is still valid.
+                // For the growing and paging modes, keep the current value of `requested_end`,
+                // which is still valid.
                 Ok(self.ranges.clone())
             }
 
@@ -326,7 +328,6 @@ fn create_range(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sliding_sync::SlidingSyncSelectiveModeBuilder;
 
     #[test]
     fn test_create_range_from() {
@@ -377,8 +378,8 @@ mod tests {
 
     #[test]
     fn test_request_generator_selective_from_sync_mode() {
-        let sync_mode = SlidingSyncMode::new_selective(SlidingSyncSelectiveModeBuilder::new());
-        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode);
+        let sync_mode = SlidingSyncMode::new_selective();
+        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode.build());
 
         assert!(request_generator.ranges.is_empty());
         assert_eq!(request_generator.kind, SlidingSyncListRequestGeneratorKind::Selective);

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -379,7 +379,7 @@ mod tests {
     #[test]
     fn test_request_generator_selective_from_sync_mode() {
         let sync_mode = SlidingSyncMode::new_selective();
-        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode.build());
+        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode.into());
 
         assert!(request_generator.ranges.is_empty());
         assert_eq!(request_generator.kind, SlidingSyncListRequestGeneratorKind::Selective);

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -247,7 +247,7 @@ impl SlidingSyncListRequestGenerator {
                     *fully_loaded = false;
 
                     // Update the range to cover from 0 to `range_end`.
-                    self.ranges = [0..=range_end].to_vec();
+                    self.ranges = vec![0..=range_end];
 
                     // Finally, return the new state.
                     Ok(SlidingSyncState::PartiallyLoaded)
@@ -262,7 +262,7 @@ impl SlidingSyncListRequestGenerator {
                     *fully_loaded = true;
 
                     // The range is covering the entire list, from 0 to its maximum.
-                    self.ranges = [0..=range_maximum].to_vec();
+                    self.ranges = vec![0..=range_maximum];
 
                     // Finally, let's update the list' state.
                     Ok(SlidingSyncState::FullyLoaded)

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -189,11 +189,6 @@ impl SlidingSyncListRequestGenerator {
         list_name: &str,
         maximum_number_of_rooms: u32,
     ) -> Result<SlidingSyncState, Error> {
-        let range_end: u32 =
-            self.ranges().first().map(|r| *r.end()).ok_or_else(|| {
-                Error::RequestGeneratorHasNotBeenInitialized(list_name.to_owned())
-            })?;
-
         match &mut self.kind {
             SlidingSyncListRequestGeneratorKind::Paging {
                 number_of_fetched_rooms,
@@ -207,6 +202,10 @@ impl SlidingSyncListRequestGenerator {
                 maximum_number_of_rooms_to_fetch,
                 ..
             } => {
+                let range_end: u32 = self.ranges.first().map(|r| *r.end()).ok_or_else(|| {
+                    Error::RequestGeneratorHasNotBeenInitialized(list_name.to_owned())
+                })?;
+
                 // Calculate the maximum bound for the range.
                 // At this step, the server has given us a maximum number of rooms for this
                 // list. That's our `range_maximum`.

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -221,9 +221,8 @@ fn create_range(
 
 #[cfg(test)]
 mod tests {
-    use crate::sliding_sync::SlidingSyncSelectiveModeBuilder;
-
     use super::*;
+    use crate::sliding_sync::SlidingSyncSelectiveModeBuilder;
 
     #[test]
     fn test_create_range_from() {

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -231,8 +231,7 @@ impl SlidingSyncListRequestGenerator {
                     // The list is still not fully loaded.
                     *fully_loaded = false;
 
-                    // Update the _list range_ to cover from 0 to `range_end`.
-                    // The list's range is different from the request generator (this) range.
+                    // Update the range to cover from 0 to `range_end`.
                     self.ranges = [0..=range_end].to_vec();
 
                     // Finally, return the new state.

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -779,7 +779,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscribe_to_room() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
         .await?;
 
         let _stream = sliding_sync.sync();
@@ -826,7 +826,7 @@ mod tests {
     #[tokio::test]
     async fn test_to_device_token_properly_cached() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
         .await?;
 
         // When no to-device token is present, `prepare_extensions_config` doesn't fill
@@ -862,7 +862,7 @@ mod tests {
     #[tokio::test]
     async fn test_add_list() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
         .await?;
 
         let _stream = sliding_sync.sync();
@@ -871,7 +871,7 @@ mod tests {
         sliding_sync
             .add_list(
                 SlidingSyncList::builder("bar")
-                    .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(50..=60).build()),
+                    .sync_mode(SlidingSyncMode::new_selective().add_range(50..=60)),
             )
             .await?;
 
@@ -888,7 +888,7 @@ mod tests {
     #[tokio::test]
     async fn test_stop_sync_loop() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
+            .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
         .await?;
 
         let stream = sliding_sync.sync();

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -779,8 +779,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscribe_to_room() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncMode::Selective)
-            .add_range(0..=10)])
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
         .await?;
 
         let _stream = sliding_sync.sync();
@@ -827,8 +826,7 @@ mod tests {
     #[tokio::test]
     async fn test_to_device_token_properly_cached() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncMode::Selective)
-            .add_range(0..=10)])
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
         .await?;
 
         // When no to-device token is present, `prepare_extensions_config` doesn't fill
@@ -864,8 +862,7 @@ mod tests {
     #[tokio::test]
     async fn test_add_list() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncMode::Selective)
-            .add_range(0..=10)])
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
         .await?;
 
         let _stream = sliding_sync.sync();
@@ -874,8 +871,7 @@ mod tests {
         sliding_sync
             .add_list(
                 SlidingSyncList::builder("bar")
-                    .sync_mode(SlidingSyncMode::Selective)
-                    .add_range(50..=60),
+                    .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(50..=60).build()),
             )
             .await?;
 
@@ -892,8 +888,7 @@ mod tests {
     #[tokio::test]
     async fn test_stop_sync_loop() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncMode::Selective)
-            .add_range(0..=10)])
+            .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())])
         .await?;
 
         let stream = sliding_sync.sync();

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -2,10 +2,7 @@
 
 use anyhow::Context;
 use futures_util::{pin_mut, stream::StreamExt};
-use matrix_sdk::{
-    sliding_sync::SlidingSyncSelectiveModeBuilder, Client, RoomListEntry, SlidingSyncBuilder,
-    SlidingSyncList,
-};
+use matrix_sdk::{Client, RoomListEntry, SlidingSyncBuilder, SlidingSyncList, SlidingSyncMode};
 use matrix_sdk_integration_testing::helpers::get_client_for_user;
 
 async fn setup(
@@ -43,7 +40,7 @@ async fn it_works_smoke_test() -> anyhow::Result<()> {
     let sync_proxy = sync_builder
         .add_list(
             SlidingSyncList::builder("foo")
-                .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())
+                .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))
                 .timeline_limit(0),
         )
         .build()

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -2,7 +2,10 @@
 
 use anyhow::Context;
 use futures_util::{pin_mut, stream::StreamExt};
-use matrix_sdk::{Client, RoomListEntry, SlidingSyncBuilder, SlidingSyncList, SlidingSyncMode};
+use matrix_sdk::{
+    sliding_sync::SlidingSyncSelectiveModeBuilder, Client, RoomListEntry, SlidingSyncBuilder,
+    SlidingSyncList,
+};
 use matrix_sdk_integration_testing::helpers::get_client_for_user;
 
 async fn setup(
@@ -40,8 +43,7 @@ async fn it_works_smoke_test() -> anyhow::Result<()> {
     let sync_proxy = sync_builder
         .add_list(
             SlidingSyncList::builder("foo")
-                .sync_mode(SlidingSyncMode::Selective)
-                .add_range(0..=10)
+                .sync_mode(SlidingSyncSelectiveModeBuilder::new().add_range(0..=10).build())
                 .timeline_limit(0),
         )
         .build()


### PR DESCRIPTION
This gets rid of many Range API methods that were unused, and reworks how ranges work internally. Also, this removes the weird duplication of `sync_mode` and `ranges` in both the request generator and the list. Now, the data is only stored once in the request generator.

Overall, this reduces the whole API surface, and gets rid of entire category of bugs (settings ranges for non-selective lists).

# Creating a new list

## Before

```rust
sliding_sync
            .add_list(
                SlidingSyncList::builder("bar")
                    .sync_mode(SlidingSyncMode::Selective)
                    .set_range(50..=60),
            )
```

## After

```rust
sliding_sync
            .add_list(
                SlidingSyncList::builder("bar")
                    .sync_mode(SlidingSyncMode::new_selective().add_range(50..=60)),
            )
```

# Setting range for an existing list

There's no more a `set_range` method in the FFI; we could actually add it back, as an helper, if needs be.

## Before

```rust
sliding_sync_list.set_range(50..=60)
```

## After

```rust
sliding_sync_list.set_sync_mode(SlidingSyncMode::new_selective().add_range(50..=60));
```