### PR TITLE
ui: Remove read-only mode for timeline

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -365,7 +365,7 @@ impl Timeline {
         let txn_id = txn_id.map_or_else(TransactionId::new, ToOwned::to_owned);
         self.inner.handle_local_event(txn_id.clone(), content.clone()).await;
         if self.msg_sender.send(LocalMessage { content, txn_id }).await.is_err() {
-            error!("Tried to send a message through a read-only Timeline");
+            error!("Internal error: timeline message receiver is closed");
         }
     }
 
@@ -509,7 +509,7 @@ impl Timeline {
 
         let txn_id = txn_id.to_owned();
         if self.msg_sender.send(LocalMessage { content, txn_id }).await.is_err() {
-            error!("Tried to re-send a message through a read-only Timeline");
+            error!("Internal error: timeline message receiver is closed");
         }
 
         Ok(())


### PR DESCRIPTION
It was used when getting the latest message was done through the timeline, which is no longer the case.
