### PR TITLE
Sliding sync: split the loops, v2

### DIFF
--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -58,8 +58,8 @@ pub use media::Media;
 pub use ruma::{IdParseError, OwnedServerName, ServerName};
 #[cfg(feature = "experimental-sliding-sync")]
 pub use sliding_sync::{
-    RoomListEntry, SlidingSync, SlidingSyncBuilder, SlidingSyncList, SlidingSyncListBuilder,
-    SlidingSyncMode, SlidingSyncRoom, SlidingSyncState, UpdateSummary,
+    RoomListEntry, SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode,
+    SlidingSyncRoom, SlidingSyncState, UpdateSummary,
 };
 
 #[cfg(any(test, feature = "testing"))]

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -1,4 +1,9 @@
-use std::{collections::BTreeMap, fmt::Debug, sync::RwLock as StdRwLock};
+use std::{
+    collections::BTreeMap,
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+    sync::RwLock as StdRwLock,
+};
 
 use ruma::{
     api::client::sync::sync_events::v4::{
@@ -12,50 +17,43 @@ use tokio::sync::broadcast::channel;
 use url::Url;
 
 use super::{
-    cache::restore_sliding_sync_state, SlidingSync, SlidingSyncInner, SlidingSyncListBuilder,
-    SlidingSyncPositionMarkers, SlidingSyncRoom,
+    cache::restore_sliding_sync_state, CommonLoopComponents, SlidingSync, SlidingSyncInner,
+    SlidingSyncInternalMessage, SlidingSyncListBuilder, SlidingSyncListLoop,
+    SlidingSyncPositionMarkers, SlidingSyncRole, SlidingSyncRoom,
 };
-use crate::{Client, Result};
+use crate::{Client, Result, SlidingSyncList};
 
-/// Configuration for a Sliding Sync instance.
-///
-/// Get a new builder with methods like [`crate::Client::sliding_sync`], or
-/// [`crate::SlidingSync::builder`].
-#[derive(Debug, Clone)]
-pub struct SlidingSyncBuilder {
-    storage_key: Option<String>,
-    homeserver: Option<Url>,
-    client: Client,
-    lists: Vec<SlidingSyncListBuilder>,
-    bump_event_types: Vec<TimelineEventType>,
-    extensions: Option<ExtensionsConfig>,
-    subscriptions: BTreeMap<OwnedRoomId, v4::RoomSubscription>,
-    rooms: BTreeMap<OwnedRoomId, SlidingSyncRoom>,
+pub struct SlidingSyncNotificationLoopBuilder {
+    common: SlidingSyncCommonBuilder,
 }
 
-impl SlidingSyncBuilder {
-    pub(super) fn new(client: Client) -> Self {
+impl SlidingSyncNotificationLoopBuilder {
+    pub fn new(client: Client) -> Self {
+        Self { common: SlidingSyncCommonBuilder::new(client) }
+    }
+}
+
+#[derive(Debug)]
+pub struct SlidingSyncListLoopBuilder {
+    common: SlidingSyncCommonBuilder,
+    lists: Vec<SlidingSyncListBuilder>,
+    rooms: BTreeMap<OwnedRoomId, SlidingSyncRoom>,
+    bump_event_types: Vec<TimelineEventType>,
+}
+
+impl SlidingSyncListLoopBuilder {
+    /// Create a new `SlidingSyncListLoopBuilder`.
+    pub fn new(client: Client) -> Self {
         Self {
-            storage_key: None,
-            homeserver: None,
-            client,
+            common: SlidingSyncCommonBuilder::new(client),
             lists: Vec::new(),
-            bump_event_types: Vec::new(),
-            extensions: None,
-            subscriptions: BTreeMap::new(),
             rooms: BTreeMap::new(),
+            bump_event_types: Vec::new(),
         }
     }
 
-    /// Set the storage key to keep this cache at and load it from.
-    pub fn storage_key(mut self, value: Option<String>) -> Self {
-        self.storage_key = value;
-        self
-    }
-
-    /// Set the homeserver for sliding sync only.
-    pub fn homeserver(mut self, value: Url) -> Self {
-        self.homeserver = Some(value);
+    pub fn storage_key(mut self, storage_key: Option<String>) -> Self {
+        self.common.storage_key = storage_key;
         self
     }
 
@@ -75,19 +73,89 @@ impl SlidingSyncBuilder {
     ///
     /// Replace any list with the same name.
     pub async fn add_cached_list(mut self, mut list: SlidingSyncListBuilder) -> Result<Self> {
-        let Some(ref storage_key) = self.storage_key else {
+        let Some(ref storage_key) = self.common.storage_key else {
             return Err(super::error::Error::MissingStorageKeyForCaching.into());
         };
 
-        let reloaded_rooms = list.set_cached_and_reload(&self.client, storage_key).await?;
+        let reloaded_rooms = list.set_cached_and_reload(&self.common.client, storage_key).await?;
 
         for (key, frozen) in reloaded_rooms {
-            self.rooms
-                .entry(key)
-                .or_insert_with(|| SlidingSyncRoom::from_frozen(frozen, self.client.clone()));
+            self.rooms.entry(key).or_insert_with(|| {
+                SlidingSyncRoom::from_frozen(frozen, self.common.client.clone())
+            });
         }
 
         Ok(self.add_list(list))
+    }
+
+    /// Allowlist of event types which should be considered recent activity
+    /// when sorting `by_recency`. By omitting event types, clients can ensure
+    /// that uninteresting events (e.g. a profile rename) do not cause a
+    /// room to jump to the top of its list(s). Empty or
+    /// omitted `bump_event_types` have no effect: all events in a room will
+    /// be considered recent activity.
+    pub fn bump_event_types(mut self, bump_event_types: &[TimelineEventType]) -> Self {
+        self.bump_event_types = bump_event_types.to_vec();
+        self
+    }
+
+    pub async fn build(self) -> Result<SlidingSync> {
+        let (internal_channel_sender, _internal_channel_receiver) = channel(8);
+
+        let mut lists = BTreeMap::new();
+        for list_builder in self.lists {
+            let list = list_builder.build(internal_channel_sender.clone());
+            lists.insert(list.name().to_owned(), list);
+        }
+
+        let (common, delta_token, _to_device_token) =
+            self.common.build(internal_channel_sender, &lists).await?;
+
+        let role = SlidingSyncRole::Lists(SlidingSyncListLoop { lists, rooms: self.rooms, common });
+
+        Ok(SlidingSync::new(SlidingSyncInner {
+            role: StdRwLock::new(role),
+
+            bump_event_types: self.bump_event_types,
+
+            reset_counter: Default::default(),
+
+            position: StdRwLock::new(SlidingSyncPositionMarkers { pos: None, delta_token }),
+        }))
+    }
+}
+
+/// Common configuration for a Sliding Sync instance.
+#[derive(Debug, Clone)]
+struct SlidingSyncCommonBuilder {
+    storage_key: Option<String>,
+    homeserver: Option<Url>,
+    client: Client,
+    extensions: Option<ExtensionsConfig>,
+    subscriptions: BTreeMap<OwnedRoomId, v4::RoomSubscription>,
+}
+
+impl SlidingSyncCommonBuilder {
+    pub(super) fn new(client: Client) -> Self {
+        Self {
+            storage_key: None,
+            homeserver: None,
+            client,
+            extensions: None,
+            subscriptions: BTreeMap::new(),
+        }
+    }
+
+    /// Set the storage key to keep this cache at and load it from.
+    pub fn storage_key(&mut self, value: Option<String>) -> &mut Self {
+        self.storage_key = value;
+        self
+    }
+
+    /// Set the homeserver for sliding sync only.
+    pub fn homeserver(&mut self, value: Url) -> &mut Self {
+        self.homeserver = Some(value);
+        self
     }
 
     /// Activate e2ee, to-device-message and account data extensions if not yet
@@ -95,7 +163,7 @@ impl SlidingSyncBuilder {
     ///
     /// Will leave any extension configuration found untouched, so the order
     /// does not matter.
-    pub fn with_common_extensions(mut self) -> Self {
+    pub fn with_common_extensions(&mut self) -> &mut Self {
         {
             let cfg = self.extensions.get_or_insert_with(Default::default);
             if cfg.to_device.enabled.is_none() {
@@ -118,7 +186,7 @@ impl SlidingSyncBuilder {
     ///
     /// Will leave any extension configuration found untouched, so the order
     /// does not matter.
-    pub fn with_all_extensions(mut self) -> Self {
+    pub fn with_all_extensions(&mut self) -> &mut Self {
         {
             let cfg = self.extensions.get_or_insert_with(Default::default);
             if cfg.to_device.enabled.is_none() {
@@ -145,74 +213,63 @@ impl SlidingSyncBuilder {
     }
 
     /// Set the E2EE extension configuration.
-    pub fn with_e2ee_extension(mut self, e2ee: E2EEConfig) -> Self {
+    pub fn with_e2ee_extension(&mut self, e2ee: E2EEConfig) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).e2ee = e2ee;
         self
     }
 
     /// Unset the E2EE extension configuration.
-    pub fn without_e2ee_extension(mut self) -> Self {
+    pub fn without_e2ee_extension(&mut self) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).e2ee = E2EEConfig::default();
         self
     }
 
     /// Set the ToDevice extension configuration.
-    pub fn with_to_device_extension(mut self, to_device: ToDeviceConfig) -> Self {
+    pub fn with_to_device_extension(&mut self, to_device: ToDeviceConfig) -> &Self {
         self.extensions.get_or_insert_with(Default::default).to_device = to_device;
         self
     }
 
     /// Unset the ToDevice extension configuration.
-    pub fn without_to_device_extension(mut self) -> Self {
+    pub fn without_to_device_extension(&mut self) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).to_device = ToDeviceConfig::default();
         self
     }
 
     /// Set the account data extension configuration.
-    pub fn with_account_data_extension(mut self, account_data: AccountDataConfig) -> Self {
+    pub fn with_account_data_extension(&mut self, account_data: AccountDataConfig) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).account_data = account_data;
         self
     }
 
     /// Unset the account data extension configuration.
-    pub fn without_account_data_extension(mut self) -> Self {
+    pub fn without_account_data_extension(&mut self) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).account_data =
             AccountDataConfig::default();
         self
     }
 
     /// Set the Typing extension configuration.
-    pub fn with_typing_extension(mut self, typing: TypingConfig) -> Self {
+    pub fn with_typing_extension(&mut self, typing: TypingConfig) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).typing = typing;
         self
     }
 
     /// Unset the Typing extension configuration.
-    pub fn without_typing_extension(mut self) -> Self {
+    pub fn without_typing_extension(&mut self) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).typing = TypingConfig::default();
         self
     }
 
     /// Set the Receipt extension configuration.
-    pub fn with_receipt_extension(mut self, receipt: ReceiptsConfig) -> Self {
+    pub fn with_receipt_extension(&mut self, receipt: ReceiptsConfig) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).receipts = receipt;
         self
     }
 
     /// Unset the Receipt extension configuration.
-    pub fn without_receipt_extension(mut self) -> Self {
+    pub fn without_receipt_extension(&mut self) -> &mut Self {
         self.extensions.get_or_insert_with(Default::default).receipts = ReceiptsConfig::default();
-        self
-    }
-
-    /// Allowlist of event types which should be considered recent activity
-    /// when sorting `by_recency`. By omitting event types, clients can ensure
-    /// that uninteresting events (e.g. a profile rename) do not cause a
-    /// room to jump to the top of its list(s). Empty or
-    /// omitted `bump_event_types` have no effect: all events in a room will
-    /// be considered recent activity.
-    pub fn bump_event_types(mut self, bump_event_types: &[TimelineEventType]) -> Self {
-        self.bump_event_types = bump_event_types.to_vec();
         self
     }
 
@@ -220,59 +277,38 @@ impl SlidingSyncBuilder {
     ///
     /// If `self.storage_key` is `Some(_)`, load the cached data from cold
     /// storage.
-    pub async fn build(self) -> Result<SlidingSync> {
+    async fn build(
+        self,
+        internal_channel_sender: tokio::sync::broadcast::Sender<SlidingSyncInternalMessage>,
+        lists: &BTreeMap<String, SlidingSyncList>,
+    ) -> Result<(CommonLoopComponents, Option<String>, Option<String>)> {
         let client = self.client;
 
         let mut delta_token = None;
         let mut to_device_token = None;
-
-        let (internal_channel_sender, _internal_channel_receiver) = channel(8);
-
-        let mut lists = BTreeMap::new();
-
-        for list_builder in self.lists {
-            let list = list_builder.build(internal_channel_sender.clone());
-
-            lists.insert(list.name().to_owned(), list);
-        }
 
         // Load an existing state from the cache.
         if let Some(storage_key) = &self.storage_key {
             restore_sliding_sync_state(
                 &client,
                 storage_key,
-                &lists,
+                lists,
                 &mut delta_token,
                 &mut to_device_token,
             )
             .await?;
         }
 
-        let rooms = StdRwLock::new(self.rooms);
-        let lists = StdRwLock::new(lists);
-
-        Ok(SlidingSync::new(SlidingSyncInner {
-            homeserver: self.homeserver,
-            client,
+        let common = CommonLoopComponents {
             storage_key: self.storage_key,
-
-            lists,
-            rooms,
-            bump_event_types: self.bump_event_types,
-
-            extensions: self.extensions.unwrap_or_default(),
-            reset_counter: Default::default(),
-
-            position: StdRwLock::new(SlidingSyncPositionMarkers {
-                pos: None,
-                delta_token,
-                to_device_token,
-            }),
-
-            room_subscriptions: StdRwLock::new(self.subscriptions),
-            room_unsubscriptions: Default::default(),
-
+            client,
+            homeserver: self.homeserver,
             internal_channel: internal_channel_sender,
-        }))
+            extensions: self.extensions.unwrap_or_default(),
+            room_subscriptions: self.subscriptions,
+            room_unsubscriptions: Default::default(),
+        };
+
+        Ok((common, delta_token, to_device_token))
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -2,13 +2,18 @@ use matrix_sdk_base::sync::SyncResponse;
 use ruma::api::client::sync::sync_events::v4;
 use tracing::{debug, instrument};
 
-use super::{SlidingSync, SlidingSyncBuilder};
+use super::{SlidingSync, SlidingSyncListLoopBuilder, SlidingSyncNotificationLoopBuilder};
 use crate::{Client, Result};
 
 impl Client {
-    /// Create a [`SlidingSyncBuilder`] tied to this client.
-    pub fn sliding_sync(&self) -> SlidingSyncBuilder {
-        SlidingSync::builder(self.clone())
+    /// Create a [`SlidingSyncListLoopBuilder`] tied to this client.
+    pub fn sliding_sync_list_loop(&self) -> SlidingSyncListLoopBuilder {
+        SlidingSync::new_list_loop(self.clone())
+    }
+
+    /// Create a [`SlidingSyncNotificationLoopBuilder`] tied to this client.
+    pub fn sliding_sync_notification_loop(&self) -> SlidingSyncNotificationLoopBuilder {
+        SlidingSync::new_notification_loop(self.clone())
     }
 
     #[instrument(skip(self, response))]


### PR DESCRIPTION
This is one direction where I try to split the sync loops into two disjoint parts, assuming that a loop can't be both a "main" loop (polling list and room events) and a "to-device" loop (polling to-device and e2ee events). I'm holding off working on this, since this might be too adhoc, so I'm tempted to throw it away and revisit the approach a second time; cc @Hywan.