### PR TITLE
sliding sync: lazily generate and include the transaction id, only if it's useful

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -46,7 +46,7 @@ use ruma::{
         error::ErrorKind,
         sync::sync_events::v4::{self, ExtensionsConfig},
     },
-    assign, OwnedRoomId, OwnedTransactionId, RoomId,
+    assign, OwnedRoomId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -56,7 +56,7 @@ use tokio::{
 use tracing::{debug, error, instrument, warn, Instrument, Span};
 use url::Url;
 
-use self::sticky_parameters::{SlidingSyncStickyManager, StickyData};
+use self::sticky_parameters::{LazyTransactionId, SlidingSyncStickyManager, StickyData};
 use crate::{config::RequestConfig, Client, Result};
 
 /// Number of times a Sliding Sync session can expire before raising an error.
@@ -376,7 +376,7 @@ impl SlidingSync {
 
     async fn generate_sync_request(
         &self,
-        txn_id: &mut Option<OwnedTransactionId>,
+        txn_id: &mut LazyTransactionId,
     ) -> Result<(v4::Request, RequestConfig, BTreeSet<OwnedRoomId>)> {
         // Collect requests for lists.
         let mut requests_lists = BTreeMap::new();
@@ -423,7 +423,7 @@ impl SlidingSync {
         }
 
         // Apply the transaction id if one was generated.
-        if let Some(txn_id) = txn_id.as_ref() {
+        if let Some(txn_id) = txn_id.get() {
             request.txn_id = Some(txn_id.to_string());
         }
 
@@ -440,7 +440,7 @@ impl SlidingSync {
     #[instrument(skip_all, fields(pos))]
     async fn sync_once(&self) -> Result<UpdateSummary> {
         let (request, request_config, requested_room_unsubscriptions) =
-            self.generate_sync_request(&mut None).await?;
+            self.generate_sync_request(&mut LazyTransactionId::new()).await?;
 
         debug!("Sending the sliding sync request");
 
@@ -922,7 +922,7 @@ mod tests {
         let mut request = v4::Request::default();
         request.txn_id = Some(txn_id.to_string());
 
-        sticky.maybe_apply(&mut request, &mut Some(txn_id.to_owned()));
+        sticky.maybe_apply(&mut request, &mut LazyTransactionId::from_owned(txn_id.to_owned()));
 
         assert!(request.txn_id.is_some());
         assert_eq!(request.room_subscriptions.len(), 1);
@@ -948,7 +948,7 @@ mod tests {
         let txn_id1: &TransactionId = "tid456".into();
         let mut request1 = v4::Request::default();
         request1.txn_id = Some(txn_id1.to_string());
-        sticky.maybe_apply(&mut request1, &mut Some(txn_id1.to_owned()));
+        sticky.maybe_apply(&mut request1, &mut LazyTransactionId::from_owned(txn_id1.to_owned()));
 
         assert!(sticky.is_invalidated());
         assert_eq!(request1.room_subscriptions.len(), 2);
@@ -957,7 +957,7 @@ mod tests {
         let mut request2 = v4::Request::default();
         request2.txn_id = Some(txn_id2.to_string());
 
-        sticky.maybe_apply(&mut request2, &mut Some(txn_id2.to_owned()));
+        sticky.maybe_apply(&mut request2, &mut LazyTransactionId::from_owned(txn_id2.to_owned()));
         assert!(sticky.is_invalidated());
         assert_eq!(request2.room_subscriptions.len(), 2);
 
@@ -997,7 +997,7 @@ mod tests {
         let txn_id: &TransactionId = "tid123".into();
         let mut request = v4::Request::default();
         request.txn_id = Some(txn_id.to_string());
-        sticky.maybe_apply(&mut request, &mut Some(txn_id.to_owned()));
+        sticky.maybe_apply(&mut request, &mut LazyTransactionId::from_owned(txn_id.to_owned()));
         assert!(sticky.is_invalidated());
         assert_eq!(request.extensions.to_device.enabled, None);
         assert_eq!(request.extensions.to_device.since, None);
@@ -1027,7 +1027,9 @@ mod tests {
         // Even without a since token, the first request will contain the extensions
         // configuration, at least.
         let txn_id = TransactionId::new();
-        let (request, _, _) = sync.generate_sync_request(&mut Some(txn_id.to_owned())).await?;
+        let (request, _, _) = sync
+            .generate_sync_request(&mut LazyTransactionId::from_owned(txn_id.to_owned()))
+            .await?;
 
         assert_eq!(request.extensions.e2ee.enabled, Some(true));
         assert_eq!(request.extensions.to_device.enabled, Some(true));
@@ -1045,7 +1047,9 @@ mod tests {
 
         // Regenerating a request will yield the same one.
         let txn_id2 = TransactionId::new();
-        let (request, _, _) = sync.generate_sync_request(&mut Some(txn_id2.to_owned())).await?;
+        let (request, _, _) = sync
+            .generate_sync_request(&mut LazyTransactionId::from_owned(txn_id2.to_owned()))
+            .await?;
 
         assert_eq!(request.extensions.e2ee.enabled, Some(true));
         assert_eq!(request.extensions.to_device.enabled, Some(true));
@@ -1063,7 +1067,9 @@ mod tests {
 
         // The next request should contain no sticky parameters.
         let txn_id = TransactionId::new();
-        let (request, _, _) = sync.generate_sync_request(&mut Some(txn_id.to_owned())).await?;
+        let (request, _, _) = sync
+            .generate_sync_request(&mut LazyTransactionId::from_owned(txn_id.to_owned()))
+            .await?;
         assert!(request.extensions.e2ee.enabled.is_none());
         assert!(request.extensions.to_device.enabled.is_none());
         assert!(request.extensions.to_device.since.is_none());
@@ -1075,7 +1081,9 @@ mod tests {
         sync.inner.position.write().unwrap().to_device_token = Some(since_token.to_owned());
 
         let txn_id = TransactionId::new();
-        let (request, _, _) = sync.generate_sync_request(&mut Some(txn_id.to_owned())).await?;
+        let (request, _, _) = sync
+            .generate_sync_request(&mut LazyTransactionId::from_owned(txn_id.to_owned()))
+            .await?;
 
         assert!(request.extensions.e2ee.enabled.is_none());
         assert!(request.extensions.to_device.enabled.is_none());
@@ -1096,7 +1104,8 @@ mod tests {
             .await?;
 
         // First request asks to enable the extension.
-        let (request, _, _) = sliding_sync.generate_sync_request(&mut None).await?;
+        let (request, _, _) =
+            sliding_sync.generate_sync_request(&mut LazyTransactionId::new()).await?;
         assert!(request.extensions.to_device.enabled.is_some());
 
         let sync = sliding_sync.sync();
@@ -1133,7 +1142,8 @@ mod tests {
         assert_matches!(next, Some(Ok(_update_summary)));
 
         // Next request doesn't ask to enable the extension.
-        let (request, _, _) = sliding_sync.generate_sync_request(&mut None).await?;
+        let (request, _, _) =
+            sliding_sync.generate_sync_request(&mut LazyTransactionId::new()).await?;
         assert!(request.extensions.to_device.enabled.is_none());
 
         let next = sync.next().await;
@@ -1158,7 +1168,8 @@ mod tests {
         assert_matches!(next, Some(Err(err)) if err.client_api_error_kind() == Some(&ErrorKind::UnknownPos));
 
         // Next request asks to enable the extension again.
-        let (request, _, _) = sliding_sync.generate_sync_request(&mut None).await?;
+        let (request, _, _) =
+            sliding_sync.generate_sync_request(&mut LazyTransactionId::new()).await?;
         assert!(request.extensions.to_device.enabled.is_some());
 
         Ok(())

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -46,7 +46,7 @@ use ruma::{
         error::ErrorKind,
         sync::sync_events::v4::{self, ExtensionsConfig},
     },
-    assign, OwnedRoomId, OwnedTransactionId, RoomId, TransactionId,
+    assign, OwnedRoomId, OwnedTransactionId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -376,7 +376,7 @@ impl SlidingSync {
 
     async fn generate_sync_request(
         &self,
-        txn_id: OwnedTransactionId,
+        txn_id: &mut Option<OwnedTransactionId>,
     ) -> Result<(v4::Request, RequestConfig, BTreeSet<OwnedRoomId>)> {
         // Collect requests for lists.
         let mut requests_lists = BTreeMap::new();
@@ -385,7 +385,7 @@ impl SlidingSync {
             let lists = self.inner.lists.read().await;
 
             for (name, list) in lists.iter() {
-                requests_lists.insert(name.clone(), list.next_request(&txn_id)?);
+                requests_lists.insert(name.clone(), list.next_request(txn_id)?);
             }
         }
 
@@ -403,7 +403,6 @@ impl SlidingSync {
         let timeout = Duration::from_secs(30);
 
         let mut request = assign!(v4::Request::new(), {
-            txn_id: Some(txn_id.to_string()),
             pos,
             delta_token,
             timeout: Some(timeout),
@@ -414,13 +413,18 @@ impl SlidingSync {
         {
             let mut sticky_params = self.inner.sticky.write().unwrap();
 
-            sticky_params.maybe_apply(&mut request, &txn_id);
+            sticky_params.maybe_apply(&mut request, txn_id);
 
             // Set the to_device token if the extension is enabled.
             if sticky_params.data().extensions.to_device.enabled == Some(true) {
                 request.extensions.to_device.since =
                     self.inner.position.read().unwrap().to_device_token.clone();
             }
+        }
+
+        // Apply the transaction id if one was generated.
+        if let Some(txn_id) = txn_id.as_ref() {
+            request.txn_id = Some(txn_id.to_string());
         }
 
         Ok((
@@ -436,7 +440,7 @@ impl SlidingSync {
     #[instrument(skip_all, fields(pos))]
     async fn sync_once(&self) -> Result<UpdateSummary> {
         let (request, request_config, requested_room_unsubscriptions) =
-            self.generate_sync_request(TransactionId::new()).await?;
+            self.generate_sync_request(&mut None).await?;
 
         debug!("Sending the sliding sync request");
 
@@ -775,7 +779,7 @@ impl StickyData for SlidingSyncStickyParameters {
 mod tests {
     use assert_matches::assert_matches;
     use futures_util::{pin_mut, StreamExt};
-    use ruma::{api::client::sync::sync_events::v4::ToDeviceConfig, room_id};
+    use ruma::{api::client::sync::sync_events::v4::ToDeviceConfig, room_id, TransactionId};
     use serde_json::json;
     use wiremock::{Match, MockServer};
 
@@ -918,7 +922,7 @@ mod tests {
         let mut request = v4::Request::default();
         request.txn_id = Some(txn_id.to_string());
 
-        sticky.maybe_apply(&mut request, txn_id);
+        sticky.maybe_apply(&mut request, &mut Some(txn_id.to_owned()));
 
         assert!(request.txn_id.is_some());
         assert_eq!(request.room_subscriptions.len(), 1);
@@ -944,7 +948,7 @@ mod tests {
         let txn_id1: &TransactionId = "tid456".into();
         let mut request1 = v4::Request::default();
         request1.txn_id = Some(txn_id1.to_string());
-        sticky.maybe_apply(&mut request1, txn_id1);
+        sticky.maybe_apply(&mut request1, &mut Some(txn_id1.to_owned()));
 
         assert!(sticky.is_invalidated());
         assert_eq!(request1.room_subscriptions.len(), 2);
@@ -953,7 +957,7 @@ mod tests {
         let mut request2 = v4::Request::default();
         request2.txn_id = Some(txn_id2.to_string());
 
-        sticky.maybe_apply(&mut request2, txn_id2);
+        sticky.maybe_apply(&mut request2, &mut Some(txn_id2.to_owned()));
         assert!(sticky.is_invalidated());
         assert_eq!(request2.room_subscriptions.len(), 2);
 
@@ -993,7 +997,7 @@ mod tests {
         let txn_id: &TransactionId = "tid123".into();
         let mut request = v4::Request::default();
         request.txn_id = Some(txn_id.to_string());
-        sticky.maybe_apply(&mut request, txn_id);
+        sticky.maybe_apply(&mut request, &mut Some(txn_id.to_owned()));
         assert!(sticky.is_invalidated());
         assert_eq!(request.extensions.to_device.enabled, None);
         assert_eq!(request.extensions.to_device.since, None);
@@ -1023,7 +1027,7 @@ mod tests {
         // Even without a since token, the first request will contain the extensions
         // configuration, at least.
         let txn_id = TransactionId::new();
-        let (request, _, _) = sync.generate_sync_request(txn_id.clone()).await?;
+        let (request, _, _) = sync.generate_sync_request(&mut Some(txn_id.to_owned())).await?;
 
         assert_eq!(request.extensions.e2ee.enabled, Some(true));
         assert_eq!(request.extensions.to_device.enabled, Some(true));
@@ -1041,7 +1045,7 @@ mod tests {
 
         // Regenerating a request will yield the same one.
         let txn_id2 = TransactionId::new();
-        let (request, _, _) = sync.generate_sync_request(txn_id2.clone()).await?;
+        let (request, _, _) = sync.generate_sync_request(&mut Some(txn_id2.to_owned())).await?;
 
         assert_eq!(request.extensions.e2ee.enabled, Some(true));
         assert_eq!(request.extensions.to_device.enabled, Some(true));
@@ -1059,7 +1063,7 @@ mod tests {
 
         // The next request should contain no sticky parameters.
         let txn_id = TransactionId::new();
-        let (request, _, _) = sync.generate_sync_request(txn_id).await?;
+        let (request, _, _) = sync.generate_sync_request(&mut Some(txn_id.to_owned())).await?;
         assert!(request.extensions.e2ee.enabled.is_none());
         assert!(request.extensions.to_device.enabled.is_none());
         assert!(request.extensions.to_device.since.is_none());
@@ -1071,7 +1075,7 @@ mod tests {
         sync.inner.position.write().unwrap().to_device_token = Some(since_token.to_owned());
 
         let txn_id = TransactionId::new();
-        let (request, _, _) = sync.generate_sync_request(txn_id).await?;
+        let (request, _, _) = sync.generate_sync_request(&mut Some(txn_id.to_owned())).await?;
 
         assert!(request.extensions.e2ee.enabled.is_none());
         assert!(request.extensions.to_device.enabled.is_none());
@@ -1092,7 +1096,7 @@ mod tests {
             .await?;
 
         // First request asks to enable the extension.
-        let (request, _, _) = sliding_sync.generate_sync_request(TransactionId::new()).await?;
+        let (request, _, _) = sliding_sync.generate_sync_request(&mut None).await?;
         assert!(request.extensions.to_device.enabled.is_some());
 
         let sync = sliding_sync.sync();
@@ -1129,7 +1133,7 @@ mod tests {
         assert_matches!(next, Some(Ok(_update_summary)));
 
         // Next request doesn't ask to enable the extension.
-        let (request, _, _) = sliding_sync.generate_sync_request(TransactionId::new()).await?;
+        let (request, _, _) = sliding_sync.generate_sync_request(&mut None).await?;
         assert!(request.extensions.to_device.enabled.is_none());
 
         let next = sync.next().await;
@@ -1154,7 +1158,7 @@ mod tests {
         assert_matches!(next, Some(Err(err)) if err.client_api_error_kind() == Some(&ErrorKind::UnknownPos));
 
         // Next request asks to enable the extension again.
-        let (request, _, _) = sliding_sync.generate_sync_request(TransactionId::new()).await?;
+        let (request, _, _) = sliding_sync.generate_sync_request(&mut None).await?;
         assert!(request.extensions.to_device.enabled.is_some());
 
         Ok(())

--- a/crates/matrix-sdk/src/sliding_sync/sticky_parameters.rs
+++ b/crates/matrix-sdk/src/sliding_sync/sticky_parameters.rs
@@ -7,6 +7,40 @@
 
 use ruma::{OwnedTransactionId, TransactionId};
 
+/// An `OwnedTransactionId` that is either initialized at creation, or
+/// lazily-generated once.
+#[derive(Debug)]
+pub struct LazyTransactionId {
+    txn_id: Option<OwnedTransactionId>,
+}
+
+impl LazyTransactionId {
+    /// Create a new `LazyTransactionId`, not set.
+    pub fn new() -> Self {
+        Self { txn_id: None }
+    }
+
+    /// Get (or create it, if never set) a `TransactionId`.
+    pub fn get_or_create(&mut self) -> &TransactionId {
+        self.txn_id.get_or_insert_with(TransactionId::new)
+    }
+
+    /// Attempt to get the underlying `TransactionId` without creating it, if
+    /// missing.
+    pub fn get(&self) -> Option<&TransactionId> {
+        self.txn_id.as_deref()
+    }
+}
+
+#[cfg(test)]
+impl LazyTransactionId {
+    /// Create a `LazyTransactionId` for a given known transaction id. For
+    /// testing only.
+    pub fn from_owned(owned: OwnedTransactionId) -> Self {
+        Self { txn_id: Some(owned) }
+    }
+}
+
 /// A trait to implement for data that can be sticky, given a context.
 pub trait StickyData {
     /// Request type that will be applied to, if the sticky parameters have been
@@ -75,10 +109,10 @@ impl<D: StickyData> SlidingSyncStickyManager<D> {
     ///
     /// If no `txn_id` is provided, it will generate one that can be reused
     /// later.
-    pub fn maybe_apply(&mut self, req: &mut D::Request, txn_id: &mut Option<OwnedTransactionId>) {
+    pub fn maybe_apply(&mut self, req: &mut D::Request, txn_id: &mut LazyTransactionId) {
         if self.invalidated {
-            let txn_id = txn_id.get_or_insert_with(TransactionId::new);
-            self.txn_id = Some(txn_id.clone());
+            let txn_id = txn_id.get_or_create();
+            self.txn_id = Some(txn_id.to_owned());
             self.data.apply(req);
         }
     }
@@ -120,28 +154,28 @@ mod tests {
         assert!(sticky.is_invalidated());
 
         let mut applied = false;
-        let mut txn_id = None;
+        let mut txn_id = LazyTransactionId::new();
         sticky.maybe_apply(&mut applied, &mut txn_id);
         assert!(applied);
         assert!(sticky.is_invalidated());
-        assert!(txn_id.is_some(), "a transaction id was lazily generated");
+        assert!(txn_id.get().is_some(), "a transaction id was lazily generated");
 
         // Committing with the wrong transaction id won't commit.
         sticky.maybe_commit("tid456".into());
         assert!(sticky.is_invalidated());
 
         // Providing the correct transaction id will commit.
-        sticky.maybe_commit(txn_id.as_ref().unwrap());
+        sticky.maybe_commit(txn_id.get().unwrap());
         assert!(!sticky.is_invalidated());
 
         // Applying without being invalidated won't do anything, and not generate a
         // transaction id.
-        let mut txn_id = None;
+        let mut txn_id = LazyTransactionId::new();
         let mut applied = false;
         sticky.maybe_apply(&mut applied, &mut txn_id);
 
         assert!(!applied);
         assert!(!sticky.is_invalidated());
-        assert!(txn_id.is_none());
+        assert!(txn_id.get().is_none());
     }
 }


### PR DESCRIPTION
The `txn_id` (transaction id) was always being generated, and this confused the sliding sync proxy server. As per the spec, it's useful to [include it only when the request parameters have changed](https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#sticky-request-parameters). As a matter of fact, we were slightly deviating from the spec by always generating one, and even then it would cost us bandwidth we could avoid.

With this patch, the transaction id is now lazily generated by any `StickyManager` that would make use of it, and included in the request only if it was generated and used by any set of sticky parameters.