### PR TITLE
fix(sdk): Remove the Sliding Sync retry mechanism on `M_UNKNOWN_POS`

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/notification.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification.rs
@@ -20,12 +20,12 @@ async fn test_smoke_test_notification_api() -> anyhow::Result<()> {
             "conn_id": "notifs",
             "extensions": {
                 "e2ee": {
-                    "enabled": true
+                    "enabled": true,
                 },
                 "to_device": {
-                    "enabled": true
-                }
-            }
+                    "enabled": true,
+                },
+            },
         },
         respond with = {
             "pos": "0"
@@ -44,9 +44,9 @@ async fn test_smoke_test_notification_api() -> anyhow::Result<()> {
             "pos": "1",
             "extensions": {
                 "to_device": {
-                    "next_batch": "nb0"
-                }
-            }
+                    "next_batch": "nb0",
+                },
+            },
         },
     };
 
@@ -59,39 +59,33 @@ async fn test_smoke_test_notification_api() -> anyhow::Result<()> {
             "conn_id": "notifs",
             "extensions": {
                 "to_device": {
-                    "since": "nb0"
-                }
-            }
+                    "since": "nb0",
+                },
+            },
         },
         respond with = {
             "pos": "2",
             "extensions": {
                 "to_device": {
-                    "next_batch": "nb1"
-                }
-            }
+                    "next_batch": "nb1",
+                },
+            },
         },
     };
 
     // The to-device since token is passed from the previous request.
     // The extensions haven't changed, so they're not updated (sticky parameters
-    // ftw)... in the first request. Then, the sliding sync instance will retry
-    // those requests, so it will include them again; as a matter of fact, the
-    // last request that we assert against will contain those.
+    // ftw).
     sliding_sync_then_assert_request_and_fake_response! {
         [server, notification_stream]
         sync matches Some(Err(_)),
         assert request = {
             "conn_id": "notifs",
             "extensions": {
-                "e2ee": {
-                    "enabled": true,
-                },
                 "to_device": {
-                    "enabled": true,
-                    "since": "nb1"
-                }
-            }
+                    "since": "nb1",
+                },
+            },
         },
         respond with = (code 400) {
             "error": "foo",

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -280,8 +280,6 @@ impl SlidingSyncBuilder {
             lists,
             rooms,
 
-            reset_counter: Default::default(),
-
             position: StdRwLock::new(SlidingSyncPositionMarkers {
                 pos: None,
                 delta_token,


### PR DESCRIPTION
`SlidingSync::sync` had a legacy behaviour when a `M_UNKNOWN_POS`
error was received from the server: It was resetting `pos` and sticky
parameters before re-running a sync-loop iteration, hoping to get a
valid response from the server after that. This retrying
mechanism was running up to 3 times in row (represented by the
`MAXIMUM_SLIDING_SYNC_SESSION_EXPIRATION` constant) before stopping the
`sync` for real.

While it seemed a good idea, it actually brings numerous problems:

1. Each iteration in the sync-loop generates a new request, thus making
   the `ranges` of the requests to move forwards. For `SlidingSyncList`
   that are in `Selective` sync-mode, there is no problem, but for
   `Growing` or `Paging` sync-modes, the `ranges` increased. Thus,
   when a `SlidingSync` session expires, instead of returning to
   the caller to do something clever (like what `RoomList` does: start
   again with a small range so that the “first” sync after a session
   expiration is guaranteed to be fast), it was running larger and
   larger requests, up to 3 times.
2. `M_UNKNOWN_POS` _is_ an error. Yes, `SlidingSync` must reset `pos`
   and must invalidate sticky parameters, but the `sync` must be
   stopped, and the error must be returned so that the caller can do
   something about it. Until now, this error was likely to be missed by
   the caller.
3. This legacy mechanism was forbidding `SlidingSync::sync`'s caller to
   do something with this special error. And since the caller was blind to
   this error, it disallowed more smart error management.

This patch removes this legacy retry mechanism entirely. When
`M_UNKNOWN_POS` is received from the server, `pos` is reset and sticky
parameters are invalidated as before, but the error is returned like any
other error.

This patch renames and updates an existing test that was testing sticky
parameters invalidation on `M_UNKNOWN_POS`, to include some assertions
on `pos` and to ensure that the sync-loop is stopped accordingly.
