### PR TITLE
feat(ui): Implement room subscriptions in `RoomList` + notification counts

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -241,7 +241,7 @@ impl Room {
 
             let listener: Arc<dyn TimelineListener> = listener.into();
             let timeline_stream =
-                Arc::new(TaskHandle::new(RUNTIME.spawn(timeline_stream.for_each(move |diff| {
+                TaskHandle::new(RUNTIME.spawn(timeline_stream.for_each(move |diff| {
                     let listener = listener.clone();
                     let fut = RUNTIME.spawn_blocking(move || {
                         listener.on_update(Arc::new(TimelineDiff::new(diff)))
@@ -252,11 +252,11 @@ impl Room {
                             error!("Timeline listener error: {e}");
                         }
                     }
-                }))));
+                })));
 
             RoomTimelineListenerResult {
                 items: timeline_items.into_iter().map(TimelineItem::from_arc).collect(),
-                items_stream: timeline_stream,
+                items_stream: Arc::new(timeline_stream),
             }
         })
     }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    fmt::Debug,
+    sync::{Arc, RwLock},
+};
 
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt};
@@ -203,7 +206,10 @@ impl RoomListItem {
     }
 
     fn full_room(&self) -> Arc<Room> {
-        Arc::new(Room::new(self.inner.inner_room().clone()))
+        Arc::new(Room::with_timeline(
+            self.inner.inner_room().clone(),
+            Arc::new(RwLock::new(Some(RUNTIME.block_on(async { self.inner.timeline().await })))),
+        ))
     }
 
     fn subscribe(&self, settings: Option<RoomSubscription>) {

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -5,8 +5,8 @@ use futures_util::{pin_mut, StreamExt};
 use ruma::RoomId;
 
 use crate::{
-    Client, EventTimelineItem, Room, RoomListEntry, TaskHandle, TimelineDiff, TimelineItem,
-    TimelineListener, RUNTIME,
+    Client, EventTimelineItem, Room, RoomListEntry, RoomSubscription, TaskHandle, TimelineDiff,
+    TimelineItem, TimelineListener, RUNTIME,
 };
 
 #[uniffi::export]
@@ -200,6 +200,14 @@ impl RoomListItem {
 
     fn full_room(&self) -> Arc<Room> {
         Arc::new(Room::new(self.inner.inner_room().clone()))
+    }
+
+    fn subscribe(&self, settings: Option<RoomSubscription>) {
+        self.inner.subscribe(settings.map(Into::into));
+    }
+
+    fn unsubscribe(&self) {
+        self.inner.unsubscribe();
     }
 
     async fn timeline(&self, listener: Box<dyn TimelineListener>) -> RoomListItemTimelineResult {

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -5,7 +5,8 @@ use futures_util::{pin_mut, StreamExt};
 use ruma::RoomId;
 
 use crate::{
-    Client, EventTimelineItem, Room, RoomListEntry, RoomSubscription, TaskHandle, RUNTIME,
+    Client, EventTimelineItem, Room, RoomListEntry, RoomSubscription, TaskHandle,
+    UnreadNotificationsCount, RUNTIME,
 };
 
 #[uniffi::export]
@@ -217,5 +218,13 @@ impl RoomListItem {
         RUNTIME.block_on(async {
             self.inner.latest_event().await.map(EventTimelineItem).map(Arc::new)
         })
+    }
+
+    fn has_unread_notifications(&self) -> bool {
+        self.inner.has_unread_notifications()
+    }
+
+    fn unread_notifications(&self) -> Arc<UnreadNotificationsCount> {
+        Arc::new(self.inner.unread_notifications().into())
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -194,6 +194,10 @@ pub struct RoomListItem {
 
 #[uniffi::export]
 impl RoomListItem {
+    fn id(&self) -> String {
+        self.inner.id().to_string()
+    }
+
     fn name(&self) -> Option<String> {
         RUNTIME.block_on(async { self.inner.name().await })
     }

--- a/crates/matrix-sdk-ui/src/room_list/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list/room.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_once_cell::OnceCell as AsyncOnceCell;
 use matrix_sdk::{SlidingSync, SlidingSyncRoom};
-use ruma::api::client::sync::sync_events::v4::RoomSubscription;
+use ruma::{api::client::sync::sync_events::v4::RoomSubscription, RoomId};
 
 use super::Error;
 use crate::{timeline::EventTimelineItem, Timeline};
@@ -56,6 +56,11 @@ impl Room {
                 sneaky_timeline: AsyncOnceCell::new(),
             }),
         })
+    }
+
+    /// Get the room ID.
+    pub fn id(&self) -> &RoomId {
+        self.inner.room.room_id()
     }
 
     /// Get the best possible name for the room.

--- a/crates/matrix-sdk-ui/src/room_list/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list/room.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use async_once_cell::OnceCell as AsyncOnceCell;
 use matrix_sdk::{SlidingSync, SlidingSyncRoom};
-use ruma::{api::client::sync::sync_events::v4::RoomSubscription, RoomId};
+use ruma::{
+    api::client::sync::sync_events::{v4::RoomSubscription, UnreadNotificationsCount},
+    RoomId,
+};
 
 use super::Error;
 use crate::{timeline::EventTimelineItem, Timeline};
@@ -130,5 +133,15 @@ impl Room {
             .await
             .latest_event()
             .await
+    }
+
+    /// Is there any unread notifications?
+    pub fn has_unread_notifications(&self) -> bool {
+        self.inner.sliding_sync_room.has_unread_notifications()
+    }
+
+    /// Get unread notifications.
+    pub fn unread_notifications(&self) -> UnreadNotificationsCount {
+        self.inner.sliding_sync_room.unread_notifications()
     }
 }

--- a/crates/matrix-sdk-ui/tests/integration/room_list.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list.rs
@@ -83,7 +83,9 @@ macro_rules! sync_then_assert_request_and_fake_response {
             $(
                 use State::*;
 
-                assert_matches!($room_list.state().get(), $pre_state, "pre state");
+                let mut state = $room_list.state();
+
+                assert_matches!(state.get(), $pre_state, "pre state");
             )?
 
             let next = $room_list_sync_stream.next().await;
@@ -107,7 +109,7 @@ macro_rules! sync_then_assert_request_and_fake_response {
                 }
             }
 
-            $( assert_matches!($room_list.state().get(), $post_state, "post state"); )?
+            $( assert_matches!(state.next().now_or_never(), Some(Some($post_state)), "post state"); )?
 
             next
         }

