### PR TITLE
 feat(ui): Do not update the viewport of the room list if it hasn't changed

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -54,7 +54,7 @@ impl Client {
 pub enum RoomListError {
     SlidingSync { error: String },
     UnknownList { list_name: String },
-    InputHasNotBeenApplied,
+    InputCannotBeApplied,
     RoomNotFound { room_name: String },
     InvalidRoomId { error: String },
 }
@@ -66,7 +66,7 @@ impl From<matrix_sdk_ui::room_list::Error> for RoomListError {
         match value {
             SlidingSync(error) => Self::SlidingSync { error: error.to_string() },
             UnknownList(list_name) => Self::UnknownList { list_name },
-            InputHasNotBeenApplied(_) => Self::InputHasNotBeenApplied,
+            InputCannotBeApplied(_) => Self::InputCannotBeApplied,
             RoomNotFound(room_id) => Self::RoomNotFound { room_name: room_id.to_string() },
         }
     }
@@ -167,7 +167,7 @@ impl RoomListService {
     }
 
     async fn apply_input(&self, input: RoomListInput) -> Result<(), RoomListError> {
-        self.inner.apply_input(input.into()).await.map_err(Into::into)
+        self.inner.apply_input(input.into()).await.map(|_| ()).map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -78,6 +78,7 @@ pub(in super::super) struct SlidingSyncListRequestGenerator {
     ///
     /// Note there's only one range in the `Growing` and `Paging` mode.
     ranges: Ranges,
+
     /// The kind of request generator.
     pub(super) kind: SlidingSyncListRequestGeneratorKind,
 }


### PR DESCRIPTION
Address #1911.

Imagine the room list has the viewport set to the range `0..=19`. The
user scrolls quickly to `50..=69` to see something below and immediately
scrolls back to its initial position, without stopping the scroll
at any moment in between. The app using this API might update the
viewport from `0..=19` to… `0..=19`. Updating the viewport, updates the
`visible_rooms` sliding sync list. Since a list is modified, the current
sync-loop iteration is skipped over and a new one restarts, i.e. the
current in-flight request is cancelled… for nothing.

This patch prevents this situation. The current viewport ranges is
stored in `RoomListService`. `RoomListService::apply_input` used to
return `Result<(), Error>`, now it returns `Result<InputResult, Error>`.
The `InputResult` enum is a new type. It represents whether an input has
been applied or ignored, which must be differentiate from errors.

So now, if the viewport changes and it's not different from the previous
value, `InputResult::Ignored` is returned.