### PR TITLE
ffi: Expose the senders of reactions

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -313,10 +313,10 @@ impl EventTimelineItem {
         self.0
             .reactions()
             .iter()
-            .map(|(k, v)| Reaction { 
-                key: k.to_owned(), 
-                count: v.len().try_into().unwrap(), 
-                senders: v.senders().map(ToString::to_string).collect()
+            .map(|(k, v)| Reaction {
+                key: k.to_owned(),
+                count: v.len().try_into().unwrap(),
+                senders: v.senders().map(ToString::to_string).collect(),
             })
             .collect()
     }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -313,7 +313,11 @@ impl EventTimelineItem {
         self.0
             .reactions()
             .iter()
-            .map(|(k, v)| Reaction { key: k.to_owned(), count: v.len().try_into().unwrap() })
+            .map(|(k, v)| Reaction { 
+                key: k.to_owned(), 
+                count: v.len().try_into().unwrap(), 
+                senders: v.senders().map(ToString::to_string).collect()
+            })
             .collect()
     }
 
@@ -1049,7 +1053,7 @@ impl EncryptedMessage {
 pub struct Reaction {
     pub key: String,
     pub count: u64,
-    // TODO: Also expose senders
+    pub senders: Vec<String>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This PR exposes the reaction sender userIds in `matrix-sdk-ffi`. This allows clients highlight a users own reactions and also provide detail on who else added a particular reaction. 
