### PR TITLE
ui: Spawn a background task for decryption retrying

### DIFF
--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -23,3 +23,13 @@ pub mod timeline;
 #[cfg(feature = "experimental-room-list")]
 pub use self::room_list_service::RoomListService;
 pub use self::timeline::Timeline;
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[ctor::ctor]
+fn init_logging() {
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(tracing_subscriber::fmt::layer().with_test_writer())
+        .init();
+}

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -111,7 +111,7 @@ impl TimelineBuilder {
                 .await
             {
                 Ok(Some(read_receipt)) => {
-                    inner.set_initial_user_receipt(ReceiptType::Read, read_receipt);
+                    inner.set_initial_user_receipt(ReceiptType::Read, read_receipt).await;
                 }
                 Err(e) => {
                     error!("Failed to get public read receipt of own user from the store: {e}");
@@ -128,7 +128,9 @@ impl TimelineBuilder {
                 .await
             {
                 Ok(Some(private_read_receipt)) => {
-                    inner.set_initial_user_receipt(ReceiptType::ReadPrivate, private_read_receipt);
+                    inner
+                        .set_initial_user_receipt(ReceiptType::ReadPrivate, private_read_receipt)
+                        .await;
                 }
                 Err(e) => {
                     error!("Failed to get private read receipt of own user from the store: {e}");
@@ -144,7 +146,6 @@ impl TimelineBuilder {
             inner.load_fully_read_event().await;
         }
 
-        let inner = Arc::new(inner);
         let room = inner.room();
         let client = room.client();
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -97,7 +97,7 @@ const DEFAULT_SANITIZER_MODE: HtmlSanitizerMode = HtmlSanitizerMode::Compat;
 /// messages.
 #[derive(Debug)]
 pub struct Timeline {
-    inner: Arc<TimelineInner<room::Common>>,
+    inner: TimelineInner<room::Common>,
 
     start_token: Arc<Mutex<Option<String>>>,
     start_token_condvar: Arc<Condvar>,
@@ -266,14 +266,14 @@ impl Timeline {
     /// # anyhow::Ok(()) };
     /// ```
     #[cfg(feature = "e2e-encryption")]
-    pub async fn retry_decryption<'a, S: AsRef<str> + 'a>(
-        &'a self,
-        session_ids: impl IntoIterator<Item = &'a S>,
+    pub async fn retry_decryption<S: Into<String>>(
+        &self,
+        session_ids: impl IntoIterator<Item = S>,
     ) {
         self.inner
             .retry_event_decryption(
                 self.room(),
-                Some(session_ids.into_iter().map(AsRef::as_ref).collect()),
+                Some(session_ids.into_iter().map(Into::into).collect()),
             )
             .await;
     }

--- a/crates/matrix-sdk-ui/src/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/src/timeline/queue.rs
@@ -44,7 +44,7 @@ pub(super) struct LocalMessage {
 
 #[instrument(skip_all, fields(room_id = ?room.room_id()))]
 pub(super) async fn send_queued_messages(
-    timeline_inner: Arc<TimelineInner>,
+    timeline_inner: TimelineInner,
     room: room::Common,
     mut msg_receiver: Receiver<LocalMessage>,
 ) {
@@ -100,7 +100,7 @@ async fn handle_message(
     room: room::Common,
     send_task: &mut SendMessageTask,
     queue: &mut VecDeque<LocalMessage>,
-    timeline_inner: &Arc<TimelineInner>,
+    timeline_inner: &TimelineInner,
 ) {
     if queue.is_empty() && send_task.is_idle() {
         match Room::from(room) {
@@ -129,7 +129,7 @@ async fn handle_task_ready(
     result: SendMessageResult,
     send_task: &mut SendMessageTask,
     queue: &mut VecDeque<LocalMessage>,
-    timeline_inner: &Arc<TimelineInner>,
+    timeline_inner: &TimelineInner,
 ) {
     match result {
         SendMessageResult::Success { room } => {
@@ -198,7 +198,7 @@ impl SendMessageTask {
         matches!(self, Self::Idle)
     }
 
-    fn start(&mut self, room: room::Joined, timeline_inner: Arc<TimelineInner>, msg: LocalMessage) {
+    fn start(&mut self, room: room::Joined, timeline_inner: TimelineInner, msg: LocalMessage) {
         debug!("Spawning message-sending task");
         let txn_id = msg.txn_id.clone();
         let join_handle = spawn(async move {

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -14,7 +14,7 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::{collections::BTreeSet, io::Cursor, iter};
+use std::{io::Cursor, iter};
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
@@ -101,8 +101,8 @@ async fn retry_message_decryption() {
         .inner
         .retry_event_decryption_test(
             room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost"),
-            &olm_machine,
-            Some(iter::once(SESSION_ID).collect()),
+            olm_machine,
+            Some(iter::once(SESSION_ID.to_owned()).collect()),
         )
         .await;
 
@@ -192,6 +192,9 @@ async fn retry_edit_decryption() {
         )
         .await;
 
+    let items = timeline.inner.items().await;
+    assert_eq!(items.len(), 3);
+
     let mut keys = decrypt_room_key_export(Cursor::new(SESSION1_KEY), "1234").unwrap();
     keys.extend(decrypt_room_key_export(Cursor::new(SESSION2_KEY), "1234").unwrap());
 
@@ -203,7 +206,7 @@ async fn retry_edit_decryption() {
         .inner
         .retry_event_decryption_test(
             room_id!("!bdsREiCPHyZAPkpXer:morpheus.localhost"),
-            &olm_machine,
+            olm_machine,
             None,
         )
         .await;
@@ -306,8 +309,8 @@ async fn retry_edit_and_more() {
         .inner
         .retry_event_decryption_test(
             room_id!("!wFnAUSQbxMcfIMgvNX:flipdot.org"),
-            &olm_machine,
-            Some(BTreeSet::from_iter([SESSION_ID])),
+            olm_machine,
+            Some(iter::once(SESSION_ID.to_owned()).collect()),
         )
         .await;
 
@@ -391,8 +394,8 @@ async fn retry_message_decryption_highlighted() {
         .inner
         .retry_event_decryption_test(
             room_id!("!rYtFvMGENJleNQVJzb:matrix.org"),
-            &olm_machine,
-            Some(iter::once(SESSION_ID).collect()),
+            olm_machine,
+            Some(iter::once(SESSION_ID.to_owned()).collect()),
         )
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -367,6 +367,7 @@ impl TestTimeline {
     }
 }
 
+#[derive(Clone)]
 struct TestRoomDataProvider;
 
 #[async_trait]

--- a/crates/matrix-sdk-ui/src/timeline/to_device.rs
+++ b/crates/matrix-sdk-ui/src/timeline/to_device.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{iter, sync::Arc};
+use std::iter;
 
 use matrix_sdk::{event_handler::EventHandler, Client};
 use ruma::{
@@ -24,7 +24,7 @@ use tracing::{debug_span, error, trace, Instrument};
 use super::inner::TimelineInner;
 
 pub(super) fn handle_room_key_event(
-    inner: Arc<TimelineInner>,
+    inner: TimelineInner,
     room_id: OwnedRoomId,
 ) -> impl EventHandler<ToDeviceRoomKeyEvent, (Client,)> {
     move |event: ToDeviceRoomKeyEvent, client: Client| {
@@ -40,7 +40,7 @@ pub(super) fn handle_room_key_event(
 }
 
 pub(super) fn handle_forwarded_room_key_event(
-    inner: Arc<TimelineInner>,
+    inner: TimelineInner,
     room_id: OwnedRoomId,
 ) -> impl EventHandler<ToDeviceForwardedRoomKeyEvent, (Client,)> {
     move |event: ToDeviceForwardedRoomKeyEvent, client: Client| {
@@ -57,7 +57,7 @@ pub(super) fn handle_forwarded_room_key_event(
 
 async fn retry_decryption(
     client: Client,
-    inner: Arc<TimelineInner>,
+    inner: TimelineInner,
     room_id: OwnedRoomId,
     event_room_id: OwnedRoomId,
     session_id: String,
@@ -75,5 +75,5 @@ async fn retry_decryption(
         return;
     };
 
-    inner.retry_event_decryption(&room, Some(iter::once(session_id.as_str()).collect())).await;
+    inner.retry_event_decryption(&room, Some(iter::once(session_id).collect())).await;
 }


### PR DESCRIPTION
… except for unit tests (for convenience).

Took a while to get this right, since we were borrowing a lot of things, which of course doesn't fly when you want to spawn a task.

The two removed `get_mut`s that were changed to locks could potentially be refactored away, by adding the initial events / setting the initial user receipt before wrapping `TimelineInnerState` in `Arc<Mutex<_>>>`.

Replaces #2107.