### PR TITLE
doc(crypto): Fix a typo

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -86,8 +86,8 @@ pub enum MegolmError {
     #[error(transparent)]
     JsonError(#[from] SerdeError),
 
-    /// Decryption failed because we're missing the room key that was to encrypt
-    /// the event.
+    /// Decryption failed because we're missing the room key that was used to
+    /// encrypt the event.
     #[error("Can't find the room key to decrypt the event, withheld code: {0:?}")]
     MissingRoomKey(Option<WithheldCode>),
 


### PR DESCRIPTION
Everything is in the title :-).
