### PR TITLE
feat(fii): Implement `RoomList::apply_input`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -198,3 +198,13 @@ interface RoomListEntriesUpdate {
 callback interface RoomListEntriesListener {
     void on_update(RoomListEntriesUpdate room_entries_update);
 };
+
+[Enum]
+interface RoomListInput {
+    Viewport(sequence<RoomListRange> ranges);
+};
+
+dictionary RoomListRange {
+    u32 start;
+    u32 end_inclusive;
+};

--- a/crates/matrix-sdk-ui/tests/integration/room_list.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list.rs
@@ -1573,8 +1573,8 @@ async fn test_input_viewport() -> Result<(), Error> {
                 VISIBLE_ROOMS: {
                     "ranges": [],
                     "timeline_limit": 20,
-                }
-            }
+                },
+            },
         },
         respond with = {
             "pos": "1",
@@ -1596,8 +1596,8 @@ async fn test_input_viewport() -> Result<(), Error> {
                 VISIBLE_ROOMS: {
                     "ranges": [[10, 15], [20, 25]],
                     "timeline_limit": 20,
-                }
-            }
+                },
+            },
         },
         respond with = {
             "pos": "1",


### PR DESCRIPTION
Address #1911.

This patch implements `RoomList::apply_input`. Usage example:

```rust
room_list.apply_input(RoomListInput::Viewport { ranges: vec![RoomListRange { start: 10, end_inclusive: 20 }]}).await?;
```