### PR TITLE
sliding sync: reduce `Range` surface API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -757,10 +757,6 @@ impl SlidingSync {
         })
     }
 
-    pub fn reset_lists(&self) -> Result<(), SlidingSyncError> {
-        self.inner.reset_lists().map_err(Into::into)
-    }
-
     pub fn sync(&self) -> Arc<TaskHandle> {
         let inner = self.inner.clone();
         let client = self.client.clone();

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -532,12 +532,6 @@ impl SlidingSyncListBuilder {
         Arc::new(builder)
     }
 
-    pub fn reset_ranges(self: Arc<Self>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.reset_ranges();
-        Arc::new(builder)
-    }
-
     pub fn once_built(self: Arc<Self>, callback: Box<dyn SlidingSyncListOnceBuilt>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -220,7 +220,7 @@ impl Match for SlidingSyncMatcher {
 async fn test_timeline_basic() -> Result<()> {
     let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
         .sync_mode(SlidingSyncMode::Selective)
-        .set_range(0..=10)])
+        .add_range(0..=10)])
     .await?;
 
     let stream = sliding_sync.sync();
@@ -267,7 +267,7 @@ async fn test_timeline_basic() -> Result<()> {
 async fn test_timeline_duplicated_events() -> Result<()> {
     let (server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
         .sync_mode(SlidingSyncMode::Selective)
-        .set_range(0..=10)])
+        .add_range(0..=10)])
     .await?;
 
     let stream = sliding_sync.sync();

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -77,7 +77,7 @@ let list_builder = SlidingSyncList::builder("main_list")
         v4::SyncRequestListFilters::default(), { is_dm: Some(true)}
     )))
     .sort(vec!["by_recency".to_owned()])
