### PR TITLE
Add a missing backtick in sync_with_result_callback() documentation.

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2345,12 +2345,12 @@ impl Client {
     ///
     /// * `callback` - A callback that will be called every time after a
     ///   response has been received, failure or not. The callback returns a
-    ///   `Result<LoopCtrl, Error>, too. When returning `Ok(LoopCtrl::Continue)`
-    ///   the sync will continue, if the callback returns `Ok(LoopCtrl::Break)`
-    ///   the sync will be stopped and the function returns `Ok(())`. In case
-    ///   the callback can't handle the `Error` or has a different malfunction,
-    ///   it can return an `Err(Error)`, which results in the sync ending and
-    ///   the `Err(Error)` being returned.
+    ///   `Result<LoopCtrl, Error>`, too. When returning
+    ///   `Ok(LoopCtrl::Continue)` the sync will continue, if the callback
+    ///   returns `Ok(LoopCtrl::Break)` the sync will be stopped and the
+    ///   function returns `Ok(())`. In case the callback can't handle the
+    ///   `Error` or has a different malfunction, it can return an `Err(Error)`,
+    ///   which results in the sync ending and the `Err(Error)` being returned.
     ///
     /// # Return
     /// The sync runs until an error occurs that the callback can't handle or


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fix a minor typo (mismatched backticks) in documentation.

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
