### PR TITLE
When refusing a verification, send cancel to the originating device

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -21,6 +21,10 @@
 - Add new API `store::Store::room_keys_received_stream` to provide
   updates of room keys being received.
 
-- Add new method `identities::device::Device::first_time_seen_ts` 
+- Add new method `identities::device::Device::first_time_seen_ts`
   that allows to get a local timestamp of when the device was first seen by
   the sdk (in seconds since epoch).
+
+- When rejecting a key-verification request over to-device messages, send the
+  `m.key.verification.cancel` to the device that made the request, rather than
+  broadcasting to all devices.

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -1697,18 +1697,15 @@ mod tests {
 
         // the outgoing message should target bob's device specifically
         {
-            let OutgoingVerificationRequest::ToDevice(to_device_request) = &outgoing_request else {
-                panic!("Not a to-device message");
-            };
+            let to_device_request =
+                assert_matches!(&outgoing_request, OutgoingVerificationRequest::ToDevice(r) => r);
 
             assert_eq!(to_device_request.messages.len(), 1);
             let device_ids: Vec<&DeviceIdOrAllDevices> =
                 to_device_request.messages.values().next().unwrap().keys().collect();
             assert_eq!(device_ids.len(), 1);
 
-            let DeviceIdOrAllDevices::DeviceId(device_id) = device_ids[0] else {
-                panic!("Not a device id");
-            };
+            let device_id = assert_matches!(device_ids[0], DeviceIdOrAllDevices::DeviceId(r) => r);
             assert_eq!(device_id, bob_device.device_id());
         }
 

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -895,7 +895,9 @@ impl InnerRequest {
     fn other_device_id(&self) -> DeviceIdOrAllDevices {
         match self {
             InnerRequest::Created(_) => DeviceIdOrAllDevices::AllDevices,
-            InnerRequest::Requested(_) => DeviceIdOrAllDevices::AllDevices,
+            InnerRequest::Requested(r) => {
+                DeviceIdOrAllDevices::DeviceId(r.state.other_device_id.to_owned())
+            }
             InnerRequest::Ready(r) => {
                 DeviceIdOrAllDevices::DeviceId(r.state.other_device_id.to_owned())
             }
@@ -1596,17 +1598,19 @@ mod tests {
     use matrix_sdk_test::async_test;
     #[cfg(feature = "qrcode")]
     use ruma::events::key::verification::VerificationMethod;
-    use ruma::{event_id, room_id};
+    use ruma::{event_id, room_id, to_device::DeviceIdOrAllDevices};
 
     use super::VerificationRequest;
     use crate::{
         verification::{
             cache::VerificationCache,
-            event_enums::{OutgoingContent, ReadyContent, RequestContent, StartContent},
+            event_enums::{
+                CancelContent, OutgoingContent, ReadyContent, RequestContent, StartContent,
+            },
             test::{alice_id, bob_id, setup_stores},
             FlowId, Verification,
         },
-        ReadOnlyDevice, VerificationRequestState,
+        OutgoingVerificationRequest, ReadOnlyDevice, VerificationRequestState,
     };
 
     #[async_test]
@@ -1656,6 +1660,65 @@ mod tests {
         assert_matches!(alice_request.state(), VerificationRequestState::Ready { .. });
         assert!(bob_request.is_ready());
         assert!(alice_request.is_ready());
+    }
+
+    #[async_test]
+    async fn test_request_refusal_to_device() {
+        // test what happens when we cancel() a request that we have just received over
+        // to-device messages.
+        let (alice_store, bob_store) = setup_stores().await;
+        let bob_device = ReadOnlyDevice::from_account(&bob_store.account).await;
+
+        let flow_id = FlowId::ToDevice("TEST_FLOW_ID".into());
+
+        let bob_request = VerificationRequest::new(
+            VerificationCache::new(),
+            bob_store,
+            flow_id,
+            alice_id(),
+            vec![],
+            None,
+        );
+
+        let request = bob_request.request_to_device();
+        let content: OutgoingContent = request.try_into().unwrap();
+        let content = RequestContent::try_from(&content).unwrap();
+        let flow_id = bob_request.flow_id().to_owned();
+
+        let alice_request = VerificationRequest::from_request(
+            VerificationCache::new(),
+            alice_store,
+            bob_id(),
+            flow_id,
+            &content,
+        );
+
+        let outgoing_request = alice_request.cancel().unwrap();
+
+        // the outgoing message should target bob's device specifically
+        {
+            let OutgoingVerificationRequest::ToDevice(to_device_request) = &outgoing_request else {
+                panic!("Not a to-device message");
+            };
+
+            assert_eq!(to_device_request.messages.len(), 1);
+            let device_ids: Vec<&DeviceIdOrAllDevices> =
+                to_device_request.messages.values().next().unwrap().keys().collect();
+            assert_eq!(device_ids.len(), 1);
+
+            let DeviceIdOrAllDevices::DeviceId(device_id) = device_ids[0] else {
+                panic!("Not a device id");
+            };
+            assert_eq!(device_id, bob_device.device_id());
+        }
+
+        let content = OutgoingContent::try_from(outgoing_request).unwrap();
+        let content = CancelContent::try_from(&content).unwrap();
+
+        bob_request.receive_cancel(alice_id(), &content);
+
+        assert_matches!(bob_request.state(), VerificationRequestState::Cancelled { .. });
+        assert_matches!(alice_request.state(), VerificationRequestState::Cancelled { .. });
     }
 
     #[async_test]


### PR DESCRIPTION
According to the [spec](https://spec.matrix.org/v1.7/client-server-api/#device-verification), when a device receives a verification request and wants to refuse it, it should send the `m.key.verification.cancel` to the originating device, rather than broadcasting it:

> When Bob accepts or declines the verification on one of his devices (sending either an `m.key.verification.ready` or `m.key.verification.cancel` event), **Alice** will send an` m.key.verification.cancel` event to Bob’s other devices...