### PR TITLE
feat: add a new `NotificationClient` API :mailbox_with_mail: 

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -29,7 +29,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption", "experimental-room-list", "experimental-encryption-sync"] }
+matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption", "experimental-room-list", "experimental-encryption-sync", "experimental-notification-client"] }
 mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -24,21 +24,14 @@ use matrix_sdk::{
     },
     Client as MatrixClient,
 };
-use ruma::{
-    push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat},
-    RoomId,
-};
+use ruma::push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat};
 use serde_json::Value;
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error};
 use url::Url;
 
 use super::{room::Room, session_verification::SessionVerificationController, RUNTIME};
-use crate::{
-    client,
-    notification::{NotificationClientBuilder, NotificationItem},
-    ClientError,
-};
+use crate::{client, notification::NotificationClientBuilder, ClientError};
 
 #[derive(Clone, uniffi::Record)]
 pub struct PusherIdentifiers {
@@ -106,11 +99,6 @@ pub trait ClientDelegate: Sync + Send {
 }
 
 #[uniffi::export(callback_interface)]
-pub trait NotificationDelegate: Sync + Send {
-    fn did_receive_notification(&self, notification: NotificationItem);
-}
-
-#[uniffi::export(callback_interface)]
 pub trait ProgressWatcher: Send + Sync {
     fn transmission_progress(&self, progress: TransmissionProgress);
 }
@@ -134,7 +122,6 @@ impl From<matrix_sdk::TransmissionProgress> for TransmissionProgress {
 pub struct Client {
     pub(crate) inner: MatrixClient,
     delegate: Arc<RwLock<Option<Box<dyn ClientDelegate>>>>,
-    notification_delegate: Arc<RwLock<Option<Box<dyn NotificationDelegate>>>>,
     session_verification_controller:
         Arc<tokio::sync::RwLock<Option<SessionVerificationController>>>,
 }
@@ -160,7 +147,6 @@ impl Client {
         let client = Client {
             inner: sdk_client,
             delegate: Arc::new(RwLock::new(None)),
-            notification_delegate: Arc::new(RwLock::new(None)),
             session_verification_controller,
         };
 

--- a/bindings/matrix-sdk-ffi/src/encryption_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption_sync.rs
@@ -110,7 +110,7 @@ impl Client {
         id: String,
         listener: Box<dyn EncryptionSyncListener>,
     ) -> Result<Arc<EncryptionSync>, ClientError> {
-        self.encryption_sync(id, listener, EncryptionSyncMode::NeverStop)
+        self.encryption_sync(id, listener, EncryptionSyncMode::Loop)
     }
 
     /// Encryption loop for a notification process.
@@ -129,6 +129,14 @@ impl Client {
         listener: Box<dyn EncryptionSyncListener>,
         num_iters: u8,
     ) -> Result<Arc<EncryptionSync>, ClientError> {
-        self.encryption_sync(id, listener, EncryptionSyncMode::RunFixedIterations(num_iters))
+        self.encryption_sync(
+            id,
+            listener,
+            EncryptionSyncMode::LimitedMode {
+                num_iterations: num_iters,
+                proxy_timeout: std::time::Duration::ZERO,
+                network_timeout: std::time::Duration::ZERO,
+            },
+        )
     }
 }

--- a/bindings/matrix-sdk-ffi/src/encryption_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption_sync.rs
@@ -94,7 +94,15 @@ impl Client {
         listener: Box<dyn EncryptionSyncListener>,
     ) -> Result<Arc<EncryptionSync>, ClientError> {
         RUNTIME.block_on(async move {
-            let inner = Arc::new(MatrixEncryptionSync::new(id, self.inner.clone(), None).await?);
+            let inner = Arc::new(
+                MatrixEncryptionSync::new(
+                    id,
+                    self.inner.clone(),
+                    None,
+                    matrix_sdk_ui::encryption_sync::WithLocking::Yes,
+                )
+                .await?,
+            );
 
             let handle = EncryptionSync::start(inner.clone(), listener);
 

--- a/bindings/matrix-sdk-ffi/src/encryption_sync.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption_sync.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use futures_util::{pin_mut, StreamExt as _};
-use matrix_sdk_ui::encryption_sync::{EncryptionSync as MatrixEncryptionSync, EncryptionSyncMode};
+use matrix_sdk_ui::encryption_sync::EncryptionSync as MatrixEncryptionSync;
 use tracing::{error, warn};
 
 use crate::{client::Client, error::ClientError, task_handle::TaskHandle, RUNTIME};
@@ -75,23 +75,6 @@ impl EncryptionSync {
     }
 }
 
-impl Client {
-    fn encryption_sync(
-        &self,
-        id: String,
-        listener: Box<dyn EncryptionSyncListener>,
-        mode: EncryptionSyncMode,
-    ) -> Result<Arc<EncryptionSync>, ClientError> {
-        RUNTIME.block_on(async move {
-            let inner = Arc::new(MatrixEncryptionSync::new(id, self.inner.clone(), mode).await?);
-
-            let handle = EncryptionSync::start(inner.clone(), listener);
-
-            Ok(Arc::new(EncryptionSync { _handle: handle, sync: inner }))
-        })
-    }
-}
-
 #[uniffi::export]
 impl Client {
     /// Must be called to get the encryption loop running.
@@ -110,33 +93,12 @@ impl Client {
         id: String,
         listener: Box<dyn EncryptionSyncListener>,
     ) -> Result<Arc<EncryptionSync>, ClientError> {
-        self.encryption_sync(id, listener, EncryptionSyncMode::Loop)
-    }
+        RUNTIME.block_on(async move {
+            let inner = Arc::new(MatrixEncryptionSync::new(id, self.inner.clone(), None).await?);
 
-    /// Encryption loop for a notification process.
-    ///
-    /// A fixed number of iterations can be given, to limit the time spent in
-    /// that loop.
-    ///
-    /// This should be avoided, whenever possible, and be used only in
-    /// situations where the encryption sync loop needs to run from multiple
-    /// processes at the same time (on iOS for instance, where notifications
-    /// are handled in a separate process). If you aren't in such a
-    /// situation, prefer using `Client::room_list(true)`.
-    pub fn notification_encryption_sync(
-        &self,
-        id: String,
-        listener: Box<dyn EncryptionSyncListener>,
-        num_iters: u8,
-    ) -> Result<Arc<EncryptionSync>, ClientError> {
-        self.encryption_sync(
-            id,
-            listener,
-            EncryptionSyncMode::LimitedMode {
-                num_iterations: num_iters,
-                proxy_timeout: std::time::Duration::ZERO,
-                network_timeout: std::time::Duration::ZERO,
-            },
-        )
+            let handle = EncryptionSync::start(inner.clone(), listener);
+
+            Ok(Arc::new(EncryptionSync { _handle: handle, sync: inner }))
+        })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use matrix_sdk::{self, encryption::CryptoStoreError, HttpError, IdParseError, StoreError};
-use matrix_sdk_ui::{encryption_sync, timeline};
+use matrix_sdk_ui::{encryption_sync, notification_client, timeline};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
@@ -77,6 +77,12 @@ impl From<encryption_sync::Error> for ClientError {
 
 impl From<timeline::Error> for ClientError {
     fn from(e: timeline::Error) -> Self {
+        Self::new(e)
+    }
+}
+
+impl From<notification_client::Error> for ClientError {
+    fn from(e: notification_client::Error) -> Self {
         Self::new(e)
     }
 }

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -89,26 +89,27 @@ impl NotificationClient {
         let room_id = RoomId::parse(room_id)?;
         let event_id = EventId::parse(event_id)?;
         RUNTIME.block_on(async move {
-            let notif = self
+            let item = self
                 .inner
                 .get_notification(&room_id, &event_id)
                 .await
-                .map_err(|err| ClientError::from(err))?;
-            Ok(notif.map(|notif| NotificationItem {
-                event: Arc::new(TimelineEvent(notif.event)),
+                .map_err(ClientError::from)?;
+
+            Ok(item.map(|item| NotificationItem {
+                event: Arc::new(TimelineEvent(item.event)),
                 sender_info: NotificationSenderInfo {
-                    display_name: notif.sender_display_name,
-                    avatar_url: notif.sender_avatar_url,
+                    display_name: item.sender_display_name,
+                    avatar_url: item.sender_avatar_url,
                 },
                 room_info: NotificationRoomInfo {
-                    display_name: notif.room_display_name,
-                    avatar_url: notif.room_avatar_url,
-                    canonical_alias: notif.room_canonical_alias,
-                    joined_members_count: notif.joined_members_count,
-                    is_encrypted: notif.is_room_encrypted,
-                    is_direct: notif.is_direct_message_room,
+                    display_name: item.room_display_name,
+                    avatar_url: item.room_avatar_url,
+                    canonical_alias: item.room_canonical_alias,
+                    joined_members_count: item.joined_members_count,
+                    is_encrypted: item.is_room_encrypted,
+                    is_direct: item.is_direct_message_room,
                 },
-                is_noisy: notif.is_noisy,
+                is_noisy: item.is_noisy,
             }))
         })
     }

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -1,4 +1,3 @@
-use crate::RUNTIME;
 use std::sync::Arc;
 
 use matrix_sdk_ui::notification_client::{
@@ -7,7 +6,7 @@ use matrix_sdk_ui::notification_client::{
 };
 use ruma::{EventId, RoomId};
 
-use crate::{error::ClientError, event::TimelineEvent, helpers::unwrap_or_clone_arc};
+use crate::{error::ClientError, event::TimelineEvent, helpers::unwrap_or_clone_arc, RUNTIME};
 
 #[derive(uniffi::Record)]
 pub struct NotificationSenderInfo {
@@ -48,18 +47,21 @@ impl NotificationClientBuilder {
 
 #[uniffi::export]
 impl NotificationClientBuilder {
-    /// Filter out the notification event according to the push rules present in the event.
+    /// Filter out the notification event according to the push rules present in
+    /// the event.
     pub fn filter_by_push_rules(self: Arc<Self>) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
         let builder = this.builder.filter_by_push_rules();
         Arc::new(Self { builder })
     }
 
-    /// Automatically retry decryption once, if the notification was received encrypted.
+    /// Automatically retry decryption once, if the notification was received
+    /// encrypted.
     ///
-    /// The boolean indicates whether we're making use of a cross-process lock for the
-    /// crypto-store. This should be set to true, if and only if, the notification is received in a
-    /// process that's different from the main app.
+    /// The boolean indicates whether we're making use of a cross-process lock
+    /// for the crypto-store. This should be set to true, if and only if,
+    /// the notification is received in a process that's different from the
+    /// main app.
     pub fn retry_decryption(self: Arc<Self>, with_cross_process_lock: bool) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
         let builder = this.builder.retry_decryption(with_cross_process_lock);

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -4,15 +4,16 @@ version = "0.6.0"
 edition = "2021"
 
 [features]
-default = ["e2e-encryption", "native-tls", "experimental-room-list", "experimental-encryption-sync"]
+default = ["e2e-encryption", "native-tls", "experimental-room-list", "experimental-encryption-sync", "experimental-notification-client"]
 
 e2e-encryption = ["matrix-sdk/e2e-encryption"]
 
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
 
-experimental-room-list = ["experimental-sliding-sync", "dep:async-stream", "dep:eyeball-im-util"]
 experimental-encryption-sync = ["experimental-sliding-sync", "dep:async-stream"]
+experimental-notification-client = ["experimental-encryption-sync"]
+experimental-room-list = ["experimental-sliding-sync", "dep:async-stream", "dep:eyeball-im-util"]
 experimental-sliding-sync = ["matrix-sdk/experimental-sliding-sync"]
 
 testing = ["dep:eyeball-im-util"]

--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -148,7 +148,7 @@ impl EncryptionSync {
 
                 if lock_guard.is_none() {
                     tracing::debug!(
-                        "Second attempt at locking outside the main app failed, so aborting."
+                        "Second attempt at locking outside the main app failed, aborting."
                     );
                     return Ok(());
                 }

--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -42,6 +42,16 @@ pub enum WithLocking {
     No,
 }
 
+impl From<bool> for WithLocking {
+    fn from(value: bool) -> Self {
+        if value {
+            Self::Yes
+        } else {
+            Self::No
+        }
+    }
+}
+
 /// High-level helper for synchronizing encryption events using sliding sync.
 ///
 /// See the module's documentation for more details.

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -16,6 +16,8 @@ mod events;
 
 #[cfg(feature = "experimental-encryption-sync")]
 pub mod encryption_sync;
+#[cfg(feature = "experimental-notification-client")]
+pub mod notification_client;
 #[cfg(feature = "experimental-room-list")]
 pub mod room_list_service;
 pub mod timeline;

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Matrix.org Foundation C.I.C..
+// Copyright 2023 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -224,7 +224,6 @@ impl NotificationClientBuilder {
 /// A notification with its full content.
 pub struct NotificationItem {
     /// Underlying Ruma event.
-    /// TODO(bnjbvr) can we get rid of this?
     pub event: AnySyncTimelineEvent,
 
     /// Display name of the sender.

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -102,8 +102,9 @@ impl NotificationClient {
             )
             .await;
 
-            // Just log out errors, but don't have them abort the notification processing: an
-            // undecrypted notification is still better than no notifications.
+            // Just log out errors, but don't have them abort the notification processing:
+            // an undecrypted notification is still better than no
+            // notifications.
 
             match encryption_sync {
                 Ok(sync) => match sync.run_fixed_iterations(2).await {

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -21,25 +21,27 @@ use thiserror::Error;
 
 use crate::encryption_sync::{EncryptionSync, WithLocking};
 
-/// A client specialized for handling push notifications received over the network, for an app.
+/// A client specialized for handling push notifications received over the
+/// network, for an app.
 ///
-/// In particular, it takes care of running a full decryption sync, in case the event in the
-/// notification was impossible to decrypt beforehands.
+/// In particular, it takes care of running a full decryption sync, in case the
+/// event in the notification was impossible to decrypt beforehands.
 pub struct NotificationClient {
     /// SDK client.
     client: Client,
 
-    /// Should we retry decrypting an event, after it was impossible to decrypt on the first
-    /// attempt?
+    /// Should we retry decrypting an event, after it was impossible to decrypt
+    /// on the first attempt?
     retry_decryption: bool,
 
-    /// Should the encryption sync happening in case the notification event was encrypted use a
-    /// cross-process lock?
+    /// Should the encryption sync happening in case the notification event was
+    /// encrypted use a cross-process lock?
     ///
     /// Only meaningful if `retry_decryption` is true.
     with_cross_process_lock: bool,
 
-    /// Should we try to filter out the notification event according to the push rules?
+    /// Should we try to filter out the notification event according to the push
+    /// rules?
     filter_by_push_rules: bool,
 }
 
@@ -55,8 +57,8 @@ impl NotificationClient {
         room_id: &RoomId,
         event_id: &EventId,
     ) -> Result<Option<NotificationItem>, Error> {
-        // TODO(bnjbvr) invites don't have access to the room! Make a separate path to handle
-        // those?
+        // TODO(bnjbvr) invites don't have access to the room! Make a separate path to
+        // handle those?
         let Some(room) = self.client.get_room(&room_id) else { return Err(Error::UnknownRoom) };
 
         let mut timeline_event = room.event(&event_id).await?;
@@ -169,17 +171,20 @@ impl NotificationClientBuilder {
         }
     }
 
-    /// Filter out the notification event according to the push rules present in the event.
+    /// Filter out the notification event according to the push rules present in
+    /// the event.
     pub fn filter_by_push_rules(mut self) -> Self {
         self.filter_by_push_rules = true;
         self
     }
 
-    /// Automatically retry decryption once, if the notification was received encrypted.
+    /// Automatically retry decryption once, if the notification was received
+    /// encrypted.
     ///
-    /// The boolean indicates whether we're making use of a cross-process lock for the
-    /// crypto-store. This should be set to true, if and only if, the notification is received in a
-    /// process that's different from the main app.
+    /// The boolean indicates whether we're making use of a cross-process lock
+    /// for the crypto-store. This should be set to true, if and only if,
+    /// the notification is received in a process that's different from the
+    /// main app.
     pub fn retry_decryption(mut self, with_cross_process_lock: bool) -> Self {
         self.retry_decryption = true;
         self.with_cross_process_lock = with_cross_process_lock;
@@ -221,7 +226,8 @@ pub struct NotificationItem {
     /// Numbers of members who joined the room.
     pub joined_members_count: u64,
 
-    /// Is it a noisy notification? (i.e. does any push action contain a sound action)
+    /// Is it a noisy notification? (i.e. does any push action contain a sound
+    /// action)
     pub is_noisy: bool,
 }
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -25,7 +25,7 @@ use crate::encryption_sync::{EncryptionSync, WithLocking};
 /// network, for an app.
 ///
 /// In particular, it takes care of running a full decryption sync, in case the
-/// event in the notification was impossible to decrypt beforehands.
+/// event in the notification was impossible to decrypt beforehand.
 pub struct NotificationClient {
     /// SDK client.
     client: Client,

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -76,8 +76,7 @@ impl NotificationClient {
                 // Don't iloop retrying decryption another time.
                 retry_decryption = false;
 
-                let with_locking =
-                    if self.with_cross_process_lock { WithLocking::Yes } else { WithLocking::No };
+                let with_locking = WithLocking::from(self.with_cross_process_lock);
 
                 let encryption_sync = EncryptionSync::new(
                     "notifications".to_owned(),

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -1,0 +1,199 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for that specific language governing permissions and
+// limitations under the License.
+
+use std::{sync::Arc, time::Duration};
+
+use matrix_sdk::{room::Room, Client};
+use matrix_sdk_base::StoreError;
+use ruma::{events::AnySyncTimelineEvent, EventId, RoomId};
+use thiserror::Error;
+
+use crate::encryption_sync::{self, EncryptionSync, WithLocking};
+
+pub struct NotificationClient {
+    client: Client,
+    with_cross_process_lock: bool,
+    retry_decryption: bool,
+    filter_by_push_rules: bool,
+}
+
+impl NotificationClient {
+    pub fn builder(client: Client) -> NotificationClientBuilder {
+        NotificationClientBuilder::new(client)
+    }
+
+    pub async fn get_notification_item(
+        &self,
+        room_id: &RoomId,
+        event_id: &EventId,
+    ) -> Result<Option<NotificationItem>, Error> {
+        let Some(room) = self.client.get_room(&room_id) else { return Err(Error::UnknownRoom) };
+
+        let (ruma_event, event) = loop {
+            let ruma_event = room.event(&event_id).await?;
+            if self.filter_by_push_rules
+                && !ruma_event.push_actions.iter().any(|a| a.should_notify())
+            {
+                return Ok(None);
+            }
+
+            let event: AnySyncTimelineEvent =
+                ruma_event.event.deserialize().map_err(|_| Error::InvalidRumaEvent)?.into();
+
+            let event_type = event.event_type();
+
+            let is_still_encrypted =
+                matches!(event_type, ruma::events::TimelineEventType::RoomEncrypted);
+
+            #[cfg(feature = "unstable-msc3956")]
+            let is_still_encrypted = is_still_encrypted
+                || matches!(event_type, ruma::events::TimelineEventType::Encrypted);
+
+            if is_still_encrypted && self.retry_decryption {
+                // The message is still encrypted, and the client is configured to retry
+                // decryption.
+                //
+                // Spawn an `EncryptionSync` that runs two iterations of the sliding sync loop:
+                // - the first iteration allows to get SS events as well as send e2ee requests.
+                // - the second one let the SS proxy forward events triggered by the sending of
+                // e2ee requests.
+                //
+                // Keep timeouts small for both, since we might be short on time.
+
+                let with_locking =
+                    if self.with_cross_process_lock { WithLocking::Yes } else { WithLocking::No };
+
+                let encryption_sync = EncryptionSync::new(
+                    "notifications".to_owned(),
+                    self.client.clone(),
+                    Some((Duration::from_secs(3), Duration::from_secs(1))),
+                    with_locking,
+                )
+                .await;
+
+                if let Ok(sync) = encryption_sync {
+                    if sync.run_fixed_iterations(2).await.is_ok() {
+                        continue;
+                    }
+                }
+            }
+
+            break (ruma_event, event);
+        };
+
+        let sender = match &room {
+            Room::Invited(invited) => invited.invite_details().await?.inviter,
+            _ => room.get_member(event.sender()).await?,
+        };
+        let mut sender_display_name = None;
+        let mut sender_avatar_url = None;
+        if let Some(sender) = sender {
+            sender_display_name = sender.display_name().map(|s| s.to_owned());
+            sender_avatar_url = sender.avatar_url().map(|s| s.to_string());
+        }
+
+        let is_noisy = ruma_event.push_actions.iter().any(|a| a.sound().is_some());
+
+        let item = NotificationItem {
+            event: Arc::new(event),
+            room_id: room.room_id().to_string(),
+            sender_display_name,
+            sender_avatar_url,
+            room_display_name: room.display_name().await?.to_string(),
+            room_avatar_url: room.avatar_url().map(|s| s.to_string()),
+            room_canonical_alias: room.canonical_alias().map(|c| c.to_string()),
+            is_noisy,
+            is_direct: room.is_direct().await?,
+            is_room_encrypted: room.is_encrypted().await.ok(),
+        };
+
+        Ok(Some(item))
+    }
+}
+
+pub struct NotificationClientBuilder {
+    with_cross_process_lock: bool,
+    filter_by_push_rules: bool,
+    retry_decryption: bool,
+    client: Client,
+}
+
+impl NotificationClientBuilder {
+    fn new(client: Client) -> Self {
+        Self {
+            with_cross_process_lock: false,
+            filter_by_push_rules: false,
+            retry_decryption: false,
+            client,
+        }
+    }
+
+    pub fn with_cross_process_lock(mut self) -> Self {
+        self.with_cross_process_lock = true;
+        self
+    }
+
+    pub fn filter_by_push_rules(mut self) -> Self {
+        self.filter_by_push_rules = true;
+        self
+    }
+
+    pub fn retry_decryption(mut self) -> Self {
+        self.retry_decryption = true;
+        self
+    }
+
+    pub fn build(self) -> NotificationClient {
+        NotificationClient {
+            client: self.client,
+            with_cross_process_lock: self.with_cross_process_lock,
+            filter_by_push_rules: self.filter_by_push_rules,
+            retry_decryption: self.retry_decryption,
+        }
+    }
+}
+
+pub struct NotificationItem {
+    pub event: Arc<AnySyncTimelineEvent>,
+    pub room_id: String,
+
+    pub sender_display_name: Option<String>,
+    pub sender_avatar_url: Option<String>,
+
+    pub room_display_name: String,
+    pub room_avatar_url: Option<String>,
+    pub room_canonical_alias: Option<String>,
+
+    pub is_noisy: bool,
+    pub is_direct: bool,
+    pub is_room_encrypted: Option<bool>,
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("unknown room for a notification")]
+    UnknownRoom,
+
+    #[error("invalid ruma event")]
+    InvalidRumaEvent,
+
+    #[error(transparent)]
+    SdkError(#[from] matrix_sdk::Error),
+
+    #[error(transparent)]
+    StoreError(#[from] StoreError),
+
+    #[error(transparent)]
+    EncryptionSync(#[from] encryption_sync::Error),
+}

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -12,7 +12,7 @@
 // See the License for that specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use matrix_sdk::{room::Room, Client};
 use matrix_sdk_base::StoreError;
@@ -132,7 +132,7 @@ impl NotificationClient {
         let is_noisy = timeline_event.push_actions.iter().any(|a| a.sound().is_some());
 
         let item = NotificationItem {
-            event: Arc::new(raw_event),
+            event: raw_event,
             sender_display_name,
             sender_avatar_url,
             room_display_name: room.display_name().await?.to_string(),
@@ -151,6 +151,7 @@ impl NotificationClient {
 /// Builder for a `NotificationClient`.
 ///
 /// Fields have the same meaning as in `NotificationClient`.
+#[derive(Clone)]
 pub struct NotificationClientBuilder {
     client: Client,
     retry_decryption: bool,
@@ -200,7 +201,7 @@ impl NotificationClientBuilder {
 pub struct NotificationItem {
     /// Underlying Ruma event.
     /// TODO(bnjbvr) can we get rid of this?
-    pub event: Arc<AnySyncTimelineEvent>,
+    pub event: AnySyncTimelineEvent,
 
     /// Display name of the sender.
     pub sender_display_name: Option<String>,

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
@@ -150,7 +150,7 @@ async fn setup_mocking_sliding_sync_server(server: &MockServer) -> MockGuard {
                 "pos": pos_as_str
             }))
         })
-        .mount_as_scoped(&server)
+        .mount_as_scoped(server)
         .await
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
@@ -157,9 +157,7 @@ async fn setup_mocking_sliding_sync_server(server: &MockServer) -> MockGuard {
 async fn check_requests(server: MockServer, expected_requests: &[serde_json::Value]) {
     let mut num_requests = 0;
 
-    for request in
-        server.received_requests().await.expect("Request recording has been disabled").iter()
-    {
+    for request in &server.received_requests().await.expect("Request recording has been disabled") {
         if !SlidingSyncMatcher.matches(request) {
             continue;
         }
@@ -182,7 +180,7 @@ async fn check_requests(server: MockServer, expected_requests: &[serde_json::Val
             assert_json_diff::Config::new(assert_json_diff::CompareMode::Strict),
         ) {
             dbg!(json_value);
-            panic!("{}", error);
+            panic!("{error}");
         }
 
         num_requests += 1;

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::SlidingSync;
 use matrix_sdk_test::async_test;
@@ -10,7 +12,7 @@ async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
     let (client, server) = logged_in_client().await;
 
     let encryption_sync =
-        EncryptionSync::new("tests".to_owned(), client, EncryptionSyncMode::NeverStop).await?;
+        EncryptionSync::new("tests".to_owned(), client, EncryptionSyncMode::Loop).await?;
 
     let stream = encryption_sync.sync();
     pin_mut!(stream);
@@ -131,9 +133,16 @@ async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
 async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
     let (client, server) = logged_in_client().await;
 
-    let encryption_sync =
-        EncryptionSync::new("tests".to_owned(), client, EncryptionSyncMode::RunFixedIterations(1))
-            .await?;
+    let encryption_sync = EncryptionSync::new(
+        "tests".to_owned(),
+        client,
+        EncryptionSyncMode::LimitedMode {
+            num_iterations: 1,
+            proxy_timeout: Duration::ZERO,
+            network_timeout: Duration::ZERO,
+        },
+    )
+    .await?;
 
     let stream = encryption_sync.sync();
     pin_mut!(stream);
@@ -167,9 +176,16 @@ async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
 async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
     let (client, server) = logged_in_client().await;
 
-    let encryption_sync =
-        EncryptionSync::new("tests".to_owned(), client, EncryptionSyncMode::RunFixedIterations(2))
-            .await?;
+    let encryption_sync = EncryptionSync::new(
+        "tests".to_owned(),
+        client,
+        EncryptionSyncMode::LimitedMode {
+            num_iterations: 2,
+            proxy_timeout: Duration::ZERO,
+            network_timeout: Duration::ZERO,
+        },
+    )
+    .await?;
 
     let stream = encryption_sync.sync();
     pin_mut!(stream);
@@ -216,8 +232,7 @@ async fn test_encryption_sync_always_reloads_todevice_token() -> anyhow::Result<
     let (client, server) = logged_in_client().await;
 
     let encryption_sync =
-        EncryptionSync::new("tests".to_owned(), client.clone(), EncryptionSyncMode::NeverStop)
-            .await?;
+        EncryptionSync::new("tests".to_owned(), client.clone(), EncryptionSyncMode::Loop).await?;
 
     let stream = encryption_sync.sync();
     pin_mut!(stream);

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::SlidingSync;
 use matrix_sdk_test::async_test;
-use matrix_sdk_ui::encryption_sync::EncryptionSync;
+use matrix_sdk_ui::encryption_sync::{EncryptionSync, WithLocking};
 use serde_json::json;
 use wiremock::{Match as _, Mock, MockGuard, MockServer, Request, ResponseTemplate};
 
@@ -17,7 +17,8 @@ use crate::{
 async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
     let (client, server) = logged_in_client().await;
 
-    let encryption_sync = EncryptionSync::new("tests".to_owned(), client, None).await?;
+    let encryption_sync =
+        EncryptionSync::new("tests".to_owned(), client, None, WithLocking::Yes).await?;
 
     let stream = encryption_sync.sync();
     pin_mut!(stream);
@@ -196,7 +197,8 @@ async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
 
     let _guard = setup_mocking_sliding_sync_server(&server).await;
 
-    let encryption_sync = EncryptionSync::new("tests".to_owned(), client, None).await?;
+    let encryption_sync =
+        EncryptionSync::new("tests".to_owned(), client, None, WithLocking::Yes).await?;
 
     // Run all the iterations.
     encryption_sync.run_fixed_iterations(1).await?;
@@ -225,7 +227,8 @@ async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
 
     let _guard = setup_mocking_sliding_sync_server(&server).await;
 
-    let encryption_sync = EncryptionSync::new("tests".to_owned(), client, None).await?;
+    let encryption_sync =
+        EncryptionSync::new("tests".to_owned(), client, None, WithLocking::Yes).await?;
 
     encryption_sync.run_fixed_iterations(2).await?;
 
@@ -257,7 +260,8 @@ async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
 async fn test_encryption_sync_always_reloads_todevice_token() -> anyhow::Result<()> {
     let (client, server) = logged_in_client().await;
 
-    let encryption_sync = EncryptionSync::new("tests".to_owned(), client.clone(), None).await?;
+    let encryption_sync =
+        EncryptionSync::new("tests".to_owned(), client.clone(), None, WithLocking::Yes).await?;
 
     let stream = encryption_sync.sync();
     pin_mut!(stream);

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -28,6 +28,8 @@ use wiremock::{
 
 #[cfg(feature = "experimental-encryption-sync")]
 mod encryption_sync;
+#[cfg(feature = "experimental-notification-client")]
+mod notification_client;
 #[cfg(feature = "experimental-room-list")]
 mod room_list_service;
 mod sliding_sync;

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -1,0 +1,94 @@
+use std::time::Duration;
+
+use matrix_sdk::config::SyncSettings;
+use matrix_sdk_test::{async_test, EventBuilder, JoinedRoomBuilder, TimelineTestEvent};
+use matrix_sdk_ui::notification_client::NotificationClient;
+use ruma::{event_id, events::TimelineEventType, room_id, user_id};
+use serde_json::json;
+use wiremock::{
+    matchers::{header, method, path, path_regex},
+    Mock, ResponseTemplate,
+};
+
+use crate::{logged_in_client, mock_encryption_state, mock_sync};
+
+#[async_test]
+async fn test_notification_client_simple() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client().await;
+
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let event_id = event_id!("$example_event_id");
+    let sender = user_id!("@user:example.org");
+    let event_json = json!({
+        "content": {
+            "body": "Hello world!",
+            "msgtype": "m.text",
+        },
+        "room_id": room_id.clone(),
+        "event_id": event_id,
+        "origin_server_ts": 152049794,
+        "sender": sender.clone(),
+        "type": "m.room.message",
+    });
+
+    let mut ev_builder = EventBuilder::new();
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id.clone())
+            .add_timeline_event(TimelineTestEvent::Custom(event_json.clone())),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let notification_client = NotificationClient::builder(client).build();
+
+    {
+        Mock::given(method("GET"))
+            .and(path(format!("/_matrix/client/r0/rooms/{room_id}/event/{event_id}")))
+            .and(header("authorization", "Bearer 1234"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(event_json))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/members"))
+            .and(header("authorization", "Bearer 1234"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "chunk": [
+                {
+                    "content": {
+                        "avatar_url": null,
+                        "displayname": "John Mastodon",
+                        "membership": "join"
+                    },
+                    "room_id": room_id.clone(),
+                    "event_id": "$151800140517rfvjc:example.org",
+                    "membership": "join",
+                    "origin_server_ts": 151800140,
+                    "sender": sender.clone(),
+                    "state_key": sender,
+                    "type": "m.room.member",
+                    "unsigned": {
+                        "age": 2970366,
+                    }
+                }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        mock_encryption_state(&server, false).await;
+    }
+
+    let item = notification_client.get_notification(room_id, event_id).await.unwrap();
+
+    server.reset().await;
+
+    let item = item.expect("the notification should be found");
+
+    assert_eq!(item.event.event_type(), TimelineEventType::RoomMessage);
+    assert_eq!(item.sender_display_name.as_deref(), Some("John Mastodon"));
+}


### PR DESCRIPTION
This is extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/2204, and this implements a proper `NotificationClient`, that will take care of handling event decryption for notification events. It's also more logical to have something like this in the UI crate, instead of having custom code at the FFI layer.

For now, the FFI code has been moved, and the encryption sync usage for the notification decryption has been included there. In the future, I'm planning to add more, like properly handling invites, and more goodness to address https://github.com/matrix-org/matrix-rust-sdk/issues/2179.

I'd like to include tests too, but might be nice to do as a follow-up to not inflate this PR too much.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1962.