### PR TITLE
(WIP) Add a method to invalidate and reload crypto stores caches

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1008,6 +1008,10 @@ impl GossipMachine {
             }
         }
     }
+
+    pub(crate) fn invalidate_caches(&self) {
+        self.outbound_group_sessions.invalidate_caches();
+    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1728,6 +1728,26 @@ impl OlmMachine {
     pub fn backup_machine(&self) -> &BackupMachine {
         &self.inner.backup_machine
     }
+
+    /// Invalidates all the caches in the `OlmMachine`.
+    ///
+    /// This must be done if there's some other process that might have written
+    /// to the same database, if there's a suspicion this other process did
+    /// in fact write.
+    pub async fn invalidate_caches(&self) -> StoreResult<()> {
+        self.store().invalidate_caches().await?;
+
+        // TODO could the account be invalidated, and as such should it be reloaded in
+        // all the data structures too?
+        // TODO are there other cached fields? 😅
+
+        self.inner.group_session_manager.invalidate_caches();
+        self.inner.session_manager.invalidate_caches();
+
+        self.inner.key_request_machine.invalidate_caches();
+
+        Ok(())
+    }
 }
 
 #[cfg(any(feature = "testing", test))]

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -110,6 +110,11 @@ impl GroupSessionCache {
     ) -> Option<OutboundGroupSession> {
         self.get_or_load(room_id).await.filter(|o| session_id == o.session_id())
     }
+
+    pub(crate) fn invalidate_caches(&self) {
+        self.sessions.clear();
+        self.sessions_being_shared.clear();
+    }
 }
 
 /// Returned by `collect_session_recipients`.
@@ -842,6 +847,10 @@ impl GroupSessionManager {
         }
 
         Ok(requests)
+    }
+
+    pub(crate) fn invalidate_caches(&self) {
+        self.sessions.invalidate_caches();
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -431,6 +431,10 @@ impl SessionManager {
 
         Ok(())
     }
+
+    pub(crate) fn invalidate_caches(&self) {
+        self.key_request_machine.invalidate_caches();
+    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -71,6 +71,11 @@ impl SessionStore {
     pub fn set_for_sender(&self, sender_key: &str, sessions: Vec<Session>) {
         self.entries.insert(sender_key.to_owned(), Arc::new(Mutex::new(sessions)));
     }
+
+    /// Clears all the session entries in the list of sessions.
+    pub fn clear(&self) {
+        self.entries.clear();
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -311,6 +311,11 @@ impl CryptoStore for MemoryStore {
         warn!("Method not implemented");
         Ok(())
     }
+
+    async fn invalidate_caches(&self) -> Result<()> {
+        warn!("Method invalidate_caches not implemented");
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -38,6 +38,9 @@ pub trait CryptoStore: AsyncTraitDeps {
     /// The error type used by this crypto store.
     type Error: fmt::Debug + Into<CryptoStoreError>;
 
+    /// Force invalidating the in-memory caches used by this store, if any.
+    async fn invalidate_caches(&self) -> Result<(), Self::Error>;
+
     /// Load an account that was previously stored.
     async fn load_account(&self) -> Result<Option<ReadOnlyAccount>, Self::Error>;
 
@@ -371,6 +374,10 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
 
     async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error> {
         self.0.set_custom_value(key, value).await.map_err(Into::into)
+    }
+
+    async fn invalidate_caches(&self) -> Result<()> {
+        self.0.invalidate_caches().await.map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
This will be useful in the context of having multiple notification sync loops running at the same time: after one sync loop has taken "the lock" to get a hold onto the database, they'll need to make sure to invalidate internal caches, in case the other sync loop has written something. Of course, invalidating might not need to happen every single time, only if a write happened; that's a different concern for later.

There's more than the `CryptoStore` implementations, though; other `OlmMachine`'s fields seem to keep data in cache. I've put some `TODO`s with questions in the code, and I'm actually thinking that this might not be the right approach; maybe we should refactor the code such that there's only one single, mutably shared data structure used for caching everywhere. Or some other approach (maybe get rid of some caches?). @poljar what do you think?