### PR TITLE
Add first_time_seen timestamp to devices

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/device.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/device.rs
@@ -26,7 +26,7 @@ pub struct Device {
     /// device.
     pub cross_signing_trusted: bool,
     /// The first time this device was seen in local timestamp, seconds since
-    /// epoch
+    /// epoch.
     pub first_time_seen_ts: u64,
 }
 

--- a/bindings/matrix-sdk-crypto-ffi/src/device.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/device.rs
@@ -25,6 +25,8 @@ pub struct Device {
     /// Is our cross signing identity trusted and does the identity trust the
     /// device.
     pub cross_signing_trusted: bool,
+    /// The first time this device was seen in local timestamp, seconds since epoch
+    pub first_time_seen_ts: u64,
 }
 
 impl From<InnerDevice> for Device {
@@ -38,6 +40,7 @@ impl From<InnerDevice> for Device {
             is_blocked: d.is_blacklisted(),
             locally_trusted: d.is_locally_trusted(),
             cross_signing_trusted: d.is_cross_signing_trusted(),
+            first_time_seen_ts: d.first_time_seen_ts(),
         }
     }
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/device.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/device.rs
@@ -25,7 +25,8 @@ pub struct Device {
     /// Is our cross signing identity trusted and does the identity trust the
     /// device.
     pub cross_signing_trusted: bool,
-    /// The first time this device was seen in local timestamp, seconds since epoch
+    /// The first time this device was seen in local timestamp, seconds since
+    /// epoch
     pub first_time_seen_ts: u64,
 }
 

--- a/bindings/matrix-sdk-crypto-ffi/src/device.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/device.rs
@@ -41,7 +41,7 @@ impl From<InnerDevice> for Device {
             is_blocked: d.is_blacklisted(),
             locally_trusted: d.is_locally_trusted(),
             cross_signing_trusted: d.is_cross_signing_trusted(),
-            first_time_seen_ts: d.first_time_seen_ts(),
+            first_time_seen_ts: d.first_time_seen_ts().0.into(),
         }
     }
 }

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -43,7 +43,8 @@ pub use responses::{
 };
 use ruma::{
     events::room::history_visibility::HistoryVisibility as RustHistoryVisibility,
-    DeviceKeyAlgorithm, OwnedDeviceId, OwnedUserId, RoomId, SecondsSinceUnixEpoch, UserId, MilliSecondsSinceUnixEpoch,
+    DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedUserId, RoomId,
+    SecondsSinceUnixEpoch, UserId,
 };
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Runtime;

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -244,7 +244,7 @@ async fn migrate_data(
         pickle,
         shared: data.account.shared,
         uploaded_signed_key_count: data.account.uploaded_signed_key_count as u64,
-        creation_local_time_ts: 0u64,
+        creation_local_time_ts: UInt::default(),
     };
     let account = matrix_sdk_crypto::olm::ReadOnlyAccount::from_pickle(pickled_account)?;
 

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -43,7 +43,7 @@ pub use responses::{
 };
 use ruma::{
     events::room::history_visibility::HistoryVisibility as RustHistoryVisibility,
-    DeviceKeyAlgorithm, OwnedDeviceId, OwnedUserId, RoomId, SecondsSinceUnixEpoch, UserId,
+    DeviceKeyAlgorithm, OwnedDeviceId, OwnedUserId, RoomId, SecondsSinceUnixEpoch, UserId, MilliSecondsSinceUnixEpoch,
 };
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Runtime;
@@ -244,7 +244,7 @@ async fn migrate_data(
         pickle,
         shared: data.account.shared,
         uploaded_signed_key_count: data.account.uploaded_signed_key_count as u64,
-        creation_local_time: UInt::default(),
+        creation_local_time: MilliSecondsSinceUnixEpoch(UInt::default()),
     };
     let account = matrix_sdk_crypto::olm::ReadOnlyAccount::from_pickle(pickled_account)?;
 

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -244,6 +244,7 @@ async fn migrate_data(
         pickle,
         shared: data.account.shared,
         uploaded_signed_key_count: data.account.uploaded_signed_key_count as u64,
+        creation_local_time_ts: 0u64,
     };
     let account = matrix_sdk_crypto::olm::ReadOnlyAccount::from_pickle(pickled_account)?;
 

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -244,7 +244,7 @@ async fn migrate_data(
         pickle,
         shared: data.account.shared,
         uploaded_signed_key_count: data.account.uploaded_signed_key_count as u64,
-        creation_local_time_ts: UInt::default(),
+        creation_local_time: UInt::default(),
     };
     let account = matrix_sdk_crypto::olm::ReadOnlyAccount::from_pickle(pickled_account)?;
 

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -190,7 +190,7 @@ impl Device {
     /// Is the device deleted?
     #[wasm_bindgen(js_name = "firstTimeSeen")]
     pub fn first_time_seen(&self) -> u64 {
-        self.inner.first_time_seen_ts()
+        self.inner.first_time_seen_ts().0.into()
     }
 }
 

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -186,6 +186,12 @@ impl Device {
     pub fn is_deleted(&self) -> bool {
         self.inner.is_deleted()
     }
+
+    /// Is the device deleted?
+    #[wasm_bindgen(js_name = "firstTimeSeen")]
+    pub fn first_time_seen(&self) -> u64 {
+        self.inner.first_time_seen_ts()
+    }
 }
 
 /// The local trust state of a device.

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -15,3 +15,7 @@
 
 - Add new API `store::Store::room_keys_received_stream` to provide
   updates of room keys being received.
