### PR TITLE
base: Fix deserialization failure leading to database corruption

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -299,7 +299,7 @@ impl BaseClient {
     fn process_sliding_sync_room_membership(
         &self,
         room_data: &v4::SlidingSyncRoom,
-        required_state: &[AnySyncStateEvent],
+        required_state: &[Option<AnySyncStateEvent>],
         store: &Store,
         room_id: &RoomId,
         changes: &mut StateChanges,
@@ -353,11 +353,11 @@ impl BaseClient {
     /// the state in room_info to reflect the "membership" property.
     pub(crate) fn handle_own_room_membership(
         &self,
-        required_state: &[AnySyncStateEvent],
+        required_state: &[Option<AnySyncStateEvent>],
         room_info: &mut RoomInfo,
     ) {
         for event in required_state {
-            if let AnySyncStateEvent::RoomMember(member) = &event {
+            if let Some(AnySyncStateEvent::RoomMember(member)) = &event {
                 // If this event updates the current user's membership, record that in the
                 // room_info.
                 if let Some(meta) = self.session_meta() {


### PR DESCRIPTION
f36a5b8cd71fc2185d55f098b4b62307431db506 introduced `deserialize_events`, moving the deserialization out of `handle_state`. However, the new code in `deserialize_events` used `filter_map`, which caused a deserialization failure to lead to the indices of the serialized and deserialized events to no longer match up.

This was not caught because `iter::zip` also does not require that its arguments have matching lengths, causing the mismatch to cascade for that batch of events, and persist in the store.  An application affected by this form of corruption can, for example, call `room.get_state_events` requesting events of a certain type, and getting back events of a different type.

Fix the bug by using `Option` to preserve the length of `deserialize_events`' return value, and add an assertion to ensure `handle_state`'s contract.

- [ ] Public API changes documented in changelogs (optional)

Signed-off-by: Vladimir Panteleev <git@cy.md>
