### PR TITLE
sdk: Keep all the discovered `AuthenticationServerInfo`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, RwLock};
 
-use futures_util::future::join3;
+use futures_util::future::join;
 use matrix_sdk::{
     ruma::{IdParseError, OwnedDeviceId, UserId},
     Session,
@@ -258,16 +258,11 @@ impl AuthenticationService {
         &self,
         client: &Arc<Client>,
     ) -> Result<HomeserverLoginDetails, AuthenticationError> {
-        let login_details = join3(
-            client.async_homeserver(),
-            client.authentication_issuer(),
-            client.supports_password_login(),
-        )
-        .await;
+        let login_details = join(client.async_homeserver(), client.supports_password_login()).await;
 
         let url = login_details.0;
-        let authentication_issuer = login_details.1;
-        let supports_password_login = login_details.2?;
+        let supports_password_login = login_details.1?;
+        let authentication_issuer = client.authentication_issuer();
 
         Ok(HomeserverLoginDetails { url, authentication_issuer, supports_password_login })
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -259,8 +259,8 @@ impl Client {
 
     /// The OIDC Provider that is trusted by the homeserver. `None` when
     /// not configured.
-    pub(crate) async fn authentication_issuer(&self) -> Option<String> {
-        self.inner.authentication_issuer().await
+    pub(crate) fn authentication_issuer(&self) -> Option<String> {
+        self.inner.authentication_server_info().map(|i| i.issuer.clone())
     }
 
     /// The sliding sync proxy that is trusted by the homeserver. `None` when

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Add `Client::subscribe_to_room_updates` and `room::Common::subscribe_to_updates`
 - `Client::rooms` now returns all rooms, even invited, as advertised.
 - Add `Client::rooms_filtered`
+- Replace `Client::authentication_issuer` with `Client::authentication_server_info` that contains
+  all the fields discovered from the homeserver for authenticating with OIDC
 
 # 0.6.2
 


### PR DESCRIPTION
It has an `account` field besides the `issuer` field.

Also store it as immutable, the data used for authentication will be stored in another variable.

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

