### PR TITLE
feat(sdk): Ensure `SlidingSync::sync` “drains” its internal channel

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -195,16 +195,16 @@ impl SlidingSyncRoom {
         Ok(SlidingSyncAddTimelineListenerResult { items, task_handle: Arc::new(stoppable_spawn) })
     }
 
-    pub fn subscribe_to_room(&self, settings: Option<RoomSubscription>) -> Result<(), ClientError> {
+    pub fn subscribe_to_room(&self, settings: Option<RoomSubscription>) {
         let room_id = self.inner.room_id().to_owned();
 
-        self.sliding_sync.subscribe_to_room(room_id, settings.map(Into::into)).map_err(Into::into)
+        self.sliding_sync.subscribe_to_room(room_id, settings.map(Into::into));
     }
 
-    pub fn unsubscribe_from_room(&self) -> Result<(), ClientError> {
+    pub fn unsubscribe_from_room(&self) {
         let room_id = self.inner.room_id().to_owned();
 
-        self.sliding_sync.unsubscribe_from_room(room_id).map_err(Into::into)
+        self.sliding_sync.unsubscribe_from_room(room_id);
     }
 }
 
@@ -649,12 +649,9 @@ impl SlidingSyncList {
 
     /// Changes the sync mode, and automatically restarts the sliding sync
     /// internally.
-    pub fn set_sync_mode(
-        &self,
-        builder: Arc<SlidingSyncSelectiveModeBuilder>,
-    ) -> Result<(), ClientError> {
+    pub fn set_sync_mode(&self, builder: Arc<SlidingSyncSelectiveModeBuilder>) {
         let builder = unwrap_or_clone_arc(builder);
-        self.inner.set_sync_mode(builder.inner).map_err(Into::into)
+        self.inner.set_sync_mode(builder.inner);
     }
 }
 
@@ -688,13 +685,17 @@ impl SlidingSync {
     ) -> Result<(), ClientError> {
         let room_id = room_id.try_into()?;
 
-        self.inner.subscribe_to_room(room_id, settings.map(Into::into)).map_err(Into::into)
+        self.inner.subscribe_to_room(room_id, settings.map(Into::into));
+
+        Ok(())
     }
 
     pub fn unsubscribe_from_room(&self, room_id: String) -> Result<(), ClientError> {
         let room_id = room_id.try_into()?;
 
-        self.inner.unsubscribe_from_room(room_id).map_err(Into::into)
+        self.inner.unsubscribe_from_room(room_id);
+
+        Ok(())
     }
 
     pub fn get_room(&self, room_id: String) -> Result<Option<Arc<SlidingSyncRoom>>, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -195,22 +195,16 @@ impl SlidingSyncRoom {
         Ok(SlidingSyncAddTimelineListenerResult { items, task_handle: Arc::new(stoppable_spawn) })
     }
 
-    pub fn subscribe_to_room(&self, settings: Option<RoomSubscription>) -> Arc<TaskHandle> {
+    pub fn subscribe_to_room(&self, settings: Option<RoomSubscription>) -> Result<(), ClientError> {
         let room_id = self.inner.room_id().to_owned();
-        let sliding_sync = self.sliding_sync.clone();
 
-        Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
-            sliding_sync.subscribe_to_room(room_id, settings.map(Into::into)).await.unwrap();
-        })))
+        self.sliding_sync.subscribe_to_room(room_id, settings.map(Into::into)).map_err(Into::into)
     }
 
-    pub fn unsubscribe_from_room(&self) -> Arc<TaskHandle> {
+    pub fn unsubscribe_from_room(&self) -> Result<(), ClientError> {
         let room_id = self.inner.room_id().to_owned();
-        let sliding_sync = self.sliding_sync.clone();
 
-        Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
-            sliding_sync.unsubscribe_from_room(room_id).await.unwrap();
-        })))
+        self.sliding_sync.unsubscribe_from_room(room_id).map_err(Into::into)
     }
 }
 
