### PR TITLE
crypto-js: Simplify response type of `Sas::confirm`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.0-alpha.11
+
+- Simplify the respionse type of `Sas.confirm()`.
+
 # v0.1.0-alpha.10
 
 -   Add `masterKey`, `userSigningKey`, `selfSigningKey` to `UserIdentity` and `OwnUserIdentity`

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -243,30 +243,28 @@ impl Sas {
     /// This confirms that the short auth strings match on both sides.
     ///
     /// Does nothing if we’re not in a state where we can confirm the
-    /// short auth string, otherwise returns a `MacEventContent` that
-    /// needs to be sent to the server.
+    /// short auth string.
+    ///
+    /// Returns a `Promise` for an array of `OutgoingRequest`s.
     pub fn confirm(&self) -> Promise {
         let me = self.inner.clone();
 
         future_to_promise(async move {
             let (outgoing_verification_requests, signature_upload_request) = me.confirm().await?;
-            let outgoing_verification_requests = outgoing_verification_requests
+            let outgoing_verification_requests: Array = outgoing_verification_requests
                 .into_iter()
                 .map(OutgoingVerificationRequest::from)
                 .map(JsValue::try_from)
                 .collect::<Result<Array, _>>()?;
 
-            let tuple = Array::new();
-            tuple.set(0, outgoing_verification_requests.into());
-            tuple.set(
-                1,
-                signature_upload_request
-                    .map(|request| requests::SignatureUploadRequest::try_from(&request))
-                    .transpose()?
-                    .into(),
-            );
+            // if a signature upload request was returned, push it onto the end of the array
+            // of OutgoingRequests we just built.
+            if let Some(sig_rq) = signature_upload_request {
+                outgoing_verification_requests
+                    .push(&requests::SignatureUploadRequest::try_from(&sig_rq)?.into());
+            }
 
-            Ok(tuple)
+            Ok(outgoing_verification_requests)
         })
     }
 


### PR DESCRIPTION
On the javascript side, everything is just an `OutgoingRequest`, so we may
as well return a single array rather than a tuple.