### PR TITLE
Fix `receiveSyncChanges` js bindings, and release 0.1.3

### DIFF
--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,4 +1,11 @@
+# v0.1.3
+
+Fix bug introduced in v0.1.2 which caused an undocumented change to the results of `OlmMachine.receiveSyncChanges`.
+
 # v0.1.2
+
+**WARNING**: this version had a breaking change in the result type of `OlmMachine.receiveSyncChanges`.
+This is corrected in v0.1.3.
 
 ## Changes in the Javascript bindings
 

--- a/bindings/matrix-sdk-crypto-js/CHANGELOG.md
+++ b/bindings/matrix-sdk-crypto-js/CHANGELOG.md
@@ -1,6 +1,12 @@
 # v0.1.3
 
-Fix bug introduced in v0.1.2 which caused an undocumented change to the results of `OlmMachine.receiveSyncChanges`.
+## Changes in the Javascript bindings
+
+-   Fix bug introduced in v0.1.2 which caused an undocumented change to the results of `OlmMachine.receiveSyncChanges`.
+
+## Changes in the underlying Rust crate
+
+-   Fix a bug which could cause generated one-time-keys not to be persisted.
 
 # v0.1.2
 

--- a/bindings/matrix-sdk-crypto-js/package.json
+++ b/bindings/matrix-sdk-crypto-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@matrix-org/matrix-sdk-crypto-js",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "homepage": "https://github.com/matrix-org/matrix-rust-sdk",
     "description": "Matrix encryption library, for JavaScript",
     "license": "Apache-2.0",

--- a/bindings/matrix-sdk-crypto-js/tests/helper.js
+++ b/bindings/matrix-sdk-crypto-js/tests/helper.js
@@ -20,7 +20,7 @@ async function addMachineToMachine(machineToAdd, machine) {
         await machineToAdd.receiveSyncChanges(toDeviceEvents, changedDevices, oneTimeKeyCounts, unusedFallbackKeys),
     );
 
-    expect(receiveSyncChanges).toEqual([[], []]);
+    expect(receiveSyncChanges).toEqual([]);
 
     const outgoingRequests = await machineToAdd.outgoingRequests();
 

--- a/bindings/matrix-sdk-crypto-js/tests/machine.test.js
+++ b/bindings/matrix-sdk-crypto-js/tests/machine.test.js
@@ -217,7 +217,7 @@ describe(OlmMachine.name, () => {
             await m.receiveSyncChanges(toDeviceEvents, changedDevices, oneTimeKeyCounts, unusedFallbackKeys),
         );
 
-        expect(receiveSyncChanges).toEqual([[], []]);
+        expect(receiveSyncChanges).toEqual([]);
     });
 
     test("can receive sync changes with unusedFallbackKeys as undefined", async () => {
@@ -230,7 +230,7 @@ describe(OlmMachine.name, () => {
             await m.receiveSyncChanges(toDeviceEvents, changedDevices, oneTimeKeyCounts, undefined),
         );
 
-        expect(receiveSyncChanges).toEqual([[], []]);
+        expect(receiveSyncChanges).toEqual([]);
     });
 
     test("can get the outgoing requests that need to be send out", async () => {
@@ -244,7 +244,7 @@ describe(OlmMachine.name, () => {
             await m.receiveSyncChanges(toDeviceEvents, changedDevices, oneTimeKeyCounts, unusedFallbackKeys),
         );
 
-        expect(receiveSyncChanges).toEqual([[], []]);
+        expect(receiveSyncChanges).toEqual([]);
 
         const outgoingRequests = await m.outgoingRequests();
 

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -38,3 +38,5 @@
   "Airplane", for consistency with the Matrix spec.
 
 - Fix handling of SAS verification start events once we have shown a QR code.
+
+- Fix a bug which could cause generated one-time-keys not to be persisted.

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1105,7 +1105,9 @@ impl OlmMachine {
     ///
     /// [`decrypt_room_event`]: #method.decrypt_room_event
     ///
-    /// Returns a tuple of (pending verification events, updated room keys)
+    /// # Returns
+    ///
+    /// A tuple of (decrypted to-device events, updated room keys).
     #[instrument(skip_all)]
     pub async fn receive_sync_changes(
         &self,


### PR DESCRIPTION
https://github.com/matrix-org/matrix-rust-sdk/pull/2142 introduced an  unintended change such that `receiveSyncChanges` returned an array of arrays.

Fix it up and release a hasty v0.1.3.