### PR TITLE
chore: Update Cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,16 +1115,6 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ctor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
@@ -2443,11 +2433,10 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 dependencies = [
- "cfg-if",
  "value-bag",
 ]
 
@@ -2537,7 +2526,7 @@ dependencies = [
  "backoff",
  "bytes",
  "bytesize",
- "ctor 0.2.0",
+ "ctor",
  "dashmap",
  "dirs",
  "event-listener",
@@ -2611,7 +2600,7 @@ dependencies = [
  "assign",
  "async-trait",
  "bitflags 2.3.0",
- "ctor 0.2.0",
+ "ctor",
  "dashmap",
  "eyeball",
  "futures-executor",
@@ -2664,7 +2653,7 @@ dependencies = [
  "byteorder",
  "cbc",
  "cfg-if",
- "ctor 0.2.0",
+ "ctor",
  "ctr",
  "dashmap",
  "eyeball",
@@ -2840,7 +2829,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assign",
- "ctor 0.2.0",
+ "ctor",
  "matrix-sdk",
  "once_cell",
  "tempfile",
@@ -2867,7 +2856,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "async-trait",
- "ctor 0.2.0",
+ "ctor",
  "deadpool-sqlite",
  "glob",
  "matrix-sdk-base",
@@ -2938,7 +2927,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "chrono",
- "ctor 0.2.0",
+ "ctor",
  "eyeball-im",
  "futures-core",
  "futures-util",
@@ -3074,7 +3063,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49ac8112fe5998579b22e29903c7b277fc7f91c7860c0236f35792caf8156e18"
 dependencies = [
  "bitflags 2.3.0",
- "ctor 0.2.0",
+ "ctor",
  "napi-derive",
  "napi-sys",
  "once_cell",
@@ -5598,13 +5587,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.9"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor 0.1.26",
- "version_check",
-]
+checksum = "a4d330786735ea358f3bc09eea4caa098569c1c93f342d9aca0514915022fe7e"
 
 [[package]]
 name = "vcpkg"

--- a/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/recovery.rs
@@ -292,7 +292,7 @@ mod tests {
             }
         });
 
-        let key_backup_data: KeyBackupData = serde_json::from_value(data.to_owned()).unwrap();
+        let key_backup_data: KeyBackupData = serde_json::from_value(data).unwrap();
         let ephemeral = key_backup_data.session_data.ephemeral.encode();
         let ciphertext = key_backup_data.session_data.ciphertext.encode();
         let mac = key_backup_data.session_data.mac.encode();


### PR DESCRIPTION
After updating my rust toolchains this morning, I stumbled upon this issue with the nightly toolchain: https://github.com/sval-rs/value-bag/issues/64. I ran `cargo update` to fix the compilation.

The second commit is a new error raised by clippy nightly.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>