### PR TITLE
Use forked `tracing-android` to have readable logs in Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5073,8 +5073,7 @@ dependencies = [
 [[package]]
 name = "tracing-android"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12612be8f868a09c0ceae7113ff26afe79d81a24473a393cb9120ece162e86c0"
+source = "git+https://github.com/jmartinesp/tracing-android?rev=b9c0e89448dc93c5264721bbd41be64f1a84cded#b9c0e89448dc93c5264721bbd41be64f1a84cded"
 dependencies = [
  "android_log-sys",
  "tracing",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -52,7 +52,7 @@ zeroize = { workspace = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 log-panics = { version = "2", features = ["with-backtrace"]}
-tracing-android = "0.2.0"
+tracing-android = { git = "https://github.com/jmartinesp/tracing-android", rev = "b9c0e89448dc93c5264721bbd41be64f1a84cded" }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 tracing = { workspace = true }


### PR DESCRIPTION
Uses a forked and improved version for `tracing-android` as a temporary measure to have readable logs in Android. Ideally, we should move to [paranoid-android](https://crates.io/crates/paranoid-android) in the near future, but we're in a bit of a hurry to have proper logs in Android.

- [ ] Public API changes documented in changelogs (optional)