### PR TITLE
sliding sync: always fall back to the auto-discovered proxy URL, if any

### DIFF
--- a/bindings/matrix-sdk-ffi/src/sliding_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/sliding_sync.rs
@@ -865,12 +865,7 @@ impl Client {
     ///
     /// Note: the identifier must be less than 16 chars long.
     pub fn sliding_sync(&self, id: String) -> Result<Arc<SlidingSyncBuilder>, ClientError> {
-        let mut inner = self.inner.sliding_sync(id)?;
-
-        if let Some(sliding_sync_proxy) = self.inner.sliding_sync_proxy() {
-            inner = inner.sliding_sync_proxy(sliding_sync_proxy);
-        }
-
+        let inner = self.inner.sliding_sync(id)?;
         Ok(Arc::new(SlidingSyncBuilder { inner, client: self.clone() }))
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list/mod.rs
@@ -96,14 +96,9 @@ impl RoomList {
     /// A [`matrix_sdk::SlidingSync`] client will be created, with a cached list
     /// already pre-configured.
     pub async fn new(client: Client) -> Result<Self, Error> {
-        let mut sliding_sync_builder =
-            client.sliding_sync("room-list").map_err(Error::SlidingSync)?;
-
-        if let Some(sliding_sync_proxy_url) = client.sliding_sync_proxy() {
-            sliding_sync_builder = sliding_sync_builder.sliding_sync_proxy(sliding_sync_proxy_url);
-        }
-
-        let sliding_sync = sliding_sync_builder
+        let sliding_sync = client
+            .sliding_sync("room-list")
+            .map_err(Error::SlidingSync)?
             // Enable the account data extension.
             .with_account_data_extension(
                 assign! { AccountDataConfig::default(), { enabled: Some(true) }},

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -262,6 +262,10 @@ impl SlidingSyncBuilder {
         let rooms = AsyncRwLock::new(self.rooms);
         let lists = AsyncRwLock::new(lists);
 
+        // Use the configured sliding sync proxy, or if not set, try to use the one
+        // auto-discovered by the client, if any.
+        let sliding_sync_proxy = self.sliding_sync_proxy.or_else(|| client.sliding_sync_proxy());
+
         // Always enable to-device events and the e2ee-extension on the initial request,
         // no matter what the caller wants.
         let mut extensions = self.extensions.unwrap_or_default();
@@ -270,7 +274,7 @@ impl SlidingSyncBuilder {
 
         Ok(SlidingSync::new(SlidingSyncInner {
             _id: Some(self.id),
-            sliding_sync_proxy: self.sliding_sync_proxy,
+            sliding_sync_proxy,
             client,
             storage_key: self.storage_key,
 


### PR DESCRIPTION
Don't expect the `SlidingSyncBuilder` to retrieve the proxy URL from the Client, but do it for them automatically. This removes a bit of duplication, as it's done in both the FFI and the Room API (and soon, the Notification API too). And it actually makes reality match with the comment (I wrote, but at the time misunderstood) of `SlidingSyncBuilder::sliding_sync_proxy`.