### PR TITLE
feat: make it possible to configure the state store as an in-memory store in FFI

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -63,11 +63,11 @@ path = "../../crates/matrix-sdk"
 default-features = false
 features = [
     "anyhow",
-    "experimental-sliding-sync",
     "e2e-encryption",
+    "experimental-sliding-sync",
     "markdown",
+    "rustls-tls", # note: differ from block below
     "socks",
-    "rustls-tls",
     "sqlite",
 ]
 
@@ -76,10 +76,10 @@ path = "../../crates/matrix-sdk"
 default-features = false
 features = [
     "anyhow",
-    "experimental-sliding-sync",
     "e2e-encryption",
+    "experimental-sliding-sync",
     "markdown",
-    "native-tls",
+    "native-tls", # note: differ from block above
     "socks",
     "sqlite",
 ]

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -22,7 +22,7 @@ pub use bytes;
 pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
     deserialized_responses,
-    store::{DynStateStore, StateStoreExt},
+    store::{DynStateStore, MemoryStore, StateStoreExt},
     DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomMemberships,
     RoomState, SessionMeta, StateChanges, StateStore, StoreError,
 };
@@ -50,7 +50,6 @@ pub mod sliding_sync;
 
 #[cfg(feature = "e2e-encryption")]
 pub mod encryption;
-
 pub use account::Account;
 pub use authentication::{AuthApi, AuthSession};
 pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, UnknownToken};
@@ -61,6 +60,8 @@ pub use error::{
     RumaApiError,
 };
 pub use http_client::TransmissionProgress;
+#[cfg(all(feature = "e2e-encryption", feature = "sqlite"))]
+pub use matrix_sdk_sqlite::SqliteCryptoStore;
 pub use media::Media;
 pub use ruma::{IdParseError, OwnedServerName, ServerName};
 #[cfg(feature = "experimental-sliding-sync")]


### PR DESCRIPTION
Part of #2179.

This allows a Frankenstein-monster-mode where we have an in-memory state store but use the actual sqlite crypto store, for the plan mentioned in https://github.com/matrix-org/matrix-rust-sdk/issues/2179#issuecomment-1625176865.