### PR TITLE
chore(sdk): Log SlidingSync list updates

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -24,7 +24,7 @@ pub use room_list_entry::RoomListEntry;
 use ruma::{api::client::sync::sync_events::v4, assign, OwnedRoomId, TransactionId};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::Sender;
-use tracing::{info, instrument, warn};
+use tracing::{instrument, warn};
 
 use self::sticky::SlidingSyncListStickyParameters;
 use super::{
@@ -519,8 +519,6 @@ fn apply_sync_operations(
     room_list: &mut ObservableVector<RoomListEntry>,
     rooms_that_have_received_an_update: &mut HashSet<OwnedRoomId>,
 ) -> Result<(), Error> {
-    info!(?operations);
-
     for operation in operations {
         match &operation.op {
             // Specification says:

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -342,6 +342,11 @@ impl SlidingSync {
 
             // Update the lists.
             let updated_lists = {
+                debug!(
+                    lists = ?sliding_sync_response.lists,
+                    "Update lists"
+                );
+
                 let mut updated_lists = Vec::with_capacity(sliding_sync_response.lists.len());
                 let mut lists = self.inner.lists.write().await;
 


### PR DESCRIPTION
This patch removes an old log and adds a better one with more context.