+
+- Add new method `identities::device::Device::first_time_seen_ts` 
+  that allows to get a local timestamp of when the device was first seen by
+  the sdk (in seconds since epoch).

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -939,7 +939,7 @@ impl ReadOnlyDevice {
     }
 
     /// Get the local timestamp of when this device was first persisted, in
-    /// seconds since epoch.
+    /// seconds since epoch (client local time).
     pub fn first_time_seen_ts(&self) -> u64 {
         self.first_time_seen_ts.into()
     }

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -931,9 +931,11 @@ impl ReadOnlyDevice {
     /// replicated locally.
     pub async fn from_account(account: &ReadOnlyAccount) -> ReadOnlyDevice {
         let device_keys = account.device_keys().await;
-        let from_keys = ReadOnlyDevice::try_from(&device_keys)
+        let mut device = ReadOnlyDevice::try_from(&device_keys)
             .expect("Creating a device from our own account should always succeed");
-        ReadOnlyDevice { first_time_seen_ts: account.creation_local_time_ts().into(), ..from_keys }
+        device.first_time_seen_ts = account.creation_local_time_ts().into();
+
+        device
     }
 
     /// Get the local timestamp of when this device was first persisted, in

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::{
-    cmp,
     collections::{BTreeMap, HashMap},
     convert::{TryFrom, TryInto},
     ops::Deref,

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -21,10 +21,10 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::SystemTime,
 };
 
 use atomic::Atomic;
+use matrix_sdk_common::instant::SystemTime;
 use ruma::{
     api::client::keys::upload_signatures::v3::Request as SignatureUploadRequest,
     events::{key::verification::VerificationMethod, AnyToDeviceEventContent},
@@ -71,7 +71,7 @@ pub enum MaybeEncryptedRoomKey {
     },
 }
 
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(from = "u64", into = "u64")]
 struct SecondsSinceUnixEpoch(u64);
 
@@ -83,12 +83,6 @@ impl SecondsSinceUnixEpoch {
                 .map_or(0f64, |t| t.as_secs_f64())
                 .to_bits(),
         )
