### PR TITLE
`RoomList` API: enable `account_data` extension by default

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list/mod.rs
@@ -104,13 +104,13 @@ impl RoomList {
             .with_account_data_extension(
                 assign! { AccountDataConfig::default(), { enabled: Some(true) }},
             )
-            .add_cached_list(
+            // TODO revert to `add_cached_list` when reloading rooms from the cache is blazingly
+            // fast
+            .add_list(
                 SlidingSyncList::builder(ALL_ROOMS_LIST_NAME)
                     .sync_mode(SlidingSyncMode::new_selective().add_range(0..=19))
                     .timeline_limit(1),
             )
-            .await
-            .map_err(Error::SlidingSync)?
             .build()
             .await
             .map_err(Error::SlidingSync)?;

--- a/crates/matrix-sdk-ui/src/room_list/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list/mod.rs
@@ -74,7 +74,7 @@ use matrix_sdk::{
     SlidingSyncMode, SlidingSyncRoom,
 };
 use once_cell::sync::Lazy;
-use ruma::{OwnedRoomId, RoomId};
+use ruma::{api::client::sync::sync_events::v4::AccountDataConfig, assign, OwnedRoomId, RoomId};
 use thiserror::Error;
 
 use crate::{timeline::EventTimelineItem, Timeline};
@@ -100,6 +100,10 @@ impl RoomList {
             .map_err(Error::SlidingSync)?
             .enable_caching()
             .map_err(Error::SlidingSync)?
+            // Enable the account data extension.
+            .with_account_data_extension(
+                assign! { AccountDataConfig::default(), { enabled: Some(true) }},
+            )
             .add_cached_list(
                 SlidingSyncList::builder(ALL_ROOMS_LIST_NAME)
                     .sync_mode(SlidingSyncMode::new_selective().add_range(0..=19))

--- a/crates/matrix-sdk-ui/tests/integration/room_list.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list.rs
@@ -252,6 +252,9 @@ async fn test_sync_from_init_to_enjoy() -> Result<(), Error> {
                 "to_device": {
                     "enabled": true,
                 },
+                "account_data": {
+                    "enabled": true
+                }
             },
         },
         respond with = {


### PR DESCRIPTION
Users of the RoomList API have previously used `with_common_extensions` on the sliding sync builders to enable three extensions:

- `account_data`
- `e2ee`
- `to_device`

Considering that the last two will be handled by the `NotificationApi` in the future, they may still want to enable the `account_data` extension. There are two ways to do that:

- expose setters for each extension,
- or enable it for them

Since RoomList has an opiniated design, I think it should enable it by default, on behalf of the users; that's up to discussion.

The second commit replaces the `add_cached_list` with `add_list`, as I am 95% sure we will run into the slow reloading perf issue that we've ran into, in the past, if we keep it and put it in production before the perf issue with reloading from the cache has been fixed.