### PR TITLE
Emit room keys after they have been persisted, not before.

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2340,7 +2340,11 @@ pub(crate) mod tests {
         // when we decrypt the room key, the
         // inbound_group_session_streamroom_keys_received_stream should tell us
         // about it.
-        let room_keys = room_keys_received_stream.next().await.unwrap();
+        let room_keys = room_keys_received_stream
+            .next()
+            .now_or_never()
+            .flatten()
+            .expect("We should have received an update of room key infos");
         assert_eq!(room_keys.len(), 1);
         assert_eq!(room_keys[0].session_id, group_session.session_id());
 


### PR DESCRIPTION
Not sure what to do about this now being an async method and having the stack
size increased again.
