### PR TITLE
ffi: Include causes when stringifying anyhow::Error

### DIFF
--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use matrix_sdk::{self, encryption::CryptoStoreError, HttpError, IdParseError, StoreError};
 
 #[derive(Debug, thiserror::Error)]
@@ -6,57 +8,63 @@ pub enum ClientError {
     Generic { msg: String },
 }
 
+impl ClientError {
+    fn new<E: Display>(error: E) -> Self {
+        Self::Generic { msg: error.to_string() }
+    }
+}
+
 impl From<anyhow::Error> for ClientError {
     fn from(e: anyhow::Error) -> ClientError {
-        ClientError::Generic { msg: e.to_string() }
+        ClientError::Generic { msg: format!("{e:#}") }
     }
 }
 
 impl From<matrix_sdk::Error> for ClientError {
     fn from(e: matrix_sdk::Error) -> Self {
-        anyhow::Error::from(e).into()
+        Self::new(e)
     }
 }
 
 impl From<StoreError> for ClientError {
     fn from(e: StoreError) -> Self {
-        anyhow::Error::from(e).into()
+        Self::new(e)
     }
 }
 
 impl From<CryptoStoreError> for ClientError {
     fn from(e: CryptoStoreError) -> Self {
-        anyhow::Error::from(e).into()
+        Self::new(e)
     }
 }
 
 impl From<HttpError> for ClientError {
     fn from(e: HttpError) -> Self {
-        anyhow::Error::from(e).into()
+        Self::new(e)
     }
 }
 
 impl From<IdParseError> for ClientError {
     fn from(e: IdParseError) -> Self {
-        anyhow::Error::from(e).into()
+        Self::new(e)
     }
 }
 
 impl From<serde_json::Error> for ClientError {
     fn from(e: serde_json::Error) -> Self {
-        anyhow::Error::from(e).into()
+        Self::new(e)
     }
 }
 
 impl From<url::ParseError> for ClientError {
     fn from(e: url::ParseError) -> Self {
-        anyhow::Error::from(e).into()
+        Self::new(e)
     }
 }
 
 impl From<mime::FromStrError> for ClientError {
     fn from(e: mime::FromStrError) -> Self {
-        anyhow::Error::from(e).into()
+        Self::new(e)
     }
 }
 


### PR DESCRIPTION
> To print causes as well using anyhow’s default formatting of causes, use the alternate selector “{:#}”.

https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations