### PR TITLE
In sliding sync, handle required state in invited rooms as well as joined

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -276,7 +276,14 @@ impl BaseClient {
 
 #[cfg(test)]
 mod test {
-    use ruma::{device_id, room_id, uint, user_id, RoomId};
+    use ruma::{
+        device_id, event_id,
+        events::{room::avatar::RoomAvatarEventContent, StateEventContent},
+        mxc_uri, room_id,
+        serde::Raw,
+        uint, user_id, MxcUri, RoomId, UserId,
+    };
+    use serde_json::{json, Value as JsonValue};
 
     use super::*;
     use crate::SessionMeta;
@@ -324,6 +331,26 @@ mod test {
         assert_eq!(client_room.name(), Some("little room".to_owned()));
     }
 
+    #[tokio::test]
+    async fn avatar_is_found_when_processing_sliding_sync_response() {
+        // Given a logged-in client
+        let client = logged_in_client().await;
+        let room_id = room_id!("!r:e.uk");
+        let user_id = user_id!("@u:e.uk");
+
+        // When I send sliding sync response containing a room with an avatar
+        let room = room_with_avatar(mxc_uri!("mxc://e.uk/med1"), user_id);
+        let response = response_with_room(room_id, room).await;
+        client.process_sliding_sync(&response).await.expect("Failed to process sync");
+
+        // Then the room in the client has the avatar
+        let client_room = client.get_room(room_id).expect("No room found");
+        assert_eq!(
+            client_room.avatar_url().expect("No avatar URL").media_id().expect("No media ID"),
+            "med1"
+        );
+    }
+
     async fn logged_in_client() -> BaseClient {
         let client = BaseClient::new();
         client
@@ -340,5 +367,43 @@ mod test {
         let mut response = v4::Response::new("5".to_owned());
         response.rooms.insert(room_id.to_owned(), room);
         response
+    }
+
+    fn room_with_avatar(avatar_uri: &MxcUri, user_id: &UserId) -> v4::SlidingSyncRoom {
+        let mut room = v4::SlidingSyncRoom::new();
+
+        let mut avatar_event_content = RoomAvatarEventContent::new();
+        avatar_event_content.url = Some(avatar_uri.to_owned());
+
+        room.required_state.push(
+            Raw::new(&make_state_event(user_id, "", avatar_event_content, None))
+                .expect("Failed to create state event")
+                .cast(),
+        );
+
+        room
+    }
+
+    fn make_state_event<C: StateEventContent>(
+        sender: &UserId,
+        state_key: &str,
+        content: C,
+        prev_content: Option<C>,
+    ) -> JsonValue {
+        let unsigned = if let Some(prev_content) = prev_content {
+            json!({ "prev_content": prev_content })
+        } else {
+            json!({})
+        };
+
+        json!({
+            "type": content.event_type(),
+            "state_key": state_key,
+            "content": content,
+            "event_id": event_id!("$evt"),
+            "sender": sender,
+            "origin_server_ts": 10,
+            "unsigned": unsigned,
+        })
     }
 }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -104,7 +104,7 @@ impl BaseClient {
         let mut new_rooms = Rooms::default();
 
         for (room_id, room_data) in rooms {
-            let (room_to_add, joined_room, invited_room) = self
+            let (room_to_store, joined_room, invited_room) = self
                 .process_sliding_sync_room(
                     room_id,
                     room_data,
@@ -114,8 +114,8 @@ impl BaseClient {
                     account_data,
                 )
                 .await?;
-            if let Some(room_to_add) = room_to_add {
-                changes.add_room(room_to_add);
+            if let Some(room_to_store) = room_to_store {
+                changes.add_room(room_to_store);
             }
             if let Some(joined_room) = joined_room {
                 new_rooms.join.insert(room_id.clone(), joined_room);
@@ -198,7 +198,7 @@ impl BaseClient {
             let mut room_info = room.clone_info();
             room_info.mark_state_partially_synced();
 
-            let room_to_add = if let Some(r) = store.get_room(room_id) {
+            let room_to_store = if let Some(r) = store.get_room(room_id) {
                 let mut room_info = r.clone_info();
                 room_info.mark_as_invited(); // FIXME: this might not be accurate
                 room_info.mark_state_partially_synced();
@@ -211,7 +211,7 @@ impl BaseClient {
 
             let invited_room = v3::InvitedRoom::from(v3::InviteState::from(invite_state.clone()));
 
-            Ok((room_to_add, None, Some(invited_room)))
+            Ok((room_to_store, None, Some(invited_room)))
         } else {
             let room = store.get_or_create_room(room_id, RoomState::Joined).await;
             let mut room_info = room.clone_info();


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1771

I suggest reviewing commit by commit. Includes a refactor to extract the relevant code into a (slightly) shorter method.

In the previous code, if we were dealing with an invited room we never called `self.handle_state` to process the `required_state` that was included with this room. Now, we do.

The code could still do with some refactoring, which I will do in a later PR.

Applies on top of https://github.com/matrix-org/matrix-rust-sdk/pull/2032