### PR TITLE
fix(sdk): Change `SlidingSyncList::room_list`'s capacity

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -223,7 +223,9 @@ impl SlidingSyncListBuilder {
                 // otherwise.
                 state: StdRwLock::new(Observable::new(Default::default())),
                 maximum_number_of_rooms: StdRwLock::new(Observable::new(None)),
-                room_list: StdRwLock::new(ObservableVector::from(Vector::new())),
+                // TODO: We need to do batching here instead of increasing the capacity. We want to
+                // avoid triggering `VectorDiff::Reset` as much as possible.
+                room_list: StdRwLock::new(ObservableVector::with_capacity(4096)),
 
                 // Internal data.
                 sliding_sync_internal_channel_sender,


### PR DESCRIPTION
Address #1911.

This patch changes the capacity of the internal buffer of `ObservableVector` for `SlidingSyncList::room_list` from 16 to 4096. With an increased capacity, we reduce the probability to send a `VectorDiff::Reset` to subscribers. `Reset` are happening quite often for apps using `matrix-sdk`, and it impacts their performance. This patch tries to improve this situation. This `room_list` contains `RoomListEntry`, which is quite cheap in terms of memory, compared to the impact of sending `Reset`s too often. That's a tradeoff.
