### PR TITLE
Upgrade Ruma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4302,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=54a4223caa1c1052464ecdba0f1e08f126e07bcd#54a4223caa1c1052464ecdba0f1e08f126e07bcd"
+source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
 dependencies = [
  "assign",
  "js_int",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=54a4223caa1c1052464ecdba0f1e08f126e07bcd#54a4223caa1c1052464ecdba0f1e08f126e07bcd"
+source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=54a4223caa1c1052464ecdba0f1e08f126e07bcd#54a4223caa1c1052464ecdba0f1e08f126e07bcd"
+source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
 dependencies = [
  "assign",
  "bytes",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=54a4223caa1c1052464ecdba0f1e08f126e07bcd#54a4223caa1c1052464ecdba0f1e08f126e07bcd"
+source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4378,7 +4378,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=54a4223caa1c1052464ecdba0f1e08f126e07bcd#54a4223caa1c1052464ecdba0f1e08f126e07bcd"
+source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=54a4223caa1c1052464ecdba0f1e08f126e07bcd#54a4223caa1c1052464ecdba0f1e08f126e07bcd"
+source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4398,7 +4398,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=54a4223caa1c1052464ecdba0f1e08f126e07bcd#54a4223caa1c1052464ecdba0f1e08f126e07bcd"
+source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=54a4223caa1c1052464ecdba0f1e08f126e07bcd#54a4223caa1c1052464ecdba0f1e08f126e07bcd"
+source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ futures-core = "0.3.28"
 futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
-ruma = { git = "https://github.com/ruma/ruma", rev = "54a4223caa1c1052464ecdba0f1e08f126e07bcd", features = ["client-api-c", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "54a4223caa1c1052464ecdba0f1e08f126e07bcd" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "854d8076eff1c5b6454c42e4309b1b070b815893", features = ["client-api-c", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "854d8076eff1c5b6454c42e4309b1b070b815893" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -43,7 +43,7 @@ js-sys = "0.3.49"
 matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../../crates/matrix-sdk-indexeddb" }
 matrix-sdk-qrcode = { version = "0.4.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
-ruma = { workspace = true, features = ["js", "rand", "unstable-msc2677"] }
+ruma = { workspace = true, features = ["js", "rand"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std"] }

--- a/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-nodejs/Cargo.toml
@@ -27,7 +27,7 @@ tracing = ["dep:tracing-subscriber"]
 matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
 matrix-sdk-sled = { version = "0.2.0", path = "../../crates/matrix-sdk-sled", default-features = false, features = ["crypto-store"] }
 matrix-sdk-sqlite = { version = "0.1.0", path = "../../crates/matrix-sdk-sqlite", features = ["crypto-store"] }
-ruma = { workspace = true, features = ["rand", "unstable-msc2677"] }
+ruma = { workspace = true, features = ["rand"] }
 napi = { version = "2.9.1", default-features = false, features = ["napi6", "tokio_rt"] }
 napi-derive = "2.9.1"
 serde_json = { workspace = true }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -50,7 +50,7 @@ matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 pbkdf2 = { version = "0.11.0", default-features = false }
 rand = "0.8.5"
 rmp-serde = "1.1.1"
-ruma = { workspace = true, features = ["rand", "canonical-json", "unstable-msc2677"] }
+ruma = { workspace = true, features = ["rand", "canonical-json"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 sha2 = "0.10.2"

--- a/crates/matrix-sdk-crypto/src/backups/keys/compat.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/compat.rs
@@ -176,6 +176,7 @@ pub enum MessageDecodeError {
     Key(#[from] KeyError),
 }
 
+#[derive(Debug)]
 pub struct Message {
     pub ciphertext: Vec<u8>,
     pub mac: Vec<u8>,
@@ -225,12 +226,12 @@ mod test {
         }
     }
 
-    impl Into<PkMessage> for Message {
-        fn into(self) -> PkMessage {
+    impl From<Message> for PkMessage {
+        fn from(val: Message) -> Self {
             PkMessage {
-                ciphertext: encode(self.ciphertext),
-                mac: encode(self.mac),
-                ephemeral_key: self.ephemeral_key.to_base64(),
+                ciphertext: encode(val.ciphertext),
+                mac: encode(val.mac),
+                ephemeral_key: val.ephemeral_key.to_base64(),
             }
         }
     }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -25,7 +25,7 @@ matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = fal
 mime = "0.3.16"
 once_cell = { workspace = true }
 pin-project-lite = "0.2.9"
-ruma = { workspace = true, features = ["unstable-msc2677", "unstable-sanitize"] }
+ruma = { workspace = true, features = ["unstable-sanitize"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
Matrix 1.7 (stabilizing reactions!) is out and Ruma has already mostly upgraded. After this PR, the last remaining `unstable-` features we use from Ruma are `unstable-sanitize` for HTML sanitization, and `unstable-unspecified` for Apple push stuff (IIRC).