--- a/crates/matrix-sdk-ui/tests/integration/room_list.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list.rs
@@ -11,7 +11,10 @@ use matrix_sdk_ui::{
     timeline::{TimelineItem, VirtualTimelineItem},
     RoomList,
 };
-use ruma::{event_id, room_id};
+use ruma::{
+    api::client::sync::sync_events::v4::RoomSubscription, assign, event_id, events::StateEventType,
+    room_id, uint,
+};
 use serde_json::json;
 use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
 
@@ -304,8 +307,8 @@ async fn test_sync_from_init_to_enjoy() -> Result<(), Error> {
                     },
                     "sort": ["by_recency", "by_name"],
                     "timeline_limit": 20,
-                }
-            }
+                },
+            },
         },
         respond with = {
             "pos": "1",
@@ -848,8 +851,8 @@ async fn test_entries_stream() -> Result<(), Error> {
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [],
-                }
-            }
+                },
+            },
         },
         respond with = {
             "pos": "1",
@@ -976,8 +979,8 @@ async fn test_entries_stream_with_updated_filter() -> Result<(), Error> {
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [],
-                }
-            }
+                },
+            },
         },
         respond with = {
             "pos": "1",
@@ -1135,6 +1138,127 @@ async fn test_room_not_found() -> Result<(), Error> {
             assert_eq!(error_room_id, room_id.to_owned());
         }
     );
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_room_subscription() -> Result<(), Error> {
+    let (server, room_list) = new_room_list().await?;
+
+    let sync = room_list.sync();
+    pin_mut!(sync);
+
+    let room_id_0 = room_id!("!r0:bar.org");
+    let room_id_1 = room_id!("!r1:bar.org");
+    let room_id_2 = room_id!("!r2:bar.org");
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        assert request = {
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 19]],
+                },
+            },
+        },
+        respond with = {
+            "pos": "0",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 3,
+                    "ops": [
+                        {
+                            "op": "SYNC",
+                            "range": [0, 2],
+                            "room_ids": [
+                                room_id_0,
+                                room_id_1,
+                                room_id_2,
+                            ],
+                        },
+                    ],
+                },
+            },
+            "rooms": {
+                room_id_0: {
+                    "name": "Room #0",
+                    "initial": true,
+                },
+                room_id_1: {
+                    "name": "Room #1",
+                    "initial": true,
+                },
+                room_id_2: {
+                    "name": "Room #2",
+                    "initial": true,
+                }
+            },
+        },
+    };
+
+    let room1 = room_list.room(room_id_1).await.unwrap();
+
+    // Subscribe.
+
+    room1.subscribe(Some(assign!(RoomSubscription::default(), {
+        required_state: vec![
+            (StateEventType::RoomName, "".to_owned()),
+            (StateEventType::RoomTopic, "".to_owned()),
+            (StateEventType::RoomAvatar, "".to_owned()),
+            (StateEventType::RoomCanonicalAlias, "".to_owned()),
+        ],
+        timeline_limit: Some(uint!(30)),
+    })));
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        assert request = {
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 2]],
+                },
+            },
+            "room_subscriptions": {
+                room_id_1: {
+                    "required_state": [
+                        ["m.room.name", ""],
+                        ["m.room.topic", ""],
+                        ["m.room.avatar", ""],
+                        ["m.room.canonical_alias", ""],
+                    ],
+                    "timeline_limit": 30,
+                },
+            },
+        },
+        respond with = {
+            "pos": "1",
+            "lists": {},
+            "rooms": {},
+        },
+    };
+
+    // Unsubscribe.
+
+    room1.unsubscribe();
+    room_list.room(room_id_2).await?.unsubscribe(); // unsubscribe from a room that has no subscription.
+
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        assert request = {
+            "lists": {
+                ALL_ROOMS: {
+                    "ranges": [[0, 2]],
+                },
+            },
+            "unsubscribe_rooms": [room_id_1, /* `room_id_2` is absent */],
+        },
+        respond with = {
+            "pos": "2",
+            "lists": {},
+            "rooms": {},
+        },
+    };
 
     Ok(())
 }


### PR DESCRIPTION
Address #1911.

This PR does 4 things:

1. It implements the `matrix_sdk_ui::room_list::Room::subscribe` and `::unsubscribe` methods, with the appropriate tests. The FFI bindings are implemented too.
2. It implements `matrix_sdk_ui::room_list::Room::id()` as a shortcut to `room.inner_room().room_id()`. It's especially useful for FFI users where creating such a “full room” (`inner_room`) may be expensive.
3. It removes `matrix_sdk_ffi::RoomListItem::timeline()` in favor of `matrix_sdk_ffi::Room::add_timeline_listener()`. It also updates the latter to return a `RoomTimelineListenerResult { items: Vec<Arc<TimelineEvent>>, items_stream: TaskHandle }`, so that now, it's finally possible to stop a timeline listener stream. Previously, it was impossible.
4. It implements `Room::*unread_notifications`, because it was easy and quick :-)