### PR TITLE
feat(ui): Add `toggle_reaction` function to timeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,9 +2820,15 @@ name = "matrix-sdk-integration-testing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "assign",
  "ctor",
+ "eyeball",
+ "eyeball-im",
+ "futures-core",
+ "futures-util",
  "matrix-sdk",
+ "matrix-sdk-ui",
  "once_cell",
  "tempfile",
  "tokio",

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -198,7 +198,7 @@ impl TimelineBuilder {
                 event_handler_handles: handles,
                 room_update_join_handle,
             }),
-            reaction_queue: Mutex::new(0),
+            reaction_lock: Mutex::new(()),
         };
 
         #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -198,6 +198,7 @@ impl TimelineBuilder {
                 event_handler_handles: handles,
                 room_update_join_handle,
             }),
+            reaction_queue: Mutex::new(0),
         };
 
         #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -516,7 +516,7 @@ impl<'a> TimelineEventHandler<'a> {
                 Some(event_item.with_kind(remote_event_item.with_reactions(reactions)))
             });
 
-            if !self.result.items_updated > 0 {
+            if self.result.items_updated == 0 {
                 if let Some(reactions) = self.pending_reactions.get_mut(&rel.event_id) {
                     if !reactions.remove(&redacts) {
                         error!(

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -77,7 +77,7 @@ pub(super) struct TimelineEventMetadata {
     pub(super) is_highlighted: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(super) enum TimelineEventKind {
     Message {
         content: AnyMessageLikeEventContent,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
@@ -387,12 +387,12 @@ impl From<RoomEncryptedEventContent> for EncryptedMessage {
 pub type BundledReactions = IndexMap<String, ReactionGroup>;
 
 pub trait BundledReactionsExt {
-    fn group(&self, key: &str) -> Option<&ReactionGroup>;
+    fn by_key(&self, key: &str) -> Option<&ReactionGroup>;
 }
 
 impl BundledReactionsExt for BundledReactions {
     /// Get a reaction group by it's key
-    fn group(&self, key: &str) -> Option<&ReactionGroup> {
+    fn by_key(&self, key: &str) -> Option<&ReactionGroup> {
         self.iter().find_map(|(k, v)| match k == key {
             true => Some(v),
             false => None,
@@ -421,8 +421,9 @@ impl ReactionGroup {
     /// Note that it is possible for a user to have sent multiple reactions with the same key
     pub fn by_sender(
         &self,
-        user_id: OwnedUserId,
+        user_id: &UserId,
     ) -> impl Iterator<Item = (Option<&OwnedTransactionId>, Option<&OwnedEventId>)> {
+        let user_id = user_id.to_owned();
         self.as_refs().filter_map(move |(k, v)| match v == &user_id {
             true => Some(k),
             false => None,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -29,9 +29,9 @@ mod local;
 mod remote;
 
 pub use self::content::{
-    AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, InReplyToDetails,
-    MemberProfileChange, MembershipChange, Message, OtherState, ReactionGroup, RepliedToEvent,
-    RoomMembershipChange, Sticker, TimelineItemContent,
+    AnyOtherFullStateEventContent, BundledReactions, BundledReactionsExt, EncryptedMessage,
+    InReplyToDetails, MemberProfileChange, MembershipChange, Message, OtherState, ReactionGroup,
+    RepliedToEvent, RoomMembershipChange, Sticker, TimelineItemContent,
 };
 pub(super) use self::{
     local::LocalEventTimelineItem,

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -10,10 +10,16 @@ publish = false
 helpers = []
 
 [dependencies]
+assert_matches = { workspace = true }
 anyhow = { workspace = true }
 assign = "1"
 ctor = { workspace = true }
-matrix-sdk = { path = "../../crates/matrix-sdk" }
+eyeball = { workspace = true }
+eyeball-im = { workspace = true }
+futures-core = { workspace = true }
+futures-util = { workspace = true }
+matrix-sdk = { path = "../../crates/matrix-sdk", features = ["testing"] }
+matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", features = ["testing"] }
 once_cell = { workspace = true }
 tempfile = "3.3.0"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/testing/matrix-sdk-integration-testing/src/lib.rs
+++ b/testing/matrix-sdk-integration-testing/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 #[cfg(test)]
 mod tests;
 

--- a/testing/matrix-sdk-integration-testing/src/tests.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests.rs
@@ -1,3 +1,4 @@
 mod invitations;
+mod reactions;
 mod redaction;
 mod repeated_join;

--- a/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
@@ -1,0 +1,162 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use assert_matches::assert_matches;
+use std::sync::Arc;
+
+use anyhow::{Ok, Result};
+use assign::assign;
+use eyeball_im::VectorDiff;
+use futures_core::Stream;
+use futures_util::{future::join_all, StreamExt};
+use matrix_sdk::{
+    config::SyncSettings,
+    ruma::{
+        api::client::room::create_room::v3::Request as CreateRoomRequest,
+        events::{relation::Annotation, room::message::RoomMessageEventContent},
+        EventId, OwnedEventId, RoomId,
+    },
+    Client, LoopCtrl,
+};
+use matrix_sdk_ui::timeline::{EventTimelineItem, RoomExt, TimelineItem};
+
+use crate::helpers::get_client_for_user;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_toggling_reaction() -> Result<()> {
+    // Set up
+    let alice = get_client_for_user("alice".to_owned(), true).await?;
+    let user_id = alice.user_id().unwrap();
+    let room = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            is_direct: true,
+        }))
+        .await?;
+    let room_id = room.room_id();
+    let timeline = room.timeline().await;
+    let reaction_key = "👍";
+    let (_items, mut stream) = timeline.subscribe().await;
+
+    // Send message
+    timeline.send(RoomMessageEventContent::text_plain("hi!").into(), None).await;
+    {
+        let _day_divider = stream.next().await;
+        let event =
+            assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+        let event = event.as_event().unwrap();
+        assert_matches!(event.content().as_message(), Some(_));
+        assert!(event.is_local_echo());
+        assert!(event.reactions().is_empty());
+    }
+
+    // Receive updated local echo with event ID
+    let event_id = {
+        let event = assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+        let event = event.as_event().unwrap();
+        event.event_id().unwrap().to_owned()
+    };
+
+    // Sync remaining remote events
+    sync_room(&alice, room_id).await?;
+    {
+        let _room_create = stream.next().await;
+        let _membership_change = stream.next().await;
+        let _power_levels = stream.next().await;
+        let _join_rules = stream.next().await;
+        let _history_visibility = stream.next().await;
+        let _guest_access = stream.next().await;
+        let _remove_local_event = stream.next().await;
+    }
+
+    // Check we have the remote echo
+    {
+        let event =
+            assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+        let event = event.as_event().unwrap();
+        assert_eq!(event.event_id().unwrap(), &event_id);
+        assert!(!event.is_local_echo());
+    };
+
+    // Toggle reaction multiple times
+    for _ in 0..3 {
+        // Send a reaction
+        let reaction = Annotation::new(event_id.clone(), reaction_key.into());
+
+        // Add the reaction many times
+        join_all((0..100).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
+
+        let message_position = timeline.items().await.len() - 1;
+
+        // Check we have a local echo of the reaction
+        {
+            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
+            let (reaction_tx_id, reaction_event_id) = {
+                let reactions = event.reactions().get(reaction_key).unwrap();
+                let reaction = reactions.by_sender(user_id).next().unwrap();
+                reaction.to_owned()
+            };
+            assert_matches!(reaction_tx_id, Some(_));
+            assert_matches!(reaction_event_id, None); // Event ID hasn't been received from homeserver yet
+        }
+
+        // Check we have the remote echo of the reaction
+        let _reaction_event_id: OwnedEventId = {
+            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
+            let reactions = event.reactions().get(reaction_key).unwrap();
+            assert_eq!(reactions.senders().count(), 1);
+            let reaction = reactions.by_sender(user_id).next().unwrap();
+            let (reaction_tx_id, reaction_event_id) = reaction;
+            assert_matches!(reaction_tx_id, None);
+            let reaction_event_id = assert_matches!(reaction_event_id, Some(value) => value);
+            reaction_event_id.to_owned()
+        };
+
+        // Redact the reaction many times
+        join_all((0..100).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
+
+        // Check the message has no local reaction
+        {
+            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
+            assert_matches!(event.reactions().get(reaction_key), None);
+        }
+    }
+
+    Ok(())
+}
+async fn sync_room(client: &Client, room_id: &RoomId) -> Result<()> {
+    client
+        .sync_with_callback(SyncSettings::default(), |response| async move {
+            if response.rooms.join.iter().any(|(id, _)| id == room_id) {
+                LoopCtrl::Break
+            } else {
+                LoopCtrl::Continue
+            }
+        })
+        .await?;
+    Ok(())
+}
+
+async fn assert_event_is_updated(
+    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
+    event_id: &EventId,
+    _position: usize,
+) -> EventTimelineItem {
+    let event = assert_matches!(
+        stream.next().await,
+        Some(VectorDiff::Set { index: _position, value }) => value
+    );
+    let event = event.as_event().unwrap();
+    assert_eq!(event.event_id().unwrap(), event_id);
+    event.to_owned()
+}

--- a/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
@@ -1,13 +1,25 @@
-use anyhow::Result;
+use assert_matches::assert_matches;
+use std::sync::Arc;
+
+use anyhow::{Ok, Result};
 use assign::assign;
+use eyeball_im::VectorDiff;
+use futures_core::Stream;
+use futures_util::StreamExt;
 use matrix_sdk::{
     config::SyncSettings,
     ruma::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
-        events::{room::name::RoomNameEventContent, StateEventType},
+        events::{
+            relation::Annotation,
+            room::{message::RoomMessageEventContent, name::RoomNameEventContent},
+            StateEventType,
+        },
+        EventId, OwnedEventId, RoomId,
     },
-    Client,
+    Client, LoopCtrl,
 };
+use matrix_sdk_ui::timeline::{EventTimelineItem, RoomExt, TimelineItem};
 
 use crate::helpers::get_client_for_user;
 
@@ -179,4 +191,136 @@ async fn test_redacting_name_static() -> Result<()> {
     );
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_redacting_reaction() -> Result<()> {
+    // Set up
+    let alice = get_client_for_user("alice".to_owned(), true).await?;
+    let user_id = alice.user_id().unwrap();
+    let room = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            is_direct: true,
+        }))
+        .await?;
+    let room_id = room.room_id();
+    let timeline = room.timeline().await;
+    let reaction_key = "👍";
+    let (_items, mut stream) = timeline.subscribe().await;
+
+    // Send message
+    timeline.send(RoomMessageEventContent::text_plain("hi!").into(), None).await;
+    {
+        let _day_divider = stream.next().await;
+        let event =
+            assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+        let event = event.as_event().unwrap();
+        assert_matches!(event.content().as_message(), Some(_));
+        assert!(event.is_local_echo());
+        assert!(event.reactions().is_empty());
+    }
+
+    // Receive updated local echo with event ID
+    let event_id = {
+        let event = assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+        let event = event.as_event().unwrap();
+        event.event_id().unwrap().to_owned()
+    };
+
+    // Sync remaining remote events
+    sync_room(&alice, room_id).await?;
+    {
+        let _room_create = stream.next().await;
+        let _membership_change = stream.next().await;
+        let _power_levels = stream.next().await;
+        let _join_rules = stream.next().await;
+        let _history_visibility = stream.next().await;
+        let _guest_access = stream.next().await;
+        let _remove_local_event = stream.next().await;
+    }
+
+    // Check we have the remote echo
+    {
+        let event =
+            assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+        let event = event.as_event().unwrap();
+        assert_eq!(event.event_id().unwrap(), &event_id);
+        assert!(!event.is_local_echo());
+    };
+
+    // Toggle reaction multiple times
+    for _ in 0..3 {
+        // Send a reaction
+        let reaction = Annotation::new(event_id.clone(), reaction_key.into());
+        {
+            timeline.toggle_reaction(&reaction).await?;
+        }
+
+        let message_position = timeline.items().await.len() - 1;
+
+        // Check we have a local echo of the reaction
+        {
+            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
+            let (reaction_tx_id, reaction_event_id) = {
+                let reactions = event.reactions().get(reaction_key).unwrap();
+                let reaction = reactions.by_sender(user_id.to_owned()).next().unwrap();
+                reaction.to_owned()
+            };
+            assert_matches!(reaction_tx_id, Some(_));
+            assert_matches!(reaction_event_id, None); // Event ID hasn't been received from homeserver yet
+        }
+
+        // Sync reaction from remote echo
+        sync_room(&alice, room_id).await?;
+
+        // Check we have the remote echo of the reaction
+        let _reaction_event_id: OwnedEventId = {
+            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
+            let reactions = event.reactions().get(reaction_key).unwrap();
+            assert_eq!(reactions.senders().count(), 1);
+            let reaction = reactions.by_sender(user_id.to_owned()).next().unwrap();
+            let (reaction_tx_id, reaction_event_id) = reaction;
+            assert_matches!(reaction_tx_id, None);
+            let reaction_event_id = assert_matches!(reaction_event_id, Some(value) => value);
+            reaction_event_id.to_owned()
+        };
+
+        // Redact the reaction
+        timeline.toggle_reaction(&reaction).await?;
+
+        // Check the message has no local reaction
+        {
+            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
+            assert_matches!(event.reactions().get(reaction_key), None);
+        }
+    }
+
+    Ok(())
+}
+
+async fn sync_room(client: &Client, room_id: &RoomId) -> Result<()> {
+    client
+        .sync_with_callback(SyncSettings::default(), |response| async move {
+            if response.rooms.join.iter().any(|(id, _)| id == room_id) {
+                LoopCtrl::Break
+            } else {
+                LoopCtrl::Continue
+            }
+        })
+        .await?;
+    Ok(())
+}
+
+async fn assert_event_is_updated(
+    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
+    event_id: &EventId,
+    _position: usize,
+) -> EventTimelineItem {
+    let event = assert_matches!(
+        stream.next().await,
+        Some(VectorDiff::Set { index: _position, value }) => value
+    );
+    let event = event.as_event().unwrap();
+    assert_eq!(event.event_id().unwrap(), event_id);
+    event.to_owned()
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
@@ -263,7 +263,7 @@ async fn test_redacting_reaction() -> Result<()> {
             let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
             let (reaction_tx_id, reaction_event_id) = {
                 let reactions = event.reactions().get(reaction_key).unwrap();
-                let reaction = reactions.by_sender(user_id.to_owned()).next().unwrap();
+                let reaction = reactions.by_sender(user_id).next().unwrap();
                 reaction.to_owned()
             };
             assert_matches!(reaction_tx_id, Some(_));
@@ -275,7 +275,7 @@ async fn test_redacting_reaction() -> Result<()> {
             let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
             let reactions = event.reactions().get(reaction_key).unwrap();
             assert_eq!(reactions.senders().count(), 1);
-            let reaction = reactions.by_sender(user_id.to_owned()).next().unwrap();
+            let reaction = reactions.by_sender(user_id).next().unwrap();
             let (reaction_tx_id, reaction_event_id) = reaction;
             assert_matches!(reaction_tx_id, None);
             let reaction_event_id = assert_matches!(reaction_event_id, Some(value) => value);

--- a/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
@@ -252,9 +252,8 @@ async fn test_redacting_reaction() -> Result<()> {
     for _ in 0..3 {
         // Send a reaction
         let reaction = Annotation::new(event_id.clone(), reaction_key.into());
-        {
-            timeline.toggle_reaction(&reaction).await?;
-        }
+
+        timeline.toggle_reaction(&reaction).await?;
 
         let message_position = timeline.items().await.len() - 1;
 
@@ -269,9 +268,6 @@ async fn test_redacting_reaction() -> Result<()> {
             assert_matches!(reaction_tx_id, Some(_));
             assert_matches!(reaction_event_id, None); // Event ID hasn't been received from homeserver yet
         }
-
-        // Sync reaction from remote echo
-        sync_room(&alice, room_id).await?;
 
         // Check we have the remote echo of the reaction
         let _reaction_event_id: OwnedEventId = {

--- a/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
@@ -1,25 +1,13 @@
-use assert_matches::assert_matches;
-use std::sync::Arc;
-
 use anyhow::{Ok, Result};
 use assign::assign;
-use eyeball_im::VectorDiff;
-use futures_core::Stream;
-use futures_util::{future::join_all, StreamExt};
 use matrix_sdk::{
     config::SyncSettings,
     ruma::{
         api::client::room::create_room::v3::Request as CreateRoomRequest,
-        events::{
-            relation::Annotation,
-            room::{message::RoomMessageEventContent, name::RoomNameEventContent},
-            StateEventType,
-        },
-        EventId, OwnedEventId, RoomId,
+        events::{room::name::RoomNameEventContent, StateEventType},
     },
-    Client, LoopCtrl,
+    Client,
 };
-use matrix_sdk_ui::timeline::{EventTimelineItem, RoomExt, TimelineItem};
 
 use crate::helpers::get_client_for_user;
 
@@ -191,133 +179,4 @@ async fn test_redacting_name_static() -> Result<()> {
     );
 
     Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_redacting_reaction() -> Result<()> {
-    // Set up
-    let alice = get_client_for_user("alice".to_owned(), true).await?;
-    let user_id = alice.user_id().unwrap();
-    let room = alice
-        .create_room(assign!(CreateRoomRequest::new(), {
-            is_direct: true,
-        }))
-        .await?;
-    let room_id = room.room_id();
-    let timeline = room.timeline().await;
-    let reaction_key = "👍";
-    let (_items, mut stream) = timeline.subscribe().await;
-
-    // Send message
-    timeline.send(RoomMessageEventContent::text_plain("hi!").into(), None).await;
-    {
-        let _day_divider = stream.next().await;
-        let event =
-            assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-        let event = event.as_event().unwrap();
-        assert_matches!(event.content().as_message(), Some(_));
-        assert!(event.is_local_echo());
-        assert!(event.reactions().is_empty());
-    }
-
-    // Receive updated local echo with event ID
-    let event_id = {
-        let event = assert_matches!(stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
-        let event = event.as_event().unwrap();
-        event.event_id().unwrap().to_owned()
-    };
-
-    // Sync remaining remote events
-    sync_room(&alice, room_id).await?;
-    {
-        let _room_create = stream.next().await;
-        let _membership_change = stream.next().await;
-        let _power_levels = stream.next().await;
-        let _join_rules = stream.next().await;
-        let _history_visibility = stream.next().await;
-        let _guest_access = stream.next().await;
-        let _remove_local_event = stream.next().await;
-    }
-
-    // Check we have the remote echo
-    {
-        let event =
-            assert_matches!(stream.next().await, Some(VectorDiff::PushBack { value }) => value);
-        let event = event.as_event().unwrap();
-        assert_eq!(event.event_id().unwrap(), &event_id);
-        assert!(!event.is_local_echo());
-    };
-
-    // Toggle reaction multiple times
-    for _ in 0..3 {
-        // Send a reaction
-        let reaction = Annotation::new(event_id.clone(), reaction_key.into());
-
-        // Add the reaction many times
-        join_all((0..100).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-
-        let message_position = timeline.items().await.len() - 1;
-
-        // Check we have a local echo of the reaction
-        {
-            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
-            let (reaction_tx_id, reaction_event_id) = {
-                let reactions = event.reactions().get(reaction_key).unwrap();
-                let reaction = reactions.by_sender(user_id).next().unwrap();
-                reaction.to_owned()
-            };
-            assert_matches!(reaction_tx_id, Some(_));
-            assert_matches!(reaction_event_id, None); // Event ID hasn't been received from homeserver yet
-        }
-
-        // Check we have the remote echo of the reaction
-        let _reaction_event_id: OwnedEventId = {
-            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
-            let reactions = event.reactions().get(reaction_key).unwrap();
-            assert_eq!(reactions.senders().count(), 1);
-            let reaction = reactions.by_sender(user_id).next().unwrap();
-            let (reaction_tx_id, reaction_event_id) = reaction;
-            assert_matches!(reaction_tx_id, None);
-            let reaction_event_id = assert_matches!(reaction_event_id, Some(value) => value);
-            reaction_event_id.to_owned()
-        };
-
-        // Redact the reaction many times
-        join_all((0..100).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-
-        // Check the message has no local reaction
-        {
-            let event = assert_event_is_updated(&mut stream, &event_id, message_position).await;
-            assert_matches!(event.reactions().get(reaction_key), None);
-        }
-    }
-
-    Ok(())
-}
-
-async fn sync_room(client: &Client, room_id: &RoomId) -> Result<()> {
-    client
-        .sync_with_callback(SyncSettings::default(), |response| async move {
-            if response.rooms.join.iter().any(|(id, _)| id == room_id) {
-                LoopCtrl::Break
-            } else {
-                LoopCtrl::Continue
-            }
-        })
-        .await?;
-    Ok(())
-}
-
-async fn assert_event_is_updated(
-    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
-    event_id: &EventId,
-    _position: usize,
-) -> EventTimelineItem {
-    let event = assert_matches!(
-        stream.next().await,
-        Some(VectorDiff::Set { index: _position, value }) => value
-    );
-    let event = event.as_event().unwrap();
-    assert_eq!(event.event_id().unwrap(), event_id);
-    event.to_owned()
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
@@ -5,7 +5,7 @@ use anyhow::{Ok, Result};
 use assign::assign;
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
-use futures_util::StreamExt;
+use futures_util::{future::join_all, StreamExt};
 use matrix_sdk::{
     config::SyncSettings,
     ruma::{
@@ -253,7 +253,8 @@ async fn test_redacting_reaction() -> Result<()> {
         // Send a reaction
         let reaction = Annotation::new(event_id.clone(), reaction_key.into());
 
-        timeline.toggle_reaction(&reaction).await?;
+        // Add the reaction many times
+        join_all((0..100).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
 
         let message_position = timeline.items().await.len() - 1;
 
@@ -281,8 +282,8 @@ async fn test_redacting_reaction() -> Result<()> {
             reaction_event_id.to_owned()
         };
 
-        // Redact the reaction
-        timeline.toggle_reaction(&reaction).await?;
+        // Redact the reaction many times
+        join_all((0..100).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
 
         // Check the message has no local reaction
         {


### PR DESCRIPTION
_Work in progress_

- Add local echo for timeline reactions
- Add crude debounce mechanism

```[tasklist]
- [ ] Public API changes documented in changelogs (TBC)
- [x] Add `toggle_reaction` function to timeline
  - [x] Integration test
  - [ ] Unit tests
```
  

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
