### PR TITLE
sliding sync: enable read-receipts in the common extensions

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -121,6 +121,10 @@ impl SlidingSyncBuilder {
             if cfg.account_data.enabled.is_none() {
                 cfg.account_data.enabled = Some(true);
             }
+
+            if cfg.receipts.enabled.is_none() {
+                cfg.receipts.enabled = Some(true);
+            }
         }
         self
     }


### PR DESCRIPTION
Enable read receipts by default in the common extensions; that's the only `*extension*` method used by ElementX clients, at the very least. I expect that the importance of this will be lowered when we have the `RoomList`/`NotificationApi` in place, but in the meanwhile it's useful to have.