### PR TITLE
Bump eyeball-im, enable its tracing feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,14 +1491,15 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21fb87d8fd4bdb2e140007b79d350ad93c574989abd2be322a0534054e68a67"
+checksum = "f35f976c6b485baca970899897e4c5b67701da6e11a57ef4f4951c1aa64f7d6e"
 dependencies = [
  "futures-core",
  "imbl",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ byteorder = "1.4.3"
 ctor = "0.2.0"
 dashmap = "5.2.0"
 eyeball = "0.8.3"
-eyeball-im = "0.2.4"
+eyeball-im = { version = "0.2.5", features = ["tracing"] }
 eyeball-im-util = "0.2.1"
 futures-core = "0.3.28"
 futures-executor = "0.3.21"


### PR DESCRIPTION
… so we get log events whenever an `ObservableVector` is updated, with affected indices.
