### PR TITLE
WebR Expose matrix-sdk-crypto-js bindings for KeyBackup#100

### DIFF
--- a/bindings/matrix-sdk-crypto-js/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-js/Cargo.toml
@@ -38,13 +38,19 @@ tracing = []
 anyhow = { workspace = true }
 console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"
+hmac = "0.12.1"
 http = { workspace = true }
+pbkdf2 = "0.11.0"
+rand = "0.8.5"
 js-sys = "0.3.49"
 matrix-sdk-common = { version = "0.6.0", path = "../../crates/matrix-sdk-common", features = ["js"] }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../../crates/matrix-sdk-indexeddb" }
 matrix-sdk-qrcode = { version = "0.4.0", path = "../../crates/matrix-sdk-qrcode", optional = true }
 ruma = { workspace = true, features = ["js", "rand"] }
+serde = { workspace = true }
 serde_json = { workspace = true }
+serde-wasm-bindgen = "0.5.0"
+sha2 = "0.10.2"
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std"] }
 vodozemac = { workspace = true, features = ["js"] }
@@ -56,4 +62,4 @@ zeroize = { workspace = true }
 path = "../../crates/matrix-sdk-crypto"
 version = "0.6.0"
 default_features = false
-features = ["js", "automatic-room-key-forwarding"]
+features = ["js", "backups_v1", "automatic-room-key-forwarding"]

--- a/bindings/matrix-sdk-crypto-js/src/backup_recovery_key.rs
+++ b/bindings/matrix-sdk-crypto-js/src/backup_recovery_key.rs
@@ -6,16 +6,12 @@ use js_sys::{JsString, JSON};
 use wasm_bindgen::prelude::*;
 
 use hmac::Hmac;
-use matrix_sdk_crypto::{
-    backups::MegolmV1BackupKey as InnerMegolmV1BackupKey,
-    store::RecoveryKey,
-};
-
+use matrix_sdk_crypto::{backups::MegolmV1BackupKey as InnerMegolmV1BackupKey, store::RecoveryKey};
 
 use pbkdf2::pbkdf2;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
-use sha2::Sha512;
 use serde_wasm_bindgen;
+use sha2::Sha512;
 use zeroize::Zeroize;
 
 /// The private part of the backup key, the one used for recovery.
@@ -46,39 +42,38 @@ pub struct MegolmV1BackupKey {
     passphrase_info: Option<PassphraseInfo>,
 }
 
-
 #[wasm_bindgen]
 impl MegolmV1BackupKey {
-
     /// The actual base64 encoded public key.
-    #[wasm_bindgen(getter, js_name="publicKeyBase64")]
+    #[wasm_bindgen(getter, js_name = "publicKeyBase64")]
     pub fn public_key(&self) -> JsString {
         self.inner.to_base64().into()
     }
 
     /// The passphrase info, if the key was derived from one.
-    #[wasm_bindgen(getter, js_name="passphraseInfo")]
+    #[wasm_bindgen(getter, js_name = "passphraseInfo")]
     pub fn passphrase_info(&self) -> Option<PassphraseInfo> {
         self.passphrase_info.clone()
     }
 
     /// Get the full name of the backup algorithm this backup key supports.
-    #[wasm_bindgen(getter, js_name="algorithm")]
+    #[wasm_bindgen(getter, js_name = "algorithm")]
     pub fn backup_algorithm(&self) -> JsString {
         self.inner.backup_algorithm().into()
     }
 
     /// Signatures that have signed our backup key.
     /// map of userId to map of deviceOrKeyId to signature
-    #[wasm_bindgen(getter, js_name="signatures")]
+    #[wasm_bindgen(getter, js_name = "signatures")]
     pub fn signatures(&self) -> JsValue {
-        let signatures: HashMap<String, HashMap<String, String>> = self.inner
+        let signatures: HashMap<String, HashMap<String, String>> = self
+            .inner
             .signatures()
             .into_iter()
             .map(|(k, v)| (k.to_string(), v.into_iter().map(|(k, v)| (k.to_string(), v)).collect()))
             .collect();
 
-            serde_wasm_bindgen::to_value(&signatures).unwrap()
+        serde_wasm_bindgen::to_value(&signatures).unwrap()
     }
 }
 
