### PR TITLE
Make pending local echoes sticky

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ruma::{EventId, OwnedTransactionId};
+use std::sync::Arc;
 
-use super::EventSendState;
+use matrix_sdk::Error;
+use ruma::{EventId, OwnedEventId, OwnedTransactionId};
 
 /// An item for an event that was created locally and not yet echoed back by
 /// the homeserver.
@@ -42,4 +43,25 @@ impl LocalEventTimelineItem {
     pub fn with_send_state(&self, send_state: EventSendState) -> Self {
         Self { send_state, ..self.clone() }
     }
+}
+
+/// This type represents the "send state" of a local event timeline item.
+#[derive(Clone, Debug)]
+pub enum EventSendState {
+    /// The local event has not been sent yet.
+    NotSentYet,
+    /// The local event has been sent to the server, but unsuccessfully: The
+    /// sending has failed.
+    SendingFailed {
+        /// Details about how sending the event failed.
+        error: Arc<Error>,
+    },
+    /// Sending has been cancelled because an earlier event in the
+    /// message-sending queue failed.
+    Cancelled,
+    /// The local event has been sent successfully to the server.
+    Sent {
+        /// The event ID assigned by the server.
+        event_id: OwnedEventId,
+    },
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -27,13 +27,16 @@ mod content;
 mod local;
 mod remote;
 
-pub use self::content::{
-    AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, InReplyToDetails,
-    MemberProfileChange, MembershipChange, Message, OtherState, ReactionGroup, RepliedToEvent,
-    RoomMembershipChange, Sticker, TimelineItemContent,
+pub use self::{
+    content::{
+        AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, InReplyToDetails,
+        MemberProfileChange, MembershipChange, Message, OtherState, ReactionGroup, RepliedToEvent,
+        RoomMembershipChange, Sticker, TimelineItemContent,
+    },
+    local::EventSendState,
 };
 pub(super) use self::{
-    local::{EventSendState, LocalEventTimelineItem},
+    local::LocalEventTimelineItem,
     remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -20,8 +20,7 @@ use once_cell::sync::Lazy;
 use ruma::{
     events::{receipt::Receipt, room::message::MessageType, AnySyncTimelineEvent},
     serde::Raw,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedUserId, TransactionId,
-    UserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedUserId, TransactionId, UserId,
 };
 
 mod content;
@@ -34,7 +33,7 @@ pub use self::content::{
     RoomMembershipChange, Sticker, TimelineItemContent,
 };
 pub(super) use self::{
-    local::LocalEventTimelineItem,
+    local::{EventSendState, LocalEventTimelineItem},
     remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };
 
@@ -288,27 +287,6 @@ impl EventTimelineItem {
     pub(super) fn with_sender_profile(&self, sender_profile: TimelineDetails<Profile>) -> Self {
         Self { sender_profile, ..self.clone() }
     }
-}
-
-/// This type represents the "send state" of a local event timeline item.
-#[derive(Clone, Debug)]
-pub enum EventSendState {
-    /// The local event has not been sent yet.
-    NotSentYet,
-    /// The local event has been sent to the server, but unsuccessfully: The
-    /// sending has failed.
-    SendingFailed {
-        /// Details about how sending the event failed.
-        error: Arc<Error>,
-    },
-    /// Sending has been cancelled because an earlier event in the
-    /// message-sending queue failed.
-    Cancelled,
-    /// The local event has been sent successfully to the server.
-    Sent {
-        /// The event ID assigned by the server.
-        event_id: OwnedEventId,
-    },
 }
 
 impl From<LocalEventTimelineItem> for EventTimelineItemKind {

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -57,9 +57,9 @@ async fn initial_events() {
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_matches!(&*item, TimelineItem::Virtual(VirtualTimelineItem::DayDivider(_)));
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     assert_eq!(item.as_event().unwrap().sender(), *ALICE);
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     assert_eq!(item.as_event().unwrap().sender(), *BOB);
 }
 
@@ -87,7 +87,7 @@ async fn sticker() {
         }))
         .await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
     assert_matches!(item.content(), TimelineItemContent::Sticker(_));
 }
 
@@ -107,7 +107,7 @@ async fn room_member() {
         )
         .await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
     let membership =
         assert_matches!(item.content(), TimelineItemContent::MembershipChange(ev) => ev);
     assert_matches!(membership.content(), FullStateEventContent::Original { .. });
@@ -124,7 +124,7 @@ async fn room_member() {
         )
         .await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let membership =
         assert_matches!(item.content(), TimelineItemContent::MembershipChange(ev) => ev);
     assert_matches!(membership.content(), FullStateEventContent::Original { .. });
@@ -141,7 +141,7 @@ async fn room_member() {
         )
         .await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     let profile = assert_matches!(item.content(), TimelineItemContent::ProfileChange(ev) => ev);
     assert_matches!(profile.displayname_change(), Some(_));
     assert_matches!(profile.avatar_url_change(), None);
@@ -154,7 +154,7 @@ async fn room_member() {
         )
         .await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 3, value } => value);
     let membership =
         assert_matches!(item.content(), TimelineItemContent::MembershipChange(ev) => ev);
     assert_matches!(membership.content(), FullStateEventContent::Redacted(_));
