### PR TITLE
Use async-uniffi more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5250,7 +5250,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "uniffi"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "anyhow",
  "camino",
@@ -5271,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "anyhow",
  "askama",
@@ -5295,7 +5295,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "anyhow",
  "camino",
@@ -5305,7 +5305,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "quote",
  "syn 2.0.22",
@@ -5314,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5330,7 +5330,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "bincode",
  "camino",
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5361,7 +5361,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "anyhow",
  "camino",
@@ -5375,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "anyhow",
  "uniffi_meta",
@@ -5697,7 +5697,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=41b91c8df67d8324be3da883591f82692d9b8596#41b91c8df67d8324be3da883591f82692d9b8596"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=b7d7bbd4a22733e1856a346af97e7bc974c44e61#b7d7bbd4a22733e1856a346af97e7bc974c44e61"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ thiserror = "1.0.38"
 tokio = { version = "1.24", default-features = false, features = ["sync"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-core = "0.1.30"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "41b91c8df67d8324be3da883591f82692d9b8596" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "41b91c8df67d8324be3da883591f82692d9b8596" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "b7d7bbd4a22733e1856a346af97e7bc974c44e61" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "b7d7bbd4a22733e1856a346af97e7bc974c44e61" }
 vodozemac = "0.4.0"
 zeroize = "1.3.0"
 

--- a/bindings/matrix-sdk-ffi/src/app.rs
+++ b/bindings/matrix-sdk-ffi/src/app.rs
@@ -52,7 +52,7 @@ pub struct App {
     inner: MatrixApp,
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl App {
     pub fn room_list_service(&self) -> Arc<RoomListService> {
         Arc::new(RoomListService { inner: self.inner.room_list_service() })
@@ -70,9 +70,9 @@ impl App {
         })))
     }
 
-    pub fn start(&self) -> Result<(), ClientError> {
+    pub async fn start(&self) -> Result<(), ClientError> {
         let start = self.inner.start();
-        RUNTIME.block_on(async { Ok(start.await?) })
+        Ok(start.await?)
     }
 
     pub fn pause(&self) -> Result<(), ClientError> {
@@ -91,7 +91,7 @@ impl AppBuilder {
     }
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl AppBuilder {
     pub fn with_encryption_sync(
         self: Arc<Self>,
@@ -103,8 +103,8 @@ impl AppBuilder {
         Arc::new(Self { builder })
     }
 
-    pub fn finish(self: Arc<Self>) -> Result<Arc<App>, ClientError> {
+    pub async fn finish(self: Arc<Self>) -> Result<Arc<App>, ClientError> {
         let this = unwrap_or_clone_arc(self);
-        RUNTIME.block_on(async move { Ok(Arc::new(App { inner: this.builder.build().await? })) })
+        Ok(Arc::new(App { inner: this.builder.build().await? }))
     }
 }

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -102,7 +102,7 @@ impl Drop for NotificationSettings {
     }
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl NotificationSettings {
     pub fn set_delegate(&self, delegate: Option<Box<dyn NotificationSettingsDelegate>>) {
         if let Some(delegate) = delegate {
@@ -130,12 +130,9 @@ impl NotificationSettings {
             });
         }
     }
-}
 
-#[uniffi::export(async_runtime = "tokio")]
-impl NotificationSettings {
     /// Gets the notification settings for a room.
-    ///     
+    ///
     /// # Arguments
     ///
     /// * `room_id` - the room ID

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -971,10 +971,7 @@ impl SendAttachmentJoinHandle {
     pub async fn join(&self) -> Result<(), RoomError> {
         (&mut *self.join_hdl.lock().await).await.unwrap()
     }
-}
 
-#[uniffi::export]
-impl SendAttachmentJoinHandle {
     pub fn cancel(&self) {
         self.abort_hdl.abort();
     }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -70,7 +70,7 @@ pub struct RoomListService {
     pub(crate) inner: Arc<matrix_sdk_ui::RoomListService>,
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl RoomListService {
     fn is_syncing(&self) -> bool {
         use matrix_sdk_ui::room_list_service::State;
@@ -97,10 +97,7 @@ impl RoomListService {
             inner: Arc::new(RUNTIME.block_on(async { self.inner.room(room_id).await })?),
         }))
     }
-}
 
-#[uniffi::export(async_runtime = "tokio")]
-impl RoomListService {
     async fn all_rooms(self: Arc<Self>) -> Result<Arc<RoomList>, RoomListError> {
         Ok(Arc::new(RoomList {
             room_list_service: self.clone(),
@@ -280,7 +277,7 @@ pub struct RoomListItem {
     inner: Arc<matrix_sdk_ui::room_list_service::Room>,
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl RoomListItem {
     fn id(&self) -> String {
         self.inner.id().to_string()
@@ -320,10 +317,7 @@ impl RoomListItem {
     fn unsubscribe(&self) {
         self.inner.unsubscribe();
     }
-}
 
-#[uniffi::export(async_runtime = "tokio")]
-impl RoomListItem {
     async fn latest_event(&self) -> Option<Arc<EventTimelineItem>> {
         self.inner.latest_event().await.map(EventTimelineItem).map(Arc::new)
     }

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -51,7 +51,7 @@ pub struct SessionVerificationController {
     sas_verification: Arc<RwLock<Option<SasVerification>>>,
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl SessionVerificationController {
     pub fn is_verified(&self) -> bool {
         self.user_identity.is_verified()
@@ -60,10 +60,7 @@ impl SessionVerificationController {
     pub fn set_delegate(&self, delegate: Option<Box<dyn SessionVerificationControllerDelegate>>) {
         *self.delegate.write().unwrap() = delegate;
     }
-}
 
-#[uniffi::export(async_runtime = "tokio")]
-impl SessionVerificationController {
     pub async fn request_verification(&self) -> Result<(), ClientError> {
         let methods = vec![VerificationMethod::SasV1];
         let verification_request = self


### PR DESCRIPTION
The app API has caused the dreaded `Cannot start a runtime from within a runtime.` panic from tokio. Let's use async-uniffi instead of `block_on` here. (and in all new code)