@@ -91,7 +86,7 @@ impl BackupRecoveryKey {
 #[wasm_bindgen]
 impl BackupRecoveryKey {
     /// Create a new random [`BackupRecoveryKey`].
-    #[wasm_bindgen(js_name="createRandomKey")]
+    #[wasm_bindgen(js_name = "createRandomKey")]
     pub fn create_random_key() -> BackupRecoveryKey {
         BackupRecoveryKey {
             inner: RecoveryKey::new()
@@ -101,19 +96,19 @@ impl BackupRecoveryKey {
     }
 
     /// Try to create a [`BackupRecoveryKey`] from a base 64 encoded string.
-    #[wasm_bindgen(js_name="fromBase64")]
+    #[wasm_bindgen(js_name = "fromBase64")]
     pub fn from_base64(key: String) -> Result<BackupRecoveryKey, JsError> {
         Ok(Self { inner: RecoveryKey::from_base64(&key)?, passphrase_info: None })
     }
 
     /// Try to create a [`BackupRecoveryKey`] from a base 58 encoded string.
-    #[wasm_bindgen(js_name="fromBase58")]
+    #[wasm_bindgen(js_name = "fromBase58")]
     pub fn from_base58(key: String) -> Result<BackupRecoveryKey, JsError> {
         Ok(Self { inner: RecoveryKey::from_base58(&key)?, passphrase_info: None })
     }
 
     /// Create a new [`BackupRecoveryKey`] from the given passphrase.
-    #[wasm_bindgen(js_name="newFromPassphrase")]
+    #[wasm_bindgen(js_name = "newFromPassphrase")]
     pub fn new_from_passphrase(passphrase: String) -> BackupRecoveryKey {
         let mut rng = thread_rng();
         let salt: String = iter::repeat(())
@@ -126,7 +121,7 @@ impl BackupRecoveryKey {
     }
 
     /// Restore a [`BackupRecoveryKey`] from the given passphrase.
-    #[wasm_bindgen(js_name="fromPassphrase")]
+    #[wasm_bindgen(js_name = "fromPassphrase")]
     pub fn from_passphrase(passphrase: String, salt: String, rounds: i32) -> Self {
         let mut key = Box::new([0u8; Self::KEY_SIZE]);
         let rounds = rounds as u32;
@@ -137,7 +132,7 @@ impl BackupRecoveryKey {
 
         key.zeroize();
 
-       Self {
+        Self {
             inner: recovery_key,
             passphrase_info: Some(PassphraseInfo {
                 private_key_salt: salt.into(),
@@ -147,40 +142,37 @@ impl BackupRecoveryKey {
     }
 
     /// Convert the recovery key to a base 58 encoded string.
-    #[wasm_bindgen(js_name="toBase58")]
+    #[wasm_bindgen(js_name = "toBase58")]
     pub fn to_base58(&self) -> JsString {
         self.inner.to_base58().into()
     }
 
     /// Convert the recovery key to a base 64 encoded string.
-    #[wasm_bindgen(js_name="toBase64")]
+    #[wasm_bindgen(js_name = "toBase64")]
     pub fn to_base64(&self) -> JsString {
         self.inner.to_base64().into()
     }
 
     /// Get the public part of the backup key.
-    #[wasm_bindgen(getter, js_name="megolmV1PublicKey")]
+    #[wasm_bindgen(getter, js_name = "megolmV1PublicKey")]
     pub fn megolm_v1_public_key(&self) -> MegolmV1BackupKey {
         let public_key = self.inner.megolm_v1_public_key();
 
-        MegolmV1BackupKey {
-            inner: public_key,
-            passphrase_info: self.passphrase_info.clone(),
-        }
-
+        MegolmV1BackupKey { inner: public_key, passphrase_info: self.passphrase_info.clone() }
     }
 
     /// Try to decrypt a message that was encrypted using the public part of the
     /// backup key.
-    #[wasm_bindgen(js_name="decryptV1")]
+    #[wasm_bindgen(js_name = "decryptV1")]
     pub fn decrypt_v1(
         &self,
         ephemeral_key: String,
         mac: String,
         ciphertext: String,
     ) -> Result<JsValue, JsError> {
-        self.inner.decrypt_v1(&ephemeral_key, &mac, &ciphertext)
-        .map_err(|e| e.into())
-        .map(|r| JSON::parse(&r).unwrap())
+        self.inner
+            .decrypt_v1(&ephemeral_key, &mac, &ciphertext)
+            .map_err(|e| e.into())
+            .map(|r| JSON::parse(&r).unwrap())
     }
 }

--- a/bindings/matrix-sdk-crypto-js/src/backup_recovery_key.rs
+++ b/bindings/matrix-sdk-crypto-js/src/backup_recovery_key.rs
@@ -2,16 +2,14 @@
 
 use std::{collections::HashMap, iter, ops::DerefMut};
 
-use js_sys::{JsString, JSON};
-use wasm_bindgen::prelude::*;
-
 use hmac::Hmac;
+use js_sys::{JsString, JSON};
 use matrix_sdk_crypto::{backups::MegolmV1BackupKey as InnerMegolmV1BackupKey, store::RecoveryKey};
-
 use pbkdf2::pbkdf2;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde_wasm_bindgen;
 use sha2::Sha512;
+use wasm_bindgen::prelude::*;
 use zeroize::Zeroize;
 
 /// The private part of the backup key, the one used for recovery.

--- a/bindings/matrix-sdk-crypto-js/src/backup_recovery_key.rs
+++ b/bindings/matrix-sdk-crypto-js/src/backup_recovery_key.rs
@@ -1,0 +1,186 @@
+//! Megolm backup types
+
+use std::{collections::HashMap, iter, ops::DerefMut};
+
+use js_sys::{JsString, JSON};
+use wasm_bindgen::prelude::*;
+
+use hmac::Hmac;
+use matrix_sdk_crypto::{
+    backups::MegolmV1BackupKey as InnerMegolmV1BackupKey,
+    store::RecoveryKey,
+};
+
+
+use pbkdf2::pbkdf2;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use sha2::Sha512;
+use serde_wasm_bindgen;
+use zeroize::Zeroize;
+
+/// The private part of the backup key, the one used for recovery.
+#[derive(Debug)]
+#[wasm_bindgen]
+pub struct BackupRecoveryKey {
+    pub(crate) inner: RecoveryKey,
+    pub(crate) passphrase_info: Option<PassphraseInfo>,
+}
+
+/// Struct containing info about the way the backup key got derived from a
+/// passphrase.
+#[derive(Debug, Clone)]
+#[wasm_bindgen]
+pub struct PassphraseInfo {
+    /// The salt that was used during key derivation.
+    #[wasm_bindgen(getter_with_clone)]
+    pub private_key_salt: JsString,
+    /// The number of PBKDF rounds that were used for key derivation.
+    pub private_key_iterations: i32,
+}
+
+/// The public part of the backup key.
+#[derive(Debug, Clone)]
+#[wasm_bindgen]
+pub struct MegolmV1BackupKey {
+    inner: InnerMegolmV1BackupKey,
+    passphrase_info: Option<PassphraseInfo>,
+}
+
+
+#[wasm_bindgen]
+impl MegolmV1BackupKey {
+
+    /// The actual base64 encoded public key.
+    #[wasm_bindgen(getter, js_name="publicKeyBase64")]
+    pub fn public_key(&self) -> JsString {
+        self.inner.to_base64().into()
+    }
+
+    /// The passphrase info, if the key was derived from one.
+    #[wasm_bindgen(getter, js_name="passphraseInfo")]
+    pub fn passphrase_info(&self) -> Option<PassphraseInfo> {
+        self.passphrase_info.clone()
+    }
+
+    /// Get the full name of the backup algorithm this backup key supports.
+    #[wasm_bindgen(getter, js_name="algorithm")]
+    pub fn backup_algorithm(&self) -> JsString {
+        self.inner.backup_algorithm().into()
+    }
+
+    /// Signatures that have signed our backup key.
+    /// map of userId to map of deviceOrKeyId to signature
+    #[wasm_bindgen(getter, js_name="signatures")]
+    pub fn signatures(&self) -> JsValue {
+        let signatures: HashMap<String, HashMap<String, String>> = self.inner
+            .signatures()
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.into_iter().map(|(k, v)| (k.to_string(), v)).collect()))
+            .collect();
+
+            serde_wasm_bindgen::to_value(&signatures).unwrap()
+    }
+}
+
+impl BackupRecoveryKey {
+    const KEY_SIZE: usize = 32;
+    const SALT_SIZE: usize = 32;
+    const PBKDF_ROUNDS: i32 = 500_000;
+}
+
+#[wasm_bindgen]
+impl BackupRecoveryKey {
+    /// Create a new random [`BackupRecoveryKey`].
+    #[wasm_bindgen(js_name="createRandomKey")]
+    pub fn create_random_key() -> BackupRecoveryKey {
+        BackupRecoveryKey {
+            inner: RecoveryKey::new()
+                .expect("Can't gather enough randomness to create a recovery key"),
+            passphrase_info: None,
+        }
+    }
+
+    /// Try to create a [`BackupRecoveryKey`] from a base 64 encoded string.
+    #[wasm_bindgen(js_name="fromBase64")]
+    pub fn from_base64(key: String) -> Result<BackupRecoveryKey, JsError> {
+        Ok(Self { inner: RecoveryKey::from_base64(&key)?, passphrase_info: None })
+    }
+
+    /// Try to create a [`BackupRecoveryKey`] from a base 58 encoded string.
+    #[wasm_bindgen(js_name="fromBase58")]
+    pub fn from_base58(key: String) -> Result<BackupRecoveryKey, JsError> {
+        Ok(Self { inner: RecoveryKey::from_base58(&key)?, passphrase_info: None })
+    }
+
+    /// Create a new [`BackupRecoveryKey`] from the given passphrase.
+    #[wasm_bindgen(js_name="newFromPassphrase")]
+    pub fn new_from_passphrase(passphrase: String) -> BackupRecoveryKey {
+        let mut rng = thread_rng();
+        let salt: String = iter::repeat(())
+            .map(|()| rng.sample(Alphanumeric))
+            .map(char::from)
+            .take(Self::SALT_SIZE)
+            .collect();
+
+        BackupRecoveryKey::from_passphrase(passphrase, salt, Self::PBKDF_ROUNDS)
+    }
+
+    /// Restore a [`BackupRecoveryKey`] from the given passphrase.
+    #[wasm_bindgen(js_name="fromPassphrase")]
+    pub fn from_passphrase(passphrase: String, salt: String, rounds: i32) -> Self {
+        let mut key = Box::new([0u8; Self::KEY_SIZE]);
+        let rounds = rounds as u32;
+
+        pbkdf2::<Hmac<Sha512>>(passphrase.as_bytes(), salt.as_bytes(), rounds, key.deref_mut());
+
+        let recovery_key = RecoveryKey::from_bytes(&key);
+
+        key.zeroize();
+
+       Self {
+            inner: recovery_key,
+            passphrase_info: Some(PassphraseInfo {
+                private_key_salt: salt.into(),
+                private_key_iterations: rounds as i32,
+            }),
+        }
+    }
+
+    /// Convert the recovery key to a base 58 encoded string.
+    #[wasm_bindgen(js_name="toBase58")]
+    pub fn to_base58(&self) -> JsString {
+        self.inner.to_base58().into()
+    }
+
+    /// Convert the recovery key to a base 64 encoded string.
+    #[wasm_bindgen(js_name="toBase64")]
+    pub fn to_base64(&self) -> JsString {
+        self.inner.to_base64().into()
+    }
+
+    /// Get the public part of the backup key.
+    #[wasm_bindgen(getter, js_name="megolmV1PublicKey")]
+    pub fn megolm_v1_public_key(&self) -> MegolmV1BackupKey {
+        let public_key = self.inner.megolm_v1_public_key();
+
+        MegolmV1BackupKey {
+            inner: public_key,
+            passphrase_info: self.passphrase_info.clone(),
+        }
+
+    }
+
+    /// Try to decrypt a message that was encrypted using the public part of the
+    /// backup key.
+    #[wasm_bindgen(js_name="decryptV1")]
+    pub fn decrypt_v1(
+        &self,
+        ephemeral_key: String,
+        mac: String,
+        ciphertext: String,
+    ) -> Result<JsValue, JsError> {
+        self.inner.decrypt_v1(&ephemeral_key, &mac, &ciphertext)
+        .map_err(|e| e.into())
+        .map(|r| JSON::parse(&r).unwrap())
+    }
+}

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -37,6 +37,7 @@ mod tracing;
 pub mod types;
 pub mod verification;
 pub mod vodozemac;
+pub mod backup_recovery_key;
 
 use js_sys::JsString;
 use wasm_bindgen::prelude::*;

--- a/bindings/matrix-sdk-crypto-js/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-js/src/lib.rs
@@ -19,6 +19,7 @@
 #![allow(clippy::drop_non_drop)]
 
 pub mod attachment;
+pub mod backup_recovery_key;
 pub mod device;
 pub mod encryption;
 pub mod events;
@@ -37,7 +38,6 @@ mod tracing;
 pub mod types;
 pub mod verification;
 pub mod vodozemac;
-pub mod backup_recovery_key;
 
 use js_sys::JsString;
 use wasm_bindgen::prelude::*;

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -837,7 +837,7 @@ impl OlmMachine {
     /// trusted, otherwise we might be encrypting room keys that a malicious
     /// party could decrypt.
     ///
-    /// The [`OlmMachine::verifyBackup`] method can be used to so.
+    /// The [`OlmMachine::verify_backup`] method can be used to so.
     #[wasm_bindgen(js_name = "enableBackupV1")]
     pub fn enable_backup_v1(
         &self,

--- a/bindings/matrix-sdk-crypto-js/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-js/src/machine.rs
@@ -850,7 +850,7 @@ impl OlmMachine {
         let me = self.inner.clone();
 
         Ok(future_to_promise(async move {
-            let _ = me.backup_machine().enable_backup_v1(backup_key).await?;
+            me.backup_machine().enable_backup_v1(backup_key).await?;
             Ok(JsValue::NULL)
         }))
     }

--- a/bindings/matrix-sdk-crypto-js/src/types.rs
+++ b/bindings/matrix-sdk-crypto-js/src/types.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use js_sys::{Map, JSON};
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use tracing::trace;
 use wasm_bindgen::prelude::*;
 
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use matrix_sdk_crypto::{
-    backups::SignatureVerification as InnerSignatureVerification,
     backups::SignatureState as InnerSignatureState,
+    backups::SignatureVerification as InnerSignatureVerification,
 };
 
 /// A collection of `Signature`.
@@ -95,34 +95,40 @@ impl Signatures {
     }
 
     /// Get the json with all signatures
-    #[wasm_bindgen(js_name="asJSON")]
+    #[wasm_bindgen(js_name = "asJSON")]
     pub fn as_json(&self) -> JsValue {
         trace!(?self.inner, "The signature");
         // can't use directly serde_wasm_bindgen as there is an issue with BTreeMap
         // It's always returning an empty {} if I do:
         // serde_wasm_bindgen::to_value(&self.inner).unwrap()
-        
+
         // Keep it like that for now as it's working
-        let map : BTreeMap<String, BTreeMap<String,String>> = self.inner.clone().into_iter().map(|(u,sign)| {
-            (
-                u.as_str().to_owned(),
-                sign.iter().map(|(device, maybe_sign)| {
-                    (
-                        device.as_str().to_owned(),
-                        match maybe_sign {
-                           Ok(s) => s.to_base64(),
-                           Err(e) => e.source.to_owned()
-                        }
-                    )
-                }).collect()
-            )
-        }).collect();
+        let map: BTreeMap<String, BTreeMap<String, String>> = self
+            .inner
+            .clone()
+            .into_iter()
+            .map(|(u, sign)| {
+                (
+                    u.as_str().to_owned(),
+                    sign.iter()
+                        .map(|(device, maybe_sign)| {
+                            (
+                                device.as_str().to_owned(),
+                                match maybe_sign {
+                                    Ok(s) => s.to_base64(),
+                                    Err(e) => e.source.to_owned(),
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect();
 
         let raw_string = serde_json::to_string(&map).unwrap();
 
         JSON::parse(&raw_string).unwrap()
     }
-
 }
 
 /// Represents a potentially decoded signature (but not a validated
@@ -194,12 +200,11 @@ impl MaybeSignature {
     }
 }
 
-
 /// The result of a signature verification of a signed JSON object.
 #[derive(Debug)]
 #[wasm_bindgen]
 pub struct SignatureVerification {
-    pub(crate) inner: InnerSignatureVerification
+    pub(crate) inner: InnerSignatureVerification,
 }
 
 /// The result of a signature check.
@@ -231,22 +236,20 @@ impl Into<SignatureState> for InnerSignatureState {
 
 #[wasm_bindgen]
 impl SignatureVerification {
-
-    /// Give the backup signature state from the current device. 
+    /// Give the backup signature state from the current device.
     /// See SignatureState for values
-    #[wasm_bindgen(getter, js_name="deviceState")]
+    #[wasm_bindgen(getter, js_name = "deviceState")]
     pub fn device_state(&self) -> SignatureState {
         self.inner.device_signature.into()
     }
 
-    /// Give the backup signature state from the current user identity. 
+    /// Give the backup signature state from the current user identity.
     /// See SignatureState for values
-    #[wasm_bindgen(getter, js_name="userState")]
+    #[wasm_bindgen(getter, js_name = "userState")]
     pub fn user_state(&self) -> SignatureState {
         self.inner.user_identity_signature.into()
     }
 }
-
 
 /// Struct holding the number of room keys we have.
 #[derive(Debug, Serialize, Deserialize)]
@@ -254,7 +257,7 @@ pub struct RoomKeyCounts {
     /// The total number of room keys.
     pub total: i64,
     /// The number of backed up room keys.
-    #[serde(rename="backedUp")]
+    #[serde(rename = "backedUp")]
     pub backed_up: i64,
 }
 
@@ -262,9 +265,9 @@ pub struct RoomKeyCounts {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BackupKeys {
     /// The total number of room keys.
-    #[serde(rename="recoveryKeyBase58")]
+    #[serde(rename = "recoveryKeyBase58")]
     pub recovery_key: Option<String>,
     /// The number of backed up room keys.
-    #[serde(rename="backupVersion")]
+    #[serde(rename = "backupVersion")]
     pub backup_version: Option<String>,
 }

--- a/bindings/matrix-sdk-crypto-js/src/types.rs
+++ b/bindings/matrix-sdk-crypto-js/src/types.rs
@@ -257,3 +257,14 @@ pub struct RoomKeyCounts {
     #[serde(rename="backedUp")]
     pub backed_up: i64,
 }
+
+/// The backup recovery key has saved by sdk
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BackupKeys {
+    /// The total number of room keys.
+    #[serde(rename="recoveryKeyBase58")]
+    pub recovery_key: Option<String>,
+    /// The number of backed up room keys.
+    #[serde(rename="backupVersion")]
+    pub backup_version: Option<String>,
+}

--- a/bindings/matrix-sdk-crypto-js/src/types.rs
+++ b/bindings/matrix-sdk-crypto-js/src/types.rs
@@ -221,9 +221,9 @@ pub enum SignatureState {
     ValidAndTrusted = 3,
 }
 
-impl Into<SignatureState> for InnerSignatureState {
-    fn into(self) -> SignatureState {
-        match self {
+impl From<InnerSignatureState> for SignatureState {
+    fn from(val: InnerSignatureState) -> Self {
+        match val {
             InnerSignatureState::Missing => SignatureState::Missing,
             InnerSignatureState::Invalid => SignatureState::Invalid,
             InnerSignatureState::ValidButNotTrusted => SignatureState::ValidButNotTrusted,

--- a/bindings/matrix-sdk-crypto-js/src/types.rs
+++ b/bindings/matrix-sdk-crypto-js/src/types.rs
@@ -3,6 +3,9 @@
 use std::collections::BTreeMap;
 
 use js_sys::{Map, JSON};
+use matrix_sdk_crypto::backups::{
+    SignatureState as InnerSignatureState, SignatureVerification as InnerSignatureVerification,
+};
 use serde::{Deserialize, Serialize};
 use tracing::trace;
 use wasm_bindgen::prelude::*;
@@ -11,11 +14,6 @@ use crate::{
     identifiers::{DeviceKeyId, UserId},
     impl_from_to_inner,
     vodozemac::Ed25519Signature,
-};
-
-use matrix_sdk_crypto::{
-    backups::SignatureState as InnerSignatureState,
-    backups::SignatureVerification as InnerSignatureVerification,
 };
 
 /// A collection of `Signature`.

--- a/bindings/matrix-sdk-crypto-js/tests/backup_recovery_key.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/backup_recovery_key.test.js
@@ -1,14 +1,13 @@
-const {BackupRecoveryKey} = require("../pkg/matrix_sdk_crypto_js");
-
+const { BackupRecoveryKey } = require("../pkg/matrix_sdk_crypto_js");
 
 const aMegolmKey = {
-    "algorithm": "m.megolm.v1.aes-sha2",
-    "sender_key": "wREG/hBdSspoqM9xPCEXd/4YwjpBFXlsobRkyDTo/Q8",
-    "session_key": "AQAAAABwCEYsl5BrvPW0N8HTYP11phC7LOzItQLS3Zen6j1j9qMydUHVDeuMLxwo5i3GYfLWGjJEjsCj0Q99TZMABnJBCFg9MheV8cNSBfj7mHSZr6NP8aUAAAOhsY+cJwPDHxcnU181nAEs0fovHnonZGXs6iB/K6sKfuRWUNvX50ORohgDT3TGl0gQFed1FQEtn2Q1qT35iTRfe81SGOnFJrOM",
-    "sender_claimed_keys": { "ed25519": "MnNLGwn4j9ArCvtgU6o1jG8TgJaEXQpDTxz7QU0h7GM" },
-    "forwarding_curve25519_key_chain": []
-}
-
+    algorithm: "m.megolm.v1.aes-sha2",
+    sender_key: "wREG/hBdSspoqM9xPCEXd/4YwjpBFXlsobRkyDTo/Q8",
+    session_key:
+        "AQAAAABwCEYsl5BrvPW0N8HTYP11phC7LOzItQLS3Zen6j1j9qMydUHVDeuMLxwo5i3GYfLWGjJEjsCj0Q99TZMABnJBCFg9MheV8cNSBfj7mHSZr6NP8aUAAAOhsY+cJwPDHxcnU181nAEs0fovHnonZGXs6iB/K6sKfuRWUNvX50ORohgDT3TGl0gQFed1FQEtn2Q1qT35iTRfe81SGOnFJrOM",
+    sender_claimed_keys: { ed25519: "MnNLGwn4j9ArCvtgU6o1jG8TgJaEXQpDTxz7QU0h7GM" },
+    forwarding_curve25519_key_chain: [],
+};
 
 const encryptedMegolm = {
     first_message_index: 0,
@@ -16,11 +15,11 @@ const encryptedMegolm = {
     is_verified: false,
     session_data: {
         ephemeral: "HlLi76oV6wxHz3PCqE/bxJi6yF1HnYz5Dq3T+d/KpRw",
-        ciphertext: "MuM8E3Yc6TSAvhVGb77rQ++jE6p9dRepx63/3YPD2wACKAppkZHeFrnTH6wJ/HSyrmzo7HfwqVl6tKNpfooSTHqUf6x1LHz+h4B/Id5ITO1WYt16AaI40LOnZqTkJZCfSPuE2oxalwEHnCS3biWybutcnrBFPR3LMtaeHvvkb+k3ny9l5ZpsU9G7vCm3XoeYkWfLekWXvDhbqWrylXD0+CNUuaQJ/S527TzLd4XKctqVjjO/cCH7q+9utt9WJAfK8LGaWT/mZ3AeWjf5kiqOpKKf5Cn4n5SSil5p/pvGYmjnURvZSEeQIzHgvunIBEPtzK/MYEPOXe/P5achNGlCx+5N19Ftyp9TFaTFlTWCTi0mpD7ePfCNISrwpozAz9HZc0OhA8+1aSc7rhYFIeAYXFU326NuFIFHI5pvpSxjzPQlOA+mavIKmiRAtjlLw11IVKTxgrdT4N8lXeMr4ndCSmvIkAzFMo1uZA4fzjiAdQJE4/2WeXFNNpvdfoYmX8Zl9CAYjpSO5HvpwkAbk4/iLEH3hDfCVUwDfMh05PdGLnxeRpiEFWSMSsJNp+OWAA+5JsF41BoRGrxoXXT+VKqlUDONd+O296Psu8Q+d8/S618",
-        mac: "GtMrurhDTwo"
-    }
+        ciphertext:
+            "MuM8E3Yc6TSAvhVGb77rQ++jE6p9dRepx63/3YPD2wACKAppkZHeFrnTH6wJ/HSyrmzo7HfwqVl6tKNpfooSTHqUf6x1LHz+h4B/Id5ITO1WYt16AaI40LOnZqTkJZCfSPuE2oxalwEHnCS3biWybutcnrBFPR3LMtaeHvvkb+k3ny9l5ZpsU9G7vCm3XoeYkWfLekWXvDhbqWrylXD0+CNUuaQJ/S527TzLd4XKctqVjjO/cCH7q+9utt9WJAfK8LGaWT/mZ3AeWjf5kiqOpKKf5Cn4n5SSil5p/pvGYmjnURvZSEeQIzHgvunIBEPtzK/MYEPOXe/P5achNGlCx+5N19Ftyp9TFaTFlTWCTi0mpD7ePfCNISrwpozAz9HZc0OhA8+1aSc7rhYFIeAYXFU326NuFIFHI5pvpSxjzPQlOA+mavIKmiRAtjlLw11IVKTxgrdT4N8lXeMr4ndCSmvIkAzFMo1uZA4fzjiAdQJE4/2WeXFNNpvdfoYmX8Zl9CAYjpSO5HvpwkAbk4/iLEH3hDfCVUwDfMh05PdGLnxeRpiEFWSMSsJNp+OWAA+5JsF41BoRGrxoXXT+VKqlUDONd+O296Psu8Q+d8/S618",
+        mac: "GtMrurhDTwo",
+    },
 };
-
 
 describe("BackupRecoveryKey", () => {
     test("create from base64 string", () => {
@@ -29,18 +28,15 @@ describe("BackupRecoveryKey", () => {
         const decypted = backupkey.decryptV1(
             encryptedMegolm.session_data.ephemeral,
             encryptedMegolm.session_data.mac,
-            encryptedMegolm.session_data.ciphertext
+            encryptedMegolm.session_data.ciphertext,
         );
 
         expect(decypted.algorithm).toStrictEqual(aMegolmKey.algorithm);
         expect(decypted.sender_key).toStrictEqual(aMegolmKey.sender_key);
         expect(decypted.session_key).toStrictEqual(aMegolmKey.session_key);
-
     });
 
-
     test("create export and import base58", () => {
-
         const backupkey = BackupRecoveryKey.fromBase64("Ha9cklU/9NqFo9WKdVfGzmqUL/9wlkdxfEitbSIPVXw");
         const base58 = backupkey.toBase58();
         const imported = BackupRecoveryKey.fromBase58(base58);
@@ -51,16 +47,14 @@ describe("BackupRecoveryKey", () => {
     test("with passphrase", () => {
         const recoveryKey = BackupRecoveryKey.newFromPassphrase("aSecretPhrase");
 
-        expect(recoveryKey.megolmV1PublicKey.passphraseInfo).toBeDefined()
+        expect(recoveryKey.megolmV1PublicKey.passphraseInfo).toBeDefined();
         expect(recoveryKey.megolmV1PublicKey.passphraseInfo.private_key_iterations).toStrictEqual(500000);
-    })
-
+    });
 
     test("errors", () => {
         expect(() => {
-            BackupRecoveryKey.fromBase64("notBase64")
-        }).toThrow()
-
+            BackupRecoveryKey.fromBase64("notBase64");
+        }).toThrow();
 
         const wrongKey = BackupRecoveryKey.newFromPassphrase("aSecretPhrase");
 
@@ -68,10 +62,8 @@ describe("BackupRecoveryKey", () => {
             wrongKey.decryptV1(
                 encryptedMegolm.session_data.ephemeral,
                 encryptedMegolm.session_data.mac,
-                encryptedMegolm.session_data.ciphertext
+                encryptedMegolm.session_data.ciphertext,
             );
-        }).toThrow()
-
-    })
-
+        }).toThrow();
+    });
 });

--- a/bindings/matrix-sdk-crypto-js/tests/backup_recovery_key.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/backup_recovery_key.test.js
@@ -1,0 +1,77 @@
+const {BackupRecoveryKey} = require("../pkg/matrix_sdk_crypto_js");
+
+
+const aMegolmKey = {
+    "algorithm": "m.megolm.v1.aes-sha2",
+    "sender_key": "wREG/hBdSspoqM9xPCEXd/4YwjpBFXlsobRkyDTo/Q8",
+    "session_key": "AQAAAABwCEYsl5BrvPW0N8HTYP11phC7LOzItQLS3Zen6j1j9qMydUHVDeuMLxwo5i3GYfLWGjJEjsCj0Q99TZMABnJBCFg9MheV8cNSBfj7mHSZr6NP8aUAAAOhsY+cJwPDHxcnU181nAEs0fovHnonZGXs6iB/K6sKfuRWUNvX50ORohgDT3TGl0gQFed1FQEtn2Q1qT35iTRfe81SGOnFJrOM",
+    "sender_claimed_keys": { "ed25519": "MnNLGwn4j9ArCvtgU6o1jG8TgJaEXQpDTxz7QU0h7GM" },
+    "forwarding_curve25519_key_chain": []
+}
+
+
+const encryptedMegolm = {
+    first_message_index: 0,
+    forwarded_count: 0,
+    is_verified: false,
+    session_data: {
+        ephemeral: "HlLi76oV6wxHz3PCqE/bxJi6yF1HnYz5Dq3T+d/KpRw",
+        ciphertext: "MuM8E3Yc6TSAvhVGb77rQ++jE6p9dRepx63/3YPD2wACKAppkZHeFrnTH6wJ/HSyrmzo7HfwqVl6tKNpfooSTHqUf6x1LHz+h4B/Id5ITO1WYt16AaI40LOnZqTkJZCfSPuE2oxalwEHnCS3biWybutcnrBFPR3LMtaeHvvkb+k3ny9l5ZpsU9G7vCm3XoeYkWfLekWXvDhbqWrylXD0+CNUuaQJ/S527TzLd4XKctqVjjO/cCH7q+9utt9WJAfK8LGaWT/mZ3AeWjf5kiqOpKKf5Cn4n5SSil5p/pvGYmjnURvZSEeQIzHgvunIBEPtzK/MYEPOXe/P5achNGlCx+5N19Ftyp9TFaTFlTWCTi0mpD7ePfCNISrwpozAz9HZc0OhA8+1aSc7rhYFIeAYXFU326NuFIFHI5pvpSxjzPQlOA+mavIKmiRAtjlLw11IVKTxgrdT4N8lXeMr4ndCSmvIkAzFMo1uZA4fzjiAdQJE4/2WeXFNNpvdfoYmX8Zl9CAYjpSO5HvpwkAbk4/iLEH3hDfCVUwDfMh05PdGLnxeRpiEFWSMSsJNp+OWAA+5JsF41BoRGrxoXXT+VKqlUDONd+O296Psu8Q+d8/S618",
+        mac: "GtMrurhDTwo"
+    }
+};
+
+
+describe("BackupRecoveryKey", () => {
+    test("create from base64 string", () => {
+        const backupkey = BackupRecoveryKey.fromBase64("Ha9cklU/9NqFo9WKdVfGzmqUL/9wlkdxfEitbSIPVXw");
+
+        const decypted = backupkey.decryptV1(
+            encryptedMegolm.session_data.ephemeral,
+            encryptedMegolm.session_data.mac,
+            encryptedMegolm.session_data.ciphertext
+        );
+
+        expect(decypted.algorithm).toStrictEqual(aMegolmKey.algorithm);
+        expect(decypted.sender_key).toStrictEqual(aMegolmKey.sender_key);
+        expect(decypted.session_key).toStrictEqual(aMegolmKey.session_key);
+
+    });
+
+
+    test("create export and import base58", () => {
+
+        const backupkey = BackupRecoveryKey.fromBase64("Ha9cklU/9NqFo9WKdVfGzmqUL/9wlkdxfEitbSIPVXw");
+        const base58 = backupkey.toBase58();
+        const imported = BackupRecoveryKey.fromBase58(base58);
+
+        expect(backupkey.megolmV1PublicKey.publicKeyBase64).toStrictEqual(imported.megolmV1PublicKey.publicKeyBase64);
+    });
+
+    test("with passphrase", () => {
+        const recoveryKey = BackupRecoveryKey.newFromPassphrase("aSecretPhrase");
+
+        expect(recoveryKey.megolmV1PublicKey.passphraseInfo).toBeDefined()
+        expect(recoveryKey.megolmV1PublicKey.passphraseInfo.private_key_iterations).toStrictEqual(500000);
+    })
+
+
+    test("errors", () => {
+        expect(() => {
+            BackupRecoveryKey.fromBase64("notBase64")
+        }).toThrow()
+
+
+        const wrongKey = BackupRecoveryKey.newFromPassphrase("aSecretPhrase");
+
+        expect(() => {
+            wrongKey.decryptV1(
+                encryptedMegolm.session_data.ephemeral,
+                encryptedMegolm.session_data.mac,
+                encryptedMegolm.session_data.ciphertext
+            );
+        }).toThrow()
+
+    })
+
+});

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -972,8 +972,6 @@ describe(OlmMachine.name, () => {
 
             let counts = await m.roomKeyCounts();
 
-            console.log("Counts " + JSON.stringify(counts));
-
             expect(counts.total).toStrictEqual(1);
             expect(counts.backedUp).toStrictEqual(0);
 
@@ -1010,6 +1008,21 @@ describe(OlmMachine.name, () => {
             expect(newCounts.total).toStrictEqual(1);
             expect(newCounts.backedUp).toStrictEqual(1);
 
+        });
+
+        test("test save and get private key", async () => {
+
+            let m = await machine();
+
+            let keyBackupKey = BackupRecoveryKey.createRandomKey();
+
+            await m.saveBackupRecoveryKey(keyBackupKey.toBase58(), "3");
+
+            let savedKey = await m.getBackupKeys();
+
+            expect(savedKey.recoveryKeyBase58).toStrictEqual(keyBackupKey.toBase58());
+            expect(savedKey.backupVersion).toStrictEqual("3");
+            
         });
     });
 });

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -907,26 +907,27 @@ describe(OlmMachine.name, () => {
     });
 
     describe("can manage key backups", () => {
-        
         test("test unknown signature", async () => {
             let m = await machine();
 
             let backupData = {
-                    "version": "2",
-                    "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
-                    "auth_data": {
-                        "public_key": "ddIQtIjfCzfR69I/imE7XiGsPPKA1KF74aclXsiWh08",
-                        "signatures": {
-                            "@web:example.org": {
-                                "ed25519:WVJSAIOBUZ": "zzqyWl3ek5dSWKKeNPrpMFDQyu9ZlHrA2XpAaXtcSyo8BoZIu0K2flfT+N0YgVee2gmAZdLAribwgoCopvTeAg",
-                                "ed25519:LHMKRoMYl7haWnst5Xo54DuRqjZ5h/Sk1lxc4heSEcI": "YwRj5UqKrbMbAb/VK0Dwj4HspiOjSN64cM5SwFQ7HEcFiHp4gJmHtV90kl+12OLiE5JqRWvgzsx61hSXM/JDCA"
-                            }
-                        }
+                version: "2",
+                algorithm: "m.megolm_backup.v1.curve25519-aes-sha2",
+                auth_data: {
+                    public_key: "ddIQtIjfCzfR69I/imE7XiGsPPKA1KF74aclXsiWh08",
+                    signatures: {
+                        "@web:example.org": {
+                            "ed25519:WVJSAIOBUZ":
+                                "zzqyWl3ek5dSWKKeNPrpMFDQyu9ZlHrA2XpAaXtcSyo8BoZIu0K2flfT+N0YgVee2gmAZdLAribwgoCopvTeAg",
+                            "ed25519:LHMKRoMYl7haWnst5Xo54DuRqjZ5h/Sk1lxc4heSEcI":
+                                "YwRj5UqKrbMbAb/VK0Dwj4HspiOjSN64cM5SwFQ7HEcFiHp4gJmHtV90kl+12OLiE5JqRWvgzsx61hSXM/JDCA",
+                        },
                     },
-                    "etag": "0",
-                    "count": 0
-                }
-            
+                },
+                etag: "0",
+                count: 0,
+            };
+
             const state = await m.verifyBackup(backupData);
 
             expect(state.deviceState).toStrictEqual(SignatureState.Missing);
@@ -934,15 +935,14 @@ describe(OlmMachine.name, () => {
         });
 
         test("test validate own signatures", async () => {
-
             let m = await machine();
             let _ = m.bootstrapCrossSigning(true);
 
             let keyBackupKey = BackupRecoveryKey.createRandomKey();
 
             let auth_data = {
-                public_key: keyBackupKey.megolmV1PublicKey.publicKeyBase64
-            }
+                public_key: keyBackupKey.megolmV1PublicKey.publicKeyBase64,
+            };
 
             let canonical = JSON.stringify(auth_data);
 
@@ -952,20 +952,17 @@ describe(OlmMachine.name, () => {
                 algorithm: keyBackupKey.megolmV1PublicKey.algorithm,
                 auth_data: {
                     signatures: signatures,
-                    ...auth_data
-                }
-            }
+                    ...auth_data,
+                },
+            };
 
             const state = await m.verifyBackup(backupData);
 
             expect(state.deviceState).toStrictEqual(SignatureState.ValidAndTrusted);
             expect(state.userState).toStrictEqual(SignatureState.ValidAndTrusted);
-
         });
 
-
         test("test backup keys", async () => {
-
             let m = await machine();
 
             await m.shareRoomKey(room, [new UserId("@bob:example.org")], new EncryptionSettings());
@@ -977,7 +974,6 @@ describe(OlmMachine.name, () => {
 
             let backupEnabled = await m.isBackupEnabled();
             expect(backupEnabled).toStrictEqual(false);
-
 
             let keyBackupKey = BackupRecoveryKey.createRandomKey();
 
@@ -997,7 +993,7 @@ describe(OlmMachine.name, () => {
             let session_data = Object.values(sessions)[0].session_data;
 
             // should decrypt with the created key
-            let decrypted = keyBackupKey.decryptV1(session_data.ephemeral,session_data.mac, session_data.ciphertext);
+            let decrypted = keyBackupKey.decryptV1(session_data.ephemeral, session_data.mac, session_data.ciphertext);
             expect(decrypted.algorithm).toStrictEqual("m.megolm.v1.aes-sha2");
 
             // simulate key backed up
@@ -1007,11 +1003,9 @@ describe(OlmMachine.name, () => {
 
             expect(newCounts.total).toStrictEqual(1);
             expect(newCounts.backedUp).toStrictEqual(1);
-
         });
 
         test("test save and get private key", async () => {
-
             let m = await machine();
 
             let keyBackupKey = BackupRecoveryKey.createRandomKey();
@@ -1022,7 +1016,6 @@ describe(OlmMachine.name, () => {
 
             expect(savedKey.recoveryKeyBase58).toStrictEqual(keyBackupKey.toBase58());
             expect(savedKey.backupVersion).toStrictEqual("3");
-            
         });
     });
 });


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Expose `matrix-sdk-crypto-js` bindings for:
 * `BackupMachine`, including `BackupMachine::backup_key::version`, which is not currently exposed in the underlying crate
 * `RoomKeyBackupInfo` (? actually perhaps just pass the raw json into `verify_backup`).
 * `MegolmV1BackupKey` (this is the public part of the key)
 * `RecoveryKey` (this is the private part of the key)
 * `SignatureVerification`
 * `Signatures::serialize` (for signing the backup)


Fixes:  https://github.com/vector-im/crypto-internal/issues/100
- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
