### PR TITLE
feat(sdk): add an optional temporary directory to `get_media_file`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -193,6 +193,7 @@ impl Client {
         media_source: Arc<MediaSource>,
         body: Option<String>,
         mime_type: String,
+        temp_dir: Option<String>,
     ) -> Result<Arc<MediaFileHandle>, ClientError> {
         let client = self.inner.clone();
         let source = (*media_source).clone();
@@ -206,6 +207,7 @@ impl Client {
                     body,
                     &mime_type,
                     true,
+                    temp_dir,
                 )
                 .await?;
 


### PR DESCRIPTION
By default, `get_media_file` will attempt to use a default directory for temporary files and directories. Unfortunately, there might not be such a thing on some older Android devices, which use per-application directories.

For this specific case, an optional temporary directory parameter is added to the `get_media_file` parameters, so one can provide their own temporary directory path.

This new parameter is expected to be set at least on Android; other platforms should work just fine without it.