### PR TITLE
Update reldbg profile to optimize our own packages too

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,6 @@ debug = 2
 # `--profile reldbg` to select
 [profile.reldbg]
 inherits = "dev"
-incremental = false
-
-# Compile all non-workspace crate in the dependency tree with optimizations
-[profile.reldbg.package."*"]
 opt-level = 3
 
 [patch.crates-io]


### PR DESCRIPTION
… and enable incremental compilation for it.

Replaces #2072.

@stefanceriu, @Hywan: I think this should fix the iOS crashes if I understood the test results, and the profile names / descriptions still make sense this way.