### PR TITLE
ffi: Send initial back-pagination status to subscriber immediately

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -274,6 +274,9 @@ impl Room {
         };
 
         Ok(Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
+            // Send the current state even if it hasn't changed right away.
+            listener.on_update(subscriber.next_now());
+
             while let Some(status) = subscriber.next().await {
                 listener.on_update(status);
             }


### PR DESCRIPTION
… right as the subscriber is registered. Previously it wasn't possible to get the current state without waiting for an update. Buf reported by @ganfra.