### PR TITLE
sdk: Remove questionable use of assign! macro

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -783,10 +783,8 @@ impl StickyData for SlidingSyncStickyParameters {
     type Request = v4::Request;
 
     fn apply(&self, request: &mut Self::Request) {
-        assign!(request, {
-            room_subscriptions: self.room_subscriptions.clone(),
-            extensions: self.extensions.clone(),
-        });
+        request.room_subscriptions = self.room_subscriptions.clone();
+        request.extensions = self.extensions.clone();
     }
 }
 


### PR DESCRIPTION
The assign macro is for returning a modified instance of something. Here we don't return, so just using assigns directly makes more sense. Fixes a rust-analyzer warning.
