### PR TITLE
ui: Fix imports behind sliding-sync feature flag

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
@@ -18,7 +18,10 @@ use imbl::{vector, Vector};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use matrix_sdk::{deserialized_responses::TimelineEvent, Result};
+#[cfg(feature = "experimental-sliding-sync")]
 use matrix_sdk_base::latest_event::{is_suitable_for_latest_event, PossibleLatestEvent};
+#[cfg(feature = "experimental-sliding-sync")]
+use ruma::events::{AnySyncTimelineEvent, OriginalSyncMessageLikeEvent};
 use ruma::{
     assign,
     events::{
@@ -53,12 +56,14 @@ use ruma::{
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         sticker::StickerEventContent,
         AnyFullStateEventContent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent,
-        AnySyncTimelineEvent, AnyTimelineEvent, BundledMessageLikeRelations, FullStateEventContent,
-        MessageLikeEventType, OriginalSyncMessageLikeEvent, StateEventType,
+        AnyTimelineEvent, BundledMessageLikeRelations, FullStateEventContent, MessageLikeEventType,
+        StateEventType,
     },
     OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedTransactionId, OwnedUserId, UserId,
 };
-use tracing::{debug, error, warn};
+#[cfg(feature = "experimental-sliding-sync")]
+use tracing::warn;
+use tracing::{debug, error};
 
 use super::{EventItemIdentifier, EventTimelineItem, Profile, ReactionSenderData, TimelineDetails};
 use crate::timeline::{
@@ -150,6 +155,7 @@ impl TimelineItemContent {
     /// Given some message content that is from an event that we have already
     /// determined is suitable for use as a latest event in a message preview,
     /// extract its contents and wrap it as a TimelineItemContent.
+    #[cfg(feature = "experimental-sliding-sync")]
     fn from_suitable_latest_event_content(
         message: &OriginalSyncMessageLikeEvent<RoomMessageEventContent>,
     ) -> Option<TimelineItemContent> {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -15,7 +15,10 @@
 use std::sync::Arc;
 
 use indexmap::IndexMap;
-use matrix_sdk::{deserialized_responses::EncryptionInfo, Error, SlidingSyncRoom};
+#[cfg(feature = "experimental-sliding-sync")]
+use matrix_sdk::SlidingSyncRoom;
+use matrix_sdk::{deserialized_responses::EncryptionInfo, Error};
+#[cfg(feature = "experimental-sliding-sync")]
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use once_cell::sync::Lazy;
 use ruma::{
@@ -24,6 +27,7 @@ use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedTransactionId,
     OwnedUserId, TransactionId, UserId,
 };
+#[cfg(feature = "experimental-sliding-sync")]
 use tracing::warn;
 
 mod content;
@@ -574,12 +578,14 @@ mod test {
         .unwrap()
     }
 
+    #[cfg(feature = "experimental-sliding-sync")]
     async fn response_with_room(room_id: &RoomId, room: v4::SlidingSyncRoom) -> v4::Response {
         let mut response = v4::Response::new("6".to_owned());
         response.rooms.insert(room_id.to_owned(), room);
         response
     }
 
+    #[cfg(feature = "experimental-sliding-sync")]
     fn message_event(
         room_id: &RoomId,
         user_id: &UserId,


### PR DESCRIPTION
Using the crate in Fractal, where we don't use any of the sliding-sync features, we got a few compile-time errors for imports that are not available without the `experimental-sliding-sync` feature enabled.

This makes sure that no warning is reported when running `cargo check` with the features depending on sliding-sync disabled.