### PR TITLE
chore(sdk): Log the `SyncOp`s

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -24,7 +24,7 @@ pub use room_list_entry::RoomListEntry;
 use ruma::{api::client::sync::sync_events::v4, assign, OwnedRoomId, TransactionId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::Sender;
-use tracing::{instrument, warn};
+use tracing::{info, instrument, warn};
 
 use self::sticky::SlidingSyncListStickyParameters;
 use super::{
@@ -514,12 +514,13 @@ impl SlidingSyncListInner {
     }
 }
 
-#[instrument(skip(operations))]
 fn apply_sync_operations(
     operations: &[v4::SyncOp],
     room_list: &mut ObservableVector<RoomListEntry>,
     rooms_that_have_received_an_update: &mut HashSet<OwnedRoomId>,
 ) -> Result<(), Error> {
+    info!(?operations);
+
     for operation in operations {
         match &operation.op {
             // Specification says:


### PR DESCRIPTION
Address #1911.

Sometimes, ElementX sees a duplicated ID in the `RoomList` entries. How is it possible? Well, it's impossible except if the server sends unexpected sync operations:

* If the server sends an `INSERT` for a room ID has already been inserted,
* If the server tries to move a room, but instead of sending `DELETE` + `INSERT` (because there is no `MOVE` operation), it sends `INSERT` + `DELETE` (then, it's similar to the previous use case).

This patch logs the `SyncOp`s we receive from the server, so that we can dig into this deeper and confirm where the problem comes from.