### PR TITLE
feat: implement time lease based locks for the `CryptoStore`

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -59,7 +59,7 @@ macro_rules! cryptostore_integration_tests {
                 device_id!("BOBDEVICE")
             }
 
-            async fn get_loaded_store(name: &str) -> (ReadOnlyAccount, impl CryptoStore) {
+            pub async fn get_loaded_store(name: &str) -> (ReadOnlyAccount, impl CryptoStore) {
                 let store = get_store(name, None).await;
                 let account = get_account();
                 store.save_account(account.clone()).await.expect("Can't save account");
@@ -852,6 +852,21 @@ macro_rules! cryptostore_integration_tests {
                 let loaded = store2.get_custom_value("A").await.unwrap();
                 assert_eq!(loaded, Some(val2.clone()));
             }
+        }
+    };
+}
+
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! cryptostore_integration_tests_time {
+    () => {
+        mod cryptostore_integration_tests_time {
+            use std::time::Duration;
+
+            use matrix_sdk_test::async_test;
+            use $crate::store::CryptoStore as _;
+
+            use super::cryptostore_integration_tests::*;
 
             #[async_test]
             async fn test_lease_locks() {
@@ -877,26 +892,26 @@ macro_rules! cryptostore_integration_tests {
                 assert!(!acquired5);
 
                 // That's a nice test we got here, go take a little nap.
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                tokio::time::sleep(Duration::from_millis(50)).await;
 
                 // Still too early.
                 let acquired55 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();
                 assert!(!acquired55);
 
                 // Ok you can take another nap then.
-                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                tokio::time::sleep(Duration::from_millis(250)).await;
 
                 // At some point, we do get the lock.
                 let acquired6 = store.try_take_leased_lock(0, "key", "bob").await.unwrap();
                 assert!(acquired6);
 
-                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                tokio::time::sleep(Duration::from_millis(1)).await;
 
                 // The other gets it almost immediately too.
                 let acquired7 = store.try_take_leased_lock(0, "key", "alice").await.unwrap();
                 assert!(acquired7);
 
-                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                tokio::time::sleep(Duration::from_millis(1)).await;
 
                 // But when we take a longer lease...
                 let acquired8 = store.try_take_leased_lock(300, "key", "bob").await.unwrap();

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -152,6 +152,10 @@ impl CryptoStoreLock {
         // If another thread obtained the lock, make sure to only superficially increase
         // the number of holders, and carry on.
         if self.num_holders.load(atomic::Ordering::SeqCst) > 0 {
+            // Note: between the above load and the fetch_add below, another thread may
+            // decrement `num_holders`. That's fine because that means the lock
+            // was taken by at least one thread, and after this call it will be
+            // taken by at least one thread.
             trace!("We already had the lock, incrementing holder count");
             self.num_holders.fetch_add(1, atomic::Ordering::SeqCst);
             let guard = CryptoStoreLockGuard { num_holders: self.num_holders.clone() };

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -107,7 +107,7 @@ pub struct CryptoStoreLock {
 
 impl CryptoStoreLock {
     /// Amount of time a lease of the lock should last, in milliseconds.
-    const LEASE_DURATION_MS: u32 = 2000;
+    pub const LEASE_DURATION_MS: u32 = 2000;
 
     /// Period of time between two attempts to extend the lease. We'll
     /// re-request a lease for an entire duration of `LEASE_DURATION_MS`

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -173,7 +173,7 @@ impl CryptoStoreLock {
             // Clone data to be owned by the task.
             let this = self.clone();
 
-            tokio::spawn(async move {
+            matrix_sdk_common::executor::spawn(async move {
                 loop {
                     {
                         // First, check if there are still users of this lock.

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -186,6 +186,14 @@ impl CryptoStoreLock {
                         // If there are no more users, we can quit.
                         if this.num_holders.load(atomic::Ordering::SeqCst) == 0 {
                             tracing::info!("exiting the lease extension loop");
+
+                            // Cancel the lease with another 0ms lease.
+                            // If we don't get the lock, that's (weird but) fine.
+                            let _ = this
+                                .store
+                                .try_take_leased_lock(0, &this.lock_key, &this.lock_holder)
+                                .await;
+
                             // Exit the loop.
                             break;
                         }

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -76,9 +76,6 @@ impl Drop for CryptoStoreLockGuard {
     }
 }
 
-#[derive(Debug)]
-struct SharedState {}
-
 /// A store-based lock for the `CryptoStore`.
 #[derive(Clone, Debug)]
 pub struct CryptoStoreLock {

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, convert::Infallible, sync::Arc};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use async_trait::async_trait;
 use dashmap::{DashMap, DashSet};
@@ -57,6 +62,7 @@ pub struct MemoryStore {
     key_requests_by_info: Arc<DashMap<String, OwnedTransactionId>>,
     direct_withheld_info: Arc<DashMap<OwnedRoomId, DashMap<String, RoomKeyWithheldEvent>>>,
     custom_values: Arc<DashMap<String, Vec<u8>>>,
+    leases: Arc<DashMap<String, (String, Instant)>>,
 }
 
 impl Default for MemoryStore {
@@ -71,6 +77,7 @@ impl Default for MemoryStore {
             key_requests_by_info: Default::default(),
             direct_withheld_info: Default::default(),
             custom_values: Default::default(),
+            leases: Default::default(),
         }
     }
 }
@@ -325,6 +332,43 @@ impl CryptoStore for MemoryStore {
     async fn remove_custom_value(&self, key: &str) -> Result<bool> {
         let was_there = self.custom_values.remove(key).is_some();
         Ok(was_there)
+    }
+
+    async fn try_take_leased_lock(
+        &self,
+        lease_duration_ms: u32,
+        key: &str,
+        holder: &str,
+    ) -> Result<bool> {
+        let now = Instant::now();
+        let expiration = now + Duration::from_millis(lease_duration_ms.into());
+        if let Some(mut prev) = self.leases.get_mut(key) {
+            if prev.0 == holder {
+                // We had the lease before, extend it.
+                prev.1 = expiration;
+                Ok(true)
+            } else {
+                // We didn't have it.
+                if prev.1 < now {
+                    // Steal it!
+                    prev.0 = holder.to_owned();
+                    prev.1 = expiration;
+                    Ok(true)
+                } else {
+                    // We tried our best.
+                    Ok(false)
+                }
+            }
+        } else {
+            self.leases.insert(
+                key.to_owned(),
+                (
+                    holder.to_string(),
+                    Instant::now() + Duration::from_millis(lease_duration_ms.into()),
+                ),
+            );
+            Ok(true)
+        }
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -363,7 +363,7 @@ impl CryptoStore for MemoryStore {
             self.leases.insert(
                 key.to_owned(),
                 (
-                    holder.to_string(),
+                    holder.to_owned(),
                     Instant::now() + Duration::from_millis(lease_duration_ms.into()),
                 ),
             );

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -243,6 +243,18 @@ pub trait CryptoStore: AsyncTraitDeps {
     /// Returns a boolean indicating whether the value was actually present in
     /// the store.
     async fn remove_custom_value(&self, key: &str) -> Result<bool, Self::Error>;
+
+    /// Try to take a leased lock.
+    ///
+    /// TODO
+    ///
+    /// Returns whether taking the lock succeeded.
+    async fn try_take_leased_lock(
+        &self,
+        lease_duration_ms: u32,
+        key: &str,
+        holder: &str,
+    ) -> Result<bool, Self::Error>;
 }
 
 #[repr(transparent)]
@@ -400,6 +412,15 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
 
     async fn remove_custom_value(&self, key: &str) -> Result<bool, Self::Error> {
         self.0.remove_custom_value(key).await.map_err(Into::into)
+    }
+
+    async fn try_take_leased_lock(
+        &self,
+        lease_duration_ms: u32,
+        key: &str,
+        holder: &str,
+    ) -> Result<bool, Self::Error> {
+        self.0.try_take_leased_lock(lease_duration_ms, key, holder).await.map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -246,7 +246,13 @@ pub trait CryptoStore: AsyncTraitDeps {
 
     /// Try to take a leased lock.
     ///
-    /// TODO
+    /// This attempts to take a lock for the given lease duration.
+    ///
+    /// - If we already had the lease, this will extend the lease.
+    /// - If we didn't, but the previous lease has expired, we will acquire the
+    ///   lock.
+    /// - If there was no previous lease, we will acquire the lock.
+    /// - Otherwise, we don't get the lock.
     ///
     /// Returns whether taking the lock succeeded.
     async fn try_take_leased_lock(

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -15,6 +15,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
@@ -37,6 +38,7 @@ use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, RoomId, TransactionId, UserId};
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::Mutex;
+use tracing::warn;
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
 
@@ -1089,6 +1091,16 @@ impl_crypto_store! {
         } else {
             Ok(false)
         }
+    }
+
+    async fn try_take_leased_lock(
+        &self,
+        lease_duration_ms: u32,
+        key: &str,
+        holder: &str,
+    ) -> Result<bool> {
+        warn!("try_take_leased_lock NYI on this platform"); // time is complicated in wasm
+        Ok(false)
     }
 }
 

--- a/crates/matrix-sdk-sqlite/migrations/crypto_store/007_lock_leases.sql
+++ b/crates/matrix-sdk-sqlite/migrations/crypto_store/007_lock_leases.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "lease_locks" (
+    "key" TEXT PRIMARY KEY NOT NULL,
+    "holder" TEXT NOT NULL,
+    "expiration_ts" REAL NOT NULL
+);

--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -110,7 +110,7 @@ impl EncryptionSync {
             let mut mode = self.mode;
 
             loop {
-                let _guard = match &mut mode {
+                let guard = match &mut mode {
                     EncryptionSyncMode::RunFixedIterations(ref mut val) => {
                         if *val == 0 {
                             // The previous attempt was the last one, stop now.
@@ -160,12 +160,18 @@ impl EncryptionSync {
 
                         // Cool cool, let's do it again.
                         trace!("Encryption sync received an update!");
+
+                        drop(guard);
+
                         yield Ok(());
                         continue;
                     }
 
                     Some(Err(err)) => {
                         trace!("Encryption sync stopped because of an error: {err:#}");
+
+                        drop(guard);
+
                         yield Err(Error::SlidingSync(err));
                         break;
                     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -185,8 +185,8 @@ async fn retry_order() {
         assert_eq!(value.content().as_message().unwrap().body(), "First!");
     });
 
-    // Wait 200ms for the first msg, 100ms for the second, 200ms for overhead
-    sleep(Duration::from_millis(500)).await;
+    // Wait 200ms for the first msg, 100ms for the second, 300ms for overhead
+    sleep(Duration::from_millis(600)).await;
 
     // The second item should be updated first, since it was retried first
     assert_next_matches!(timeline_stream, VectorDiff::Set { index: 1, value } => {

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -412,7 +412,7 @@ impl Joined {
         };
 
         // Take and release the lock on the store, if needs be.
-        self.client.encryption().spin_lock_store(Some(60000)).await?;
+        let _guard = self.client.encryption().spin_lock_store(Some(60000)).await?;
 
         inner().await
     }

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -414,11 +414,7 @@ impl Joined {
         // Take and release the lock on the store, if needs be.
         self.client.encryption().spin_lock_store(Some(60000)).await?;
 
-        let result = inner().await;
-
-        self.client.encryption().unlock_store().await?;
-
-        result
+        inner().await
     }
 
     /// Share a group session for a room.

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use http::Response;
 pub use matrix_sdk_test_macros::async_test;
 use ruma::api::{client::sync::sync_events::v3::Response as SyncResponse, IncomingResponse};

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use http::Response;
 pub use matrix_sdk_test_macros::async_test;
 use ruma::api::{client::sync::sync_events::v3::Response as SyncResponse, IncomingResponse};


### PR DESCRIPTION
This implements a new time lease based lock for the `CryptoStore`, that doesn't require explicit unlocking, so that's more robust in the context of #1928, where any process may die because the device is running out of battery, or unexpected flows cause a lock to not be released properly in one or the other process.

```
//! This is a per-process lock that may be used only for very specific use
//! cases, where multiple processes might concurrently write to the same
//! database at the same time; this would invalidate crypto store caches, so
//! that should be done mindfully. Such a lock can be acquired multiple times by
//! the same process, and it remains active as long as there's at least one user
//! in a given process.
//!
//! The lock is implemented using time-based leases to values inserted in a
//! crypto store. The store maintains the lock identifier (key), who's the
//! current holder (value), and an expiration timestamp on the side; see also
//! `CryptoStore::try_take_leased_lock` for more details.
//!
//! The lock is initially acquired for a certain period of time (namely, the
//! duration of a lease, aka `LEASE_DURATION_MS`), and then a "heartbeat" task
//! renews the lease to extend its duration, every so often (namely, every
//! `EXTEND_LEASE_EVERY_MS`). Since the tokio scheduler might be busy, the
//! extension request should happen way more frequently than the duration of a
//! lease, in case a deadline is missed. The current values have been chosen to
//! reflect that, with a ratio of 1:10 as of 2023-06-23.
//!
//! Releasing the lock happens naturally, by not renewing a lease. It happens
//! automatically after the duration of the last lease, at most.
```

## Notes

- This is not implemented on indexeddb, because time in wasm is slightly more complicated (requires a host API). Maybe we already have that, but I haven't bothered since I'm not sure that wasm may need the lock in the first place (maybe for a Web app using the SDK, running from multiple tabs?).
- I've kept the former implementation for `insert_custom_value_if_missing`/`remove_custom_value` at the moment, but we could remove them if this lock proves to be more robust.