### PR TITLE
feat(ui): Spawn a new task to retry event decryption in `Timeline`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -227,12 +227,6 @@ impl Timeline {
             .await;
     }
 
-    #[cfg(feature = "e2e-encryption")]
-    #[tracing::instrument(skip(self))]
-    async fn retry_decryption_for_all_events(&self) {
-        self.inner.retry_event_decryption(self.room(), None).await;
-    }
-
     /// Get the current timeline item for the given event ID, if any.
     ///
     /// It's preferable to store the timeline items in the model for your UI, if


### PR DESCRIPTION
In order to make `TimelineBuilder::build` faster to finish, this patch spawns a new task to retry event decryption if there is more than 5 events to decrypt. I've no measurement to decide whether 5 is an appropriate number or not though.