### PR TITLE
feat(ffi): Add methods on `RoomListItem` so that `full_room` isn't necessary

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -339,6 +339,18 @@ impl RoomListItem {
         RUNTIME.block_on(async { self.inner.name().await })
     }
 
+    pub fn is_direct(&self) -> Option<bool> {
+        RUNTIME.block_on(async { self.inner.inner_room().is_direct().await.ok() })
+    }
+
+    pub fn avatar_url(&self) -> Option<String> {
+        self.inner.inner_room().avatar_url().map(|uri| uri.to_string())
+    }
+
+    pub fn canonical_alias(&self) -> Option<String> {
+        self.inner.inner_room().canonical_alias().map(|alias| alias.to_string())
+    }
+
     fn full_room(&self) -> Arc<Room> {
         Arc::new(Room::with_timeline(
             self.inner.inner_room().clone(),

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -351,6 +351,10 @@ impl RoomListItem {
         self.inner.inner_room().canonical_alias().map(|alias| alias.to_string())
     }
 
+    /// Building a `Room`.
+    ///
+    /// Be careful that building a `Room` builds its entire `Timeline` at the
+    /// same time.
     fn full_room(&self) -> Arc<Room> {
         Arc::new(Room::with_timeline(
             self.inner.inner_room().clone(),

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -339,8 +339,8 @@ impl RoomListItem {
         RUNTIME.block_on(async { self.inner.name().await })
     }
 
-    pub fn is_direct(&self) -> Option<bool> {
-        RUNTIME.block_on(async { self.inner.inner_room().is_direct().await.ok() })
+    pub fn is_direct(&self) -> bool {
+        RUNTIME.block_on(async { self.inner.inner_room().is_direct().await.unwrap_or(false) })
     }
 
     pub fn avatar_url(&self) -> Option<String> {


### PR DESCRIPTION
Address #1911.

Calling `RoomListItem::full_room` creates its associated `Timeline`.

ElementX calls `full_room` to get the `is_direct`, `avatar_url` and `canonical_alias` values for _all_ rooms in the room list. Instead of doing so, let's add those methods directly in `RoomListItem` so that the `Timeline` isn't created for _all_ rooms.