### PR TITLE
Add EventTimelineItem::origin

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -71,3 +71,9 @@ callback interface SessionVerificationControllerDelegate {
     void did_cancel();
     void did_finish();
 };
+
+enum EventItemOrigin {
+    "Local",
+    "Sync",
+    "Pagination",
+};

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -43,6 +43,7 @@ use matrix_sdk::{
     ruma::events::room::{message::RoomMessageEventContent, MediaSource},
     SlidingSyncListLoadingState,
 };
+use matrix_sdk_ui::timeline::EventItemOrigin;
 
 use self::{
     client::{CreateRoomParameters, RoomPreset, RoomVisibility},

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -26,7 +26,7 @@ use matrix_sdk::{
         },
     },
 };
-use matrix_sdk_ui::timeline::{Profile, TimelineDetails};
+use matrix_sdk_ui::timeline::{EventItemOrigin, Profile, TimelineDetails};
 use ruma::{assign, UInt};
 use tracing::warn;
 
@@ -345,6 +345,10 @@ impl EventTimelineItem {
 
     pub fn read_receipts(&self) -> HashMap<String, Receipt> {
         self.0.read_receipts().iter().map(|(k, v)| (k.to_string(), v.clone().into())).collect()
+    }
+
+    pub fn origin(&self) -> Option<EventItemOrigin> {
+        self.0.origin()
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -259,6 +259,20 @@ impl EventTimelineItem {
         }
     }
 
+    /// Get the origin of the event, i.e. where it came from.
+    ///
+    /// May return `None` in some edge cases that are subject to change.
+    pub fn origin(&self) -> Option<EventItemOrigin> {
+        match &self.kind {
+            EventTimelineItemKind::Local(_) => Some(EventItemOrigin::Local),
+            EventTimelineItemKind::Remote(remote_event) => match remote_event.origin {
+                RemoteEventOrigin::Sync => Some(EventItemOrigin::Sync),
+                RemoteEventOrigin::Pagination => Some(EventItemOrigin::Pagination),
+                _ => None,
+            },
+        }
+    }
+
     pub(super) fn set_content(&mut self, content: TimelineItemContent) {
         self.content = content;
     }
@@ -356,4 +370,15 @@ impl<T> TimelineDetails<T> {
     {
         matches!(self, Self::Ready(v) if v == value)
     }
+}
+
+/// Where this event came.
+#[derive(Clone, Copy, Debug)]
+pub enum EventItemOrigin {
+    /// The event was created locally.
+    Local,
+    /// The event came from a sync response.
+    Sync,
+    /// The event came from pagination.
+    Pagination,
 }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -70,9 +70,9 @@ pub(crate) use self::builder::TimelineBuilder;
 pub use self::sliding_sync_ext::SlidingSyncRoomExt;
 pub use self::{
     event_item::{
-        AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, EventSendState,
-        EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange, Message,
-        OtherState, Profile, ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker,
+        AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, EventItemOrigin,
+        EventSendState, EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange,
+        Message, OtherState, Profile, ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker,
         TimelineDetails, TimelineItemContent,
     },
     futures::SendAttachment,
@@ -390,7 +390,7 @@ impl Timeline {
         let room = self.joined_room();
 
         let Ok(room) = room else {
-            return ReactionToggleResult::RedactFailure { event_id: event_id.to_owned() }
+            return ReactionToggleResult::RedactFailure { event_id: event_id.to_owned() };
         };
 
         let response = room.redact(event_id, no_reason.reason.as_deref(), Some(txn_id)).await;
@@ -408,9 +408,7 @@ impl Timeline {
         txn_id: OwnedTransactionId,
     ) -> ReactionToggleResult {
         let room = self.joined_room();
-        let Ok(room) = room else {
-            return ReactionToggleResult::AddFailure { txn_id }
-        };
+        let Ok(room) = room else { return ReactionToggleResult::AddFailure { txn_id } };
 
         let event_content =
             AnyMessageLikeEventContent::Reaction(ReactionEventContent::from(annotation.clone()));


### PR DESCRIPTION
Similar to the internal field we have already, but accounting for local events and papering over things we probably shouldn't be exposing in their current form.

Requested by @ganfra.