### PR TITLE
ui: Move message-sending loop start log event

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -21,7 +21,7 @@ use matrix_sdk::{
 };
 use ruma::events::receipt::{ReceiptThread, ReceiptType};
 use tokio::sync::{broadcast, mpsc};
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 #[cfg(feature = "e2e-encryption")]
 use super::to_device::{handle_forwarded_room_key_event, handle_room_key_event};
@@ -210,6 +210,7 @@ impl TimelineBuilder {
 
         let (msg_sender, msg_receiver) = mpsc::channel(1);
         if !read_only {
+            info!("Starting message-sending loop");
             spawn(send_queued_messages(inner.clone(), room.clone(), msg_receiver));
         }
 

--- a/crates/matrix-sdk-ui/src/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/src/timeline/queue.rs
@@ -48,8 +48,6 @@ pub(super) async fn send_queued_messages(
     room: room::Common,
     mut msg_receiver: Receiver<LocalMessage>,
 ) {
-    info!("Starting message-sending loop");
-
     let mut queue = VecDeque::new();
     let mut send_task: SendMessageTask = SendMessageTask::Idle;
     let mut recv_fut: Either<_, Pending<Option<LocalMessage>>> =


### PR DESCRIPTION
… such that it gets the timeline builder's tracing span.
