### PR TITLE
ffi: Provide tokio context for async exported method

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -320,11 +320,17 @@ impl RoomListItem {
     fn unsubscribe(&self) {
         self.inner.unsubscribe();
     }
+}
 
+#[uniffi::export(async_runtime = "tokio")]
+impl RoomListItem {
     async fn latest_event(&self) -> Option<Arc<EventTimelineItem>> {
         self.inner.latest_event().await.map(EventTimelineItem).map(Arc::new)
     }
+}
 
+#[uniffi::export]
+impl RoomListItem {
     fn has_unread_notifications(&self) -> bool {
         self.inner.has_unread_notifications()
     }


### PR DESCRIPTION
Fixes `there is no reactor running, must be called from the context of a tokio runtime` errors.