### PR TITLE
ci: Remove serverName from setup-matrix-synapse arguments

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,7 +54,6 @@ jobs:
         uploadLogs: true
         httpPort: 8228
         disableRateLimiting: true
-        serverName: "matrix-sdk.rs"
 
     - name: Run tarpaulin
       run: |


### PR DESCRIPTION
We're getting warnings because this is not a supported parameter (it was when we were using a fork of that action).