### PR TITLE
chore: get rid of unused notification delegate

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -103,16 +103,10 @@ pub trait ClientDelegate: Sync + Send {
     fn did_receive_auth_error(&self, is_soft_logout: bool);
 }
 
-#[uniffi::export(callback_interface)]
-pub trait NotificationDelegate: Sync + Send {
-    fn did_receive_notification(&self, notification: NotificationItem);
-}
-
 #[derive(Clone, uniffi::Object)]
 pub struct Client {
     pub(crate) inner: MatrixClient,
     delegate: Arc<RwLock<Option<Box<dyn ClientDelegate>>>>,
-    notification_delegate: Arc<RwLock<Option<Box<dyn NotificationDelegate>>>>,
     session_verification_controller:
         Arc<tokio::sync::RwLock<Option<SessionVerificationController>>>,
     pub(crate) sliding_sync_reset_broadcast_tx: Arc<SharedObservable<()>>,
@@ -139,7 +133,6 @@ impl Client {
         let client = Client {
             inner: sdk_client,
             delegate: Arc::new(RwLock::new(None)),
-            notification_delegate: Arc::new(RwLock::new(None)),
             session_verification_controller,
             sliding_sync_reset_broadcast_tx: Default::default(),
         };
@@ -552,36 +545,6 @@ impl Client {
             };
 
             Ok(user_profile)
-        })
-    }
-
-    /// Sets a notification delegate and a handler.
-    ///
-    /// The sliding sync requires to have registered m.room.member with value
-    /// $ME and m.room.power_levels to be able to intercept the events.
-    /// This function blocks execution and should be dispatched concurrently.
-    pub fn set_notification_delegate(
-        &self,
-        notification_delegate: Option<Box<dyn NotificationDelegate>>,
-    ) {
-        *self.notification_delegate.write().unwrap() = notification_delegate;
-        let notification_delegate = Arc::clone(&self.notification_delegate);
-        let handler = move |notification, room: SdkRoom, _| {
-            let notification_delegate = Arc::clone(&notification_delegate);
-            async move {
-                if let Ok(notification_item) =
-                    NotificationItem::new_from_notification(notification, room).await
-                {
-                    if let Some(notification_delegate) =
-                        notification_delegate.read().unwrap().as_ref()
-                    {
-                        notification_delegate.did_receive_notification(notification_item);
-                    }
-                }
-            }
-        };
-        RUNTIME.block_on(async move {
-            self.inner.register_notification_handler(handler).await;
         })
     }
 


### PR DESCRIPTION
This is unused by both ElementX iOS and Android, and at least for iOS it doesn't make sense to have such a thing because an extension process is spawned with the content of one notification.