### PR TITLE
feat(sdk): Implement `SlidingSync::stop_sync`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -794,7 +794,7 @@ impl SlidingSync {
                     }
 
                     None => {
-                        warn!("Inner streaming loop ended unexpectedly");
+                        warn!("SlidingSync sync-loop ended");
                         break;
                     }
                 };
@@ -804,6 +804,10 @@ impl SlidingSync {
                 }
             }
         })))
+    }
+
+    pub fn stop_sync(&self) {
+        RUNTIME.block_on(async move { self.inner.stop_sync().await.unwrap() });
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -777,7 +777,7 @@ impl SlidingSync {
         let observer = self.observer.clone();
 
         Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
-            let stream = inner.stream();
+            let stream = inner.sync();
             pin_mut!(stream);
 
             loop {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -223,7 +223,7 @@ async fn test_timeline_basic() -> Result<()> {
         .set_range(0..=10)])
     .await?;
 
-    let stream = sliding_sync.stream();
+    let stream = sliding_sync.sync();
     pin_mut!(stream);
 
     let room_id = room_id!("!foo:bar.org");
@@ -270,7 +270,7 @@ async fn test_timeline_duplicated_events() -> Result<()> {
         .set_range(0..=10)])
     .await?;
 
-    let stream = sliding_sync.stream();
+    let stream = sliding_sync.sync();
     pin_mut!(stream);
 
     let room_id = room_id!("!foo:bar.org");

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -240,7 +240,7 @@ does after.
 This is modelled as a [async `Stream`][`futures_core::stream::Stream`] in
 our API, that one basically wants to continue polling. Once one has made its
 setup ready and build its sliding sync sessions, one wants to acquire its
-[`.stream()`](`SlidingSync::stream`) and continuously poll it.
+[`.sync()`](`SlidingSync::sync`) and continuously poll it.
 
 While the async stream API allows for streams to end (by returning `None`)
 Sliding Sync streams items `Result<UpdateSummary, Error>`. For every
@@ -276,7 +276,7 @@ let sliding_sync = client
     .build()
     .await?;
 
-let stream = sliding_sync.stream();
+let stream = sliding_sync.sync();
 
 // continuously poll for updates
 pin_mut!(stream);
@@ -321,7 +321,7 @@ the [`SlidingSync`][] will only process new data and skip the processing
 even across restarts.
 
 To support this, in practice, one can spawn a `Future` that runs
-[`SlidingSync::stream`]. The spawned `Future` can be cancelled safely. If
+[`SlidingSync::sync`]. The spawned `Future` can be cancelled safely. If
 the client was waiting on a response, it's cancelled without any issue. If
 a response was just received, it
 will be fully handled by `SlidingSync`. This _response is always
@@ -470,7 +470,7 @@ tokio::spawn(async move {
     }
 });
 
-let stream = sliding_sync.stream();
+let stream = sliding_sync.sync();
 
 // continuously poll for updates
 pin_mut!(stream);

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -230,7 +230,7 @@ impl SlidingSyncBuilder {
 
         let mut delta_token = None;
 
-        let (internal_channel_sender, internal_channel_receiver) = channel(256);
+        let (internal_channel_sender, internal_channel_receiver) = channel(8);
 
         let mut lists = BTreeMap::new();
 

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -661,6 +661,7 @@ impl SlidingSyncListInner {
     }
 
     /// Send a message over the internal channel.
+    #[instrument]
     fn internal_channel_blocking_send(
         &self,
         message: SlidingSyncInternalMessage,

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -699,12 +699,7 @@ impl SlidingSyncInner {
         &self,
         message: SlidingSyncInternalMessage,
     ) -> Result<(), Error> {
-        Ok(self
-            .internal_channel
-            .0
-            .send(message)
-            .await
-            .map_err(|_| Error::InternalChannelIsBroken)?)
+        self.internal_channel.0.send(message).await.map_err(|_| Error::InternalChannelIsBroken)
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -695,6 +695,7 @@ impl SlidingSync {
 
 impl SlidingSyncInner {
     /// Send a message over the internal channel.
+    #[instrument]
     async fn internal_channel_send(
         &self,
         message: SlidingSyncInternalMessage,

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -711,7 +711,6 @@ impl SlidingSyncInner {
 #[derive(Debug)]
 enum SlidingSyncInternalMessage {
     /// Instruct the sync loop to stop.
-    #[allow(unused)] // temporary
     SyncLoopStop,
 
     /// Instruct the sync loop to skip over any remaining work in its iteration,

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -596,6 +596,10 @@ impl SlidingSync {
                     internal_message = internal_channel_receiver_lock.recv() => {
                         use SlidingSyncInternalMessage::*;
 
+                        sync_span.in_scope(|| {
+                            debug!(?internal_message, "Sync-loop has received an internal message");
+                        });
+
                         match internal_message {
                             None | Some(SyncLoopStop) => {
                                 break;

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -49,7 +49,7 @@ async fn it_works_smoke_test() -> anyhow::Result<()> {
         )
         .build()
         .await?;
-    let stream = sync_proxy.stream();
+    let stream = sync_proxy.sync();
     pin_mut!(stream);
     let room_summary =
         stream.next().await.context("No room summary found, loop ended unsuccessfully")?;


### PR DESCRIPTION
In case it's not obvious to drop the `Stream` returned by
`SlidingSync::sync` immediately to “stop” the sync-loop, one can use the
new `stop_sync` method to achieve the same result.

This patch also renames `SlidingSync::stream` to `::sync`.

This patch takes the liberty to log when an internal message is received, and
when internal messages are sent.

This patch also restores the internal channel size to 8, as it just postpones
the problem, making it harder to debug, without fixing anything.

Finally, this patch adds the `SlidingSync::stop_sync` method at the FFI layer.