### PR TITLE
ui: filter redacted reactions from the timeline

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -83,7 +83,9 @@ pub(super) enum TimelineEventKind {
         content: AnyMessageLikeEventContent,
         relations: BundledMessageLikeRelations<AnySyncMessageLikeEvent>,
     },
-    RedactedMessage,
+    RedactedMessage {
+        event_type: MessageLikeEventType,
+    },
     Redaction {
         redacts: OwnedEventId,
         content: RoomRedactionEventContent,
@@ -147,7 +149,7 @@ impl From<AnySyncTimelineEvent> for TimelineEventKind {
             )) => Self::Redaction { redacts, content },
             AnySyncTimelineEvent::MessageLike(ev) => match ev.original_content() {
                 Some(content) => Self::Message { content, relations: ev.relations() },
-                None => Self::RedactedMessage,
+                None => Self::RedactedMessage { event_type: ev.event_type() },
             },
             AnySyncTimelineEvent::State(ev) => match ev {
                 AnySyncStateEvent::RoomMember(ev) => match ev {
@@ -302,9 +304,20 @@ impl<'a> TimelineEventHandler<'a> {
                 }
             },
 
-            TimelineEventKind::RedactedMessage => {
-                self.add(NewEventTimelineItem::redacted_message());
-            }
+            TimelineEventKind::RedactedMessage { event_type } => match event_type {
+                MessageLikeEventType::Reaction => {
+                    if let Flow::Remote { position: TimelineItemPosition::Update(idx), .. } =
+                        self.flow
+                    {
+                        // Filter out redacted reactions from the timeline.
+                        self.items.remove(idx);
+                        self.result.item_removed = true;
+                    }
+                }
+                _ => {
+                    self.add(NewEventTimelineItem::redacted_message());
+                }
+            },
 
             TimelineEventKind::Redaction { redacts, content } => {
                 self.handle_redaction(redacts, content);


### PR DESCRIPTION
This aims at filtering out redacted reactions from the timeline. This is currently done at a high level but perhaps, if these reaction redaction appearing in the timeline are considered a bug it should probably be filtered out at a deeper level. 

Also, looking at this PR: https://github.com/matrix-org/matrix-rust-sdk/pull/2114, it seems that this could be build on top of it (again depending on whether we consider this to be a bug or not).