### PR TITLE
Use the short auth strings from the start content when accepting a verification

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v0.7.0
 
+- Ensure that the correct short authentication strings are used when accepting a
+  SAS verification with the `Sas::accept()` method.
+
 - Add a new optional `message-ids` feature which adds a unique ID to the content
   of `m.room.encrypted` event contents which get sent out.
 

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -125,7 +125,7 @@ impl VerificationMachine {
         device: ReadOnlyDevice,
     ) -> Result<(Sas, OutgoingVerificationRequest), CryptoStoreError> {
         let identities = self.store.get_identities(device.clone()).await?;
-        let (sas, content) = Sas::start(identities, TransactionId::new(), true, None);
+        let (sas, content) = Sas::start(identities, TransactionId::new(), true, None, None);
 
         let request = match content {
             OutgoingContent::Room(r, c) => {
@@ -564,7 +564,8 @@ mod tests {
             bob_store.get_device(alice_id(), alice_device_id()).await.unwrap().unwrap();
 
         let identities = bob_store.get_identities(alice_device).await.unwrap();
-        let (bob_sas, start_content) = Sas::start(identities, TransactionId::new(), true, None);
+        let (bob_sas, start_content) =
+            Sas::start(identities, TransactionId::new(), true, None, None);
 
         machine
             .receive_any_event(&wrap_any_to_device_content(bob_sas.user_id(), start_content))
@@ -672,7 +673,7 @@ mod tests {
 
         // Start the first sas verification.
         let (bob_sas, start_content) =
-            Sas::start(identities.clone(), TransactionId::new(), true, None);
+            Sas::start(identities.clone(), TransactionId::new(), true, None, None);
 
         machine
             .receive_any_event(&wrap_any_to_device_content(bob_sas.user_id(), start_content))
@@ -686,7 +687,7 @@ mod tests {
 
         let second_transaction_id = TransactionId::new();
         let (bob_sas, start_content) =
-            Sas::start(identities, second_transaction_id.clone(), true, None);
+            Sas::start(identities, second_transaction_id.clone(), true, None, None);
         machine
             .receive_any_event(&wrap_any_to_device_content(bob_sas.user_id(), start_content))
             .await

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -1463,7 +1463,7 @@ async fn start_sas<T: Clone>(
     let (state, sas, content) = match request_state.flow_id.as_ref() {
         FlowId::ToDevice(t) => {
             let (sas, content) =
-                Sas::start(identities, t.to_owned(), we_started, Some(request_handle));
+                Sas::start(identities, t.to_owned(), we_started, Some(request_handle), None);
 
             let state =
                 Transitioned { ready: state.to_owned(), verification: sas.to_owned().into() };

--- a/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
@@ -63,6 +63,7 @@ impl InnerSas {
         other_identity: Option<ReadOnlyUserIdentities>,
         transaction_id: FlowId,
         started_from_request: bool,
+        short_auth_string: Option<Vec<ShortAuthenticationString>>,
     ) -> (InnerSas, OutgoingContent) {
         let sas = SasState::<Created>::new(
             account,
@@ -71,6 +72,7 @@ impl InnerSas {
             other_identity,
             transaction_id,
             started_from_request,
+            short_auth_string,
         );
         let content = sas.as_content();
         (InnerSas::Created(sas), content.into())

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -79,7 +79,7 @@ fn the_protocol_definitions(
     short_auth_strings: Option<Vec<ShortAuthenticationString>>,
 ) -> SasV1Content {
     SasV1ContentInit {
-        short_authentication_string: short_auth_stings.unwrap_or_else(|| STRINGS.to_owned()),
+        short_authentication_string: short_auth_strings.unwrap_or_else(|| STRINGS.to_owned()),
         key_agreement_protocols: KEY_AGREEMENT_PROTOCOLS.to_vec(),
         message_authentication_codes: vec![
             #[allow(deprecated)]

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -75,9 +75,11 @@ const HASHES: &[HashAlgorithm] = &[HashAlgorithm::Sha256];
 const STRINGS: &[ShortAuthenticationString] =
     &[ShortAuthenticationString::Decimal, ShortAuthenticationString::Emoji];
 
-fn the_protocol_definitions() -> SasV1Content {
+fn the_protocol_definitions(
+    short_auth_stings: Option<Vec<ShortAuthenticationString>>,
+) -> SasV1Content {
     SasV1ContentInit {
-        short_authentication_string: STRINGS.to_vec(),
+        short_authentication_string: short_auth_stings.unwrap_or_else(|| STRINGS.to_owned()),
         key_agreement_protocols: KEY_AGREEMENT_PROTOCOLS.to_vec(),
         message_authentication_codes: vec![
             #[allow(deprecated)]
@@ -547,6 +549,7 @@ impl SasState<Created> {
         other_identity: Option<ReadOnlyUserIdentities>,
         flow_id: FlowId,
         started_from_request: bool,
+        short_auth_strings: Option<Vec<ShortAuthenticationString>>,
     ) -> SasState<Created> {
         Self::new_helper(
             flow_id,
@@ -555,6 +558,7 @@ impl SasState<Created> {
             own_identity,
             other_identity,
             started_from_request,
+            short_auth_strings,
         )
     }
 
@@ -565,9 +569,12 @@ impl SasState<Created> {
         own_identity: Option<ReadOnlyOwnUserIdentity>,
         other_identity: Option<ReadOnlyUserIdentities>,
         started_from_request: bool,
+        short_auth_strings: Option<Vec<ShortAuthenticationString>>,
     ) -> SasState<Created> {
         let sas = Sas::new();
         let our_public_key = sas.public_key();
+
+        let protocol_definitions = the_protocol_definitions(short_auth_strings);
 
         SasState {
             inner: Arc::new(Mutex::new(Some(sas))),
@@ -579,7 +586,7 @@ impl SasState<Created> {
             last_event_time: Arc::new(Instant::now()),
             started_from_request,
 
-            state: Arc::new(Created { protocol_definitions: the_protocol_definitions() }),
+            state: Arc::new(Created { protocol_definitions }),
         }
     }
 
@@ -785,14 +792,14 @@ impl SasState<Started> {
                 OwnedStartContent::ToDevice(ToDeviceKeyVerificationStartEventContent::new(
                     self.device_id().into(),
                     s.clone(),
-                    StartMethod::SasV1(the_protocol_definitions()),
+                    StartMethod::SasV1(self.state.protocol_definitions.to_owned()),
                 ))
             }
             FlowId::InRoom(r, e) => OwnedStartContent::Room(
                 r.clone(),
                 KeyVerificationStartEventContent::new(
                     self.device_id().into(),
-                    StartMethod::SasV1(the_protocol_definitions()),
+                    StartMethod::SasV1(self.state.protocol_definitions.to_owned()),
                     Reference::new(e.clone()),
                 ),
             ),
@@ -1552,7 +1559,7 @@ mod tests {
 
         let flow_id = TransactionId::new().into();
         let alice_sas =
-            SasState::<Created>::new(alice.clone(), bob_device, None, None, flow_id, false);
+            SasState::<Created>::new(alice.clone(), bob_device, None, None, flow_id, false, None);
 
         let start_content = alice_sas.as_content();
         let flow_id = start_content.flow_id();
@@ -1790,7 +1797,7 @@ mod tests {
 
         let flow_id = TransactionId::new().into();
         let alice_sas =
-            SasState::<Created>::new(alice.clone(), bob_device, None, None, flow_id, false);
+            SasState::<Created>::new(alice.clone(), bob_device, None, None, flow_id, false, None);
 
         let mut start_content = alice_sas.as_content();
         let method = start_content.method_mut();

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -76,7 +76,7 @@ const STRINGS: &[ShortAuthenticationString] =
     &[ShortAuthenticationString::Decimal, ShortAuthenticationString::Emoji];
 
 fn the_protocol_definitions(
-    short_auth_stings: Option<Vec<ShortAuthenticationString>>,
+    short_auth_strings: Option<Vec<ShortAuthenticationString>>,
 ) -> SasV1Content {
     SasV1ContentInit {
         short_authentication_string: short_auth_stings.unwrap_or_else(|| STRINGS.to_owned()),


### PR DESCRIPTION
Closes: https://github.com/matrix-org/matrix-rust-sdk/issues/2060.