### PR TITLE
test(sdk): Ensure `SlidingSync` starts after it has been stopped manually

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -891,17 +891,30 @@ mod tests {
             .sync_mode(SlidingSyncMode::new_selective().add_range(0..=10))])
         .await?;
 
+        // Start the sync-loop.
         let stream = sliding_sync.sync();
         pin_mut!(stream);
 
+        // The sync-loop is actually running.
         for _ in 0..3 {
             assert!(stream.next().await.is_some());
         }
 
+        // Stop the sync-loop.
         sliding_sync.stop_sync().await?;
 
+        // The sync-loop is actually stopped.
         for _ in 0..3 {
             assert!(stream.next().await.is_none());
+        }
+
+        // Start a new sync-loop.
+        let stream = sliding_sync.sync();
+        pin_mut!(stream);
+
+        // The sync-loop is actually running.
+        for _ in 0..3 {
+            assert!(stream.next().await.is_some());
         }
 
         Ok(())


### PR DESCRIPTION
Everything is in the title :-).