### PR TITLE
Stop restarting all rooms from growing mode on sliding sync restarts

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list/state.rs
@@ -215,7 +215,7 @@ impl Actions {
     actions! {
         none => [],
         first_rooms_are_loaded => [SetAllRoomsListToGrowingSyncMode, AddVisibleRoomsList, AddInvitesList],
-        refresh_lists => [SetAllRoomsListToGrowingSyncMode],
+        refresh_lists => [],
     }
 
     fn iter(&self) -> &[OneAction] {


### PR DESCRIPTION
Following the discussion [here](https://matrix.to/#/!kCCQTCfnABLKGGvQjo:matrix.org/$ivcgoI94OoNiueJyRFb7a0NIFBIzDookUhhj4Sy8BCc?via=matrix.org&via=element.io&via=one.ems.host) we believe that resetting the all rooms list and having it start paginating again gets in the way of receiving new data.
Empirically, asking for one "big" request instead of multiple ones is faster on the `bigtestaccount` but mine wasn't necessarily a very scientific test.