### PR TITLE
chore(sliding sync): remove useless mutex around ExtensionsConfig

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::BTreeMap,
-    fmt::Debug,
-    sync::{Mutex, RwLock as StdRwLock},
-};
+use std::{collections::BTreeMap, fmt::Debug, sync::RwLock as StdRwLock};
 
 use ruma::{
     api::client::sync::sync_events::v4::{
@@ -264,7 +260,7 @@ impl SlidingSyncBuilder {
             rooms,
             bump_event_types: self.bump_event_types,
 
-            extensions: Mutex::new(self.extensions),
+            extensions: self.extensions.unwrap_or_default(),
             reset_counter: Default::default(),
 
             position: StdRwLock::new(SlidingSyncPositionMarkers {

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -27,7 +27,7 @@ use std::{
     fmt::Debug,
     sync::{
         atomic::{AtomicU8, Ordering},
-        Arc, Mutex, RwLock as StdRwLock,
+        Arc, RwLock as StdRwLock,
     },
     time::Duration,
 };
@@ -116,9 +116,9 @@ pub(super) struct SlidingSyncInner {
     /// Number of times a Sliding Sync session has been reset.
     reset_counter: AtomicU8,
 
-    /// The intended state of the extensions being supplied to Sliding Sync
-    /// calls.
-    extensions: Mutex<Option<ExtensionsConfig>>,
+    /// Static configuration for extensions, passed in the slidinc sync
+    /// requests.
+    extensions: ExtensionsConfig,
 
     /// Internal channel used to pass messages between Sliding Sync and other
     /// types.
@@ -260,7 +260,7 @@ impl SlidingSync {
     }
 
     fn prepare_extension_config(&self, pos: Option<&str>) -> ExtensionsConfig {
-        let mut extensions = { self.inner.extensions.lock().unwrap().clone().unwrap_or_default() };
+        let mut extensions = self.inner.extensions.clone();
 
         if pos.is_none() {
             // The pos is `None`, it's either our initial sync or the proxy forgot about us


### PR DESCRIPTION
I've made `SlidingSync::ExtensionsConfig` read-only in a previous PR, but forgot to remove the mutex around it, which isn't needed anymore. Also moved the default-ing behavior of `ExtensionsConfig` closer to where configuration happens (in the builder's `build` method) instead of deep within the code, elsewhere.