### PR TITLE
sliding sync: move the `bump_event_types` to be per-list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
+source = "git+https://github.com/bnjbvr/ruma?rev=97fc09cd81ab32a2f1f6178b4996b3855ada565d#97fc09cd81ab32a2f1f6178b4996b3855ada565d"
 dependencies = [
  "assign",
  "js_int",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
+source = "git+https://github.com/bnjbvr/ruma?rev=97fc09cd81ab32a2f1f6178b4996b3855ada565d#97fc09cd81ab32a2f1f6178b4996b3855ada565d"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
+source = "git+https://github.com/bnjbvr/ruma?rev=97fc09cd81ab32a2f1f6178b4996b3855ada565d#97fc09cd81ab32a2f1f6178b4996b3855ada565d"
 dependencies = [
  "assign",
  "bytes",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
+source = "git+https://github.com/bnjbvr/ruma?rev=97fc09cd81ab32a2f1f6178b4996b3855ada565d#97fc09cd81ab32a2f1f6178b4996b3855ada565d"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
+source = "git+https://github.com/bnjbvr/ruma?rev=97fc09cd81ab32a2f1f6178b4996b3855ada565d#97fc09cd81ab32a2f1f6178b4996b3855ada565d"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4318,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
+source = "git+https://github.com/bnjbvr/ruma?rev=97fc09cd81ab32a2f1f6178b4996b3855ada565d#97fc09cd81ab32a2f1f6178b4996b3855ada565d"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4327,7 +4327,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
+source = "git+https://github.com/bnjbvr/ruma?rev=97fc09cd81ab32a2f1f6178b4996b3855ada565d#97fc09cd81ab32a2f1f6178b4996b3855ada565d"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=854d8076eff1c5b6454c42e4309b1b070b815893#854d8076eff1c5b6454c42e4309b1b070b815893"
+source = "git+https://github.com/bnjbvr/ruma?rev=97fc09cd81ab32a2f1f6178b4996b3855ada565d#97fc09cd81ab32a2f1f6178b4996b3855ada565d"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ futures-core = "0.3.28"
 futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
-ruma = { git = "https://github.com/ruma/ruma", rev = "854d8076eff1c5b6454c42e4309b1b070b815893", features = ["client-api-c", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "854d8076eff1c5b6454c42e4309b1b070b815893" }
+ruma = { git = "https://github.com/bnjbvr/ruma", rev = "97fc09cd81ab32a2f1f6178b4996b3855ada565d", features = ["client-api-c", "compat-user-id"] }
+ruma-common = { git = "https://github.com/bnjbvr/ruma", rev = "97fc09cd81ab32a2f1f6178b4996b3855ada565d" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -560,6 +560,14 @@ impl SlidingSyncListBuilder {
         );
         Arc::new(builder)
     }
+
+    pub fn bump_event_types(self: Arc<Self>, bump_event_types: Vec<String>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.inner = builder.inner.bump_event_types(
+            bump_event_types.into_iter().map(Into::into).collect::<Vec<_>>().as_slice(),
+        );
+        Arc::new(builder)
+    }
 }
 
 pub trait SlidingSyncListOnceBuilt: Sync + Send {
@@ -873,14 +881,6 @@ impl SlidingSyncBuilder {
     pub fn with_all_extensions(self: Arc<Self>) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.inner = builder.inner.with_all_extensions();
-        Arc::new(builder)
-    }
-
-    pub fn bump_event_types(self: Arc<Self>, bump_event_types: Vec<String>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.bump_event_types(
-            bump_event_types.into_iter().map(Into::into).collect::<Vec<_>>().as_slice(),
-        );
         Arc::new(builder)
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -5,7 +5,6 @@ use ruma::{
         self, AccountDataConfig, E2EEConfig, ExtensionsConfig, ReceiptsConfig, ToDeviceConfig,
         TypingConfig,
     },
-    events::TimelineEventType,
     OwnedRoomId,
 };
 use tokio::sync::broadcast::channel;
@@ -27,7 +26,6 @@ pub struct SlidingSyncBuilder {
     homeserver: Option<Url>,
     client: Client,
     lists: Vec<SlidingSyncListBuilder>,
-    bump_event_types: Vec<TimelineEventType>,
     extensions: Option<ExtensionsConfig>,
     subscriptions: BTreeMap<OwnedRoomId, v4::RoomSubscription>,
     rooms: BTreeMap<OwnedRoomId, SlidingSyncRoom>,
@@ -40,7 +38,6 @@ impl SlidingSyncBuilder {
             homeserver: None,
             client,
             lists: Vec::new(),
-            bump_event_types: Vec::new(),
             extensions: None,
             subscriptions: BTreeMap::new(),
             rooms: BTreeMap::new(),
@@ -205,17 +202,6 @@ impl SlidingSyncBuilder {
         self
     }
 
-    /// Allowlist of event types which should be considered recent activity
-    /// when sorting `by_recency`. By omitting event types, clients can ensure
-    /// that uninteresting events (e.g. a profile rename) do not cause a
-    /// room to jump to the top of its list(s). Empty or
-    /// omitted `bump_event_types` have no effect: all events in a room will
-    /// be considered recent activity.
-    pub fn bump_event_types(mut self, bump_event_types: &[TimelineEventType]) -> Self {
-        self.bump_event_types = bump_event_types.to_vec();
-        self
-    }
-
     /// Build the Sliding Sync.
     ///
     /// If `self.storage_key` is `Some(_)`, load the cached data from cold
@@ -258,7 +244,6 @@ impl SlidingSyncBuilder {
 
             lists,
             rooms,
-            bump_event_types: self.bump_event_types,
 
             extensions: self.extensions.unwrap_or_default(),
             reset_counter: Default::default(),

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -10,7 +10,11 @@ use std::{
 use eyeball::unique::Observable;
 use eyeball_im::ObservableVector;
 use imbl::Vector;
-use ruma::{api::client::sync::sync_events::v4, events::StateEventType, OwnedRoomId};
+use ruma::{
+    api::client::sync::sync_events::v4,
+    events::{StateEventType, TimelineEventType},
+    OwnedRoomId,
+};
 use tokio::sync::broadcast::Sender;
 
 use super::{
@@ -53,6 +57,8 @@ pub struct SlidingSyncListBuilder {
     reloaded_cached_data: Option<SlidingSyncListCachedData>,
 
     once_built: Arc<Box<dyn Fn(SlidingSyncList) -> SlidingSyncList + Send + Sync>>,
+
+    bump_event_types: Vec<TimelineEventType>,
 }
 
 // Print debug values for the builder, except `once_built` which is ignored.
@@ -66,6 +72,7 @@ impl fmt::Debug for SlidingSyncListBuilder {
             .field("filters", &self.filters)
             .field("timeline_limit", &self.timeline_limit)
             .field("name", &self.name)
+            .field("bump_event_types", &self.bump_event_types)
             .finish_non_exhaustive()
     }
 }
@@ -85,6 +92,7 @@ impl SlidingSyncListBuilder {
             reloaded_cached_data: None,
             cache_policy: SlidingSyncListCachePolicy::Disabled,
             once_built: Arc::new(Box::new(identity)),
+            bump_event_types: Vec::new(),
         }
     }
 
@@ -166,6 +174,19 @@ impl SlidingSyncListBuilder {
         }
     }
 
+    /// Allowlist of event types which should be considered recent activity
+    /// when sorting `by_recency`.
+    ///
+    /// By omitting event types, clients can ensure
+    /// that uninteresting events (e.g. a profile rename) do not cause a
+    /// room to jump to the top of its list(s). Empty or
+    /// omitted `bump_event_types` have no effect: all events in a room will
+    /// be considered recent activity.
+    pub fn bump_event_types(mut self, bump_event_types: &[TimelineEventType]) -> Self {
+        self.bump_event_types = bump_event_types.to_vec();
+        self
+    }
+
     /// Build the list.
     pub(in super::super) fn build(
         self,
@@ -180,6 +201,7 @@ impl SlidingSyncListBuilder {
                 timeline_limit: StdRwLock::new(self.timeline_limit),
                 name: self.name,
                 cache_policy: self.cache_policy,
+                bump_event_types: self.bump_event_types,
 
                 // Computed from the builder.
                 request_generator: StdRwLock::new(SlidingSyncListRequestGenerator::new(

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -18,7 +18,12 @@ pub(super) use frozen::FrozenSlidingSyncList;
 use futures_core::Stream;
 pub(super) use request_generator::*;
 pub use room_list_entry::RoomListEntry;
-use ruma::{api::client::sync::sync_events::v4, assign, events::StateEventType, OwnedRoomId};
+use ruma::{
+    api::client::sync::sync_events::v4,
+    assign,
+    events::{StateEventType, TimelineEventType},
+    OwnedRoomId,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::Sender;
 use tracing::{instrument, warn};
@@ -251,6 +256,10 @@ pub(super) struct SlidingSyncListInner {
     /// The Sliding Sync internal channel sender. See
     /// [`SlidingSyncInner::internal_channel`] to learn more.
     sliding_sync_internal_channel_sender: Sender<SlidingSyncInternalMessage>,
+
+    /// The `bump_event_types` field. See
+    /// [`SlidingSyncListBuilder::bump_event_types`] to learn more.
+    bump_event_types: Vec<TimelineEventType>,
 }
 
 impl SlidingSyncListInner {
@@ -314,6 +323,7 @@ impl SlidingSyncListInner {
             }),
             sort,
             filters,
+            bump_event_types: self.bump_event_types.clone(),
         })
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -44,9 +44,7 @@ use ruma::{
         error::ErrorKind,
         sync::sync_events::v4::{self, ExtensionsConfig},
     },
-    assign,
-    events::TimelineEventType,
-    OwnedRoomId, RoomId,
+    assign, OwnedRoomId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -98,10 +96,6 @@ pub(super) struct SlidingSyncInner {
 
     /// The rooms details
     rooms: StdRwLock<BTreeMap<OwnedRoomId, SlidingSyncRoom>>,
-
-    /// The `bump_event_types` field. See
-    /// [`SlidingSyncBuilder::bump_event_types`] to learn more.
-    bump_event_types: Vec<TimelineEventType>,
 
     /// Room subscriptions, i.e. rooms that may be out-of-scope of all lists but
     /// one wants to receive updates.
@@ -418,7 +412,6 @@ impl SlidingSync {
                     delta_token,
                     timeout: Some(timeout),
                     lists: requests_lists,
-                    bump_event_types: self.inner.bump_event_types.clone(),
                     room_subscriptions,
                     unsubscribe_rooms: room_unsubscriptions.iter().cloned().collect(),
                     extensions,


### PR DESCRIPTION
- [x] Wait for https://github.com/ruma/ruma/pull/1569 to land first.

Moves the `bump_event_types` from the main request to the list sub-request; ditto for all the builders, etc., according to the change in https://github.com/matrix-org/sliding-sync/pull/129.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2001.