-    .set_range(0u32..=9);
+    .add_range(0u32..=9);
 ```
 
 Please refer to the [specification][MSC], the [Ruma types][ruma-types],
@@ -425,7 +425,7 @@ let full_sync_list = SlidingSyncList::builder(&full_sync_list_name)
 
 let active_list = SlidingSyncList::builder(&active_list_name) // the active window
     .sync_mode(SlidingSyncMode::Selective)  // sync up the specific range only
-    .set_range(0u32..=9) // only the top 10 items
+    .add_range(0u32..=9) // only the top 10 items
     .sort(vec!["by_recency".to_owned()]) // last active
     .timeline_limit(5u32) // add the last 5 timeline items for room preview and faster timeline loading
     .required_state(vec![ // we want to know immediately:

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -154,12 +154,6 @@ impl SlidingSyncListBuilder {
         self
     }
 
-    /// Reset the ranges to fetch.
-    pub fn reset_ranges(mut self) -> Self {
-        self.ranges.clear();
-        self
-    }
-
     /// Marks this list as sync'd from the cache, and attempts to reload it from
     /// storage.
     ///

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -142,12 +142,6 @@ impl SlidingSyncListBuilder {
         self
     }
 
-    /// Set the ranges to fetch.
-    pub fn ranges(mut self, ranges: Vec<RangeInclusive<Bound>>) -> Self {
-        self.ranges = ranges;
-        self
-    }
-
     /// Set a single range to fetch.
     pub fn set_range(mut self, range: RangeInclusive<Bound>) -> Self {
         self.ranges = vec![range];

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -142,12 +142,6 @@ impl SlidingSyncListBuilder {
         self
     }
 
-    /// Set a single range to fetch.
-    pub fn set_range(mut self, range: RangeInclusive<Bound>) -> Self {
-        self.ranges = vec![range];
-        self
-    }
-
     /// Set the ranges to fetch.
     pub fn add_range(mut self, range: RangeInclusive<Bound>) -> Self {
         self.ranges.push(range);

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -1021,7 +1021,8 @@ mod tests {
 
         let list = SlidingSyncList::builder("foo")
             .sync_mode(SlidingSyncMode::new_selective())
-            .ranges(vec![0..=1, 2..=3])
+            .add_range(0..=1)
+            .add_range(2..=3)
             .build(sender);
 
         assert_eq!(*list.inner.ranges.read().unwrap(), &[0..=1, 2..=3]);
@@ -1038,7 +1039,8 @@ mod tests {
         {
             let list = SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::new_selective())
-                .ranges(vec![0..=1, 2..=3])
+                .add_range(0..=1)
+                .add_range(2..=3)
                 .build(sender.clone());
 
             assert_eq!(*list.inner.ranges.read().unwrap(), &[0..=1, 2..=3]);
@@ -1074,7 +1076,7 @@ mod tests {
         {
             let list = SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::new_selective())
-                .ranges(vec![0..=1])
+                .add_range(0..=1)
                 .build(sender.clone());
 
             assert_eq!(*list.inner.ranges.read().unwrap(), &[0..=1]);
@@ -1110,7 +1112,7 @@ mod tests {
         {
             let list = SlidingSyncList::builder("foo")
                 .sync_mode(SlidingSyncMode::new_selective())
-                .ranges(vec![0..=1])
+                .add_range(0..=1)
                 .build(sender.clone());
 
             assert_eq!(*list.inner.ranges.read().unwrap(), &[0..=1]);
@@ -1144,7 +1146,7 @@ mod tests {
 
         let list = SlidingSyncList::builder("foo")
             .sync_mode(SlidingSyncMode::new_selective())
-            .ranges(vec![0..=1])
+            .add_range(0..=1)
             .timeline_limit(7)
             .build(sender);
 
@@ -1408,7 +1410,8 @@ mod tests {
 
         let mut list = SlidingSyncList::builder("testing")
             .sync_mode(SlidingSyncMode::new_selective())
-            .ranges(vec![0..=10, 42..=153])
+            .add_range(0..=10)
+            .add_range(42..=153)
             .build(sender);
 
         assert_ranges! {
@@ -1441,7 +1444,8 @@ mod tests {
 
         let mut list = SlidingSyncList::builder("testing")
             .sync_mode(SlidingSyncMode::new_selective())
-            .ranges(vec![0..=10, 42..=153].to_vec())
+            .add_range(0..=10)
+            .add_range(42..=153)
             .build(sender);
 
         assert_ranges! {
@@ -1526,7 +1530,8 @@ mod tests {
 
         let mut list = SlidingSyncList::builder("testing")
             .sync_mode(SlidingSyncMode::new_selective())
-            .ranges(vec![0..=10, 42..=153].to_vec())
+            .add_range(0..=10)
+            .add_range(42..=153)
             .build(sender);
 
         assert_ranges! {

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -83,18 +83,6 @@ impl SlidingSyncList {
         Ok(())
     }
 
-    /// Set the ranges to fetch.
-    pub fn set_ranges(&self, ranges: &[RangeInclusive<Bound>]) -> Result<(), Error> {
-        if self.inner.sync_mode.read().unwrap().ranges_can_be_modified_by_user().not() {
-            return Err(Error::CannotModifyRanges(self.name().to_owned()));
-        }
-
-        self.inner.set_ranges(ranges);
-        self.reset()?;
-
-        Ok(())
-    }
-
     /// Reset the ranges to a particular set.
     pub fn set_range(&self, range: RangeInclusive<Bound>) -> Result<(), Error> {
         if self.inner.sync_mode.read().unwrap().ranges_can_be_modified_by_user().not() {
@@ -1016,22 +1004,6 @@ mod tests {
     }
 
     #[test]
-    fn test_sliding_sync_list_set_ranges() {
-        let (sender, _receiver) = channel(1);
-
-        let list = SlidingSyncList::builder("foo")
-            .sync_mode(SlidingSyncMode::new_selective())
-            .add_range(0..=1)
-            .add_range(2..=3)
-            .build(sender);
-
-        assert_eq!(*list.inner.ranges.read().unwrap(), &[0..=1, 2..=3]);
-
-        list.set_ranges(&[4..=5, 6..=7]).unwrap();
-        assert_eq!(*list.inner.ranges.read().unwrap(), &[4..=5, 6..=7]);
-    }
-
-    #[test]
     fn test_sliding_sync_list_set_range() {
         let (sender, _receiver) = channel(1);
 
@@ -1471,7 +1443,7 @@ mod tests {
             }
         };
 
-        list.set_ranges(&[3..=7]).unwrap();
+        list.set_range(3..=7).unwrap();
 
         assert_ranges! {
             list = list,

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -791,7 +791,7 @@ mod tests {
     async fn test_subscribe_to_room() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(0..=10)])
+            .add_range(0..=10)])
         .await?;
 
         let _stream = sliding_sync.sync();
@@ -839,7 +839,7 @@ mod tests {
     async fn test_to_device_token_properly_cached() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(0..=10)])
+            .add_range(0..=10)])
         .await?;
 
         // When no to-device token is present, `prepare_extensions_config` doesn't fill
@@ -876,7 +876,7 @@ mod tests {
     async fn test_add_list() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(0..=10)])
+            .add_range(0..=10)])
         .await?;
 
         let _stream = sliding_sync.sync();
@@ -886,7 +886,7 @@ mod tests {
             .add_list(
                 SlidingSyncList::builder("bar")
                     .sync_mode(SlidingSyncMode::Selective)
-                    .set_range(50..=60),
+                    .add_range(50..=60),
             )
             .await?;
 
@@ -904,7 +904,7 @@ mod tests {
     async fn test_stop_sync_loop() -> Result<()> {
         let (_server, sliding_sync) = new_sliding_sync(vec![SlidingSyncList::builder("foo")
             .sync_mode(SlidingSyncMode::Selective)
-            .set_range(0..=10)])
+            .add_range(0..=10)])
         .await?;
 
         let stream = sliding_sync.sync();

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -632,17 +632,6 @@ impl SlidingSync {
     pub async fn stop_sync(&self) -> Result<(), Error> {
         self.inner.internal_channel_send(SlidingSyncInternalMessage::SyncLoopStop).await
     }
-
-    /// Resets the lists.
-    pub fn reset_lists(&self) -> Result<(), Error> {
-        let lists = self.inner.lists.read().unwrap();
-
-        for list in lists.values() {
-            list.reset()?;
-        }
-
-        Ok(())
-    }
 }
 
 impl SlidingSyncInner {


### PR DESCRIPTION
This is extracted from #1955: this removes unused public APIs (at least unused by ElementX iOS and Android), and replaces some internal methods with other existing functions that do more or less the same thing.