### PR TITLE
bindings: Rename subscribe_to_back_pagination_{status => state}

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -259,7 +259,7 @@ impl Room {
         }
     }
 
-    pub fn subscribe_to_back_pagination_state(
+    pub fn subscribe_to_back_pagination_status(
         &self,
         listener: Box<dyn BackPaginationStatusListener>,
     ) -> Result<Arc<TaskHandle>, ClientError> {

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -230,12 +230,12 @@ impl Timeline {
             }
         }
 
-        let back_pagination_state = if from.is_some() {
+        let status = if from.is_some() {
             BackPaginationStatus::Idle
         } else {
             BackPaginationStatus::TimelineStartReached
         };
-        self.back_pagination_status.set(back_pagination_state);
+        self.back_pagination_status.set(status);
         *start_lock = from;
 
         Ok(())


### PR DESCRIPTION
For consistency with the UI crate.

An earlier iteration of the PR called it state and I failed to change it everywhere.
