### PR TITLE
sliding sync: infer the storage key from the loop id and user id

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -894,8 +894,8 @@ impl SlidingSyncBuilder {
 
 #[uniffi::export]
 impl Client {
-    pub fn sliding_sync(&self, loop_id: String) -> Arc<SlidingSyncBuilder> {
-        let mut inner = self.inner.sliding_sync(loop_id);
+    pub fn sliding_sync(&self, id: String) -> Arc<SlidingSyncBuilder> {
+        let mut inner = self.inner.sliding_sync(id);
         if let Some(sliding_sync_proxy) = self
             .sliding_sync_proxy
             .read()

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -894,8 +894,11 @@ impl SlidingSyncBuilder {
 
 #[uniffi::export]
 impl Client {
-    pub fn sliding_sync(&self, id: String) -> Arc<SlidingSyncBuilder> {
-        let mut inner = self.inner.sliding_sync(id);
+    /// Creates a new Sliding Sync instance with the given identifier.
+    ///
+    /// Note: the identifier must be less than 16 chars long.
+    pub fn sliding_sync(&self, id: String) -> Result<Arc<SlidingSyncBuilder>, ClientError> {
+        let mut inner = self.inner.sliding_sync(id)?;
         if let Some(sliding_sync_proxy) = self
             .sliding_sync_proxy
             .read()
@@ -905,6 +908,6 @@ impl Client {
         {
             inner = inner.homeserver(sliding_sync_proxy);
         }
-        Arc::new(SlidingSyncBuilder { inner, client: self.clone() })
+        Ok(Arc::new(SlidingSyncBuilder { inner, client: self.clone() }))
     }
 }

--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -811,10 +811,10 @@ impl SlidingSyncBuilder {
         Ok(Arc::new(builder))
     }
 
-    pub fn storage_key(self: Arc<Self>, name: Option<String>) -> Arc<Self> {
+    pub fn enable_caching(self: Arc<Self>) -> Result<Arc<Self>, ClientError> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.storage_key(name);
-        Arc::new(builder)
+        builder.inner = builder.inner.enable_caching()?;
+        Ok(Arc::new(builder))
     }
 
     pub fn add_list(self: Arc<Self>, list_builder: Arc<SlidingSyncListBuilder>) -> Arc<Self> {
@@ -894,8 +894,8 @@ impl SlidingSyncBuilder {
 
 #[uniffi::export]
 impl Client {
-    pub fn sliding_sync(&self) -> Arc<SlidingSyncBuilder> {
-        let mut inner = self.inner.sliding_sync();
+    pub fn sliding_sync(&self, loop_id: String) -> Arc<SlidingSyncBuilder> {
+        let mut inner = self.inner.sliding_sync(loop_id);
         if let Some(sliding_sync_proxy) = self
             .sliding_sync_proxy
             .read()

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -151,7 +151,7 @@ macro_rules! assert_timeline_stream {
 async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockServer, SlidingSync)> {
     let (client, server) = logged_in_client().await;
 
-    let mut sliding_sync_builder = client.sliding_sync();
+    let mut sliding_sync_builder = client.sliding_sync("integration-timeline-test");
 
     for list in lists {
         sliding_sync_builder = sliding_sync_builder.add_list(list);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -151,7 +151,7 @@ macro_rules! assert_timeline_stream {
 async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockServer, SlidingSync)> {
     let (client, server) = logged_in_client().await;
 
-    let mut sliding_sync_builder = client.sliding_sync("integration-timeline-test");
+    let mut sliding_sync_builder = client.sliding_sync("integration-test")?;
 
     for list in lists {
         sliding_sync_builder = sliding_sync_builder.add_list(list);

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -27,12 +27,16 @@ To create a new Sliding Sync session, one must query an existing
 [`Client::sliding_sync`](`super::Client::sliding_sync`). The
 [`SlidingSyncBuilder`] is the baseline configuration to create a
 [`SlidingSync`] session by calling `.build()` once everything is ready.
-Typically one configures the custom homeserver endpoint.
+Typically one configures the custom homeserver endpoint, although it's
+automatically detected using the `.well-known` endpoint, if configured.
 
 At the time of writing, no Matrix server natively supports Sliding Sync;
 a sidecar called the [Sliding Sync Proxy][proxy] is needed. As that
 typically runs on a separate domain, it can be configured on the
-[`SlidingSyncBuilder`]:
+[`SlidingSyncBuilder`].
+
+A unique identifier, less than 16 chars long, is required for each instance
+of Sliding Sync, and must be provided when getting a builder:
 
 ```rust,no_run
 # use matrix_sdk::Client;
@@ -41,7 +45,7 @@ typically runs on a separate domain, it can be configured on the
 # let homeserver = Url::parse("http://example.com")?;
 # let client = Client::new(homeserver).await?;
 let sliding_sync_builder = client
-    .sliding_sync()
+    .sliding_sync("main-sync")?
     .homeserver(Url::parse("http://sliding-sync.example.org")?);
 
 # anyhow::Ok(())
@@ -268,7 +272,7 @@ In full, this typically looks like this:
 # let homeserver = Url::parse("http://example.com")?;
 # let client = Client::new(homeserver).await?;
 let sliding_sync = client
-    .sliding_sync()
+    .sliding_sync("main-sync")?
     // any lists you want are added here.
     .build()
     .await?;
@@ -351,22 +355,25 @@ timeline events as well as all list `room_lists` and
 out).
 
 This is a purely in-memory cache layer though. If one wants Sliding Sync to
-persist and load from cold (storage) cache, one needs to set its key with
-[`storage_key(name)`][`SlidingSyncBuilder::storage_key`] and for each list
-present at `.build()`[`SlidingSyncBuilder::build`] sliding sync will attempt
-to load their latest cached version from storage, as well as some overall
-information of Sliding Sync. If that succeeded the lists `state` has been
-set to [`Preloaded`][SlidingSyncState::Preloaded]. Only room data of rooms
-present in one of the lists is loaded from storage.
+persist and load from cold (storage) cache, one needs to explicitly
+[`enable_caching()`][`SlidingSyncBuilder::enable_caching`]. This will reload the
+Sliding Sync state from the storage, namely since tokens.
 
-Notice that lists added after Sliding Sync has been built **will not be
-loaded from cache** regardless of their settings (as this could lead to
-inconsistencies between lists). The same goes for any extension: some
-extension data (like the to-device-message position) are stored to storage,
-but only retrieved upon `build()` of the `SlidingSyncBuilder`. So if one
-only adds them later, they will not be reading the data from storage (to
-avoid inconsistencies) and might require more data to be sent in their first
-request than if they were loaded form cold-cache.
+Caching for lists can be enabled independently, using the
+[`add_cached_list`][`SlidingSyncBuilder::add_cached_list`] method, assuming
+caching has been enabled before. In this case, during
+`.build()`[`SlidingSyncBuilder::build`] sliding sync will attempt to load their
+latest cached version from storage, as well as some overall information of
+Sliding Sync. If that succeeded the lists `state` has been set to
+[`Preloaded`][SlidingSyncState::Preloaded]. Only room data of rooms present in
+one of the lists is loaded from storage.
+
+Any extension data will not be loaded from the cache, if added after Sliding
+Sync has been built: some extension data (like the to-device-message position)
+are stored to storage, but only retrieved upon `build()` of the
+`SlidingSyncBuilder`. So if one only adds them later, they will not be reading
+the data from storage (to avoid inconsistencies) and might require more data to
+be sent in their first request than if they were loaded from a cold cache.
 
 When loading from storage `room_list` entries found are set to
 `Invalidated` — the initial setting here is communicated as a single
@@ -410,10 +417,10 @@ use url::Url;
 let full_sync_list_name = "full-sync".to_owned();
 let active_list_name = "active-list".to_owned();
 let sliding_sync_builder = client
-    .sliding_sync()
+    .sliding_sync("main-sync")?
     .homeserver(Url::parse("http://sliding-sync.example.org")?) // our proxy server
     .with_common_extensions() // we want the e2ee and to-device enabled, please
-    .storage_key(Some("example-cache".to_owned())); // we want these to be loaded from and stored into the persistent storage
+    .enable_caching()?; // we want these to be loaded from and stored into the persistent storage
 
 let full_sync_list = SlidingSyncList::builder(&full_sync_list_name)
     .sync_mode(SlidingSyncMode::Growing { batch_size: 50, maximum_number_of_rooms_to_fetch: Some(500) }) // sync up by growing the window

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 use super::{
     cache::{format_base_storage_key_for_sliding_sync, restore_sliding_sync_state},
-    SlidingSync, SlidingSyncInner, SlidingSyncListBuilder, SlidingSyncPositionMarkers,
+    Error, SlidingSync, SlidingSyncInner, SlidingSyncListBuilder, SlidingSyncPositionMarkers,
     SlidingSyncRoom,
 };
 use crate::{Client, Result};
@@ -36,17 +36,21 @@ pub struct SlidingSyncBuilder {
 }
 
 impl SlidingSyncBuilder {
-    pub(super) fn new(id: String, client: Client) -> Self {
-        Self {
-            id,
-            storage_key: None,
-            homeserver: None,
-            client,
-            lists: Vec::new(),
-            bump_event_types: Vec::new(),
-            extensions: None,
-            subscriptions: BTreeMap::new(),
-            rooms: BTreeMap::new(),
+    pub(super) fn new(id: String, client: Client) -> Result<Self, Error> {
+        if id.len() > 16 {
+            Err(Error::InvalidSlidingSyncIdentifier)
+        } else {
+            Ok(Self {
+                id,
+                storage_key: None,
+                homeserver: None,
+                client,
+                lists: Vec::new(),
+                bump_event_types: Vec::new(),
+                extensions: None,
+                subscriptions: BTreeMap::new(),
+                rooms: BTreeMap::new(),
+            })
         }
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -12,7 +12,7 @@ use tokio::sync::broadcast::channel;
 use url::Url;
 
 use super::{
-    cache::{format_base_storage_key_for_sliding_sync, restore_sliding_sync_state},
+    cache::{format_storage_key_prefix, restore_sliding_sync_state},
     Error, SlidingSync, SlidingSyncInner, SlidingSyncListBuilder, SlidingSyncPositionMarkers,
     SlidingSyncRoom,
 };
@@ -60,7 +60,7 @@ impl SlidingSyncBuilder {
     /// restored from the cache.
     pub fn enable_caching(mut self) -> Result<Self> {
         // Compute the final storage key now.
-        self.storage_key = Some(format_base_storage_key_for_sliding_sync(
+        self.storage_key = Some(format_storage_key_prefix(
             &self.id,
             self.client.user_id().ok_or(super::Error::UnauthenticatedUser)?,
         ));

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -24,7 +24,7 @@ use crate::{Client, Result};
 /// [`crate::SlidingSync::builder`].
 #[derive(Debug, Clone)]
 pub struct SlidingSyncBuilder {
-    loop_id: String,
+    id: String,
     storage_key: Option<String>,
     homeserver: Option<Url>,
     client: Client,
@@ -36,9 +36,9 @@ pub struct SlidingSyncBuilder {
 }
 
 impl SlidingSyncBuilder {
-    pub(super) fn new(loop_id: String, client: Client) -> Self {
+    pub(super) fn new(id: String, client: Client) -> Self {
         Self {
-            loop_id,
+            id,
             storage_key: None,
             homeserver: None,
             client,
@@ -57,7 +57,7 @@ impl SlidingSyncBuilder {
     pub fn enable_caching(mut self) -> Result<Self> {
         // Compute the final storage key now.
         self.storage_key = Some(format_base_storage_key_for_sliding_sync(
-            &self.loop_id,
+            &self.id,
             self.client.user_id().ok_or(super::Error::UnauthenticatedUser)?,
         ));
         Ok(self)
@@ -263,7 +263,7 @@ impl SlidingSyncBuilder {
         let lists = StdRwLock::new(lists);
 
         Ok(SlidingSync::new(SlidingSyncInner {
-            _loop_id: Some(self.loop_id),
+            _id: Some(self.id),
             homeserver: self.homeserver,
             client,
             storage_key: self.storage_key,

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -216,7 +216,7 @@ mod tests {
         block_on(async {
             let client = logged_in_client(Some("https://foo.bar".to_owned())).await;
             let err = client
-                .sliding_sync("test")
+                .sliding_sync("test")?
                 .add_cached_list(SlidingSyncList::builder("list_foo"))
                 .await
                 .unwrap_err();
@@ -262,7 +262,7 @@ mod tests {
                 let storage_key =
                     format_base_storage_key_for_sliding_sync(sync_id, client.user_id().unwrap());
                 let sliding_sync = client
-                    .sliding_sync(sync_id)
+                    .sliding_sync(sync_id)?
                     .enable_caching()?
                     .add_cached_list(SlidingSyncList::builder("list_foo"))
                     .await?
@@ -314,7 +314,7 @@ mod tests {
                 let max_number_of_room_stream = Arc::new(RwLock::new(None));
                 let cloned_stream = max_number_of_room_stream.clone();
                 let sliding_sync = client
-                    .sliding_sync(sync_id)
+                    .sliding_sync(sync_id)?
                     .enable_caching()?
                     .add_cached_list(SlidingSyncList::builder("list_foo").once_built(move |list| {
                         // In the `once_built()` handler, nothing has been read from the cache yet.

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -13,8 +13,8 @@ use tracing::{trace, warn};
 use super::{FrozenSlidingSync, FrozenSlidingSyncList, SlidingSync, SlidingSyncList};
 use crate::{sliding_sync::SlidingSyncListCachePolicy, Client, Result};
 
-pub(super) fn format_base_storage_key_for_sliding_sync(loop_id: &str, user_id: &UserId) -> String {
-    format!("{}::{}", loop_id, user_id.to_string())
+pub(super) fn format_base_storage_key_for_sliding_sync(id: &str, user_id: &UserId) -> String {
+    format!("{}::{}", id, user_id.to_string())
 }
 
 /// Be careful: as this is used as a storage key; changing it requires migrating
@@ -258,11 +258,11 @@ mod tests {
 
             // Create a new `SlidingSync` instance, and store it.
             let storage_key = {
-                let loop_id = "test-loop-id";
+                let sync_id = "test-sync-id";
                 let storage_key =
-                    format_base_storage_key_for_sliding_sync(loop_id, client.user_id().unwrap());
+                    format_base_storage_key_for_sliding_sync(sync_id, client.user_id().unwrap());
                 let sliding_sync = client
-                    .sliding_sync(loop_id)
+                    .sliding_sync(sync_id)
                     .enable_caching()?
                     .add_cached_list(SlidingSyncList::builder("list_foo"))
                     .await?
@@ -308,13 +308,13 @@ mod tests {
 
             // Create a new `SlidingSync`, and it should be read from the cache.
             let storage_key = {
-                let loop_id = "test-loop-id";
+                let sync_id = "test-sync-id";
                 let storage_key =
-                    format_base_storage_key_for_sliding_sync(loop_id, client.user_id().unwrap());
+                    format_base_storage_key_for_sliding_sync(sync_id, client.user_id().unwrap());
                 let max_number_of_room_stream = Arc::new(RwLock::new(None));
                 let cloned_stream = max_number_of_room_stream.clone();
                 let sliding_sync = client
-                    .sliding_sync(loop_id)
+                    .sliding_sync(sync_id)
                     .enable_caching()?
                     .add_cached_list(SlidingSyncList::builder("list_foo").once_built(move |list| {
                         // In the `once_built()` handler, nothing has been read from the cache yet.

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -16,7 +16,7 @@ use crate::{sliding_sync::SlidingSyncListCachePolicy, Client, Result};
 /// Be careful: as this is used as a storage key; changing it requires migrating
 /// data!
 pub(super) fn format_storage_key_prefix(id: &str, user_id: &UserId) -> String {
-    format!("sliding_sync_store::{}::{}", id, user_id.to_string())
+    format!("sliding_sync_store::{}::{}", id, user_id)
 }
 
 /// Be careful: as this is used as a storage key; changing it requires migrating

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -7,8 +7,8 @@ use crate::{Client, Result};
 
 impl Client {
     /// Create a [`SlidingSyncBuilder`] tied to this client.
-    pub fn sliding_sync(&self) -> SlidingSyncBuilder {
-        SlidingSync::builder(self.clone())
+    pub fn sliding_sync(&self, loop_id: impl Into<String>) -> SlidingSyncBuilder {
+        SlidingSync::builder(loop_id.into(), self.clone())
     }
 
     #[instrument(skip(self, response))]

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -6,9 +6,12 @@ use super::{SlidingSync, SlidingSyncBuilder};
 use crate::{Client, Result};
 
 impl Client {
-    /// Create a [`SlidingSyncBuilder`] tied to this client.
-    pub fn sliding_sync(&self, id: impl Into<String>) -> SlidingSyncBuilder {
-        SlidingSync::builder(id.into(), self.clone())
+    /// Create a [`SlidingSyncBuilder`] tied to this client, with the given
+    /// identifier.
+    ///
+    /// Note: the identifier must not be more than 16 chars long!
+    pub fn sliding_sync(&self, id: impl Into<String>) -> Result<SlidingSyncBuilder> {
+        Ok(SlidingSync::builder(id.into(), self.clone())?)
     }
 
     #[instrument(skip(self, response))]

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -7,8 +7,8 @@ use crate::{Client, Result};
 
 impl Client {
     /// Create a [`SlidingSyncBuilder`] tied to this client.
-    pub fn sliding_sync(&self, loop_id: impl Into<String>) -> SlidingSyncBuilder {
-        SlidingSync::builder(loop_id.into(), self.clone())
+    pub fn sliding_sync(&self, id: impl Into<String>) -> SlidingSyncBuilder {
+        SlidingSync::builder(id.into(), self.clone())
     }
 
     #[instrument(skip(self, response))]

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -30,8 +30,14 @@ pub enum Error {
 
     /// Missing storage key when asking to deserialize some sub-state of sliding
     /// sync.
-    #[error("A caching request was made but a storage key is missing in sliding sync")]
-    MissingStorageKeyForCaching,
+    #[error(
+        "A caching request was made but caching was not enabled in this instance of sliding sync"
+    )]
+    CacheDisabled,
+
+    /// We tried to read the user id of a client but it was missing.
+    #[error("Unauthenticated user in sliding sync")]
+    UnauthenticatedUser,
 
     /// The internal channel of `SlidingSync` seems to be broken.
     #[error("SlidingSync's internal channel is broken")]

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -42,4 +42,8 @@ pub enum Error {
     /// The internal channel of `SlidingSync` seems to be broken.
     #[error("SlidingSync's internal channel is broken")]
     InternalChannelIsBroken,
+
+    /// The name of the Sliding Sync instance is too long.
+    #[error("The Sliding Sync instance's identifier must be less than 16 chars long")]
+    InvalidSlidingSyncIdentifier,
 }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -137,7 +137,7 @@ impl SlidingSync {
     }
 
     /// Create a new [`SlidingSyncBuilder`].
-    pub fn builder(id: String, client: Client) -> SlidingSyncBuilder {
+    pub fn builder(id: String, client: Client) -> Result<SlidingSyncBuilder, Error> {
         SlidingSyncBuilder::new(id, client)
     }
 
@@ -727,7 +727,7 @@ mod tests {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
-        let sync = client.sliding_sync("test-sliding-sync").build().await?;
+        let sync = client.sliding_sync("test-slidingsync")?.build().await?;
         let extensions = sync.prepare_extension_config(None);
 
         // If the user doesn't provide any extension config, we enable to-device and
@@ -768,7 +768,7 @@ mod tests {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
 
-        let mut sliding_sync_builder = client.sliding_sync("test-sliding-sync");
+        let mut sliding_sync_builder = client.sliding_sync("test-slidingsync")?;
 
         for list in lists {
             sliding_sync_builder = sliding_sync_builder.add_list(list);

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -84,7 +84,7 @@ pub(super) struct SlidingSyncInner {
     /// A unique identifier for this instance of sliding sync.
     ///
     /// Used to distinguish different connections to the sliding sync proxy.
-    _loop_id: Option<String>,
+    _id: Option<String>,
 
     /// Customize the homeserver for sliding sync only
     homeserver: Option<Url>,
@@ -137,8 +137,8 @@ impl SlidingSync {
     }
 
     /// Create a new [`SlidingSyncBuilder`].
-    pub fn builder(loop_id: String, client: Client) -> SlidingSyncBuilder {
-        SlidingSyncBuilder::new(loop_id, client)
+    pub fn builder(id: String, client: Client) -> SlidingSyncBuilder {
+        SlidingSyncBuilder::new(id, client)
     }
 
     /// Subscribe to a given room.
@@ -419,7 +419,7 @@ impl SlidingSync {
             (
                 // Build the request itself.
                 assign!(v4::Request::new(), {
-                    // conn_id: self.inner.loop_id.clone(),
+                    // conn_id: self.inner.id.clone(),
                     pos,
                     delta_token,
                     timeout: Some(timeout),

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -12,8 +12,10 @@ async fn setup(
     let sliding_sync_proxy_url =
         option_env!("SLIDING_SYNC_PROXY_URL").unwrap_or("http://localhost:8338").to_owned();
     let client = get_client_for_user(name, use_sqlite_store).await?;
-    let sliding_sync_builder =
-        client.sliding_sync().homeserver(sliding_sync_proxy_url.parse()?).with_common_extensions();
+    let sliding_sync_builder = client
+        .sliding_sync("test-sliding-sync")
+        .homeserver(sliding_sync_proxy_url.parse()?)
+        .with_common_extensions();
     Ok((client, sliding_sync_builder))
 }
 

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -13,7 +13,7 @@ async fn setup(
         option_env!("SLIDING_SYNC_PROXY_URL").unwrap_or("http://localhost:8338").to_owned();
     let client = get_client_for_user(name, use_sqlite_store).await?;
     let sliding_sync_builder = client
-        .sliding_sync("test-sliding-sync")
+        .sliding_sync("test-sliding-sync")?
         .homeserver(sliding_sync_proxy_url.parse()?)
         .with_common_extensions();
     Ok((client, sliding_sync_builder))

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -13,7 +13,7 @@ async fn setup(
         option_env!("SLIDING_SYNC_PROXY_URL").unwrap_or("http://localhost:8338").to_owned();
     let client = get_client_for_user(name, use_sqlite_store).await?;
     let sliding_sync_builder = client
-        .sliding_sync("test-sliding-sync")?
+        .sliding_sync("test-slidingsync")?
         .homeserver(sliding_sync_proxy_url.parse()?)
         .with_common_extensions();
     Ok((client, sliding_sync_builder))


### PR DESCRIPTION
This replaces the `storage_key` public API with another one `enable_caching` that doesn't take a string argument. Instead, sliding sync constructors are expected to receive a `loop_id` argument, that will be used to 1. be part of the storage key for this sliding sync instance, 2. be used as the `conn_id` (connection id) in the request to the proxy (paving the way for #1928).

The storage key is also inferred from the user id, such that a single app may be used for multiple users.

Fixes #2007.