### PR TITLE
feat(sdk): use the builder pattern for the other sliding sync mode too

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -492,9 +492,11 @@ impl SlidingSyncListBuilder {
         maximum_number_of_rooms_to_fetch: Option<u32>,
     ) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder
-            .inner
-            .sync_mode(SlidingSyncMode::new_paging(batch_size, maximum_number_of_rooms_to_fetch));
+        let mut mode_builder = SlidingSyncMode::new_paging(batch_size);
+        if let Some(num) = maximum_number_of_rooms_to_fetch {
+            mode_builder = mode_builder.maximum_number_of_rooms_to_fetch(num);
+        }
+        builder.inner = builder.inner.sync_mode(mode_builder);
         Arc::new(builder)
     }
 
@@ -504,9 +506,11 @@ impl SlidingSyncListBuilder {
         maximum_number_of_rooms_to_fetch: Option<u32>,
     ) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder
-            .inner
-            .sync_mode(SlidingSyncMode::new_growing(batch_size, maximum_number_of_rooms_to_fetch));
+        let mut mode_builder = SlidingSyncMode::new_growing(batch_size);
+        if let Some(num) = maximum_number_of_rooms_to_fetch {
+            mode_builder = mode_builder.maximum_number_of_rooms_to_fetch(num);
+        }
+        builder.inner = builder.inner.sync_mode(mode_builder);
         Arc::new(builder)
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -736,6 +736,47 @@ impl From<SlidingSyncSelectiveModeBuilder> for SlidingSyncMode {
     }
 }
 
+#[derive(Clone, Debug)]
+enum WindowedModeBuilderKind {
+    Paging,
+    Growing,
+}
+
+/// Builder for a new sliding sync list in growing/paging mode.
+#[derive(Clone, Debug)]
+pub struct SlidingSyncWindowedModeBuilder {
+    mode: WindowedModeBuilderKind,
+    batch_size: u32,
+    maximum_number_of_rooms_to_fetch: Option<u32>,
+}
+
+impl SlidingSyncWindowedModeBuilder {
+    fn new(mode: WindowedModeBuilderKind, batch_size: u32) -> Self {
+        Self { mode, batch_size, maximum_number_of_rooms_to_fetch: None }
+    }
+
+    /// The maximum number of rooms to fetch.
+    pub fn maximum_number_of_rooms_to_fetch(mut self, num: u32) -> Self {
+        self.maximum_number_of_rooms_to_fetch = Some(num);
+        self
+    }
+}
+
+impl From<SlidingSyncWindowedModeBuilder> for SlidingSyncMode {
+    fn from(builder: SlidingSyncWindowedModeBuilder) -> Self {
+        match builder.mode {
+            WindowedModeBuilderKind::Paging => Self::Paging {
+                batch_size: builder.batch_size,
+                maximum_number_of_rooms_to_fetch: builder.maximum_number_of_rooms_to_fetch,
+            },
+            WindowedModeBuilderKind::Growing => Self::Growing {
+                batch_size: builder.batch_size,
+                maximum_number_of_rooms_to_fetch: builder.maximum_number_of_rooms_to_fetch,
+            },
+        }
+    }
+}
+
 /// How a [`SlidingSyncList`] fetches the data.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SlidingSyncMode {
@@ -782,13 +823,13 @@ impl SlidingSyncMode {
     }
 
     /// Create a `SlidingSyncMode::Paging`.
