### PR TITLE
feat(ffi): Allow to set the notification mode for a room

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,7 +4239,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=e3282d8bfebc69d2e64815105ebe9dced130b94a#e3282d8bfebc69d2e64815105ebe9dced130b94a"
+source = "git+https://github.com/ruma/ruma?rev=a2b64c20bc715239142e522fc6ea6d4936ef54d1#a2b64c20bc715239142e522fc6ea6d4936ef54d1"
 dependencies = [
  "assign",
  "js_int",
@@ -4254,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=e3282d8bfebc69d2e64815105ebe9dced130b94a#e3282d8bfebc69d2e64815105ebe9dced130b94a"
+source = "git+https://github.com/ruma/ruma?rev=a2b64c20bc715239142e522fc6ea6d4936ef54d1#a2b64c20bc715239142e522fc6ea6d4936ef54d1"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=e3282d8bfebc69d2e64815105ebe9dced130b94a#e3282d8bfebc69d2e64815105ebe9dced130b94a"
+source = "git+https://github.com/ruma/ruma?rev=a2b64c20bc715239142e522fc6ea6d4936ef54d1#a2b64c20bc715239142e522fc6ea6d4936ef54d1"
 dependencies = [
  "assign",
  "bytes",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=e3282d8bfebc69d2e64815105ebe9dced130b94a#e3282d8bfebc69d2e64815105ebe9dced130b94a"
+source = "git+https://github.com/ruma/ruma?rev=a2b64c20bc715239142e522fc6ea6d4936ef54d1#a2b64c20bc715239142e522fc6ea6d4936ef54d1"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=e3282d8bfebc69d2e64815105ebe9dced130b94a#e3282d8bfebc69d2e64815105ebe9dced130b94a"
+source = "git+https://github.com/ruma/ruma?rev=a2b64c20bc715239142e522fc6ea6d4936ef54d1#a2b64c20bc715239142e522fc6ea6d4936ef54d1"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4326,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=e3282d8bfebc69d2e64815105ebe9dced130b94a#e3282d8bfebc69d2e64815105ebe9dced130b94a"
+source = "git+https://github.com/ruma/ruma?rev=a2b64c20bc715239142e522fc6ea6d4936ef54d1#a2b64c20bc715239142e522fc6ea6d4936ef54d1"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4335,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=e3282d8bfebc69d2e64815105ebe9dced130b94a#e3282d8bfebc69d2e64815105ebe9dced130b94a"
+source = "git+https://github.com/ruma/ruma?rev=a2b64c20bc715239142e522fc6ea6d4936ef54d1#a2b64c20bc715239142e522fc6ea6d4936ef54d1"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=e3282d8bfebc69d2e64815105ebe9dced130b94a#e3282d8bfebc69d2e64815105ebe9dced130b94a"
+source = "git+https://github.com/ruma/ruma?rev=a2b64c20bc715239142e522fc6ea6d4936ef54d1#a2b64c20bc715239142e522fc6ea6d4936ef54d1"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ futures-core = "0.3.28"
 futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
-ruma = { git = "https://github.com/ruma/ruma", rev = "e3282d8bfebc69d2e64815105ebe9dced130b94a", features = ["client-api-c", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "e3282d8bfebc69d2e64815105ebe9dced130b94a" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "a2b64c20bc715239142e522fc6ea6d4936ef54d1", features = ["client-api-c", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "a2b64c20bc715239142e522fc6ea6d4936ef54d1" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -167,3 +167,7 @@ callback interface SessionVerificationControllerDelegate {
     void did_cancel();
     void did_finish();
 };
+
+callback interface NotificationSettingsDelegate {
+    void notification_settings_did_change();
+};

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -34,7 +34,10 @@ use serde_json::Value;
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error, warn};
 
-use super::{room::Room, session_verification::SessionVerificationController, RUNTIME};
+use super::{
+    notification_settings::NotificationSettings, room::Room,
+    session_verification::SessionVerificationController, RUNTIME,
+};
 use crate::{client, ClientError, NotificationItem};
 
 #[derive(Clone, uniffi::Record)]
@@ -112,6 +115,7 @@ pub struct Client {
     notification_delegate: Arc<RwLock<Option<Box<dyn NotificationDelegate>>>>,
     session_verification_controller:
         Arc<tokio::sync::RwLock<Option<SessionVerificationController>>>,
+    notification_settings: Arc<NotificationSettings>,
     /// The sliding sync proxy that the client is configured to use by default.
     /// If this value is `Some`, it will be automatically added to the builder
     /// when calling `sliding_sync()`.
@@ -137,11 +141,14 @@ impl Client {
             }
         });
 
+        let notification_settings = Arc::new(NotificationSettings::new(sdk_client.clone()));
+
         let client = Client {
             inner: sdk_client,
             delegate: Arc::new(RwLock::new(None)),
             notification_delegate: Arc::new(RwLock::new(None)),
             session_verification_controller,
+            notification_settings,
             sliding_sync_proxy: Arc::new(RwLock::new(None)),
             sliding_sync_reset_broadcast_tx: Default::default(),
         };
@@ -595,6 +602,10 @@ impl Client {
             let notification = NotificationItem::new_from_event_id(&event_id, room).await?;
             Ok(notification)
         })
+    }
+
+    pub fn get_notification_settings(&self) -> Arc<NotificationSettings> {
+        self.notification_settings.to_owned()
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -107,9 +107,6 @@ pub enum NotificationSettingsError {
     /// Invalid room id.
     #[error("Invalid room id")]
     InvalidRoomId,
-    /// Mentions not enabled.
-    #[error("Mentions not enabled")]
-    MentionsNotEnabled,
     /// Room not found
     #[error("Room not found")]
     RoomNotFound,
@@ -131,7 +128,6 @@ impl From<SdkNotificationSettingsError> for NotificationSettingsError {
     fn from(value: SdkNotificationSettingsError) -> Self {
         match value {
             SdkNotificationSettingsError::InvalidRoomId => Self::InvalidRoomId,
-            SdkNotificationSettingsError::MentionsNotEnabled => Self::MentionsNotEnabled,
             SdkNotificationSettingsError::RuleNotFound => Self::RuleNotFound,
             SdkNotificationSettingsError::UnableToAddPushRule => Self::UnableToAddPushRule,
             SdkNotificationSettingsError::UnableToRemovePushRule => Self::UnableToRemovePushRule,

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
-use matrix_sdk::{self, encryption::CryptoStoreError, HttpError, IdParseError, StoreError};
+use matrix_sdk::{
+    self, encryption::CryptoStoreError, HttpError, IdParseError, StoreError,
+    NotificationSettingsError as SdkNotificationSettingsError, StoreError,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
@@ -68,6 +71,12 @@ impl From<mime::FromStrError> for ClientError {
     }
 }
 
+impl From<NotificationSettingsError> for ClientError {
+    fn from(e: NotificationSettingsError) -> Self {
+        anyhow::Error::from(e).into()
+    }
+}
+
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi(flat_error)]
 pub enum RoomError {
@@ -90,4 +99,43 @@ pub enum TimelineError {
     MissingMediaInfoField,
     #[error("Media info field invalid")]
     InvalidMediaInfoField,
+}
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi(flat_error)]
+pub enum NotificationSettingsError {
+    /// Invalid room id.
+    #[error("Invalid room id")]
+    InvalidRoomId,
+    /// Mentions not enabled.
+    #[error("Mentions not enabled")]
+    MentionsNotEnabled,
+    /// Room not found
+    #[error("Room not found")]
+    RoomNotFound,
+    /// Rule not found
+    #[error("Rule not found")]
+    RuleNotFound,
+    /// Unable to add push rule.
+    #[error("Unable to add push rule")]
+    UnableToAddPushRule,
+    /// Unable to remove push rule.
+    #[error("Unable to remove push rule")]
+    UnableToRemovePushRule,
+    /// Unable to save the push rules
+    #[error("Unable to save push rules")]
+    UnableToSavePushRules,
+}
+
+impl From<SdkNotificationSettingsError> for NotificationSettingsError {
+    fn from(value: SdkNotificationSettingsError) -> Self {
+        match value {
+            SdkNotificationSettingsError::InvalidRoomId => Self::InvalidRoomId,
+            SdkNotificationSettingsError::MentionsNotEnabled => Self::MentionsNotEnabled,
+            SdkNotificationSettingsError::RuleNotFound => Self::RuleNotFound,
+            SdkNotificationSettingsError::UnableToAddPushRule => Self::UnableToAddPushRule,
+            SdkNotificationSettingsError::UnableToRemovePushRule => Self::UnableToRemovePushRule,
+            SdkNotificationSettingsError::UnableToSavePushRules => Self::UnableToSavePushRules,
+        }
+    }
 }

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -107,8 +107,8 @@ pub enum NotificationSettingsError {
     #[error("client error: {msg}")]
     Generic { msg: String },
     /// Invalid room id.
-    #[error("Invalid room id")]
-    InvalidRoomId,
+    #[error("Invalid room ID `{0}`")]
+    InvalidRoomId(String),
     /// Room not found
     #[error("Room not found")]
     RoomNotFound,
@@ -129,7 +129,6 @@ pub enum NotificationSettingsError {
 impl From<SdkNotificationSettingsError> for NotificationSettingsError {
     fn from(value: SdkNotificationSettingsError) -> Self {
         match value {
-            SdkNotificationSettingsError::InvalidRoomId => Self::InvalidRoomId,
             SdkNotificationSettingsError::RuleNotFound => Self::RuleNotFound,
             SdkNotificationSettingsError::UnableToAddPushRule => Self::UnableToAddPushRule,
             SdkNotificationSettingsError::UnableToRemovePushRule => Self::UnableToRemovePushRule,

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use matrix_sdk::{
-    self, encryption::CryptoStoreError, HttpError, IdParseError, StoreError,
+    self, encryption::CryptoStoreError, HttpError, IdParseError,
     NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
 
@@ -104,6 +104,8 @@ pub enum TimelineError {
 #[derive(Debug, thiserror::Error, uniffi::Error)]
 #[uniffi(flat_error)]
 pub enum NotificationSettingsError {
+    #[error("client error: {msg}")]
+    Generic { msg: String },
     /// Invalid room id.
     #[error("Invalid room id")]
     InvalidRoomId,
@@ -133,5 +135,11 @@ impl From<SdkNotificationSettingsError> for NotificationSettingsError {
             SdkNotificationSettingsError::UnableToRemovePushRule => Self::UnableToRemovePushRule,
             SdkNotificationSettingsError::UnableToSavePushRules => Self::UnableToSavePushRules,
         }
+    }
+}
+
+impl From<matrix_sdk::Error> for NotificationSettingsError {
+    fn from(e: matrix_sdk::Error) -> Self {
+        Self::Generic { msg: e.to_string() }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -29,6 +29,7 @@ mod error;
 pub mod event;
 mod helpers;
 pub mod notification;
+pub mod notification_settings;
 pub mod room;
 pub mod room_member;
 pub mod session_verification;
@@ -42,8 +43,8 @@ pub use matrix_sdk_ui::timeline::PaginationOutcome;
 pub use platform::*;
 
 pub use self::{
-    authentication_service::*, client::*, event::*, notification::*, room::*, room_member::*,
-    session_verification::*, sliding_sync::*, timeline::*, tracing::*,
+    authentication_service::*, client::*, event::*, notification::*, notification_settings::*,
+    room::*, room_member::*, session_verification::*, sliding_sync::*, timeline::*, tracing::*,
 };
 // Re-exports for more convenient use inside other submodules
 use self::{client::Client, error::ClientError};

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -1,0 +1,180 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use matrix_sdk::{
+    notification_settings::RoomNotificationMode as SdkRoomNotificationMode,
+    ruma::events::push_rules::PushRulesEvent, Client as MatrixClient,
+};
+use ruma::{push::Ruleset, RoomId};
+use tokio::sync::RwLock;
+
+use crate::error::NotificationSettingsError;
+
+#[derive(Clone, uniffi::Enum)]
+pub enum RoomNotificationMode {
+    AllMessages,
+    MentionsAndKeywordsOnly,
+    Mute,
+}
+
+impl From<SdkRoomNotificationMode> for RoomNotificationMode {
+    fn from(value: SdkRoomNotificationMode) -> Self {
+        match value {
+            SdkRoomNotificationMode::AllMessages => Self::AllMessages,
+            SdkRoomNotificationMode::MentionsAndKeywordsOnly => Self::MentionsAndKeywordsOnly,
+            SdkRoomNotificationMode::Mute => Self::Mute,
+        }
+    }
+}
+
+pub trait NotificationSettingsDelegate: Sync + Send {
+    fn notification_settings_did_change(&self);
+}
+
+#[derive(Clone, uniffi::Record)]
+pub struct RoomNotificationSettings {
+    mode: RoomNotificationMode,
+    is_default: bool,
+}
+
+impl RoomNotificationSettings {
+    fn new(mode: RoomNotificationMode, is_default: bool) -> Self {
+        RoomNotificationSettings { mode, is_default }
+    }
+}
+
+#[derive(Clone, uniffi::Object)]
+pub struct NotificationSettings {
+    pub(crate) sdk_client: MatrixClient,
+    push_rules: Arc<RwLock<Ruleset>>,
+    delegate: Arc<RwLock<Option<Box<dyn NotificationSettingsDelegate>>>>,
+}
+
+impl NotificationSettings {
+    pub(crate) fn new(sdk_client: MatrixClient) -> Self {
+        let push_rules = Arc::new(tokio::sync::RwLock::new(Ruleset::new()));
+        let delegate: Arc<RwLock<Option<Box<dyn NotificationSettingsDelegate>>>> =
+            Arc::new(RwLock::new(None));
+
+        // Listen for PushRulesEvent
+        let push_rules_clone = push_rules.to_owned();
+        let delegate_clone = delegate.to_owned();
+        sdk_client.add_event_handler(move |ev: PushRulesEvent| {
+            let push_rules = push_rules_clone.clone();
+            let delegate = delegate_clone.clone();
+            async move {
+                *push_rules.write().await = ev.content.global;
+                if let Some(delegate) = delegate.read().await.as_ref() {
+                    delegate.notification_settings_did_change();
+                }
+            }
+        });
+
+        Self { sdk_client, push_rules, delegate }
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl NotificationSettings {
+    /// Sets a delegate.
+    pub async fn set_delegate(&self, delegate: Option<Box<dyn NotificationSettingsDelegate>>) {
+        *self.delegate.write().await = delegate;
+    }
+
+    /// Gets the notification mode for a given room
+    pub async fn get_room_notification_mode(
+        &self,
+        room_id: String,
+    ) -> Result<RoomNotificationSettings, NotificationSettingsError> {
+        let ruleset = &*self.push_rules.read().await;
+        let notification_settings = self.sdk_client.notification_settings();
+        // Get the current user defined mode for this room
+        if let Some(mode) =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, ruleset)
+        {
+            return Ok(RoomNotificationSettings::new(mode.into(), false));
+        }
+
+        // If the user didn't defined a notification mode, return the default one for
+        // this room
+        let room_id =
+            RoomId::parse(room_id).map_err(|_| NotificationSettingsError::InvalidRoomId)?;
+        let room = self
+            .sdk_client
+            .get_room(&room_id)
+            .context("Room not found")
+            .map_err(|_| NotificationSettingsError::RoomNotFound)?;
+
+        let is_encrypted = room.is_encrypted().await.unwrap_or(false);
+        let members_count = room.joined_members_count();
+
+        let mode = notification_settings.get_default_room_notification_mode(
+            is_encrypted,
+            members_count,
+            ruleset,
+        )?;
+        Ok(RoomNotificationSettings::new(mode.into(), true))
+    }
+
+    /// Sets a notification mode for a given room
+    pub async fn set_room_notification_mode(
+        &self,
+        room_id: String,
+        mode: RoomNotificationMode,
+    ) -> Result<(), NotificationSettingsError> {
+        let ruleset = &mut *self.push_rules.write().await;
+        let notification_settings = self.sdk_client.notification_settings();
+        let mode = match mode {
+            RoomNotificationMode::AllMessages => SdkRoomNotificationMode::AllMessages,
+            RoomNotificationMode::MentionsAndKeywordsOnly => {
+                SdkRoomNotificationMode::MentionsAndKeywordsOnly
+            }
+            RoomNotificationMode::Mute => SdkRoomNotificationMode::Mute,
+        };
+        notification_settings.set_room_notification_mode(&room_id, mode, ruleset).await?;
+        Ok(())
+    }
+
+    /// Restores the default notification mode for a given room
+    pub async fn restore_default_room_notification_mode(
+        &self,
+        room_id: String,
+    ) -> Result<(), NotificationSettingsError> {
+        let ruleset = &mut *self.push_rules.write().await;
+        self.sdk_client
+            .notification_settings()
+            .restore_room_default_push_rule(&room_id, ruleset)
+            .await?;
+        Ok(())
+    }
+
+    /// Get whether keyword rules exist.
+    pub async fn contains_keywords_rules(&self) -> bool {
+        let ruleset = &*self.push_rules.read().await;
+        self.sdk_client.notification_settings().contains_keywords_rules(ruleset)
+    }
+
+    /// Get whether @room mentions are enabled.
+    pub async fn is_room_mention_enabled(&self) -> bool {
+        let ruleset = &*self.push_rules.read().await;
+        self.sdk_client.notification_settings().is_room_mention_enabled(ruleset)
+    }
+
+    /// Set whether @room mentions are enabled.
+    pub async fn set_room_mention_enabled(&self, enabled: bool) {
+        let ruleset = &mut *self.push_rules.write().await;
+        self.sdk_client.notification_settings().set_room_mention_enabled(enabled, ruleset)
+    }
+
+    /// Get whether user mentions are enabled.
+    pub async fn is_user_mention_enabled(&self) -> bool {
+        let ruleset = &*self.push_rules.read().await;
+        self.sdk_client.notification_settings().is_user_mention_enabled(ruleset)
+    }
+
+    /// Set whether user mentions are enabled.
+    pub async fn set_user_mention_enabled(&self, enabled: bool) {
+        let ruleset = &mut *self.push_rules.write().await;
+        self.sdk_client.notification_settings().set_user_mention_enabled(enabled, ruleset)
+    }
+}

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -151,7 +151,7 @@ impl NotificationSettings {
     /// Get whether keyword rules exist.
     pub async fn contains_keywords_rules(&self) -> bool {
         let ruleset = &*self.push_rules.read().await;
-        self.sdk_client.notification_settings().contains_keywords_rules(ruleset)
+        self.sdk_client.notification_settings().contains_keyword_rules(ruleset)
     }
 
     /// Get whether @room mentions are enabled.

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -143,9 +143,7 @@ impl NotificationSettings {
     ) -> Result<(), NotificationSettingsError> {
         let mut ruleset = self.push_rules.read().await.clone();
         let notification_settings = self.sdk_client.notification_settings();
-        notification_settings
-            .delete_user_defined_room_notification_mode(&room_id, &mut ruleset)
-            .await?;
+        notification_settings.delete_user_defined_room_rules(&room_id, &mut ruleset).await?;
         *self.push_rules.write().await = ruleset;
         Ok(())
     }

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -116,7 +116,7 @@ impl NotificationSettings {
             is_encrypted,
             members_count,
             ruleset,
-        )?;
+        );
         Ok(RoomNotificationSettings::new(mode.into(), true))
     }
 

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -131,8 +131,7 @@ impl NotificationSettings {
             }
             RoomNotificationMode::Mute => SdkRoomNotificationMode::Mute,
         };
-        notification_settings.set_room_notification_mode(&room_id, mode, &mut ruleset)?;
-        notification_settings.save_push_rules(&ruleset).await?;
+        notification_settings.set_room_notification_mode(&room_id, mode, &mut ruleset).await?;
         *self.push_rules.write().await = ruleset;
         Ok(())
     }
@@ -144,13 +143,14 @@ impl NotificationSettings {
     ) -> Result<(), NotificationSettingsError> {
         let mut ruleset = self.push_rules.read().await.clone();
         let notification_settings = self.sdk_client.notification_settings();
-        notification_settings.restore_room_default_push_rule(&room_id, &mut ruleset)?;
-        notification_settings.save_push_rules(&ruleset).await?;
+        notification_settings
+            .delete_user_defined_room_notification_mode(&room_id, &mut ruleset)
+            .await?;
         *self.push_rules.write().await = ruleset;
         Ok(())
     }
 
-    /// Get whether keyword rules exist.
+    /// Get whether some enabled keyword rules exist.
     pub async fn contains_keywords_rules(&self) -> bool {
         let ruleset = &*self.push_rules.read().await;
         self.sdk_client.notification_settings().contains_keyword_rules(ruleset)
@@ -169,8 +169,7 @@ impl NotificationSettings {
     ) -> Result<(), NotificationSettingsError> {
         let mut ruleset = self.push_rules.read().await.clone();
         let notification_settings = self.sdk_client.notification_settings();
-        notification_settings.set_room_mention_enabled(enabled, &mut ruleset);
-        notification_settings.save_push_rules(&ruleset).await?;
+        notification_settings.set_room_mention_enabled(enabled, &mut ruleset).await?;
         *self.push_rules.write().await = ruleset;
         Ok(())
     }
@@ -188,8 +187,7 @@ impl NotificationSettings {
     ) -> Result<(), NotificationSettingsError> {
         let mut ruleset = self.push_rules.read().await.clone();
         let notification_settings = self.sdk_client.notification_settings();
-        notification_settings.set_user_mention_enabled(enabled, &mut ruleset);
-        notification_settings.save_push_rules(&ruleset).await?;
+        notification_settings.set_user_mention_enabled(enabled, &mut ruleset).await?;
         *self.push_rules.write().await = ruleset;
         Ok(())
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -79,6 +79,7 @@ use crate::{
         EventHandler, EventHandlerDropGuard, EventHandlerHandle, EventHandlerStore, SyncEvent,
     },
     http_client::HttpClient,
+    notification_settings::NotificationSettings,
     room,
     sync::{RoomUpdate, SyncResponse},
     Account, Error, Media, RefreshTokenError, Result, RumaApiError,
@@ -538,6 +539,11 @@ impl Client {
     /// Get the account of the current owner of the client.
     pub fn account(&self) -> Account {
         Account::new(self.clone())
+    }
+
+    /// Get the notification settings of the current owner of the client.
+    pub fn notification_settings(&self) -> NotificationSettings {
+        NotificationSettings::new(self.clone())
     }
 
     /// Get the encryption manager of the client.

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -30,6 +30,7 @@ use ruma::{
         error::{FromHttpResponseError, IntoHttpError},
     },
     events::tag::InvalidUserTagName,
+    push::{InsertPushRuleError, RemovePushRuleError, RuleNotFoundError},
     IdParseError,
 };
 use serde_json::Error as JsonError;
@@ -421,4 +422,51 @@ pub enum RefreshTokenError {
     /// not be forwarded.
     #[error("the access token could not be refreshed")]
     UnableToRefreshToken,
+}
+
+/// Errors that can occur when manipulating push notification settings.
+#[derive(Debug, Error, Clone)]
+pub enum NotificationSettingsError {
+    /// Invalid room id.
+    #[error("Invalid room id")]
+    InvalidRoomId,
+    /// Mentions not enabled.
+    #[error("Mentions not enabled")]
+    MentionsNotEnabled,
+    /// Unable to add push rule.
+    #[error("Unable to add push rule")]
+    UnableToAddPushRule,
+    /// Unable to remove push rule.
+    #[error("Unable to remove push rule")]
+    UnableToRemovePushRule,
+    /// Rule not found
+    #[error("Rule not found")]
+    RuleNotFound,
+    /// Unable to save the push rules
+    #[error("Unable to save push rules")]
+    UnableToSavePushRules,
+}
+
+impl From<IdParseError> for NotificationSettingsError {
+    fn from(_: IdParseError) -> Self {
+        NotificationSettingsError::InvalidRoomId
+    }
+}
+
+impl From<InsertPushRuleError> for NotificationSettingsError {
+    fn from(_: InsertPushRuleError) -> Self {
+        NotificationSettingsError::UnableToAddPushRule
+    }
+}
+
+impl From<RemovePushRuleError> for NotificationSettingsError {
+    fn from(_: RemovePushRuleError) -> Self {
+        NotificationSettingsError::UnableToRemovePushRule
+    }
+}
+
+impl From<RuleNotFoundError> for NotificationSettingsError {
+    fn from(_: RuleNotFoundError) -> Self {
+        NotificationSettingsError::RuleNotFound
+    }
 }

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -427,9 +427,6 @@ pub enum RefreshTokenError {
 /// Errors that can occur when manipulating push notification settings.
 #[derive(Debug, Error, Clone)]
 pub enum NotificationSettingsError {
-    /// Invalid room id.
-    #[error("Invalid room id")]
-    InvalidRoomId,
     /// Unable to add push rule.
     #[error("Unable to add push rule")]
     UnableToAddPushRule,
@@ -442,12 +439,6 @@ pub enum NotificationSettingsError {
     /// Unable to save the push rules
     #[error("Unable to save push rules")]
     UnableToSavePushRules,
-}
-
-impl From<IdParseError> for NotificationSettingsError {
-    fn from(_: IdParseError) -> Self {
-        NotificationSettingsError::InvalidRoomId
-    }
 }
 
 impl From<InsertPushRuleError> for NotificationSettingsError {

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -430,9 +430,6 @@ pub enum NotificationSettingsError {
     /// Invalid room id.
     #[error("Invalid room id")]
     InvalidRoomId,
-    /// Mentions not enabled.
-    #[error("Mentions not enabled")]
-    MentionsNotEnabled,
     /// Unable to add push rule.
     #[error("Unable to add push rule")]
     UnableToAddPushRule,

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -37,6 +37,7 @@ mod error;
 pub mod event_handler;
 mod http_client;
 pub mod media;
+pub mod notification_settings;
 pub mod room;
 pub mod sync;
 
@@ -52,7 +53,10 @@ pub use client::SsoLoginBuilder;
 pub use client::{Client, ClientBuildError, ClientBuilder, LoginBuilder, LoopCtrl, UnknownToken};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;
-pub use error::{Error, HttpError, HttpResult, RefreshTokenError, Result, RumaApiError};
+pub use error::{
+    Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError, Result,
+    RumaApiError,
+};
 pub use http_client::HttpSend;
 pub use media::Media;
 pub use ruma::{IdParseError, OwnedServerName, ServerName};

--- a/crates/matrix-sdk/src/notification_settings.rs
+++ b/crates/matrix-sdk/src/notification_settings.rs
@@ -42,15 +42,164 @@ impl NotificationSettings {
         mode: RoomNotificationMode,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
-        match mode {
-            RoomNotificationMode::AllMessages => {
-                self.insert_notify_room_rule(room_id, ruleset).await
+        // Get the current mode
+        let current_mode = self.get_user_defined_room_notification_mode(room_id, ruleset);
+
+        match (current_mode, mode) {
+            // Default > AllMessages
+            (None, RoomNotificationMode::AllMessages) => {
+                self.insert_room_rule(room_id, true, ruleset).await?;
             }
-            RoomNotificationMode::MentionsAndKeywordsOnly => {
-                self.insert_mention_and_keywords_room_rule(room_id, ruleset).await
+            // Mentions&Keywords > AllMessages
+            (
+                Some(RoomNotificationMode::MentionsAndKeywordsOnly),
+                RoomNotificationMode::AllMessages,
+            ) => {
+                // Insert the rule before deleting the other custom rules to obtain the correct
+                // mode in the next sync response.
+                let current_custom_rules = self.get_custom_rules_for_room(room_id, ruleset);
+                self.insert_room_rule(room_id, true, ruleset).await?;
+                self.delete_rules(
+                    current_custom_rules,
+                    vec![(RuleKind::Room, room_id.clone())],
+                    ruleset,
+                )
+                .await?;
             }
-            RoomNotificationMode::Mute => self.insert_mute_room_rule(room_id, ruleset).await,
+            // Mute > AllMessages
+            (Some(RoomNotificationMode::Mute), RoomNotificationMode::AllMessages) => {
+                // Insert the rule before deleting the other custom rules to obtain the correct
+                // mode in the next sync response.
+                let current_custom_rules = self.get_custom_rules_for_room(room_id, ruleset);
+                self.insert_room_rule(room_id, true, ruleset).await?;
+                self.delete_rules(current_custom_rules, vec![], ruleset).await?;
+            }
+            // Default > Mentions&Keywords
+            (None, RoomNotificationMode::MentionsAndKeywordsOnly) => {
+                self.insert_room_rule(room_id, false, ruleset).await?;
+            }
+            // AllMessages > Mentions&Keywords
+            (
+                Some(RoomNotificationMode::AllMessages),
+                RoomNotificationMode::MentionsAndKeywordsOnly,
+            ) => {
+                // Insert the rule before deleting the other custom rules to obtain the correct
+                // mode in the next sync response.
+                let current_custom_rules = self.get_custom_rules_for_room(room_id, ruleset);
+                self.insert_room_rule(room_id, false, ruleset).await?;
+                self.delete_rules(
+                    current_custom_rules,
+                    vec![(RuleKind::Room, room_id.clone())],
+                    ruleset,
+                )
+                .await?;
+            }
+            // Mute > Mentions&Keywords
+            (Some(RoomNotificationMode::Mute), RoomNotificationMode::MentionsAndKeywordsOnly) => {
+                // Insert the rule before deleting the other custom rules to obtain the correct
+                // mode in the next sync response.
+                let current_custom_rules = self.get_custom_rules_for_room(room_id, ruleset);
+                self.insert_room_rule(room_id, false, ruleset).await?;
+                self.delete_rules(
+                    current_custom_rules,
+                    vec![(RuleKind::Room, room_id.clone())],
+                    ruleset,
+                )
+                .await?;
+            }
+            // Mute > Mute
+            (Some(RoomNotificationMode::Mute), RoomNotificationMode::Mute) => {}
+            // _ > Mute
+            (_, RoomNotificationMode::Mute) => {
+                // Insert the rule before deleting the other custom rules to obtain the correct
+                // mode in the next sync response.
+                let current_custom_rules = self.get_custom_rules_for_room(room_id, ruleset);
+                self.insert_override_room_rule(room_id, false, ruleset).await?;
+                self.delete_rules(current_custom_rules, vec![], ruleset).await?;
+            }
+            // Other cases
+            (_, _) => {}
         }
+
+        Ok(())
+    }
+
+    /// Gets all user defined rules matching a given room_id
+    fn get_custom_rules_for_room(
+        &self,
+        room_id: &String,
+        ruleset: &Ruleset,
+    ) -> Vec<(RuleKind, String)> {
+        let mut custom_rules: Vec<(RuleKind, String)> = Vec::new();
+
+        // add any Override rules matching this room_id
+        for rule in ruleset.override_.clone().iter() {
+            // if the rule_id is the room_id
+            if rule.rule_id == *room_id {
+                custom_rules.push((RuleKind::Override, rule.rule_id.clone()));
+                continue;
+            }
+            // if the rule contains a condition matching this room_id
+            if rule.conditions.iter().any(|x| match x {
+                PushCondition::EventMatch { key, pattern } => {
+                    key == "room_id" && *pattern == *room_id
+                }
+                _ => false,
+            }) {
+                custom_rules.push((RuleKind::Override, rule.rule_id.clone()));
+                continue;
+            }
+        }
+
+        // add any Room rules matching this room_id
+        if let Some(rule) = ruleset.room.clone().iter().find(|x| x.rule_id == *room_id) {
+            custom_rules.push((RuleKind::Room, rule.rule_id.to_string()));
+        }
+
+        // add any Underride rules matching this room_id
+        for rule in ruleset.underride.clone().iter() {
+            // if the rule_id is the room_id
+            if rule.rule_id == *room_id {
+                custom_rules.push((RuleKind::Underride, rule.rule_id.clone()));
+                continue;
+            }
+            // if the rule contains a condition matching this room_id
+            if rule.conditions.iter().any(|x| match x {
+                PushCondition::EventMatch { key, pattern } => {
+                    key == "room_id" && *pattern == *room_id
+                }
+                _ => false,
+            }) {
+                custom_rules.push((RuleKind::Underride, rule.rule_id.clone()));
+                continue;
+            }
+        }
+
+        custom_rules
+    }
+
+    /// Deletes a list of rules
+    async fn delete_rules(
+        &self,
+        rules: Vec<(RuleKind, String)>,
+        exception: Vec<(RuleKind, String)>,
+        ruleset: &mut Ruleset,
+    ) -> Result<(), NotificationSettingsError> {
+        for (rule_kind, rule_id) in rules.iter() {
+            if exception.contains(&(rule_kind.clone(), rule_id.clone())) {
+                continue;
+            }
+            let request = delete_pushrule::v3::Request::new(
+                RuleScope::Global,
+                rule_kind.clone(),
+                rule_id.clone(),
+            );
+            if self.client.send(request, None).await.is_err() {
+                return Err(NotificationSettingsError::UnableToRemovePushRule);
+            }
+            ruleset.remove(rule_kind.clone(), rule_id)?;
+        }
+        Ok(())
     }
 
     /// Gets the user defined push notification mode for a given room id
@@ -89,100 +238,14 @@ impl NotificationSettings {
         None
     }
 
-    /// Delete any user defined rules for a given room id
-    pub async fn delete_user_defined_room_notification_mode(
+    /// Delete all user defined rules for a given room id
+    pub async fn delete_user_defined_room_rules(
         &self,
         room_id: &String,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
-        // remove any Override rules matching this room_id
-        for rule in ruleset.override_.clone().iter() {
-            // if the rule_id is the room_id
-            if rule.rule_id == *room_id {
-                let request = delete_pushrule::v3::Request::new(
-                    RuleScope::Global,
-                    RuleKind::Override,
-                    rule.rule_id.clone(),
-                );
-                if self.client.send(request, None).await.is_err() {
-                    return Err(NotificationSettingsError::UnableToRemovePushRule);
-                }
-                ruleset.remove(RuleKind::Override, &rule.rule_id)?;
-
-                continue;
-            }
-            // if the rule contains a condition matching this room_id
-            if rule.conditions.iter().any(|x| match x {
-                PushCondition::EventMatch { key, pattern } => {
-                    key == "room_id" && *pattern == *room_id
-                }
-                _ => false,
-            }) {
-                let request = delete_pushrule::v3::Request::new(
-                    RuleScope::Global,
-                    RuleKind::Override,
-                    rule.rule_id.clone(),
-                );
-                if self.client.send(request, None).await.is_err() {
-                    return Err(NotificationSettingsError::UnableToRemovePushRule);
-                }
-                ruleset.remove(RuleKind::Override, &rule.rule_id)?;
-
-                continue;
-            }
-        }
-
-        // remove any Room rules matching this room_id
-        if let Some(rule) = ruleset.room.clone().iter().find(|x| x.rule_id == *room_id) {
-            let request = delete_pushrule::v3::Request::new(
-                RuleScope::Global,
-                RuleKind::Room,
-                rule.rule_id.to_string(),
-            );
-            if self.client.send(request, None).await.is_err() {
-                return Err(NotificationSettingsError::UnableToRemovePushRule);
-            }
-            ruleset.remove(RuleKind::Room, &rule.rule_id)?;
-        }
-
-        // remove any Underride rules matching this room_id
-        for rule in ruleset.underride.clone().iter() {
-            // if the rule_id is the room_id
-            if rule.rule_id == *room_id {
-                let request = delete_pushrule::v3::Request::new(
-                    RuleScope::Global,
-                    RuleKind::Underride,
-                    rule.rule_id.clone(),
-                );
-                if self.client.send(request, None).await.is_err() {
-                    return Err(NotificationSettingsError::UnableToRemovePushRule);
-                }
-                ruleset.remove(RuleKind::Underride, &rule.rule_id)?;
-
-                continue;
-            }
-            // if the rule contains a condition matching this room_id
-            if rule.conditions.iter().any(|x| match x {
-                PushCondition::EventMatch { key, pattern } => {
-                    key == "room_id" && *pattern == *room_id
-                }
-                _ => false,
-            }) {
-                let request = delete_pushrule::v3::Request::new(
-                    RuleScope::Global,
-                    RuleKind::Underride,
-                    rule.rule_id.clone(),
-                );
-                if self.client.send(request, None).await.is_err() {
-                    return Err(NotificationSettingsError::UnableToRemovePushRule);
-                }
-                ruleset.remove(RuleKind::Underride, &rule.rule_id)?;
-
-                continue;
-            }
-        }
-
-        Ok(())
+        let rules = self.get_custom_rules_for_room(room_id, ruleset);
+        self.delete_rules(rules, vec![], ruleset).await
     }
 
     /// Gets the default push notification mode for a given room id
@@ -352,20 +415,24 @@ impl NotificationSettings {
         ruleset.content.iter().any(|r| !r.default && r.enabled)
     }
 
-    /// Insert a new rule to mute a given room in the given ruleset
-    async fn insert_mute_room_rule(
+    /// Insert a new override rule for a given room_id
+    async fn insert_override_room_rule(
         &self,
-        room_id: &String,
+        room_id: &str,
+        notify: bool,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
-        // Try to remove any existing rule for this room
-        self.delete_user_defined_room_notification_mode(room_id, ruleset).await?;
+        let actions = if notify {
+            vec![Action::Notify, Action::SetTweak(Tweak::Sound("default".into()))]
+        } else {
+            vec![]
+        };
 
-        // Insert a new Override push rule without any actions
+        // Insert a new push rule without any actions
         let new_rule = NewConditionalPushRule::new(
-            room_id.clone(),
-            vec![PushCondition::EventMatch { key: "room_id".into(), pattern: room_id.clone() }],
-            vec![],
+            room_id.to_owned(),
+            vec![PushCondition::EventMatch { key: "room_id".into(), pattern: room_id.to_owned() }],
+            actions,
         );
         let request = set_pushrule::v3::Request::new(
             RuleScope::Global,
@@ -379,41 +446,21 @@ impl NotificationSettings {
         Ok(())
     }
 
-    /// Insert a mention and keywords rule for a given room in the given
-    /// ruleset
-    async fn insert_mention_and_keywords_room_rule(
+    /// Insert a new room rule for a given room in the given ruleset
+    async fn insert_room_rule(
         &self,
         room_id: &String,
+        notify: bool,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
-        // Try to remove any existing rule for this room
-        self.delete_user_defined_room_notification_mode(room_id, ruleset).await?;
-
-        // Insert a new Room push rule
-        let new_rule = NewSimplePushRule::new(RoomId::parse(room_id)?, vec![]);
-        let request =
-            set_pushrule::v3::Request::new(RuleScope::Global, NewPushRule::Room(new_rule.clone()));
-        if self.client.send(request, None).await.is_err() {
-            return Err(NotificationSettingsError::UnableToAddPushRule);
-        }
-        ruleset.insert(NewPushRule::Room(new_rule), None, None)?;
-        Ok(())
-    }
-
-    /// Insert a notify rule for a given room in the given ruleset
-    async fn insert_notify_room_rule(
-        &self,
-        room_id: &String,
-        ruleset: &mut Ruleset,
-    ) -> Result<(), NotificationSettingsError> {
-        // Try to remove any existing rule for this room
-        self.delete_user_defined_room_notification_mode(room_id, ruleset).await?;
+        let actions = if notify {
+            vec![Action::Notify, Action::SetTweak(Tweak::Sound("default".into()))]
+        } else {
+            vec![]
+        };
 
         // Insert a new Room push rule with a Notify action.
-        let new_rule = NewSimplePushRule::new(
-            RoomId::parse(room_id)?,
-            vec![Action::Notify, Action::SetTweak(Tweak::Sound("default".into()))],
-        );
+        let new_rule = NewSimplePushRule::new(RoomId::parse(room_id)?, actions);
         let request =
             set_pushrule::v3::Request::new(RuleScope::Global, NewPushRule::Room(new_rule.clone()));
         if self.client.send(request, None).await.is_err() {
@@ -428,13 +475,14 @@ impl NotificationSettings {
 // The http mocking library is not supported for wasm32
 #[cfg(all(test, not(target_arch = "wasm32")))]
 pub(crate) mod tests {
+
     use matrix_sdk_test::async_test;
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use ruma::push::{
         Action, NewPatternedPushRule, NewPushRule, PredefinedOverrideRuleId,
-        PredefinedUnderrideRuleId, RuleKind,
+        PredefinedUnderrideRuleId, RuleKind, Ruleset,
     };
     use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
 
@@ -637,30 +685,6 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn insert_notify_room_rule() {
-        let server = MockServer::start().await;
-        let client = logged_in_client(Some(server.uri())).await;
-
-        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
-        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
-
-        let mut ruleset = client.account().push_rules().await.unwrap();
-        let notification_settings = client.notification_settings();
-        let room_id = "!test_room:matrix.org".to_string();
-
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert!(mode.is_none());
-
-        let result = notification_settings.insert_notify_room_rule(&room_id, &mut ruleset).await;
-        assert!(result.is_ok());
-
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert_eq!(mode, Some(RoomNotificationMode::AllMessages));
-    }
-
-    #[async_test]
     async fn insert_notify_room_rule_invalid_room_id() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
@@ -673,7 +697,7 @@ pub(crate) mod tests {
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
         assert!(mode.is_none());
 
-        let result = notification_settings.insert_notify_room_rule(&room_id, &mut ruleset).await;
+        let result = notification_settings.insert_room_rule(&room_id, true, &mut ruleset).await;
         match result {
             Err(error) => {
                 assert!(matches!(error, NotificationSettingsError::InvalidRoomId))
@@ -685,7 +709,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn insert_mention_and_keywords_room_rule() {
+    async fn delete_user_defined_room_rules() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
         Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
@@ -695,29 +719,73 @@ pub(crate) mod tests {
         let notification_settings = client.notification_settings();
         let room_id = "!test_room:matrix.org".to_string();
 
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        // Add a Room rule
+        let result = notification_settings.insert_room_rule(&room_id, false, &mut ruleset).await;
+        assert!(result.is_ok());
+
+        // Add a an Override rule
+        let result =
+            notification_settings.insert_override_room_rule(&room_id, false, &mut ruleset).await;
+        assert!(result.is_ok());
+
+        let custom_rules = notification_settings.get_custom_rules_for_room(&room_id, &ruleset);
+        assert_eq!(custom_rules.len(), 2);
+
+        // Delete the custom rules
+        let result =
+            notification_settings.delete_user_defined_room_rules(&room_id, &mut ruleset).await;
+        assert!(result.is_ok());
+
+        let custom_rules = notification_settings.get_custom_rules_for_room(&room_id, &ruleset);
+        assert!(custom_rules.is_empty());
+    }
+
+    #[async_test]
+    async fn set_room_notification_mode_default_to_all_messages() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        // Default -> All
         let mode =
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
         assert!(mode.is_none());
 
         let result = notification_settings
-            .insert_mention_and_keywords_room_rule(&room_id, &mut ruleset)
+            .set_room_notification_mode(&room_id, RoomNotificationMode::AllMessages, &mut ruleset)
             .await;
         assert!(result.is_ok());
 
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert_eq!(
-            mode,
-            Some(RoomNotificationMode::MentionsAndKeywordsOnly),
-            "wrong mode, should be {:#?}",
-            RoomNotificationMode::MentionsAndKeywordsOnly
-        );
+        let expected_mode = &RoomNotificationMode::AllMessages;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
+            }
+        }
     }
 
     #[async_test]
-    async fn insert_mute_room_rule() {
+    async fn set_room_notification_mode_mentions_keywords_to_all_messages() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
+
         Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
         Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
 
@@ -725,62 +793,77 @@ pub(crate) mod tests {
         let notification_settings = client.notification_settings();
         let room_id = "!test_room:matrix.org".to_string();
 
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert!(mode.is_none());
-
-        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset).await;
+        let result = notification_settings.insert_room_rule(&room_id, false, &mut ruleset).await;
         assert!(result.is_ok());
 
         let mode =
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert_eq!(
-            mode,
-            Some(RoomNotificationMode::Mute),
-            "wrong mode, should be {:#?}",
-            RoomNotificationMode::Mute
-        );
-    }
+        assert_eq!(mode, Some(RoomNotificationMode::MentionsAndKeywordsOnly));
 
-    #[async_test]
-    async fn delete_user_defined_room_notification_mode() {
-        let server = MockServer::start().await;
-        let client = logged_in_client(Some(server.uri())).await;
-        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
-        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
-
-        let mut ruleset = client.account().push_rules().await.unwrap();
-        let notification_settings = client.notification_settings();
-        let room_id = "!test_room:matrix.org".to_string();
-
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert!(mode.is_none());
-
-        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset).await;
-        assert!(result.is_ok());
-
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert_eq!(
-            mode,
-            Some(RoomNotificationMode::Mute),
-            "wrong mode, should be {:#?}",
-            RoomNotificationMode::Mute
-        );
-
+        // M&K -> All
         let result = notification_settings
-            .delete_user_defined_room_notification_mode(&room_id, &mut ruleset)
+            .set_room_notification_mode(&room_id, RoomNotificationMode::AllMessages, &mut ruleset)
             .await;
+        assert!(result.is_ok());
+
+        let expected_mode = &RoomNotificationMode::AllMessages;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
+            }
+        }
+    }
+
+    #[async_test]
+    async fn set_room_notification_mode_mute_to_all_messages() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let result =
+            notification_settings.insert_override_room_rule(&room_id, false, &mut ruleset).await;
         assert!(result.is_ok());
 
         let mode =
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert!(mode.is_none());
+        assert_eq!(mode, Some(RoomNotificationMode::Mute));
+
+        // Mute -> All
+        let result = notification_settings
+            .set_room_notification_mode(&room_id, RoomNotificationMode::AllMessages, &mut ruleset)
+            .await;
+        assert!(result.is_ok());
+
+        let expected_mode = &RoomNotificationMode::AllMessages;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
+            }
+        }
     }
 
     #[async_test]
-    async fn set_room_notification_mode() {
+    async fn set_room_notification_mode_default_to_mentions_keywords() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
@@ -795,27 +878,233 @@ pub(crate) mod tests {
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
         assert!(mode.is_none());
 
-        // Test to set each modes
-        for expected_mode in [
-            RoomNotificationMode::AllMessages,
-            RoomNotificationMode::MentionsAndKeywordsOnly,
-            RoomNotificationMode::Mute,
-        ]
-        .iter()
-        {
-            let result = notification_settings
-                .set_room_notification_mode(&room_id, expected_mode.clone(), &mut ruleset)
-                .await;
-            assert!(result.is_ok());
+        // Default -> M&K
+        let result = notification_settings
+            .set_room_notification_mode(
+                &room_id,
+                RoomNotificationMode::MentionsAndKeywordsOnly,
+                &mut ruleset,
+            )
+            .await;
+        assert!(result.is_ok());
 
-            match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset)
-            {
-                Some(new_mode) => {
-                    assert_eq!(&new_mode, expected_mode)
-                }
-                None => {
-                    panic!("mode {:?} is expected.", expected_mode)
-                }
+        let expected_mode = &RoomNotificationMode::MentionsAndKeywordsOnly;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
+            }
+        }
+    }
+
+    #[async_test]
+    async fn set_room_notification_mode_all_messages_to_mentions_keywords() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let result = notification_settings.insert_room_rule(&room_id, true, &mut ruleset).await;
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert_eq!(mode, Some(RoomNotificationMode::AllMessages));
+
+        // AllMessage -> M&K
+        let result = notification_settings
+            .set_room_notification_mode(
+                &room_id,
+                RoomNotificationMode::MentionsAndKeywordsOnly,
+                &mut ruleset,
+            )
+            .await;
+        assert!(result.is_ok());
+
+        let expected_mode = &RoomNotificationMode::MentionsAndKeywordsOnly;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
+            }
+        }
+    }
+
+    #[async_test]
+    async fn set_room_notification_mode_mute_to_mentions_keywords() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let result =
+            notification_settings.insert_override_room_rule(&room_id, false, &mut ruleset).await;
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert_eq!(mode, Some(RoomNotificationMode::Mute));
+
+        // Mute -> M&K
+        let result = notification_settings
+            .set_room_notification_mode(
+                &room_id,
+                RoomNotificationMode::MentionsAndKeywordsOnly,
+                &mut ruleset,
+            )
+            .await;
+        assert!(result.is_ok());
+
+        let expected_mode = &RoomNotificationMode::MentionsAndKeywordsOnly;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
+            }
+        }
+    }
+
+    #[async_test]
+    async fn set_room_notification_default_to_mute() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        // Default -> Mute
+        let result = notification_settings
+            .set_room_notification_mode(&room_id, RoomNotificationMode::Mute, &mut ruleset)
+            .await;
+        assert!(result.is_ok());
+
+        let expected_mode = &RoomNotificationMode::Mute;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
+            }
+        }
+    }
+
+    #[async_test]
+    async fn set_room_notification_all_messages_to_mute() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let result = notification_settings.insert_room_rule(&room_id, true, &mut ruleset).await;
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert_eq!(mode, Some(RoomNotificationMode::AllMessages));
+
+        // AllMessages -> Mute
+        let result = notification_settings
+            .set_room_notification_mode(&room_id, RoomNotificationMode::Mute, &mut ruleset)
+            .await;
+        assert!(result.is_ok());
+
+        let expected_mode = &RoomNotificationMode::Mute;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
+            }
+        }
+    }
+
+    #[async_test]
+    async fn set_room_notification_mentions_keywords_to_mute() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let result = notification_settings.insert_room_rule(&room_id, false, &mut ruleset).await;
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert_eq!(mode, Some(RoomNotificationMode::MentionsAndKeywordsOnly));
+
+        // M&K -> Mute
+        let result = notification_settings
+            .set_room_notification_mode(&room_id, RoomNotificationMode::Mute, &mut ruleset)
+            .await;
+        assert!(result.is_ok());
+
+        let expected_mode = &RoomNotificationMode::Mute;
+        match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
+            Some(new_mode) => {
+                assert_eq!(
+                    &new_mode, expected_mode,
+                    "mode {:?} is expected (got {:?})",
+                    expected_mode, &new_mode
+                )
+            }
+            None => {
+                panic!("mode {:?} is expected.", expected_mode)
             }
         }
     }
@@ -835,5 +1124,33 @@ pub(crate) mod tests {
 
         _ = ruleset.insert(NewPushRule::Content(rule), None, None);
         assert!(notification_settings.contains_keyword_rules(&ruleset));
+    }
+
+    #[async_test]
+    async fn is_user_mention_enabled() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+
+        let result =
+            ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true);
+        assert!(result.is_ok());
+        assert!(notification_settings.is_user_mention_enabled(&ruleset));
+    }
+
+    #[async_test]
+    async fn is_room_mention_enabled() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset: Ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+
+        let result =
+            ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention, true);
+        assert!(result.is_ok());
+        assert!(notification_settings.is_room_mention_enabled(&ruleset));
     }
 }

--- a/crates/matrix-sdk/src/notification_settings.rs
+++ b/crates/matrix-sdk/src/notification_settings.rs
@@ -1,7 +1,7 @@
 //! High-level push notification settings API
 
 use ruma::{
-    events::push_rules::PushRulesEventContent,
+    api::client::push::{delete_pushrule, set_pushrule, set_pushrule_enabled, RuleScope},
     push::{
         Action, NewConditionalPushRule, NewPushRule, NewSimplePushRule, PredefinedContentRuleId,
         PredefinedOverrideRuleId, PredefinedUnderrideRuleId, PushCondition, RuleKind, Ruleset,
@@ -35,50 +35,21 @@ impl NotificationSettings {
         Self { client }
     }
 
-    /// Save a given ruleset to the client's owner account data
-    pub async fn save_push_rules(
-        &self,
-        ruleset: &Ruleset,
-    ) -> Result<(), NotificationSettingsError> {
-        let content = PushRulesEventContent::new(ruleset.clone());
-        self.client
-            .account()
-            .set_account_data::<PushRulesEventContent>(content)
-            .await
-            .map_err(|_| NotificationSettingsError::UnableToSavePushRules)?;
-        Ok(())
-    }
-
-    /// Restore the default push rule for a given room
-    ///
-    /// Owner's account data will not be updated
-    pub fn restore_room_default_push_rule(
-        &self,
-        room_id: &String,
-        ruleset: &mut Ruleset,
-    ) -> Result<(), NotificationSettingsError> {
-        // Only if we have a custom mode for this room
-        if self.get_user_defined_room_notification_mode(room_id, ruleset).is_some() {
-            self.delete_user_defined_room_notification_mode(room_id, ruleset)?;
-        }
-        Ok(())
-    }
-
     /// Sets a notification mode for a given room
-    ///
-    /// Owner's account data will not be updated
-    pub fn set_room_notification_mode(
+    pub async fn set_room_notification_mode(
         &self,
         room_id: &String,
         mode: RoomNotificationMode,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
         match mode {
-            RoomNotificationMode::AllMessages => self.insert_notify_room_rule(room_id, ruleset),
-            RoomNotificationMode::MentionsAndKeywordsOnly => {
-                self.insert_mention_and_keywords_room_rule(room_id, ruleset)
+            RoomNotificationMode::AllMessages => {
+                self.insert_notify_room_rule(room_id, ruleset).await
             }
-            RoomNotificationMode::Mute => self.insert_mute_room_rule(room_id, ruleset),
+            RoomNotificationMode::MentionsAndKeywordsOnly => {
+                self.insert_mention_and_keywords_room_rule(room_id, ruleset).await
+            }
+            RoomNotificationMode::Mute => self.insert_mute_room_rule(room_id, ruleset).await,
         }
     }
 
@@ -109,59 +80,104 @@ impl NotificationSettings {
             // if this rule contains a Notify action
             if rule.actions.iter().any(|x| matches!(x, Action::Notify)) {
                 return Some(RoomNotificationMode::AllMessages);
-            }
-            // if this rule does not contain a Notify action
-            if !rule.actions.iter().any(|x| matches!(x, Action::Notify)) {
+            } else {
                 return Some(RoomNotificationMode::MentionsAndKeywordsOnly);
             }
-            return Some(RoomNotificationMode::Mute);
         }
 
         // There is no custom rule matching this room_id
         None
     }
 
-    /// Delete any user defined rules for this room in the given ruleset
-    fn delete_user_defined_room_notification_mode(
+    /// Delete any user defined rules for a given room id
+    pub async fn delete_user_defined_room_notification_mode(
         &self,
         room_id: &String,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
         // remove any Override rules matching this room_id
         for rule in ruleset.override_.clone().iter() {
+            // if the rule_id is the room_id
             if rule.rule_id == *room_id {
+                let request = delete_pushrule::v3::Request::new(
+                    RuleScope::Global,
+                    RuleKind::Override,
+                    rule.rule_id.clone(),
+                );
+                if self.client.send(request, None).await.is_err() {
+                    return Err(NotificationSettingsError::UnableToRemovePushRule);
+                }
                 ruleset.remove(RuleKind::Override, &rule.rule_id)?;
+
                 continue;
             }
+            // if the rule contains a condition matching this room_id
             if rule.conditions.iter().any(|x| match x {
                 PushCondition::EventMatch { key, pattern } => {
                     key == "room_id" && *pattern == *room_id
                 }
                 _ => false,
             }) {
+                let request = delete_pushrule::v3::Request::new(
+                    RuleScope::Global,
+                    RuleKind::Override,
+                    rule.rule_id.clone(),
+                );
+                if self.client.send(request, None).await.is_err() {
+                    return Err(NotificationSettingsError::UnableToRemovePushRule);
+                }
                 ruleset.remove(RuleKind::Override, &rule.rule_id)?;
+
                 continue;
             }
         }
 
         // remove any Room rules matching this room_id
         if let Some(rule) = ruleset.room.clone().iter().find(|x| x.rule_id == *room_id) {
+            let request = delete_pushrule::v3::Request::new(
+                RuleScope::Global,
+                RuleKind::Room,
+                rule.rule_id.to_string(),
+            );
+            if self.client.send(request, None).await.is_err() {
+                return Err(NotificationSettingsError::UnableToRemovePushRule);
+            }
             ruleset.remove(RuleKind::Room, &rule.rule_id)?;
         }
 
         // remove any Underride rules matching this room_id
         for rule in ruleset.underride.clone().iter() {
+            // if the rule_id is the room_id
             if rule.rule_id == *room_id {
+                let request = delete_pushrule::v3::Request::new(
+                    RuleScope::Global,
+                    RuleKind::Underride,
+                    rule.rule_id.clone(),
+                );
+                if self.client.send(request, None).await.is_err() {
+                    return Err(NotificationSettingsError::UnableToRemovePushRule);
+                }
                 ruleset.remove(RuleKind::Underride, &rule.rule_id)?;
+
                 continue;
             }
+            // if the rule contains a condition matching this room_id
             if rule.conditions.iter().any(|x| match x {
                 PushCondition::EventMatch { key, pattern } => {
                     key == "room_id" && *pattern == *room_id
                 }
                 _ => false,
             }) {
+                let request = delete_pushrule::v3::Request::new(
+                    RuleScope::Global,
+                    RuleKind::Underride,
+                    rule.rule_id.clone(),
+                );
+                if self.client.send(request, None).await.is_err() {
+                    return Err(NotificationSettingsError::UnableToRemovePushRule);
+                }
                 ruleset.remove(RuleKind::Underride, &rule.rule_id)?;
+
                 continue;
             }
         }
@@ -203,9 +219,8 @@ impl NotificationSettings {
     pub fn is_user_mention_enabled(&self, ruleset: &Ruleset) -> bool {
         // Search for an enabled Override rule IsUserMention (MSC3952).
         // This is a new push rule that may not yet be present.
-        // The rule_id will be replaced by `PredefinedOverrideRuleId::IsUserMention`
-        // once available in ruma-common.
-        if let Some(rule) = ruleset.get(RuleKind::Override, ".m.rule.is_user_mention") {
+        if let Some(rule) = ruleset.get(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention)
+        {
             if rule.enabled() {
                 return true;
             }
@@ -224,29 +239,56 @@ impl NotificationSettings {
     }
 
     /// Set whether the IsUserMention rule is enabled.
-    ///
-    /// Owner's account data will not be updated
     #[allow(deprecated)]
-    pub fn set_user_mention_enabled(&self, enabled: bool, ruleset: &mut Ruleset) {
+    pub async fn set_user_mention_enabled(
+        &self,
+        enabled: bool,
+        ruleset: &mut Ruleset,
+    ) -> Result<()> {
         // Sets the IsUserMention Override rule (MSC3952).
         // This is a new push rule that may not yet be present.
-        // The rule_id will be replaced by `PredefinedOverrideRuleId::IsUserMention`
-        // once available in ruma-common.
-        _ = ruleset.set_enabled(RuleKind::Override, ".m.rule.is_user_mention", enabled);
+        let request = set_pushrule_enabled::v3::Request::new(
+            RuleScope::Global,
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsUserMention.to_string(),
+            enabled,
+        );
+        self.client.send(request, None).await?;
+        _ = ruleset.set_enabled(
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsUserMention,
+            enabled,
+        );
 
         // For compatibility purpose, we still need to set ContainsUserName and
         // ContainsDisplayName (deprecated rules).
+        let request = set_pushrule_enabled::v3::Request::new(
+            RuleScope::Global,
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            enabled,
+        );
+        self.client.send(request, None).await?;
         _ = ruleset.set_enabled(
             RuleKind::Content,
             PredefinedContentRuleId::ContainsUserName,
             enabled,
         );
 
+        let request = set_pushrule_enabled::v3::Request::new(
+            RuleScope::Global,
+            RuleKind::Content,
+            PredefinedOverrideRuleId::ContainsDisplayName.to_string(),
+            enabled,
+        );
+        self.client.send(request, None).await?;
         _ = ruleset.set_enabled(
             RuleKind::Content,
             PredefinedOverrideRuleId::ContainsDisplayName,
             enabled,
         );
+
+        Ok(())
     }
 
     /// Get whether the IsRoomMention rule is enabled.
@@ -254,9 +296,8 @@ impl NotificationSettings {
     pub fn is_room_mention_enabled(&self, ruleset: &Ruleset) -> bool {
         // Search for an enabled Override rule IsRoomMention (MSC3952).
         // This is a new push rule that may not yet be present.
-        // The rule_id will be replaced by `PredefinedOverrideRuleId::IsRoomMention`
-        // once available in ruma-common.
-        if let Some(rule) = ruleset.get(RuleKind::Override, ".m.rule.is_room_mention") {
+        if let Some(rule) = ruleset.get(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention)
+        {
             if rule.enabled() {
                 return true;
             }
@@ -271,18 +312,38 @@ impl NotificationSettings {
     }
 
     /// Set whether the IsRoomMention rule is enabled.
-    ///
-    /// Owner's account data will not be updated
     #[allow(deprecated)]
-    pub fn set_room_mention_enabled(&self, enabled: bool, ruleset: &mut Ruleset) {
+    pub async fn set_room_mention_enabled(
+        &self,
+        enabled: bool,
+        ruleset: &mut Ruleset,
+    ) -> Result<()> {
         // Sets the IsRoomMention Override rule (MSC3952).
         // This is a new push rule that may not yet be present.
-        // The rule_id will be replaced by `PredefinedOverrideRuleId::IsRoomMention`
-        // once available in ruma-common.
-        _ = ruleset.set_enabled(RuleKind::Override, ".m.rule.is_room_mention", enabled);
+        let request = set_pushrule_enabled::v3::Request::new(
+            RuleScope::Global,
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsRoomMention.to_string(),
+            enabled,
+        );
+        self.client.send(request, None).await?;
+        _ = ruleset.set_enabled(
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsRoomMention,
+            enabled,
+        );
 
         // For compatibility purpose, we still need to set RoomNotif (deprecated rule).
+        let request = set_pushrule_enabled::v3::Request::new(
+            RuleScope::Global,
+            RuleKind::Content,
+            PredefinedOverrideRuleId::RoomNotif.to_string(),
+            enabled,
+        );
+        self.client.send(request, None).await?;
         _ = ruleset.set_enabled(RuleKind::Content, PredefinedOverrideRuleId::RoomNotif, enabled);
+
+        Ok(())
     }
 
     /// Get whether the given ruleset contains some keywords rules
@@ -292,13 +353,13 @@ impl NotificationSettings {
     }
 
     /// Insert a new rule to mute a given room in the given ruleset
-    fn insert_mute_room_rule(
+    async fn insert_mute_room_rule(
         &self,
         room_id: &String,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
         // Try to remove any existing rule for this room
-        _ = self.delete_user_defined_room_notification_mode(room_id, ruleset);
+        self.delete_user_defined_room_notification_mode(room_id, ruleset).await?;
 
         // Insert a new Override push rule without any actions
         let new_rule = NewConditionalPushRule::new(
@@ -306,6 +367,13 @@ impl NotificationSettings {
             vec![PushCondition::EventMatch { key: "room_id".into(), pattern: room_id.clone() }],
             vec![],
         );
+        let request = set_pushrule::v3::Request::new(
+            RuleScope::Global,
+            NewPushRule::Override(new_rule.clone()),
+        );
+        if self.client.send(request, None).await.is_err() {
+            return Err(NotificationSettingsError::UnableToAddPushRule);
+        }
         ruleset.insert(NewPushRule::Override(new_rule), None, None)?;
 
         Ok(())
@@ -313,34 +381,44 @@ impl NotificationSettings {
 
     /// Insert a mention and keywords rule for a given room in the given
     /// ruleset
-    fn insert_mention_and_keywords_room_rule(
+    async fn insert_mention_and_keywords_room_rule(
         &self,
         room_id: &String,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
         // Try to remove any existing rule for this room
-        _ = self.delete_user_defined_room_notification_mode(room_id, ruleset);
+        self.delete_user_defined_room_notification_mode(room_id, ruleset).await?;
 
         // Insert a new Room push rule
         let new_rule = NewSimplePushRule::new(RoomId::parse(room_id)?, vec![]);
+        let request =
+            set_pushrule::v3::Request::new(RuleScope::Global, NewPushRule::Room(new_rule.clone()));
+        if self.client.send(request, None).await.is_err() {
+            return Err(NotificationSettingsError::UnableToAddPushRule);
+        }
         ruleset.insert(NewPushRule::Room(new_rule), None, None)?;
         Ok(())
     }
 
     /// Insert a notify rule for a given room in the given ruleset
-    fn insert_notify_room_rule(
+    async fn insert_notify_room_rule(
         &self,
         room_id: &String,
         ruleset: &mut Ruleset,
     ) -> Result<(), NotificationSettingsError> {
         // Try to remove any existing rule for this room
-        _ = self.delete_user_defined_room_notification_mode(room_id, ruleset);
+        self.delete_user_defined_room_notification_mode(room_id, ruleset).await?;
 
         // Insert a new Room push rule with a Notify action.
         let new_rule = NewSimplePushRule::new(
             RoomId::parse(room_id)?,
             vec![Action::Notify, Action::SetTweak(Tweak::Sound("default".into()))],
         );
+        let request =
+            set_pushrule::v3::Request::new(RuleScope::Global, NewPushRule::Room(new_rule.clone()));
+        if self.client.send(request, None).await.is_err() {
+            return Err(NotificationSettingsError::UnableToAddPushRule);
+        }
         ruleset.insert(NewPushRule::Room(new_rule), None, None)?;
 
         Ok(())
@@ -355,7 +433,7 @@ pub(crate) mod tests {
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
     use ruma::push::{
-        Action, NewPatternedPushRule, NewPushRule, PredefinedContentRuleId,
+        Action, NewPatternedPushRule, NewPushRule, PredefinedOverrideRuleId,
         PredefinedUnderrideRuleId, RuleKind,
     };
     use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
@@ -394,12 +472,12 @@ pub(crate) mod tests {
         assert!(result.is_ok());
 
         let result =
-            ruleset.set_enabled(RuleKind::Content, PredefinedContentRuleId::ContainsUserName, true);
+            ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true);
         assert!(result.is_ok());
 
         let result = ruleset.set_actions(
-            RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName,
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsUserMention,
             vec![Action::Notify],
         );
         assert!(result.is_ok());
@@ -444,14 +522,11 @@ pub(crate) mod tests {
         assert!(result.is_ok());
 
         let result =
-            ruleset.set_enabled(RuleKind::Content, PredefinedContentRuleId::ContainsUserName, true);
+            ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true);
         assert!(result.is_ok());
 
-        let result = ruleset.set_actions(
-            RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName,
-            vec![Action::Notify],
-        );
+        let result =
+            ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true);
         assert!(result.is_ok());
 
         if let Ok(mode) = notification_settings.get_default_room_notification_mode(
@@ -469,6 +544,8 @@ pub(crate) mod tests {
     async fn get_default_room_notification_mode_encrypted_room() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
 
         let mut ruleset = client.account().push_rules().await.unwrap();
         let notification_settings = client.notification_settings();
@@ -491,12 +568,12 @@ pub(crate) mod tests {
         assert!(result.is_ok());
 
         let result =
-            ruleset.set_enabled(RuleKind::Content, PredefinedContentRuleId::ContainsUserName, true);
+            ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true);
         assert!(result.is_ok());
 
         let result = ruleset.set_actions(
-            RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName,
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsUserMention,
             vec![Action::Notify],
         );
         assert!(result.is_ok());
@@ -538,12 +615,12 @@ pub(crate) mod tests {
         assert!(result.is_ok());
 
         let result =
-            ruleset.set_enabled(RuleKind::Content, PredefinedContentRuleId::ContainsUserName, true);
+            ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true);
         assert!(result.is_ok());
 
         let result = ruleset.set_actions(
-            RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName,
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsUserMention,
             vec![Action::Notify],
         );
         assert!(result.is_ok());
@@ -564,6 +641,9 @@ pub(crate) mod tests {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
         let mut ruleset = client.account().push_rules().await.unwrap();
         let notification_settings = client.notification_settings();
         let room_id = "!test_room:matrix.org".to_string();
@@ -572,7 +652,7 @@ pub(crate) mod tests {
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
         assert!(mode.is_none());
 
-        let result = notification_settings.insert_notify_room_rule(&room_id, &mut ruleset);
+        let result = notification_settings.insert_notify_room_rule(&room_id, &mut ruleset).await;
         assert!(result.is_ok());
 
         let mode =
@@ -593,13 +673,13 @@ pub(crate) mod tests {
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
         assert!(mode.is_none());
 
-        let result = notification_settings.insert_notify_room_rule(&room_id, &mut ruleset);
+        let result = notification_settings.insert_notify_room_rule(&room_id, &mut ruleset).await;
         match result {
             Err(error) => {
                 assert!(matches!(error, NotificationSettingsError::InvalidRoomId))
             }
             _ => {
-                panic!("a 'NotificationSettingsError::InvalidRoomId' error is expected.")
+                panic!("a {:#?} error is expected.", NotificationSettingsError::InvalidRoomId)
             }
         }
     }
@@ -608,6 +688,8 @@ pub(crate) mod tests {
     async fn insert_mention_and_keywords_room_rule() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
 
         let mut ruleset = client.account().push_rules().await.unwrap();
         let notification_settings = client.notification_settings();
@@ -617,8 +699,9 @@ pub(crate) mod tests {
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
         assert!(mode.is_none());
 
-        let result =
-            notification_settings.insert_mention_and_keywords_room_rule(&room_id, &mut ruleset);
+        let result = notification_settings
+            .insert_mention_and_keywords_room_rule(&room_id, &mut ruleset)
+            .await;
         assert!(result.is_ok());
 
         let mode =
@@ -626,7 +709,8 @@ pub(crate) mod tests {
         assert_eq!(
             mode,
             Some(RoomNotificationMode::MentionsAndKeywordsOnly),
-            "wrong mode, should be 'RoomNotificationMode::MentionsAndKeywordsOnly'"
+            "wrong mode, should be {:#?}",
+            RoomNotificationMode::MentionsAndKeywordsOnly
         );
     }
 
@@ -634,6 +718,8 @@ pub(crate) mod tests {
     async fn insert_mute_room_rule() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
 
         let mut ruleset = client.account().push_rules().await.unwrap();
         let notification_settings = client.notification_settings();
@@ -643,7 +729,7 @@ pub(crate) mod tests {
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
         assert!(mode.is_none());
 
-        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset);
+        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset).await;
         assert!(result.is_ok());
 
         let mode =
@@ -651,7 +737,8 @@ pub(crate) mod tests {
         assert_eq!(
             mode,
             Some(RoomNotificationMode::Mute),
-            "wrong mode, should be 'RoomNotificationMode::Mute'"
+            "wrong mode, should be {:#?}",
+            RoomNotificationMode::Mute
         );
     }
 
@@ -659,6 +746,8 @@ pub(crate) mod tests {
     async fn delete_user_defined_room_notification_mode() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
 
         let mut ruleset = client.account().push_rules().await.unwrap();
         let notification_settings = client.notification_settings();
@@ -668,7 +757,7 @@ pub(crate) mod tests {
             notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
         assert!(mode.is_none());
 
-        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset);
+        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset).await;
         assert!(result.is_ok());
 
         let mode =
@@ -676,11 +765,13 @@ pub(crate) mod tests {
         assert_eq!(
             mode,
             Some(RoomNotificationMode::Mute),
-            "wrong mode, should be 'RoomNotificationMode::Mute'"
+            "wrong mode, should be {:#?}",
+            RoomNotificationMode::Mute
         );
 
         let result = notification_settings
-            .delete_user_defined_room_notification_mode(&room_id, &mut ruleset);
+            .delete_user_defined_room_notification_mode(&room_id, &mut ruleset)
+            .await;
         assert!(result.is_ok());
 
         let mode =
@@ -692,6 +783,9 @@ pub(crate) mod tests {
     async fn set_room_notification_mode() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
 
         let mut ruleset = client.account().push_rules().await.unwrap();
         let notification_settings = client.notification_settings();
@@ -709,11 +803,9 @@ pub(crate) mod tests {
         ]
         .iter()
         {
-            let result = notification_settings.set_room_notification_mode(
-                &room_id,
-                expected_mode.clone(),
-                &mut ruleset,
-            );
+            let result = notification_settings
+                .set_room_notification_mode(&room_id, expected_mode.clone(), &mut ruleset)
+                .await;
             assert!(result.is_ok());
 
             match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset)
@@ -726,41 +818,6 @@ pub(crate) mod tests {
                 }
             }
         }
-    }
-
-    #[async_test]
-    async fn restore_room_default_push_rule() {
-        let server = MockServer::start().await;
-        let client = logged_in_client(Some(server.uri())).await;
-
-        let mut ruleset = client.account().push_rules().await.unwrap();
-        let notification_settings = client.notification_settings();
-        let room_id = "!test_room:matrix.org".to_string();
-
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert!(mode.is_none());
-
-        // Calling set_room_notification_mode will perform an API call
-        let mock = Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200));
-        server.register(mock).await;
-
-        // Mute the room
-        let result = notification_settings.set_room_notification_mode(
-            &room_id,
-            RoomNotificationMode::Mute,
-            &mut ruleset,
-        );
-        assert!(result.is_ok());
-
-        // Restore to default mode
-        let result = notification_settings.restore_room_default_push_rule(&room_id, &mut ruleset);
-        assert!(result.is_ok());
-
-        // All user defined rules should have be deleted
-        assert!(notification_settings
-            .get_user_defined_room_notification_mode(&room_id, &ruleset)
-            .is_none());
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/notification_settings.rs
+++ b/crates/matrix-sdk/src/notification_settings.rs
@@ -270,13 +270,13 @@ impl NotificationSettings {
         // ContainsDisplayName (deprecated rules).
         _ = ruleset.set_enabled(
             RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
+            PredefinedContentRuleId::ContainsUserName,
             enabled,
         );
 
         _ = ruleset.set_enabled(
             RuleKind::Content,
-            PredefinedOverrideRuleId::ContainsDisplayName.to_string(),
+            PredefinedOverrideRuleId::ContainsDisplayName,
             enabled,
         );
     }
@@ -312,11 +312,7 @@ impl NotificationSettings {
         _ = ruleset.set_enabled(RuleKind::Override, ".m.rule.is_room_mention", enabled);
 
         // For compatibility purpose, we still need to set RoomNotif (deprecated rule).
-        _ = ruleset.set_enabled(
-            RuleKind::Content,
-            PredefinedOverrideRuleId::RoomNotif.to_string(),
-            enabled,
-        );
+        _ = ruleset.set_enabled(RuleKind::Content, PredefinedOverrideRuleId::RoomNotif, enabled);
     }
 
     /// Get whether the given ruleset contains some keywords rules
@@ -433,21 +429,18 @@ pub(crate) mod tests {
 
         let result = ruleset.set_enabled(
             RuleKind::Underride,
-            PredefinedUnderrideRuleId::EncryptedRoomOneToOne.to_string(),
+            PredefinedUnderrideRuleId::EncryptedRoomOneToOne,
             false,
         );
         assert!(result.is_ok());
 
-        let result = ruleset.set_enabled(
-            RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
-            true,
-        );
+        let result =
+            ruleset.set_enabled(RuleKind::Content, PredefinedContentRuleId::ContainsUserName, true);
         assert!(result.is_ok());
 
         let result = ruleset.set_actions(
             RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
+            PredefinedContentRuleId::ContainsUserName,
             vec![Action::Notify],
         );
         assert!(result.is_ok());
@@ -486,21 +479,18 @@ pub(crate) mod tests {
 
         let result = ruleset.set_enabled(
             RuleKind::Underride,
-            PredefinedUnderrideRuleId::RoomOneToOne.to_string(),
+            PredefinedUnderrideRuleId::RoomOneToOne,
             false,
         );
         assert!(result.is_ok());
 
-        let result = ruleset.set_enabled(
-            RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
-            true,
-        );
+        let result =
+            ruleset.set_enabled(RuleKind::Content, PredefinedContentRuleId::ContainsUserName, true);
         assert!(result.is_ok());
 
         let result = ruleset.set_actions(
             RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
+            PredefinedContentRuleId::ContainsUserName,
             vec![Action::Notify],
         );
         assert!(result.is_ok());
@@ -537,23 +527,17 @@ pub(crate) mod tests {
             panic!("A default mode should be defined.")
         }
 
-        let result = ruleset.set_enabled(
-            RuleKind::Underride,
-            PredefinedUnderrideRuleId::Encrypted.to_string(),
-            false,
-        );
+        let result =
+            ruleset.set_enabled(RuleKind::Underride, PredefinedUnderrideRuleId::Encrypted, false);
         assert!(result.is_ok());
 
-        let result = ruleset.set_enabled(
-            RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
-            true,
-        );
+        let result =
+            ruleset.set_enabled(RuleKind::Content, PredefinedContentRuleId::ContainsUserName, true);
         assert!(result.is_ok());
 
         let result = ruleset.set_actions(
             RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
+            PredefinedContentRuleId::ContainsUserName,
             vec![Action::Notify],
         );
         assert!(result.is_ok());
@@ -590,23 +574,17 @@ pub(crate) mod tests {
             panic!("A default mode should be defined.")
         }
 
-        let result = ruleset.set_enabled(
-            RuleKind::Underride,
-            PredefinedUnderrideRuleId::Message.to_string(),
-            false,
-        );
+        let result =
+            ruleset.set_enabled(RuleKind::Underride, PredefinedUnderrideRuleId::Message, false);
         assert!(result.is_ok());
 
-        let result = ruleset.set_enabled(
-            RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
-            true,
-        );
+        let result =
+            ruleset.set_enabled(RuleKind::Content, PredefinedContentRuleId::ContainsUserName, true);
         assert!(result.is_ok());
 
         let result = ruleset.set_actions(
             RuleKind::Content,
-            PredefinedContentRuleId::ContainsUserName.to_string(),
+            PredefinedContentRuleId::ContainsUserName,
             vec![Action::Notify],
         );
         assert!(result.is_ok());
@@ -938,12 +916,12 @@ pub(crate) mod tests {
         let mut ruleset = client.account().push_rules().await.unwrap();
         let notification_settings = client.notification_settings();
 
-        assert_eq!(notification_settings.contains_keyword_rules(&ruleset), false);
+        assert!(!notification_settings.contains_keyword_rules(&ruleset));
 
         let rule =
             NewPatternedPushRule::new("keyword".into(), "keyword".into(), vec![Action::Notify]);
 
         _ = ruleset.insert(NewPushRule::Content(rule), None, None);
-        assert_eq!(notification_settings.contains_keyword_rules(&ruleset), true);
+        assert!(notification_settings.contains_keyword_rules(&ruleset));
     }
 }

--- a/crates/matrix-sdk/src/notification_settings.rs
+++ b/crates/matrix-sdk/src/notification_settings.rs
@@ -133,13 +133,7 @@ impl NotificationSettings {
             }
             // if this rule does not contain a Notify action
             if !rule.actions.iter().any(|x| matches!(x, Action::Notify)) {
-                // check if mentions or keywords are enabled
-                if self.is_user_mention_enabled(ruleset)
-                    || self.is_room_mention_enabled(ruleset)
-                    || self.contains_keyword_rules(ruleset)
-                {
-                    return Some(RoomNotificationMode::MentionsAndKeywordsOnly);
-                }
+                return Some(RoomNotificationMode::MentionsAndKeywordsOnly);
             }
             return Some(RoomNotificationMode::Mute);
         }
@@ -353,14 +347,6 @@ impl NotificationSettings {
     ) -> Result<(), NotificationSettingsError> {
         // Try to remove any existing rule for this room
         _ = self.delete_user_defined_room_notification_mode(room_id, ruleset);
-
-        // Check if mentions or keywords are enabled
-        let mentions_or_keywords_enabled = self.is_user_mention_enabled(ruleset)
-            || self.is_room_mention_enabled(ruleset)
-            || self.contains_keyword_rules(ruleset);
-        if !mentions_or_keywords_enabled {
-            return Err(NotificationSettingsError::MentionsNotEnabled);
-        }
 
         // Insert a new Room push rule
         let new_rule = NewSimplePushRule::new(RoomId::parse(room_id)?, vec![]);
@@ -667,37 +653,6 @@ pub(crate) mod tests {
         assert_eq!(
             mode,
             Some(RoomNotificationMode::MentionsAndKeywordsOnly),
-            "wrong mode, should be 'RoomNotificationMode::MentionsAndKeywordsOnly'"
-        );
-    }
-
-    #[async_test]
-    async fn insert_mention_and_keywords_room_rule_with_mentions_disabled() {
-        let server = MockServer::start().await;
-        let client = logged_in_client(Some(server.uri())).await;
-
-        let mut ruleset = client.account().push_rules().await.unwrap();
-        let notification_settings = client.notification_settings();
-        let room_id = "!test_room:matrix.org".to_string();
-
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert!(mode.is_none());
-
-        // Disable users mentions and room mentions
-        notification_settings.set_user_mention_enabled(false, &mut ruleset);
-        notification_settings.set_room_mention_enabled(false, &mut ruleset);
-
-        // An error is expected
-        let result =
-            notification_settings.insert_mention_and_keywords_room_rule(&room_id, &mut ruleset);
-        assert!(result.is_err(), "An error is expected.");
-
-        // And the mode must remain at None
-        let mode =
-            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
-        assert!(
-            mode.is_none(),
             "wrong mode, should be 'RoomNotificationMode::MentionsAndKeywordsOnly'"
         );
     }

--- a/crates/matrix-sdk/src/notification_settings.rs
+++ b/crates/matrix-sdk/src/notification_settings.rs
@@ -502,15 +502,10 @@ pub(crate) mod tests {
         let encrypted: bool = true;
         let members_count = 2;
 
-        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
-            encrypted,
-            members_count,
-            &ruleset,
-        ) {
-            assert_eq!(mode, RoomNotificationMode::AllMessages)
-        } else {
-            panic!("A default mode should be defined.")
-        }
+        let mode = notification_settings
+            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
+            .expect("A default mode should be defined.");
+        assert_eq!(mode, RoomNotificationMode::AllMessages);
 
         let result = ruleset.set_enabled(
             RuleKind::Underride,
@@ -530,15 +525,10 @@ pub(crate) mod tests {
         );
         assert!(result.is_ok());
 
-        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
-            encrypted,
-            members_count,
-            &ruleset,
-        ) {
-            assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
-        } else {
-            panic!("A default mode should be defined.")
-        }
+        let mode = notification_settings
+            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
+            .expect("A default mode should be defined.");
+        assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
     }
 
     #[async_test]
@@ -552,15 +542,10 @@ pub(crate) mod tests {
         let encrypted = false;
         let members_count = 2;
 
-        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
-            encrypted,
-            members_count,
-            &ruleset,
-        ) {
-            assert_eq!(mode, RoomNotificationMode::AllMessages)
-        } else {
-            panic!("A default mode should be defined.")
-        }
+        let mode = notification_settings
+            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
+            .expect("A default mode should be defined.");
+        assert_eq!(mode, RoomNotificationMode::AllMessages);
 
         let result = ruleset.set_enabled(
             RuleKind::Underride,
@@ -577,15 +562,10 @@ pub(crate) mod tests {
             ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true);
         assert!(result.is_ok());
 
-        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
-            encrypted,
-            members_count,
-            &ruleset,
-        ) {
-            assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
-        } else {
-            panic!("A default mode should be defined.")
-        }
+        let mode = notification_settings
+            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
+            .expect("A default mode should be defined.");
+        assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly);
     }
 
     #[async_test]
@@ -601,15 +581,10 @@ pub(crate) mod tests {
         let encrypted: bool = true;
         let members_count = 3;
 
-        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
-            encrypted,
-            members_count,
-            &ruleset,
-        ) {
-            assert_eq!(mode, RoomNotificationMode::AllMessages)
-        } else {
-            panic!("A default mode should be defined.")
-        }
+        let mode = notification_settings
+            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
+            .expect("A default mode should be defined.");
+        assert_eq!(mode, RoomNotificationMode::AllMessages);
 
         let result =
             ruleset.set_enabled(RuleKind::Underride, PredefinedUnderrideRuleId::Encrypted, false);
@@ -626,15 +601,10 @@ pub(crate) mod tests {
         );
         assert!(result.is_ok());
 
-        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
-            encrypted,
-            members_count,
-            &ruleset,
-        ) {
-            assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
-        } else {
-            panic!("A default mode should be defined.")
-        }
+        let mode = notification_settings
+            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
+            .expect("A default mode should be defined.");
+        assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly);
     }
 
     #[async_test]
@@ -648,15 +618,10 @@ pub(crate) mod tests {
         let encrypted: bool = false;
         let members_count = 3;
 
-        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
-            encrypted,
-            members_count,
-            &ruleset,
-        ) {
-            assert_eq!(mode, RoomNotificationMode::AllMessages)
-        } else {
-            panic!("A default mode should be defined.")
-        }
+        let mode = notification_settings
+            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
+            .expect("A default mode should be defined.");
+        assert_eq!(mode, RoomNotificationMode::AllMessages);
 
         let result =
             ruleset.set_enabled(RuleKind::Underride, PredefinedUnderrideRuleId::Message, false);
@@ -673,15 +638,10 @@ pub(crate) mod tests {
         );
         assert!(result.is_ok());
 
-        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
-            encrypted,
-            members_count,
-            &ruleset,
-        ) {
-            assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
-        } else {
-            panic!("A default mode should be defined.")
-        }
+        let mode = notification_settings
+            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
+            .expect("A default mode should be defined.");
+        assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly);
     }
 
     #[async_test]
@@ -769,11 +729,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::AllMessages;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)
@@ -809,11 +765,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::AllMessages;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)
@@ -850,11 +802,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::AllMessages;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)
@@ -891,11 +839,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::MentionsAndKeywordsOnly;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)
@@ -935,11 +879,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::MentionsAndKeywordsOnly;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)
@@ -980,11 +920,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::MentionsAndKeywordsOnly;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)
@@ -1017,11 +953,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::Mute;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)
@@ -1057,11 +989,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::Mute;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)
@@ -1097,11 +1025,7 @@ pub(crate) mod tests {
         let expected_mode = &RoomNotificationMode::Mute;
         match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset) {
             Some(new_mode) => {
-                assert_eq!(
-                    &new_mode, expected_mode,
-                    "mode {:?} is expected (got {:?})",
-                    expected_mode, &new_mode
-                )
+                assert_eq!(&new_mode, expected_mode)
             }
             None => {
                 panic!("mode {:?} is expected.", expected_mode)

--- a/crates/matrix-sdk/src/notification_settings.rs
+++ b/crates/matrix-sdk/src/notification_settings.rs
@@ -291,7 +291,7 @@ impl NotificationSettings {
         is_encrypted: bool,
         members_count: u64,
         ruleset: &Ruleset,
-    ) -> Result<RoomNotificationMode, NotificationSettingsError> {
+    ) -> RoomNotificationMode {
         // get the correct default rule ID based on `is_encrypted` and `members_count`
         let rule_id = match (is_encrypted, members_count) {
             (true, 2) => PredefinedUnderrideRuleId::EncryptedRoomOneToOne,
@@ -307,10 +307,10 @@ impl NotificationSettings {
                 && r.rule_id == rule_id.to_string()
                 && r.actions.iter().any(|a| a.should_notify())
         }) {
-            Ok(RoomNotificationMode::AllMessages)
+            RoomNotificationMode::AllMessages
         } else {
             // Otherwise, the mode is `MentionsAndKeywordsOnly`
-            Ok(RoomNotificationMode::MentionsAndKeywordsOnly)
+            RoomNotificationMode::MentionsAndKeywordsOnly
         }
     }
 
@@ -591,9 +591,11 @@ pub(crate) mod tests {
         let encrypted: bool = true;
         let members_count = 2;
 
-        let mode = notification_settings
-            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
-            .expect("A default mode should be defined.");
+        let mode = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        );
         assert_eq!(mode, RoomNotificationMode::AllMessages);
 
         let result = ruleset.set_enabled(
@@ -614,9 +616,11 @@ pub(crate) mod tests {
         );
         assert!(result.is_ok());
 
-        let mode = notification_settings
-            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
-            .expect("A default mode should be defined.");
+        let mode = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        );
         assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
     }
 
@@ -631,9 +635,11 @@ pub(crate) mod tests {
         let encrypted = false;
         let members_count = 2;
 
-        let mode = notification_settings
-            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
-            .expect("A default mode should be defined.");
+        let mode = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        );
         assert_eq!(mode, RoomNotificationMode::AllMessages);
 
         let result = ruleset.set_enabled(
@@ -651,9 +657,11 @@ pub(crate) mod tests {
             ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, true);
         assert!(result.is_ok());
 
-        let mode = notification_settings
-            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
-            .expect("A default mode should be defined.");
+        let mode = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        );
         assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly);
     }
 
@@ -670,9 +678,11 @@ pub(crate) mod tests {
         let encrypted: bool = true;
         let members_count = 3;
 
-        let mode = notification_settings
-            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
-            .expect("A default mode should be defined.");
+        let mode = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        );
         assert_eq!(mode, RoomNotificationMode::AllMessages);
 
         let result =
@@ -690,9 +700,11 @@ pub(crate) mod tests {
         );
         assert!(result.is_ok());
 
-        let mode = notification_settings
-            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
-            .expect("A default mode should be defined.");
+        let mode = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        );
         assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly);
     }
 
@@ -707,9 +719,11 @@ pub(crate) mod tests {
         let encrypted: bool = false;
         let members_count = 3;
 
-        let mode = notification_settings
-            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
-            .expect("A default mode should be defined.");
+        let mode = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        );
         assert_eq!(mode, RoomNotificationMode::AllMessages);
 
         let result =
@@ -727,9 +741,11 @@ pub(crate) mod tests {
         );
         assert!(result.is_ok());
 
-        let mode = notification_settings
-            .get_default_room_notification_mode(encrypted, members_count, &ruleset)
-            .expect("A default mode should be defined.");
+        let mode = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        );
         assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly);
     }
 

--- a/crates/matrix-sdk/src/notification_settings.rs
+++ b/crates/matrix-sdk/src/notification_settings.rs
@@ -88,7 +88,7 @@ impl NotificationSettings {
         room_id: &String,
         ruleset: &Ruleset,
     ) -> Option<RoomNotificationMode> {
-        // Search for an enabled Override rule where rule_id is the room_id
+        // Search for an enabled Override
         if let Some(rule) = ruleset.override_.iter().find(|x| x.enabled) {
             // without a Notify action
             if !rule.actions.iter().any(|x| matches!(x, Action::Notify)) {
@@ -191,18 +191,11 @@ impl NotificationSettings {
                 && r.rule_id == rule_id.to_string()
                 && r.actions.iter().any(|a| a.should_notify())
         }) {
-            return Ok(RoomNotificationMode::AllMessages);
+            Ok(RoomNotificationMode::AllMessages)
+        } else {
+            // Otherwise, the mode is 'MentionsAndKeywordsOnly'
+            Ok(RoomNotificationMode::MentionsAndKeywordsOnly)
         }
-
-        // If user mention is enabled, the mode is 'MentionsAndKeywordsOnly'
-        if self.is_user_mention_enabled(ruleset)
-            || self.contains_keyword_rules(ruleset)
-            || self.is_room_mention_enabled(ruleset)
-        {
-            return Ok(RoomNotificationMode::MentionsAndKeywordsOnly);
-        }
-
-        Ok(RoomNotificationMode::Mute)
     }
 
     /// Get whether the IsUserMention rule is enabled.

--- a/crates/matrix-sdk/src/notification_settings.rs
+++ b/crates/matrix-sdk/src/notification_settings.rs
@@ -1,0 +1,898 @@
+//! High-level push notification settings API
+
+use ruma::{
+    events::push_rules::PushRulesEventContent,
+    push::{
+        Action, NewConditionalPushRule, NewPushRule, NewSimplePushRule, PredefinedContentRuleId,
+        PredefinedOverrideRuleId, PredefinedUnderrideRuleId, PushCondition, RuleKind, Ruleset,
+        Tweak,
+    },
+    RoomId,
+};
+
+use crate::{error::NotificationSettingsError, Client, Result};
+
+/// Enum representing the push notification modes for a room
+#[derive(Debug, Clone, PartialEq)]
+pub enum RoomNotificationMode {
+    /// All messages
+    AllMessages,
+    /// Mentions and keywords only
+    MentionsAndKeywordsOnly,
+    /// Mute
+    Mute,
+}
+
+/// A high-level API to manage the client owner's push notification settings.
+#[derive(Debug, Clone)]
+pub struct NotificationSettings {
+    /// The underlying HTTP client.
+    client: Client,
+}
+
+impl NotificationSettings {
+    pub(crate) fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Save a given ruleset to the client's owner account data
+    async fn save_push_rules(&self, ruleset: &Ruleset) -> Result<(), NotificationSettingsError> {
+        let content = PushRulesEventContent::new(ruleset.clone());
+        self.client
+            .account()
+            .set_account_data::<PushRulesEventContent>(content)
+            .await
+            .map_err(|_| NotificationSettingsError::UnableToSavePushRules)?;
+        Ok(())
+    }
+
+    /// Restore the default push rule for a given room
+    ///
+    /// The owner's account data will be updated.
+    /// If an error occurs, the ruleset will not be modified.
+    pub async fn restore_room_default_push_rule(
+        &self,
+        room_id: &String,
+        ruleset: &mut Ruleset,
+    ) -> Result<(), NotificationSettingsError> {
+        // Only if we have a custom mode for this room
+        if self.get_user_defined_room_notification_mode(room_id, ruleset).is_some() {
+            let updated_ruleset = &mut ruleset.clone();
+            // get a new ruleset without the custom rules
+            self.delete_user_defined_room_notification_mode(room_id, updated_ruleset)?;
+            // save the updated ruleset
+            if self.save_push_rules(updated_ruleset).await.is_ok() {
+                *ruleset = updated_ruleset.clone();
+            } else {
+                return Err(NotificationSettingsError::UnableToSavePushRules);
+            }
+        }
+        Ok(())
+    }
+
+    /// Sets a notification mode for a given room
+    ///
+    /// The owner's account data will be updated.
+    /// If an error occurs, the ruleset will not be modified.
+    pub async fn set_room_notification_mode(
+        &self,
+        room_id: &String,
+        mode: RoomNotificationMode,
+        ruleset: &mut Ruleset,
+    ) -> Result<(), NotificationSettingsError> {
+        let updated_ruleset = &mut ruleset.clone();
+        match mode {
+            RoomNotificationMode::AllMessages => {
+                self.insert_notify_room_rule(room_id, updated_ruleset)?;
+            }
+            RoomNotificationMode::MentionsAndKeywordsOnly => {
+                self.insert_mention_and_keywords_room_rule(room_id, updated_ruleset)?;
+            }
+            RoomNotificationMode::Mute => {
+                self.insert_mute_room_rule(room_id, updated_ruleset)?;
+            }
+        }
+        // Save the updated ruleset
+        if self.save_push_rules(updated_ruleset).await.is_ok() {
+            *ruleset = updated_ruleset.clone();
+            Ok(())
+        } else {
+            Err(NotificationSettingsError::UnableToSavePushRules)
+        }
+    }
+
+    /// Gets the user defined push notification mode for a given room id
+    pub fn get_user_defined_room_notification_mode(
+        &self,
+        room_id: &String,
+        ruleset: &Ruleset,
+    ) -> Option<RoomNotificationMode> {
+        // Search for an enabled Override rule where rule_id is the room_id
+        if let Some(rule) =
+            ruleset.override_.iter().find(|x| x.enabled /* && x.rule_id == *room_id */)
+        {
+            // without a Notify action
+            if !rule.actions.iter().any(|x| matches!(x, Action::Notify)) {
+                // with a condition of type `EventMatch` for this room_id
+                if rule.conditions.iter().any(|x| match x {
+                    PushCondition::EventMatch { key, pattern } => {
+                        key == "room_id" && *pattern == *room_id
+                    }
+                    _ => false,
+                }) {
+                    return Some(RoomNotificationMode::Mute);
+                }
+            }
+        }
+
+        // Search for an enabled Room rule where rule_id is the room_id
+        if let Some(rule) = ruleset.room.iter().find(|x| x.enabled && x.rule_id == *room_id) {
+            // if this rule contains a Notify action
+            if rule.actions.iter().any(|x| matches!(x, Action::Notify)) {
+                return Some(RoomNotificationMode::AllMessages);
+            }
+            // if this rule does not contain a Notify action
+            if !rule.actions.iter().any(|x| matches!(x, Action::Notify)) {
+                // check if mentions or keywords are enabled
+                if self.is_user_mention_enabled(ruleset)
+                    || self.is_room_mention_enabled(ruleset)
+                    || self.contains_keywords_rules(ruleset)
+                {
+                    return Some(RoomNotificationMode::MentionsAndKeywordsOnly);
+                }
+            }
+            return Some(RoomNotificationMode::Mute);
+        }
+
+        // There is no custom rule matching this room_id
+        None
+    }
+
+    /// Delete any user defined rules for this room in the given ruleset
+    fn delete_user_defined_room_notification_mode(
+        &self,
+        room_id: &String,
+        ruleset: &mut Ruleset,
+    ) -> Result<(), NotificationSettingsError> {
+        // remove any Override rules matching this room_id
+        for rule in ruleset.override_.clone().iter() {
+            if rule.rule_id == *room_id {
+                ruleset.remove(RuleKind::Override, &rule.rule_id)?;
+                continue;
+            }
+            if rule.conditions.iter().any(|x| match x {
+                PushCondition::EventMatch { key, pattern } => {
+                    key == "room_id" && *pattern == *room_id
+                }
+                _ => false,
+            }) {
+                ruleset.remove(RuleKind::Override, &rule.rule_id)?;
+                continue;
+            }
+        }
+
+        // remove any Room rules matching this room_id
+        if let Some(rule) = ruleset.room.clone().iter().find(|x| x.rule_id == *room_id) {
+            ruleset.remove(RuleKind::Room, &rule.rule_id)?;
+        }
+
+        // remove any Underride rules matching this room_id
+        for rule in ruleset.underride.clone().iter() {
+            if rule.rule_id == *room_id {
+                ruleset.remove(RuleKind::Underride, &rule.rule_id)?;
+                continue;
+            }
+            if rule.conditions.iter().any(|x| match x {
+                PushCondition::EventMatch { key, pattern } => {
+                    key == "room_id" && *pattern == *room_id
+                }
+                _ => false,
+            }) {
+                ruleset.remove(RuleKind::Underride, &rule.rule_id)?;
+                continue;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Gets the default push notification mode for a given room id
+    pub fn get_default_room_notification_mode(
+        &self,
+        is_encrypted: bool,
+        members_count: u64,
+        ruleset: &Ruleset,
+    ) -> Result<RoomNotificationMode, NotificationSettingsError> {
+        // get the correct default rule id based on is_encrypted and members_count
+        let rule_id = match (is_encrypted, members_count) {
+            (true, 2) => PredefinedUnderrideRuleId::EncryptedRoomOneToOne,
+            (false, 2) => PredefinedUnderrideRuleId::RoomOneToOne,
+            (true, _) => PredefinedUnderrideRuleId::Encrypted,
+            (false, _) => PredefinedUnderrideRuleId::Message,
+        };
+
+        // If there is an Underride rule that should trigger a notification, the mode is
+        // 'AllMessages'
+        if ruleset.underride.iter().any(|r| {
+            r.enabled
+                && r.rule_id == rule_id.to_string()
+                && r.actions.iter().any(|a| a.should_notify())
+        }) {
+            return Ok(RoomNotificationMode::AllMessages);
+        }
+
+        // If user mention is enabled, the mode is 'MentionsAndKeywordsOnly'
+        if self.is_user_mention_enabled(ruleset)
+            || self.contains_keywords_rules(ruleset)
+            || self.is_room_mention_enabled(ruleset)
+        {
+            return Ok(RoomNotificationMode::MentionsAndKeywordsOnly);
+        }
+
+        Ok(RoomNotificationMode::Mute)
+    }
+
+    /// Get whether the IsUserMention rule is enabled.
+    #[allow(deprecated)]
+    pub fn is_user_mention_enabled(&self, ruleset: &Ruleset) -> bool {
+        // Search for an enabled Override rule IsUserMention (MSC3952).
+        // This is a new push rule that may not yet be present.
+        // The rule_id will be replaced by `PredefinedOverrideRuleId::IsUserMention`
+        // once available in ruma-common.
+        if let Some(rule) = ruleset.get(RuleKind::Override, ".m.rule.is_user_mention") {
+            if rule.enabled() {
+                return true;
+            }
+        }
+
+        // Fallback to deprecated rules for compatibility.
+        let mentions_and_keywords_rules_id = vec![
+            PredefinedOverrideRuleId::ContainsDisplayName.to_string(),
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+        ];
+        ruleset.content.iter().any(|r| {
+            r.enabled
+                && mentions_and_keywords_rules_id.contains(&r.rule_id)
+                && r.actions.iter().any(|a| a.should_notify())
+        })
+    }
+
+    /// Set whether the IsUserMention rule is enabled.
+    #[allow(deprecated)]
+    pub fn set_user_mention_enabled(&self, enabled: bool, ruleset: &mut Ruleset) {
+        // Sets the IsUserMention Override rule (MSC3952).
+        // This is a new push rule that may not yet be present.
+        // The rule_id will be replaced by `PredefinedOverrideRuleId::IsUserMention`
+        // once available in ruma-common.
+        _ = ruleset.set_enabled(RuleKind::Override, ".m.rule.is_user_mention", enabled);
+
+        // For compatibility purpose, we still need to set ContainsUserName and
+        // ContainsDisplayName (deprecated rules).
+        _ = ruleset.set_enabled(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            enabled,
+        );
+
+        _ = ruleset.set_enabled(
+            RuleKind::Content,
+            PredefinedOverrideRuleId::ContainsDisplayName.to_string(),
+            enabled,
+        );
+    }
+
+    /// Get whether the IsRoomMention rule is enabled.
+    #[allow(deprecated)]
+    pub fn is_room_mention_enabled(&self, ruleset: &Ruleset) -> bool {
+        // Search for an enabled Override rule IsRoomMention (MSC3952).
+        // This is a new push rule that may not yet be present.
+        // The rule_id will be replaced by `PredefinedOverrideRuleId::IsRoomMention`
+        // once available in ruma-common.
+        if let Some(rule) = ruleset.get(RuleKind::Override, ".m.rule.is_room_mention") {
+            if rule.enabled() {
+                return true;
+            }
+        }
+
+        // Fallback to deprecated rule for compatibility
+        ruleset.content.iter().any(|r| {
+            r.enabled
+                && r.rule_id == PredefinedOverrideRuleId::RoomNotif.to_string()
+                && r.actions.iter().any(|a| a.should_notify())
+        })
+    }
+
+    /// Set whether the IsRoomMention rule is enabled.
+    #[allow(deprecated)]
+    pub fn set_room_mention_enabled(&self, enabled: bool, ruleset: &mut Ruleset) {
+        // Sets the IsRoomMention Override rule (MSC3952).
+        // This is a new push rule that may not yet be present.
+        // The rule_id will be replaced by `PredefinedOverrideRuleId::IsRoomMention`
+        // once available in ruma-common.
+        _ = ruleset.set_enabled(RuleKind::Override, ".m.rule.is_room_mention", enabled);
+
+        // For compatibility purpose, we still need to set RoomNotif (deprecated rule).
+        _ = ruleset.set_enabled(
+            RuleKind::Content,
+            PredefinedOverrideRuleId::RoomNotif.to_string(),
+            enabled,
+        );
+    }
+
+    /// Get whether the given ruleset contains some keywords rules
+    pub fn contains_keywords_rules(&self, ruleset: &Ruleset) -> bool {
+        // Search for a user defined Content rule.
+        ruleset.content.iter().any(|r| !r.default && r.enabled)
+    }
+
+    /// Insert a new rule to mute a given room in the given ruleset
+    fn insert_mute_room_rule(
+        &self,
+        room_id: &String,
+        ruleset: &mut Ruleset,
+    ) -> Result<(), NotificationSettingsError> {
+        // Try to remove any existing rule for this room
+        _ = self.delete_user_defined_room_notification_mode(room_id, ruleset);
+
+        // Insert a new Override push rule without any actions
+        let new_rule = NewConditionalPushRule::new(
+            room_id.clone(),
+            vec![PushCondition::EventMatch { key: "room_id".into(), pattern: room_id.clone() }],
+            vec![],
+        );
+        ruleset.insert(NewPushRule::Override(new_rule), None, None)?;
+
+        Ok(())
+    }
+
+    /// Insert a mention and keywords rule for a given room in the given
+    /// ruleset
+    ///
+    /// Returns an error if mention rules are disabled and no keyword rules
+    /// exists.
+    fn insert_mention_and_keywords_room_rule(
+        &self,
+        room_id: &String,
+        ruleset: &mut Ruleset,
+    ) -> Result<(), NotificationSettingsError> {
+        // Try to remove any existing rule for this room
+        _ = self.delete_user_defined_room_notification_mode(room_id, ruleset);
+
+        // Check if mentions or keywords are enabled
+        let mentions_or_keywords_enabled = self.is_user_mention_enabled(ruleset)
+            || self.is_room_mention_enabled(ruleset)
+            || self.contains_keywords_rules(ruleset);
+        if !mentions_or_keywords_enabled {
+            return Err(NotificationSettingsError::MentionsNotEnabled);
+        }
+
+        // Insert a new Room push rule
+        let new_rule = NewSimplePushRule::new(RoomId::parse(room_id)?, vec![]);
+        ruleset.insert(NewPushRule::Room(new_rule), None, None)?;
+        Ok(())
+    }
+
+    /// Insert a notify rule for a given room in the given ruleset
+    fn insert_notify_room_rule(
+        &self,
+        room_id: &String,
+        ruleset: &mut Ruleset,
+    ) -> Result<(), NotificationSettingsError> {
+        // Try to remove any existing rule for this room
+        _ = self.delete_user_defined_room_notification_mode(room_id, ruleset);
+
+        // Insert a new Room push rule with a Notify action.
+        let new_rule = NewSimplePushRule::new(
+            RoomId::parse(room_id)?,
+            vec![Action::Notify, Action::SetTweak(Tweak::Sound("default".into()))],
+        );
+        ruleset.insert(NewPushRule::Room(new_rule), None, None)?;
+
+        Ok(())
+    }
+}
+
+// The http mocking library is not supported for wasm32
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) mod tests {
+    use matrix_sdk_test::async_test;
+    #[cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+    use ruma::push::{Action, PredefinedContentRuleId, PredefinedUnderrideRuleId, RuleKind};
+    use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
+
+    use crate::{
+        notification_settings::RoomNotificationMode, test_utils::logged_in_client,
+        NotificationSettingsError,
+    };
+
+    #[async_test]
+    async fn get_default_room_notification_mode_encrypted_one_to_one() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+
+        let encrypted: bool = true;
+        let members_count = 2;
+
+        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        ) {
+            assert_eq!(mode, RoomNotificationMode::AllMessages)
+        } else {
+            panic!("A default mode should be defined.")
+        }
+
+        let result = ruleset.set_enabled(
+            RuleKind::Underride,
+            PredefinedUnderrideRuleId::EncryptedRoomOneToOne.to_string(),
+            false,
+        );
+        assert!(result.is_ok());
+
+        let result = ruleset.set_enabled(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            true,
+        );
+        assert!(result.is_ok());
+
+        let result = ruleset.set_actions(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            vec![Action::Notify],
+        );
+        assert!(result.is_ok());
+
+        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        ) {
+            assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
+        } else {
+            panic!("A default mode should be defined.")
+        }
+    }
+
+    #[async_test]
+    async fn get_default_room_notification_mode_one_to_one() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+
+        let encrypted = false;
+        let members_count = 2;
+
+        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        ) {
+            assert_eq!(mode, RoomNotificationMode::AllMessages)
+        } else {
+            panic!("A default mode should be defined.")
+        }
+
+        let result = ruleset.set_enabled(
+            RuleKind::Underride,
+            PredefinedUnderrideRuleId::RoomOneToOne.to_string(),
+            false,
+        );
+        assert!(result.is_ok());
+
+        let result = ruleset.set_enabled(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            true,
+        );
+        assert!(result.is_ok());
+
+        let result = ruleset.set_actions(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            vec![Action::Notify],
+        );
+        assert!(result.is_ok());
+
+        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        ) {
+            assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
+        } else {
+            panic!("A default mode should be defined.")
+        }
+    }
+
+    #[async_test]
+    async fn get_default_room_notification_mode_encrypted_room() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+
+        let encrypted: bool = true;
+        let members_count = 3;
+
+        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        ) {
+            assert_eq!(mode, RoomNotificationMode::AllMessages)
+        } else {
+            panic!("A default mode should be defined.")
+        }
+
+        let result = ruleset.set_enabled(
+            RuleKind::Underride,
+            PredefinedUnderrideRuleId::Encrypted.to_string(),
+            false,
+        );
+        assert!(result.is_ok());
+
+        let result = ruleset.set_enabled(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            true,
+        );
+        assert!(result.is_ok());
+
+        let result = ruleset.set_actions(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            vec![Action::Notify],
+        );
+        assert!(result.is_ok());
+
+        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        ) {
+            assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
+        } else {
+            panic!("A default mode should be defined.")
+        }
+    }
+
+    #[async_test]
+    async fn get_default_room_notification_mode_unencrypted_room() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+
+        let encrypted: bool = false;
+        let members_count = 3;
+
+        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        ) {
+            assert_eq!(mode, RoomNotificationMode::AllMessages)
+        } else {
+            panic!("A default mode should be defined.")
+        }
+
+        let result = ruleset.set_enabled(
+            RuleKind::Underride,
+            PredefinedUnderrideRuleId::Message.to_string(),
+            false,
+        );
+        assert!(result.is_ok());
+
+        let result = ruleset.set_enabled(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            true,
+        );
+        assert!(result.is_ok());
+
+        let result = ruleset.set_actions(
+            RuleKind::Content,
+            PredefinedContentRuleId::ContainsUserName.to_string(),
+            vec![Action::Notify],
+        );
+        assert!(result.is_ok());
+
+        if let Ok(mode) = notification_settings.get_default_room_notification_mode(
+            encrypted,
+            members_count,
+            &ruleset,
+        ) {
+            assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly)
+        } else {
+            panic!("A default mode should be defined.")
+        }
+    }
+
+    #[async_test]
+    async fn insert_notify_room_rule() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        let result = notification_settings.insert_notify_room_rule(&room_id, &mut ruleset);
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert_eq!(mode, Some(RoomNotificationMode::AllMessages));
+    }
+
+    #[async_test]
+    async fn insert_notify_room_rule_invalid_room_id() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "invalid_test_room_id".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        let result = notification_settings.insert_notify_room_rule(&room_id, &mut ruleset);
+        match result {
+            Err(error) => {
+                assert!(matches!(error, NotificationSettingsError::InvalidRoomId))
+            }
+            _ => {
+                panic!("a 'NotificationSettingsError::InvalidRoomId' error is expected.")
+            }
+        }
+    }
+
+    #[async_test]
+    async fn insert_mention_and_keywords_room_rule() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        let result =
+            notification_settings.insert_mention_and_keywords_room_rule(&room_id, &mut ruleset);
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert_eq!(
+            mode,
+            Some(RoomNotificationMode::MentionsAndKeywordsOnly),
+            "wrong mode, should be 'RoomNotificationMode::MentionsAndKeywordsOnly'"
+        );
+    }
+
+    #[async_test]
+    async fn insert_mute_room_rule() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset);
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert_eq!(
+            mode,
+            Some(RoomNotificationMode::Mute),
+            "wrong mode, should be 'RoomNotificationMode::Mute'"
+        );
+    }
+
+    #[async_test]
+    async fn delete_user_defined_room_notification_mode() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset);
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert_eq!(
+            mode,
+            Some(RoomNotificationMode::Mute),
+            "wrong mode, should be 'RoomNotificationMode::Mute'"
+        );
+
+        let result = notification_settings
+            .delete_user_defined_room_notification_mode(&room_id, &mut ruleset);
+        assert!(result.is_ok());
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+    }
+
+    #[async_test]
+    async fn set_room_notification_mode() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        // Calling set_room_notification_mode will perform an API call
+        let mock = Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200));
+        server.register(mock).await;
+
+        // Test to set each modes
+        for expected_mode in [
+            RoomNotificationMode::AllMessages,
+            RoomNotificationMode::MentionsAndKeywordsOnly,
+            RoomNotificationMode::Mute,
+        ]
+        .iter()
+        {
+            let result = notification_settings
+                .set_room_notification_mode(&room_id, expected_mode.clone(), &mut ruleset)
+                .await;
+            assert!(result.is_ok());
+
+            match notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset)
+            {
+                Some(new_mode) => {
+                    assert_eq!(&new_mode, expected_mode)
+                }
+                None => {
+                    panic!("mode {:?} is expected.", expected_mode)
+                }
+            }
+        }
+    }
+
+    #[async_test]
+    async fn set_room_notification_mode_unable_to_save() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        // Calling set_room_notification_mode will perform an API call
+        let mock = Mock::given(method("PUT")).respond_with(ResponseTemplate::new(500));
+        server.register(mock).await;
+
+        // Test to set each modes
+        for expected_mode in [
+            RoomNotificationMode::AllMessages,
+            RoomNotificationMode::MentionsAndKeywordsOnly,
+            RoomNotificationMode::Mute,
+        ]
+        .iter()
+        {
+            let result = notification_settings
+                .set_room_notification_mode(&room_id, expected_mode.clone(), &mut ruleset)
+                .await;
+            assert!(result.is_err());
+
+            assert!(
+                notification_settings
+                    .get_user_defined_room_notification_mode(&room_id, &ruleset)
+                    .is_none(),
+                "ruleset should not have been updated."
+            );
+        }
+    }
+
+    #[async_test]
+    async fn restore_room_default_push_rule() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        // Calling set_room_notification_mode will perform an API call
+        let mock = Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200));
+        server.register(mock).await;
+
+        // Mute the room
+        let result = notification_settings
+            .set_room_notification_mode(&room_id, RoomNotificationMode::Mute, &mut ruleset)
+            .await;
+        assert!(result.is_ok());
+
+        // Restore to default mode
+        let result =
+            notification_settings.restore_room_default_push_rule(&room_id, &mut ruleset).await;
+        assert!(result.is_ok());
+
+        // All user defined rules should have be deleted
+        assert!(notification_settings
+            .get_user_defined_room_notification_mode(&room_id, &ruleset)
+            .is_none());
+    }
+
+    #[async_test]
+    async fn restore_room_default_push_rule_unable_to_save() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        let notification_settings = client.notification_settings();
+        let room_id = "!test_room:matrix.org".to_string();
+
+        let mode =
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset);
+        assert!(mode.is_none());
+
+        // Calling set_room_notification_mode will perform an API call
+        let mock = Mock::given(method("PUT")).respond_with(ResponseTemplate::new(500));
+        server.register(mock).await;
+
+        // Mute the room
+        let result = notification_settings.insert_mute_room_rule(&room_id, &mut ruleset);
+        assert!(result.is_ok());
+
+        // Restore to default mode
+        let result =
+            notification_settings.restore_room_default_push_rule(&room_id, &mut ruleset).await;
+        assert!(result.is_err());
+
+        // Ruleset should not have been modified
+        assert_eq!(
+            notification_settings.get_user_defined_room_notification_mode(&room_id, &ruleset),
+            Some(RoomNotificationMode::Mute)
+        );
+    }
+}


### PR DESCRIPTION
This PR implements the first part of https://github.com/matrix-org/matrix-rust-sdk/issues/1959 

It exposes a new `NotificationSettings` object in order to update the notification settings for a given room.
The logic behind has been placed in matrix-sdk, with some unit tests.

The following MSC were considered:
[MSC3987: Push actions clean-up](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3987-push-actions-clean-up.md#msc3987-push-actions-clean-up)
[MSC3952: Intentional Mentions](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3952-intentional-mentions.md) 