### PR TITLE
Small improvements to `App` API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -72,12 +72,6 @@ pub struct RoomListService {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl RoomListService {
-    fn is_syncing(&self) -> bool {
-        use matrix_sdk_ui::room_list_service::State;
-
-        matches!(self.inner.state().get(), State::SettingUp | State::Running)
-    }
-
     fn state(&self, listener: Box<dyn RoomListServiceStateListener>) -> Arc<TaskHandle> {
         let state_stream = self.inner.state();
 

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -59,7 +59,7 @@ impl SyncService {
         Arc::new(RoomListService { inner: self.inner.room_list_service() })
     }
 
-    fn state(&self, listener: Box<dyn SyncServiceStateObserver>) -> Arc<TaskHandle> {
+    pub fn state(&self, listener: Box<dyn SyncServiceStateObserver>) -> Arc<TaskHandle> {
         let state_stream = self.inner.observe_state();
 
         Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
@@ -69,6 +69,10 @@ impl SyncService {
                 listener.on_update(state.into());
             }
         })))
+    }
+
+    pub fn current_state(&self) -> AppState {
+        self.inner.observe_state().get().into()
     }
 
     pub async fn start(&self) -> Result<(), ClientError> {

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -62,7 +62,7 @@ impl SyncService {
     }
 
     pub fn state(&self, listener: Box<dyn SyncServiceStateObserver>) -> Arc<TaskHandle> {
-        let state_stream = self.inner.observe_state();
+        let state_stream = self.inner.state();
 
         Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
             pin_mut!(state_stream);
@@ -74,7 +74,7 @@ impl SyncService {
     }
 
     pub fn current_state(&self) -> SyncServiceState {
-        self.inner.observe_state().get().into()
+        self.inner.state().get().into()
     }
 
     pub async fn start(&self) -> Result<(), ClientError> {

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -28,6 +28,7 @@ use crate::{
 
 #[derive(uniffi::Enum)]
 pub enum SyncServiceState {
+    Idle,
     Running,
     Terminated,
     Error,
@@ -36,6 +37,7 @@ pub enum SyncServiceState {
 impl From<MatrixSyncServiceState> for SyncServiceState {
     fn from(value: MatrixSyncServiceState) -> Self {
         match value {
+            MatrixSyncServiceState::Idle => Self::Idle,
             MatrixSyncServiceState::Running => Self::Running,
             MatrixSyncServiceState::Terminated => Self::Terminated,
             MatrixSyncServiceState::Error => Self::Error,
@@ -71,7 +73,7 @@ impl SyncService {
         })))
     }
 
-    pub fn current_state(&self) -> AppState {
+    pub fn current_state(&self) -> SyncServiceState {
         self.inner.observe_state().get().into()
     }
 

--- a/crates/matrix-sdk-ui/src/sync_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/sync_service/mod.rs
@@ -19,8 +19,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use eyeball::SharedObservable;
-use futures_core::Stream;
+use eyeball::{SharedObservable, Subscriber};
 use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::Client;
 use thiserror::Error;
@@ -74,7 +73,7 @@ impl SyncService {
     /// Observe the current state of the application.
     ///
     /// See also [`SyncServiceState`].
-    pub fn observe_state(&self) -> impl Stream<Item = SyncServiceState> {
+    pub fn observe_state(&self) -> Subscriber<SyncServiceState> {
         self.state_observer.subscribe()
     }
 

--- a/crates/matrix-sdk-ui/src/sync_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/sync_service/mod.rs
@@ -40,7 +40,7 @@ use crate::{
 /// It is the responsibility of the caller to restart the application using the
 /// [`SyncService::start`] method, in case it terminated, gracefully or not.
 ///
-/// This can be observed with [`SyncService::observe_state`].
+/// This can be observed with [`SyncService::state`].
 #[derive(Clone)]
 pub enum SyncServiceState {
     /// The service hasn't ever been started yet.
@@ -75,7 +75,7 @@ impl SyncService {
     /// Observe the current state of the application.
     ///
     /// See also [`SyncServiceState`].
-    pub fn observe_state(&self) -> Subscriber<SyncServiceState> {
+    pub fn state(&self) -> Subscriber<SyncServiceState> {
         self.state_observer.subscribe()
     }
 

--- a/crates/matrix-sdk-ui/src/sync_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/sync_service/mod.rs
@@ -226,9 +226,9 @@ impl SyncServiceBuilder {
 
     /// Finish setting up the `SyncService`.
     ///
-    /// This creates the underlying sliding syncs, and will start them in the
-    /// background. The resulting `SyncService` must be kept alive as long as
-    /// the sliding syncs are supposed to run.
+    /// This creates the underlying sliding syncs, and will *not* start them in
+    /// the background. The resulting `SyncService` must be kept alive as
+    /// long as the sliding syncs are supposed to run.
     pub async fn build(self) -> Result<SyncService, Error> {
         let (room_list, encryption_sync) = if self.with_encryption_sync {
             let room_list = RoomListService::new(self.client.clone()).await?;
@@ -245,16 +245,12 @@ impl SyncServiceBuilder {
             (room_list, None)
         };
 
-        let app = SyncService {
+        Ok(SyncService {
             room_list_service: Arc::new(room_list),
             encryption_sync,
             state_observer: SharedObservable::new(SyncServiceState::Running),
             task_handle: Default::default(),
-        };
-
-        app.start().await?;
-
-        Ok(app)
+        })
     }
 }
 


### PR DESCRIPTION
- get rid of `RoomListService::is_syncing`; on the one hand it's slightly confusing in itself (because it considers that it's not syncing while in init state, which is eyebrow-raising worthy at the bare minimum), but now it's also incorrect to look at this state if used with the `App` API. The encryption sync may be stopped and cause a stop of the `App` stream, but the room list service's SS would only be interrupted slightly later, causing some confusing race conditions. Fixes #2247.
- don't automatically start the `App` upon creation. After feedback from both @ganfra and @stefanceriu this is more confusing than helpful.
- add `App::current_state` to provide the current application's state, in addition to the state subscriber. Both are useful at different times, and having both makes it so that the client doesn't need to store the state anymore, causing fewer opportunities for state mismanagement.