### PR TITLE
Tidy sliding sync processing code

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -276,7 +276,14 @@ impl BaseClient {
 
 #[cfg(test)]
 mod test {
-    use ruma::{device_id, room_id, uint, user_id, RoomId};
+    use ruma::{
+        device_id, event_id,
+        events::{room::avatar::RoomAvatarEventContent, StateEventContent},
+        mxc_uri, room_id,
+        serde::Raw,
+        uint, user_id, MxcUri, RoomId, UserId,
+    };
+    use serde_json::{json, Value as JsonValue};
 
     use super::*;
     use crate::SessionMeta;
@@ -324,6 +331,26 @@ mod test {
         assert_eq!(client_room.name(), Some("little room".to_owned()));
     }
 
+    #[tokio::test]
+    async fn avatar_is_found_when_processing_sliding_sync_response() {
+        // Given a logged-in client
+        let client = logged_in_client().await;
+        let room_id = room_id!("!r:e.uk");
+        let user_id = user_id!("@u:e.uk");
+
+        // When I send sliding sync response containing a room with an avatar
+        let room = room_with_avatar(mxc_uri!("mxc://e.uk/med1"), user_id);
+        let response = response_with_room(room_id, room).await;
+        client.process_sliding_sync(&response).await.expect("Failed to process sync");
+
+        // Then the room in the client has the avatar
+        let client_room = client.get_room(room_id).expect("No room found");
+        assert_eq!(
+            client_room.avatar_url().expect("No avatar URL").media_id().expect("No media ID"),
+            "med1"
+        );
+    }
+
     async fn logged_in_client() -> BaseClient {
         let client = BaseClient::new();
         client
@@ -340,5 +367,43 @@ mod test {
         let mut response = v4::Response::new("5".to_owned());
         response.rooms.insert(room_id.to_owned(), room);
         response
+    }
+
+    fn room_with_avatar(avatar_uri: &MxcUri, user_id: &UserId) -> v4::SlidingSyncRoom {
+        let mut room = v4::SlidingSyncRoom::new();
+
+        let mut avatar_event_content = RoomAvatarEventContent::new();
+        avatar_event_content.url = Some(avatar_uri.to_owned());
+
+        room.required_state.push(
+            Raw::new(&make_state_event(user_id, "", avatar_event_content, None))
+                .expect("Failed to create state event")
+                .cast(),
+        );
+
+        room
+    }
+
+    fn make_state_event<C: StateEventContent>(
+        sender: &UserId,
+        state_key: &str,
+        content: C,
+        prev_content: Option<C>,
+    ) -> JsonValue {
+        let unsigned = if let Some(prev_content) = prev_content {
+            json!({ "prev_content": prev_content })
+        } else {
+            json!({})
+        };
+
+        json!({
+            "type": content.event_type(),
+            "state_key": state_key,
+            "content": content,
+            "event_id": event_id!("$evt"),
+            "sender": sender,
+            "origin_server_ts": 10,
+            "unsigned": unsigned,
+        })
     }
 }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -193,22 +193,24 @@ impl BaseClient {
         ambiguity_cache: &mut AmbiguityCache,
         account_data: &AccountData,
     ) -> Result<(Option<RoomInfo>, Option<JoinedRoom>, Option<InvitedRoom>)> {
-        // If any invite_state exists, we take it to mean that we are invited to this room
-        // https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#room-list-parameters
+        // If any invite_state exists, we take it to mean that we are invited to this
+        // room https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#room-list-parameters
         if let Some(invite_state) = &room_data.invite_state {
             let room = store.get_or_create_stripped_room(room_id).await;
             let mut room_info = room.clone_info();
             room_info.mark_state_partially_synced();
 
-            // We don't actually know what events are inside invite_state. In theory, they might
-            // not contain an m.room.member event, or they might set the membership to something
-            // other than invite. This would be very weird behaviour by the server, because
-            // invite_state is supposed to contain an m.room.member.
-            // Later, we will call handle_invited_state, which will reflect any information found
-            // in the real events inside invite_state, but we default to considering this room
-            // invited simply because invite_state exists. This is needed in the normal case,
-            // because the sliding sync server tries to send minimal state, meaning that we
-            // normally actually just receive {"type": "m.room.member"} with no content at all.
+            // We don't actually know what events are inside invite_state. In theory, they
+            // might not contain an m.room.member event, or they might set the
+            // membership to something other than invite. This would be very
+            // weird behaviour by the server, because invite_state is supposed
+            // to contain an m.room.member. Later, we will call
+            // handle_invited_state, which will reflect any information found in
+            // the real events inside invite_state, but we default to considering this room
+            // invited simply because invite_state exists. This is needed in the normal
+            // case, because the sliding sync server tries to send minimal
+            // state, meaning that we normally actually just receive {"type":
+            // "m.room.member"} with no content at all.
             room_info.mark_as_invited();
 
             room_info.mark_state_partially_synced();
@@ -232,9 +234,10 @@ impl BaseClient {
             let room = store.get_or_create_room(room_id, RoomState::Joined).await;
             let mut room_info = room.clone_info();
 
-            // We default to considering this room joined if it's not an invite, but we expect to
-            // find a m.room.member event in the required_state, so this should get fixed to the
-            // real correct value when we call self.handle_state below.
+            // We default to considering this room joined if it's not an invite, but we
+            // expect to find a m.room.member event in the required_state, so
+            // this should get fixed to the real correct value when we call
+            // self.handle_state below.
             room_info.mark_as_joined();
 
             room_info.mark_state_partially_synced();
@@ -526,8 +529,8 @@ mod test {
     }
 
     fn set_room_invited(room: &mut v4::SlidingSyncRoom) {
-        // MSC3575 shows an almost-empty event to indicate that we are invited to a room.
-        // Just the type is supplied.
+        // MSC3575 shows an almost-empty event to indicate that we are invited to a
+        // room. Just the type is supplied.
 
         let evt = Raw::new(&json!({
             "type": "m.room.member",

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -104,7 +104,7 @@ impl BaseClient {
         let mut new_rooms = Rooms::default();
 
         for (room_id, room_data) in rooms {
-            let (room_to_add, joined_room, invited_room) = self
+            let (room_to_store, joined_room, invited_room) = self
                 .process_sliding_sync_room(
                     room_id,
                     room_data,
@@ -114,8 +114,8 @@ impl BaseClient {
                     account_data,
                 )
                 .await?;
-            if let Some(room_to_add) = room_to_add {
-                changes.add_room(room_to_add);
+            if let Some(room_to_store) = room_to_store {
+                changes.add_room(room_to_store);
             }
             if let Some(joined_room) = joined_room {
                 new_rooms.join.insert(room_id.clone(), joined_room);
@@ -198,7 +198,7 @@ impl BaseClient {
             let mut room_info = room.clone_info();
             room_info.mark_state_partially_synced();
 
-            let room_to_add = if let Some(r) = store.get_room(room_id) {
+            let room_to_store = if let Some(r) = store.get_room(room_id) {
                 let mut room_info = r.clone_info();
                 room_info.mark_as_invited(); // FIXME: this might not be accurate
                 room_info.mark_state_partially_synced();
@@ -211,7 +211,7 @@ impl BaseClient {
 
             let invited_room = v3::InvitedRoom::from(v3::InviteState::from(invite_state.clone()));
 
-            Ok((room_to_add, None, Some(invited_room)))
+            Ok((room_to_store, None, Some(invited_room)))
         } else {
             let room = store.get_or_create_room(room_id, RoomState::Joined).await;
             let mut room_info = room.clone_info();


### PR DESCRIPTION
### Clarify in tests that invite_state contains very minimal JSON

Supply JSON similar to what is found in MSC3575 for `invite_state`

### Simplify invited room sliding sync processing

Added some comments based on my understanding of MSC3575. Previously we
had a FIXME about how we were setting the room state to invite or join
based on the presence or absence of the invite_state property. I think
this behaviour is correct, so I added some comments explaining why.

The functional change here is to note that we call
store.get_or_create_stripped_room to find/create the stripped room, and
this actually deletes any room of this ID that is in the store, so our
later call to store.get_room would always fall back to getting the
stripped room, which we already have, so there was no need to do the
get_room call at all.

Applies on top of https://github.com/matrix-org/matrix-rust-sdk/pull/2039