### PR TITLE
feat: make `OlmMachine` resettable

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -28,8 +28,6 @@ use matrix_sdk_crypto::{
     store::DynCryptoStore, EncryptionSettings, OlmError, OlmMachine, ToDeviceRequest,
 };
 #[cfg(feature = "e2e-encryption")]
-use once_cell::sync::OnceCell;
-#[cfg(feature = "e2e-encryption")]
 use ruma::events::{
     room::{
         history_visibility::HistoryVisibility, message::MessageType,
@@ -54,6 +52,8 @@ use ruma::{
     MilliSecondsSinceUnixEpoch, OwnedUserId, RoomId, UInt, UserId,
 };
 use tokio::sync::RwLock;
+#[cfg(feature = "e2e-encryption")]
+use tokio::sync::RwLockReadGuard;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
@@ -88,7 +88,7 @@ pub struct BaseClient {
     /// [`SessionMeta`][crate::session::SessionMeta] is set via
     /// [`BaseClient::set_session_meta`]
     #[cfg(feature = "e2e-encryption")]
-    olm_machine: OnceCell<OlmMachine>,
+    olm_machine: Arc<RwLock<Option<OlmMachine>>>,
     pub(crate) ignore_user_list_changes_tx: Arc<SharedObservable<()>>,
 }
 
@@ -244,9 +244,7 @@ impl BaseClient {
             .await
             .map_err(OlmError::from)?;
 
-            if self.olm_machine.set(olm_machine).is_err() {
-                return Err(Error::BadCryptoStoreState);
-            }
+            *self.olm_machine.write().await = Some(olm_machine);
         }
 
         Ok(())
@@ -264,7 +262,7 @@ impl BaseClient {
         event: &AnySyncMessageLikeEvent,
         room_id: &RoomId,
     ) -> Result<()> {
-        if let Some(olm) = self.olm_machine() {
+        if let Some(olm) = self.olm_machine().await.as_ref() {
             olm.receive_verification_event(&event.clone().into_full_event(room_id.to_owned()))
                 .await?;
         }
@@ -278,7 +276,8 @@ impl BaseClient {
         event: &Raw<AnySyncTimelineEvent>,
         room_id: &RoomId,
     ) -> Result<Option<SyncTimelineEvent>> {
-        let Some(olm) = self.olm_machine() else { return Ok(None) };
+        let olm = self.olm_machine().await;
+        let Some(olm) = olm.as_ref() else { return Ok(None) };
 
         let event: SyncTimelineEvent =
             olm.decrypt_room_event(event.cast_ref(), room_id).await?.into();
@@ -606,7 +605,7 @@ impl BaseClient {
         one_time_keys_counts: &BTreeMap<ruma::DeviceKeyAlgorithm, UInt>,
         unused_fallback_keys: Option<&[ruma::DeviceKeyAlgorithm]>,
     ) -> Result<Vec<Raw<ruma::events::AnyToDeviceEvent>>> {
-        if let Some(o) = self.olm_machine() {
+        if let Some(o) = self.olm_machine().await.as_ref() {
             // Let the crypto machine handle the sync response, this
             // decrypts to-device events, but leaves room events alone.
             // This makes sure that we have the decryption keys for the room
@@ -769,7 +768,7 @@ impl BaseClient {
 
             #[cfg(feature = "e2e-encryption")]
             if room_info.is_encrypted() {
-                if let Some(o) = self.olm_machine() {
+                if let Some(o) = self.olm_machine().await.as_ref() {
                     if !room.is_encrypted() {
                         // The room turned on encryption in this sync, we need
                         // to also get all the existing users and mark them for
@@ -986,7 +985,7 @@ impl BaseClient {
 
             #[cfg(feature = "e2e-encryption")]
             if room_info.is_encrypted() {
-                if let Some(o) = self.olm_machine() {
+                if let Some(o) = self.olm_machine().await.as_ref() {
                     o.update_tracked_users(user_ids.iter().map(Deref::deref)).await?
                 }
             }
@@ -1058,7 +1057,7 @@ impl BaseClient {
     /// Get a to-device request that will share a room key with users in a room.
     #[cfg(feature = "e2e-encryption")]
     pub async fn share_room_key(&self, room_id: &RoomId) -> Result<Vec<Arc<ToDeviceRequest>>> {
-        match self.olm_machine() {
+        match self.olm_machine().await.as_ref() {
             Some(o) => {
                 let (history_visibility, settings) = self
                     .get_room(room_id)
@@ -1095,8 +1094,8 @@ impl BaseClient {
 
     /// Get the olm machine.
     #[cfg(feature = "e2e-encryption")]
-    pub fn olm_machine(&self) -> Option<&OlmMachine> {
-        self.olm_machine.get()
+    pub async fn olm_machine(&self) -> RwLockReadGuard<'_, Option<OlmMachine>> {
+        self.olm_machine.read().await
     }
 
     /// Get the push rules.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -231,7 +231,7 @@ impl BaseClient {
 
         #[cfg(feature = "e2e-encryption")]
         if room_info.is_encrypted() {
-            if let Some(o) = self.olm_machine() {
+            if let Some(o) = self.olm_machine().await.as_ref() {
                 if !room.is_encrypted() {
                     // The room turned on encryption in this sync, we need
                     // to also get all the existing users and mark them for

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -35,7 +35,7 @@ pub use matrix_sdk_base::crypto::{
     LocalTrust, MediaEncryptionInfo, MegolmError, OlmError, RoomKeyImportResult, SecretImportError,
     SessionCreationError, SignatureError, VERSION,
 };
-use matrix_sdk_base::crypto::{OutgoingRequest, RoomMessageRequest, ToDeviceRequest};
+use matrix_sdk_base::crypto::{OlmMachine, OutgoingRequest, RoomMessageRequest, ToDeviceRequest};
 use ruma::{
     api::client::{
         backup::add_backup_keys::v3::Response as KeysBackupResponse,
@@ -50,6 +50,7 @@ use ruma::{
     },
     assign, DeviceId, OwnedDeviceId, OwnedUserId, TransactionId, UserId,
 };
+use tokio::sync::RwLockReadGuard;
 use tracing::{debug, instrument, trace, warn};
 
 pub use crate::error::RoomKeyImportError;
@@ -64,8 +65,8 @@ use crate::{
 };
 
 impl Client {
-    pub(crate) fn olm_machine(&self) -> Option<&matrix_sdk_base::crypto::OlmMachine> {
-        self.base_client().olm_machine()
+    pub(crate) async fn olm_machine(&self) -> RwLockReadGuard<'_, Option<OlmMachine>> {
+        self.base_client().olm_machine().await
     }
 
     pub(crate) async fn mark_request_as_sent(
@@ -75,6 +76,8 @@ impl Client {
     ) -> Result<(), matrix_sdk_base::Error> {
         Ok(self
             .olm_machine()
+            .await
+            .as_ref()
             .expect(
                 "We should have an olm machine once we try to mark E2EE related requests as sent",
             )
@@ -261,6 +264,8 @@ impl Client {
 
         if let Some((request_id, request)) = self
             .olm_machine()
+            .await
+            .as_ref()
             .ok_or(Error::AuthenticationRequired)?
             .get_missing_sessions(users)
             .await?
@@ -413,7 +418,12 @@ impl Client {
         }
 
         let outgoing_requests = stream::iter(
-            self.olm_machine().ok_or(Error::AuthenticationRequired)?.outgoing_requests().await?,
+            self.olm_machine()
+                .await
+                .as_ref()
+                .ok_or(Error::AuthenticationRequired)?
+                .outgoing_requests()
+                .await?,
         )
         .map(|r| self.send_outgoing_request(r));
 
@@ -449,7 +459,7 @@ impl Encryption {
     /// Get the public ed25519 key of our own device. This is usually what is
     /// called the fingerprint of the device.
     pub async fn ed25519_key(&self) -> Option<String> {
-        self.client.olm_machine().map(|o| o.identity_keys().ed25519.to_base64())
+        self.client.olm_machine().await.as_ref().map(|o| o.identity_keys().ed25519.to_base64())
     }
 
     /// Get the status of the private cross signing keys.
@@ -457,7 +467,8 @@ impl Encryption {
     /// This can be used to check which private cross signing keys we have
     /// stored locally.
     pub async fn cross_signing_status(&self) -> Option<CrossSigningStatus> {
-        let machine = self.client.olm_machine()?;
+        let olm = self.client.olm_machine().await;
+        let machine = olm.as_ref()?;
         Some(machine.cross_signing_status().await)
     }
 
@@ -466,7 +477,7 @@ impl Encryption {
     /// Tracked users are users for which we keep the device list of E2EE
     /// capable devices up to date.
     pub async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>, CryptoStoreError> {
-        if let Some(machine) = self.client.olm_machine() {
+        if let Some(machine) = self.client.olm_machine().await.as_ref() {
             machine.tracked_users().await
         } else {
             Ok(HashSet::new())
@@ -475,7 +486,8 @@ impl Encryption {
 
     /// Get a verification object with the given flow id.
     pub async fn get_verification(&self, user_id: &UserId, flow_id: &str) -> Option<Verification> {
-        let olm = self.client.olm_machine()?;
+        let olm = self.client.olm_machine().await;
+        let olm = olm.as_ref()?;
         #[allow(clippy::bind_instead_of_map)]
         olm.get_verification(user_id, flow_id).and_then(|v| match v {
             matrix_sdk_base::crypto::Verification::SasV1(s) => {
@@ -496,7 +508,8 @@ impl Encryption {
         user_id: &UserId,
         flow_id: impl AsRef<str>,
     ) -> Option<VerificationRequest> {
-        let olm = self.client.olm_machine()?;
+        let olm = self.client.olm_machine().await;
+        let olm = olm.as_ref()?;
 
         olm.get_verification_request(user_id, flow_id)
             .map(|r| VerificationRequest { inner: r, client: self.client.clone() })
@@ -540,7 +553,8 @@ impl Encryption {
         user_id: &UserId,
         device_id: &DeviceId,
     ) -> Result<Option<Device>, CryptoStoreError> {
-        let Some(machine) = self.client.olm_machine() else { return Ok(None) };
+        let olm = self.client.olm_machine().await;
+        let Some(machine) = olm.as_ref() else { return Ok(None) };
         let device = machine.get_device(user_id, device_id, None).await?;
         Ok(device.map(|d| Device { inner: d, client: self.client.clone() }))
     }
@@ -574,6 +588,8 @@ impl Encryption {
         let devices = self
             .client
             .olm_machine()
+            .await
+            .as_ref()
             .ok_or(Error::AuthenticationRequired)?
             .get_user_devices(user_id, None)
             .await?;
@@ -616,7 +632,8 @@ impl Encryption {
     ) -> Result<Option<crate::encryption::identities::UserIdentity>, CryptoStoreError> {
         use crate::encryption::identities::UserIdentity;
 
-        let Some(olm) = self.client.olm_machine() else { return Ok(None) };
+        let olm = self.client.olm_machine().await;
+        let Some(olm) = olm.as_ref() else { return Ok(None) };
         let identity = olm.get_identity(user_id, None).await?;
 
         Ok(identity.map(|i| match i {
@@ -668,7 +685,8 @@ impl Encryption {
     /// }
     /// # anyhow::Ok(()) };
     pub async fn bootstrap_cross_signing(&self, auth_data: Option<AuthData>) -> Result<()> {
-        let olm = self.client.olm_machine().ok_or(Error::AuthenticationRequired)?;
+        let olm = self.client.olm_machine().await;
+        let olm = olm.as_ref().ok_or(Error::AuthenticationRequired)?;
 
         let (request, signature_request) = olm.bootstrap_cross_signing(false).await?;
 
@@ -744,7 +762,8 @@ impl Encryption {
         passphrase: &str,
         predicate: impl FnMut(&matrix_sdk_base::crypto::olm::InboundGroupSession) -> bool,
     ) -> Result<()> {
-        let olm = self.client.olm_machine().ok_or(Error::AuthenticationRequired)?;
+        let olm = self.client.olm_machine().await;
+        let olm = olm.as_ref().ok_or(Error::AuthenticationRequired)?;
 
         let keys = olm.export_room_keys(predicate).await?;
         let passphrase = zeroize::Zeroizing::new(passphrase.to_owned());
@@ -804,7 +823,8 @@ impl Encryption {
         path: PathBuf,
         passphrase: &str,
     ) -> Result<RoomKeyImportResult, RoomKeyImportError> {
-        let olm = self.client.olm_machine().ok_or(RoomKeyImportError::StoreClosed)?;
+        let olm = self.client.olm_machine().await;
+        let olm = olm.as_ref().ok_or(RoomKeyImportError::StoreClosed)?;
         let passphrase = zeroize::Zeroizing::new(passphrase.to_owned());
 
         let decrypt = move || {

--- a/crates/matrix-sdk/src/room/common.rs
+++ b/crates/matrix-sdk/src/room/common.rs
@@ -221,7 +221,8 @@ impl Common {
         };
 
         #[cfg(feature = "e2e-encryption")]
-        if let Some(machine) = self.client.olm_machine() {
+        let machine = self.client.olm_machine().await;
+        if let Some(machine) = machine.as_ref() {
             for event in http_response.chunk {
                 let decrypted_event = if let Ok(AnySyncTimelineEvent::MessageLike(
                     AnySyncMessageLikeEvent::RoomEncrypted(SyncMessageLikeEvent::Original(_)),
@@ -875,7 +876,8 @@ impl Common {
         &self,
         event: &Raw<OriginalSyncRoomEncryptedEvent>,
     ) -> Result<TimelineEvent> {
-        if let Some(machine) = self.client.olm_machine() {
+        let machine = self.client.olm_machine().await;
+        if let Some(machine) = machine.as_ref() {
             let mut event =
                 machine.decrypt_room_event(event.cast_ref(), self.inner.room_id()).await?;
 

--- a/crates/matrix-sdk/src/room/joined.rs
+++ b/crates/matrix-sdk/src/room/joined.rs
@@ -401,7 +401,8 @@ impl Joined {
             // session as using it would end up in undecryptable
             // messages.
             if let Err(r) = response {
-                if let Some(machine) = self.client.olm_machine() {
+                let machine = self.client.olm_machine().await;
+                if let Some(machine) = machine.as_ref() {
                     machine.invalidate_group_session(self.inner.room_id()).await?;
                 }
                 return Err(r);
@@ -633,7 +634,8 @@ impl Joined {
 
                 self.preshare_room_key().await?;
 
-                let olm = self.client.olm_machine().expect("Olm machine wasn't started");
+                let olm = self.client.olm_machine().await;
+                let olm = olm.as_ref().expect("Olm machine wasn't started");
 
                 let encrypted_content =
                     olm.encrypt_room_event_raw(self.inner.room_id(), content, event_type).await?;


### PR DESCRIPTION
`OlmMachine` was a `OnceCell`, which is not a good fit for our current plan to allow resetting the `OlmMachine` in the #1928. I made it an `Arc<tokio::RwLock>`, based on the assumption that it should be mostly read, and rarely written to. Fortunately, most callers are already async, so this change went relatively smoothly.