### PR TITLE
ui: Improve logging for message-sending queue

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list/room.rs
@@ -145,6 +145,7 @@ impl Room {
                             self.inner.sliding_sync_room.prev_batch(),
                             self.inner.sliding_sync_room.timeline_queue(),
                         )
+                        .read_only()
                         .build()
                         .await,
                 )

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -319,7 +319,7 @@ impl Timeline {
         let txn_id = txn_id.map_or_else(TransactionId::new, ToOwned::to_owned);
         self.inner.handle_local_event(txn_id.clone(), content.clone()).await;
         if self.msg_sender.send(LocalMessage { content, txn_id }).await.is_err() {
-            error!("Internal error: timeline message receiver is closed");
+            error!("Tried to send a message through a read-only Timeline");
         }
     }
 
@@ -388,7 +388,7 @@ impl Timeline {
 
         let txn_id = txn_id.to_owned();
         if self.msg_sender.send(LocalMessage { content, txn_id }).await.is_err() {
-            error!("Internal error: timeline message receiver is closed");
+            error!("Tried to re-send a message through a read-only Timeline");
         }
 
         Ok(())

--- a/crates/matrix-sdk-ui/src/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/src/timeline/queue.rs
@@ -48,6 +48,8 @@ pub(super) async fn send_queued_messages(
     room: room::Common,
     mut msg_receiver: Receiver<LocalMessage>,
 ) {
+    info!("Starting message-sending loop");
+
     let mut queue = VecDeque::new();
     let mut send_task: SendMessageTask = SendMessageTask::Idle;
     let mut recv_fut: Either<_, Pending<Option<LocalMessage>>> =

--- a/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
+++ b/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
@@ -38,7 +38,7 @@ impl SlidingSyncRoomExt for SlidingSyncRoom {
 
     #[instrument(skip_all)]
     async fn latest_event(&self) -> Option<EventTimelineItem> {
-        sliding_sync_timeline_builder(self)?.build().await.latest_event().await
+        sliding_sync_timeline_builder(self)?.read_only().build().await.latest_event().await
     }
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -87,8 +87,8 @@ async fn message_order() {
         assert_eq!(value.content().as_message().unwrap().body(), "Second.");
     });
 
-    // Wait 200ms for the first msg, 100ms for the second, 100ms for overhead
-    sleep(Duration::from_millis(400)).await;
+    // Wait 200ms for the first msg, 100ms for the second, 200ms for overhead
+    sleep(Duration::from_millis(500)).await;
 
     // The first item should be updated first
     assert_next_matches!(timeline_stream, VectorDiff::Set { index: 0, value } => {


### PR DESCRIPTION
Currently, we get way too many logs from the message-sending queue because we create it for all the "sneaky" timelines in the room list API. This fixes that by adding an internal read-only mode where we don't spawn the message-sending task (also more efficient), and using it for those "sneaky" timelines.