### PR TITLE
sdk: Export Invite

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -12,7 +12,7 @@ mod member;
 
 pub use self::{
     common::{Common, Messages, MessagesOptions},
-    invited::Invited,
+    invited::{Invite, Invited},
     joined::{Joined, Receipts},
     left::Left,
     member::RoomMember,


### PR DESCRIPTION
It's the type returned from Invited::invite_details() but it is not available publicly.

