### PR TITLE
test(ui): Replace `sleep` by `yield_now`

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/room_list.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list.rs
@@ -1,4 +1,4 @@
-use std::{ops::Not, time::Duration};
+use std::ops::Not;
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
@@ -21,7 +21,7 @@ use ruma::{
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
-use tokio::time::sleep;
+use tokio::task::yield_now;
 use wiremock::MockServer;
 
 use crate::{
@@ -1142,7 +1142,7 @@ async fn test_loading_states() -> Result<(), Error> {
     };
 
     // Wait on Tokio to run all the tasks. It won't happen in the main app.
-    sleep(Duration::from_millis(50)).await;
+    yield_now().await;
 
     // There is a loading state update, it's loaded now!
     assert_next_matches!(
@@ -1174,7 +1174,7 @@ async fn test_loading_states() -> Result<(), Error> {
     };
 
     // Wait on Tokio to run all the tasks. It won't happen in the main app.
-    sleep(Duration::from_millis(50)).await;
+    yield_now().await;
 
     // There is a loading state update because the number of rooms has been updated.
     assert_next_matches!(
@@ -1206,7 +1206,7 @@ async fn test_loading_states() -> Result<(), Error> {
     };
 
     // Wait on Tokio to run all the tasks. It won't happen in the main app.
-    sleep(Duration::from_millis(50)).await;
+    yield_now().await;
 
     // No loading state update.
     assert_pending!(all_rooms_loading_state);


### PR DESCRIPTION
Eh, removing `sleep` from the tests is always a pleasure right?