### PR TITLE
feat: split the `SlidingSyncBuilder` `with_timeouts` method into two

### DIFF
--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -71,7 +71,7 @@ impl EncryptionSync {
     pub async fn new(
         process_id: String,
         client: Client,
-        proxy_and_network_timeouts: Option<(Duration, Duration)>,
+        poll_and_network_timeouts: Option<(Duration, Duration)>,
         with_locking: WithLocking,
     ) -> Result<Self, Error> {
         // Make sure to use the same `conn_id` and caching store identifier, whichever
@@ -85,8 +85,8 @@ impl EncryptionSync {
             )
             .with_e2ee_extension(assign!(v4::E2EEConfig::default(), { enabled: Some(true)}));
 
-        if let Some((proxy_timeout, network_timeout)) = proxy_and_network_timeouts {
-            builder = builder.with_timeouts(proxy_timeout, network_timeout);
+        if let Some((poll_timeout, network_timeout)) = poll_and_network_timeouts {
+            builder = builder.poll_timeout(poll_timeout).network_timeout(network_timeout);
         }
 
         let sliding_sync = builder.build().await.map_err(Error::SlidingSync)?;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -87,7 +87,7 @@ pub(super) struct SlidingSyncInner {
     client: Client,
 
     /// Long-polling timeout that appears the sliding sync proxy request.
-    polling_timeout: Duration,
+    poll_timeout: Duration,
 
     /// Extra duration for the sliding sync request to timeout. This is added to
     /// the [`Self::proxy_timeout`].
@@ -414,7 +414,7 @@ impl SlidingSync {
             conn_id: Some(self.inner.id.clone()),
             pos,
             delta_token,
-            timeout: Some(self.inner.polling_timeout),
+            timeout: Some(self.inner.poll_timeout),
             lists: requests_lists,
             unsubscribe_rooms: room_unsubscriptions.iter().cloned().collect(),
         });
@@ -454,8 +454,7 @@ impl SlidingSync {
             request,
             // Configure long-polling. We need some time for the long-poll itself,
             // and extra time for the network delays.
-            RequestConfig::default()
-                .timeout(self.inner.polling_timeout + self.inner.network_timeout),
+            RequestConfig::default().timeout(self.inner.poll_timeout + self.inner.network_timeout),
             room_unsubscriptions,
         ))
     }


### PR DESCRIPTION
Following a comment from Jonas in another PR.