### PR TITLE
Clean up timeline unit tests

### DIFF
--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -46,6 +46,7 @@ anyhow = { workspace = true }
 assert-json-diff = "2.0"
 assert_matches = { workspace = true }
 ctor = { workspace = true }
+eyeball-im-util = { workspace = true }
 matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 stream_assert = "0.1.0"

--- a/crates/matrix-sdk-ui/src/timeline/inner.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeSet;
 use std::{collections::HashMap, sync::Arc};
 
 use eyeball_im::{ObservableVector, VectorSubscriber};
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 use eyeball_im_util::{FilterMapVectorSubscriber, VectorExt};
 use imbl::Vector;
 use indexmap::IndexSet;
@@ -128,7 +128,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         (items, stream)
     }
 
-    #[cfg(feature = "testing")]
+    #[cfg(any(test, feature = "testing"))]
     pub(super) async fn subscribe_filter_map<U, F>(
         &self,
         f: F,

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -72,7 +72,7 @@ async fn initial_events() {
 #[async_test]
 async fn sticker() {
     let timeline = TestTimeline::new();
-    let mut stream = timeline.subscribe().await;
+    let mut stream = timeline.subscribe_events().await;
 
     timeline
         .handle_live_custom_event(json!({
@@ -93,17 +93,14 @@ async fn sticker() {
         }))
         .await;
 
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::Sticker(_));
+    assert_matches!(item.content(), TimelineItemContent::Sticker(_));
 }
 
 #[async_test]
 async fn room_member() {
     let timeline = TestTimeline::new();
-    let mut stream = timeline.subscribe().await;
+    let mut stream = timeline.subscribe_events().await;
 
     let mut first_room_member_content = RoomMemberEventContent::new(MembershipState::Invite);
     first_room_member_content.displayname = Some("Alice".to_owned());
@@ -116,11 +113,9 @@ async fn room_member() {
         )
         .await;
 
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let membership = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::MembershipChange(ev) => ev);
+    let membership =
+        assert_matches!(item.content(), TimelineItemContent::MembershipChange(ev) => ev);
     assert_matches!(membership.content(), FullStateEventContent::Original { .. });
     assert_matches!(membership.change(), Some(MembershipChange::Invited));
 
@@ -136,7 +131,8 @@ async fn room_member() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let membership = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::MembershipChange(ev) => ev);
+    let membership =
+        assert_matches!(item.content(), TimelineItemContent::MembershipChange(ev) => ev);
     assert_matches!(membership.content(), FullStateEventContent::Original { .. });
     assert_matches!(membership.change(), Some(MembershipChange::InvitationAccepted));
 
@@ -152,7 +148,7 @@ async fn room_member() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let profile = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::ProfileChange(ev) => ev);
+    let profile = assert_matches!(item.content(), TimelineItemContent::ProfileChange(ev) => ev);
     assert_matches!(profile.displayname_change(), Some(_));
     assert_matches!(profile.avatar_url_change(), None);
 
