### PR TITLE
feat(ui): Disable caching and make `Timeline`s lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fddec5f567375e0a634f94bc8dab1059b9d59a8aba12134c32f5ee21ce3f5f89"
+
+[[package]]
 name = "async-process"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,6 +2945,7 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "assert_matches",
+ "async-once-cell",
  "async-stream",
  "async-trait",
  "chrono",

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -17,6 +17,7 @@ experimental-sliding-sync = ["matrix-sdk/experimental-sliding-sync"]
 testing = ["matrix-sdk/testing"]
 
 [dependencies]
+async-once-cell = "0.5.2"
 async-stream = { workspace = true, optional = true }
 async-trait = { workspace = true }
 chrono = "0.4.23"

--- a/crates/matrix-sdk-ui/src/room_list/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list/mod.rs
@@ -98,8 +98,6 @@ impl RoomList {
         let sliding_sync = client
             .sliding_sync("room-list")
             .map_err(Error::SlidingSync)?
-            .enable_caching()
-            .map_err(Error::SlidingSync)?
             // Enable the account data extension.
             .with_account_data_extension(
                 assign! { AccountDataConfig::default(), { enabled: Some(true) }},

--- a/crates/matrix-sdk-ui/tests/integration/room_list.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list.rs
@@ -1166,7 +1166,7 @@ async fn test_room_timeline() -> Result<(), Error> {
     };
 
     let room = room_list.room(room_id).await?;
-    let timeline = room.timeline();
+    let timeline = room.timeline().await;
 
     let (previous_timeline_items, mut timeline_items_stream) = timeline.subscribe().await;
 


### PR DESCRIPTION
This PR iterates over #2024 by first, disabling Sliding Sync caching in `RoomList`. Second, it makes `Room::timeline` and `Room::sneaky_timeline` lazy by using `async-once-cell`.