### PR TITLE
ci: Switch to branch-less GitHub pages workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   docs:
     name: All crates
@@ -61,10 +66,13 @@ jobs:
           mv target/doc/* doc/
           mv bindings/matrix-sdk-crypto-js/docs/* doc/bindings/matrix-sdk-crypto-js/
 
-      - name: Deploy documentation
+      - name: Upload artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc/
-          force_orphan: true
+          path: './doc/'
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
I discovered this option when setting up the matrix-rust-sdk-crypto-nodejs repo. Have also converted Ruma to it, and it's working great.

This will decrease the repo size since we'll no longer have to commit the built docs to be able to host them on GitHub pages.