@@ -165,7 +161,8 @@ async fn room_member() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let membership = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::MembershipChange(ev) => ev);
+    let membership =
+        assert_matches!(item.content(), TimelineItemContent::MembershipChange(ev) => ev);
     assert_matches!(membership.content(), FullStateEventContent::Redacted(_));
     assert_matches!(membership.change(), None);
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -14,7 +14,6 @@
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use futures_util::StreamExt;
 use matrix_sdk_test::async_test;
 use ruma::{
     assign,
@@ -28,6 +27,7 @@ use ruma::{
     server_name, EventId,
 };
 use serde_json::json;
+use stream_assert::assert_next_matches;
 
 use super::{TestTimeline, ALICE};
 use crate::timeline::TimelineItemContent;
@@ -40,9 +40,8 @@ async fn live_redacted() {
     timeline
         .handle_live_redacted_message_event(*ALICE, RedactedRoomMessageEventContent::new())
         .await;
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
     let redacted_event_id = item.as_event().unwrap().event_id().unwrap();
 
@@ -72,10 +71,9 @@ async fn live_sanitized() {
         )
         .await;
 
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let first_event = item.as_event().unwrap();
     let message = assert_matches!(first_event.content(), TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
@@ -100,8 +98,7 @@ async fn live_sanitized() {
     );
     timeline.handle_live_message_event(&ALICE, edit).await;
 
-    let item =
-        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+    let item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
     let first_event = item.as_event().unwrap();
     let message = assert_matches!(first_event.content(), TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
@@ -155,9 +152,8 @@ async fn aggregated_sanitized() {
     });
     timeline.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
 
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let first_event = item.as_event().unwrap();
     let message = assert_matches!(first_event.content(), TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -18,7 +18,6 @@ use std::{collections::BTreeSet, io::Cursor, iter};
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use futures_util::StreamExt;
 use matrix_sdk::crypto::{decrypt_room_key_export, OlmMachine};
 use matrix_sdk_test::async_test;
 use ruma::{
@@ -29,6 +28,7 @@ use ruma::{
     },
     room_id, user_id,
 };
+use stream_assert::assert_next_matches;
 
 use super::{TestTimeline, BOB};
 use crate::timeline::{EncryptedMessage, TimelineItemContent};
@@ -80,9 +80,8 @@ async fn retry_message_decryption() {
 
     assert_eq!(timeline.inner.items().await.len(), 2);
 
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event = item.as_event().unwrap();
     let session_id = assert_matches!(
         event.content(),
@@ -109,8 +108,7 @@ async fn retry_message_decryption() {
 
     assert_eq!(timeline.inner.items().await.len(), 2);
 
-    let item =
-        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+    let item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
     let event = item.as_event().unwrap();
     assert_matches!(event.encryption_info(), Some(_));
     let text = assert_matches!(event.content(), TimelineItemContent::Message(msg) => msg.body());
@@ -372,9 +370,8 @@ async fn retry_message_decryption_highlighted() {
 
     assert_eq!(timeline.inner.items().await.len(), 2);
 
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event = item.as_event().unwrap();
     let session_id = assert_matches!(
         event.content(),
@@ -401,8 +398,7 @@ async fn retry_message_decryption_highlighted() {
 
     assert_eq!(timeline.inner.items().await.len(), 2);
 
-    let item =
-        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+    let item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
     let event = item.as_event().unwrap();
     assert_matches!(event.encryption_info(), Some(_));
     let text = assert_matches!(event.content(), TimelineItemContent::Message(msg) => msg.body());

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -14,7 +14,6 @@
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use futures_util::StreamExt;
 use matrix_sdk_test::async_test;
 use ruma::{
     assign,
@@ -26,6 +25,7 @@ use ruma::{
     uint, MilliSecondsSinceUnixEpoch,
 };
 use serde_json::json;
+use stream_assert::assert_next_matches;
 
 use super::{TestTimeline, ALICE, BOB};
 use crate::timeline::TimelineItemContent;
@@ -36,7 +36,7 @@ async fn invalid_edit() {
     let mut stream = timeline.subscribe_events().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("test")).await;
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let msg = item.content().as_message().unwrap();
     assert_eq!(msg.body(), "test");
 
@@ -73,7 +73,7 @@ async fn invalid_event_content() {
         }))
         .await;
 
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_eq!(item.sender(), "@alice:example.org");
     assert_eq!(item.event_id().unwrap(), "$eeG0HA0FAZ37wP8kXlNkxx3I");
     assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(10)));
@@ -96,7 +96,7 @@ async fn invalid_event_content() {
         }))
         .await;
 
-    let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_eq!(item.sender(), "@alice:example.org");
     assert_eq!(item.event_id().unwrap(), "$d5G0HA0FAZ37wP8kXlNkxx3I");
     assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(2179)));

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -33,17 +33,14 @@ use crate::timeline::TimelineItemContent;
 #[async_test]
 async fn invalid_edit() {
     let timeline = TestTimeline::new();
-    let mut stream = timeline.subscribe().await;
+    let mut stream = timeline.subscribe_events().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("test")).await;
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event = item.as_event().unwrap();
-    let msg = event.content().as_message().unwrap();
+    let msg = item.content().as_message().unwrap();
     assert_eq!(msg.body(), "test");
 
-    let msg_event_id = event.event_id().unwrap();
+    let msg_event_id = item.event_id().unwrap();
 
     let edit = assign!(RoomMessageEventContent::text_plain(" * fake"), {
         relates_to: Some(message::Relation::Replacement(Replacement::new(
@@ -62,7 +59,7 @@ async fn invalid_edit() {
 #[async_test]
 async fn invalid_event_content() {
     let timeline = TestTimeline::new();
-    let mut stream = timeline.subscribe().await;
+    let mut stream = timeline.subscribe_events().await;
 
     // m.room.message events must have a msgtype and body in content, so this
     // event with an empty content object should fail to deserialize.
@@ -76,15 +73,12 @@ async fn invalid_event_content() {
         }))
         .await;
 
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event_item = item.as_event().unwrap();
-    assert_eq!(event_item.sender(), "@alice:example.org");
-    assert_eq!(event_item.event_id().unwrap(), "$eeG0HA0FAZ37wP8kXlNkxx3I");
-    assert_eq!(event_item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(10)));
+    assert_eq!(item.sender(), "@alice:example.org");
+    assert_eq!(item.event_id().unwrap(), "$eeG0HA0FAZ37wP8kXlNkxx3I");
+    assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(10)));
     let event_type = assert_matches!(
-        event_item.content(),
+        item.content(),
         TimelineItemContent::FailedToParseMessageLike { event_type, .. } => event_type
     );
     assert_eq!(*event_type, MessageLikeEventType::RoomMessage);
@@ -103,12 +97,11 @@ async fn invalid_event_content() {
         .await;
 
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event_item = item.as_event().unwrap();
-    assert_eq!(event_item.sender(), "@alice:example.org");
-    assert_eq!(event_item.event_id().unwrap(), "$d5G0HA0FAZ37wP8kXlNkxx3I");
-    assert_eq!(event_item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(2179)));
+    assert_eq!(item.sender(), "@alice:example.org");
+    assert_eq!(item.event_id().unwrap(), "$d5G0HA0FAZ37wP8kXlNkxx3I");
+    assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(2179)));
     let (event_type, state_key) = assert_matches!(
-        event_item.content(),
+        item.content(),
         TimelineItemContent::FailedToParseState {
             event_type,
             state_key,

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -45,7 +45,7 @@ use ruma::{
 };
 use serde_json::{json, Value as JsonValue};
 
-use super::{traits::RoomDataProvider, Profile, TimelineInner, TimelineItem};
+use super::{traits::RoomDataProvider, EventTimelineItem, Profile, TimelineInner, TimelineItem};
 
 mod basic;
 mod echo;
@@ -77,6 +77,13 @@ impl TestTimeline {
 
     async fn subscribe(&self) -> impl Stream<Item = VectorDiff<Arc<TimelineItem>>> {
         let (items, stream) = self.inner.subscribe().await;
+        assert_eq!(items.len(), 0, "Please subscribe to TestTimeline before adding items to it");
+        stream
+    }
+
+    async fn subscribe_events(&self) -> impl Stream<Item = VectorDiff<EventTimelineItem>> {
+        let (items, stream) =
+            self.inner.subscribe_filter_map(|item| item.as_event().cloned()).await;
         assert_eq!(items.len(), 0, "Please subscribe to TestTimeline before adding items to it");
         stream
     }

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -28,33 +28,28 @@ use super::{TestTimeline, ALICE, BOB};
 #[async_test]
 async fn reaction_redaction() {
     let timeline = TestTimeline::new();
-    let mut stream = timeline.subscribe().await;
+    let mut stream = timeline.subscribe_events().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("hi!")).await;
-    let _day_divider =
-        assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     let item = assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-    let event = item.as_event().unwrap();
-    assert_eq!(event.reactions().len(), 0);
+    assert_eq!(item.reactions().len(), 0);
 
-    let msg_event_id = event.event_id().unwrap();
+    let msg_event_id = item.event_id().unwrap();
 
     let rel = Annotation::new(msg_event_id.to_owned(), "+1".to_owned());
     timeline.handle_live_message_event(&BOB, ReactionEventContent::new(rel)).await;
     let item =
-        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    let event = item.as_event().unwrap();
-    assert_eq!(event.reactions().len(), 1);
+        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 0, value }) => value);
+    assert_eq!(item.reactions().len(), 1);
 
     // TODO: After adding raw timeline items, check for one here
 
-    let reaction_event_id = event.event_id().unwrap();
+    let reaction_event_id = item.event_id().unwrap();
 
     timeline.handle_live_redaction(&BOB, reaction_event_id).await;
     let item =
-        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-    let event = item.as_event().unwrap();
-    assert_eq!(event.reactions().len(), 0);
+        assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 0, value }) => value);
+    assert_eq!(item.reactions().len(), 0);
 }
 
 #[async_test]


### PR DESCRIPTION
- A little more concise and thus easier to read
- The stream not yielding an item immediately will cause failure, instead of making the test hang