### PR TITLE
feat: implement a generation counter for the CryptoStore lock

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption_sync.rs
@@ -73,12 +73,6 @@ impl EncryptionSync {
             error!("Error when stopping the encryption sync: {err}");
         }
     }
-
-    pub fn reload_caches(&self) {
-        if let Err(err) = RUNTIME.block_on(self.sync.reload_caches()) {
-            error!("Error when reloading caches: {err}");
-        }
-    }
 }
 
 impl Client {

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1843,6 +1843,14 @@ impl OlmMachine {
 
         Ok(true)
     }
+
+    #[cfg(any(feature = "testing", test))]
+    /// Returns whether this `OlmMachine` is the same another one.
+    ///
+    /// Useful for testing purposes only.
+    pub fn same_as(&self, other: &OlmMachine) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
 }
 
 #[cfg(any(feature = "testing", test))]

--- a/crates/matrix-sdk-crypto/src/store/locks.rs
+++ b/crates/matrix-sdk-crypto/src/store/locks.rs
@@ -314,6 +314,15 @@ pub enum LockStoreError {
     /// Spent too long waiting for a database lock.
     #[error("a lock timed out")]
     LockTimeout,
+
+    /// The generation counter is missing, and should always be present.
+    #[error("missing generation counter in the store")]
+    MissingGeneration,
+
+    /// Unexpected format for the generation counter. Is someone tampering the
+    /// database?
+    #[error("invalid format of the generation counter")]
+    InvalidGenerationFormat,
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = { workspace = true }
 
 [features]
 default = ["state-store"]
+testing = ["matrix-sdk-crypto?/testing"]
 
 bundled = ["rusqlite/bundled"]
 crypto-store = [

--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -213,19 +213,6 @@ impl EncryptionSync {
 
         Ok(())
     }
-
-    /// Request a reload of the internal caches used by this sync.
-    ///
-    /// This must be called every time the process running this loop was
-    /// suspended and got back into the foreground, and another process may have
-    /// written to the same underlying store (e.g. notification process vs
-    /// main process).
-    pub async fn reload_caches(&self) -> Result<(), Error> {
-        // Regenerate the crypto store caches first.
-        self.client.encryption().reload_caches().await.map_err(Error::ClientError)?;
-
-        Ok(())
-    }
 }
 
 /// Errors for the [`EncryptionSync`].

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite", "native-tls"]
-testing = []
+testing = ["matrix-sdk-sqlite?/testing"]
 
 e2e-encryption = [
     "matrix-sdk-base/e2e-encryption",

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -195,18 +195,21 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
     let args = BTreeMap::from([
         (
             FeatureSet::NoEncryption,
-            "--no-default-features --features sqlite,native-tls,experimental-sliding-sync",
+            "--no-default-features --features sqlite,native-tls,experimental-sliding-sync,testing",
         ),
-        (FeatureSet::NoSqlite, "--no-default-features --features e2e-encryption,native-tls"),
-        (FeatureSet::NoEncryptionAndSqlite, "--no-default-features --features native-tls"),
+        (
+            FeatureSet::NoSqlite,
+            "--no-default-features --features e2e-encryption,native-tls,testing",
+        ),
+        (FeatureSet::NoEncryptionAndSqlite, "--no-default-features --features native-tls,testing"),
         (
             FeatureSet::SqliteCryptostore,
-            "--no-default-features --features e2e-encryption,sqlite,native-tls",
+            "--no-default-features --features e2e-encryption,sqlite,native-tls,testing",
         ),
-        (FeatureSet::RustlsTls, "--no-default-features --features rustls-tls"),
-        (FeatureSet::Markdown, "--features markdown"),
-        (FeatureSet::Socks, "--features socks"),
-        (FeatureSet::SsoLogin, "--features sso-login"),
+        (FeatureSet::RustlsTls, "--no-default-features --features rustls-tls,testing"),
+        (FeatureSet::Markdown, "--features markdown,testing"),
+        (FeatureSet::Socks, "--features socks,testing"),
+        (FeatureSet::SsoLogin, "--features sso-login,testing"),
     ]);
 
     let run = |arg_set: &str| {
@@ -237,25 +240,29 @@ fn run_crypto_tests() -> Result<()> {
         "rustup run stable cargo clippy -p matrix-sdk-crypto --features=backups_v1 -- -D warnings"
     )
     .run()?;
-    cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --no-default-features").run()?;
-    cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --features=backups_v1").run()?;
-    cmd!("rustup run stable cargo test --doc -p matrix-sdk-crypto --features=backups_v1").run()?;
+    cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --no-default-features --features testing").run()?;
+    cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --features=backups_v1,testing")
+        .run()?;
+    cmd!("rustup run stable cargo test --doc -p matrix-sdk-crypto --features=backups_v1,testing")
+        .run()?;
     cmd!(
         "rustup run stable cargo clippy -p matrix-sdk-crypto --features=experimental-algorithms -- -D warnings"
     )
     .run()?;
     cmd!(
-        "rustup run stable cargo nextest run -p matrix-sdk-crypto --features=experimental-algorithms"
+        "rustup run stable cargo nextest run -p matrix-sdk-crypto --features=experimental-algorithms,testing"
     ).run()?;
     cmd!(
-        "rustup run stable cargo test --doc -p matrix-sdk-crypto --features=experimental-algorithms"
+        "rustup run stable cargo test --doc -p matrix-sdk-crypto --features=experimental-algorithms,testing"
     )
     .run()?;
 
     cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto-ffi").run()?;
 
-    cmd!("rustup run stable cargo nextest run -p matrix-sdk-sqlite --features crypto-store")
-        .run()?;
+    cmd!(
+        "rustup run stable cargo nextest run -p matrix-sdk-sqlite --features crypto-store,testing"
+    )
+    .run()?;
 
     Ok(())
 }


### PR DESCRIPTION
This implements a generation counter for the CryptoStore lock, aiming at solving the following problem. Consider ElementX iOS:

- the main app goes in the background, releasing the crypto store lock
- a push notification shows up, NSE process is created, acquires the crypto store lock, does its thing, then releases lock
- the main app goes back in the foreground, acquires the crypto store lock

Then it's possible that the crypto store caches in the main app are now _stale_, but the main app won't realize, because trying to acquire the lock may succeed on the first attempt.

The solution is to introduce a "generation" counter, maintained in both a process embedding the SDK, and the store. It is updated any time we acquire a lock and we observed a different value in the store.

Now observe what happens with the above scenario, annotated with generations:

- the main app goes in the background, releasing the crypto store lock; generation was e.g. 1
- a push notification shows up, NSE process is created, acquires the crypto store lock, sees that generation was 1, increments it to 2 in the store, does its thing, then releases lock
- the main app goes back in the foreground, sees that generation in store is 2 while the one it knew about was 1; sets generation to 3 and reloads its internal caches because of the mismatch.

(When there's no mismatch, there's nothing to do, of course.)

Because of this, we don't need explicit cache reloading when the app goes back into the foreground, so it's slightly easier to use for ElementX embedders. And, it's more precise too as it won't do spurious cache reloads (in a scenario like main app goes to background / main app goes to foreground, with no NSE process involved).