### PR TITLE
Somewhat crazy refactoring

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -414,7 +414,6 @@ impl ClientBuilder {
             encryption_state_request_locks: Default::default(),
             typing_notice_times: Default::default(),
             event_handlers: Default::default(),
-            notification_handlers: Default::default(),
             sync_gap_broadcast_txs: Default::default(),
             appservice_mode: self.appservice_mode,
             respect_login_well_known: self.respect_login_well_known,

--- a/crates/matrix-sdk/src/event_handler/static_events.rs
+++ b/crates/matrix-sdk/src/event_handler/static_events.rs
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 use ruma::{
+    api::client::push::get_notifications::v3::Notification,
     events::{
         self,
         presence::{PresenceEvent, PresenceEventContent},
@@ -28,163 +29,211 @@ use ruma::{
     },
     serde::Raw,
 };
+use serde::de::DeserializeOwned;
 
 use super::{HandlerKind, SyncEvent};
 
+impl SyncEvent for Notification {
+    const KIND: HandlerKind = HandlerKind::Notification;
+    const TYPE: Option<&'static str> = None;
+
+    type Raw = Notification;
+    fn from_raw(raw: &Self::Raw) -> serde_json::Result<Self> {
+        Ok(raw.clone())
+    }
+}
+
+macro_rules! raw_json_event {
+    () => {
+        type Raw = serde_json::value::RawValue;
+        fn from_raw(raw: &Self::Raw) -> serde_json::Result<Self> {
+            serde_json::from_str(raw.get())
+        }
+    };
+}
+
 impl<C> SyncEvent for events::GlobalAccountDataEvent<C>
 where
-    C: StaticEventContent + GlobalAccountDataEventContent,
+    C: StaticEventContent + GlobalAccountDataEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::GlobalAccountData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::RoomAccountDataEvent<C>
 where
-    C: StaticEventContent + RoomAccountDataEventContent,
+    C: StaticEventContent + RoomAccountDataEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::RoomAccountData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::SyncEphemeralRoomEvent<C>
 where
-    C: StaticEventContent + EphemeralRoomEventContent,
+    C: StaticEventContent + EphemeralRoomEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::EphemeralRoomData;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::SyncMessageLikeEvent<C>
 where
-    C: StaticEventContent + MessageLikeEventContent + RedactContent,
-    C::Redacted: RedactedMessageLikeEventContent,
+    C: StaticEventContent + MessageLikeEventContent + RedactContent + DeserializeOwned,
+    C::Redacted: RedactedMessageLikeEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::OriginalSyncMessageLikeEvent<C>
 where
-    C: StaticEventContent + MessageLikeEventContent,
+    C: StaticEventContent + MessageLikeEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::OriginalMessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::RedactedSyncMessageLikeEvent<C>
 where
-    C: StaticEventContent + RedactedMessageLikeEventContent,
+    C: StaticEventContent + RedactedMessageLikeEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::RedactedMessageLike;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl SyncEvent for events::room::redaction::SyncRoomRedactionEvent {
     const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
+    raw_json_event!();
 }
 
 impl SyncEvent for events::room::redaction::OriginalSyncRoomRedactionEvent {
     const KIND: HandlerKind = HandlerKind::OriginalMessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
+    raw_json_event!();
 }
 
 impl SyncEvent for events::room::redaction::RedactedSyncRoomRedactionEvent {
     const KIND: HandlerKind = HandlerKind::RedactedMessageLike;
     const TYPE: Option<&'static str> =
         Some(events::room::redaction::RoomRedactionEventContent::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::SyncStateEvent<C>
 where
-    C: StaticEventContent + StaticStateEventContent + RedactContent,
-    C::Redacted: RedactedStateEventContent,
+    C: StaticEventContent + StaticStateEventContent + RedactContent + DeserializeOwned,
+    C::Redacted: RedactedStateEventContent<StateKey = C::StateKey> + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::State;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::OriginalSyncStateEvent<C>
 where
-    C: StaticEventContent + StaticStateEventContent,
+    C: StaticEventContent + StaticStateEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::OriginalState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::RedactedSyncStateEvent<C>
 where
-    C: StaticEventContent + RedactedStateEventContent,
+    C: StaticEventContent + RedactedStateEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::RedactedState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::StrippedStateEvent<C>
 where
-    C: StaticEventContent + PossiblyRedactedStateEventContent,
+    C: StaticEventContent + PossiblyRedactedStateEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::StrippedState;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl<C> SyncEvent for events::ToDeviceEvent<C>
 where
-    C: StaticEventContent + ToDeviceEventContent,
+    C: StaticEventContent + ToDeviceEventContent + DeserializeOwned,
 {
     const KIND: HandlerKind = HandlerKind::ToDevice;
     const TYPE: Option<&'static str> = Some(C::TYPE);
+    raw_json_event!();
 }
 
 impl SyncEvent for PresenceEvent {
     const KIND: HandlerKind = HandlerKind::Presence;
     const TYPE: Option<&'static str> = Some(PresenceEventContent::TYPE);
+    raw_json_event!();
 }
 
 impl SyncEvent for AnyGlobalAccountDataEvent {
     const KIND: HandlerKind = HandlerKind::GlobalAccountData;
     const TYPE: Option<&'static str> = None;
+    raw_json_event!();
 }
 
 impl SyncEvent for AnyRoomAccountDataEvent {
     const KIND: HandlerKind = HandlerKind::RoomAccountData;
     const TYPE: Option<&'static str> = None;
+    raw_json_event!();
 }
 
 impl SyncEvent for AnySyncEphemeralRoomEvent {
     const KIND: HandlerKind = HandlerKind::EphemeralRoomData;
     const TYPE: Option<&'static str> = None;
+    raw_json_event!();
 }
 
 impl SyncEvent for AnySyncTimelineEvent {
     const KIND: HandlerKind = HandlerKind::Timeline;
     const TYPE: Option<&'static str> = None;
+    raw_json_event!();
 }
 
 impl SyncEvent for AnySyncMessageLikeEvent {
     const KIND: HandlerKind = HandlerKind::MessageLike;
     const TYPE: Option<&'static str> = None;
+    raw_json_event!();
 }
 
 impl SyncEvent for AnySyncStateEvent {
     const KIND: HandlerKind = HandlerKind::State;
     const TYPE: Option<&'static str> = None;
+    raw_json_event!();
 }
 
 impl SyncEvent for AnyStrippedStateEvent {
     const KIND: HandlerKind = HandlerKind::StrippedState;
     const TYPE: Option<&'static str> = None;
+    raw_json_event!();
 }
 
 impl SyncEvent for AnyToDeviceEvent {
     const KIND: HandlerKind = HandlerKind::ToDevice;
     const TYPE: Option<&'static str> = None;
+    raw_json_event!();
 }
 
 impl<T: SyncEvent> SyncEvent for Raw<T> {
     const KIND: HandlerKind = T::KIND;
     const TYPE: Option<&'static str> = T::TYPE;
+
+    type Raw = serde_json::value::RawValue;
+    fn from_raw(raw: &Self::Raw) -> serde_json::Result<Self> {
+        Ok(Self::from_json(raw.to_owned()))
+    }
 }


### PR DESCRIPTION
I'd like to "swap out" the layer under the timeline API to be one "event" handler that receives (pretty much) all information that we get from sync responses in one batch – including the `prev_batch` token that we need for proper back pagination.

Now the easy way to this would be to introduce another `add_foo_handler` function the way we have `add_event_handler` and `register_notification_handler` but that doesn't feel great in terms of API, especially as `register_notification_handler` is already a bit ugly (not nearly as flexible as `add_event_handler`) and replicating all of the mechanisms of `add_event_handler` for it and the new `add_room_handler` or whatever would be a lot of boilerplate code.

So... how about "just" adding more generics to `add_event_handler` so it can handle all of these use cases? That's what this PR explores. It converts notification handlers to be just another kind of event handler, and deprecated `register_notification_handler` (which is now just a less flexible version of `add_notification_handler`). This means:

- notification handlers can now be removed again
- notification handlers don't require exactly `(Notification, Room, Client)` as arguments, the requirements are like with previous event handlers: `Notification` as the first argument, then optional `Room`, `Client` and `Ctx<_>` arguments (trying to use `RawEvent` is a compile error, `Option<EncryptionInfo>` will work but currently always be `None`, this is probably something we can provide?)

This comes at the expense of making the complex / ugly generics for event handlers even more complex / uglier though. So I wonder: What do you think?