### PR TITLE
base: Move `StateStore::get_member_event` to `StateStoreExt` 

### DIFF
--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -20,6 +20,7 @@
   - `can_send_message`
   - `can_send_state`
   - `can_trigger_room_notification`
+- Move `StateStore::get_member_event` to `StateStoreExt`
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -27,7 +27,10 @@ use ruma::{
 use tracing::trace;
 
 use super::{DynStateStore, Result, StateChanges};
-use crate::deserialized_responses::{AmbiguityChange, RawMemberEvent};
+use crate::{
+    deserialized_responses::{AmbiguityChange, RawMemberEvent},
+    store::StateStoreExt,
+};
 
 #[derive(Debug)]
 pub(crate) struct AmbiguityCache {

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -37,9 +37,8 @@ use tracing::{debug, warn};
 
 use super::{Result, RoomInfo, StateChanges, StateStore, StoreError};
 use crate::{
-    deserialized_responses::{RawAnySyncOrStrippedState, RawMemberEvent},
-    media::MediaRequest,
-    MinimalRoomMemberEvent, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
+    deserialized_responses::RawAnySyncOrStrippedState, media::MediaRequest, MinimalRoomMemberEvent,
+    RoomMemberships, StateStoreDataKey, StateStoreDataValue,
 };
 
 /// In-Memory, non-persistent implementation of the `StateStore`
@@ -429,16 +428,6 @@ impl MemoryStore {
         Ok(self.profiles.get(room_id).and_then(|p| p.get(user_id).map(|p| p.clone())))
     }
 
-    async fn get_member_event(
-        &self,
-        room_id: &RoomId,
-        state_key: &UserId,
-    ) -> Result<Option<RawMemberEvent>> {
-        self.get_state_event(room_id, StateEventType::RoomMember, state_key.as_str())
-            .await
-            .map(|opt| opt.map(|raw| raw.cast()))
-    }
-
     /// Get the user IDs for the given room with the given memberships and
     /// stripped state.
     ///
@@ -614,14 +603,6 @@ impl StateStore for MemoryStore {
         user_id: &UserId,
     ) -> Result<Option<MinimalRoomMemberEvent>> {
         self.get_profile(room_id, user_id).await
-    }
-
-    async fn get_member_event(
-        &self,
-        room_id: &RoomId,
-        state_key: &UserId,
-    ) -> Result<Option<RawMemberEvent>> {
-        self.get_member_event(room_id, state_key).await
     }
 
     async fn get_user_ids(

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -130,19 +130,6 @@ pub trait StateStore: AsyncTraitDeps {
         user_id: &UserId,
     ) -> Result<Option<MinimalRoomMemberEvent>, Self::Error>;
 
-    /// Get the `MemberEvent` for the given state key in the given room id.
-    ///
-    /// # Arguments
-    ///
-    /// * `room_id` - The room id the member event belongs to.
-    ///
-    /// * `state_key` - The user id that the member event defines the state for.
-    async fn get_member_event(
-        &self,
-        room_id: &RoomId,
-        state_key: &UserId,
-    ) -> Result<Option<RawMemberEvent>, Self::Error>;
-
     /// Get the user ids of members for a given room with the given memberships,
     /// for stripped and regular rooms alike.
     async fn get_user_ids(
@@ -390,14 +377,6 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         self.0.get_profile(room_id, user_id).await.map_err(Into::into)
     }
 
-    async fn get_member_event(
-        &self,
-        room_id: &RoomId,
-        state_key: &UserId,
-    ) -> Result<Option<RawMemberEvent>, Self::Error> {
-        self.0.get_member_event(room_id, state_key).await.map_err(Into::into)
-    }
-
     async fn get_user_ids(
         &self,
         room_id: &RoomId,
@@ -607,6 +586,21 @@ pub trait StateStoreExt: StateStore {
         C: StaticEventContent + RoomAccountDataEventContent,
     {
         Ok(self.get_room_account_data_event(room_id, C::TYPE.into()).await?.map(Raw::cast))
+    }
+
+    /// Get the `MemberEvent` for the given state key in the given room id.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The room id the member event belongs to.
+    ///
+    /// * `state_key` - The user id that the member event defines the state for.
+    async fn get_member_event(
+        &self,
+        room_id: &RoomId,
+        state_key: &UserId,
+    ) -> Result<Option<RawMemberEvent>, Self::Error> {
+        self.get_state_event_static_for_key(room_id, state_key).await
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -604,8 +604,8 @@ mod tests {
     use assert_matches::assert_matches;
     use indexed_db_futures::prelude::*;
     use matrix_sdk_base::{
-        deserialized_responses::RawMemberEvent, RoomInfo, RoomMemberships, RoomState, StateStore,
-        StateStoreDataKey, StoreError,
+        deserialized_responses::RawMemberEvent, store::StateStoreExt, RoomInfo, RoomMemberships,
+        RoomState, StateStore, StateStoreDataKey, StoreError,
     };
     use matrix_sdk_test::{async_test, test_json};
     use ruma::{

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use gloo_utils::format::JsValueSerdeExt;
 use indexed_db_futures::prelude::*;
 use matrix_sdk_base::{
-    deserialized_responses::{RawAnySyncOrStrippedState, RawMemberEvent},
+    deserialized_responses::RawAnySyncOrStrippedState,
     media::{MediaRequest, UniqueKey},
     store::{StateChanges, StateStore, StoreError},
     MinimalStateEvent, RoomInfo, RoomMemberships, StateStoreDataKey, StateStoreDataValue,
@@ -889,42 +889,6 @@ impl_state_store!({
             .await?
             .map(|f| self.deserialize_event(&f))
             .transpose()
-    }
-
-    async fn get_member_event(
-        &self,
-        room_id: &RoomId,
-        state_key: &UserId,
-    ) -> Result<Option<RawMemberEvent>> {
-        if let Some(e) = self
-            .inner
-            .transaction_on_one_with_mode(keys::STRIPPED_ROOM_STATE, IdbTransactionMode::Readonly)?
-            .object_store(keys::STRIPPED_ROOM_STATE)?
-            .get(&self.encode_key(
-                keys::STRIPPED_ROOM_STATE,
-                (room_id, StateEventType::RoomMember, state_key),
-            ))?
-            .await?
-            .map(|f| self.deserialize_event(&f))
-            .transpose()?
-        {
-            Ok(Some(RawMemberEvent::Stripped(e)))
-        } else if let Some(e) = self
-            .inner
-            .transaction_on_one_with_mode(keys::ROOM_STATE, IdbTransactionMode::Readonly)?
-            .object_store(keys::ROOM_STATE)?
-            .get(
-                &self
-                    .encode_key(keys::ROOM_STATE, (room_id, StateEventType::RoomMember, state_key)),
-            )?
-            .await?
-            .map(|f| self.deserialize_event(&f))
-            .transpose()?
-        {
-            Ok(Some(RawMemberEvent::Sync(e)))
-        } else {
-            Ok(None)
-        }
     }
 
     async fn get_room_infos(&self) -> Result<Vec<RoomInfo>> {

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -9,7 +9,7 @@ use std::{
 use async_trait::async_trait;
 use deadpool_sqlite::{Object as SqliteConn, Pool as SqlitePool, Runtime};
 use matrix_sdk_base::{
-    deserialized_responses::{RawAnySyncOrStrippedState, RawMemberEvent},
+    deserialized_responses::RawAnySyncOrStrippedState,
     media::{MediaRequest, UniqueKey},
     RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore, StateStoreDataKey,
     StateStoreDataValue,
@@ -1126,29 +1126,6 @@ impl StateStore for SqliteStateStore {
             .get_profile(room_id, user_id)
             .await?
             .map(|data| self.deserialize_json(&data))
-            .transpose()
-    }
-
-    async fn get_member_event(
-        &self,
-        room_id: &RoomId,
-        state_key: &UserId,
-    ) -> Result<Option<RawMemberEvent>> {
-        let room_id = self.encode_key(keys::STATE_EVENT, room_id);
-        let event_type = self.encode_key(keys::STATE_EVENT, StateEventType::RoomMember.to_string());
-        let state_key = self.encode_key(keys::STATE_EVENT, state_key);
-
-        self.acquire()
-            .await?
-            .get_maybe_stripped_state_event(room_id, event_type, state_key)
-            .await?
-            .map(|(stripped, data)| {
-                Ok(if stripped {
-                    RawMemberEvent::Stripped(self.deserialize_json(&data)?)
-                } else {
-                    RawMemberEvent::Sync(self.deserialize_json(&data)?)
-                })
-            })
             .transpose()
     }
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -21,8 +21,10 @@ pub use bytes;
 #[cfg(feature = "e2e-encryption")]
 pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
-    deserialized_responses, DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember,
-    RoomMemberships, RoomState, Session, StateChanges, StoreError,
+    deserialized_responses,
+    store::{DynStateStore, StateStoreExt},
+    DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomMemberships,
+    RoomState, Session, StateChanges, StateStore, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;

--- a/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
@@ -9,7 +9,7 @@ use matrix_sdk::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
         events::room::member::{MembershipState, StrippedRoomMemberEvent},
     },
-    Client, RoomMemberships, RoomState,
+    Client, RoomMemberships, RoomState, StateStoreExt,
 };
 use tokio::sync::Notify;
 


### PR DESCRIPTION
In the store implementations, it is a wrapper around `StateStore::get_state_event` since #1991.

We could keep it for convenience instead but it should probably be moved to `StateStoreExt` in that case. However given that these are low-level traits it doesn't seem necessary.

Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