@@ -691,22 +685,16 @@ impl SlidingSync {
         &self,
         room_id: String,
         settings: Option<RoomSubscription>,
-    ) -> Result<Arc<TaskHandle>, ClientError> {
+    ) -> Result<(), ClientError> {
         let room_id = room_id.try_into()?;
-        let this = self.inner.clone();
 
-        Ok(Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
-            this.subscribe_to_room(room_id, settings.map(Into::into)).await.unwrap();
-        }))))
+        self.inner.subscribe_to_room(room_id, settings.map(Into::into)).map_err(Into::into)
     }
 
-    pub fn unsubscribe_from_room(&self, room_id: String) -> Result<Arc<TaskHandle>, ClientError> {
+    pub fn unsubscribe_from_room(&self, room_id: String) -> Result<(), ClientError> {
         let room_id = room_id.try_into()?;
-        let this = self.inner.clone();
 
-        Ok(Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
-            this.unsubscribe_from_room(room_id).await.unwrap();
-        }))))
+        self.inner.unsubscribe_from_room(room_id).map_err(Into::into)
     }
 
     pub fn get_room(&self, room_id: String) -> Result<Option<Arc<SlidingSyncRoom>>, ClientError> {
@@ -801,8 +789,8 @@ impl SlidingSync {
         })))
     }
 
