### PR TITLE
Add Timeline::retry_send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im-util"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988b102aa389565187ccb138e51339c72258deb8af8e459180a582af40ca323b"
+checksum = "fe7c462b9be62f7b7f85912db70ce3e8b5dc371d00b91869778a399518fd8098"
 dependencies = [
  "eyeball-im",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ ctor = "0.2.0"
 dashmap = "5.2.0"
 eyeball = "0.7.0"
 eyeball-im = "0.2.0"
-eyeball-im-util = "0.1.0"
+eyeball-im-util = "0.2.1"
 futures-core = "0.3.28"
 futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -14,7 +14,7 @@ rustls-tls = ["matrix-sdk/rustls-tls"]
 experimental-room-list = ["experimental-sliding-sync", "dep:async-stream", "dep:eyeball-im-util"]
 experimental-sliding-sync = ["matrix-sdk/experimental-sliding-sync"]
 
-testing = ["matrix-sdk/testing"]
+testing = ["matrix-sdk/testing", "dep:eyeball-im-util"]
 
 [dependencies]
 async-stream = { workspace = true, optional = true }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
@@ -18,11 +18,13 @@ use imbl::{vector, Vector};
 use indexmap::IndexMap;
 use matrix_sdk::{deserialized_responses::TimelineEvent, Result};
 use ruma::{
+    assign,
     events::{
         policy::rule::{
             room::PolicyRuleRoomEventContent, server::PolicyRuleServerEventContent,
             user::PolicyRuleUserEventContent,
         },
+        relation::InReplyTo,
         room::{
             aliases::RoomAliasesEventContent,
             avatar::RoomAvatarEventContent,
@@ -229,6 +231,15 @@ impl Message {
 
     pub(in crate::timeline) fn with_in_reply_to(&self, in_reply_to: InReplyToDetails) -> Self {
         Self { in_reply_to: Some(in_reply_to), ..self.clone() }
+    }
+}
+
+impl From<Message> for RoomMessageEventContent {
+    fn from(msg: Message) -> Self {
+        let relates_to = msg.in_reply_to.map(|details| message::Relation::Reply {
+            in_reply_to: InReplyTo::new(details.event_id),
+        });
+        assign!(Self::new(msg.msgtype), { relates_to })
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner.rs
@@ -331,7 +331,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let local_item = item.as_local()?;
 
         if !matches!(&local_item.send_state, EventSendState::SendingFailed { .. }) {
-            debug!("Attempted to retry sending of an item that is not in failed state");
+            debug!("Attempted to retry the sending of an item that is not in failed state");
             return None;
         }
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list.rs
@@ -1069,11 +1069,11 @@ async fn test_room() -> Result<(), Error> {
 
     // Room has received a name from sliding sync.
     let room0 = room_list.room(room_id_0).await?;
-    assert_eq!(room0.name().await, Some("Room #0".to_string()));
+    assert_eq!(room0.name().await, Some("Room #0".to_owned()));
 
     // Room has not received a name from sliding sync, then it's calculated.
     let room1 = room_list.room(room_id_1).await?;
-    assert_eq!(room1.name().await, Some("Empty Room".to_string()));
+    assert_eq!(room1.name().await, Some("Empty Room".to_owned()));
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -1103,7 +1103,7 @@ async fn test_room() -> Result<(), Error> {
     };
 
     // Room has _now_ received a name from sliding sync!
-    assert_eq!(room1.name().await, Some("Room #1".to_string()));
+    assert_eq!(room1.name().await, Some("Room #1".to_owned()));
 
     Ok(())
 }

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -14,7 +14,7 @@ use std::{
 pub use builder::*;
 use eyeball::unique::Observable;
 use eyeball_im::{ObservableVector, VectorDiff};
-use eyeball_im_util::{FilteredVectorSubscriber, VectorExt};
+use eyeball_im_util::{FilterVectorSubscriber, VectorExt};
 pub(super) use frozen::FrozenSlidingSyncList;
 use futures_core::Stream;
 use imbl::Vector;
@@ -160,14 +160,11 @@ impl SlidingSyncList {
     pub fn room_list_filtered_stream<F>(
         &self,
         filter: F,
-    ) -> (Vector<RoomListEntry>, FilteredVectorSubscriber<RoomListEntry, BoxedRoomListEntryFilter>)
+    ) -> (Vector<RoomListEntry>, FilterVectorSubscriber<RoomListEntry, BoxedRoomListEntryFilter>)
     where
         F: Fn(&RoomListEntry) -> bool + Sync + Send + 'static,
     {
-        ObservableVector::subscribe_filtered(
-            &self.inner.room_list.read().unwrap(),
-            Box::new(filter),
-        )
+        ObservableVector::subscribe_filter(&self.inner.room_list.read().unwrap(), Box::new(filter))
     }
 
     /// Get the maximum number of rooms. See [`Self::maximum_number_of_rooms`]


### PR DESCRIPTION
Previously a pretty obvious hole in the timeline API: When sending failed, there was no way to deal with the failed local echo. This adds one way to do that, we should also add the ability to cancel a failed local echo (in a separate PR).