### PR TITLE
sdk: Allow to get stripped state events from the store

### DIFF
--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -14,13 +14,15 @@
 
 //! SDK-specific variations of response types from Ruma.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
 pub use matrix_sdk_common::deserialized_responses::*;
 use ruma::{
-    events::room::member::{
-        MembershipState, RoomMemberEvent, RoomMemberEventContent, StrippedRoomMemberEvent,
-        SyncRoomMemberEvent,
+    events::{
+        room::member::{MembershipState, RoomMemberEvent, RoomMemberEventContent},
+        AnyStrippedStateEvent, AnySyncStateEvent, EventContentFromType,
+        PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
+        StateEventContent, StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
     },
     serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, UserId,
@@ -61,69 +63,196 @@ pub struct MembersResponse {
     pub ambiguity_changes: AmbiguityChanges,
 }
 
-/// Raw version of [`MemberEvent`].
-#[derive(Debug, Serialize)]
+/// Wrapper around both versions of any raw state event.
+#[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
-pub enum RawMemberEvent {
-    /// A member event from a room in joined or left state.
-    Sync(Raw<SyncRoomMemberEvent>),
-    /// A member event from a room in invited state.
-    Stripped(Raw<StrippedRoomMemberEvent>),
+pub enum RawAnySyncOrStrippedState {
+    /// An event from a room in joined or left state.
+    Sync(Raw<AnySyncStateEvent>),
+    /// An event from a room in invited state.
+    Stripped(Raw<AnyStrippedStateEvent>),
 }
 
-impl RawMemberEvent {
+impl RawAnySyncOrStrippedState {
     /// Try to deserialize the inner JSON as the expected type.
-    pub fn deserialize(&self) -> serde_json::Result<MemberEvent> {
+    pub fn deserialize(&self) -> serde_json::Result<AnySyncOrStrippedState> {
         match self {
-            Self::Sync(e) => Ok(MemberEvent::Sync(e.deserialize()?)),
-            Self::Stripped(e) => Ok(MemberEvent::Stripped(e.deserialize()?)),
+            Self::Sync(raw) => Ok(AnySyncOrStrippedState::Sync(raw.deserialize()?)),
+            Self::Stripped(raw) => Ok(AnySyncOrStrippedState::Stripped(raw.deserialize()?)),
+        }
+    }
+
+    /// Turns this `RawAnySyncOrStrippedState` into `RawSyncOrStrippedState<C>`
+    /// without changing the underlying JSON.
+    pub fn cast<C>(self) -> RawSyncOrStrippedState<C>
+    where
+        C: StaticStateEventContent + RedactContent,
+        C::Redacted: RedactedStateEventContent,
+    {
+        match self {
+            Self::Sync(raw) => RawSyncOrStrippedState::Sync(raw.cast()),
+            Self::Stripped(raw) => RawSyncOrStrippedState::Stripped(raw.cast()),
         }
     }
 }
 
-/// Wrapper around both MemberEvent-Types
+/// Wrapper around both versions of any state event.
 #[derive(Clone, Debug)]
-pub enum MemberEvent {
-    /// A member event from a room in joined or left state.
-    Sync(SyncRoomMemberEvent),
-    /// A member event from a room in invited state.
-    Stripped(StrippedRoomMemberEvent),
+pub enum AnySyncOrStrippedState {
+    /// An event from a room in joined or left state.
+    Sync(AnySyncStateEvent),
+    /// An event from a room in invited state.
+    Stripped(AnyStrippedStateEvent),
 }
 
-impl MemberEvent {
-    /// The inner Content of the wrapped Event
-    pub fn original_content(&self) -> Option<&RoomMemberEventContent> {
+impl AnySyncOrStrippedState {
+    /// If this is an `AnySyncStateEvent`, return a reference to the inner
+    /// event.
+    pub fn as_sync(&self) -> Option<&AnySyncStateEvent> {
         match self {
-            MemberEvent::Sync(e) => e.as_original().map(|e| &e.content),
-            MemberEvent::Stripped(e) => Some(&e.content),
+            Self::Sync(ev) => Some(ev),
+            Self::Stripped(_) => None,
+        }
+    }
+
+    /// If this is an `AnyStrippedStateEvent`, return a reference to the inner
+    /// event.
+    pub fn as_stripped(&self) -> Option<&AnyStrippedStateEvent> {
+        match self {
+            Self::Sync(_) => None,
+            Self::Stripped(ev) => Some(ev),
+        }
+    }
+}
+
+/// Wrapper around both versions of a raw state event.
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
+pub enum RawSyncOrStrippedState<C>
+where
+    C: StaticStateEventContent + RedactContent,
+    C::Redacted: RedactedStateEventContent,
+{
+    /// An event from a room in joined or left state.
+    Sync(Raw<SyncStateEvent<C>>),
+    /// An event from a room in invited state.
+    Stripped(Raw<StrippedStateEvent<C::PossiblyRedacted>>),
+}
+
+impl<C> RawSyncOrStrippedState<C>
+where
+    C: StaticStateEventContent + RedactContent,
+    C::Redacted: RedactedStateEventContent + fmt::Debug + Clone,
+{
+    /// Try to deserialize the inner JSON as the expected type.
+    pub fn deserialize(&self) -> serde_json::Result<SyncOrStrippedState<C>>
+    where
+        C: StaticStateEventContent + EventContentFromType + RedactContent,
+        C::Redacted: RedactedStateEventContent<StateKey = C::StateKey> + EventContentFromType,
+        C::PossiblyRedacted: PossiblyRedactedStateEventContent + EventContentFromType,
+    {
+        match self {
+            Self::Sync(ev) => Ok(SyncOrStrippedState::Sync(ev.deserialize()?)),
+            Self::Stripped(ev) => Ok(SyncOrStrippedState::Stripped(ev.deserialize()?)),
+        }
+    }
+}
+
+/// Raw version of [`MemberEvent`].
+pub type RawMemberEvent = RawSyncOrStrippedState<RoomMemberEventContent>;
+
+/// Wrapper around both versions of a state event.
+#[derive(Clone, Debug)]
+pub enum SyncOrStrippedState<C>
+where
+    C: StaticStateEventContent + RedactContent,
+    C::Redacted: RedactedStateEventContent + fmt::Debug + Clone,
+{
+    /// An event from a room in joined or left state.
+    Sync(SyncStateEvent<C>),
+    /// An event from a room in invited state.
+    Stripped(StrippedStateEvent<C::PossiblyRedacted>),
+}
+
+impl<C> SyncOrStrippedState<C>
+where
+    C: StaticStateEventContent + RedactContent,
+    C::Redacted: RedactedStateEventContent<StateKey = C::StateKey> + fmt::Debug + Clone,
+    C::PossiblyRedacted: PossiblyRedactedStateEventContent<StateKey = C::StateKey>,
+{
+    /// If this is a `SyncStateEvent`, return a reference to the inner event.
+    pub fn as_sync(&self) -> Option<&SyncStateEvent<C>> {
+        match self {
+            Self::Sync(ev) => Some(ev),
+            Self::Stripped(_) => None,
+        }
+    }
+
+    /// If this is a `StrippedStateEvent`, return a reference to the inner
+    /// event.
+    pub fn as_stripped(&self) -> Option<&StrippedStateEvent<C::PossiblyRedacted>> {
+        match self {
+            Self::Sync(_) => None,
+            Self::Stripped(ev) => Some(ev),
         }
     }
 
     /// The sender of this event.
     pub fn sender(&self) -> &UserId {
         match self {
-            MemberEvent::Sync(e) => e.sender(),
-            MemberEvent::Stripped(e) => &e.sender,
+            Self::Sync(e) => e.sender(),
+            Self::Stripped(e) => &e.sender,
         }
     }
 
     /// The ID of this event.
     pub fn event_id(&self) -> Option<&EventId> {
         match self {
-            MemberEvent::Sync(e) => Some(e.event_id()),
-            MemberEvent::Stripped(_) => None,
+            Self::Sync(e) => Some(e.event_id()),
+            Self::Stripped(_) => None,
         }
     }
 
-    /// The Server Timestamp of this event.
+    /// The server timestamp of this event.
     pub fn origin_server_ts(&self) -> Option<MilliSecondsSinceUnixEpoch> {
         match self {
-            MemberEvent::Sync(e) => Some(e.origin_server_ts()),
-            MemberEvent::Stripped(_) => None,
+            Self::Sync(e) => Some(e.origin_server_ts()),
+            Self::Stripped(_) => None,
         }
     }
 
-    /// The membership state of the user
+    /// The state key associated to this state event.
+    pub fn state_key(&self) -> &C::StateKey {
+        match self {
+            Self::Sync(e) => e.state_key(),
+            Self::Stripped(e) => &e.state_key,
+        }
+    }
+}
+
+impl<C> SyncOrStrippedState<C>
+where
+    C: StaticStateEventContent<PossiblyRedacted = C>
+        + RedactContent
+        + PossiblyRedactedStateEventContent,
+    C::Redacted: RedactedStateEventContent<StateKey = <C as StateEventContent>::StateKey>
+        + fmt::Debug
+        + Clone,
+{
+    /// The inner content of the wrapped event.
+    pub fn original_content(&self) -> Option<&C> {
+        match self {
+            Self::Sync(e) => e.as_original().map(|e| &e.content),
+            Self::Stripped(e) => Some(&e.content),
+        }
+    }
+}
+
+/// Wrapper around both MemberEvent-Types
+pub type MemberEvent = SyncOrStrippedState<RoomMemberEventContent>;
+
+impl MemberEvent {
+    /// The membership state of the user.
     pub fn membership(&self) -> &MembershipState {
         match self {
             MemberEvent::Sync(e) => e.membership(),
@@ -131,11 +260,8 @@ impl MemberEvent {
         }
     }
 
-    /// The user id associated to this member event
+    /// The user id associated to this member event.
     pub fn user_id(&self) -> &UserId {
-        match self {
-            MemberEvent::Sync(e) => e.state_key(),
-            MemberEvent::Stripped(e) => &e.state_key,
-        }
+        self.state_key()
     }
 }

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -19,7 +19,10 @@ use std::{collections::BTreeMap, fmt};
 pub use matrix_sdk_common::deserialized_responses::*;
 use ruma::{
     events::{
-        room::member::{MembershipState, RoomMemberEvent, RoomMemberEventContent},
+        room::{
+            member::{MembershipState, RoomMemberEvent, RoomMemberEventContent},
+            power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
+        },
         AnyStrippedStateEvent, AnySyncStateEvent, EventContentFromType,
         PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
         StateEventContent, StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
@@ -263,5 +266,15 @@ impl MemberEvent {
     /// The user id associated to this member event.
     pub fn user_id(&self) -> &UserId {
         self.state_key()
+    }
+}
+
+impl SyncOrStrippedState<RoomPowerLevelsEventContent> {
+    /// The power levels of the event.
+    pub fn power_levels(&self) -> RoomPowerLevels {
+        match self {
+            Self::Sync(e) => e.power_levels(),
+            Self::Stripped(e) => e.power_levels(),
+        }
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/members.rs
+++ b/crates/matrix-sdk-base/src/rooms/members.rs
@@ -19,14 +19,17 @@ use ruma::{
         presence::PresenceEvent,
         room::{
             member::MembershipState,
-            power_levels::{PowerLevelAction, RoomPowerLevels, SyncRoomPowerLevelsEvent},
+            power_levels::{PowerLevelAction, RoomPowerLevels, RoomPowerLevelsEventContent},
         },
         MessageLikeEventType, StateEventType,
     },
     MxcUri, UserId,
 };
 
-use crate::{deserialized_responses::MemberEvent, MinimalRoomMemberEvent};
+use crate::{
+    deserialized_responses::{MemberEvent, SyncOrStrippedState},
+    MinimalRoomMemberEvent,
+};
 
 /// A member of a room.
 #[derive(Clone, Debug)]
@@ -38,7 +41,7 @@ pub struct RoomMember {
     pub(crate) profile: Arc<Option<MinimalRoomMemberEvent>>,
     #[allow(dead_code)]
     pub(crate) presence: Arc<Option<PresenceEvent>>,
-    pub(crate) power_levels: Arc<Option<SyncRoomPowerLevelsEvent>>,
+    pub(crate) power_levels: Arc<Option<SyncOrStrippedState<RoomPowerLevelsEventContent>>>,
     pub(crate) max_power_level: i64,
     pub(crate) is_room_creator: bool,
     pub(crate) display_name_ambiguous: bool,

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -37,8 +37,9 @@ use tracing::{debug, warn};
 
 use super::{Result, RoomInfo, StateChanges, StateStore, StoreError};
 use crate::{
-    deserialized_responses::RawMemberEvent, media::MediaRequest, MinimalRoomMemberEvent,
-    RoomMemberships, StateStoreDataKey, StateStoreDataValue,
+    deserialized_responses::{RawAnySyncOrStrippedState, RawMemberEvent},
+    media::MediaRequest,
+    MinimalRoomMemberEvent, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
 };
 
 /// In-Memory, non-persistent implementation of the `StateStore`
@@ -376,25 +377,48 @@ impl MemoryStore {
         room_id: &RoomId,
         event_type: StateEventType,
         state_key: &str,
-    ) -> Result<Option<Raw<AnySyncStateEvent>>> {
-        Ok(self
+    ) -> Result<Option<RawAnySyncOrStrippedState>> {
+        if let Some(e) = self
+            .stripped_room_state
+            .get(room_id)
+            .as_ref()
+            .and_then(|events| events.get(&event_type))
+            .and_then(|m| m.get(state_key).map(|m| m.clone()))
+        {
+            Ok(Some(RawAnySyncOrStrippedState::Stripped(e)))
+        } else if let Some(e) = self
             .room_state
             .get(room_id)
-            .and_then(|e| e.get(&event_type).and_then(|s| s.get(state_key).map(|e| e.clone()))))
+            .as_ref()
+            .and_then(|events| events.get(&event_type))
+            .and_then(|m| m.get(state_key).map(|m| m.clone()))
+        {
+            Ok(Some(RawAnySyncOrStrippedState::Sync(e)))
+        } else {
+            Ok(None)
+        }
     }
 
     async fn get_state_events(
         &self,
         room_id: &RoomId,
         event_type: StateEventType,
-    ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
-        Ok(self
-            .room_state
-            .get(room_id)
-            .and_then(|e| {
-                e.get(&event_type).map(|s| s.iter().map(|e| e.clone()).collect::<Vec<_>>())
+    ) -> Result<Vec<RawAnySyncOrStrippedState>> {
+        if let Some(v) = self.stripped_room_state.get(room_id).as_ref().and_then(|events| {
+            events.get(&event_type).map(|s| {
+                s.iter().map(|e| RawAnySyncOrStrippedState::Stripped(e.clone())).collect::<Vec<_>>()
             })
-            .unwrap_or_default())
+        }) {
+            Ok(v)
+        } else if let Some(v) = self.room_state.get(room_id).as_ref().and_then(|events| {
+            events.get(&event_type).map(|s| {
+                s.iter().map(|e| RawAnySyncOrStrippedState::Sync(e.clone())).collect::<Vec<_>>()
+            })
+        }) {
+            Ok(v)
+        } else {
+            Ok(Vec::new())
+        }
     }
 
     async fn get_profile(
@@ -410,25 +434,9 @@ impl MemoryStore {
         room_id: &RoomId,
         state_key: &UserId,
     ) -> Result<Option<RawMemberEvent>> {
-        if let Some(e) = self
-            .stripped_room_state
-            .get(room_id)
-            .as_ref()
-            .and_then(|events| events.get(&StateEventType::RoomMember))
-            .and_then(|m| m.get(state_key.as_str()).map(|m| m.clone().cast()))
-        {
-            Ok(Some(RawMemberEvent::Stripped(e)))
-        } else if let Some(e) = self
-            .room_state
-            .get(room_id)
-            .as_ref()
-            .and_then(|events| events.get(&StateEventType::RoomMember))
-            .and_then(|m| m.get(state_key.as_str()).map(|m| m.clone().cast()))
-        {
-            Ok(Some(RawMemberEvent::Sync(e)))
-        } else {
-            Ok(None)
-        }
+        self.get_state_event(room_id, StateEventType::RoomMember, state_key.as_str())
+            .await
+            .map(|opt| opt.map(|raw| raw.cast()))
     }
 
     /// Get the user IDs for the given room with the given memberships and
@@ -588,7 +596,7 @@ impl StateStore for MemoryStore {
         room_id: &RoomId,
         event_type: StateEventType,
         state_key: &str,
-    ) -> Result<Option<Raw<AnySyncStateEvent>>> {
+    ) -> Result<Option<RawAnySyncOrStrippedState>> {
         self.get_state_event(room_id, event_type, state_key).await
     }
 
@@ -596,7 +604,7 @@ impl StateStore for MemoryStore {
         &self,
         room_id: &RoomId,
         event_type: StateEventType,
-    ) -> Result<Vec<Raw<AnySyncStateEvent>>> {
+    ) -> Result<Vec<RawAnySyncOrStrippedState>> {
         self.get_state_events(room_id, event_type).await
     }
 

--- a/crates/matrix-sdk-sled/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-sled/src/state_store/migrations.rs
@@ -402,7 +402,10 @@ mod test {
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{
         events::{
-            room::member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
+            room::{
+                member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
+                topic::RoomTopicEventContent,
+            },
             AnySyncStateEvent, StateEventType,
         },
         room_id,
@@ -553,7 +556,7 @@ mod test {
             .unwrap();
         let event =
             store.get_state_event(room_id, StateEventType::RoomTopic, "").await.unwrap().unwrap();
-        event.deserialize().unwrap();
+        event.cast::<RoomTopicEventContent>().deserialize().unwrap();
     }
 
     #[async_test]

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -10,6 +10,8 @@
   - `Common::active_members(_no_sync)` and `Common::joined_members(_no_sync)` are deprecated.
 - `matrix-sdk-sqlite` is the new default store implementation outside of WASM, behind the `sqlite` feature.
   - The `sled` feature was removed. It is still possible to use `matrix-sdk-sled` as a custom store.
+- The `Common` methods to retrieve state events can now return a sync or stripped event, so it can be used
+  for invited rooms too.
 
 # 0.6.2
 

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -171,7 +171,10 @@ async fn test_state_event_getting() {
         .deserialize()
         .unwrap();
 
-    assert_matches::assert_matches!(encryption_event, AnySyncStateEvent::RoomEncryption(_));
+    assert_matches::assert_matches!(
+        encryption_event.as_sync(),
+        Some(AnySyncStateEvent::RoomEncryption(_))
+    );
 }
 
 #[async_test]


### PR DESCRIPTION
Previously it was not possible to get state events for invited rooms.

This is a pre-requisite for #1979, to be able to use `get_state_events` in `get_members`.

Should we deprecate `StateStore::get_member_event`? It doesn't do anything more than `StateStoreExt::get_state_event_static_for_key` now.

- [x] Public API changes documented in changelogs (optional)

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>