-    pub fn new_paging(batch_size: u32, maximum_number_of_rooms_to_fetch: Option<u32>) -> Self {
-        Self::Paging { batch_size, maximum_number_of_rooms_to_fetch }
+    pub fn new_paging(batch_size: u32) -> SlidingSyncWindowedModeBuilder {
+        SlidingSyncWindowedModeBuilder::new(WindowedModeBuilderKind::Paging, batch_size)
     }
 
     /// Create a `SlidingSyncMode::Growing`.
-    pub fn new_growing(batch_size: u32, maximum_number_of_rooms_to_fetch: Option<u32>) -> Self {
-        Self::Growing { batch_size, maximum_number_of_rooms_to_fetch }
+    pub fn new_growing(batch_size: u32) -> SlidingSyncWindowedModeBuilder {
+        SlidingSyncWindowedModeBuilder::new(WindowedModeBuilderKind::Growing, batch_size)
     }
 }
 
@@ -957,7 +998,7 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         let mut list = SlidingSyncList::builder("testing")
-            .sync_mode(SlidingSyncMode::new_paging(10, None))
+            .sync_mode(SlidingSyncMode::new_paging(10))
             .build(sender);
 
         assert_ranges! {
@@ -999,7 +1040,7 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         let mut list = SlidingSyncList::builder("testing")
-            .sync_mode(SlidingSyncMode::new_paging(10, Some(22)))
+            .sync_mode(SlidingSyncMode::new_paging(10).maximum_number_of_rooms_to_fetch(22))
             .build(sender);
 
         assert_ranges! {
@@ -1041,7 +1082,7 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         let mut list = SlidingSyncList::builder("testing")
-            .sync_mode(SlidingSyncMode::new_growing(10, None))
+            .sync_mode(SlidingSyncMode::new_growing(10))
             .build(sender);
 
         assert_ranges! {
@@ -1083,7 +1124,7 @@ mod tests {
         let (sender, _receiver) = channel(1);
 
         let mut list = SlidingSyncList::builder("testing")
-            .sync_mode(SlidingSyncMode::new_growing(10, Some(22)))
+            .sync_mode(SlidingSyncMode::new_growing(10).maximum_number_of_rooms_to_fetch(22))
             .build(sender);
 
         assert_ranges! {
@@ -1255,7 +1296,7 @@ mod tests {
         };
 
         // Changing from `Selective` to `Growing`.
-        list.set_sync_mode(SlidingSyncMode::new_growing(10, None)).unwrap();
+        list.set_sync_mode(SlidingSyncMode::new_growing(10)).unwrap();
 
         assert_ranges! {
             list = list,
@@ -1291,7 +1332,7 @@ mod tests {
         };
 
         // Changing from `Growing` to `Paging`.
-        list.set_sync_mode(SlidingSyncMode::new_paging(10, None)).unwrap();
+        list.set_sync_mode(SlidingSyncMode::new_paging(10)).unwrap();
 
         assert_ranges! {
             list = list,
@@ -1490,7 +1531,7 @@ mod tests {
     #[test]
     fn test_sliding_sync_mode_serialization() {
         assert_json_roundtrip!(
-            from SlidingSyncMode: SlidingSyncMode::new_paging(1, Some(2)) => json!({
+            from SlidingSyncMode: SlidingSyncMode::from(SlidingSyncMode::new_paging(1).maximum_number_of_rooms_to_fetch(2)) => json!({
                 "Paging": {
                     "batch_size": 1,
                     "maximum_number_of_rooms_to_fetch": 2
@@ -1498,7 +1539,7 @@ mod tests {
             })
         );
         assert_json_roundtrip!(
-            from SlidingSyncMode: SlidingSyncMode::new_growing(1, Some(2)) => json!({
+            from SlidingSyncMode: SlidingSyncMode::from(SlidingSyncMode::new_growing(1).maximum_number_of_rooms_to_fetch(2)) => json!({
                 "Growing": {
                     "batch_size": 1,
                     "maximum_number_of_rooms_to_fetch": 2

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -387,8 +387,8 @@ mod tests {
 
     #[test]
     fn test_request_generator_paging_from_sync_mode() {
-        let sync_mode = SlidingSyncMode::new_paging(1, Some(2));
-        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode);
+        let sync_mode = SlidingSyncMode::new_paging(1).maximum_number_of_rooms_to_fetch(2);
+        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode.into());
 
         assert!(request_generator.ranges.is_empty());
         assert_eq!(
@@ -405,8 +405,8 @@ mod tests {
 
     #[test]
     fn test_request_generator_growing_from_sync_mode() {
-        let sync_mode = SlidingSyncMode::new_growing(1, Some(2));
-        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode);
+        let sync_mode = SlidingSyncMode::new_growing(1).maximum_number_of_rooms_to_fetch(2);
+        let request_generator = SlidingSyncListRequestGenerator::new(sync_mode.into());
 
         assert!(request_generator.ranges.is_empty());
         assert_eq!(


### PR DESCRIPTION
Add builder patterns for the `Growing` and `Paging` sync modes too. As they're quite common, I've used the same builder struct with a sub enum for both.