### PR TITLE
Add location message type to UniFFI

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -12,6 +12,7 @@ use matrix_sdk::{
             FileMessageEventContent as RumaFileMessageEventContent,
             FormattedBody as RumaFormattedBody,
             ImageMessageEventContent as RumaImageMessageEventContent,
+            LocationMessageEventContent as RumaLocationMessageEventContent,
             MessageType as RumaMessageType,
             NoticeMessageEventContent as RumaNoticeMessageEventContent, RoomMessageEventContent,
             TextMessageEventContent as RumaTextMessageEventContent, VideoInfo as RumaVideoInfo,
@@ -515,6 +516,7 @@ pub enum MessageType {
     File { content: FileMessageContent },
     Notice { content: NoticeMessageContent },
     Text { content: TextMessageContent },
+    Location { content: LocationContent },
 }
 
 impl From<MessageType> for RumaMessageType {
@@ -552,6 +554,9 @@ impl From<MessageType> for RumaMessageType {
                     formatted: content.formatted.map(Into::into),
                 }))
             }
+            MessageType::Location { content } => Self::Location(
+                RumaLocationMessageEventContent::new(content.body.clone(), content.geo_uri.clone()),
+            ),
         }
     }
 }
@@ -607,6 +612,9 @@ impl TryFrom<RumaMessageType> for MessageType {
                     body: c.body.clone(),
                     formatted: c.formatted.as_ref().map(Into::into),
                 },
+            },
+            RumaMessageType::Location(c) => MessageType::Location {
+                content: LocationContent { body: c.body.clone(), geo_uri: c.geo_uri.clone() },
             },
             _ => bail!("Unsupported type"),
         };
@@ -848,6 +856,12 @@ pub struct NoticeMessageContent {
 pub struct TextMessageContent {
     pub body: String,
     pub formatted: Option<FormattedBody>,
+}
+
+#[derive(Clone, uniffi::Record)]
+pub struct LocationContent {
+    pub body: String,
+    pub geo_uri: String,
 }
 
 #[derive(Clone, uniffi::Record)]

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -554,9 +554,9 @@ impl From<MessageType> for RumaMessageType {
                     formatted: content.formatted.map(Into::into),
                 }))
             }
-            MessageType::Location { content } => Self::Location(
-                RumaLocationMessageEventContent::new(content.body, content.geo_uri),
-            ),
+            MessageType::Location { content } => {
+                Self::Location(RumaLocationMessageEventContent::new(content.body, content.geo_uri))
+            }
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -555,7 +555,7 @@ impl From<MessageType> for RumaMessageType {
                 }))
             }
             MessageType::Location { content } => Self::Location(
-                RumaLocationMessageEventContent::new(content.body.clone(), content.geo_uri.clone()),
+                RumaLocationMessageEventContent::new(content.body, content.geo_uri),
             ),
         }
     }
@@ -614,7 +614,7 @@ impl TryFrom<RumaMessageType> for MessageType {
                 },
             },
             RumaMessageType::Location(c) => MessageType::Location {
-                content: LocationContent { body: c.body.clone(), geo_uri: c.geo_uri.clone() },
+                content: LocationContent { body: c.body, geo_uri: c.geo_uri },
             },
             _ => bail!("Unsupported type"),
         };


### PR DESCRIPTION
This PR adds the support for location events inside a `m.room.message`. 
Aka: `"msgtype": "m.location"`