### PR TITLE
crypto-js: wait for device updates in `getIdentity`

### DIFF
--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.1.0-alpha.12
+
+## Changes in the Javascript bindings
+
+-   In `OlmMachine.getIdentity`, wait a limited time for any in-flight
+    device-list updates to complete.
+
 # v0.1.0-alpha.11
 
 ## Changes in the Javascript bindings

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -477,7 +477,12 @@ impl OlmMachine {
         let user_id = user_id.inner.clone();
 
         future_to_promise(async move {
-            Ok(me.get_identity(user_id.as_ref(), None).await?.map(identities::UserIdentities::from))
+            // wait for up to a second for any in-flight device list requests to complete.
+            // The reason for this isn't so much to avoid races, but to make testing easier.
+            Ok(me
+                .get_identity(user_id.as_ref(), Some(Duration::from_secs(1)))
+                .await?
+                .map(identities::UserIdentities::from))
         })
     }
 


### PR DESCRIPTION
We previously did something similar for `getUserDevices` in #1790. Turns out it's useful for `getIdentity` too.