### PR TITLE
sdk: Allow to update notification settings

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -62,8 +62,10 @@ use ruma::{
         error::FromHttpResponseError,
         MatrixVersion, OutgoingRequest,
     },
-    assign, DeviceId, OwnedDeviceId, OwnedRoomId, OwnedServerName, RoomAliasId, RoomId,
-    RoomOrAliasId, ServerName, UInt, UserId,
+    assign,
+    push::Ruleset,
+    DeviceId, OwnedDeviceId, OwnedRoomId, OwnedServerName, RoomAliasId, RoomId, RoomOrAliasId,
+    ServerName, UInt, UserId,
 };
 use serde::de::DeserializeOwned;
 use tokio::sync::{broadcast, Mutex, OnceCell, RwLock, RwLockReadGuard};
@@ -81,6 +83,7 @@ use crate::{
     },
     http_client::HttpClient,
     matrix_auth::MatrixAuth,
+    notification_settings::NotificationSettings,
     room,
     sync::{RoomUpdate, SyncResponse},
     Account, AuthApi, AuthSession, Error, Media, RefreshTokenError, Result, TransmissionProgress,
@@ -1925,6 +1928,12 @@ impl Client {
     pub async fn get_profile(&self, user_id: &UserId) -> Result<get_profile::v3::Response> {
         let request = get_profile::v3::Request::new(user_id.to_owned());
         Ok(self.send(request, Some(RequestConfig::short_retry())).await?)
+    }
+
+    /// Get the notification settings of the current owner of the client.
+    pub async fn notification_settings(&self) -> NotificationSettings {
+        let ruleset = self.account().push_rules().await.unwrap_or_else(|_| Ruleset::new());
+        NotificationSettings::new(self.clone(), ruleset)
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -30,7 +30,7 @@ use ruma::{
         error::{FromHttpResponseError, IntoHttpError},
     },
     events::tag::InvalidUserTagName,
-    push::{InsertPushRuleError, RuleNotFoundError},
+    push::{InsertPushRuleError, RemovePushRuleError, RuleNotFoundError},
     IdParseError,
 };
 use serde_json::Error as JsonError;
@@ -430,17 +430,32 @@ pub enum NotificationSettingsError {
     /// Invalid parameter.
     #[error("Invalid parameter `{0}`")]
     InvalidParameter(String),
-    /// Rule not found
-    #[error("Rule not found")]
-    RuleNotFound,
     /// Unable to add push rule.
     #[error("Unable to add push rule")]
     UnableToAddPushRule,
+    /// Unable to remove push rule.
+    #[error("Unable to remove push rule")]
+    UnableToRemovePushRule,
+    /// Unable to update push rule.
+    #[error("Unable to update push rule")]
+    UnableToUpdatePushRule,
+    /// Rule not found
+    #[error("Rule not found")]
+    RuleNotFound,
+    /// Unable to save the push rules
+    #[error("Unable to save push rules")]
+    UnableToSavePushRules,
 }
 
 impl From<InsertPushRuleError> for NotificationSettingsError {
     fn from(_: InsertPushRuleError) -> Self {
         Self::UnableToAddPushRule
+    }
+}
+
+impl From<RemovePushRuleError> for NotificationSettingsError {
+    fn from(_: RemovePushRuleError) -> Self {
+        Self::UnableToRemovePushRule
     }
 }
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -56,7 +56,10 @@ pub use authentication::{AuthApi, AuthSession};
 pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, UnknownToken};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;
-pub use error::{Error, HttpError, HttpResult, RefreshTokenError, Result, RumaApiError};
+pub use error::{
+    Error, HttpError, HttpResult, NotificationSettingsError, RefreshTokenError, Result,
+    RumaApiError,
+};
 pub use http_client::TransmissionProgress;
 pub use media::Media;
 pub use ruma::{IdParseError, OwnedServerName, ServerName};

--- a/crates/matrix-sdk/src/notification_settings/command.rs
+++ b/crates/matrix-sdk/src/notification_settings/command.rs
@@ -1,0 +1,62 @@
+use std::fmt::Debug;
+
+use ruma::{
+    api::client::push::RuleScope,
+    push::{
+        Action, NewConditionalPushRule, NewPushRule, NewSimplePushRule, PushCondition, RuleKind,
+        Tweak,
+    },
+    OwnedRoomId,
+};
+
+use crate::NotificationSettingsError;
+
+/// enum describing the commands required to modify the owner's account data.
+#[derive(Clone, Debug)]
+pub(crate) enum Command {
+    /// Set a new `Room` push rule
+    SetRoomPushRule { scope: RuleScope, room_id: OwnedRoomId, notify: bool },
+    /// Set a new `Override` push rule
+    SetOverridePushRule { scope: RuleScope, rule_id: String, room_id: OwnedRoomId, notify: bool },
+    /// Set whether a push rule is enabled
+    SetPushRuleEnabled { scope: RuleScope, kind: RuleKind, rule_id: String, enabled: bool },
+    /// Delete a push rule
+    DeletePushRule { scope: RuleScope, kind: RuleKind, rule_id: String },
+}
+
+impl Command {
+    fn build_actions(&self, notify: bool) -> Vec<Action> {
+        if notify {
+            vec![Action::Notify, Action::SetTweak(Tweak::Sound("default".into()))]
+        } else {
+            vec![]
+        }
+    }
+
+    /// Tries to create a push rule corresponding to this command
+    pub(crate) fn to_push_rule(&self) -> Result<NewPushRule, NotificationSettingsError> {
+        match self {
+            Self::SetRoomPushRule { scope: _, room_id, notify } => {
+                // `Room` push rule for this `room_id`
+                let new_rule =
+                    NewSimplePushRule::new(room_id.to_owned(), self.build_actions(*notify));
+                Ok(NewPushRule::Room(new_rule))
+            }
+            Self::SetOverridePushRule { scope: _, rule_id, room_id, notify } => {
+                // `Override` push rule matching this `room_id`
+                let new_rule = NewConditionalPushRule::new(
+                    rule_id.to_owned(),
+                    vec![PushCondition::EventMatch {
+                        key: "room_id".into(),
+                        pattern: room_id.to_string(),
+                    }],
+                    self.build_actions(*notify),
+                );
+                Ok(NewPushRule::Override(new_rule))
+            }
+            _ => Err(NotificationSettingsError::InvalidParameter(
+                "cannot create a push rule from this command.".to_owned(),
+            )),
+        }
+    }
+}

