### PR TITLE
feat: Immediately fail if a sliding sync request failed (follow up of #2209)

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -1,10 +1,10 @@
 //! Sliding Sync errors.
 
 use thiserror::Error;
+use tokio::task::JoinError;
 
 /// Internal representation of errors in Sliding Sync.
 #[derive(Error, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
 #[non_exhaustive]
 pub enum Error {
     /// The response we've received from the server can't be parsed or doesn't
@@ -41,6 +41,11 @@ pub enum Error {
     InvalidSlidingSyncIdentifier,
 
     /// A task failed to execute to completion.
-    #[error("A task failed to execute to completion; task description: {0}")]
-    JoinError(String),
+    #[error("A task failed to execute to completion; task description: {task_description}")]
+    JoinError {
+        /// Task description.
+        task_description: String,
+        /// The original `JoinError`.
+        error: JoinError,
+    },
 }

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -39,4 +39,8 @@ pub enum Error {
     /// The name of the Sliding Sync instance is too long.
     #[error("The Sliding Sync instance's identifier must be less than 16 chars long")]
     InvalidSlidingSyncIdentifier,
+
+    /// A task failed to execute to completion.
+    #[error("A task failed to execute to completion; task description: {0}")]
+    JoinError(String),
 }

--- a/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/request_generator.rs
@@ -326,53 +326,57 @@ fn create_range(
 
 #[cfg(test)]
 mod tests {
+    use std::ops::RangeInclusive;
+
+    use assert_matches::assert_matches;
+
     use super::*;
 
     #[test]
     fn test_create_range_from() {
         // From 0, we want 100 items.
-        assert_eq!(create_range(0, 100, None, None), Ok(0..=99));
+        assert_matches!(create_range(0, 100, None, None), Ok(range) if range == RangeInclusive::new(0, 99));
 
         // From 100, we want 100 items.
-        assert_eq!(create_range(100, 100, None, None), Ok(100..=199));
+        assert_matches!(create_range(100, 100, None, None), Ok(range) if range == RangeInclusive::new(100, 199));
 
         // From 0, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 50.
-        assert_eq!(create_range(0, 100, Some(50), None), Ok(0..=49));
+        assert_matches!(create_range(0, 100, Some(50), None), Ok(range) if range == RangeInclusive::new(0, 49));
 
         // From 49, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 50. There is 1 item to load.
-        assert_eq!(create_range(49, 100, Some(50), None), Ok(49..=49));
+        assert_matches!(create_range(49, 100, Some(50), None), Ok(range) if range == RangeInclusive::new(49, 49));
 
         // From 50, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 50.
-        assert_eq!(
+        assert_matches!(
             create_range(50, 100, Some(50), None),
             Err(Error::InvalidRange { start: 50, end: 49 })
         );
 
         // From 0, we want 100 items, but there is a maximum number of rooms defined at
         // 50.
-        assert_eq!(create_range(0, 100, None, Some(50)), Ok(0..=49));
+        assert_matches!(create_range(0, 100, None, Some(50)), Ok(range) if range == RangeInclusive::new(0, 49));
 
         // From 49, we want 100 items, but there is a maximum number of rooms defined at
         // 50. There is 1 item to load.
-        assert_eq!(create_range(49, 100, None, Some(50)), Ok(49..=49));
+        assert_matches!(create_range(49, 100, None, Some(50)), Ok(range) if range == RangeInclusive::new(49, 49));
 
         // From 50, we want 100 items, but there is a maximum number of rooms defined at
         // 50.
-        assert_eq!(
+        assert_matches!(
             create_range(50, 100, None, Some(50)),
             Err(Error::InvalidRange { start: 50, end: 49 })
         );
 
         // From 0, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 75, and a maximum number of rooms defined at 50.
-        assert_eq!(create_range(0, 100, Some(75), Some(50)), Ok(0..=49));
+        assert_matches!(create_range(0, 100, Some(75), Some(50)), Ok(range) if range == RangeInclusive::new(0, 49));
 
         // From 0, we want 100 items, but there is a maximum number of rooms to fetch
         // defined at 50, and a maximum number of rooms defined at 75.
-        assert_eq!(create_range(0, 100, Some(50), Some(75)), Ok(0..=49));
+        assert_matches!(create_range(0, 100, Some(50), Some(75)), Ok(range) if range == RangeInclusive::new(0, 49));
     }
 
     #[test]

--- a/crates/matrix-sdk/src/sliding_sync/utils.rs
+++ b/crates/matrix-sdk/src/sliding_sync/utils.rs
@@ -12,7 +12,7 @@ use tokio::task::{JoinError, JoinHandle};
 pub(crate) struct AbortOnDrop<T>(JoinHandle<T>);
 
 impl<T> AbortOnDrop<T> {
-    pub fn new(join_handle: JoinHandle<T>) -> Self {
+    fn new(join_handle: JoinHandle<T>) -> Self {
         Self(join_handle)
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/utils.rs
+++ b/crates/matrix-sdk/src/sliding_sync/utils.rs
@@ -1,0 +1,43 @@
+//! Moaaar features for Sliding Sync.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::task::{JoinError, JoinHandle};
+
+/// Private type to ensure a task is aborted on drop.
+pub(crate) struct AbortOnDrop<T>(JoinHandle<T>);
+
+impl<T> AbortOnDrop<T> {
+    pub fn new(join_handle: JoinHandle<T>) -> Self {
+        Self(join_handle)
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+impl<T> Future for AbortOnDrop<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+/// Private trait to create a `AbortOnDrop` from a `JoinHandle`.
+pub(crate) trait JoinHandleExt<T> {
+    fn abort_on_drop(self) -> AbortOnDrop<T>;
+}
+
+impl<T> JoinHandleExt<T> for JoinHandle<T> {
+    fn abort_on_drop(self) -> AbortOnDrop<T> {
+        AbortOnDrop::new(self)
+    }
+}


### PR DESCRIPTION
Closes #2209.
Fixes #2206.

This patch is a follow-up of #2209. It implements `AbortOnDrop` and `JoinHandleExt` (thanks @jplatte) to ensure that the task sending E2EE requests cannot be detached.

Also, this patch moves the error log (about E2EE requests failure) inside the task.