### PR TITLE
fix(ui): Add `bump_event_types` onto `visible_rooms`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -20,7 +20,9 @@ use async_trait::async_trait;
 use matrix_sdk::{sliding_sync::Range, SlidingSync, SlidingSyncList, SlidingSyncMode};
 use once_cell::sync::Lazy;
 use ruma::{
-    api::client::sync::sync_events::v4::SyncRequestListFilters, assign, events::StateEventType,
+    api::client::sync::sync_events::v4::SyncRequestListFilters,
+    assign,
+    events::{StateEventType, TimelineEventType},
 };
 
 use super::Error;
@@ -118,7 +120,12 @@ impl Action for AddVisibleRoomsList {
                         is_invite: Some(false),
                         is_tombstoned: Some(false),
                         not_room_types: vec!["m.space".to_owned()],
-                    }))),
+                    })))
+                    .bump_event_types(&[
+                        TimelineEventType::RoomMessage,
+                        TimelineEventType::RoomEncrypted,
+                        TimelineEventType::Sticker,
+                    ]),
             )
             .await
             .map_err(Error::SlidingSync)?;

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -280,6 +280,11 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         "is_tombstoned": false,
                         "not_room_types": ["m.space"],
                     },
+                    "bump_event_types": [
+                        "m.room.message",
+                        "m.room.encrypted",
+                        "m.sticker",
+                    ],
                     "sort": ["by_recency", "by_name"],
                     "timeline_limit": 20,
                 },


### PR DESCRIPTION
Address #1911.

This patch configures the same `bump_event_types` for the `visible_rooms` list than for the `all_rooms` list, so that we may be sure that the sorting/ordering is the same between the two lists.