-    }
-}
-
-impl Default for SecondsSinceUnixEpoch {
-    fn default() -> Self {
-        SecondsSinceUnixEpoch(0u64)
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -88,7 +88,7 @@ impl SecondsSinceUnixEpoch {
 
 impl From<u64> for SecondsSinceUnixEpoch {
     fn from(value: u64) -> Self {
-        SecondsSinceUnixEpoch(cmp::max(0, value))
+        Self(value)
     }
 }
 impl From<SecondsSinceUnixEpoch> for u64 {

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -77,7 +77,7 @@ struct SecondsSinceUnixEpoch(u64);
 
 impl SecondsSinceUnixEpoch {
     fn now() -> Self {
-        SecondsSinceUnixEpoch(
+        Self(
             SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .map_or(0f64, |t| t.as_secs_f64())

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -910,7 +910,7 @@ impl ReadOnlyDevice {
         let device_keys = account.device_keys().await;
         let mut device = ReadOnlyDevice::try_from(&device_keys)
             .expect("Creating a device from our own account should always succeed");
-        device.first_time_seen_ts = account.creation_local_time_ts();
+        device.first_time_seen_ts = account.creation_local_time();
 
         device
     }

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -80,7 +80,7 @@ impl SecondsSinceUnixEpoch {
         Self(
             SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
-                .map_or(0f64, |t| t.as_secs_f64())
+                .map_or(0f64, |duration| duration.as_secs_f64())
                 .to_bits(),
         )
     }

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -988,7 +988,6 @@ pub(crate) mod testing {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::time::SystemTime;
 
     use ruma::{user_id, MilliSecondsSinceUnixEpoch};
     use vodozemac::{Curve25519PublicKey, Ed25519PublicKey};

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -1011,7 +1011,6 @@ pub(crate) mod testing {
 
 #[cfg(test)]
 pub(crate) mod tests {
-
     use std::time::SystemTime;
 
     use ruma::user_id;

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -487,7 +487,7 @@ pub struct ReadOnlyAccount {
     /// client to upload new keys.
     uploaded_signed_key_count: Arc<AtomicU64>,
     // The creation time of the account in milliseconds since epoch.
-    creation_local_time_ts: MilliSecondsSinceUnixEpoch,
+    creation_local_time: MilliSecondsSinceUnixEpoch,
 }
 
 /// A pickled version of an `Account`.
@@ -510,7 +510,7 @@ pub struct PickledAccount {
     /// The local time creation of this account (seconds since epoch), used as
     /// creation time of own device
     #[serde(default)]
-    pub creation_local_time_ts: UInt,
+    pub creation_local_time: UInt,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -546,7 +546,7 @@ impl ReadOnlyAccount {
             identity_keys: Arc::new(identity_keys),
             shared: Arc::new(AtomicBool::new(false)),
             uploaded_signed_key_count: Arc::new(AtomicU64::new(0)),
-            creation_local_time_ts: MilliSecondsSinceUnixEpoch::now(),
+            creation_local_time: MilliSecondsSinceUnixEpoch::now(),
         }
     }
 
@@ -571,8 +571,8 @@ impl ReadOnlyAccount {
     }
 
     /// Get the local timestamp creation of the account in secs since epoch
-    pub fn creation_local_time_ts(&self) -> MilliSecondsSinceUnixEpoch {
-        self.creation_local_time_ts
+    pub fn creation_local_time(&self) -> MilliSecondsSinceUnixEpoch {
+        self.creation_local_time
     }
 
     /// Update the uploaded key count.
@@ -774,7 +774,7 @@ impl ReadOnlyAccount {
             pickle,
             shared: self.shared(),
             uploaded_signed_key_count: self.uploaded_key_count(),
-            creation_local_time_ts: self.creation_local_time_ts.0,
+            creation_local_time: self.creation_local_time.0,
         }
     }
 
@@ -798,7 +798,7 @@ impl ReadOnlyAccount {
             identity_keys: Arc::new(identity_keys),
             shared: Arc::new(AtomicBool::from(pickle.shared)),
             uploaded_signed_key_count: Arc::new(AtomicU64::new(pickle.uploaded_signed_key_count)),
-            creation_local_time_ts: MilliSecondsSinceUnixEpoch(pickle.creation_local_time_ts),
+            creation_local_time: MilliSecondsSinceUnixEpoch(pickle.creation_local_time),
         })
     }
 
@@ -1395,11 +1395,11 @@ mod tests {
         let account = ReadOnlyAccount::new(user_id(), device_id());
         let then = MilliSecondsSinceUnixEpoch::now();
 
-        assert!(account.creation_local_time_ts() >= now);
-        assert!(account.creation_local_time_ts() <= then);
+        assert!(account.creation_local_time() >= now);
+        assert!(account.creation_local_time() <= then);
 
         let device = ReadOnlyDevice::from_account(&account).await;
-        assert_eq!(account.creation_local_time_ts(), device.first_time_seen_ts());
+        assert_eq!(account.creation_local_time(), device.first_time_seen_ts());
 
         Ok(())
     }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -549,7 +549,7 @@ impl ReadOnlyAccount {
             uploaded_signed_key_count: Arc::new(AtomicU64::new(0)),
             creation_local_time_ts: SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
-                .map_or(0f64, |t| t.as_secs_f64())
+                .map_or(0f64, Duration::as_secs_f64)
                 .to_bits(),
         }
     }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -507,10 +507,14 @@ pub struct PickledAccount {
     pub shared: bool,
     /// The number of uploaded one-time keys we have on the server.
     pub uploaded_signed_key_count: u64,
-    /// The local time creation of this account (seconds since epoch), used as
-    /// creation time of own device
-    #[serde(default)]
-    pub creation_local_time: UInt,
+    /// The local time creation of this account (milliseconds since epoch), used
+    /// as creation time of own device
+    #[serde(default = "default_account_creation_time")]
+    pub creation_local_time: MilliSecondsSinceUnixEpoch,
+}
+
+fn default_account_creation_time() -> MilliSecondsSinceUnixEpoch {
+    MilliSecondsSinceUnixEpoch(UInt::default())
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -774,7 +778,7 @@ impl ReadOnlyAccount {
             pickle,
             shared: self.shared(),
             uploaded_signed_key_count: self.uploaded_key_count(),
-            creation_local_time: self.creation_local_time.0,
+            creation_local_time: self.creation_local_time,
         }
     }
 
@@ -798,7 +802,7 @@ impl ReadOnlyAccount {
             identity_keys: Arc::new(identity_keys),
             shared: Arc::new(AtomicBool::from(pickle.shared)),
             uploaded_signed_key_count: Arc::new(AtomicU64::new(pickle.uploaded_signed_key_count)),
-            creation_local_time: MilliSecondsSinceUnixEpoch(pickle.creation_local_time),
+            creation_local_time: pickle.creation_local_time,
         })
     }
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1266,7 +1266,6 @@ mod tests {
     use std::{
         collections::{BTreeMap, BTreeSet},
         ops::Deref,
-        time::SystemTime,
     };
 
     use anyhow::Result;


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Added a new `first_time_seen_ts` fn to `Device`. This is used by clients to show "New login, was this you" or "You have unverified logins" banners.

Simply added as a ~~SystemTime~~ u64 wrapper in the structs, exposed in ffi binding as an `u64` seconds since epoch.
Value is populated with serde default for migration of existing persisted data.

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
