### PR TITLE
Add `verify` method to `device` bindings

### DIFF
--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Next version
+
+-   Add `verify` method to `Device`.
+
 # v0.1.0
 
 ## Changes in the Javascript bindings

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -9,7 +9,7 @@ use crate::{
     identifiers::{self, DeviceId, UserId},
     impl_from_to_inner,
     js::try_array_to_vec,
-    types, verification, vodozemac,
+    requests, types, verification, vodozemac,
 };
 
 /// A device represents a E2EE capable client of an user.
@@ -195,6 +195,17 @@ impl Device {
     #[wasm_bindgen(js_name = "firstTimeSeen")]
     pub fn first_time_seen(&self) -> u64 {
         self.inner.first_time_seen_ts().0.into()
+    }
+
+    /// Mark this device as verified.
+    ///
+    /// Returns a signature upload request that needs to be sent out.
+    pub fn verify(&self) -> Promise {
+        let device = self.inner.clone();
+
+        future_to_promise(async move {
+            Ok(requests::SignatureUploadRequest::try_from(&device.verify().await?)?)
+        })
     }
 }
 

--- a/bindings/matrix-sdk-crypto-js/src/device.rs
+++ b/bindings/matrix-sdk-crypto-js/src/device.rs
@@ -198,6 +198,7 @@ impl Device {
     }
 
     /// Mark this device as verified.
+    /// Works only if the device is owned by the current user.
     ///
     /// Returns a signature upload request that needs to be sent out.
     pub fn verify(&self) -> Promise {


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

Add `verify` method to Device bindings. I used the same implementation than `OwnUserIdentity` 

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