-    pub fn stop_sync(&self) {
-        RUNTIME.block_on(async move { self.inner.stop_sync().await.unwrap() });
+    pub fn stop_sync(&self) -> Result<(), ClientError> {
+        self.inner.stop_sync().map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -8,7 +8,7 @@ use ruma::{
     events::TimelineEventType,
     OwnedRoomId,
 };
-use tokio::sync::{mpsc::channel, RwLock as AsyncRwLock};
+use tokio::sync::broadcast::channel;
 use url::Url;
 
 use super::{
@@ -226,7 +226,7 @@ impl SlidingSyncBuilder {
         let mut delta_token = None;
         let mut to_device_token = None;
 
-        let (internal_channel_sender, internal_channel_receiver) = channel(8);
+        let (internal_channel_sender, _internal_channel_receiver) = channel(8);
 
         let mut lists = BTreeMap::new();
 
@@ -272,10 +272,7 @@ impl SlidingSyncBuilder {
             room_subscriptions: StdRwLock::new(self.subscriptions),
             room_unsubscriptions: Default::default(),
 
-            internal_channel: (
-                internal_channel_sender,
-                AsyncRwLock::new(internal_channel_receiver),
-            ),
+            internal_channel: internal_channel_sender,
         }))
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -11,7 +11,7 @@ use eyeball::unique::Observable;
 use eyeball_im::ObservableVector;
 use imbl::Vector;
 use ruma::{api::client::sync::sync_events::v4, events::StateEventType, OwnedRoomId};
-use tokio::sync::mpsc::Sender;
+use tokio::sync::broadcast::Sender;
 
 use super::{
     super::SlidingSyncInternalMessage, Bound, SlidingSyncList, SlidingSyncListCachePolicy,

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -137,35 +137,29 @@ impl SlidingSync {
     }
 
     /// Subscribe to a given room.
-    pub fn subscribe_to_room(
-        &self,
-        room_id: OwnedRoomId,
-        settings: Option<v4::RoomSubscription>,
-    ) -> Result<()> {
+    pub fn subscribe_to_room(&self, room_id: OwnedRoomId, settings: Option<v4::RoomSubscription>) {
         self.inner
             .room_subscriptions
             .write()
             .unwrap()
             .insert(room_id, settings.unwrap_or_default());
 
-        self.inner
-            .internal_channel_send(SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration)?;
-
-        Ok(())
+        self.inner.internal_channel_send_if_possible(
+            SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration,
+        );
     }
 
     /// Unsubscribe from a given room.
-    pub fn unsubscribe_from_room(&self, room_id: OwnedRoomId) -> Result<()> {
+    pub fn unsubscribe_from_room(&self, room_id: OwnedRoomId) {
         // If removing the subscription was successful…
         if self.inner.room_subscriptions.write().unwrap().remove(&room_id).is_some() {
             // … then keep the unsubscription for the next request.
             self.inner.room_unsubscriptions.write().unwrap().insert(room_id);
-            self.inner.internal_channel_send(
-                SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration,
-            )?;
-        }
 
-        Ok(())
+            self.inner.internal_channel_send_if_possible(
+                SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration,
+            );
+        }
     }
 
     /// Lookup a specific room
@@ -206,8 +200,9 @@ impl SlidingSync {
 
         let old_list = self.inner.lists.write().unwrap().insert(list.name().to_owned(), list);
 
-        self.inner
-            .internal_channel_send(SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration)?;
+        self.inner.internal_channel_send_if_possible(
+            SlidingSyncInternalMessage::SyncLoopSkipOverCurrentIteration,
+        );
 
         Ok(old_list)
     }
@@ -637,6 +632,14 @@ impl SlidingSyncInner {
     fn internal_channel_send(&self, message: SlidingSyncInternalMessage) -> Result<(), Error> {
         self.internal_channel.send(message).map(|_| ()).map_err(|_| Error::InternalChannelIsBroken)
     }
+
+    /// Send a message over the internal channel if there is a receiver, i.e. if
+    /// the sync-loop is running.
+    #[instrument]
+    fn internal_channel_send_if_possible(&self, message: SlidingSyncInternalMessage) {
+        // If there is no receiver, the send will fail, but that's OK here.
+        let _ = self.internal_channel.send(message);
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -783,8 +786,8 @@ mod tests {
         let room1 = room_id!("!r1:bar.org").to_owned();
         let room2 = room_id!("!r2:bar.org").to_owned();
 
-        sliding_sync.subscribe_to_room(room0.clone(), None)?;
-        sliding_sync.subscribe_to_room(room1.clone(), None)?;
+        sliding_sync.subscribe_to_room(room0.clone(), None);
+        sliding_sync.subscribe_to_room(room1.clone(), None);
 
         {
             let room_subscriptions = sliding_sync.inner.room_subscriptions.read().unwrap();
@@ -794,8 +797,8 @@ mod tests {
             assert!(!room_subscriptions.contains_key(&room2));
         }
 
-        sliding_sync.unsubscribe_from_room(room0.clone())?;
-        sliding_sync.unsubscribe_from_room(room2.clone())?;
+        sliding_sync.unsubscribe_from_room(room0.clone());
+        sliding_sync.unsubscribe_from_room(room2.clone());
 
         {
             let room_subscriptions = sliding_sync.inner.room_subscriptions.read().unwrap();


### PR DESCRIPTION
Something weird is happening with ElementX iOS when the app moves from foreground to background and vice versa. When `SlidingSync::stop_sync` is called, the internal message `SyncLoopStop` has time to be sent in the internal channel, but iOS decides to suspend the code before the sync-loop processes it. When ElementX decides to start the sync-loop again, it immediately processes the `SyncLoopStop` message, and… stops the sync-loop.

~~This patch ensures that `SlidingSync::sync` drains the internal channel before starting the sync-loop for real. `tokio::sync::mpsc::Receiver` type has no `drain` method, so this patch implements its own logic by calling `try_recv` in a loop, until it returns `Err(TryRecvError::Empty)`.~~

This patch changes the internal channel from a MPSC (Multiple Producer, Single Consumer) to a MPMC (Multiple Producer, Multiple Consumer). Actually, there is only one consumer/receiver at a time: it's held by the sync-loop.

It has neat property. When a new receiver is created, it “forgets” all past messages, so removing the need to drain the internal channel.

The producer/sender can send messages synchronously, thus removing the need for more async methods!

Finally, the producer/sender cannot fail, except if there is no receiver, i.e. if the sync-loop is not running. Thus, it's finally OK to  call `add_list` or `subscribe_to_room` without having to start the sync-loop. It works in both cases.

This patch should be reviewed commit-by-commit.