### PR TITLE
chore: rename `homeserver` to `sliding_sync_proxy` in sliding sync

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -806,9 +806,9 @@ pub struct SlidingSyncBuilder {
 
 #[uniffi::export]
 impl SlidingSyncBuilder {
-    pub fn homeserver(self: Arc<Self>, url: String) -> Result<Arc<Self>, ClientError> {
+    pub fn sliding_sync_proxy(self: Arc<Self>, url: String) -> Result<Arc<Self>, ClientError> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.inner = builder.inner.homeserver(url.parse()?);
+        builder.inner = builder.inner.sliding_sync_proxy(url.parse()?);
         Ok(Arc::new(builder))
     }
 
@@ -899,7 +899,7 @@ impl Client {
             .clone()
             .and_then(|p| Url::parse(p.as_str()).ok())
         {
-            inner = inner.homeserver(sliding_sync_proxy);
+            inner = inner.sliding_sync_proxy(sliding_sync_proxy);
         }
         Ok(Arc::new(SlidingSyncBuilder { inner, client: self.clone() }))
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -53,7 +53,7 @@ use ruma::{
             session::{
                 get_login_types, login, logout, refresh_token, sso_login, sso_login_with_provider,
             },
-            sync::sync_events::{self},
+            sync::sync_events,
             uiaa::{AuthData, UserIdentifier},
             user_directory::search_users,
         },
@@ -1845,13 +1845,14 @@ impl Client {
         &self,
         request: Request,
         config: Option<RequestConfig>,
-        homeserver: Option<String>,
+        sliding_sync_proxy: Option<String>,
     ) -> HttpResult<Request::IncomingResponse>
     where
         Request: OutgoingRequest + Clone + Debug,
         HttpError: From<FromHttpResponseError<Request::EndpointError>>,
     {
-        let res = Box::pin(self.send_inner(request.clone(), config, homeserver.clone())).await;
+        let res =
+            Box::pin(self.send_inner(request.clone(), config, sliding_sync_proxy.clone())).await;
 
         // If this is an `M_UNKNOWN_TOKEN` error and refresh token handling is active,
         // try to refresh the token and retry the request.
@@ -1870,7 +1871,7 @@ impl Client {
                         }
                     }
                 } else {
-                    return Box::pin(self.send_inner(request, config, homeserver)).await;
+                    return Box::pin(self.send_inner(request, config, sliding_sync_proxy)).await;
                 }
             }
         }

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -46,7 +46,7 @@ of Sliding Sync, and must be provided when getting a builder:
 # let client = Client::new(homeserver).await?;
 let sliding_sync_builder = client
     .sliding_sync("main-sync")?
-    .homeserver(Url::parse("http://sliding-sync.example.org")?);
+    .sliding_sync_proxy(Url::parse("http://sliding-sync.example.org")?);
 
 # anyhow::Ok(())
 # };
@@ -419,7 +419,7 @@ let full_sync_list_name = "full-sync".to_owned();
 let active_list_name = "active-list".to_owned();
 let sliding_sync_builder = client
     .sliding_sync("main-sync")?
-    .homeserver(Url::parse("http://sliding-sync.example.org")?) // our proxy server
+    .sliding_sync_proxy(Url::parse("http://sliding-sync.example.org")?) // our proxy server
     .with_common_extensions() // we want the e2ee and to-device enabled, please
     .enable_caching()?; // we want these to be loaded from and stored into the persistent storage
 

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -25,7 +25,7 @@ use crate::{Client, Result};
 pub struct SlidingSyncBuilder {
     id: String,
     storage_key: Option<String>,
-    homeserver: Option<Url>,
+    sliding_sync_proxy: Option<Url>,
     client: Client,
     lists: Vec<SlidingSyncListBuilder>,
     extensions: Option<ExtensionsConfig>,
@@ -41,7 +41,7 @@ impl SlidingSyncBuilder {
             Ok(Self {
                 id,
                 storage_key: None,
-                homeserver: None,
+                sliding_sync_proxy: None,
                 client,
                 lists: Vec::new(),
                 extensions: None,
@@ -64,9 +64,14 @@ impl SlidingSyncBuilder {
         Ok(self)
     }
 
-    /// Set the homeserver for sliding sync only.
-    pub fn homeserver(mut self, value: Url) -> Self {
-        self.homeserver = Some(value);
+    /// Set the sliding sync proxy URL.
+    ///
+    /// Note you might not need that in general, since the client uses the
+    /// `.well-known` endpoint to automatically find the sliding sync proxy
+    /// URL. This method should only be called if the proxy is at a
+    /// different URL than the one publicized in the `.well-known` endpoint.
+    pub fn sliding_sync_proxy(mut self, value: Url) -> Self {
+        self.sliding_sync_proxy = Some(value);
         self
     }
 
@@ -254,7 +259,7 @@ impl SlidingSyncBuilder {
 
         Ok(SlidingSync::new(SlidingSyncInner {
             _id: Some(self.id),
-            homeserver: self.homeserver,
+            sliding_sync_proxy: self.sliding_sync_proxy,
             client,
             storage_key: self.storage_key,
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -85,8 +85,8 @@ pub(super) struct SlidingSyncInner {
     /// Used to distinguish different connections to the sliding sync proxy.
     _id: Option<String>,
 
-    /// Customize the homeserver for sliding sync only
-    homeserver: Option<Url>,
+    /// Customize the sliding sync proxy URL.
+    sliding_sync_proxy: Option<Url>,
 
     /// The HTTP Matrix client.
     client: Client,
@@ -440,7 +440,7 @@ impl SlidingSync {
         let request = self.inner.client.send_with_homeserver(
             request,
             Some(request_config),
-            self.inner.homeserver.as_ref().map(ToString::to_string),
+            self.inner.sliding_sync_proxy.as_ref().map(ToString::to_string),
         );
 
         // Send the request and get a response with end-to-end encryption support.

--- a/testing/sliding-sync-integration-test/src/lib.rs
+++ b/testing/sliding-sync-integration-test/src/lib.rs
@@ -14,7 +14,7 @@ async fn setup(
     let client = get_client_for_user(name, use_sqlite_store).await?;
     let sliding_sync_builder = client
         .sliding_sync("test-slidingsync")?
-        .homeserver(sliding_sync_proxy_url.parse()?)
+        .sliding_sync_proxy(sliding_sync_proxy_url.parse()?)
         .with_common_extensions();
     Ok((client, sliding_sync_builder))
 }


### PR DESCRIPTION
Using `homeserver` to designate the sliding sync proxy has been a bit confusing in my experience, since I thought that was a real, alternate home server that was used, while it's only really used for the sliding sync request. This PR attempts to improve this by just renaming the field in a few places.