@@ -176,7 +176,7 @@ async fn other_state() {
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let ev = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::OtherState(ev) => ev);
     let full_content =
         assert_matches!(ev.content(), AnyOtherFullStateEventContent::RoomName(c) => c);
@@ -186,7 +186,7 @@ async fn other_state() {
 
     timeline.handle_live_redacted_state_event(&ALICE, RedactedRoomTopicEventContent::new()).await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     let ev = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::OtherState(ev) => ev);
     let full_content =
         assert_matches!(ev.content(), AnyOtherFullStateEventContent::RoomTopic(c) => c);
@@ -253,7 +253,7 @@ async fn sanitized() {
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let event = item.as_event().unwrap();
     let message = assert_matches!(event.content(), TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
@@ -281,7 +281,7 @@ async fn reply() {
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let first_event = item.as_event().unwrap();
     let first_event_id = first_event.event_id().unwrap();
     let first_event_sender = *ALICE;
@@ -309,7 +309,7 @@ async fn reply() {
 
     timeline.handle_live_message_event(&BOB, reply).await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     let message = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::Message(msg) => msg);
 
     let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
@@ -336,7 +336,7 @@ async fn thread() {
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let first_event = item.as_event().unwrap();
     let first_event_id = first_event.event_id().unwrap();
 
@@ -348,7 +348,7 @@ async fn thread() {
 
     timeline.handle_live_message_event(&BOB, reply).await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     let message = assert_matches!(item.as_event().unwrap().content(), TimelineItemContent::Message(msg) => msg);
 
     let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -125,8 +125,11 @@ async fn remote_echo_new_position() {
 
     // … and another event that comes back before the remote echo
     timeline.handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("test")).await;
-    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
-    let _bob_message = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    // … and is inserted before the local echo item
+    let _day_divider =
+        assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
+    let _bob_message =
+        assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
 
     // When the remote echo comes in…
     timeline
@@ -146,12 +149,12 @@ async fn remote_echo_new_position() {
         .await;
 
     // … the local echo should be removed
-    assert_next_matches!(stream, VectorDiff::Remove { index: 1 });
+    assert_next_matches!(stream, VectorDiff::Remove { index: 3 });
     // … along with its day divider
-    assert_next_matches!(stream, VectorDiff::Remove { index: 0 });
+    assert_next_matches!(stream, VectorDiff::Remove { index: 2 });
 
     // … and the remote echo added (no new day divider because both bob's and
     // alice's message are from the same day according to server timestamps)
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     assert!(!item.as_event().unwrap().is_local_echo());
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -41,7 +41,7 @@ async fn live_redacted() {
         .handle_live_redacted_message_event(*ALICE, RedactedRoomMessageEventContent::new())
         .await;
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
 
     let redacted_event_id = item.as_event().unwrap().event_id().unwrap();
 
@@ -73,7 +73,7 @@ async fn live_sanitized() {
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let first_event = item.as_event().unwrap();
     let message = assert_matches!(first_event.content(), TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);
@@ -153,7 +153,7 @@ async fn aggregated_sanitized() {
     timeline.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let first_event = item.as_event().unwrap();
     let message = assert_matches!(first_event.content(), TimelineItemContent::Message(msg) => msg);
     let text = assert_matches!(message.msgtype(), MessageType::Text(text) => text);

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -81,7 +81,7 @@ async fn retry_message_decryption() {
     assert_eq!(timeline.inner.items().await.len(), 2);
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let event = item.as_event().unwrap();
     let session_id = assert_matches!(
         event.content(),
@@ -371,7 +371,7 @@ async fn retry_message_decryption_highlighted() {
     assert_eq!(timeline.inner.items().await.len(), 2);
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let event = item.as_event().unwrap();
     let session_id = assert_matches!(
         event.content(),

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -36,7 +36,7 @@ async fn invalid_edit() {
     let mut stream = timeline.subscribe_events().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("test")).await;
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
     let msg = item.content().as_message().unwrap();
     assert_eq!(msg.body(), "test");
 
@@ -73,7 +73,7 @@ async fn invalid_event_content() {
         }))
         .await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
     assert_eq!(item.sender(), "@alice:example.org");
     assert_eq!(item.event_id().unwrap(), "$eeG0HA0FAZ37wP8kXlNkxx3I");
     assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(10)));
@@ -96,7 +96,7 @@ async fn invalid_event_content() {
         }))
         .await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     assert_eq!(item.sender(), "@alice:example.org");
     assert_eq!(item.event_id().unwrap(), "$d5G0HA0FAZ37wP8kXlNkxx3I");
     assert_eq!(item.timestamp(), MilliSecondsSinceUnixEpoch(uint!(2179)));

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -163,11 +163,14 @@ async fn send_first_message(
         .handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("I want you to react"))
         .await;
 
-    let _day_divider = assert_next_matches!(*stream, VectorDiff::PushBack { value } => value);
+    let _day_divider =
+        assert_next_matches!(*stream, VectorDiff::Insert { index: 0, value } => value);
 
-    let item = assert_next_matches!(*stream, VectorDiff::PushBack { value } => value);
+    let (index, item) =
+        assert_next_matches!(*stream, VectorDiff::Insert { index, value } => (index, value));
     let event_id = item.as_event().unwrap().clone().event_id().unwrap().to_owned();
     let position = timeline.len().await - 1;
+    assert_eq!(index, position);
     (event_id, position)
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -30,15 +30,16 @@ async fn read_receipts_updates() {
     timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("A")).await;
     timeline.handle_live_message_event(*BOB, RoomMessageEventContent::text_plain("B")).await;
 
-    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let _day_divider =
+        assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
 
     // No read receipt for our own user.
-    let item_a = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item_a = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let event_a = item_a.as_event().unwrap();
     assert!(event_a.read_receipts().is_empty());
 
     // Implicit read receipt of Bob.
-    let item_b = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item_b = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     let event_b = item_b.as_event().unwrap();
     assert_eq!(event_b.read_receipts().len(), 1);
     assert!(event_b.read_receipts().get(*BOB).is_some());
@@ -50,14 +51,14 @@ async fn read_receipts_updates() {
     let event_a = item_a.as_event().unwrap();
     assert!(event_a.read_receipts().is_empty());
 
-    let item_c = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item_c = assert_next_matches!(stream, VectorDiff::Insert { index: 3, value } => value);
     let event_c = item_c.as_event().unwrap();
     assert_eq!(event_c.read_receipts().len(), 1);
     assert!(event_c.read_receipts().get(*BOB).is_some());
 
     timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("D")).await;
 
-    let item_d = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item_d = assert_next_matches!(stream, VectorDiff::Insert { index: 4, value } => value);
     let event_d = item_d.as_event().unwrap();
     assert!(event_d.read_receipts().is_empty());
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -31,7 +31,7 @@ async fn reaction_redaction() {
     let mut stream = timeline.subscribe_events().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("hi!")).await;
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
     assert_eq!(item.reactions().len(), 0);
 
     let msg_event_id = item.event_id().unwrap();
@@ -71,7 +71,7 @@ async fn reaction_redaction_timeline_filter() {
 
     // Adding a room message
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("hi!")).await;
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
     // Creates a day divider and the message.
     assert_eq!(timeline.inner.items().await.len(), 2);
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -47,7 +47,7 @@ async fn day_divider() {
     assert_eq!(date.month(), 1);
     assert_eq!(date.day(), 1);
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     item.as_event().unwrap();
 
     timeline
@@ -57,7 +57,7 @@ async fn day_divider() {
         )
         .await;
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     item.as_event().unwrap();
 
     // Timestamps start at unix epoch, advance to one day later
@@ -70,7 +70,7 @@ async fn day_divider() {
         )
         .await;
 
-    let day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let day_divider = assert_next_matches!(stream, VectorDiff::Insert { index: 3, value } => value);
     let ts = assert_matches!(
         day_divider.as_virtual().unwrap(),
         VirtualTimelineItem::DayDivider(ts) => *ts
@@ -80,7 +80,7 @@ async fn day_divider() {
     assert_eq!(date.month(), 1);
     assert_eq!(date.day(), 2);
 
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 4, value } => value);
     item.as_event().unwrap();
 
     let _ = timeline
@@ -104,8 +104,9 @@ async fn update_read_marker() {
     let mut stream = timeline.subscribe().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("A")).await;
-    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let _day_divider =
+        assert_next_matches!(stream, VectorDiff::Insert { index: 0, value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
     let first_event_id = item.as_event().unwrap().event_id().unwrap().to_owned();
 
     timeline.inner.set_fully_read_event(first_event_id.clone()).await;
@@ -113,7 +114,7 @@ async fn update_read_marker() {
     // Nothing should happen, the marker cannot be added at the end.
 
     timeline.handle_live_message_event(&BOB, RoomMessageEventContent::text_plain("B")).await;
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 2, value } => value);
     let second_event_id = item.as_event().unwrap().event_id().unwrap().to_owned();
 
     // Now the read marker appears after the first event.
@@ -127,7 +128,7 @@ async fn update_read_marker() {
     assert_next_matches!(stream, VectorDiff::Remove { index: 2 });
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("C")).await;
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 3, value } => value);
     let third_event_id = item.as_event().unwrap().event_id().unwrap().to_owned();
 
     // Now the read marker is reinserted after the second event.
@@ -145,7 +146,7 @@ async fn update_read_marker() {
     timeline.inner.set_fully_read_event(second_event_id).await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("D")).await;
-    let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let item = assert_next_matches!(stream, VectorDiff::Insert { index: 5, value } => value);
     item.as_event().unwrap();
 
     timeline.inner.set_fully_read_event(third_event_id).await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -117,6 +117,31 @@ macro_rules! assert_timeline_stream {
         )
     };
 
+    // `insert [$nth] "$event_id"`
+    ( @_ [ $stream:ident ] [ insert [$index:literal] $event_id:literal ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_timeline_stream!(
+            @_
+            [ $stream ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                {
+                    assert_matches!(
+                        $stream.next().now_or_never(),
+                        Some(Some(VectorDiff::Insert { index: $index, value })) => {
+                            assert_matches!(
+                                value.as_ref(),
+                                TimelineItem::Event(event_timeline_item) => {
+                                    assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
+                                }
+                            );
+                        }
+                    );
+                }
+            ]
+        )
+    };
+
     // `update [$nth] "$event_id"`
     ( @_ [ $stream:ident ] [ update [$index:literal] $event_id:literal ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
         assert_timeline_stream!(


### PR DESCRIPTION
A few tests still need to be updated (replace `PushBack` by `Insert` with the `index` being the previous number of items). One test is right though and still fails ("dedup_by_event_id_late" or similar in integration tests). No idea what's going on there unfortunately.