### PR TITLE
base: Make store requests in batch for `Room::get_members`

### DIFF
--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -25,6 +25,11 @@
   `get_room_infos`.
 - `BaseClient::get_stripped_rooms` is deprecated. Use `get_rooms_filtered` with
   `RoomStateFilter::INVITED` instead.
+- Add methods to `StateStore` to be able to retrieve data in batch
+  - `get_state_events_for_keys`
+  - `get_profiles`
+  - `get_presence_events`
+  - `get_users_with_display_names`
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -267,6 +267,16 @@ impl MemberEvent {
     pub fn user_id(&self) -> &UserId {
         self.state_key()
     }
+
+    /// The name that should be displayed for this member event.
+    ///
+    /// It there is no `displayname` in the event's content, the localpart or
+    /// the user ID is returned.
+    pub fn display_name(&self) -> &str {
+        self.original_content()
+            .and_then(|c| c.displayname.as_deref())
+            .unwrap_or_else(|| self.user_id().localpart())
+    }
 }
 
 impl SyncOrStrippedState<RoomPowerLevelsEventContent> {

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -95,6 +95,16 @@ pub trait StateStore: AsyncTraitDeps {
         user_id: &UserId,
     ) -> Result<Option<Raw<PresenceEvent>>, Self::Error>;
 
+    /// Get the stored presence events for the given users.
+    ///
+    /// # Arguments
+    ///
+    /// * `user_ids` - The IDs of the users to fetch the presence events for.
+    async fn get_presence_events(
+        &self,
+        user_ids: &[OwnedUserId],
+    ) -> Result<Vec<Raw<PresenceEvent>>, Self::Error>;
+
     /// Get a state event out of the state store.
     ///
     /// # Arguments
@@ -386,6 +396,13 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         user_id: &UserId,
     ) -> Result<Option<Raw<PresenceEvent>>, Self::Error> {
         self.0.get_presence_event(user_id).await.map_err(Into::into)
+    }
+
+    async fn get_presence_events(
+        &self,
+        user_ids: &[OwnedUserId],
+    ) -> Result<Vec<Raw<PresenceEvent>>, Self::Error> {
+        self.0.get_presence_events(user_ids).await.map_err(Into::into)
     }
 
     async fn get_state_event(

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -215,6 +215,19 @@ pub trait StateStore: AsyncTraitDeps {
         display_name: &str,
     ) -> Result<BTreeSet<OwnedUserId>, Self::Error>;
 
+    /// Get all the users that use the given display names in the given room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The ID of the room to fetch the display names for.
+    ///
+    /// * `display_names` - The display names that the users use.
+    async fn get_users_with_display_names<'a>(
+        &self,
+        room_id: &RoomId,
+        display_names: &'a [String],
+    ) -> Result<BTreeMap<&'a str, BTreeSet<OwnedUserId>>, Self::Error>;
+
     /// Get an event out of the account data store.
     ///
     /// # Arguments
@@ -481,6 +494,14 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         display_name: &str,
     ) -> Result<BTreeSet<OwnedUserId>, Self::Error> {
         self.0.get_users_with_display_name(room_id, display_name).await.map_err(Into::into)
+    }
+
+    async fn get_users_with_display_names<'a>(
+        &self,
+        room_id: &RoomId,
+        display_names: &'a [String],
+    ) -> Result<BTreeMap<&'a str, BTreeSet<OwnedUserId>>, Self::Error> {
+        self.0.get_users_with_display_names(room_id, display_names).await.map_err(Into::into)
     }
 
     async fn get_account_data_event(

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Deref;
+use std::{borrow::Borrow, ops::Deref};
 
 use async_trait::async_trait;
 use rusqlite::{OptionalExtension, Params, Row, Statement, Transaction};
 
 use crate::OpenStoreError;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Key {
     Plain(Vec<u8>),
     Hashed([u8; 32]),
@@ -33,6 +33,12 @@ impl Deref for Key {
             Key::Plain(slice) => slice,
             Key::Hashed(bytes) => bytes,
         }
+    }
+}
+
+impl Borrow<[u8]> for Key {
+    fn borrow(&self) -> &[u8] {
+        self.deref()
     }
 }
 

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -578,6 +578,54 @@ impl Common {
         Ok(self.client.store().get_state_events_static(self.room_id()).await?)
     }
 
+    /// Get the state events of a given type with the given state keys in this
+    /// room.
+    pub async fn get_state_events_for_keys(
+        &self,
+        event_type: StateEventType,
+        state_keys: &[&str],
+    ) -> Result<Vec<RawAnySyncOrStrippedState>> {
+        self.client
+            .store()
+            .get_state_events_for_keys(self.room_id(), event_type, state_keys)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Get the state events of a given statically-known type with the given
+    /// state keys in this room.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async {
+    /// # let room: matrix_sdk::room::Common = todo!();
+    /// # let user_ids: &[matrix_sdk::ruma::OwnedUserId] = &[];
+    /// use matrix_sdk::ruma::events::room::member::RoomMemberEventContent;
+    ///
+    /// let room_members = room
+    ///     .get_state_events_for_keys_static::<RoomMemberEventContent, _, _>(
+    ///         user_ids,
+    ///     )
+    ///     .await?;
+    /// # anyhow::Ok(())
+    /// # };
+    /// ```
+    pub async fn get_state_events_for_keys_static<'a, C, K, I>(
+        &self,
+        state_keys: I,
+    ) -> Result<Vec<RawSyncOrStrippedState<C>>>
+    where
+        C: StaticEventContent + StaticStateEventContent + RedactContent,
+        C::StateKey: Borrow<K>,
+        C::Redacted: RedactedStateEventContent,
+        K: AsRef<str> + Sized + Sync + 'a,
+        I: IntoIterator<Item = &'a K> + Send,
+        I::IntoIter: Send,
+    {
+        Ok(self.client.store().get_state_events_for_keys_static(self.room_id(), state_keys).await?)
+    }
+
     /// Get a specific state event in this room.
     pub async fn get_state_event(
         &self,


### PR DESCRIPTION
Each commit can be viewed separately. The first commits add the methods to retrieve events in batch to the `StateStore` trait and the last one uses the new methods for `Room::get_members`.

Should fix part of #1979. What is left is to be able to paginate to not request all the results at once.

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
