### PR TITLE
feat: Only restart growing the allRooms list in case of errors

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -71,8 +71,14 @@ impl State {
                     }
 
                     Running => {
-                        // Refresh the lists.
-                        (Running, Actions::refresh_lists())
+                        // Refresh the lists only if our sync ran into an error (in particular,
+                        // when the session was invalidated by the server). Otherwise, keep on
+                        // iterating on the previous list.
+                        if matches!(self, Error { .. }) {
+                            (Running, Actions::refresh_lists())
+                        } else {
+                            (Running, Actions::none())
+                        }
                     }
 
                     Error { .. } | Terminated { .. } => {

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -970,9 +970,9 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // In `Running`, the sync-mode is still growing, but the range
-                    // hasn't been modified due to previous termination.
-                    "ranges": [[0, 49]],
+                    // In `Running`, the sync-mode is still growing, the previous termination
+                    // didn't restart the whole growing.
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     // We have set a viewport, which reflects here.
@@ -1013,9 +1013,9 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // In `Running`, the sync-mode is still growing, but the range
-                    // hasn't been modified due to the previous termination.
-                    "ranges": [[0, 49]],
+                    // In `Running`, the sync-mode is still growing, the previous termination
+                    // didn't restart the whole growing.
+                    "ranges": [[0, 109]],
                 },
                 VISIBLE_ROOMS: {
                     // Despites the termination, the range is kept.
@@ -1049,8 +1049,8 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // No termination. The range is making progress.
-                    "ranges": [[0, 99]],
+                    // No termination.
+                    "ranges": [[0, 109]],
                 },
                 VISIBLE_ROOMS: {
                     // No termination. The range is still here.
@@ -1088,10 +1088,9 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // A termination was received at the previous sync iteration.
-                    // The list is still in growing sync-mode, but its range has
-                    // been reset.
-                    "ranges": [[0, 49]],
+                    // The termination doesn't invalidate the range, we're still in the stable
+                    // state.
+                    "ranges": [[0, 109]],
                 },
                 VISIBLE_ROOMS: {
                     // The range is still here.


### PR DESCRIPTION
When the sync has been terminated and restarts (e.g. an app is going from the background to the foreground), then the sliding sync is always restarting in growing mode, independently of the previous state of the sync (error or normal termination). This is something the current sliding sync proxy can't handle nicely, because it prioritizes a change in parameters over the delivery of live data. As a matter of fact, to get a quicker response from the proxy, we can try to only restart in growing mode if we ran into an error (and not if we had a normal termination).