### PR TITLE
Add a value-based lock in the `CryptoStore`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,7 +1075,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
@@ -2965,6 +2965,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
@@ -3141,6 +3150,8 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
  "static_assertions",
 ]
 
@@ -4682,6 +4693,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "speedy"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7642861d1a1569b105c57008df95fb12ba648f7f90358f46e99bdfbf26729b84"
+dependencies = [
+ "memoffset 0.8.0",
+ "speedy-derive",
+]
+
+[[package]]
+name = "speedy-derive"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d395866cb6778625150f77a430cc0af764ce0300f6a3d3413477785fa34b6c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4694,6 +4726,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
  "der",
+]
+
+[[package]]
+name = "sqlite-lock"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "matrix-sdk-crypto",
+ "matrix-sdk-sqlite",
+ "nix",
+ "speedy",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/matrix-sdk-crypto/src/store/error.rs
+++ b/crates/matrix-sdk-crypto/src/store/error.rs
@@ -78,6 +78,18 @@ pub enum CryptoStoreError {
     /// A problem with the underlying database backend
     #[error(transparent)]
     Backend(Box<dyn std::error::Error + Send + Sync>),
+
+    /// A lock value was to be removed, but it didn't contain the expected lock value.
+    #[error("a lock value was to be removed, but it didn't contain the expected lock value")]
+    IncorrectLockValue,
+
+    /// A lock value was to be removed, but it was missing in the database.
+    #[error("a lock value was to be removed, but it was missing in the database")]
+    MissingLockValue,
+
+    /// Spent too long waiting for a database lock.
+    #[error("a lock timed out")]
+    LockTimeout,
 }
 
 impl CryptoStoreError {

--- a/crates/matrix-sdk-crypto/src/store/error.rs
+++ b/crates/matrix-sdk-crypto/src/store/error.rs
@@ -18,6 +18,7 @@ use ruma::{IdParseError, OwnedDeviceId, OwnedUserId};
 use serde_json::Error as SerdeError;
 use thiserror::Error;
 
+use super::locks::LockStoreError;
 use crate::olm::SessionCreationError;
 
 /// A `CryptoStore` specific result type.
@@ -79,17 +80,9 @@ pub enum CryptoStoreError {
     #[error(transparent)]
     Backend(Box<dyn std::error::Error + Send + Sync>),
 
-    /// A lock value was to be removed, but it didn't contain the expected lock value.
-    #[error("a lock value was to be removed, but it didn't contain the expected lock value")]
-    IncorrectLockValue,
-
-    /// A lock value was to be removed, but it was missing in the database.
-    #[error("a lock value was to be removed, but it was missing in the database")]
-    MissingLockValue,
-
-    /// Spent too long waiting for a database lock.
-    #[error("a lock timed out")]
-    LockTimeout,
+    /// An error due to locking.
+    #[error(transparent)]
+    Lock(#[from] LockStoreError),
 }
 
 impl CryptoStoreError {

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -159,9 +159,10 @@ impl CryptoStoreLock {
 /// RAII struct that implements the semantics of taking/release a
 /// `CryptoStoreLock` automatically.
 ///
-/// Note: this is dangerous and racy! Releasing the lock takes place in the `Drop` implementation,
-/// but since that can't be async, it means we have to spawn a new task there to do that. So this
-/// may be racy, in case of high contention.
+/// Note: this is dangerous and racy! Releasing the lock takes place in the
+/// `Drop` implementation, but since that can't be async, it means we have to
+/// spawn a new task there to do that. So this may be racy, in case of high
+/// contention.
 ///
 /// TODO(bnjbvr) remove this API then?
 #[derive(Debug)]

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -119,8 +119,8 @@ impl CryptoStoreLock {
             // max_backoff.
             let wait = self.backoff;
 
-            // If we've set the sentinel value before, that means this wait would be longer than
-            // the max backoff, so abort.
+            // If we've set the sentinel value before, that means this wait would be longer
+            // than the max backoff, so abort.
             if wait == u32::MAX {
                 // We've reached the maximum backoff, abandon.
                 return Err(LockStoreError::LockTimeout.into());

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -14,68 +14,120 @@
 
 //! Collection of small helpers that implement store-based locks.
 //!
-//! Those locks are implemented as one value in the key-value crypto store, that exists if and only
-//! if the lock has been taken. For this to work correctly, we rely on multiple assumptions:
+//! Those locks are implemented as one value in the key-value crypto store, that
+//! exists if and only if the lock has been taken. For this to work correctly,
+//! we rely on multiple assumptions:
 //!
-//! - the store must allow concurrent reads and writes from multiple processes. For instance, for
+//! - the store must allow concurrent reads and writes from multiple processes.
+//!   For instance, for
 //! sqlite, this means that it is running in [WAL](https://www.sqlite.org/wal.html) mode.
-//! - the two operations used in the store implementation, `insert_custom_value_if_missing` and
+//! - the two operations used in the store implementation,
+//!   `insert_custom_value_if_missing` and
 //! `remove_custom_value`, must be atomic / implemented in a transaction.
+
+use std::{sync::Arc, time::Duration};
+
+use tokio::{runtime::Handle, task::spawn_blocking, time::sleep};
 
 use super::DynCryptoStore;
 use crate::CryptoStoreError;
-use std::{sync::Arc, time::Duration};
-use tokio::{runtime::Handle, task::spawn_blocking, time::sleep};
 
 /// A store-based lock for the `CryptoStore`.
 #[derive(Debug, Clone)]
 pub struct CryptoStoreLock {
+    /// The store we're using to lock.
     store: Arc<DynCryptoStore>,
+
+    /// The key used in the key/value mapping for the lock entry.
     lock_key: String,
+
+    /// A specific value to identify the lock's holder.
+    lock_holder: String,
+
+    /// Backoff time, in milliseconds.
     backoff: u32,
+
+    /// Maximum backoff time, between two attempts.
+    max_backoff: u32,
 }
 
 impl CryptoStoreLock {
-    /// Initial backoff, in milliseconds. This is the time we wait the first time, if taking the
-    /// lock initially failed.
+    /// Initial backoff, in milliseconds. This is the time we wait the first
+    /// time, if taking the lock initially failed.
     const INITIAL_BACKOFF_MS: u32 = 10;
-    /// Maximal backoff, in milliseconds. This is the maximum amount of time we'll wait for the
-    /// lock, *between two attempts*.
-    const MAX_BACKOFF_MS: u32 = 2000;
-    // TODO generate a random value per instance of the lock?
-    const SENTINEL_VALUE: &str = "lock_taken";
 
-    /// Create a new store-based lock implemented as a value in the crypto-store.
-    pub fn new(store: Arc<DynCryptoStore>, lock_key: String) -> Self {
-        Self { store, lock_key, backoff: Self::INITIAL_BACKOFF_MS }
+    /// Maximal backoff, in milliseconds. This is the maximum amount of time
+    /// we'll wait for the lock, *between two attempts*.
+    const MAX_BACKOFF_MS: u32 = 1000;
+
+    /// Create a new store-based lock implemented as a value in the
+    /// crypto-store.
+    ///
+    /// # Parameters
+    ///
+    /// - `lock_key`: key in the key-value store to store the lock's state.
+    /// - `lock_holder`: identify the lock's holder with this given value.
+    /// - `max_backoff`: maximum time (in milliseconds) that should be waited
+    ///   for, between two
+    /// attempts. When that time is reached a second time, the lock will stop
+    /// attempting to get the lock and will return a timeout error upon
+    /// locking. If not provided, will wait for [`Self::MAX_BACKOFF_MS`].
+    pub fn new(
+        store: Arc<DynCryptoStore>,
+        lock_key: String,
+        lock_holder: String,
+        max_backoff: Option<u32>,
+    ) -> Self {
+        let max_backoff = max_backoff.unwrap_or(Self::MAX_BACKOFF_MS);
+        Self { store, lock_key, lock_holder, max_backoff, backoff: Self::INITIAL_BACKOFF_MS }
     }
 
-    /// Attempt to take the lock, with exponential backoff if the lock has already been taken
-    /// before.
+    /// Attempt to take the lock, with exponential backoff if the lock has
+    /// already been taken before.
     pub async fn lock(&mut self) -> Result<(), CryptoStoreError> {
         loop {
             let inserted = self
                 .store
                 .insert_custom_value_if_missing(
                     &self.lock_key,
-                    Self::SENTINEL_VALUE.as_bytes().to_vec(),
+                    self.lock_holder.as_bytes().to_vec(),
                 )
                 .await?;
+
             if inserted {
+                // Reset backoff before returning, for the next attempt to lock.
                 self.backoff = Self::INITIAL_BACKOFF_MS;
                 return Ok(());
             }
 
-            // Exponential backoff! Multiply by 2 the time we've waited before, cap it to 1 second.
-            let wait = self.backoff;
-
-            if wait == Self::MAX_BACKOFF_MS {
-                // We've reached the maximum backoff, abandon.
-                return Err(CryptoStoreError::LockTimeout);
+            // Double-check that we were not interrupted last time we tried to take the
+            // lock, and forgot to release it; in that case, we *still* hold it.
+            let previous = self.store.get_custom_value(&self.lock_key).await?;
+            if previous.as_deref() == Some(self.lock_holder.as_bytes()) {
+                // At this point, the only possible value for backoff is the initial one, but
+                // better be safe than sorry.
+                tracing::warn!(
+                    "Crypto-store lock {} was already taken by {}; let's pretend we just acquired it.",
+                    self.lock_key,
+                    self.lock_holder
+                );
+                self.backoff = Self::INITIAL_BACKOFF_MS;
+                return Ok(());
             }
 
-            self.backoff *= 2;
-            self.backoff = self.backoff.min(Self::MAX_BACKOFF_MS);
+            // Exponential backoff! Multiply by 2 the time we've waited before, cap it to
+            // max_backoff.
+            let wait = self.backoff;
+
+            if wait == u32::max_value() {
+                // We've reached the maximum backoff, abandon.
+                return Err(LockStoreError::LockTimeout.into());
+            }
+
+            self.backoff = self.backoff.saturating_mul(2);
+            if self.backoff >= self.max_backoff {
+                self.backoff = u32::max_value();
+            }
 
             sleep(Duration::from_millis(wait.into())).await;
         }
@@ -89,39 +141,50 @@ impl CryptoStoreLock {
             .store
             .get_custom_value(&self.lock_key)
             .await?
-            .ok_or(CryptoStoreError::MissingLockValue)?;
+            .ok_or(CryptoStoreError::from(LockStoreError::MissingLockValue))?;
 
-        if read != Self::SENTINEL_VALUE.as_bytes() {
-            return Err(CryptoStoreError::IncorrectLockValue);
+        if read != self.lock_holder.as_bytes() {
+            return Err(LockStoreError::IncorrectLockValue.into());
         }
 
         let removed = self.store.remove_custom_value(&self.lock_key).await?;
         if removed {
             Ok(())
         } else {
-            Err(CryptoStoreError::MissingLockValue)
+            Err(LockStoreError::MissingLockValue.into())
         }
     }
 }
 
-/// RAII struct that implements the semantics of taking/release a `CryptoStoreLock` automatically.
+/// RAII struct that implements the semantics of taking/release a
+/// `CryptoStoreLock` automatically.
+///
+/// Note: this is dangerous and racy! Releasing the lock takes place in the `Drop` implementation,
+/// but since that can't be async, it means we have to spawn a new task there to do that. So this
+/// may be racy, in case of high contention.
+///
+/// TODO(bnjbvr) remove this API then?
 #[derive(Debug)]
 pub struct CryptoStoreLockGuard {
     lock: CryptoStoreLock,
 }
 
 impl CryptoStoreLockGuard {
-    /// Creates a new `CryptoStoreLockGuard` with the given key, in the given store.
+    /// Creates a new `CryptoStoreLockGuard` with the given key, in the given
+    /// store.
     ///
-    /// The drop implementation assumes the code is running in a `tokio` environment, so make sure
-    /// we're inside a tokio runtime when dropping this data structure.
+    /// The drop implementation assumes the code is running in a `tokio`
+    /// environment, so make sure we're inside a tokio runtime when dropping
+    /// this data structure.
     ///
     /// See also [`CryptoStoreLock`] to learn more about the lock's properties.
     pub async fn new(
         store: Arc<DynCryptoStore>,
         lock_key: String,
+        lock_holder: String,
+        max_backoff: Option<u32>,
     ) -> Result<Self, CryptoStoreError> {
-        let mut lock = CryptoStoreLock::new(store, lock_key);
+        let mut lock = CryptoStoreLock::new(store, lock_key, lock_holder, max_backoff);
         lock.lock().await?;
         Ok(Self { lock })
     }
@@ -130,8 +193,8 @@ impl CryptoStoreLockGuard {
 impl Drop for CryptoStoreLockGuard {
     fn drop(&mut self) {
         // No async drop 😥
-        // 1. Clone the lock as a sacrifice to borrowck (otherwise the `&mut self` reference would
-        //    need to be static),
+        // 1. Clone the lock as a sacrifice to borrowck (otherwise the `&mut self`
+        // reference would    need to be static),
         // 2. We'll need to block_on; spawn a blocking task to do just that.
         let mut lock = self.lock.clone();
 
@@ -142,4 +205,21 @@ impl Drop for CryptoStoreLockGuard {
             }
         });
     }
+}
+
+/// Error related to the locking API of the crypto store.
+#[derive(Debug, thiserror::Error)]
+pub enum LockStoreError {
+    /// A lock value was to be removed, but it didn't contain the expected lock
+    /// value.
+    #[error("a lock value was to be removed, but it didn't contain the expected lock value")]
+    IncorrectLockValue,
+
+    /// A lock value was to be removed, but it was missing in the database.
+    #[error("a lock value was to be removed, but it was missing in the database")]
+    MissingLockValue,
+
+    /// Spent too long waiting for a database lock.
+    #[error("a lock timed out")]
+    LockTimeout,
 }

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -71,7 +71,7 @@ impl CryptoStoreLock {
     ///   for, between two
     /// attempts. When that time is reached a second time, the lock will stop
     /// attempting to get the lock and will return a timeout error upon
-    /// locking. If not provided, will wait for [`Self::MAX_BACKOFF_MS`].
+    /// locking. If not provided, will wait for `Self::MAX_BACKOFF_MS`.
     pub fn new(
         store: Arc<DynCryptoStore>,
         lock_key: String,
@@ -137,7 +137,7 @@ impl CryptoStoreLock {
         }
     }
 
-    /// Release the lock taken previously with [`lock()`].
+    /// Release the lock taken previously with [`Self::lock()`].
     ///
     /// Will return an error if the lock wasn't taken.
     pub async fn unlock(&mut self) -> Result<(), CryptoStoreError> {

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -1,0 +1,145 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Collection of small helpers that implement store-based locks.
+//!
+//! Those locks are implemented as one value in the key-value crypto store, that exists if and only
+//! if the lock has been taken. For this to work correctly, we rely on multiple assumptions:
+//!
+//! - the store must allow concurrent reads and writes from multiple processes. For instance, for
+//! sqlite, this means that it is running in [WAL](https://www.sqlite.org/wal.html) mode.
+//! - the two operations used in the store implementation, `insert_custom_value_if_missing` and
+//! `remove_custom_value`, must be atomic / implemented in a transaction.
+
+use super::DynCryptoStore;
+use crate::CryptoStoreError;
+use std::{sync::Arc, time::Duration};
+use tokio::{runtime::Handle, task::spawn_blocking, time::sleep};
+
+/// A store-based lock for the `CryptoStore`.
+#[derive(Debug, Clone)]
+pub struct CryptoStoreLock {
+    store: Arc<DynCryptoStore>,
+    lock_key: String,
+    backoff: u32,
+}
+
+impl CryptoStoreLock {
+    /// Initial backoff, in milliseconds. This is the time we wait the first time, if taking the
+    /// lock initially failed.
+    const INITIAL_BACKOFF_MS: u32 = 10;
+    /// Maximal backoff, in milliseconds. This is the maximum amount of time we'll wait for the
+    /// lock, *between two attempts*.
+    const MAX_BACKOFF_MS: u32 = 2000;
+    // TODO generate a random value per instance of the lock?
+    const SENTINEL_VALUE: &str = "lock_taken";
+
+    /// Create a new store-based lock implemented as a value in the crypto-store.
+    pub fn new(store: Arc<DynCryptoStore>, lock_key: String) -> Self {
+        Self { store, lock_key, backoff: Self::INITIAL_BACKOFF_MS }
+    }
+
+    /// Attempt to take the lock, with exponential backoff if the lock has already been taken
+    /// before.
+    pub async fn lock(&mut self) -> Result<(), CryptoStoreError> {
+        loop {
+            let inserted = self
+                .store
+                .insert_custom_value_if_missing(
+                    &self.lock_key,
+                    Self::SENTINEL_VALUE.as_bytes().to_vec(),
+                )
+                .await?;
+            if inserted {
+                self.backoff = Self::INITIAL_BACKOFF_MS;
+                return Ok(());
+            }
+
+            // Exponential backoff! Multiply by 2 the time we've waited before, cap it to 1 second.
+            let wait = self.backoff;
+
+            if wait == Self::MAX_BACKOFF_MS {
+                // We've reached the maximum backoff, abandon.
+                return Err(CryptoStoreError::LockTimeout);
+            }
+
+            self.backoff *= 2;
+            self.backoff = self.backoff.min(Self::MAX_BACKOFF_MS);
+
+            sleep(Duration::from_millis(wait.into())).await;
+        }
+    }
+
+    /// Release the lock taken previously with [`lock()`].
+    ///
+    /// Will return an error if the lock wasn't taken.
+    pub async fn unlock(&mut self) -> Result<(), CryptoStoreError> {
+        let read = self
+            .store
+            .get_custom_value(&self.lock_key)
+            .await?
+            .ok_or(CryptoStoreError::MissingLockValue)?;
+
+        if read != Self::SENTINEL_VALUE.as_bytes() {
+            return Err(CryptoStoreError::IncorrectLockValue);
+        }
+
+        let removed = self.store.remove_custom_value(&self.lock_key).await?;
+        if removed {
+            Ok(())
+        } else {
+            Err(CryptoStoreError::MissingLockValue)
+        }
+    }
+}
+
+/// RAII struct that implements the semantics of taking/release a `CryptoStoreLock` automatically.
+#[derive(Debug)]
+pub struct CryptoStoreLockGuard {
+    lock: CryptoStoreLock,
+}
+
+impl CryptoStoreLockGuard {
+    /// Creates a new `CryptoStoreLockGuard` with the given key, in the given store.
+    ///
+    /// The drop implementation assumes the code is running in a `tokio` environment, so make sure
+    /// we're inside a tokio runtime when dropping this data structure.
+    ///
+    /// See also [`CryptoStoreLock`] to learn more about the lock's properties.
+    pub async fn new(
+        store: Arc<DynCryptoStore>,
+        lock_key: String,
+    ) -> Result<Self, CryptoStoreError> {
+        let mut lock = CryptoStoreLock::new(store, lock_key);
+        lock.lock().await?;
+        Ok(Self { lock })
+    }
+}
+
+impl Drop for CryptoStoreLockGuard {
+    fn drop(&mut self) {
+        // No async drop 😥
+        // 1. Clone the lock as a sacrifice to borrowck (otherwise the `&mut self` reference would
+        //    need to be static),
+        // 2. We'll need to block_on; spawn a blocking task to do just that.
+        let mut lock = self.lock.clone();
+
+        spawn_blocking(move || {
+            if let Err(err) = Handle::current().block_on(lock.unlock()) {
+                tracing::error!("error when releasing a lock: {err:#}");
+                panic!("{err:#}");
+            }
+        });
+    }
+}

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -311,6 +311,16 @@ impl CryptoStore for MemoryStore {
         warn!("Method not implemented");
         Ok(())
     }
+
+    async fn insert_custom_value_if_missing(&self, key: &str, new: Vec<u8>) -> Result<bool> {
+        let actual = self.get_custom_value(key).await?;
+        if actual.is_none() {
+            self.set_custom_value(key, new).await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -312,14 +312,14 @@ impl CryptoStore for MemoryStore {
         Ok(())
     }
 
-    async fn insert_custom_value_if_missing(&self, key: &str, new: Vec<u8>) -> Result<bool> {
-        let actual = self.get_custom_value(key).await?;
-        if actual.is_none() {
-            self.set_custom_value(key, new).await?;
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+    async fn insert_custom_value_if_missing(&self, _key: &str, _new: Vec<u8>) -> Result<bool> {
+        warn!("Method insert_custom_value_if_missing not implemented");
+        Ok(false)
+    }
+
+    async fn remove_custom_value(&self, _key: &str) -> Result<bool> {
+        warn!("Method remove_custom_value not implemented");
+        Ok(false)
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -80,6 +80,7 @@ use crate::{
 
 pub mod caches;
 mod error;
+pub mod locks;
 mod memorystore;
 mod traits;
 

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -237,6 +237,12 @@ pub trait CryptoStore: AsyncTraitDeps {
         key: &str,
         new: Vec<u8>,
     ) -> Result<bool, Self::Error>;
+
+    /// Removes a custom value from the store.
+    ///
+    /// Returns a boolean indicating whether the value was actually present in
+    /// the store.
+    async fn remove_custom_value(&self, key: &str) -> Result<bool, Self::Error>;
 }
 
 #[repr(transparent)]
@@ -390,6 +396,10 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
         new: Vec<u8>,
     ) -> Result<bool, Self::Error> {
         self.0.insert_custom_value_if_missing(key, new).await.map_err(Into::into)
+    }
+
+    async fn remove_custom_value(&self, key: &str) -> Result<bool, Self::Error> {
+        self.0.remove_custom_value(key).await.map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -226,6 +226,17 @@ pub trait CryptoStore: AsyncTraitDeps {
     ///
     /// * `value` - The value to insert
     async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error>;
+
+    /// Insert a custom value only if it's missing from the database.
+    ///
+    /// In other words, doesn't do an upsert (insert or update).
+    ///
+    /// Guaranteed to be atomic.
+    async fn insert_custom_value_if_missing(
+        &self,
+        key: &str,
+        new: Vec<u8>,
+    ) -> Result<bool, Self::Error>;
 }
 
 #[repr(transparent)]
@@ -371,6 +382,14 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
 
     async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<(), Self::Error> {
         self.0.set_custom_value(key, value).await.map_err(Into::into)
+    }
+
+    async fn insert_custom_value_if_missing(
+        &self,
+        key: &str,
+        new: Vec<u8>,
+    ) -> Result<bool, Self::Error> {
+        self.0.insert_custom_value_if_missing(key, new).await.map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -1057,18 +1057,34 @@ impl_crypto_store! {
         Ok(())
     }
 
-    async fn update_custom_value_if_missing(
+    async fn insert_custom_value_if_missing(
         &self,
         key: &str,
         value: Vec<u8>,
     ) -> Result<bool> {
+        let key = JsValue::from_str(key);
         let txn = self
             .inner
             .transaction_on_one_with_mode(keys::CORE, IdbTransactionMode::Readwrite)?;
         let object_store = txn
             .object_store(keys::CORE)?;
-        if object_store.get(&JsValue::from_str(key))?.await?.is_none() {
-            object_store.put_key_val(&JsValue::from_str(key), &self.serialize_value(&value)?)?;
+        if object_store.get(&key)?.await?.is_none() {
+            object_store.put_key_val(&key, &self.serialize_value(&value)?)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    async fn remove_custom_value(&self, key: &str) -> Result<bool> {
+        let key = JsValue::from_str(key);
+        let txn = self
+            .inner
+            .transaction_on_one_with_mode(keys::CORE, IdbTransactionMode::Readwrite)?;
+        let object_store = txn
+            .object_store(keys::CORE)?;
+        if object_store.get(&key)?.await?.is_some() {
+            object_store.delete(&key)?;
             Ok(true)
         } else {
             Ok(false)

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -1056,6 +1056,24 @@ impl_crypto_store! {
             .put_key_val(&JsValue::from_str(key), &self.serialize_value(&value)?)?;
         Ok(())
     }
+
+    async fn update_custom_value_if_missing(
+        &self,
+        key: &str,
+        value: Vec<u8>,
+    ) -> Result<bool> {
+        let txn = self
+            .inner
+            .transaction_on_one_with_mode(keys::CORE, IdbTransactionMode::Readwrite)?;
+        let object_store = txn
+            .object_store(keys::CORE)?;
+        if object_store.get(&JsValue::from_str(key))?.await?.is_none() {
+            object_store.put_key_val(&JsValue::from_str(key), &self.serialize_value(&value)?)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
 }
 
 impl Drop for IndexeddbCryptoStore {

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -1108,6 +1108,35 @@ impl CryptoStore for SqliteCryptoStore {
         self.acquire().await?.set_kv(key, serialized).await?;
         Ok(())
     }
+
+    async fn insert_custom_value_if_missing(
+        &self,
+        key: &str,
+        value: Vec<u8>,
+    ) -> Result<bool, Self::Error> {
+        let key = key.to_owned();
+        let serialized = if let Some(cipher) = &self.store_cipher {
+            let encrypted = cipher.encrypt_value_data(value)?;
+            rmp_serde::to_vec_named(&encrypted)?
+        } else {
+            value
+        };
+
+        let num_touched = self
+            .acquire()
+            .await?
+            .with_transaction(move |txn| {
+                txn.execute(
+                    "INSERT INTO kv VALUES(?1, ?2) ON CONFLICT (key) DO NOTHING",
+                    (key, serialized),
+                )
+            })
+            .await?;
+
+        assert!(num_touched <= 1);
+
+        Ok(num_touched != 0)
+    }
 }
 
 #[cfg(test)]

--- a/labs/sqlite-lock/Cargo.toml
+++ b/labs/sqlite-lock/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sqlite-lock"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+matrix-sdk-sqlite = { path = "../../crates/matrix-sdk-sqlite", features = ["crypto-store"] }
+matrix-sdk-crypto = { path = "../../crates/matrix-sdk-crypto" }
+nix = "0.26.2"
+anyhow.workspace = true
+speedy = "0.8.6"
+futures = "0.3.28"
+tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }

--- a/labs/sqlite-lock/src/main.rs
+++ b/labs/sqlite-lock/src/main.rs
@@ -1,0 +1,268 @@
+use anyhow::Result;
+use matrix_sdk_crypto::store::{locks::CryptoStoreLockGuard, DynCryptoStore, IntoCryptoStore as _};
+use matrix_sdk_sqlite::SqliteCryptoStore;
+use nix::{
+    libc::rand,
+    sys::wait::wait,
+    unistd::{close, fork, pipe, read, write},
+};
+use speedy::{Readable, Writable};
+use std::{env::temp_dir, time::Duration};
+use std::{path::Path, sync::Arc};
+use tokio::{runtime::Runtime, time::sleep};
+
+#[derive(Clone, Debug, Writable, Readable)]
+enum Command {
+    WriteValue(String),
+    ReadValue(String),
+    Quit,
+}
+
+impl Command {
+    async fn assert(&self, store: &Arc<DynCryptoStore>) -> Result<()> {
+        match self {
+            Command::WriteValue(written) => {
+                // The child must have written the value.
+                let read = store.get_custom_value(KEY).await?;
+                assert_eq!(read, Some(written.as_bytes().to_vec()));
+            }
+            Command::ReadValue(_read) => {
+                // The child removes the value after validating it.
+                let read = store.get_custom_value(KEY).await?;
+                assert_eq!(read, None);
+            }
+            Command::Quit => {}
+        }
+        Ok(())
+    }
+}
+
+fn write_command(fd: i32, command: Command) -> Result<()> {
+    eprintln!("parent send: {command:?}");
+    let serialized = command.write_to_vec()?;
+    let len = write(fd, &serialized)?;
+    assert_eq!(len, serialized.len());
+    Ok(())
+}
+
+fn read_command(fd: i32) -> Result<Command> {
+    let mut buf = vec![0; 1024]; // 1024 bytes enough for anyone
+    read(fd, &mut buf)?;
+    let command = Command::read_from_buffer(&buf)?;
+    eprintln!("child received: {command:?}");
+    Ok(command)
+}
+
+const LOCK_KEY: &str = "lock_key";
+const KEY: &str = "custom_key";
+const GENERATION_KEY: &str = "generation";
+
+struct CloseChildGuard {
+    write_pipe: i32,
+}
+
+impl Drop for CloseChildGuard {
+    fn drop(&mut self) {
+        write_command(self.write_pipe, Command::Quit).unwrap();
+
+        let status = wait().unwrap();
+        eprintln!("Child status: {status:?}");
+
+        let _ = close(self.write_pipe);
+    }
+}
+
+async fn parent_main(path: &Path, write_pipe: i32) -> Result<()> {
+    let store = SqliteCryptoStore::open(path, None).await?.into_crypto_store();
+    let lock_key = LOCK_KEY.to_string();
+
+    let _close_child_guard = CloseChildGuard { write_pipe };
+
+    let mut generation = 0;
+
+    // Set initial generation to 0.
+    store.set_custom_value(GENERATION_KEY, vec![generation]).await?;
+
+    loop {
+        //while generation <= 254 {
+        // Write a command.
+        let val = unsafe { rand() } % 1;
+
+        let id = unsafe { rand() };
+        let str = format!("hello {id}");
+
+        let cmd = match val {
+            0 => {
+                // the child will write, so we remove the value
+                let cmd = Command::WriteValue(str);
+
+                store.remove_custom_value(KEY).await?;
+
+                write_command(write_pipe, cmd.clone())?;
+                cmd
+            }
+
+            1 => {
+                // the child will read, so we write the value
+                store.set_custom_value(KEY, str.as_bytes().to_vec()).await?;
+
+                let cmd = Command::ReadValue(str);
+                write_command(write_pipe, cmd.clone())?;
+                cmd
+            }
+
+            _ => unreachable!(),
+        };
+
+        loop {
+            // Compete with the child to take the lock!
+            let _lock = CryptoStoreLockGuard::new(store.clone(), lock_key.clone()).await?;
+
+            let read_generation =
+                store.get_custom_value(GENERATION_KEY).await?.expect("there's always a generation")
+                    [0];
+
+            // Check that if we've seen the latest result, based on the generation number (any
+            // write to the generation indicates somebody else wrote to the database).
+            if generation != read_generation {
+                // Run assertions here.
+                cmd.assert(&store).await?;
+
+                generation = read_generation;
+
+                break;
+            }
+            println!("parent: waiting...");
+        }
+    }
+
+    //simple_parent_test(write_pipe, &store, lock_key).await?;
+
+    #[allow(unreachable_code)]
+    Ok(())
+}
+
+#[allow(unused)]
+async fn simple_parent_test(
+    write_pipe: i32,
+    store: &Arc<DynCryptoStore>,
+    lock_key: String,
+) -> Result<()> {
+    {
+        write_command(write_pipe, Command::WriteValue("Hi there".into()))?;
+        sleep(Duration::from_millis(300)).await;
+
+        eprintln!("parent waits for lock");
+        let _lock = CryptoStoreLockGuard::new(store.clone(), lock_key.clone()).await?;
+
+        eprintln!("parent got the lock, checking custom value");
+
+        let val = store.get_custom_value(KEY).await?;
+        assert_eq!(val, Some("Hi there".as_bytes().to_vec()));
+
+        store.set_custom_value(KEY, "Yo dawg".as_bytes().to_vec()).await?;
+    }
+
+    eprintln!("parent releases the lock");
+
+    write_command(write_pipe, Command::ReadValue("Yo dawg".into()))?;
+    sleep(Duration::from_millis(300)).await;
+
+    {
+        eprintln!("parent waits for lock 2");
+        let _lock = CryptoStoreLockGuard::new(store.clone(), lock_key.clone()).await?;
+
+        eprintln!("parent got the lock 2, checking no more value");
+
+        let val = store.get_custom_value(KEY).await?;
+        assert_eq!(val, None);
+    }
+
+    eprintln!("parent released the lock 2");
+    Ok(())
+}
+
+async fn child_main(path: &Path, read_pipe: i32) -> Result<()> {
+    let store = SqliteCryptoStore::open(path, None).await?.into_crypto_store();
+    let lock_key = LOCK_KEY.to_string();
+
+    loop {
+        eprintln!("child waits for command");
+        match read_command(read_pipe)? {
+            Command::WriteValue(val) => {
+                eprintln!("child received command: write {val}; waiting for lock");
+
+                let _lock = CryptoStoreLockGuard::new(store.clone(), lock_key.clone()).await?;
+                eprintln!("child got the lock");
+
+                store.set_custom_value(KEY, val.as_bytes().to_vec()).await?;
+
+                let generation = store.get_custom_value(GENERATION_KEY).await?.unwrap()[0];
+                let generation = generation.wrapping_add(1);
+                store.set_custom_value(GENERATION_KEY, vec![generation]).await?;
+            }
+
+            Command::ReadValue(expected) => {
+                eprintln!("child received command: read {expected}; waiting for lock");
+
+                let _lock = CryptoStoreLockGuard::new(store.clone(), lock_key.clone()).await?;
+                eprintln!("child got the lock");
+
+                let val = store.get_custom_value(KEY).await?.expect("missing value in child");
+                assert_eq!(val, expected.as_bytes());
+
+                store.remove_custom_value(KEY).await?;
+
+                let generation = store.get_custom_value(GENERATION_KEY).await?.unwrap()[0];
+                store.set_custom_value(GENERATION_KEY, vec![generation + 1]).await?;
+            }
+
+            Command::Quit => {
+                break;
+            }
+        }
+    }
+
+    close(read_pipe)?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let path = temp_dir().join("db.sqlite");
+
+    if path.exists() {
+        std::fs::remove_dir_all(&path)?;
+    }
+
+    // Force running migrations first.
+    {
+        let rt = Runtime::new()?;
+        let path = path.clone();
+        rt.block_on(async {
+            let _store = SqliteCryptoStore::open(path, None).await?;
+            anyhow::Ok(())
+        })?;
+    }
+
+    let (read_pipe, write_pipe) = pipe()?;
+
+    let pid = unsafe { fork() }?;
+    match pid {
+        nix::unistd::ForkResult::Parent { .. } => {
+            // Parent doesn't read.
+            close(read_pipe)?;
+
+            let rt = Runtime::new()?;
+            rt.block_on(parent_main(&path, write_pipe))
+        }
+
+        nix::unistd::ForkResult::Child => {
+            // Child doesn't write.
+            close(write_pipe)?;
+
+            let rt = Runtime::new()?;
+            rt.block_on(child_main(&path, read_pipe))
+        }
+    }
+}


### PR DESCRIPTION
This implements a value-based lock in the crypto stores. The intent is to use that for multiple processes to be able to make writes into the store concurrently, while still cooperating on who does them. In particular, we need this for #1928, since we may have up to two different processes trying to write into the crypto store at the same time.

## New methods in the `CryptoStore` trait

The idea is to introduce two new methods touching **custom values** in the crypto store:

- one to atomically insert a value, only if it was missing (so, not following the semantics of `upsert` used in the `set_custom_value`) 
- one to atomically remove a custom value

Those two operations match the semantics we want:

- take the lock only if it ain't taken already == insert an entry only if it was missing
- release the lock = remove the entry

By looking at the number of lines affected by the query, we can infer whether the insert/remove happened or not, that is, if we managed to take the lock or not.

## High-level APIs

I've also added an high-level API, `CryptoStoreLock`, that helps managing such a lock, and adds some niceties on top of that:

- exponential backoff to retry attempts at acquiring the lock, when it was already taken
- attempt to gracefully recover when the lock has been taken by an app that's been killed by the environment
- full configuration of the key / value / backoff parameters

I've also attempted to make a `CryptoStoreLockGuard`, that would be RAII struct taking the lock upon creation and releasing it upon drop, but:

- `async Drop`s are not a thing yet, in native Rust
- even if we spawn a blocking task that runs the cleanup, we cannot ensure that it will be finished before the next attempt to take a lock. Worst case: it's the same holder trying to take the lock (someone else couldn't take it, they would wait), but then we'd consider the lock as acquired (per the graceful recover semantics), and then the deletion would happen, and then we would panic when deleting it.

As a matter of fact, I think we should probably not have the `CryptoStoreLockGuard` at all, since it's causing more problems than it fixes. I don't know how big an ergonomic issue it will be, though.

## Test program

There's also a test program in which I shamelessly show my rudimentary unix skills; I've put it in the `labs/` directory but this could as well be a large integration test. A parent program initially fills a custom crypto store, then creates a `pipe()` for 1-way communication with a child created with `fork()`; then the parent sends commands to the child. These commands consist in reading and writing into the crypto store, using a lock. And while the child attempts to perform these operations, the parent tries hard to get the lock at the same time. This helps figuring out a few issues and making sure that cross-process locking would work as intended.