--- a/crates/matrix-sdk/src/notification_settings/command.rs
+++ b/crates/matrix-sdk/src/notification_settings/command.rs
@@ -16,7 +16,7 @@ use crate::NotificationSettingsError;
 pub(crate) enum Command {
     /// Set a new `Room` push rule
     SetRoomPushRule { scope: RuleScope, room_id: OwnedRoomId, notify: bool },
-    /// Set a new `Override` push rule
+    /// Set a new `Override` push rule matching a `RoomId`
     SetOverridePushRule { scope: RuleScope, rule_id: String, room_id: OwnedRoomId, notify: bool },
     /// Set whether a push rule is enabled
     SetPushRuleEnabled { scope: RuleScope, kind: RuleKind, rule_id: String, enabled: bool },

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -1,6 +1,19 @@
 //! High-level push notification settings API
 
+use std::sync::Arc;
+
+use ruma::{
+    api::client::push::{delete_pushrule, set_pushrule, set_pushrule_enabled},
+    push::{RuleKind, Ruleset},
+    RoomId,
+};
+use tokio::sync::RwLock;
+
+use self::rules::{Command, Rules};
+
 mod rules;
+
+use crate::{error::NotificationSettingsError, Client, Result};
 
 /// Enum representing the push notification modes for a room.
 #[derive(Debug, Clone, PartialEq)]
@@ -11,4 +24,734 @@ pub enum RoomNotificationMode {
     MentionsAndKeywordsOnly,
     /// Do not receive any notifications.
     Mute,
+}
+
+/// A high-level API to manage the client owner's push notification settings.
+#[derive(Debug, Clone)]
+pub struct NotificationSettings {
+    /// The underlying HTTP client.
+    client: Client,
+    /// Owner's account push rules. They will be updated on sync.
+    ruleset: Arc<RwLock<Ruleset>>,
+}
+
+impl NotificationSettings {
+    /// Build a new `NotificationSettings``
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - A `Client` used to perform API calls
+    /// * `ruleset` - A `Ruleset` containing account's owner push rules
+    pub fn new(client: Client, ruleset: Ruleset) -> Self {
+        let ruleset = Arc::new(RwLock::new(ruleset));
+        Self { client, ruleset }
+    }
+
+    /// Replace the internal ruleset
+    ///
+    /// # Arguments
+    ///
+    /// * `ruleset` - A `Ruleset` containing account's owner push rules
+    pub async fn set_ruleset(&self, ruleset: &Ruleset) {
+        *self.ruleset.write().await = ruleset.clone();
+    }
+
+    /// Get a new `Rules` instance to interact with the ruleset.
+    async fn rules(&self) -> Rules {
+        let ruleset = &*self.ruleset.read().await;
+        Rules::new(ruleset.clone())
+    }
+
+    /// Gets all user defined rules matching a given `room_id`.
+    async fn get_custom_rules_for_room(&self, room_id: &RoomId) -> Vec<(RuleKind, String)> {
+        self.rules().await.get_custom_rules_for_room(room_id)
+    }
+
+    /// Gets the user defined notification mode for a room.
+    pub async fn get_user_defined_room_notification_mode(
+        &self,
+        room_id: &RoomId,
+    ) -> Option<RoomNotificationMode> {
+        self.rules().await.get_user_defined_room_notification_mode(room_id)
+    }
+
+    /// Gets the default notification mode for a room.
+    ///
+    /// # Arguments
+    ///
+    /// * `is_encrypted` - `true` if the room is encrypted
+    /// * `members_count` - the room members count
+    pub async fn get_default_room_notification_mode(
+        &self,
+        is_encrypted: bool,
+        members_count: u64,
+    ) -> RoomNotificationMode {
+        self.rules().await.get_default_room_notification_mode(is_encrypted, members_count)
+    }
+
+    /// Get whether the given ruleset contains some enabled keywords rules.
+    pub async fn contains_keyword_rules(&self) -> bool {
+        self.rules().await.contains_keyword_rules()
+    }
+
+    /// Get whether a push rule is enabled.
+    pub async fn is_push_rule_enabled(
+        &self,
+        kind: RuleKind,
+        rule_id: &str,
+    ) -> Result<bool, NotificationSettingsError> {
+        self.rules().await.is_enabled(kind, rule_id)
+    }
+
+    /// Set whether a push rule is enabled.
+    pub async fn set_push_rule_enabled(
+        &self,
+        kind: RuleKind,
+        rule_id: &str,
+        enabled: bool,
+    ) -> Result<(), NotificationSettingsError> {
+        let mut rules = self.rules().await;
+        // Enable the push rule
+        let commands = rules.set_enabled(kind, rule_id, enabled)?;
+        // Execute the commands to apply changes
+        self.execute_commands(&commands).await?;
+        // Update the internal ruleset
+        self.set_ruleset(&rules.ruleset).await;
+        Ok(())
+    }
+
+    /// Sets the notification mode for a room.
+    pub async fn set_room_notification_mode(
+        &self,
+        room_id: &RoomId,
+        mode: RoomNotificationMode,
+    ) -> Result<(), NotificationSettingsError> {
+        // Get the current mode
+        let current_mode = self.get_user_defined_room_notification_mode(room_id).await;
+
+        if current_mode == Some(mode.clone()) {
+            return Ok(());
+        }
+
+        let mut rules = self.rules().await;
+        let commands = match mode {
+            RoomNotificationMode::AllMessages => {
+                // insert a `Room` rule which notifies
+                rules.insert_new_rule(RuleKind::Room, room_id, true, current_mode.is_some())?
+            }
+            RoomNotificationMode::MentionsAndKeywordsOnly => {
+                // insert a `Room` rule which doesn't notify
+                rules.insert_new_rule(RuleKind::Room, room_id, false, current_mode.is_some())?
+            }
+            RoomNotificationMode::Mute => {
+                // insert an `Override` rule which doesn't notify
+                rules.insert_new_rule(RuleKind::Override, room_id, false, current_mode.is_some())?
+            }
+        };
+
+        // Execute the commands to apply changes
+        self.execute_commands(&commands).await?;
+
+        // Update the internal ruleset
+        self.set_ruleset(&rules.ruleset).await;
+
+        Ok(())
+    }
+
+    /// Deletes a list of rules and returns a list of `Command` describing the
+    /// actions to be performed on the user's account data.
+    ///
+    /// # Arguments
+    ///
+    /// * `rules` - A list of rules to delete
+    /// * `exceptions` - A list of rules to ignore
+    async fn delete_rules(
+        &self,
+        rules: &[(RuleKind, String)],
+        exceptions: &[(RuleKind, String)],
+    ) -> Result<(), NotificationSettingsError> {
+        let mut push_rules = self.rules().await;
+        let commands = push_rules
+            .delete_rules(rules, exceptions)
+            .map_err(|_| NotificationSettingsError::UnableToRemovePushRule)?;
+        // Execute the commands to apply changes
+        self.execute_commands(&commands).await?;
+        // Update the internal ruleset
+        self.set_ruleset(&push_rules.ruleset).await;
+
+        Ok(())
+    }
+
+    /// Delete all user defined rules for a room.
+    pub async fn delete_user_defined_room_rules(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<(), NotificationSettingsError> {
+        let rules = self.get_custom_rules_for_room(room_id).await;
+        self.delete_rules(&rules, &[]).await
+    }
+
+    /// Unmute a room.
+    pub async fn unmute_room(
+        &self,
+        room_id: &RoomId,
+        is_encrypted: bool,
+        members_count: u64,
+    ) -> Result<(), NotificationSettingsError> {
+        // Check if there is a user defined mode
+        if let Some(room_mode) = self.get_user_defined_room_notification_mode(room_id).await {
+            if room_mode != RoomNotificationMode::Mute {
+                // Already unmuted
+                return Ok(());
+            }
+
+            // Get default mode for this room
+            let default_mode =
+                self.get_default_room_notification_mode(is_encrypted, members_count).await;
+
+            // If the default mode is `Mute`, set it to `AllMessages`
+            if default_mode == RoomNotificationMode::Mute {
+                self.set_room_notification_mode(room_id, RoomNotificationMode::AllMessages).await
+            } else {
+                // Otherwise, delete user defined rules to use the default mode
+                self.delete_user_defined_room_rules(room_id).await
+            }
+        } else {
+            // This is the default mode, create a custom rule to unmute this room by setting
+            // the mode to `AllMessages`
+            self.set_room_notification_mode(room_id, RoomNotificationMode::AllMessages).await
+        }
+    }
+
+    /// Execute a list of commands
+    async fn execute_commands(
+        &self,
+        commands: &[Command],
+    ) -> Result<(), NotificationSettingsError> {
+        for command in commands {
+            self.execute(command).await?;
+        }
+        Ok(())
+    }
+
+    /// Execute a command
+    async fn execute(&self, command: &Command) -> Result<(), NotificationSettingsError> {
+        match command.clone() {
+            Command::DeletePushRule { scope, kind, rule_id } => {
+                let request = delete_pushrule::v3::Request::new(scope, kind, rule_id);
+                self.client
+                    .send(request, None)
+                    .await
+                    .map_err(|_| NotificationSettingsError::UnableToRemovePushRule)?;
+            }
+            Command::SetPushRule { scope, rule } => {
+                let request = set_pushrule::v3::Request::new(scope, rule);
+                self.client
+                    .send(request, None)
+                    .await
+                    .map_err(|_| NotificationSettingsError::UnableToAddPushRule)?;
+            }
+            Command::SetPushRuleEnabled { scope, kind, rule_id, enabled } => {
+                let request = set_pushrule_enabled::v3::Request::new(scope, kind, rule_id, enabled);
+                self.client
+                    .send(request, None)
+                    .await
+                    .map_err(|_| NotificationSettingsError::UnableToUpdatePushRule)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// The http mocking library is not supported for wasm32
+#[cfg(all(test, not(target_arch = "wasm32")))]
+pub(crate) mod tests {
+
+    use assert_matches::assert_matches;
+    use matrix_sdk_test::async_test;
+    use ruma::{
+        push::{
+            Action, AnyPushRuleRef, NewPatternedPushRule, NewPushRule, PredefinedOverrideRuleId,
+            PredefinedUnderrideRuleId, RuleKind,
+        },
+        OwnedRoomId, RoomId,
+    };
+    use wiremock::{matchers::method, Mock, MockServer, ResponseTemplate};
+
+    use crate::{
+        error::NotificationSettingsError,
+        notification_settings::{NotificationSettings, RoomNotificationMode},
+        test_utils::logged_in_client,
+    };
+
+    fn get_test_room_id() -> OwnedRoomId {
+        RoomId::parse("!AAAaAAAAAaaAAaaaaa:matrix.org").unwrap()
+    }
+
+    #[async_test]
+    async fn test_get_custom_rules_for_room() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+
+        let notification_settings = client.notification_settings().await;
+
+        assert!(notification_settings.get_custom_rules_for_room(&room_id).await.is_empty());
+
+        let mut rules = notification_settings.rules().await;
+        _ = rules.insert_room_rule(RuleKind::Room, &room_id, true).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+        assert_eq!(notification_settings.get_custom_rules_for_room(&room_id).await.len(), 1);
+
+        _ = rules.insert_room_rule(RuleKind::Override, &room_id, true).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+        assert_eq!(notification_settings.get_custom_rules_for_room(&room_id).await.len(), 2);
+    }
+
+    #[async_test]
+    async fn test_get_user_defined_room_notification_mode() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+
+        let notification_settings = client.notification_settings().await;
+        assert!(notification_settings
+            .get_user_defined_room_notification_mode(&room_id)
+            .await
+            .is_none());
+
+        let mut rules = notification_settings.rules().await;
+        // Set a notifying `Room` rule into the ruleset to be in `AllMessages`
+        _ = rules.insert_room_rule(RuleKind::Room, &room_id, true).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+        assert_eq!(
+            notification_settings.get_user_defined_room_notification_mode(&room_id).await.unwrap(),
+            RoomNotificationMode::AllMessages
+        );
+
+        // Set a mute `Room` rule into the ruleset to be in `MentionsAndKeywordsOnly`
+        _ = rules.insert_room_rule(RuleKind::Room, &room_id, false).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+        assert_eq!(
+            notification_settings.get_user_defined_room_notification_mode(&room_id).await.unwrap(),
+            RoomNotificationMode::MentionsAndKeywordsOnly
+        );
+
+        // Set a mute `Override` rule into the ruleset to be in `Mute`
+        _ = rules.insert_room_rule(RuleKind::Override, &room_id, false).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+        assert_eq!(
+            notification_settings.get_user_defined_room_notification_mode(&room_id).await.unwrap(),
+            RoomNotificationMode::Mute
+        );
+    }
+
+    #[async_test]
+    async fn test_get_default_room_notification_mode() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let notification_settings = client.notification_settings().await;
+        let mut rules = notification_settings.rules().await;
+
+        // notification_settings.get_default_room_notification_mode() should return the
+        // same values as rules.get_default_room_notification_mode()
+        rules
+            .ruleset
+            .set_actions(
+                RuleKind::Underride,
+                PredefinedUnderrideRuleId::RoomOneToOne,
+                vec![Action::Notify],
+            )
+            .unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+        assert_eq!(
+            notification_settings.get_default_room_notification_mode(false, 2).await,
+            rules.get_default_room_notification_mode(false, 2)
+        );
+
+        rules
+            .ruleset
+            .set_actions(RuleKind::Underride, PredefinedUnderrideRuleId::RoomOneToOne, vec![])
+            .unwrap();
+        assert_ne!(
+            notification_settings.get_default_room_notification_mode(false, 2).await,
+            rules.get_default_room_notification_mode(false, 2)
+        );
+    }
+
+    #[async_test]
+    async fn test_contains_keyword_rules() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let notification_settings = client.notification_settings().await;
+        let mut rules = notification_settings.rules().await;
+
+        let contains_keywords_rules = notification_settings.contains_keyword_rules().await;
+        assert!(!contains_keywords_rules);
+
+        let rule = NewPatternedPushRule::new(
+            "keyword_rule_id".into(),
+            "keyword".into(),
+            vec![Action::Notify],
+        );
+
+        rules.ruleset.insert(NewPushRule::Content(rule), None, None).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+
+        let contains_keywords_rules = notification_settings.contains_keyword_rules().await;
+        assert!(contains_keywords_rules);
+    }
+
+    #[async_test]
+    async fn test_is_push_rule_enabled() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        // Initial state: Reaction disabled
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction, false).unwrap();
+
+        let notification_settings = NotificationSettings::new(client.clone(), ruleset);
+
+        let enabled = notification_settings
+            .is_push_rule_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction.as_str())
+            .await
+            .unwrap();
+
+        assert!(!enabled);
+
+        // Initial state: Reaction enabled
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction, true).unwrap();
+
+        let notification_settings = NotificationSettings::new(client, ruleset);
+
+        let enabled = notification_settings
+            .is_push_rule_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction.as_str())
+            .await
+            .unwrap();
+
+        assert!(enabled);
+    }
+
+    #[async_test]
+    async fn test_set_push_rule_enabled() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        // Initial state
+        ruleset
+            .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, false)
+            .unwrap();
+
+        let notification_settings = NotificationSettings::new(client, ruleset);
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        notification_settings
+            .set_push_rule_enabled(
+                RuleKind::Override,
+                PredefinedOverrideRuleId::IsUserMention.as_str(),
+                true,
+            )
+            .await
+            .unwrap();
+
+        // The ruleset must have been updated
+        let ruleset = notification_settings.ruleset.read().await;
+        let rule =
+            ruleset.get(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention).unwrap();
+        assert!(rule.enabled());
+    }
+
+    #[async_test]
+    async fn test_set_push_rule_enabled_api_error() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let mut ruleset = client.account().push_rules().await.unwrap();
+        // Initial state
+        ruleset
+            .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, false)
+            .unwrap();
+
+        let notification_settings = NotificationSettings::new(client, ruleset);
+
+        // If the server returns an error
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(500)).mount(&server).await;
+
+        // When enabling the push rule
+        assert_eq!(
+            notification_settings
+                .set_push_rule_enabled(
+                    RuleKind::Override,
+                    PredefinedOverrideRuleId::IsUserMention.as_str(),
+                    true,
+                )
+                .await,
+            Err(NotificationSettingsError::UnableToUpdatePushRule)
+        );
+
+        // The ruleset must not have been updated
+        let ruleset = notification_settings.ruleset.read().await;
+        let rule =
+            ruleset.get(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention).unwrap();
+        assert!(!rule.enabled());
+    }
+
+    #[async_test]
+    async fn test_set_room_notification_mode() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let notification_settings = client.notification_settings().await;
+        let room_id = get_test_room_id();
+
+        let mode = notification_settings.get_user_defined_room_notification_mode(&room_id).await;
+        assert!(mode.is_none());
+
+        let new_modes = &[
+            RoomNotificationMode::AllMessages,
+            RoomNotificationMode::MentionsAndKeywordsOnly,
+            RoomNotificationMode::Mute,
+        ];
+        for new_mode in new_modes {
+            notification_settings
+                .set_room_notification_mode(&room_id, new_mode.clone())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                new_mode.clone(),
+                notification_settings
+                    .get_user_defined_room_notification_mode(&room_id)
+                    .await
+                    .unwrap()
+            );
+        }
+    }
+
+    #[async_test]
+    async fn test_set_room_notification_mode_api_error() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        // If the server returns an error
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(500)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let notification_settings = client.notification_settings().await;
+        let room_id = get_test_room_id();
+
+        let mode = notification_settings.get_user_defined_room_notification_mode(&room_id).await;
+        assert!(mode.is_none());
+
+        // Setting the new mode should failed
+        assert_eq!(
+            Err(NotificationSettingsError::UnableToAddPushRule),
+            notification_settings
+                .set_room_notification_mode(&room_id, RoomNotificationMode::AllMessages)
+                .await
+        );
+
+        // The ruleset must not have been updated
+        assert!(notification_settings
+            .get_user_defined_room_notification_mode(&room_id)
+            .await
+            .is_none());
+    }
+
+    #[async_test]
+    async fn test_delete_rules() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let notification_settings = client.notification_settings().await;
+
+        // Insert some initial rules
+        let mut rules = notification_settings.rules().await;
+        _ = rules.insert_room_rule(RuleKind::Room, &room_id, true).unwrap();
+        _ = rules.insert_room_rule(RuleKind::Override, &room_id, true).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+
+        // Delete the rules
+        let rules_to_delete =
+            &[(RuleKind::Room, room_id.to_string()), (RuleKind::Override, room_id.to_string())];
+        notification_settings.delete_rules(rules_to_delete, &[]).await.unwrap();
+
+        // No custom rules should remain
+        assert!(notification_settings.get_custom_rules_for_room(&room_id).await.is_empty());
+    }
+
+    #[async_test]
+    async fn test_delete_rules_with_exceptions() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let notification_settings = client.notification_settings().await;
+
+        // Insert some initial rules
+        let mut rules = notification_settings.rules().await;
+        _ = rules.insert_room_rule(RuleKind::Room, &room_id, true).unwrap();
+        _ = rules.insert_room_rule(RuleKind::Override, &room_id, true).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+
+        // Delete the second rule only
+        let rules_to_delete = &[(RuleKind::Override, room_id.to_string())];
+        notification_settings
+            .delete_rules(rules_to_delete, &[(RuleKind::Room, room_id.to_string())])
+            .await
+            .unwrap();
+
+        // Only the `Room` rule should remain
+        let remaining_rules = notification_settings.get_custom_rules_for_room(&room_id).await;
+        assert_eq!(remaining_rules.len(), 1);
+        assert_eq!(&remaining_rules[0], &(RuleKind::Room, room_id.to_string()));
+    }
+
+    #[async_test]
+    async fn test_delete_rules_api_error() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(500)).mount(&server).await;
+
+        let notification_settings = client.notification_settings().await;
+        let mut rules = notification_settings.rules().await;
+        _ = rules.insert_room_rule(RuleKind::Room, &room_id, true).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+
+        let rules_to_delete = &[(RuleKind::Room, room_id.to_string())];
+        assert_eq!(
+            Err(NotificationSettingsError::UnableToRemovePushRule),
+            notification_settings.delete_rules(rules_to_delete, &[]).await
+        );
+    }
+
+    #[async_test]
+    async fn test_delete_rules_not_present() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let notification_settings = client.notification_settings().await;
+
+        let rules_to_delete = &[(RuleKind::Room, room_id.to_string())];
+        assert_eq!(
+            Err(NotificationSettingsError::UnableToRemovePushRule),
+            notification_settings.delete_rules(rules_to_delete, &[]).await
+        );
+    }
+
+    #[async_test]
+    async fn test_delete_user_defined_room_rules() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id_a = RoomId::parse("!AAAaAAAAAaaAAaaaaa:matrix.org").unwrap();
+        let room_id_b = RoomId::parse("!BBBbBBBBBbbBBbbbbb:matrix.org").unwrap();
+
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+
+        let notification_settings = client.notification_settings().await;
+
+        // Insert some initial rules
+        let mut rules = notification_settings.rules().await;
+        _ = rules.insert_room_rule(RuleKind::Room, &room_id_a, true).unwrap();
+        _ = rules.insert_room_rule(RuleKind::Override, &room_id_a, true).unwrap();
+        _ = rules.insert_room_rule(RuleKind::Room, &room_id_b, true).unwrap();
+        _ = rules.insert_room_rule(RuleKind::Override, &room_id_b, true).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+
+        // Delete all user defined rules for room_id_a
+        notification_settings.delete_user_defined_room_rules(&room_id_a).await.unwrap();
+
+        // Only the rules for room_id_b should remain
+        let remaining_rules = notification_settings.get_custom_rules_for_room(&room_id_b).await;
+        assert_eq!(remaining_rules.len(), 2);
+    }
+
+    #[async_test]
+    async fn test_unmute_room_not_muted() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+        let notification_settings = client.notification_settings().await;
+        let mut rules = notification_settings.rules().await;
+
+        // Initialize with a `MentionsAndKeywordsOnly` mode
+        _ = rules.insert_new_rule(RuleKind::Room, &room_id, false, false).unwrap();
+        notification_settings.set_ruleset(&rules.ruleset).await;
+
+        notification_settings.unmute_room(&room_id, true, 2).await.unwrap();
+
+        // The ruleset must not be modified
+        let room_rules = notification_settings.get_custom_rules_for_room(&room_id).await;
+        assert_eq!(room_rules.len(), 1);
+        assert_matches!(rules.ruleset.get(RuleKind::Room, &room_id),
+            Some(AnyPushRuleRef::Room(rule)) => {
+                assert_eq!(rule.rule_id, room_id);
+                assert!(rule.actions.is_empty());
+            }
+        );
+    }
+
+    #[async_test]
+    async fn test_unmute_room() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        Mock::given(method("DELETE")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+        let notification_settings = client.notification_settings().await;
+
+        // Start with the room muted
+        notification_settings
+            .set_room_notification_mode(&room_id, RoomNotificationMode::Mute)
+            .await
+            .unwrap();
+        assert_eq!(
+            Some(RoomNotificationMode::Mute),
+            notification_settings.get_user_defined_room_notification_mode(&room_id).await
+        );
+
+        // Unmute the room
+        notification_settings.unmute_room(&room_id, false, 2).await.unwrap();
+
+        // The user defined mode must have been removed
+        assert!(notification_settings
+            .get_user_defined_room_notification_mode(&room_id)
+            .await
+            .is_none());
+    }
+
+    #[async_test]
+    async fn test_unmute_room_default_mode() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT")).respond_with(ResponseTemplate::new(200)).mount(&server).await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let room_id = get_test_room_id();
+        let notification_settings = client.notification_settings().await;
+
+        // Unmute the room
+        notification_settings.unmute_room(&room_id, false, 2).await.unwrap();
+
+        // The new mode must be `AllMessages`
+        assert_eq!(
+            Some(RoomNotificationMode::AllMessages),
+            notification_settings.get_user_defined_room_notification_mode(&room_id).await
+        );
+    }
 }

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -324,8 +324,8 @@ mod tests {
         rules: Vec<(RuleKind, &RoomId, bool)>,
     ) -> NotificationSettings {
         let ruleset = get_server_default_ruleset();
-        // XXX would be slightly better to only use `Ruleset` here too, and no `RuleCommands` so
-        // we're testing things more in isolation.
+        // XXX would be slightly better to only use `Ruleset` here too, and no
+        // `RuleCommands` so we're testing things more in isolation.
         let mut rule_commands = RuleCommands::new(ruleset);
         for (kind, room_id, notify) in rules {
             rule_commands.insert_rule(kind, room_id, notify).unwrap();

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -290,7 +290,7 @@ impl NotificationSettings {
 
 // The http mocking library is not supported for wasm32
 #[cfg(all(test, not(target_arch = "wasm32")))]
-pub(crate) mod tests {
+mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::async_test;
     use ruma::{

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -9,6 +9,8 @@ use ruma::{
 use super::command::Command;
 use crate::NotificationSettingsError;
 
+/// A `RuleCommand` allows to generate a list of `Command` needed to modify a
+/// `Ruleset`
 #[derive(Clone, Debug)]
 pub(crate) struct RuleCommands {
     pub(crate) commands: Vec<Command>,
@@ -20,6 +22,7 @@ impl RuleCommands {
         RuleCommands { commands: vec![], rules: rules.clone() }
     }
 
+    /// Insert a new rule
     pub(crate) fn insert_rule(
         &mut self,
         kind: RuleKind,
@@ -55,7 +58,7 @@ impl RuleCommands {
         Ok(())
     }
 
-    /// Build a list of commands needed to delete rules
+    /// Delete a rule
     pub(crate) fn delete_rule(
         &mut self,
         kind: RuleKind,
@@ -67,7 +70,7 @@ impl RuleCommands {
         Ok(())
     }
 
-    /// Build a list of commands needed to set whether a rule is enabled
+    /// Set whether a rule is enabled
     pub(crate) fn set_rule_enabled(
         &mut self,
         kind: RuleKind,
@@ -85,7 +88,6 @@ impl RuleCommands {
         }
     }
 
-    /// Build a command needed to set whether a rule is enabled
     fn set_enabled(
         &mut self,
         kind: RuleKind,
@@ -103,8 +105,7 @@ impl RuleCommands {
         Ok(())
     }
 
-    /// Build a list of commands needed to set whether a `IsUserMention` is
-    /// enabled
+    /// Set whether `IsUserMention` is enabled
     fn set_user_mention_enabled(&mut self, enabled: bool) -> Result<(), NotificationSettingsError> {
         // Add a command for the `IsUserMention` `Override` rule (MSC3952).
         // This is a new push rule that may not yet be present.
@@ -136,8 +137,7 @@ impl RuleCommands {
         Ok(())
     }
 
-    /// Build a list of commands needed to set whether a `IsRoomMention` is
-    /// enabled
+    /// Set whether `IsRoomMention` is enabled
     fn set_room_mention_enabled(&mut self, enabled: bool) -> Result<(), NotificationSettingsError> {
         // Sets the `IsRoomMention` `Override` rule (MSC3952).
         // This is a new push rule that may not yet be present.

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -1,0 +1,161 @@
+use ruma::{
+    api::client::push::RuleScope,
+    push::{
+        PredefinedContentRuleId, PredefinedOverrideRuleId, RemovePushRuleError, RuleKind, Ruleset,
+    },
+    RoomId,
+};
+
+use super::command::Command;
+use crate::NotificationSettingsError;
+
+#[derive(Clone, Debug)]
+pub(crate) struct RuleCommands {
+    pub(crate) commands: Vec<Command>,
+    pub(crate) rules: Ruleset,
+}
+
+impl RuleCommands {
+    pub(crate) fn new(rules: &Ruleset) -> Self {
+        RuleCommands { commands: vec![], rules: rules.clone() }
+    }
+
+    pub(crate) fn insert_rule(
+        &mut self,
+        kind: RuleKind,
+        room_id: &RoomId,
+        notify: bool,
+    ) -> Result<(), NotificationSettingsError> {
+        let command;
+        match kind {
+            RuleKind::Room => {
+                command = Command::SetRoomPushRule {
+                    scope: RuleScope::Global,
+                    room_id: room_id.to_owned(),
+                    notify,
+                };
+            }
+            RuleKind::Override => {
+                command = Command::SetOverridePushRule {
+                    scope: RuleScope::Global,
+                    rule_id: room_id.to_string(),
+                    room_id: room_id.to_owned(),
+                    notify,
+                };
+            }
+            _ => {
+                return Err(NotificationSettingsError::InvalidParameter(
+                    "cannot insert a rule for this kind.".to_owned(),
+                ))
+            }
+        }
+        self.rules.insert(command.to_push_rule()?, None, None)?;
+        self.commands.push(command);
+
+        Ok(())
+    }
+
+    /// Build a list of commands needed to delete rules
+    pub(crate) fn delete_rule(
+        &mut self,
+        kind: RuleKind,
+        rule_id: String,
+    ) -> Result<(), RemovePushRuleError> {
+        self.rules.remove(kind.clone(), &rule_id)?;
+        self.commands.push(Command::DeletePushRule { scope: RuleScope::Global, kind, rule_id });
+
+        Ok(())
+    }
+
+    /// Build a list of commands needed to set whether a rule is enabled
+    pub(crate) fn set_rule_enabled(
+        &mut self,
+        kind: RuleKind,
+        rule_id: &str,
+        enabled: bool,
+    ) -> Result<(), NotificationSettingsError> {
+        if rule_id == PredefinedOverrideRuleId::IsRoomMention.as_str() {
+            // Handle specific case for `PredefinedOverrideRuleId::IsRoomMention`
+            self.set_room_mention_enabled(enabled)
+        } else if rule_id == PredefinedOverrideRuleId::IsUserMention.as_str() {
+            // Handle specific case for `PredefinedOverrideRuleId::IsUserMention`
+            self.set_user_mention_enabled(enabled)
+        } else {
+            self.set_enabled(kind, rule_id, enabled)
+        }
+    }
+
+    /// Build a command needed to set whether a rule is enabled
+    fn set_enabled(
+        &mut self,
+        kind: RuleKind,
+        rule_id: &str,
+        enabled: bool,
+    ) -> Result<(), NotificationSettingsError> {
+        self.rules.set_enabled(kind.clone(), rule_id, enabled)?;
+        self.commands.push(Command::SetPushRuleEnabled {
+            scope: RuleScope::Global,
+            kind,
+            rule_id: rule_id.to_owned(),
+            enabled,
+        });
+
+        Ok(())
+    }
+
+    /// Build a list of commands needed to set whether a `IsUserMention` is
+    /// enabled
+    fn set_user_mention_enabled(&mut self, enabled: bool) -> Result<(), NotificationSettingsError> {
+        // Add a command for the `IsUserMention` `Override` rule (MSC3952).
+        // This is a new push rule that may not yet be present.
+        self.set_enabled(
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsUserMention.as_str(),
+            enabled,
+        )?;
+
+        // For compatibility purpose, we still need to add commands for
+        // `ContainsUserName` and `ContainsDisplayName` (deprecated rules).
+        #[allow(deprecated)]
+        {
+            // `ContainsUserName`
+            self.set_enabled(
+                RuleKind::Content,
+                PredefinedContentRuleId::ContainsUserName.as_str(),
+                enabled,
+            )?;
+
+            // `ContainsDisplayName`
+            self.set_enabled(
+                RuleKind::Override,
+                PredefinedOverrideRuleId::ContainsDisplayName.as_str(),
+                enabled,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    /// Build a list of commands needed to set whether a `IsRoomMention` is
+    /// enabled
+    fn set_room_mention_enabled(&mut self, enabled: bool) -> Result<(), NotificationSettingsError> {
+        // Sets the `IsRoomMention` `Override` rule (MSC3952).
+        // This is a new push rule that may not yet be present.
+        self.set_enabled(
+            RuleKind::Override,
+            PredefinedOverrideRuleId::IsRoomMention.as_str(),
+            enabled,
+        )?;
+
+        // For compatibility purpose, we still need to set `RoomNotif` (deprecated
+        // rule).
+        #[allow(deprecated)]
+        self.set_enabled(
+            RuleKind::Override,
+            PredefinedOverrideRuleId::RoomNotif.as_str(),
+            enabled,
+        )?;
+
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -156,7 +156,7 @@ impl RuleCommands {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
     use assert_matches::assert_matches;
     use matrix_sdk_test::async_test;
     use ruma::{

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -18,8 +18,8 @@ pub(crate) struct RuleCommands {
 }
 
 impl RuleCommands {
-    pub(crate) fn new(rules: &Ruleset) -> Self {
-        RuleCommands { commands: vec![], rules: rules.clone() }
+    pub(crate) fn new(rules: Ruleset) -> Self {
+        RuleCommands { commands: vec![], rules }
     }
 
     /// Insert a new rule
@@ -184,7 +184,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_insert_rule_room() {
         let room_id = get_test_room_id();
-        let mut rule_commands = RuleCommands::new(&get_server_default_ruleset());
+        let mut rule_commands = RuleCommands::new(get_server_default_ruleset());
         rule_commands.insert_rule(RuleKind::Room, &room_id, true).unwrap();
 
         // A rule must have been inserted in the ruleset
@@ -203,7 +203,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_insert_rule_override() {
         let room_id = get_test_room_id();
-        let mut rule_commands = RuleCommands::new(&get_server_default_ruleset());
+        let mut rule_commands = RuleCommands::new(get_server_default_ruleset());
         rule_commands.insert_rule(RuleKind::Override, &room_id, true).unwrap();
 
         // A rule must have been inserted in the ruleset
@@ -223,7 +223,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_insert_rule_unsupported() {
         let room_id = get_test_room_id();
-        let mut rule_commands = RuleCommands::new(&get_server_default_ruleset());
+        let mut rule_commands = RuleCommands::new(get_server_default_ruleset());
 
         assert_matches!(
             rule_commands.insert_rule(RuleKind::Underride, &room_id, true),
@@ -249,7 +249,7 @@ pub(crate) mod tests {
         let new_rule = NewSimplePushRule::new(room_id.to_owned(), vec![]);
         ruleset.insert(NewPushRule::Room(new_rule), None, None).unwrap();
 
-        let mut rule_commands = RuleCommands::new(&ruleset);
+        let mut rule_commands = RuleCommands::new(ruleset);
 
         // Delete must succeed
         rule_commands.delete_rule(RuleKind::Room, room_id.to_string()).unwrap();
@@ -272,7 +272,7 @@ pub(crate) mod tests {
         let room_id = get_test_room_id();
         let ruleset = get_server_default_ruleset();
 
-        let mut rule_commands = RuleCommands::new(&ruleset);
+        let mut rule_commands = RuleCommands::new(ruleset);
 
         // Deletion should fail if an attempt is made to delete a rule that does not
         // exist
@@ -285,7 +285,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_delete_rule_server_default_error() {
         let ruleset = get_server_default_ruleset();
-        let mut rule_commands = RuleCommands::new(&ruleset);
+        let mut rule_commands = RuleCommands::new(ruleset);
 
         // Deletion should fail if an attempt is made to delete a default server rule
         assert_matches!(
@@ -300,7 +300,7 @@ pub(crate) mod tests {
 
         // Initialize with `Reaction` rule disabled
         ruleset.set_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction, false).unwrap();
-        let mut rule_commands = RuleCommands::new(&ruleset);
+        let mut rule_commands = RuleCommands::new(ruleset);
 
         rule_commands
             .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::Reaction.as_str(), true)
@@ -327,7 +327,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_set_rule_enabled_not_found() {
         let ruleset = get_server_default_ruleset();
-        let mut rule_commands = RuleCommands::new(&ruleset);
+        let mut rule_commands = RuleCommands::new(ruleset);
         assert_eq!(
             rule_commands.set_enabled(RuleKind::Room, "unknown_rule_id", true),
             Err(NotificationSettingsError::RuleNotFound)
@@ -337,7 +337,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_set_rule_enabled_user_mention() {
         let mut ruleset = get_server_default_ruleset();
-        let mut rule_commands = RuleCommands::new(&ruleset);
+        let mut rule_commands = RuleCommands::new(ruleset.clone());
 
         ruleset
             .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention, false)
@@ -423,7 +423,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_set_rule_enabled_room_mention() {
         let mut ruleset = get_server_default_ruleset();
-        let mut rule_commands = RuleCommands::new(&ruleset);
+        let mut rule_commands = RuleCommands::new(ruleset.clone());
 
         ruleset
             .set_enabled(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention, false)

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -29,29 +29,25 @@ impl RuleCommands {
         room_id: &RoomId,
         notify: bool,
     ) -> Result<(), NotificationSettingsError> {
-        let command;
-        match kind {
-            RuleKind::Room => {
-                command = Command::SetRoomPushRule {
-                    scope: RuleScope::Global,
-                    room_id: room_id.to_owned(),
-                    notify,
-                };
-            }
-            RuleKind::Override => {
-                command = Command::SetOverridePushRule {
-                    scope: RuleScope::Global,
-                    rule_id: room_id.to_string(),
-                    room_id: room_id.to_owned(),
-                    notify,
-                };
-            }
+        let command = match kind {
+            RuleKind::Room => Command::SetRoomPushRule {
+                scope: RuleScope::Global,
+                room_id: room_id.to_owned(),
+                notify,
+            },
+            RuleKind::Override => Command::SetOverridePushRule {
+                scope: RuleScope::Global,
+                rule_id: room_id.to_string(),
+                room_id: room_id.to_owned(),
+                notify,
+            },
             _ => {
                 return Err(NotificationSettingsError::InvalidParameter(
                     "cannot insert a rule for this kind.".to_owned(),
                 ))
             }
-        }
+        };
+
         self.rules.insert(command.to_push_rule()?, None, None)?;
         self.commands.push(command);
 

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -276,7 +276,8 @@ mod tests {
 
         let mut rule_commands = RuleCommands::new(ruleset);
 
-        // Deletion should fail if an attempt is made to delete a rule that does not exist.
+        // Deletion should fail if an attempt is made to delete a rule that does not
+        // exist.
         assert_matches!(
             rule_commands.delete_rule(RuleKind::Room, room_id.to_string()),
             Err(RemovePushRuleError::NotFound) => {}

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -209,44 +209,6 @@ impl Rules {
         }
     }
 
-    /// Insert a new rule and optionally delete other custom rules for a room
-    pub(crate) fn insert_new_rule(
-        &mut self,
-        kind: RuleKind,
-        room_id: &RoomId,
-        notify: bool,
-        delete_other_custom_rules: bool,
-    ) -> Result<Vec<Command>, NotificationSettingsError> {
-        // Insert the rule before deleting the other custom rules to obtain the correct
-        // mode in the next sync response.
-        let mut commands = vec![];
-
-        // Insert the new rule
-        let insert_command = self
-            .insert_room_rule(kind.clone(), room_id, notify)
-            .map_err(|_| NotificationSettingsError::UnableToAddPushRule)?;
-
-        if let Some(command) = insert_command {
-            commands.push(command);
-        }
-
-        if delete_other_custom_rules {
-            // Get the current custom rules
-            let custom_rules = self.get_custom_rules_for_room(room_id);
-
-            if !custom_rules.is_empty() {
-                // Delete them, expect the one we inserted above
-                let mut delete_commands = self
-                    .delete_rules(&custom_rules, &[(kind, room_id.to_string())])
-                    .map_err(|_| NotificationSettingsError::UnableToRemovePushRule)?;
-
-                commands.append(&mut delete_commands);
-            }
-        }
-
-        Ok(commands)
-    }
-
     /// Insert a new `Room` push rule for a given `room_id` and return an
     /// optional `Command` describing the action to be performed on the
     /// user's account data.
@@ -297,30 +259,19 @@ impl Rules {
 
     /// Deletes a list of rules and returns a list of `Command` describing the
     /// actions to be performed on the user's account data.
-    ///
-    /// # Arguments
-    ///
-    /// * `rules` - A list of rules to delete
-    /// * `exceptions` - A list of rules to ignore
     pub(crate) fn delete_rules(
         &mut self,
         rules: &[(RuleKind, String)],
-        exceptions: &[(RuleKind, String)],
     ) -> Result<Vec<Command>, RemovePushRuleError> {
         let mut commands = vec![];
 
         for (rule_kind, rule_id) in rules {
-            // Ignore rules present in exceptions
-            if exceptions.iter().any(|e| e.0 == *rule_kind && e.1 == *rule_id) {
-                continue;
-            }
-
             self.ruleset.remove(rule_kind.clone(), rule_id)?;
             commands.push(Command::DeletePushRule {
                 scope: RuleScope::Global,
                 kind: rule_kind.clone(),
                 rule_id: rule_id.clone(),
-            })
+            });
         }
         Ok(commands)
     }
@@ -859,111 +810,11 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn test_insert_new_rule_room_notifying() {
-        let room_id = get_test_room_id();
-        let mut rules = Rules::new(get_server_default_ruleset());
-
-        // Insert a new notifying `Room` rule
-        let commands = rules.insert_new_rule(RuleKind::Room, &room_id, true, false).unwrap();
-
-        // The rules should contains the new rule
-        let custom_rules = rules.get_custom_rules_for_room(&room_id);
-        assert_eq!(custom_rules.len(), 1);
-        assert_eq!(&custom_rules[0], &(RuleKind::Room, room_id.to_string()));
-
-        // The command list should contains only a SetPushRule command
-        assert_eq!(commands.len(), 1);
-        assert_matches!(
-            &commands[0],
-            Command::SetPushRule { scope, rule } => {
-                assert_eq!(scope, &RuleScope::Global);
-                assert_matches!(
-                    rule,
-                    NewPushRule::Room(rule) => {
-                        assert_eq!(rule.rule_id, room_id);
-                    }
-                )
-            }
-        );
-    }
-
-    #[async_test]
-    async fn test_insert_new_rule_room_notifying_with_deletion() {
-        let room_id = get_test_room_id();
-        let mut rules = Rules::new(get_server_default_ruleset());
-
-        // Insert an override rule that should be delete after the next insertion
-        _ = rules.insert_room_rule(RuleKind::Override, &room_id, false);
-
-        // Insert a new notifying `Room` rule
-        let commands = rules.insert_new_rule(RuleKind::Room, &room_id, true, true).unwrap();
-
-        // The rules should contains the new rule
-        let custom_rules = rules.get_custom_rules_for_room(&room_id);
-        assert_eq!(custom_rules.len(), 1);
-        assert_eq!(&custom_rules[0], &(RuleKind::Room, room_id.to_string()));
-
-        // The command list should contains a SetPushRule and a DeletePushRule (the
-        // order is important)
-        assert_eq!(commands.len(), 2);
-        assert_matches!(
-            &commands[0],
-            Command::SetPushRule { scope, rule } => {
-                assert_eq!(scope, &RuleScope::Global);
-                assert_matches!(
-                    rule,
-                    NewPushRule::Room(rule) => {
-                        assert_eq!(rule.rule_id, room_id);
-                    }
-                )
-            }
-        );
-        assert_matches!(
-            &commands[1],
-            Command::DeletePushRule { scope, kind, rule_id } => {
-                assert_eq!(scope, &RuleScope::Global);
-                assert_eq!(kind, &RuleKind::Override);
-                assert_eq!(rule_id, &room_id);
-            }
-        );
-    }
-
-    #[async_test]
-    async fn test_insert_new_rule_override_notifying() {
-        let room_id = get_test_room_id();
-        let mut rules = Rules::new(get_server_default_ruleset());
-
-        // Insert a new notifying `Override` rule
-        let commands = rules.insert_new_rule(RuleKind::Override, &room_id, true, false).unwrap();
-
-        // The rules should contains the new rule
-        let custom_rules = rules.get_custom_rules_for_room(&room_id);
-        assert_eq!(custom_rules.len(), 1);
-        assert_eq!(&custom_rules[0], &(RuleKind::Override, room_id.to_string()));
-
-        // The command list should contains only a SetPushRule command
-        assert_eq!(commands.len(), 1);
-        assert_matches!(
-            &commands[0],
-            Command::SetPushRule { scope, rule } => {
-                assert_eq!(scope, &RuleScope::Global);
-                assert_matches!(
-                    rule,
-                    NewPushRule::Override(rule) => {
-                        assert_eq!(rule.rule_id, room_id);
-                        assert!(!rule.actions.is_empty());
-                    }
-                )
-            }
-        );
-    }
-
-    #[async_test]
     async fn test_delete_rules() {
         let room_id = get_test_room_id();
         let mut rules = Rules::new(get_server_default_ruleset());
 
-        rules.delete_rules(&[(RuleKind::Room, room_id.to_string())], &[]).expect_err(
+        rules.delete_rules(&[(RuleKind::Room, room_id.to_string())]).expect_err(
             "A RemovePushRuleError is expected while trying to delete an unknown rule.",
         );
 
@@ -971,7 +822,7 @@ pub(crate) mod tests {
         let new_rule = NewPushRule::Room(new_rule);
         rules.ruleset.insert(new_rule, None, None).unwrap();
 
-        let commands = rules.delete_rules(&[(RuleKind::Room, room_id.to_string())], &[]).unwrap();
+        let commands = rules.delete_rules(&[(RuleKind::Room, room_id.to_string())]).unwrap();
         // The command list should contains only a SetPushRule command
         assert_eq!(commands.len(), 1);
 
@@ -983,22 +834,6 @@ pub(crate) mod tests {
                 assert_eq!(rule_id, room_id.as_str());
             }
         );
-    }
-
-    #[async_test]
-    async fn test_delete_rules_with_exceptions() {
-        let room_id = get_test_room_id();
-        let mut rules = Rules::new(get_server_default_ruleset());
-
-        let new_rule = NewSimplePushRule::new(room_id.to_owned(), vec![]);
-        let new_rule = NewPushRule::Room(new_rule);
-        rules.ruleset.insert(new_rule, None, None).unwrap();
-
-        let rules_to_delete = vec![(RuleKind::Room, room_id.to_string())];
-        let commands = rules.delete_rules(&rules_to_delete, &rules_to_delete).unwrap();
-        // The command list should be empty as the rule to delete is also in the
-        // exceptions.
-        assert_eq!(commands.len(), 0);
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -202,9 +202,9 @@ impl Rules {
     /// between the time the command was created and the time it is applied.
     pub(crate) fn apply(&mut self, commands: &RuleCommands) {
         for command in &commands.commands {
-            match command.clone() {
+            match command {
                 Command::DeletePushRule { scope: _, kind, rule_id } => {
-                    _ = self.ruleset.remove(kind, rule_id);
+                    _ = self.ruleset.remove(kind.clone(), rule_id);
                 }
                 Command::SetRoomPushRule { scope: _, room_id: _, notify: _ }
                 | Command::SetOverridePushRule { scope: _, rule_id: _, room_id: _, notify: _ } => {
@@ -213,7 +213,7 @@ impl Rules {
                     }
                 }
                 Command::SetPushRuleEnabled { scope: _, kind, rule_id, enabled } => {
-                    _ = self.ruleset.set_enabled(kind, rule_id, enabled);
+                    _ = self.ruleset.set_enabled(kind.clone(), rule_id, *enabled);
                 }
             }
         }

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -24,6 +24,7 @@ pub(crate) enum Command {
     DeletePushRule { scope: RuleScope, kind: RuleKind, rule_id: String },
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct Rules {
     pub ruleset: Ruleset,
 }

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -274,8 +274,8 @@ pub(crate) mod tests {
         for (kind, room_id, notify) in rule_list {
             commands.insert_rule(kind, room_id, notify).unwrap();
         }
-        // XXX this should not make use of `apply()`, see other comment. Such a helper should
-        // return a `Ruleset`, and not have to do anything with `Rules`.
+        // XXX this should not make use of `apply()`, see other comment. Such a helper
+        // should return a `Ruleset`, and not have to do anything with `Rules`.
         rules.apply(commands);
         rules
     }
@@ -288,10 +288,11 @@ pub(crate) mod tests {
         assert_eq!(rules.get_custom_rules_for_room(&room_id).len(), 0);
 
         // Initialize with one rule.
-        // XXX this is not testing things in isolation: `build_rules` makes use of `apply`, and
-        // then we use `get_custom_rules_for_room`. Instead, this test should create a `Ruleset` by
-        // hand, then test single functions in isolation in it. `build_rules` should not use
-        // `Rules` method, since we're testing `Rules` methods here!
+        // XXX this is not testing things in isolation: `build_rules` makes use of
+        // `apply`, and then we use `get_custom_rules_for_room`. Instead, this
+        // test should create a `Ruleset` by hand, then test single functions in
+        // isolation in it. `build_rules` should not use `Rules` method, since
+        // we're testing `Rules` methods here!
         let rules = build_rules(vec![(RuleKind::Override, &room_id, false)]);
         assert_eq!(rules.get_custom_rules_for_room(&room_id).len(), 1);
 

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -270,7 +270,7 @@ pub(crate) mod tests {
 
     fn build_rules(rule_list: Vec<(RuleKind, &RoomId, bool)>) -> Rules {
         let mut rules = Rules::new(get_server_default_ruleset());
-        let mut commands = RuleCommands::new(&rules.ruleset);
+        let mut commands = RuleCommands::new(rules.ruleset.clone());
         for (kind, room_id, notify) in rule_list {
             commands.insert_rule(kind, room_id, notify).unwrap();
         }
@@ -576,7 +576,7 @@ pub(crate) mod tests {
         let mut rules = build_rules(vec![(RuleKind::Override, &room_id, false)]);
 
         // Build a `RuleCommands` deleting this rule
-        let mut rules_commands = RuleCommands::new(&rules.ruleset);
+        let mut rules_commands = RuleCommands::new(rules.ruleset.clone());
         rules_commands.delete_rule(RuleKind::Override, room_id.to_string()).unwrap();
 
         rules.apply(&rules_commands);
@@ -591,7 +591,7 @@ pub(crate) mod tests {
         let mut rules = build_rules(vec![]);
 
         // Build a `RuleCommands` inserting a rule
-        let mut rules_commands = RuleCommands::new(&rules.ruleset);
+        let mut rules_commands = RuleCommands::new(rules.ruleset.clone());
         rules_commands.insert_rule(RuleKind::Override, &room_id, false).unwrap();
 
         rules.apply(&rules_commands);
@@ -610,7 +610,7 @@ pub(crate) mod tests {
             .unwrap();
 
         // Build a `RuleCommands` disabling the rule
-        let mut rules_commands = RuleCommands::new(&rules.ruleset);
+        let mut rules_commands = RuleCommands::new(rules.ruleset.clone());
         rules_commands
             .set_rule_enabled(
                 RuleKind::Override,


### PR DESCRIPTION
This PR is the second step of the https://github.com/matrix-org/matrix-rust-sdk/issues/1959 implementation. 

It adds a new `notification_settings` crate in matrix-sdk to get and define notification settings for a room and enable/disable push rules.

The `pub` functions will be used by the ffi layer in a future PR.