### PR TITLE
bindings: Ignore silently malformed userId in migration of tracked users

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -286,7 +286,8 @@ async fn migrate_data(
     let tracked_users: Vec<_> = data
         .tracked_users
         .into_iter()
-        .map(|u| Ok(((parse_user_id(&u)?), true)))
+        .flat_map(|s| parse_user_id(&s))
+        .map(|u| Ok((u, true)))
         .collect::<anyhow::Result<_>>()?;
 
     let tracked_users: Vec<_> = tracked_users.iter().map(|(u, d)| (&**u, *d)).collect();
@@ -967,7 +968,8 @@ mod test {
                "@ganfra146:matrix.org",
                "@this-is-me:matrix.org",
                "@Amandine:matrix.org",
-               "@ganfra:matrix.org"
+               "@ganfra:matrix.org",
+               "NotAUser%ID"
             ],
             "room_settings": {
                 "!AZkqtjvtwPAuyNOXEt:matrix.org": {
@@ -1035,6 +1037,11 @@ mod test {
 
         let settings3 = machine.get_room_settings("!XYZ:matrix.org".into())?;
         assert!(settings3.is_none());
+
+        assert!(machine.is_user_tracked("@ganfra146:matrix.org".into()).unwrap());
+        assert!(machine.is_user_tracked("@Amandine:matrix.org".into()).unwrap());
+        assert!(machine.is_user_tracked("@this-is-me:matrix.org".into()).unwrap());
+        assert!(machine.is_user_tracked("@ganfra:matrix.org".into()).unwrap());
 
         Ok(())
     }

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -286,9 +286,8 @@ async fn migrate_data(
     let tracked_users: Vec<_> = data
         .tracked_users
         .into_iter()
-        .flat_map(|s| parse_user_id(&s))
-        .map(|u| Ok((u, true)))
-        .collect::<anyhow::Result<_>>()?;
+        .filter_map(|s| parse_user_id(&s).ok().map(|u| (u, true)))
+        .collect();
 
     let tracked_users: Vec<_> = tracked_users.iter().map(|(u, d)| (&**u, *d)).collect();
     store.save_tracked_users(tracked_users.as_slice()).await?;


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Currently when doing migration from EA, if a userId is malformed the whole migration will fail (and lock users out).
Notice that the validation has been relaxed in [ruma](https://github.com/ruma/ruma/commit/6ad007995c122561f8de7135195273ed91a9737c). 
Anyhow I think it's good to be more lax on the migration process, and it's also consistent as the `update_tracked_users()` function is already ignoring malformed userIds silently

