### PR TITLE
ui: Expose the kind of a TimelineItem

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/item.rs
+++ b/crates/matrix-sdk-ui/src/timeline/item.rs
@@ -38,6 +38,11 @@ impl TimelineItem {
         Arc::new(Self { kind: kind.into(), internal_id: self.internal_id })
     }
 
+    /// Get the [`TimelineItemKind`] of this item.
+    pub fn kind(&self) -> &TimelineItemKind {
+        &self.kind
+    }
+
     /// Get the inner `EventTimelineItem`, if this is a
     /// [`TimelineItemKind::Event`].
     pub fn as_event(&self) -> Option<&EventTimelineItem> {


### PR DESCRIPTION
It is more practical to use

```rust
match item.kind() {
  …
}
```

than

```rust
if let Some(event) = item.as_event() {
  …
} else if let Some(virtual) = item.as_virtual() {
  …
}
```
