### PR TITLE
crypto-js: Add `register_changes_callback` methods to the verification classes

### DIFF
--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.1.0-alpha.11
 
--   Add `VerificationRequest.register_changes_callback()`,
-    `Sas.register_changes_callback()`, and `Qr.register_changes_callback()`.
+-   Add `VerificationRequest.registerChangesCallback()`,
+    `Sas.registerChangesCallback()`, and `Qr.registerChangesCallback()`.
 
 # v0.1.0-alpha.10
 

--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.0-alpha.11
+
+-   Add `VerificationRequest.register_changes_callback()`,
+    `Sas.register_changes_callback()`, and `Qr.register_changes_callback()`.
+
 # v0.1.0-alpha.10
 
 -   Add `masterKey`, `userSigningKey`, `selfSigningKey` to `UserIdentity` and `OwnUserIdentity`

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -840,7 +840,9 @@ async fn send_room_key_info_to_callback(
 /// Given a result from a javascript function which returns a Promise (or throws
 /// an exception before returning one), convert the result to a rust Future
 /// which completes with the result of the promise
-async fn promise_result_to_future(res: Result<JsValue, JsValue>) -> Result<JsValue, JsValue> {
+pub(crate) async fn promise_result_to_future(
+    res: Result<JsValue, JsValue>,
+) -> Result<JsValue, JsValue> {
     match res {
         Ok(retval) => {
             if !retval.has_type::<Promise>() {

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -7,7 +7,6 @@ use futures_util::StreamExt;
 #[cfg(feature = "qrcode")]
 use js_sys::Uint8ClampedArray;
 use js_sys::{Array, Function, JsString, Promise};
-use matrix_sdk_crypto::VerificationRequestState;
 use ruma::events::key::verification::{
     cancel::CancelCode as RumaCancelCode, VerificationMethod as RumaVerificationMethod,
 };

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -1011,7 +1011,7 @@ impl VerificationRequest {
             stream.for_each(|_| send_change_info_to_callback(callback_ref)).await;
         });
     }
-      
+
     /// Has the verification flow that was started with this request
     /// been cancelled?
     #[wasm_bindgen(js_name = "isCancelled")]

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -3,19 +3,24 @@
 #[cfg(feature = "qrcode")]
 use std::fmt;
 
+use futures_util::StreamExt;
 #[cfg(feature = "qrcode")]
 use js_sys::Uint8ClampedArray;
-use js_sys::{Array, JsString, Promise};
+use js_sys::{Array, Function, JsString, Promise};
+use matrix_sdk_crypto::VerificationRequestState;
 use ruma::events::key::verification::{
     cancel::CancelCode as RumaCancelCode, VerificationMethod as RumaVerificationMethod,
 };
+use tracing::warn;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
 
 use crate::{
     future::future_to_promise,
     identifiers::{DeviceId, RoomId, UserId},
     impl_from_to_inner,
     js::try_array_to_vec,
+    machine::promise_result_to_future,
     requests,
 };
 
@@ -361,6 +366,21 @@ impl Sas {
 
         Some(out)
     }
+
+    /// Register a callback which will be called whenever there is an update to
+    /// the request.
+    ///
+    /// The `callback` is called with no parameters.
+    #[wasm_bindgen(js_name = "registerChangesCallback")]
+    pub fn register_changes_callback(&self, callback: Function) {
+        let stream = self.inner.changes();
+
+        // fire up a promise chain which will call `callback` on each result from the
+        // stream
+        spawn_local(async move {
+            stream.for_each(|_| send_change_info_to_callback(&callback)).await;
+        });
+    }
 }
 
 /// QR code based verification.
@@ -541,6 +561,21 @@ impl Qr {
             .transpose()
             .map(JsValue::from)
             .map_err(Into::into)
+    }
+
+    /// Register a callback which will be called whenever there is an update to
+    /// the request
+    ///
+    /// The `callback` is called with no parameters.
+    #[wasm_bindgen(js_name = "registerChangesCallback")]
+    pub fn register_changes_callback(&self, callback: Function) {
+        let stream = self.inner.changes();
+
+        // fire up a promise chain which will call `callback` on each result from the
+        // stream
+        spawn_local(async move {
+            stream.for_each(|_| send_change_info_to_callback(&callback)).await;
+        });
     }
 }
 
@@ -917,6 +952,25 @@ impl VerificationRequest {
         self.inner.is_done()
     }
 
+    /// Register a callback which will be called whenever there is an update to
+    /// the request.
+    ///
+    /// The `callback` is called with no parameters.
+    #[wasm_bindgen(js_name = "registerChangesCallback")]
+    pub fn register_changes_callback(&self, callback: Function) {
+        let stream = self.inner.changes();
+
+        // fire up a promise chain which will call `callback` on each result from the
+        // stream
+        spawn_local(async move {
+            // take a reference to `callback` (which we then pass into the closure), to stop
+            // the callback being moved into the closure (which would mean we could only
+            // call the closure once)
+            let callback_ref = &callback;
+            stream.for_each(|_| send_change_info_to_callback(callback_ref)).await;
+        });
+    }
+
     /// Has the verification flow that was started with this request
     /// been cancelled.
     #[wasm_bindgen(js_name = "isCancelled")]
@@ -1068,5 +1122,15 @@ impl TryFrom<OutgoingVerificationRequest> for JsValue {
                 JsValue::from(requests::RoomMessageRequest::try_from((request_id, &request))?)
             }
         })
+    }
+}
+
+// helper for register_changes_callback: calls the javascript callback
+async fn send_change_info_to_callback(callback: &Function) {
+    match promise_result_to_future(callback.call0(&JsValue::NULL)).await {
+        Ok(_) => (),
+        Err(e) => {
+            warn!("Error calling changes callback: {:?}", e);
+        }
     }
 }

--- a/bindings/matrix-sdk-crypto-js/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-js/src/verification.rs
@@ -1004,11 +1004,7 @@ impl VerificationRequest {
         // fire up a promise chain which will call `callback` on each result from the
         // stream
         spawn_local(async move {
-            // take a reference to `callback` (which we then pass into the closure), to stop
-            // the callback being moved into the closure (which would mean we could only
-            // call the closure once)
-            let callback_ref = &callback;
-            stream.for_each(|_| send_change_info_to_callback(callback_ref)).await;
+            stream.for_each(|_| send_change_info_to_callback(&callback)).await;
         });
     }
 

--- a/bindings/matrix-sdk-crypto-js/tests/device.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/device.test.js
@@ -402,7 +402,7 @@ describe("Key Verification", () => {
             const sas1Again = await verificationRequest1.getVerification();
             expect(sas1Again).toBeInstanceOf(Sas);
             expect(sas1Again.flowId).toStrictEqual(flowId);
-          
+
             // add an onChange listener so we can check it is called at the right times
             sas1.registerChangesCallback(sas1ChangesCallback);
 


### PR DESCRIPTION
... so that applications know when something happens.