### PR TITLE
chore: rename `App` to `SyncService`

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -29,7 +29,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption", "experimental-room-list", "experimental-encryption-sync", "experimental-notification-client", "experimental-app"] }
+matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption", "experimental-room-list", "experimental-encryption-sync", "experimental-notification-client", "experimental-sync-service"] }
 mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -32,8 +32,8 @@ use url::Url;
 
 use super::{room::Room, session_verification::SessionVerificationController, RUNTIME};
 use crate::{
-    app::AppBuilder, client, notification::NotificationClientBuilder,
-    notification_settings::NotificationSettings, ClientError,
+    client, notification::NotificationClientBuilder, notification_settings::NotificationSettings,
+    sync_service::SyncServiceBuilder, ClientError,
 };
 
 #[derive(Clone, uniffi::Record)]
@@ -588,8 +588,8 @@ impl Client {
         NotificationClientBuilder::new(self.inner.clone())
     }
 
-    pub fn app(&self) -> Arc<AppBuilder> {
-        AppBuilder::new(self.inner.clone())
+    pub fn sync_service(&self) -> Arc<SyncServiceBuilder> {
+        SyncServiceBuilder::new(self.inner.clone())
     }
 
     pub fn get_notification_settings(&self) -> Arc<NotificationSettings> {

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -4,7 +4,7 @@ use matrix_sdk::{
     self, encryption::CryptoStoreError, HttpError, IdParseError,
     NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
-use matrix_sdk_ui::{app, encryption_sync, notification_client, timeline};
+use matrix_sdk_ui::{encryption_sync, notification_client, sync_service, timeline};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
@@ -90,8 +90,8 @@ impl From<notification_client::Error> for ClientError {
     }
 }
 
-impl From<app::Error> for ClientError {
-    fn from(e: app::Error) -> Self {
+impl From<sync_service::Error> for ClientError {
+    fn from(e: sync_service::Error) -> Self {
         Self::new(e)
     }
 }

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -20,7 +20,6 @@ macro_rules! unwrap_or_clone_arc_into_variant {
     };
 }
 
-mod app;
 mod authentication_service;
 mod client;
 mod client_builder;
@@ -34,6 +33,7 @@ mod room;
 mod room_list;
 mod room_member;
 mod session_verification;
+mod sync_service;
 mod task_handle;
 mod timeline;
 mod tracing;

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.6.0"
 edition = "2021"
 
 [features]
-default = ["e2e-encryption", "native-tls", "experimental-room-list", "experimental-encryption-sync", "experimental-app", "experimental-notification-client"]
+default = ["e2e-encryption", "native-tls", "experimental-room-list", "experimental-encryption-sync", "experimental-sync-service", "experimental-notification-client"]
 
 e2e-encryption = ["matrix-sdk/e2e-encryption"]
 
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
 
-experimental-app = ["experimental-room-list", "experimental-encryption-sync"]
+experimental-sync-service = ["experimental-room-list", "experimental-encryption-sync"]
 experimental-encryption-sync = ["experimental-sliding-sync", "dep:async-stream"]
 experimental-notification-client = ["experimental-encryption-sync"]
 experimental-room-list = ["experimental-sliding-sync", "dep:async-stream", "dep:eyeball-im-util"]

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -14,14 +14,14 @@
 
 mod events;
 
-#[cfg(feature = "experimental-app")]
-pub mod app;
 #[cfg(feature = "experimental-encryption-sync")]
 pub mod encryption_sync;
 #[cfg(feature = "experimental-notification-client")]
 pub mod notification_client;
 #[cfg(feature = "experimental-room-list")]
 pub mod room_list_service;
+#[cfg(feature = "experimental-sync-service")]
+pub mod sync_service;
 pub mod timeline;
 
 #[cfg(feature = "experimental-room-list")]


### PR DESCRIPTION
Just renames `App` to `SyncService`. Hesitated with `SyncLoopService`, but already too much paint has been thrown at the bike shed, and _any_ name is better than `App` :upside_down_face: 