### PR TITLE
docs: updated readme - rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The rust-sdk consists of multiple crates that can be picked at your convenience:
 
 ## Minimum Supported Rust Version (MSRV)
 
-These crates are built with the Rust language version 2021 and require a minimum compiler version of `1.65`.
+These crates are built with the Rust language version 2021 and require a minimum compiler version of `1.70`.
 
 ## Status
 

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -41,12 +41,12 @@ pub use matrix_sdk::ruma::{api::client::account::register, UserId};
 pub use matrix_sdk_ui::timeline::PaginationOutcome;
 pub use platform::*;
 
+// Re-exports for more convenient use inside other submodules
+use self::error::ClientError;
 pub use self::{
     authentication_service::*, client::*, event::*, notification::*, room::*, room_member::*,
     session_verification::*, sliding_sync::*, timeline::*, tracing::*,
 };
-// Re-exports for more convenient use inside other submodules
-use self::{client::Client, error::ClientError};
 
 uniffi::include_scaffolding!("api");
 


### PR DESCRIPTION
1.70 is now the minimum required version to compile the workspace