### PR TITLE
feat: `internal_id` for TimelineItem

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -218,21 +218,20 @@ impl TimelineItem {
 #[uniffi::export]
 impl TimelineItem {
     pub fn as_event(self: Arc<Self>) -> Option<Arc<EventTimelineItem>> {
-        use matrix_sdk_ui::timeline::TimelineItem as Item;
-        unwrap_or_clone_arc_into_variant!(self, .0, Item::Event(evt) => {
-            Arc::new(EventTimelineItem(evt))
-        })
+        let event_item = self.0.as_event()?;
+        Some(Arc::new(EventTimelineItem(event_item.clone())))
     }
 
     pub fn as_virtual(self: Arc<Self>) -> Option<VirtualTimelineItem> {
-        use matrix_sdk_ui::timeline::{TimelineItem as Item, VirtualTimelineItem as VItem};
-        match &self.0 {
-            Item::Virtual(VItem::DayDivider(ts)) => {
-                Some(VirtualTimelineItem::DayDivider { ts: ts.0.into() })
-            }
-            Item::Virtual(VItem::ReadMarker) => Some(VirtualTimelineItem::ReadMarker),
-            Item::Event(_) => None,
+        use matrix_sdk_ui::timeline::VirtualTimelineItem as VItem;
+        match self.0.as_virtual()? {
+            VItem::DayDivider(ts) => Some(VirtualTimelineItem::DayDivider { ts: ts.0.into() }),
+            VItem::ReadMarker => Some(VirtualTimelineItem::ReadMarker),
         }
+    }
+
+    pub fn unique_id(&self) -> u64 {
+        self.0.unique_id()
     }
 
     pub fn fmt_debug(&self) -> String {
@@ -279,10 +278,6 @@ impl EventTimelineItem {
 
     pub fn is_remote(&self) -> bool {
         !self.0.is_local_echo()
-    }
-
-    pub fn unique_identifier(&self) -> String {
-        self.0.unique_identifier()
     }
 
     pub fn transaction_id(&self) -> Option<String> {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -46,10 +46,11 @@ use super::{
         EventTimelineItemKind, LocalEventTimelineItem, Profile, RemoteEventOrigin,
         RemoteEventTimelineItem,
     },
-    find_read_marker, new_timeline_item,
+    find_read_marker,
+    item::{new_timeline_item, timeline_item},
     read_receipts::maybe_add_implicit_read_receipt,
-    rfind_event_by_id, rfind_event_item, timeline_item, EventTimelineItem, Message, OtherState,
-    ReactionGroup, Sticker, TimelineDetails, TimelineInnerState, TimelineItem, TimelineItemContent,
+    rfind_event_by_id, rfind_event_item, EventTimelineItem, Message, OtherState, ReactionGroup,
+    Sticker, TimelineDetails, TimelineInnerState, TimelineItem, TimelineItemContent,
     VirtualTimelineItem, DEFAULT_SANITIZER_MODE,
 };
 use crate::{events::SyncTimelineEventWithoutContent, timeline::event_item::ReactionSenderData};

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -200,19 +200,6 @@ impl EventTimelineItem {
         }
     }
 
-    /// Get a unique identifier to identify the event item, either by using
-    /// transaction ID or event ID in case of a local event, or by event ID in
-    /// case of a remote event.
-    pub fn unique_identifier(&self) -> String {
-        match &self.kind {
-            EventTimelineItemKind::Local(item) => match &item.send_state {
-                EventSendState::Sent { event_id } => event_id.to_string(),
-                _ => item.transaction_id.to_string(),
-            },
-            EventTimelineItemKind::Remote(item) => item.event_id.to_string(),
-        }
-    }
-
     /// Get the event's send state, if it is a local echo.
     pub fn send_state(&self) -> Option<&EventSendState> {
         match &self.kind {

--- a/crates/matrix-sdk-ui/src/timeline/inner.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner.rs
@@ -64,12 +64,13 @@ use super::{
     },
     event_item::{EventItemIdentifier, ReactionSenderData},
     reactions::ReactionToggleResult,
-    rfind_event_by_id, rfind_event_item,
+    rfind_event_by_id, rfind_event_item, timeline_item,
     traits::RoomDataProvider,
     AnnotationKey, EventSendState, EventTimelineItem, InReplyToDetails, Message, Profile,
     RelativePosition, RepliedToEvent, TimelineDetails, TimelineItem, TimelineItemContent,
+    TimelineItemKind,
 };
-use crate::events::SyncTimelineEventWithoutContent;
+use crate::{events::SyncTimelineEventWithoutContent, timeline::new_timeline_item};
 
 #[derive(Clone, Debug)]
 pub(super) struct TimelineInner<P: RoomDataProvider = room::Common> {
@@ -81,6 +82,7 @@ pub(super) struct TimelineInner<P: RoomDataProvider = room::Common> {
 #[derive(Debug, Default)]
 pub(super) struct TimelineInnerState {
     pub(super) items: ObservableVector<Arc<TimelineItem>>,
+    pub(super) next_internal_id: u64,
     /// Reaction event / txn ID => sender and reaction data.
     pub(super) reaction_map: HashMap<EventItemIdentifier, (ReactionSenderData, Annotation)>,
     /// ID of event that is not in the timeline yet => List of reaction event
@@ -602,8 +604,8 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
         let is_error = matches!(send_state, EventSendState::SendingFailed { .. });
 
-        let new_item = TimelineItem::Event(item.with_kind(local_item.with_send_state(send_state)));
-        state.items.set(idx, Arc::new(new_item));
+        let new_item = item.with_inner_kind(local_item.with_send_state(send_state));
+        state.items.set(idx, new_item);
 
         if is_error {
             // When there is an error, sending further messages is paused. This
@@ -611,12 +613,13 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             // events to cancelled.
             let num_items = state.items.len();
             for idx in 0..num_items {
-                let Some(item) = state.items[idx].as_event() else { continue };
-                let Some(local_item) = item.as_local() else { continue };
+                let item = state.items[idx].clone();
+                let Some(event_item) = item.as_event() else { continue };
+                let Some(local_item) = event_item.as_local() else { continue };
                 if matches!(&local_item.send_state, EventSendState::NotSentYet) {
-                    let new_item =
-                        item.with_kind(local_item.with_send_state(EventSendState::Cancelled));
-                    state.items.set(idx, Arc::new(TimelineItem::Event(new_item)));
+                    let new_event_item =
+                        event_item.with_kind(local_item.with_send_state(EventSendState::Cancelled));
+                    state.items.set(idx, item.with_kind(new_event_item));
                 }
             }
         }
@@ -691,12 +694,9 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             EventSendState::SendingFailed { .. } | EventSendState::Cancelled => {}
         }
 
-        let new_item = TimelineItem::Event(
-            item.with_kind(local_item.with_send_state(EventSendState::NotSentYet)),
-        );
-
+        let new_item = item.with_inner_kind(local_item.with_send_state(EventSendState::NotSentYet));
         let content = item.content.clone();
-        state.items.set(idx, Arc::new(new_item));
+        state.items.set(idx, new_item);
 
         Some(content)
     }
@@ -894,9 +894,10 @@ impl<P: RoomDataProvider> TimelineInner<P> {
     async fn set_non_ready_sender_profiles(&self, profile_state: TimelineDetails<Profile>) {
         let mut state = self.state.lock().await;
         for idx in 0..state.items.len() {
-            let Some(event_item) = state.items[idx].as_event() else { continue };
+            let item = state.items[idx].clone();
+            let Some(event_item) = item.as_event() else { continue };
             if !matches!(event_item.sender_profile(), TimelineDetails::Ready(_)) {
-                let item = Arc::new(TimelineItem::Event(
+                let item = item.with_kind(TimelineItemKind::Event(
                     event_item.with_sender_profile(profile_state.clone()),
                 ));
                 state.items.set(idx, item);
@@ -919,20 +920,21 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
             assert_eq!(state.items.len(), num_items);
 
-            let event_item = state.items[idx].as_event().unwrap();
+            let item = state.items[idx].clone();
+            let event_item = item.as_event().unwrap();
             match maybe_profile {
                 Some(profile) => {
                     if !event_item.sender_profile().contains(&profile) {
                         let updated_item =
                             event_item.with_sender_profile(TimelineDetails::Ready(profile));
-                        state.items.set(idx, Arc::new(TimelineItem::Event(updated_item)));
+                        state.items.set(idx, item.with_kind(updated_item));
                     }
                 }
                 None => {
                     if !event_item.sender_profile().is_unavailable() {
                         let updated_item =
                             event_item.with_sender_profile(TimelineDetails::Unavailable);
-                        state.items.set(idx, Arc::new(TimelineItem::Event(updated_item)));
+                        state.items.set(idx, item.with_kind(updated_item));
                     }
                 }
             }
@@ -1028,6 +1030,7 @@ impl TimelineInner {
         };
 
         trace!("Updating in-reply-to details");
+        let internal_id = item.internal_id;
         let mut item = item.clone();
         item.set_content(TimelineItemContent::Message(
             message.with_in_reply_to(InReplyToDetails {
@@ -1035,7 +1038,7 @@ impl TimelineInner {
                 event,
             }),
         ));
-        state.items.set(index, Arc::new(item.into()));
+        state.items.set(index, timeline_item(item, internal_id));
 
         Ok(())
     }
@@ -1279,7 +1282,9 @@ async fn fetch_replied_to_event(
         event: TimelineDetails::Pending,
     });
     let event_item = item.with_content(TimelineItemContent::Message(reply), None);
-    state.items.set(index, Arc::new(event_item.into()));
+
+    let state_ref = &mut *state;
+    state_ref.items.set(index, new_timeline_item(event_item, &mut state_ref.next_internal_id));
 
     // Don't hold the state lock while the network request is made
     drop(state);
@@ -1384,7 +1389,7 @@ fn update_timeline_reaction(
         }
     }
 
-    state.items.set(idx, Arc::new(TimelineItem::Event(new_related)));
+    state.items.set(idx, timeline_item(new_related, related.internal_id));
 
     Ok(())
 }

--- a/crates/matrix-sdk-ui/src/timeline/inner.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner.rs
@@ -63,14 +63,15 @@ use super::{
         TimelineEventMetadata, TimelineItemPosition,
     },
     event_item::{EventItemIdentifier, ReactionSenderData},
+    item::{new_timeline_item, timeline_item},
     reactions::ReactionToggleResult,
-    rfind_event_by_id, rfind_event_item, timeline_item,
+    rfind_event_by_id, rfind_event_item,
     traits::RoomDataProvider,
     AnnotationKey, EventSendState, EventTimelineItem, InReplyToDetails, Message, Profile,
     RelativePosition, RepliedToEvent, TimelineDetails, TimelineItem, TimelineItemContent,
     TimelineItemKind,
 };
-use crate::{events::SyncTimelineEventWithoutContent, timeline::new_timeline_item};
+use crate::events::SyncTimelineEventWithoutContent;
 
 #[derive(Clone, Debug)]
 pub(super) struct TimelineInner<P: RoomDataProvider = room::Common> {

--- a/crates/matrix-sdk-ui/src/timeline/item.rs
+++ b/crates/matrix-sdk-ui/src/timeline/item.rs
@@ -39,7 +39,7 @@ impl TimelineItem {
     }
 
     /// Get the inner `EventTimelineItem`, if this is a
-    /// `TimelineItemKind::Event`.
+    /// [`TimelineItemKind::Event`].
     pub fn as_event(&self) -> Option<&EventTimelineItem> {
         match &self.kind {
             TimelineItemKind::Event(v) => Some(v),
@@ -48,7 +48,7 @@ impl TimelineItem {
     }
 
     /// Get the inner `VirtualTimelineItem`, if this is a
-    /// `TimelineItemKind::Virtual`.
+    /// [`TimelineItemKind::Virtual`].
     pub fn as_virtual(&self) -> Option<&VirtualTimelineItem> {
         match &self.kind {
             TimelineItemKind::Virtual(v) => Some(v),

--- a/crates/matrix-sdk-ui/src/timeline/item.rs
+++ b/crates/matrix-sdk-ui/src/timeline/item.rs
@@ -1,0 +1,125 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{ops::Deref, sync::Arc};
+
+use super::{EventTimelineItem, VirtualTimelineItem};
+
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum TimelineItemKind {
+    /// An event or aggregation of multiple events.
+    Event(EventTimelineItem),
+    /// An item that doesn't correspond to an event, for example the user's
+    /// own read marker.
+    Virtual(VirtualTimelineItem),
+}
+
+/// A single entry in timeline.
+#[derive(Clone, Debug)]
+pub struct TimelineItem {
+    pub(crate) kind: TimelineItemKind,
+    pub(crate) internal_id: u64,
+}
+
+impl TimelineItem {
+    pub(crate) fn with_kind(&self, kind: impl Into<TimelineItemKind>) -> Arc<Self> {
+        Arc::new(Self { kind: kind.into(), internal_id: self.internal_id })
+    }
+
+    /// Get the inner `EventTimelineItem`, if this is a
+    /// `TimelineItemKind::Event`.
+    pub fn as_event(&self) -> Option<&EventTimelineItem> {
+        match &self.kind {
+            TimelineItemKind::Event(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get the inner `VirtualTimelineItem`, if this is a
+    /// `TimelineItemKind::Virtual`.
+    pub fn as_virtual(&self) -> Option<&VirtualTimelineItem> {
+        match &self.kind {
+            TimelineItemKind::Virtual(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get a unique ID for this timeline item.
+    ///
+    /// It identifies the item on a best-effort basis. For instance, edits
+    /// to an [`EventTimelineItem`] will not change the ID of the
+    /// enclosing `TimelineItem`. For some virtual items like day
+    /// dividers, identity isn't easy to define though and you might
+    /// see a new ID getting generated for a day divider that you
+    /// perceive to be "the same" as a previous one.
+    pub fn unique_id(&self) -> u64 {
+        self.internal_id
+    }
+
+    pub(crate) fn read_marker() -> Arc<TimelineItem> {
+        Arc::new(Self {
+            kind: TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker),
+            internal_id: u64::MAX,
+        })
+    }
+
+    pub(crate) fn is_virtual(&self) -> bool {
+        matches!(self.kind, TimelineItemKind::Virtual(_))
+    }
+
+    pub(crate) fn is_day_divider(&self) -> bool {
+        matches!(self.kind, TimelineItemKind::Virtual(VirtualTimelineItem::DayDivider(_)))
+    }
+
+    pub(crate) fn is_read_marker(&self) -> bool {
+        matches!(self.kind, TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker))
+    }
+}
+
+impl Deref for TimelineItem {
+    type Target = TimelineItemKind;
+
+    fn deref(&self) -> &Self::Target {
+        &self.kind
+    }
+}
+
+impl From<EventTimelineItem> for TimelineItemKind {
+    fn from(item: EventTimelineItem) -> Self {
+        Self::Event(item)
+    }
+}
+
+impl From<VirtualTimelineItem> for TimelineItemKind {
+    fn from(item: VirtualTimelineItem) -> Self {
+        Self::Virtual(item)
+    }
+}
+
+pub(crate) fn timeline_item(
+    kind: impl Into<TimelineItemKind>,
+    internal_id: u64,
+) -> Arc<TimelineItem> {
+    Arc::new(TimelineItem { kind: kind.into(), internal_id })
+}
+
+pub(crate) fn new_timeline_item(
+    kind: impl Into<TimelineItemKind>,
+    next_internal_id: &mut u64,
+) -> Arc<TimelineItem> {
+    let internal_id = *next_internal_id;
+    *next_internal_id += 1;
+    timeline_item(kind, internal_id)
+}

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -25,7 +25,7 @@ use tracing::{error, warn};
 
 use super::{
     compare_events_positions, event_item::EventTimelineItemKind, inner::TimelineInnerState,
-    rfind_event_by_id, timeline_item, traits::RoomDataProvider, EventTimelineItem,
+    item::timeline_item, rfind_event_by_id, traits::RoomDataProvider, EventTimelineItem,
     RelativePosition, TimelineItem,
 };
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -34,8 +34,8 @@ use stream_assert::assert_next_matches;
 
 use super::{sync_timeline_event, TestTimeline, ALICE, BOB};
 use crate::timeline::{
-    event_item::AnyOtherFullStateEventContent, MembershipChange, TimelineDetails, TimelineItem,
-    TimelineItemContent, VirtualTimelineItem,
+    event_item::AnyOtherFullStateEventContent, MembershipChange, TimelineDetails,
+    TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
 };
 
 #[async_test]
@@ -56,7 +56,7 @@ async fn initial_events() {
         .await;
 
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
-    assert_matches!(&*item, TimelineItem::Virtual(VirtualTimelineItem::DayDivider(_)));
+    assert_matches!(&item.kind, TimelineItemKind::Virtual(VirtualTimelineItem::DayDivider(_)));
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     assert_eq!(item.as_event().unwrap().sender(), *ALICE);
     let item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -203,8 +203,11 @@ async fn dedup_pagination() {
 
     let timeline_items = timeline.inner.items().await;
     assert_eq!(timeline_items.len(), 2);
-    assert_matches!(*timeline_items[0], TimelineItem::Virtual(VirtualTimelineItem::DayDivider(_)));
-    assert_matches!(*timeline_items[1], TimelineItem::Event(_));
+    assert_matches!(
+        timeline_items[0].kind,
+        TimelineItemKind::Virtual(VirtualTimelineItem::DayDivider(_))
+    );
+    assert_matches!(timeline_items[1].kind, TimelineItemKind::Event(_));
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -23,7 +23,7 @@ use ruma::{
 use stream_assert::assert_next_matches;
 
 use super::{TestTimeline, ALICE, BOB};
-use crate::timeline::{TimelineItem, VirtualTimelineItem};
+use crate::timeline::{TimelineItemKind, VirtualTimelineItem};
 
 #[async_test]
 async fn day_divider() {
@@ -132,7 +132,7 @@ async fn update_read_marker() {
 
     // Now the read marker is reinserted after the second event.
     let marker = assert_next_matches!(stream, VectorDiff::Insert { index: 3, value } => value);
-    assert_matches!(*marker, TimelineItem::Virtual(VirtualTimelineItem::ReadMarker));
+    assert_matches!(marker.kind, TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker));
 
     // Nothing should happen if the fully read event is set back to an older event.
     timeline.inner.set_fully_read_event(first_event_id).await;
@@ -153,5 +153,5 @@ async fn update_read_marker() {
     // The read marker is moved after the third event.
     assert_next_matches!(stream, VectorDiff::Remove { index: 3 });
     let marker = assert_next_matches!(stream, VectorDiff::Insert { index: 4, value } => value);
-    assert_matches!(*marker, TimelineItem::Virtual(VirtualTimelineItem::ReadMarker));
+    assert_matches!(marker.kind, TimelineItemKind::Virtual(VirtualTimelineItem::ReadMarker));
 }

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -11,7 +11,7 @@ use matrix_sdk_ui::{
         ALL_ROOMS_LIST_NAME as ALL_ROOMS, INVITES_LIST_NAME as INVITES,
         VISIBLE_ROOMS_LIST_NAME as VISIBLE_ROOMS,
     },
-    timeline::{TimelineItem, VirtualTimelineItem},
+    timeline::{TimelineItemKind, VirtualTimelineItem},
     RoomListService,
 };
 use ruma::{
@@ -2027,12 +2027,12 @@ async fn test_room_timeline() -> Result<(), Error> {
 
     // Previous timeline items.
     assert_matches!(
-        previous_timeline_items[0].as_ref(),
-        TimelineItem::Virtual(VirtualTimelineItem::DayDivider(_))
+        **previous_timeline_items[0],
+        TimelineItemKind::Virtual(VirtualTimelineItem::DayDivider(_))
     );
     assert_matches!(
-        previous_timeline_items[1].as_ref(),
-        TimelineItem::Event(item) => {
+        &**previous_timeline_items[1],
+        TimelineItemKind::Event(item) => {
             assert_eq!(item.event_id().unwrap().as_str(), "$x0:bar.org");
         }
     );

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -20,7 +20,7 @@ use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, executor::spawn, ruma::MilliSecondsSinceUnixEpoch};
 use matrix_sdk_test::{async_test, EventBuilder, JoinedRoomBuilder, TimelineTestEvent};
 use matrix_sdk_ui::timeline::{
-    EventSendState, RoomExt, TimelineItem, TimelineItemContent, VirtualTimelineItem,
+    EventSendState, RoomExt, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
 };
 use ruma::{
     event_id,
@@ -121,7 +121,7 @@ async fn echo() {
         timeline_stream.next().await,
         Some(VectorDiff::PushBack { value }) => value
     );
-    assert_matches!(&*new_item, TimelineItem::Virtual(VirtualTimelineItem::DayDivider(_)));
+    assert_matches!(**new_item, TimelineItemKind::Virtual(VirtualTimelineItem::DayDivider(_)));
 
     // Remote echo is added
     let remote_echo = assert_matches!(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -22,7 +22,9 @@ use matrix_sdk::{
     SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
 };
 use matrix_sdk_test::async_test;
-use matrix_sdk_ui::timeline::{SlidingSyncRoomExt, TimelineItem, VirtualTimelineItem};
+use matrix_sdk_ui::timeline::{
+    SlidingSyncRoomExt, TimelineItem, TimelineItemKind, VirtualTimelineItem,
+};
 use ruma::{room_id, RoomId};
 use serde_json::json;
 use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
@@ -80,8 +82,8 @@ macro_rules! assert_timeline_stream {
                         $stream.next().now_or_never(),
                         Some(Some(VectorDiff::PushBack { value })) => {
                             assert_matches!(
-                                value.as_ref(),
-                                TimelineItem::Virtual(
+                                **value,
+                                TimelineItemKind::Virtual(
                                     VirtualTimelineItem::DayDivider(_)
                                 )
                             );
@@ -105,8 +107,8 @@ macro_rules! assert_timeline_stream {
                         $stream.next().now_or_never(),
                         Some(Some(VectorDiff::PushBack { value })) => {
                             assert_matches!(
-                                value.as_ref(),
-                                TimelineItem::Event(event_timeline_item) => {
+                                &**value,
+                                TimelineItemKind::Event(event_timeline_item) => {
                                     assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
                                 }
                             );
@@ -130,8 +132,8 @@ macro_rules! assert_timeline_stream {
                         $stream.next().now_or_never(),
                         Some(Some(VectorDiff::Insert { index: $index, value })) => {
                             assert_matches!(
-                                value.as_ref(),
-                                TimelineItem::Event(event_timeline_item) => {
+                                &**value,
+                                TimelineItemKind::Event(event_timeline_item) => {
                                     assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
                                 }
                             );
@@ -155,8 +157,8 @@ macro_rules! assert_timeline_stream {
                         $stream.next().now_or_never(),
                         Some(Some(VectorDiff::Set { index: $index, value })) => {
                             assert_matches!(
-                                value.as_ref(),
-                                TimelineItem::Event(event_timeline_item) => {
+                                &**value,
+                                TimelineItemKind::Event(event_timeline_item) => {
                                     assert_eq!(event_timeline_item.event_id().unwrap().as_str(), $event_id);
                                 }
                             );


### PR DESCRIPTION
Adding an interna unique id that we can use to identify any timeline item. This will allow for clients to understand when a timeline item has actually just changed its internal state/event, or has been just moved around, or if a new one has been inserted or a new one been deleted