### PR TITLE
Cache DisplayName in RoomInfo

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list/mod.rs
@@ -43,7 +43,7 @@
 //!   background”: it will sync the existing rooms and will fetch new rooms, by
 //!   a certain batch size.
 //! * `visible_rooms` (referred by the constant [`VISIBLE_ROOMS_LIST_NAME`]) is
-//!   the “reactive” list. It's goal is to react to the client app user actions.
+//!   the “reactive” list. Its goal is to react to the client app user actions.
 //!   If the user scrolls in the room list, the `visible_rooms` will be
 //!   configured to sync for the particular range of rooms the user is actually
 //!   seeing (the rooms in the current viewport). `visible_rooms` has a


### PR DESCRIPTION
A very tentative proposal as to how to store a cached version of `DisplayName` inside `RoomInfo`.

This should mean we don't need to recalculate it whenever we ask for it.

We do the calculation of display name in `normal::Room` because that is where the `calculate_name()` method is, because it uses the `members` method.

Inside `Room`, we protect display name from being stale by wrapping it in a lock that deletes the cached value whenever we get a write lock. This only protects things that use `RoomInfo` via `Room`.

I also looked through the code for places that modify things that affect display name, and added code to reset it. It might be better to protect everything behind modification methods that do this automatically but:

a) that would be a more invasive change, so I wanted to check first, and
b) that would pollute RoomInfo with knowledge about how to calculate the display name (unless we deleted it on _any_ change, which would work.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/2085