### PR TITLE
Update the name of a room during sliding sync processing.

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -20,7 +20,6 @@ use std::{
 use futures_util::stream::{self, StreamExt};
 use ruma::{
     api::client::sync::sync_events::v3::RoomSummary as RumaSummary,
-    event_id,
     events::{
         ignored_user_list::IgnoredUserListEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
@@ -728,7 +727,7 @@ impl RoomInfo {
     pub fn update_name(&mut self, name: String) {
         self.base_info.name = Some(MinimalStateEvent::Original(OriginalMinimalStateEvent {
             content: RoomNameEventContent::new(Some(name)),
-            event_id: Some(event_id!("$fake_event_id").to_owned()),
+            event_id: None,
         }));
     }
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -276,7 +276,7 @@ impl BaseClient {
 
 #[cfg(test)]
 mod test {
-    use ruma::{device_id, room_id, user_id, RoomId};
+    use ruma::{device_id, room_id, uint, user_id, RoomId};
 
     use super::*;
     use crate::SessionMeta;
@@ -294,10 +294,10 @@ mod test {
         let client = logged_in_client().await;
         let room_id = room_id!("!r:e.uk");
 
-        // When I send sliding sync response containing a room (with idenifiable data in
-        // joined_count)
+        // When I send sliding sync response containing a room (with identifiable data
+        // in joined_count)
         let mut room = v4::SlidingSyncRoom::new();
-        room.joined_count = Some(41.try_into().expect("Failed to make UInt"));
+        room.joined_count = Some(uint!(41));
         let response = response_with_room(room_id, room).await;
         client.process_sliding_sync(&response).await.expect("Failed to process sync");
 


### PR DESCRIPTION
Update the name of a room during sliding sync processing.

I am very unfamiliar with this code, so I may have done it wrong in multiple ways.

The most dodgy part to me is creating a fake event to hold the name of the room. Is there a better way?

Edit from @Hywan: Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1980.