### PR TITLE
Do not separate stripped and non-stripped room info 

### DIFF
--- a/benchmarks/benches/store_bench.rs
+++ b/benchmarks/benches/store_bench.rs
@@ -37,7 +37,7 @@ pub fn restore_session(c: &mut Criterion) {
 
     for i in 0..NUM_STRIPPED_JOINED_ROOMS {
         let room_id = RoomId::parse(format!("!strippedroom{i}:example.com")).unwrap().to_owned();
-        changes.add_stripped_room(RoomInfo::new(&room_id, RoomState::Joined));
+        changes.add_room(RoomInfo::new(&room_id, RoomState::Invited));
     }
 
     let session = Session {

--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -21,6 +21,8 @@
   - `can_send_state`
   - `can_trigger_room_notification`
 - Move `StateStore::get_member_event` to `StateStoreExt`
+- `StateStore::get_stripped_room_infos` is deprecated. All room infos should now be returned by
+  `get_room_infos`.
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/Changelog.md
+++ b/crates/matrix-sdk-base/Changelog.md
@@ -23,6 +23,8 @@
 - Move `StateStore::get_member_event` to `StateStoreExt`
 - `StateStore::get_stripped_room_infos` is deprecated. All room infos should now be returned by
   `get_room_infos`.
+- `BaseClient::get_stripped_rooms` is deprecated. Use `get_rooms_filtered` with
+  `RoomStateFilter::INVITED` instead.
 
 ## 0.5.1
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -65,7 +65,7 @@ use crate::{
         StateStoreDataKey, StateStoreDataValue, StateStoreExt, Store, StoreConfig,
     },
     sync::{JoinedRoom, LeftRoom, Rooms, SyncResponse, Timeline},
-    Session, SessionMeta, SessionTokens,
+    RoomStateFilter, Session, SessionMeta, SessionTokens,
 };
 #[cfg(feature = "e2e-encryption")]
 use crate::{error::Error, RoomMemberships};
@@ -166,6 +166,11 @@ impl BaseClient {
     /// Get all the rooms this client knows about.
     pub fn get_rooms(&self) -> Vec<Room> {
         self.store.get_rooms()
+    }
+
+    /// Get all the rooms this client knows about, filtered by room state.
+    pub fn get_rooms_filtered(&self, filter: RoomStateFilter) -> Vec<Room> {
+        self.store.get_rooms_filtered(filter)
     }
 
     /// Lookup the Room for the given RoomId, or create one, if it didn't exist

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -181,7 +181,7 @@ impl BaseClient {
 
     /// Get all the rooms this client knows about.
     pub fn get_stripped_rooms(&self) -> Vec<Room> {
-        self.store.get_stripped_rooms()
+        self.get_rooms_filtered(RoomStateFilter::INVITED)
     }
 
     /// Get a reference to the store.
@@ -839,15 +839,10 @@ impl BaseClient {
         }
 
         for (room_id, new_info) in response.rooms.invite {
-            let room = self.store.get_or_create_stripped_room(&room_id).await;
+            let room = self.store.get_or_create_room(&room_id, RoomState::Invited).await;
             let mut room_info = room.clone_info();
-
-            if let Some(r) = self.store.get_room(&room_id) {
-                let mut room_info = r.clone_info();
-                room_info.mark_as_invited();
-                room_info.mark_state_fully_synced();
-                changes.add_room(room_info);
-            }
+            room_info.mark_as_invited();
+            room_info.mark_state_fully_synced();
 
             self.handle_invited_state(&new_info.invite_state.events, &mut room_info, &mut changes);
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -180,6 +180,7 @@ impl BaseClient {
     }
 
     /// Get all the rooms this client knows about.
+    #[deprecated = "Use get_rooms_filtered with RoomStateFilter::INVITED instead."]
     pub fn get_stripped_rooms(&self) -> Vec<Room> {
         self.get_rooms_filtered(RoomStateFilter::INVITED)
     }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -846,7 +846,7 @@ impl BaseClient {
 
             self.handle_invited_state(&new_info.invite_state.events, &mut room_info, &mut changes);
 
-            changes.add_stripped_room(room_info);
+            changes.add_room(room_info);
 
             new_rooms.invite.insert(room_id, new_info);
         }
@@ -901,12 +901,6 @@ impl BaseClient {
         }
         for (room_id, room_info) in &changes.room_infos {
             if let Some(room) = self.store.get_room(room_id) {
-                room.update_summary(room_info.clone())
-            }
-        }
-
-        for (room_id, room_info) in &changes.stripped_room_infos {
-            if let Some(room) = self.store.get_stripped_room(room_id) {
                 room.update_summary(room_info.clone())
             }
         }

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -43,7 +43,9 @@ pub use http;
 #[cfg(feature = "e2e-encryption")]
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
-pub use rooms::{DisplayName, Room, RoomInfo, RoomMember, RoomMemberships, RoomState};
+pub use rooms::{
+    DisplayName, Room, RoomInfo, RoomMember, RoomMemberships, RoomState, RoomStateFilter,
+};
 pub use store::{StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError};
 pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -7,7 +7,7 @@ use std::{collections::HashSet, fmt};
 
 use bitflags::bitflags;
 pub use members::RoomMember;
-pub use normal::{Room, RoomInfo, RoomState};
+pub use normal::{Room, RoomInfo, RoomState, RoomStateFilter};
 use ruma::{
     assign,
     events::{

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -278,7 +278,7 @@ impl BaseClient {
         changes: &mut StateChanges,
     ) -> (Room, RoomInfo, Option<InvitedRoom>) {
         if let Some(invite_state) = &room_data.invite_state {
-            let room = store.get_or_create_stripped_room(room_id).await;
+            let room = store.get_or_create_room(room_id, RoomState::Invited).await;
             let mut room_info = room.clone_info();
 
             // We don't actually know what events are inside invite_state. In theory, they

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -307,11 +307,9 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert!(self.get_kv_data(StateStoreDataKey::SyncToken).await?.is_some());
         assert!(self.get_presence_event(user_id).await?.is_some());
         assert_eq!(self.get_room_infos().await?.len(), 2, "Expected to find 2 room infos");
-        assert_eq!(
-            self.get_stripped_room_infos().await?.len(),
-            1,
-            "Expected to find 1 stripped room info"
-        );
+        #[allow(deprecated)]
+        let stripped_rooms = self.get_stripped_room_infos().await?;
+        assert_eq!(stripped_rooms.len(), 1, "Expected to find 1 stripped room info");
         assert!(self
             .get_account_data_event(GlobalAccountDataEventType::PushRules)
             .await?
@@ -740,7 +738,9 @@ impl StateStoreIntegrationTests for DynStateStore {
     async fn test_persist_invited_room(&self) -> Result<()> {
         self.populate().await?;
 
-        assert_eq!(self.get_stripped_room_infos().await?.len(), 1);
+        #[allow(deprecated)]
+        let stripped_rooms = self.get_stripped_room_infos().await?;
+        assert_eq!(stripped_rooms.len(), 1);
 
         Ok(())
     }
@@ -751,7 +751,9 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         assert!(self.get_member_event(room_id, user_id).await.unwrap().is_none());
         assert_eq!(self.get_room_infos().await.unwrap().len(), 0);
-        assert_eq!(self.get_stripped_room_infos().await.unwrap().len(), 0);
+        #[allow(deprecated)]
+        let stripped_rooms = self.get_stripped_room_infos().await?;
+        assert_eq!(stripped_rooms.len(), 0);
 
         let mut changes = StateChanges::default();
         changes
@@ -768,7 +770,9 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_member_event(room_id, user_id).await.unwrap().unwrap().deserialize().unwrap();
         assert!(matches!(member_event, MemberEvent::Sync(_)));
         assert_eq!(self.get_room_infos().await.unwrap().len(), 1);
-        assert_eq!(self.get_stripped_room_infos().await.unwrap().len(), 0);
+        #[allow(deprecated)]
+        let stripped_rooms = self.get_stripped_room_infos().await?;
+        assert_eq!(stripped_rooms.len(), 0);
 
         let members = self.get_user_ids(room_id, RoomMemberships::empty()).await.unwrap();
         assert_eq!(members, vec![user_id.to_owned()]);
@@ -782,7 +786,9 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_member_event(room_id, user_id).await.unwrap().unwrap().deserialize().unwrap();
         assert!(matches!(member_event, MemberEvent::Stripped(_)));
         assert_eq!(self.get_room_infos().await.unwrap().len(), 1);
-        assert_eq!(self.get_stripped_room_infos().await.unwrap().len(), 1);
+        #[allow(deprecated)]
+        let stripped_rooms = self.get_stripped_room_infos().await?;
+        assert_eq!(stripped_rooms.len(), 1);
 
         let members = self.get_user_ids(room_id, RoomMemberships::empty()).await.unwrap();
         assert_eq!(members, vec![user_id.to_owned()]);
@@ -800,7 +806,9 @@ impl StateStoreIntegrationTests for DynStateStore {
         self.remove_room(room_id).await?;
 
         assert_eq!(self.get_room_infos().await?.len(), 1, "room is still there");
-        assert_eq!(self.get_stripped_room_infos().await?.len(), 1);
+        #[allow(deprecated)]
+        let stripped_rooms = self.get_stripped_room_infos().await?;
+        assert_eq!(stripped_rooms.len(), 1);
 
         assert!(self.get_state_event(room_id, StateEventType::RoomName, "").await?.is_none());
         assert!(
@@ -853,7 +861,9 @@ impl StateStoreIntegrationTests for DynStateStore {
         self.remove_room(stripped_room_id).await?;
 
         assert!(self.get_room_infos().await?.is_empty(), "still room info found");
-        assert!(self.get_stripped_room_infos().await?.is_empty(), "still stripped room info found");
+        #[allow(deprecated)]
+        let stripped_rooms = self.get_stripped_room_infos().await?;
+        assert!(stripped_rooms.is_empty(), "still stripped room info found");
         Ok(())
     }
 }

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -182,7 +182,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             )]),
         );
 
-        changes.add_stripped_room(stripped_room);
+        changes.add_room(stripped_room);
 
         let stripped_member_json: &JsonValue = &test_json::MEMBER_STRIPPED;
         let stripped_member_event = Raw::new(&stripped_member_json.clone()).unwrap().cast();
@@ -306,7 +306,7 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         assert!(self.get_kv_data(StateStoreDataKey::SyncToken).await?.is_some());
         assert!(self.get_presence_event(user_id).await?.is_some());
-        assert_eq!(self.get_room_infos().await?.len(), 1, "Expected to find 1 room info");
+        assert_eq!(self.get_room_infos().await?.len(), 2, "Expected to find 2 room infos");
         assert_eq!(
             self.get_stripped_room_infos().await?.len(),
             1,
@@ -775,13 +775,13 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         let mut changes = StateChanges::default();
         changes.add_stripped_member(room_id, user_id, custom_stripped_membership_event(user_id));
-        changes.add_stripped_room(RoomInfo::new(room_id, RoomState::Invited));
+        changes.add_room(RoomInfo::new(room_id, RoomState::Invited));
         self.save_changes(&changes).await.unwrap();
 
         let member_event =
             self.get_member_event(room_id, user_id).await.unwrap().unwrap().deserialize().unwrap();
         assert!(matches!(member_event, MemberEvent::Stripped(_)));
-        assert_eq!(self.get_room_infos().await.unwrap().len(), 0);
+        assert_eq!(self.get_room_infos().await.unwrap().len(), 1);
         assert_eq!(self.get_stripped_room_infos().await.unwrap().len(), 1);
 
         let members = self.get_user_ids(room_id, RoomMemberships::empty()).await.unwrap();
@@ -799,7 +799,7 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         self.remove_room(room_id).await?;
 
-        assert!(self.get_room_infos().await?.is_empty(), "room is still there");
+        assert_eq!(self.get_room_infos().await?.len(), 1, "room is still there");
         assert_eq!(self.get_stripped_room_infos().await?.len(), 1);
 
         assert!(self.get_state_event(room_id, StateEventType::RoomName, "").await?.is_none());

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -347,9 +347,6 @@ pub struct StateChanges {
         OwnedRoomId,
         BTreeMap<StateEventType, BTreeMap<String, Raw<AnyStrippedStateEvent>>>,
     >,
-    /// A map of `RoomId` to `RoomInfo` for stripped rooms (e.g. for invites or
-    /// while knocking)
-    pub stripped_room_infos: BTreeMap<OwnedRoomId, RoomInfo>,
 
     /// A map from room id to a map of a display name and a set of user ids that
     /// share that display name in the given room.
@@ -372,11 +369,6 @@ impl StateChanges {
     /// Update the `StateChanges` struct with the given `RoomInfo`.
     pub fn add_room(&mut self, room: RoomInfo) {
         self.room_infos.insert(room.room_id.clone(), room);
-    }
-
-    /// Update the `StateChanges` struct with the given `RoomInfo`.
-    pub fn add_stripped_room(&mut self, room: RoomInfo) {
-        self.stripped_room_infos.insert(room.room_id.clone(), room);
     }
 
     /// Update the `StateChanges` struct with the given `AnyBasicEvent`.

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -146,7 +146,6 @@ pub(crate) struct Store {
     /// The current sync token that should be used for the next sync call.
     pub(super) sync_token: Arc<RwLock<Option<String>>>,
     rooms: Arc<DashMap<OwnedRoomId, Room>>,
-    stripped_rooms: Arc<DashMap<OwnedRoomId, Room>>,
     /// A lock to synchronize access to the store, such that data by the sync is
     /// never overwritten. The sync processing is supposed to use write access,
     /// such that only it is currently accessing the store overall. Other things
@@ -164,7 +163,6 @@ impl Store {
             session_tokens: Default::default(),
             sync_token: Default::default(),
             rooms: Default::default(),
-            stripped_rooms: Default::default(),
             sync_lock: Default::default(),
         }
     }
@@ -184,11 +182,6 @@ impl Store {
         for info in self.inner.get_room_infos().await? {
             let room = Room::restore(&session_meta.user_id, self.inner.clone(), info);
             self.rooms.insert(room.room_id().to_owned(), room);
-        }
-
-        for info in self.inner.get_stripped_room_infos().await? {
-            let room = Room::restore(&session_meta.user_id, self.inner.clone(), info);
-            self.stripped_rooms.insert(room.room_id().to_owned(), room);
         }
 
         let token =
@@ -240,53 +233,14 @@ impl Store {
 
     /// Get the room with the given room id.
     pub fn get_room(&self, room_id: &RoomId) -> Option<Room> {
-        self.rooms
-            .get(room_id)
-            .and_then(|r| match r.state() {
-                RoomState::Joined => Some(r.clone()),
-                RoomState::Left => Some(r.clone()),
-                RoomState::Invited => self.get_stripped_room(room_id),
-            })
-            .or_else(|| self.get_stripped_room(room_id))
-    }
-
-    /// Get all the rooms this store knows about.
-    pub fn get_stripped_rooms(&self) -> Vec<Room> {
-        self.stripped_rooms.iter().filter_map(|r| self.get_stripped_room(r.key())).collect()
-    }
-
-    /// Get the stripped room with the given room id.
-    pub fn get_stripped_room(&self, room_id: &RoomId) -> Option<Room> {
-        self.stripped_rooms.get(room_id).map(|r| r.clone())
-    }
-
-    /// Lookup the stripped Room for the given RoomId, or create one, if it
-    /// didn't exist yet in the store
-    pub async fn get_or_create_stripped_room(&self, room_id: &RoomId) -> Room {
-        let user_id =
-            &self.session_meta.get().expect("Creating room while not being logged in").user_id;
-
-        // Remove the respective room from non-stripped rooms.
-        self.rooms.remove(room_id);
-
-        self.stripped_rooms
-            .entry(room_id.to_owned())
-            .or_insert_with(|| Room::new(user_id, self.inner.clone(), room_id, RoomState::Invited))
-            .clone()
+        self.rooms.get(room_id).map(|r| r.clone())
     }
 
     /// Lookup the Room for the given RoomId, or create one, if it didn't exist
     /// yet in the store
     pub async fn get_or_create_room(&self, room_id: &RoomId, room_type: RoomState) -> Room {
-        if room_type == RoomState::Invited {
-            return self.get_or_create_stripped_room(room_id).await;
-        }
-
         let user_id =
             &self.session_meta.get().expect("Creating room while not being logged in").user_id;
-
-        // Remove the respective room from stripped rooms.
-        self.stripped_rooms.remove(room_id);
 
         self.rooms
             .entry(room_id.to_owned())
@@ -303,7 +257,6 @@ impl fmt::Debug for Store {
             .field("session_meta", &self.session_meta)
             .field("sync_token", &self.sync_token)
             .field("rooms", &self.rooms)
-            .field("stripped_rooms", &self.stripped_rooms)
             .finish_non_exhaustive()
     }
 }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -61,7 +61,7 @@ pub type BoxStream<T> = Pin<Box<dyn futures_util::Stream<Item = T> + Send>>;
 
 use crate::{
     rooms::{RoomInfo, RoomState},
-    MinimalRoomMemberEvent, Room, Session, SessionMeta, SessionTokens,
+    MinimalRoomMemberEvent, Room, RoomStateFilter, Session, SessionMeta, SessionTokens,
 };
 
 pub(crate) mod ambiguity_map;
@@ -227,6 +227,15 @@ impl Store {
     /// Get all the rooms this store knows about.
     pub fn get_rooms(&self) -> Vec<Room> {
         self.rooms.iter().filter_map(|r| self.get_room(r.key())).collect()
+    }
+
+    /// Get all the rooms this store knows about, filtered by state.
+    pub fn get_rooms_filtered(&self, filter: RoomStateFilter) -> Vec<Room> {
+        self.rooms
+            .iter()
+            .filter(|r| filter.matches(r.state()))
+            .filter_map(|r| self.get_room(r.key()))
+            .collect()
     }
 
     /// Get the room with the given room id.

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -153,6 +153,7 @@ pub trait StateStore: AsyncTraitDeps {
     async fn get_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error>;
 
     /// Get all the pure `RoomInfo`s the store knows about.
+    #[deprecated = "Use get_room_infos instead and filter by RoomState"]
     async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error>;
 
     /// Get all the users that use the given display name in the given room.
@@ -400,6 +401,7 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         self.0.get_room_infos().await.map_err(Into::into)
     }
 
+    #[allow(deprecated)]
     async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>, Self::Error> {
         self.0.get_stripped_room_infos().await.map_err(Into::into)
     }

--- a/crates/matrix-sdk-sqlite/migrations/state_store/002_a_create_new_room_info.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/002_a_create_new_room_info.sql
@@ -1,0 +1,6 @@
+-- The rooms are not filtered by stripped state anymore but by state.
+CREATE TABLE "new_room_info" (
+    "room_id" BLOB PRIMARY KEY NOT NULL,
+    "state" BLOB NOT NULL,
+    "data" BLOB NOT NULL
+);

--- a/crates/matrix-sdk-sqlite/migrations/state_store/002_b_replace_room_info.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/002_b_replace_room_info.sql
@@ -1,0 +1,6 @@
+-- After the data was migrated, we need to replace the old table with the new.
+DROP TABLE "room_info";
+ALTER TABLE "new_room_info" RENAME TO "room_info";
+
+CREATE INDEX "room_info_room_id_state"
+    ON "room_info" ("room_id", "state");

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -101,7 +101,7 @@ impl SqliteCryptoStore {
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
         let version = load_db_version(&conn).await?;
-        run_migrations(&conn, version).await.map_err(OpenStoreError::Migration)?;
+        run_migrations(&conn, version).await?;
         let store_cipher = match passphrase {
             Some(p) => Some(Arc::new(get_or_create_store_cipher(p, &conn).await?)),
             None => None,
@@ -196,7 +196,7 @@ impl SqliteCryptoStore {
 const DATABASE_VERSION: u8 = 6;
 
 /// Run migrations for the given version of the database.
-async fn run_migrations(conn: &SqliteConn, version: u8) -> rusqlite::Result<()> {
+async fn run_migrations(conn: &SqliteConn, version: u8) -> Result<()> {
     if version == 0 {
         debug!("Creating database");
     } else if version < DATABASE_VERSION {

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -46,7 +46,7 @@ pub enum OpenStoreError {
 
     /// Failed to apply migrations.
     #[error("Failed to run migrations")]
-    Migration(#[source] rusqlite::Error),
+    Migration(#[from] Error),
 
     /// Failed to get a DB connection from the pool.
     #[error(transparent)]

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -35,7 +35,7 @@ use tracing::{debug, warn};
 use crate::{
     error::{Error, Result},
     get_or_create_store_cipher,
-    utils::{chain, load_db_version, Key, SqliteObjectExt},
+    utils::{load_db_version, Key, SqliteObjectExt},
     OpenStoreError, SqliteObjectStoreExt,
 };
 
@@ -52,6 +52,8 @@ mod keys {
     pub const DISPLAY_NAME: &str = "display_name";
     pub const MEDIA: &str = "media";
 }
+
+const DATABASE_VERSION: u8 = 2;
 
 /// A sqlite based cryptostore.
 #[derive(Clone)]
@@ -78,10 +80,7 @@ impl SqliteStateStore {
         path: impl AsRef<Path>,
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
-        let path = path.as_ref();
-        fs::create_dir_all(path).await.map_err(OpenStoreError::CreateDir)?;
-        let cfg = deadpool_sqlite::Config::new(path.join("matrix-sdk-state.sqlite3"));
-        let pool = cfg.create_pool(Runtime::Tokio1)?;
+        let pool = create_pool(path.as_ref()).await?;
 
         Self::open_with_pool(pool, passphrase).await
     }
@@ -93,14 +92,75 @@ impl SqliteStateStore {
         passphrase: Option<&str>,
     ) -> Result<Self, OpenStoreError> {
         let conn = pool.get().await?;
-        let version = load_db_version(&conn).await?;
-        run_migrations(&conn, version).await.map_err(OpenStoreError::Migration)?;
+        let mut version = load_db_version(&conn).await?;
+
+        if version == 0 {
+            init(&conn).await?;
+            version = 1;
+        }
+
         let store_cipher = match passphrase {
             Some(p) => Some(Arc::new(get_or_create_store_cipher(p, &conn).await?)),
             None => None,
         };
+        let this = Self { store_cipher, path: None, pool };
+        this.run_migrations(&conn, version, None).await?;
 
-        Ok(Self { store_cipher, path: None, pool })
+        Ok(this)
+    }
+
+    /// Run database migrations from the given `from` version to the given `to`
+    /// version
+    ///
+    /// If `to` is `None`, the current database version will be used.
+    async fn run_migrations(&self, conn: &SqliteConn, from: u8, to: Option<u8>) -> Result<()> {
+        let to = to.unwrap_or(DATABASE_VERSION);
+
+        if from < to {
+            debug!(version = from, new_version = to, "Upgrading database");
+        } else {
+            return Ok(());
+        }
+
+        if from < 2 && to >= 2 {
+            let this = self.clone();
+            conn.with_transaction(move |txn| {
+                // Create new table.
+                txn.execute_batch(include_str!(
+                    "../migrations/state_store/002_a_create_new_room_info.sql"
+                ))?;
+
+                // Migrate data to new table.
+                for data in txn
+                    .prepare("SELECT data FROM room_info")?
+                    .query_map((), |row| row.get::<_, Vec<u8>>(0))?
+                {
+                    let data = data?;
+                    let room_info: RoomInfo = this.deserialize_json(&data)?;
+
+                    let room_id = this.encode_key(keys::ROOM_INFO, room_info.room_id());
+                    let state = this
+                        .encode_key(keys::ROOM_INFO, serde_json::to_string(&room_info.state())?);
+                    txn.prepare_cached(
+                        "INSERT OR REPLACE INTO new_room_info (room_id, state, data)
+                         VALUES (?, ?, ?)",
+                    )?
+                    .execute((room_id, state, data))?;
+                }
+
+                // Replace old table.
+                txn.execute_batch(include_str!(
+                    "../migrations/state_store/002_b_replace_room_info.sql"
+                ))?;
+
+                Result::<_, Error>::Ok(())
+            })
+            .await?;
+        }
+
+        conn.set_kv("version", vec![to]).await?;
+
+        Ok(())
     }
 
     fn encode_value(&self, value: Vec<u8>) -> Result<Vec<u8>> {
@@ -185,9 +245,6 @@ impl SqliteStateStore {
         room_id: &RoomId,
         stripped: bool,
     ) -> rusqlite::Result<()> {
-        let room_info_room_id = self.encode_key(keys::ROOM_INFO, room_id);
-        txn.remove_room_info(&room_info_room_id, Some(stripped))?;
-
         let state_event_room_id = self.encode_key(keys::STATE_EVENT, room_id);
         txn.remove_room_state_events(&state_event_room_id, Some(stripped))?;
 
@@ -196,28 +253,23 @@ impl SqliteStateStore {
     }
 }
 
-const DATABASE_VERSION: u8 = 1;
+async fn create_pool(path: &Path) -> Result<SqlitePool, OpenStoreError> {
+    fs::create_dir_all(path).await.map_err(OpenStoreError::CreateDir)?;
+    let cfg = deadpool_sqlite::Config::new(path.join("matrix-sdk-state.sqlite3"));
+    Ok(cfg.create_pool(Runtime::Tokio1)?)
+}
 
-async fn run_migrations(conn: &SqliteConn, version: u8) -> rusqlite::Result<()> {
-    if version == 0 {
-        debug!("Creating database");
-    } else if version < DATABASE_VERSION {
-        debug!(version, new_version = DATABASE_VERSION, "Upgrading database");
-    } else {
-        return Ok(());
-    }
+/// Initialize the database.
+async fn init(conn: &SqliteConn) -> Result<()> {
+    // First turn on WAL mode, this can't be done in the transaction, it fails with
+    // the error message: "cannot change into wal mode from within a transaction".
+    conn.execute_batch("PRAGMA journal_mode = wal;").await?;
+    conn.with_transaction(|txn| {
+        txn.execute_batch(include_str!("../migrations/state_store/001_init.sql"))
+    })
+    .await?;
 
-    if version < 1 {
-        // First turn on WAL mode, this can't be done in the transaction, it fails with
-        // the error message: "cannot change into wal mode from within a transaction".
-        conn.execute_batch("PRAGMA journal_mode = wal;").await?;
-        conn.with_transaction(|txn| {
-            txn.execute_batch(include_str!("../migrations/state_store/001_init.sql"))
-        })
-        .await?;
-    }
-
-    conn.set_kv("version", vec![DATABASE_VERSION]).await?;
+    conn.set_kv("version", vec![1]).await?;
 
     Ok(())
 }
@@ -235,9 +287,9 @@ trait SqliteConnectionStateStoreExt {
     ) -> rusqlite::Result<()>;
     fn remove_room_account_data(&self, room_id: &[u8]) -> rusqlite::Result<()>;
 
-    fn set_room_info(&self, room_id: &[u8], stripped: bool, data: &[u8]) -> rusqlite::Result<()>;
-    fn get_room_info(&self, room_id: &[u8], stripped: bool) -> rusqlite::Result<Option<Vec<u8>>>;
-    fn remove_room_info(&self, room_id: &[u8], stripped: Option<bool>) -> rusqlite::Result<()>;
+    fn set_room_info(&self, room_id: &[u8], state: &[u8], data: &[u8]) -> rusqlite::Result<()>;
+    fn get_room_info(&self, room_id: &[u8]) -> rusqlite::Result<Option<Vec<u8>>>;
+    fn remove_room_info(&self, room_id: &[u8]) -> rusqlite::Result<()>;
 
     fn set_state_event(
         &self,
@@ -326,36 +378,23 @@ impl SqliteConnectionStateStoreExt for rusqlite::Connection {
         Ok(())
     }
 
-    fn set_room_info(&self, room_id: &[u8], stripped: bool, data: &[u8]) -> rusqlite::Result<()> {
+    fn set_room_info(&self, room_id: &[u8], state: &[u8], data: &[u8]) -> rusqlite::Result<()> {
         self.prepare_cached(
-            "INSERT OR REPLACE INTO room_info (room_id, stripped, data)
+            "INSERT OR REPLACE INTO room_info (room_id, state, data)
              VALUES (?, ?, ?)",
         )?
-        .execute((room_id, stripped, data))?;
+        .execute((room_id, state, data))?;
         Ok(())
     }
 
-    fn get_room_info(&self, room_id: &[u8], stripped: bool) -> rusqlite::Result<Option<Vec<u8>>> {
-        self.query_row(
-            "SELECT data FROM room_info WHERE room_id = ? AND stripped = ?",
-            (room_id, stripped),
-            |row| row.get(0),
-        )
-        .optional()
+    fn get_room_info(&self, room_id: &[u8]) -> rusqlite::Result<Option<Vec<u8>>> {
+        self.query_row("SELECT data FROM room_info WHERE room_id = ?", (room_id,), |row| row.get(0))
+            .optional()
     }
 
     /// Remove the room info for the given room.
-    ///
-    /// If `stripped` is `Some()`, only removes the room info if it is in the
-    /// given stripped state. Otherwise, the room info is removed regardless
-    /// of the stripped state.
-    fn remove_room_info(&self, room_id: &[u8], stripped: Option<bool>) -> rusqlite::Result<()> {
-        if let Some(stripped) = stripped {
-            self.prepare_cached("DELETE FROM room_info WHERE room_id = ? AND stripped = ?")?
-                .execute((room_id, stripped))?;
-        } else {
-            self.prepare_cached("DELETE FROM room_info WHERE room_id = ?")?.execute((room_id,))?;
-        }
+    fn remove_room_info(&self, room_id: &[u8]) -> rusqlite::Result<()> {
+        self.prepare_cached("DELETE FROM room_info WHERE room_id = ?")?.execute((room_id,))?;
         Ok(())
     }
 
@@ -517,12 +556,25 @@ trait SqliteObjectStateStoreExt: SqliteObjectExt {
         Ok(())
     }
 
-    async fn get_room_infos(&self, stripped: bool) -> Result<Vec<Vec<u8>>> {
-        Ok(self
-            .prepare("SELECT data FROM room_info WHERE stripped = ?", move |mut stmt| {
-                stmt.query_map((stripped,), |row| row.get(0))?.collect()
-            })
-            .await?)
+    async fn get_room_infos(&self, states: Vec<Key>) -> Result<Vec<Vec<u8>>> {
+        if states.is_empty() {
+            Ok(self
+                .prepare("SELECT data FROM room_info", move |mut stmt| {
+                    stmt.query_map((), |row| row.get(0))?.collect()
+                })
+                .await?)
+        } else {
+            let sql_params = vec!["?"; states.len()].join(", ");
+            let sql = format!("SELECT data FROM room_info WHERE state IN ({sql_params})");
+
+            Ok(self
+                .prepare(sql, move |mut stmt| {
+                    stmt.query(rusqlite::params_from_iter(states))?
+                        .mapped(|row| row.get(0))
+                        .collect()
+                })
+                .await?)
+        }
     }
 
     async fn get_maybe_stripped_state_event(
@@ -771,7 +823,6 @@ impl StateStore for SqliteStateStore {
                     receipts,
                     redactions,
                     stripped_state,
-                    stripped_room_infos,
                     ambiguity_maps,
                     notifications: _,
                 } = changes;
@@ -805,14 +856,16 @@ impl StateStore for SqliteStateStore {
                     txn.set_kv_blob(&key, &value)?;
                 }
 
-                for (room_id, room_info) in chain(room_infos, stripped_room_infos) {
+                for (room_id, room_info) in room_infos {
                     let stripped = room_info.state() == RoomState::Invited;
                     // Remove non-stripped data for stripped rooms and vice-versa.
                     this.remove_maybe_stripped_room_data(txn, &room_id, !stripped)?;
 
                     let room_id = this.encode_key(keys::ROOM_INFO, room_id);
+                    let state = this
+                        .encode_key(keys::ROOM_INFO, serde_json::to_string(&room_info.state())?);
                     let data = this.serialize_json(&room_info)?;
-                    txn.set_room_info(&room_id, stripped, &data)?;
+                    txn.set_room_info(&room_id, &state, &data)?;
                 }
 
                 for (room_id, state_event_types) in state {
@@ -963,7 +1016,7 @@ impl StateStore for SqliteStateStore {
                 for (room_id, redactions) in redactions {
                     let make_room_version = || {
                         let encoded_room_id = this.encode_key(keys::ROOM_INFO, &room_id);
-                        txn.get_room_info(&encoded_room_id, false)
+                        txn.get_room_info(&encoded_room_id)
                             .ok()
                             .flatten()
                             .and_then(|v| this.deserialize_json::<RoomInfo>(&v).ok())
@@ -1138,7 +1191,7 @@ impl StateStore for SqliteStateStore {
     async fn get_room_infos(&self) -> Result<Vec<RoomInfo>> {
         self.acquire()
             .await?
-            .get_room_infos(false)
+            .get_room_infos(Vec::new())
             .await?
             .into_iter()
             .map(|data| self.deserialize_json(&data))
@@ -1146,9 +1199,11 @@ impl StateStore for SqliteStateStore {
     }
 
     async fn get_stripped_room_infos(&self) -> Result<Vec<RoomInfo>> {
+        let states =
+            vec![self.encode_key(keys::ROOM_INFO, serde_json::to_string(&RoomState::Invited)?)];
         self.acquire()
             .await?
-            .get_room_infos(true)
+            .get_room_infos(states)
             .await?
             .into_iter()
             .map(|data| self.deserialize_json(&data))
@@ -1304,7 +1359,7 @@ impl StateStore for SqliteStateStore {
             .await?
             .with_transaction(move |txn| {
                 let room_info_room_id = this.encode_key(keys::ROOM_INFO, &room_id);
-                txn.remove_room_info(&room_info_room_id, None)?;
+                txn.remove_room_info(&room_info_room_id)?;
 
                 let state_event_room_id = this.encode_key(keys::STATE_EVENT, &room_id);
                 txn.remove_room_state_events(&state_event_room_id, None)?;
@@ -1383,4 +1438,90 @@ mod encrypted_tests {
     }
 
     statestore_integration_tests!(with_media_tests);
+}
+
+#[cfg(test)]
+mod migration_tests {
+    use std::{
+        path::{Path, PathBuf},
+        sync::{
+            atomic::{AtomicU32, Ordering::SeqCst},
+            Arc,
+        },
+    };
+
+    use matrix_sdk_base::{RoomInfo, RoomState, StateStore};
+    use matrix_sdk_test::async_test;
+    use once_cell::sync::Lazy;
+    use ruma::RoomId;
+    use tempfile::{tempdir, TempDir};
+
+    use super::{create_pool, init, keys, SqliteStateStore};
+    use crate::{
+        error::{Error, Result},
+        get_or_create_store_cipher,
+        utils::SqliteObjectExt,
+    };
+
+    static TMP_DIR: Lazy<TempDir> = Lazy::new(|| tempdir().unwrap());
+    static NUM: AtomicU32 = AtomicU32::new(0);
+    const SECRET: &str = "secret";
+
+    fn new_path() -> PathBuf {
+        let name = NUM.fetch_add(1, SeqCst).to_string();
+        TMP_DIR.path().join(name)
+    }
+
+    async fn create_fake_db(path: &Path, version: u8) -> Result<SqliteStateStore> {
+        let pool = create_pool(path).await.unwrap();
+        let conn = pool.get().await?;
+
+        init(&conn).await?;
+
+        let store_cipher = Some(Arc::new(get_or_create_store_cipher(SECRET, &conn).await.unwrap()));
+        let this = SqliteStateStore { store_cipher, path: None, pool };
+        this.run_migrations(&conn, 1, Some(version)).await?;
+
+        Ok(this)
+    }
+
+    #[async_test]
+    pub async fn test_migrating_v1_to_v2() {
+        let path = new_path();
+        // Create and populate db.
+        {
+            let db = create_fake_db(&path, 1).await.unwrap();
+            let conn = db.pool.get().await.unwrap();
+
+            let this = db.clone();
+            conn.with_transaction(move |txn| {
+                for i in 0..5 {
+                    let room_id = RoomId::parse(format!("!room_{i}:localhost")).unwrap();
+                    let (state, stripped) =
+                        if i < 3 { (RoomState::Joined, false) } else { (RoomState::Invited, true) };
+                    let info = RoomInfo::new(&room_id, state);
+
+                    let room_id = this.encode_key(keys::ROOM_INFO, room_id);
+                    let data = this.serialize_json(&info)?;
+
+                    txn.prepare_cached(
+                        "INSERT OR REPLACE INTO room_info (room_id, stripped, data)
+                         VALUES (?, ?, ?)",
+                    )?
+                    .execute((room_id, stripped, data))?;
+                }
+
+                Result::<_, Error>::Ok(())
+            })
+            .await
+            .unwrap();
+        }
+
+        // This transparently migrates to the latest version.
+        let store = SqliteStateStore::open(path, Some(SECRET)).await.unwrap();
+
+        // Check all room infos are there.
+        assert_eq!(store.get_room_infos().await.unwrap().len(), 5);
+        assert_eq!(store.get_stripped_room_infos().await.unwrap().len(), 2);
+    }
 }

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1522,6 +1522,8 @@ mod migration_tests {
 
         // Check all room infos are there.
         assert_eq!(store.get_room_infos().await.unwrap().len(), 5);
-        assert_eq!(store.get_stripped_room_infos().await.unwrap().len(), 2);
+        #[allow(deprecated)]
+        let stripped_rooms = store.get_stripped_room_infos().await.unwrap();
+        assert_eq!(stripped_rooms.len(), 2);
     }
 }

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -19,13 +19,6 @@ use rusqlite::{OptionalExtension, Params, Row, Statement, Transaction};
 
 use crate::OpenStoreError;
 
-pub(crate) fn chain<T>(
-    it1: impl IntoIterator<Item = T>,
-    it2: impl IntoIterator<Item = T>,
-) -> impl Iterator<Item = T> {
-    it1.into_iter().chain(it2)
-}
-
 #[derive(Clone, Debug)]
 pub(crate) enum Key {
     Plain(Vec<u8>),

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -13,6 +13,7 @@
 - The `Common` methods to retrieve state events can now return a sync or stripped event, so it can be used
   for invited rooms too.
 - Add `Client::subscribe_to_room_updates` and `room::Common::subscribe_to_updates`
+- `Client::rooms` now returns all rooms, even invited, as advertised.
 
 # 0.6.2
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -14,6 +14,7 @@
   for invited rooms too.
 - Add `Client::subscribe_to_room_updates` and `room::Common::subscribe_to_updates`
 - `Client::rooms` now returns all rooms, even invited, as advertised.
+- Add `Client::rooms_filtered`
 
 # 0.6.2
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -29,8 +29,8 @@ use eyeball::{unique::Observable, Subscriber};
 use futures_core::Stream;
 use futures_util::StreamExt;
 use matrix_sdk_base::{
-    store::DynStateStore, BaseClient, RoomState, SendOutsideWasm, Session, SessionMeta,
-    SessionTokens, SyncOutsideWasm,
+    store::DynStateStore, BaseClient, RoomState, RoomStateFilter, SendOutsideWasm, Session,
+    SessionMeta, SessionTokens, SyncOutsideWasm,
 };
 use matrix_sdk_common::instant::Instant;
 #[cfg(feature = "appservice")]
@@ -890,7 +890,7 @@ impl Client {
     /// Returns the joined rooms this client knows about.
     pub fn joined_rooms(&self) -> Vec<room::Joined> {
         self.base_client()
-            .get_rooms()
+            .get_rooms_filtered(RoomStateFilter::JOINED)
             .into_iter()
             .filter_map(|room| room::Joined::new(self, room))
             .collect()
@@ -899,7 +899,7 @@ impl Client {
     /// Returns the invited rooms this client knows about.
     pub fn invited_rooms(&self) -> Vec<room::Invited> {
         self.base_client()
-            .get_stripped_rooms()
+            .get_rooms_filtered(RoomStateFilter::INVITED)
             .into_iter()
             .filter_map(|room| room::Invited::new(self, room))
             .collect()
@@ -908,7 +908,7 @@ impl Client {
     /// Returns the left rooms this client knows about.
     pub fn left_rooms(&self) -> Vec<room::Left> {
         self.base_client()
-            .get_rooms()
+            .get_rooms_filtered(RoomStateFilter::LEFT)
             .into_iter()
             .filter_map(|room| room::Left::new(self, room))
             .collect()

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -887,6 +887,15 @@ impl Client {
             .collect()
     }
 
+    /// Get all the rooms the client knows about, filtered by room state.
+    pub fn rooms_filtered(&self, filter: RoomStateFilter) -> Vec<room::Room> {
+        self.base_client()
+            .get_rooms_filtered(filter)
+            .into_iter()
+            .map(|room| room::Common::new(self.clone(), room).into())
+            .collect()
+    }
+
     /// Returns the joined rooms this client knows about.
     pub fn joined_rooms(&self) -> Vec<room::Joined> {
         self.base_client()

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -78,7 +78,7 @@ async fn room_names() {
 
     let _response = client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
 
-    assert_eq!(client.rooms().len(), 1);
+    assert_eq!(client.rooms().len(), 2);
     let invited_room = client.get_invited_room(room_id!("!696r7674:example.com")).unwrap();
 
     assert_eq!(


### PR DESCRIPTION
Since they use the same type, it is not necessary to separate them. It is not even visible on public APIs that they are separated.

- [x] Public API changes documented in changelogs (optional)

Based on #2038.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Kévin Commaille <zecakeh@tedomum.fr>
