### PR TITLE
Remove redundant fine-grained reference counting for memory stores

### DIFF
--- a/benchmarks/benches/store_bench.rs
+++ b/benchmarks/benches/store_bench.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use criterion::*;
 use matrix_sdk::{
     config::StoreConfig,
@@ -60,7 +62,7 @@ pub fn restore_session(c: &mut Criterion) {
     const NAME: &str = "restore a session";
 
     // Memory
-    let mem_store = MemoryStore::new();
+    let mem_store = Arc::new(MemoryStore::new());
     runtime.block_on(mem_store.save_changes(&changes)).expect("initial filling of mem failed");
 
     group.bench_with_input(BenchmarkId::new("memory store", NAME), &mem_store, |b, store| {

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -15,7 +15,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
-    sync::{Arc, RwLock},
+    sync::RwLock,
 };
 
 use async_trait::async_trait;
@@ -48,36 +48,31 @@ use crate::{
 #[allow(clippy::type_complexity)]
 #[derive(Debug)]
 pub struct MemoryStore {
-    user_avatar_url: Arc<DashMap<String, String>>,
-    sync_token: Arc<RwLock<Option<String>>>,
-    filters: Arc<DashMap<String, String>>,
-    account_data: Arc<DashMap<GlobalAccountDataEventType, Raw<AnyGlobalAccountDataEvent>>>,
-    profiles: Arc<DashMap<OwnedRoomId, DashMap<OwnedUserId, MinimalRoomMemberEvent>>>,
-    display_names: Arc<DashMap<OwnedRoomId, DashMap<String, BTreeSet<OwnedUserId>>>>,
-    members: Arc<DashMap<OwnedRoomId, DashMap<OwnedUserId, MembershipState>>>,
-    room_info: Arc<DashMap<OwnedRoomId, RoomInfo>>,
+    user_avatar_url: DashMap<String, String>,
+    sync_token: RwLock<Option<String>>,
+    filters: DashMap<String, String>,
+    account_data: DashMap<GlobalAccountDataEventType, Raw<AnyGlobalAccountDataEvent>>,
+    profiles: DashMap<OwnedRoomId, DashMap<OwnedUserId, MinimalRoomMemberEvent>>,
+    display_names: DashMap<OwnedRoomId, DashMap<String, BTreeSet<OwnedUserId>>>,
+    members: DashMap<OwnedRoomId, DashMap<OwnedUserId, MembershipState>>,
+    room_info: DashMap<OwnedRoomId, RoomInfo>,
     room_state:
-        Arc<DashMap<OwnedRoomId, DashMap<StateEventType, DashMap<String, Raw<AnySyncStateEvent>>>>>,
+        DashMap<OwnedRoomId, DashMap<StateEventType, DashMap<String, Raw<AnySyncStateEvent>>>>,
     room_account_data:
-        Arc<DashMap<OwnedRoomId, DashMap<RoomAccountDataEventType, Raw<AnyRoomAccountDataEvent>>>>,
-    stripped_room_state: Arc<
+        DashMap<OwnedRoomId, DashMap<RoomAccountDataEventType, Raw<AnyRoomAccountDataEvent>>>,
+    stripped_room_state:
         DashMap<OwnedRoomId, DashMap<StateEventType, DashMap<String, Raw<AnyStrippedStateEvent>>>>,
+    stripped_members: DashMap<OwnedRoomId, DashMap<OwnedUserId, MembershipState>>,
+    presence: DashMap<OwnedUserId, Raw<PresenceEvent>>,
+    room_user_receipts: DashMap<
+        OwnedRoomId,
+        DashMap<(String, Option<String>), DashMap<OwnedUserId, (OwnedEventId, Receipt)>>,
     >,
-    stripped_members: Arc<DashMap<OwnedRoomId, DashMap<OwnedUserId, MembershipState>>>,
-    presence: Arc<DashMap<OwnedUserId, Raw<PresenceEvent>>>,
-    room_user_receipts: Arc<
-        DashMap<
-            OwnedRoomId,
-            DashMap<(String, Option<String>), DashMap<OwnedUserId, (OwnedEventId, Receipt)>>,
-        >,
+    room_event_receipts: DashMap<
+        OwnedRoomId,
+        DashMap<(String, Option<String>), DashMap<OwnedEventId, DashMap<OwnedUserId, Receipt>>>,
     >,
-    room_event_receipts: Arc<
-        DashMap<
-            OwnedRoomId,
-            DashMap<(String, Option<String>), DashMap<OwnedEventId, DashMap<OwnedUserId, Receipt>>>,
-        >,
-    >,
-    custom: Arc<DashMap<Vec<u8>, Vec<u8>>>,
+    custom: DashMap<Vec<u8>, Vec<u8>>,
 }
 
 impl Default for MemoryStore {
@@ -106,7 +101,7 @@ impl MemoryStore {
             presence: Default::default(),
             room_user_receipts: Default::default(),
             room_event_receipts: Default::default(),
-            custom: DashMap::new().into(),
+            custom: Default::default(),
         }
     }
 

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -106,10 +106,6 @@ impl MemoryStore {
             presence: Default::default(),
             room_user_receipts: Default::default(),
             room_event_receipts: Default::default(),
-            #[cfg(feature = "memory-media-cache")]
-            media: Arc::new(tokio::sync::Mutex::new(LruCache::new(
-                100.try_into().expect("100 is a non-zero usize"),
-            ))),
             custom: DashMap::new().into(),
         }
     }

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -46,7 +46,7 @@ use crate::{
 ///
 /// Default if no other is configured at startup.
 #[allow(clippy::type_complexity)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MemoryStore {
     user_avatar_url: Arc<DashMap<String, String>>,
     sync_token: Arc<RwLock<Option<String>>>,

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -73,7 +73,7 @@ impl SessionStore {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 /// In-memory store that holds inbound group sessions.
 pub struct GroupSessionStore {
     entries: Arc<DashMap<OwnedRoomId, HashMap<String, InboundGroupSession>>>,
@@ -122,7 +122,7 @@ impl GroupSessionStore {
 }
 
 /// In-memory store holding the devices of users.
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub struct DeviceStore {
     entries: Arc<DashMap<OwnedUserId, DashMap<OwnedDeviceId, ReadOnlyDevice>>>,
 }

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -76,7 +76,7 @@ impl SessionStore {
 #[derive(Debug, Default)]
 /// In-memory store that holds inbound group sessions.
 pub struct GroupSessionStore {
-    entries: Arc<DashMap<OwnedRoomId, HashMap<String, InboundGroupSession>>>,
+    entries: DashMap<OwnedRoomId, HashMap<String, InboundGroupSession>>,
 }
 
 impl GroupSessionStore {
@@ -124,7 +124,7 @@ impl GroupSessionStore {
 /// In-memory store holding the devices of users.
 #[derive(Debug, Default)]
 pub struct DeviceStore {
-    entries: Arc<DashMap<OwnedUserId, DashMap<OwnedDeviceId, ReadOnlyDevice>>>,
+    entries: DashMap<OwnedUserId, DashMap<OwnedDeviceId, ReadOnlyDevice>>,
 }
 
 impl DeviceStore {

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -51,7 +51,7 @@ fn encode_key_info(info: &SecretInfo) -> String {
 }
 
 /// An in-memory only store that will forget all the E2EE key once it's dropped.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MemoryStore {
     sessions: SessionStore,
     inbound_group_sessions: GroupSessionStore,

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -55,14 +55,14 @@ fn encode_key_info(info: &SecretInfo) -> String {
 pub struct MemoryStore {
     sessions: SessionStore,
     inbound_group_sessions: GroupSessionStore,
-    olm_hashes: Arc<DashMap<String, DashSet<String>>>,
+    olm_hashes: DashMap<String, DashSet<String>>,
     devices: DeviceStore,
-    identities: Arc<DashMap<OwnedUserId, ReadOnlyUserIdentities>>,
-    outgoing_key_requests: Arc<DashMap<OwnedTransactionId, GossipRequest>>,
-    key_requests_by_info: Arc<DashMap<String, OwnedTransactionId>>,
-    direct_withheld_info: Arc<DashMap<OwnedRoomId, DashMap<String, RoomKeyWithheldEvent>>>,
-    custom_values: Arc<DashMap<String, Vec<u8>>>,
-    leases: Arc<DashMap<String, (String, Instant)>>,
+    identities: DashMap<OwnedUserId, ReadOnlyUserIdentities>,
+    outgoing_key_requests: DashMap<OwnedTransactionId, GossipRequest>,
+    key_requests_by_info: DashMap<String, OwnedTransactionId>,
+    direct_withheld_info: DashMap<OwnedRoomId, DashMap<String, RoomKeyWithheldEvent>>,
+    custom_values: DashMap<String, Vec<u8>>,
+    leases: DashMap<String, (String, Instant)>,
 }
 
 impl Default for MemoryStore {


### PR DESCRIPTION
There's a few more changes possible in this direction, but this gets rid of most of the unnecessary reference counting in the stores.