### PR TITLE
fix(sdk): `Client::sliding_sync` doesn't need to be `async`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -905,18 +905,16 @@ impl SlidingSyncBuilder {
 #[uniffi::export]
 impl Client {
     pub fn sliding_sync(&self) -> Arc<SlidingSyncBuilder> {
-        RUNTIME.block_on(async move {
-            let mut inner = self.client.sliding_sync().await;
-            if let Some(sliding_sync_proxy) = self
-                .sliding_sync_proxy
-                .read()
-                .unwrap()
-                .clone()
-                .and_then(|p| Url::parse(p.as_str()).ok())
-            {
-                inner = inner.homeserver(sliding_sync_proxy);
-            }
-            Arc::new(SlidingSyncBuilder { inner, client: self.clone() })
-        })
+        let mut inner = self.client.sliding_sync();
+        if let Some(sliding_sync_proxy) = self
+            .sliding_sync_proxy
+            .read()
+            .unwrap()
+            .clone()
+            .and_then(|p| Url::parse(p.as_str()).ok())
+        {
+            inner = inner.homeserver(sliding_sync_proxy);
+        }
+        Arc::new(SlidingSyncBuilder { inner, client: self.clone() })
     }
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -151,7 +151,7 @@ macro_rules! assert_timeline_stream {
 async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockServer, SlidingSync)> {
     let (client, server) = logged_in_client().await;
 
-    let mut sliding_sync_builder = client.sliding_sync().await;
+    let mut sliding_sync_builder = client.sliding_sync();
 
     for list in lists {
         sliding_sync_builder = sliding_sync_builder.add_list(list);

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -42,7 +42,6 @@ typically runs on a separate domain, it can be configured on the
 # let client = Client::new(homeserver).await?;
 let sliding_sync_builder = client
     .sliding_sync()
-    .await
     .homeserver(Url::parse("http://sliding-sync.example.org")?);
 
 # anyhow::Ok(())
@@ -271,7 +270,6 @@ In full, this typically looks like this:
 # let client = Client::new(homeserver).await?;
 let sliding_sync = client
     .sliding_sync()
-    .await
     // any lists you want are added here.
     .build()
     .await?;
@@ -414,7 +412,6 @@ let full_sync_list_name = "full-sync".to_owned();
 let active_list_name = "active-list".to_owned();
 let sliding_sync_builder = client
     .sliding_sync()
-    .await
     .homeserver(Url::parse("http://sliding-sync.example.org")?) // our proxy server
     .with_common_extensions() // we want the e2ee and to-device enabled, please
     .storage_key(Some("example-cache".to_owned())); // we want these to be loaded from and stored into the persistent storage

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -218,7 +218,6 @@ mod tests {
             let client = Client::new(homeserver).await?;
             let err = client
                 .sliding_sync()
-                .await
                 .add_cached_list(SlidingSyncList::builder("list_foo"))
                 .await
                 .unwrap_err();
@@ -265,7 +264,6 @@ mod tests {
             {
                 let sliding_sync = client
                     .sliding_sync()
-                    .await
                     .storage_key(Some("hello".to_owned()))
                     .add_cached_list(SlidingSyncList::builder("list_foo"))
                     .await?
@@ -314,7 +312,6 @@ mod tests {
                 let cloned_stream = max_number_of_room_stream.clone();
                 let sliding_sync = client
                     .sliding_sync()
-                    .await
                     .storage_key(Some("hello".to_owned()))
                     .add_cached_list(SlidingSyncList::builder("list_foo").once_built(move |list| {
                         // In the `once_built()` handler, nothing has been read from the cache yet.

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -7,7 +7,7 @@ use crate::{Client, Result};
 
 impl Client {
     /// Create a [`SlidingSyncBuilder`] tied to this client.
-    pub async fn sliding_sync(&self) -> SlidingSyncBuilder {
+    pub fn sliding_sync(&self) -> SlidingSyncBuilder {
         SlidingSync::builder(self.clone())
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -774,7 +774,7 @@ mod test {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
-        let sync = client.sliding_sync().await.build().await?;
+        let sync = client.sliding_sync().build().await?;
         let extensions = sync.prepare_extension_config(None);
 
         // If the user doesn't provide any extension config, we enable to-device and
@@ -815,7 +815,7 @@ mod test {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
-        let mut sliding_sync_builder = client.sliding_sync().await;
+        let mut sliding_sync_builder = client.sliding_sync();
 
         for list in lists {
             sliding_sync_builder = sliding_sync_builder.add_list(list);

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -12,11 +12,8 @@ async fn setup(
     let sliding_sync_proxy_url =
         option_env!("SLIDING_SYNC_PROXY_URL").unwrap_or("http://localhost:8338").to_owned();
     let client = get_client_for_user(name, use_sqlite_store).await?;
-    let sliding_sync_builder = client
-        .sliding_sync()
-        .await
-        .homeserver(sliding_sync_proxy_url.parse()?)
-        .with_common_extensions();
+    let sliding_sync_builder =
+        client.sliding_sync().homeserver(sliding_sync_proxy_url.parse()?).with_common_extensions();
     Ok((client, sliding_sync_builder))
 }
 


### PR DESCRIPTION
The `Client::sliding_sync` method was declared as async. However, it's not necessary as everything happening here is sync.