### PR TITLE
feat(bindings): PowerLevels permission checks all exposed also at the room level

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -68,7 +68,7 @@ impl Room {
     }
 }
 
-#[uniffi::export]
+#[uniffi::export(async_runtime = "tokio")]
 impl Room {
     pub fn id(&self) -> String {
         self.inner.room_id().to_string()
@@ -903,13 +903,6 @@ impl Room {
         })
     }
 
-    pub fn current_user_id(&self) -> String {
-        self.inner.own_user_id().to_string()
-    }
-}
-
-#[uniffi::export(async_runtime = "tokio")]
-impl Room {
     pub async fn can_user_redact(&self, user_id: String) -> Result<bool, ClientError> {
         let room = match &self.inner {
             SdkRoom::Joined(j) => j.clone(),
@@ -918,6 +911,10 @@ impl Room {
 
         let user_id = UserId::parse(&user_id)?;
         Ok(room.can_user_redact(&user_id).await?)
+    }
+
+    pub fn current_user_id(&self) -> String {
+        self.inner.own_user_id().to_string()
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -984,7 +984,7 @@ impl Room {
         Ok(room.can_user_trigger_room_notification(&user_id).await?)
     }
 
-    pub fn current_user_id(&self) -> String {
+    pub fn own_user_id(&self) -> String {
         self.inner.own_user_id().to_string()
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -903,6 +903,13 @@ impl Room {
         })
     }
 
+    pub fn current_user_id(&self) -> String {
+        self.inner.own_user_id().to_string()
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl Room {
     pub async fn can_user_redact(&self, user_id: String) -> Result<bool, ClientError> {
         let room = match &self.inner {
             SdkRoom::Joined(j) => j.clone(),
@@ -911,10 +918,6 @@ impl Room {
 
         let user_id = UserId::parse(&user_id)?;
         Ok(room.can_user_redact(&user_id).await?)
-    }
-
-    pub fn current_user_id(&self) -> String {
-        self.inner.own_user_id().to_string()
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -902,6 +902,16 @@ impl Room {
             Ok(Arc::new(RoomMessageEventContent::new(msgtype)))
         })
     }
+
+    pub async fn can_user_redact(&self, user_id: String) -> Result<bool, ClientError> {
+        let room = match &self.inner {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => return Err(anyhow!("Can't check permissions for non joined rooms").into()),
+        };
+
+        let user_id = UserId::parse(&user_id)?;
+        Ok(room.can_user_redact(&user_id).await?)
+    }
 }
 
 impl Room {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -7,7 +7,7 @@ use matrix_sdk::{
         AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
         BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
     },
-    room::{Receipts, Room as SdkRoom},
+    room::{Joined, Receipts, Room as SdkRoom},
     ruma::{
         api::client::{receipt::create_receipt::v3::ReceiptType, room::report_content},
         events::{
@@ -35,7 +35,7 @@ use super::RUNTIME;
 use crate::{
     client::ProgressWatcher,
     error::{ClientError, RoomError},
-    room_member::RoomMember,
+    room_member::{MessageLikeEventType, RoomMember, StateEventType},
     timeline::{
         AudioInfo, FileInfo, ImageInfo, ThumbnailInfo, TimelineDiff, TimelineItem,
         TimelineListener, VideoInfo,
@@ -911,6 +911,77 @@ impl Room {
 
         let user_id = UserId::parse(&user_id)?;
         Ok(room.can_user_redact(&user_id).await?)
+    }
+
+    pub async fn can_user_ban(&self, user_id: String) -> Result<bool, ClientError> {
+        let room = match &self.inner {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => return Err(anyhow!("Can't check permissions for non joined rooms").into()),
+        };
+
+        let user_id = UserId::parse(&user_id)?;
+        Ok(room.can_user_ban(&user_id).await?)
+    }
+
+    pub async fn can_user_invite(&self, user_id: String) -> Result<bool, ClientError> {
+        let room = match &self.inner {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => return Err(anyhow!("Can't check permissions for non joined rooms").into()),
+        };
+
+        let user_id = UserId::parse(&user_id)?;
+        Ok(room.can_user_invite(&user_id).await?)
+    }
+
+    pub async fn can_user_kick(&self, user_id: String) -> Result<bool, ClientError> {
+        let room = match &self.inner {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => return Err(anyhow!("Can't check permissions for non joined rooms").into()),
+        };
+
+        let user_id = UserId::parse(&user_id)?;
+        Ok(room.can_user_kick(&user_id).await?)
+    }
+
+    pub async fn can_user_send_state(
+        &self,
+        user_id: String,
+        state_event: StateEventType,
+    ) -> Result<bool, ClientError> {
+        let room = match &self.inner {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => return Err(anyhow!("Can't check permissions for non joined rooms").into()),
+        };
+
+        let user_id = UserId::parse(&user_id)?;
+        Ok(room.can_user_send_state(&user_id, state_event.into()).await?)
+    }
+
+    pub async fn can_user_send_message(
+        &self,
+        user_id: String,
+        message: MessageLikeEventType,
+    ) -> Result<bool, ClientError> {
+        let room = match &self.inner {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => return Err(anyhow!("Can't check permissions for non joined rooms").into()),
+        };
+
+        let user_id = UserId::parse(&user_id)?;
+        Ok(room.can_user_send_message(&user_id, message.into()).await?)
+    }
+
+    pub async fn can_user_trigger_room_notification(
+        &self,
+        user_id: String,
+    ) -> Result<bool, ClientError> {
+        let room = match &self.inner {
+            SdkRoom::Joined(j) => j.clone(),
+            _ => return Err(anyhow!("Can't check permissions for non joined rooms").into()),
+        };
+
+        let user_id = UserId::parse(&user_id)?;
+        Ok(room.can_user_trigger_room_notification(&user_id).await?)
     }
 
     pub fn current_user_id(&self) -> String {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -7,7 +7,7 @@ use matrix_sdk::{
         AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
         BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
     },
-    room::{Joined, Receipts, Room as SdkRoom},
+    room::{Receipts, Room as SdkRoom},
     ruma::{
         api::client::{receipt::create_receipt::v3::ReceiptType, room::report_content},
         events::{

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -912,6 +912,10 @@ impl Room {
         let user_id = UserId::parse(&user_id)?;
         Ok(room.can_user_redact(&user_id).await?)
     }
+
+    pub fn current_user_id(&self) -> String {
+        self.inner.own_user_id().to_string()
+    }
 }
 
 impl Room {

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -1112,6 +1112,7 @@ impl Joined {
 
     /// Returns true if the user with the given  user_id is able to ban in the
     /// room.
+    ///
     /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_ban(&self, user_id: &UserId) -> Result<bool> {
         Ok(self.get_room_power_levels().await?.user_can_ban(user_id))
@@ -1119,6 +1120,7 @@ impl Joined {
 
     /// Returns true if the user with the given  user_id is able to kick in the
     /// room.
+    ///
     /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_invite(&self, user_id: &UserId) -> Result<bool> {
         Ok(self.get_room_power_levels().await?.user_can_invite(user_id))
@@ -1126,6 +1128,7 @@ impl Joined {
 
     /// Returns true if the user with the given  user_id is able to kick in the
     /// room.
+    ///
     /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_kick(&self, user_id: &UserId) -> Result<bool> {
         Ok(self.get_room_power_levels().await?.user_can_kick(user_id))
@@ -1133,6 +1136,7 @@ impl Joined {
 
     /// Returns true if the user with the given user_id is able to send a
     /// specific state event type in the room.
+    ///
     /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_send_state(
         &self,
@@ -1144,6 +1148,7 @@ impl Joined {
 
     /// Returns true if the user with the given  user_id is able to send a
     /// specific message type in the room.
+    ///
     /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_send_message(
         &self,
@@ -1155,6 +1160,7 @@ impl Joined {
 
     /// Returns true if the user with the given  user_id is able to trigger a
     /// notification in the room.
+    ///
     /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_trigger_room_notification(&self, user_id: &UserId) -> Result<bool> {
         Ok(self.get_room_power_levels().await?.user_can_trigger_room_notification(user_id))

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -35,7 +35,7 @@ use ruma::{
         StateEventType,
     },
     serde::Raw,
-    user_id, EventId, Int, MxcUri, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
+    EventId, Int, MxcUri, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
 };
 use serde_json::Value;
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -1143,7 +1143,7 @@ impl Joined {
         user_id: &UserId,
         state_event: StateEventType,
     ) -> Result<bool> {
-        Ok(self.get_room_power_levels().await?.user_can_send_state(user_id, state_event.into()))
+        Ok(self.get_room_power_levels().await?.user_can_send_state(user_id, state_event))
     }
 
     /// Returns true if the user with the given  user_id is able to send a

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -1132,7 +1132,7 @@ impl Joined {
 
     /// Returns true if the user with the given user_id is able to send a
     /// specific state event type in the room.
-    /// he call may fail if there is an error in getting the power levels.
+    /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_send_state(
         &self,
         user_id: &UserId,
@@ -1154,7 +1154,7 @@ impl Joined {
 
     /// Returns true if the user with the given  user_id is able to trigger a
     /// notification in the room.
-    /// /// The call may fail if there is an error in getting the power levels.
+    /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_trigger_room_notification(&self, user_id: &UserId) -> Result<bool> {
         Ok(self.get_room_power_levels().await?.user_can_trigger_room_notification(user_id))
     }

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -28,7 +28,7 @@ use ruma::{
             avatar::{ImageInfo, RoomAvatarEventContent},
             message::RoomMessageEventContent,
             name::RoomNameEventContent,
-            power_levels::RoomPowerLevelsEventContent,
+            power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
             topic::RoomTopicEventContent,
         },
         EmptyStateKey, MessageLikeEventContent, StateEventContent,
@@ -811,12 +811,7 @@ impl Joined {
         &self,
         updates: Vec<(&UserId, Int)>,
     ) -> Result<send_state_event::v3::Response> {
-        let raw_pl_event = self
-            .get_state_event_static::<RoomPowerLevelsEventContent>()
-            .await?
-            .ok_or(Error::InsufficientData)?;
-
-        let mut power_levels = raw_pl_event.deserialize()?.power_levels();
+        let mut power_levels = self.get_room_power_levels().await?;
 
         for (user_id, new_level) in updates {
             if new_level == power_levels.users_default {
@@ -827,6 +822,15 @@ impl Joined {
         }
 
         self.send_state_event(RoomPowerLevelsEventContent::from(power_levels)).await
+    }
+
+    async fn get_room_power_levels(&self) -> Result<RoomPowerLevels> {
+        Ok(self
+            .get_state_event_static::<RoomPowerLevelsEventContent>()
+            .await?
+            .ok_or(Error::InsufficientData)?
+            .deserialize()?
+            .power_levels())
     }
 
     /// Sets the name of this room.
@@ -1095,6 +1099,13 @@ impl Joined {
         );
 
         self.client.send(request, None).await
+    }
+
+    /// Returns true if the user with the given  user_id is able to redact
+    /// messages in the room.
+    /// The call may fail if there is an error in getting the power levels.
+    pub async fn can_user_redact(&self, user_id: &UserId) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_redact(user_id))
     }
 }
 

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -1104,6 +1104,7 @@ impl Joined {
 
     /// Returns true if the user with the given  user_id is able to redact
     /// messages in the room.
+    ///
     /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_redact(&self, user_id: &UserId) -> Result<bool> {
         Ok(self.get_room_power_levels().await?.user_can_redact(user_id))

--- a/crates/matrix-sdk/src/room/joined/mod.rs
+++ b/crates/matrix-sdk/src/room/joined/mod.rs
@@ -31,10 +31,11 @@ use ruma::{
             power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
             topic::RoomTopicEventContent,
         },
-        EmptyStateKey, MessageLikeEventContent, StateEventContent,
+        EmptyStateKey, MessageLikeEventContent, MessageLikeEventType, StateEventContent,
+        StateEventType,
     },
     serde::Raw,
-    EventId, Int, MxcUri, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
+    user_id, EventId, Int, MxcUri, OwnedEventId, OwnedTransactionId, TransactionId, UserId,
 };
 use serde_json::Value;
 #[cfg(feature = "e2e-encryption")]
@@ -1106,6 +1107,56 @@ impl Joined {
     /// The call may fail if there is an error in getting the power levels.
     pub async fn can_user_redact(&self, user_id: &UserId) -> Result<bool> {
         Ok(self.get_room_power_levels().await?.user_can_redact(user_id))
+    }
+
+    /// Returns true if the user with the given  user_id is able to ban in the
+    /// room.
+    /// The call may fail if there is an error in getting the power levels.
+    pub async fn can_user_ban(&self, user_id: &UserId) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_ban(user_id))
+    }
+
+    /// Returns true if the user with the given  user_id is able to kick in the
+    /// room.
+    /// The call may fail if there is an error in getting the power levels.
+    pub async fn can_user_invite(&self, user_id: &UserId) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_invite(user_id))
+    }
+
+    /// Returns true if the user with the given  user_id is able to kick in the
+    /// room.
+    /// The call may fail if there is an error in getting the power levels.
+    pub async fn can_user_kick(&self, user_id: &UserId) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_kick(user_id))
+    }
+
+    /// Returns true if the user with the given user_id is able to send a
+    /// specific state event type in the room.
+    /// he call may fail if there is an error in getting the power levels.
+    pub async fn can_user_send_state(
+        &self,
+        user_id: &UserId,
+        state_event: StateEventType,
+    ) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_send_state(user_id, state_event.into()))
+    }
+
+    /// Returns true if the user with the given  user_id is able to send a
+    /// specific message type in the room.
+    /// The call may fail if there is an error in getting the power levels.
+    pub async fn can_user_send_message(
+        &self,
+        user_id: &UserId,
+        message: MessageLikeEventType,
+    ) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_send_message(user_id, message))
+    }
+
+    /// Returns true if the user with the given  user_id is able to trigger a
+    /// notification in the room.
+    /// /// The call may fail if there is an error in getting the power levels.
+    pub async fn can_user_trigger_room_notification(&self, user_id: &UserId) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_trigger_room_notification(user_id))
     }
 }
 


### PR DESCRIPTION
This allows to actually check for permissions (like canRedact, canBan, canSendState...) at room level by just specifying the userID.