### PR TITLE
feat(ui): Implement `RoomList::stop_sync`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -100,6 +100,10 @@ impl RoomList {
         })))
     }
 
+    fn stop_sync(&self) -> Result<(), RoomListError> {
+        self.inner.stop_sync().map_err(Into::into)
+    }
+
     fn state(&self, listener: Box<dyn RoomListStateListener>) -> Arc<TaskHandle> {
         let state_stream = self.inner.state();
 


### PR DESCRIPTION
Address #1911.

This patch implements `RoomList::stop_sync`. The goal is twofold:

1. It forces to stop the syncing, thus putting the state-machine into
   the `Terminated` state, which is semantically better than “stop
   polling the `sync`'s `Stream`”.

2. It literally forces to stop the syncing. It cancels pending futures,
   it cancels in-flight HTTP requests etc. It's a more robust way to
   stop the `RoomList` sync.

On the FFI side, technically, it's no more useful to store the
`TaskHandle`. It's kept around in case of, but it's no more necessary
to cancel it. Calling `RoomList::stop_sync` is the way to go.