### PR TITLE
Mark our public part of the user identity as verified if we import the private part

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,8 @@
 # unreleased
 
+- Mark our `OwnUserIdentity` as verified if we successfully import the matching
+  private keys.
+
 - The `OlmMachine::export_cross_signing_keys()` method now returns a `Result`.
   This removes an `unwrap()` from the codebase.
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -406,7 +406,7 @@ impl IdentityManager {
         let private_identity = private_identity.lock().await;
         let result = private_identity.clear_if_differs(identity).await;
 
-        if result.any_cleared() {
+        if result.any_differ() {
             info!(cleared = ?result, "Removed some or all of our private cross signing keys");
             Some((*private_identity).clone())
         } else {

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -578,6 +578,11 @@ impl ReadOnlyOwnUserIdentity {
         self.verified.store(true, Ordering::SeqCst)
     }
 
+    #[cfg(test)]
+    pub fn mark_as_unverified(&self) {
+        self.verified.store(false, Ordering::SeqCst)
+    }
+
     /// Check if our identity is verified.
     pub fn is_verified(&self) -> bool {
         self.verified.load(Ordering::SeqCst)

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1947,6 +1947,7 @@ pub(crate) mod tests {
         error::EventError,
         machine::OlmMachine,
         olm::{InboundGroupSession, OutboundGroupSession, VerifyJson},
+        store::Changes,
         types::{
             events::{
                 room::encrypted::{EncryptedToDeviceEvent, ToDeviceEncryptedEventContent},
@@ -3428,6 +3429,94 @@ pub(crate) mod tests {
         assert_matches!(
             alice.decrypt_room_event(&event, room_id).await,
             Err(MegolmError::MismatchedIdentityKeys { .. })
+        );
+    }
+
+    #[async_test]
+    async fn importing_private_cross_signing_keys_verifies_the_public_identity() {
+        async fn create_additional_machine(machine: &OlmMachine) -> OlmMachine {
+            let second_machine =
+                OlmMachine::new(machine.user_id(), "ADDITIONAL_MACHINE".into()).await;
+
+            let identity = machine
+                .get_identity(machine.user_id(), None)
+                .await
+                .unwrap()
+                .expect("We should know about our own user identity if we bootstrapped it")
+                .own()
+                .unwrap();
+
+            let mut changes = Changes::default();
+            identity.mark_as_unverified();
+            changes.identities.new.push(crate::ReadOnlyUserIdentities::Own(identity.inner));
+
+            second_machine.store().save_changes(changes).await.unwrap();
+
+            second_machine
+        }
+
+        let (alice, bob) = get_machine_pair_with_setup_sessions().await;
+        setup_cross_signing_for_machine(&alice, &bob).await;
+
+        let second_alice = create_additional_machine(&alice).await;
+
+        let export = alice
+            .export_cross_signing_keys()
+            .await
+            .unwrap()
+            .expect("We should be able to export our cross signing keys");
+
+        let identity = second_alice
+            .get_identity(second_alice.user_id(), None)
+            .await
+            .unwrap()
+            .expect("We should know about our own user identity")
+            .own()
+            .unwrap();
+
+        assert!(!identity.is_verified(), "Initially our identity should not be verified");
+
+        second_alice
+            .import_cross_signing_keys(export)
+            .await
+            .expect("We should be able to import our cross signing keys");
+
+        let identity = second_alice
+            .get_identity(second_alice.user_id(), None)
+            .await
+            .unwrap()
+            .expect("We should know about our own user identity")
+            .own()
+            .unwrap();
+
+        assert!(
+            identity.is_verified(),
+            "Our identity should be verified after we imported the private cross signing keys"
+        );
+
+        let second_bob = create_additional_machine(&bob).await;
+
+        let export = second_alice
+            .export_cross_signing_keys()
+            .await
+            .unwrap()
+            .expect("The machine should be now able to export cross signing keys as well");
+
+        second_bob.import_cross_signing_keys(export).await.expect_err(
+            "Importing cross signing keys that don't match our public identity should fail.",
+        );
+
+        let identity = second_bob
+            .get_identity(second_bob.user_id(), None)
+            .await
+            .unwrap()
+            .expect("We should know about our own user identity")
+            .own()
+            .unwrap();
+
+        assert!(
+            !identity.is_verified(),
+            "Our identity should not be verified if there's a mismatch in the cross signing keys"
         );
     }
 }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -3464,7 +3464,7 @@ pub(crate) mod tests {
             .export_cross_signing_keys()
             .await
             .unwrap()
-            .expect("We should be able to export our cross signing keys");
+            .expect("We should be able to export our cross-signing keys");
 
         let identity = second_alice
             .get_identity(second_alice.user_id(), None)
@@ -3479,7 +3479,7 @@ pub(crate) mod tests {
         second_alice
             .import_cross_signing_keys(export)
             .await
-            .expect("We should be able to import our cross signing keys");
+            .expect("We should be able to import our cross-signing keys");
 
         let identity = second_alice
             .get_identity(second_alice.user_id(), None)
@@ -3491,7 +3491,7 @@ pub(crate) mod tests {
 
         assert!(
             identity.is_verified(),
-            "Our identity should be verified after we imported the private cross signing keys"
+            "Our identity should be verified after we imported the private cross-signing keys"
         );
 
         let second_bob = create_additional_machine(&bob).await;
@@ -3500,10 +3500,10 @@ pub(crate) mod tests {
             .export_cross_signing_keys()
             .await
             .unwrap()
-            .expect("The machine should be now able to export cross signing keys as well");
+            .expect("The machine should now be able to export cross-signing keys as well");
 
         second_bob.import_cross_signing_keys(export).await.expect_err(
-            "Importing cross signing keys that don't match our public identity should fail.",
+            "Importing cross-signing keys that don't match our public identity should fail",
         );
 
         let identity = second_bob
@@ -3516,7 +3516,7 @@ pub(crate) mod tests {
 
         assert!(
             !identity.is_verified(),
-            "Our identity should not be verified if there's a mismatch in the cross signing keys"
+            "Our identity should not be verified when there's a mismatch in the cross-signing keys"
         );
     }
 }

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -57,23 +57,27 @@ pub struct PrivateCrossSigningIdentity {
     pub(crate) self_signing_key: Arc<Mutex<Option<SelfSigning>>>,
 }
 
-/// A struct containing information if any of our cross signing keys were
-/// cleared because the public keys differ from the keys that are uploaded to
-/// the server.
+/// A struct containing information if any of our cross signing keys differ from
+/// the public keys that are uploaded to the server.
 #[derive(Debug, Clone)]
-pub struct ClearResult {
-    /// Was the master key cleared.
-    master_cleared: bool,
-    /// Was the self-signing key cleared.
-    self_signing_cleared: bool,
-    /// Was the user-signing key cleared.
-    user_signing_cleared: bool,
+pub struct DiffResult {
+    /// Does the master key differ.
+    master_differs: bool,
+    /// Does the self-signing key differ.
+    self_signing_differs: bool,
+    /// DOes the user-signing key differ.
+    user_signing_differs: bool,
 }
 
-impl ClearResult {
-    /// Did we clear any of the private cross signing keys.
-    pub fn any_cleared(&self) -> bool {
-        self.master_cleared || self.self_signing_cleared || self.user_signing_cleared
+impl DiffResult {
+    /// Do any of the keys differ?
+    pub fn any_differ(&self) -> bool {
+        self.master_differs || self.self_signing_differs || self.user_signing_differs
+    }
+
+    /// Do none of them differ?
+    pub fn none_differ(&self) -> bool {
+        !self.master_differs && !self.self_signing_differs && !self.user_signing_differs
     }
 }
 
@@ -309,28 +313,28 @@ impl PrivateCrossSigningIdentity {
     pub(crate) async fn clear_if_differs(
         &self,
         public_identity: &ReadOnlyOwnUserIdentity,
-    ) -> ClearResult {
+    ) -> DiffResult {
         let result = self.get_public_identity_diff(public_identity).await;
 
-        if result.master_cleared {
+        if result.master_differs {
             *self.master_key.lock().await = None;
         }
 
-        if result.user_signing_cleared {
+        if result.user_signing_differs {
             *self.user_signing_key.lock().await = None;
         }
 
-        if result.self_signing_cleared {
+        if result.self_signing_differs {
             *self.self_signing_key.lock().await = None;
         }
 
         result
     }
 
-    async fn get_public_identity_diff(
+    pub(crate) async fn get_public_identity_diff(
         &self,
         public_identity: &ReadOnlyOwnUserIdentity,
-    ) -> ClearResult {
+    ) -> DiffResult {
         let master_differs = self
             .master_public_key()
             .await
@@ -346,11 +350,7 @@ impl PrivateCrossSigningIdentity {
             .await
             .is_some_and(|subkey| &subkey != public_identity.self_signing_key());
 
-        ClearResult {
-            master_cleared: master_differs,
-            user_signing_cleared: user_signing_differs,
-            self_signing_cleared: self_signing_differs,
-        }
+        DiffResult { master_differs, user_signing_differs, self_signing_differs }
     }
 
     /// Get the names of the secrets we are missing.

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -57,25 +57,25 @@ pub struct PrivateCrossSigningIdentity {
     pub(crate) self_signing_key: Arc<Mutex<Option<SelfSigning>>>,
 }
 
-/// A struct containing information if any of our cross signing keys differ from
-/// the public keys that are uploaded to the server.
+/// A struct containing information on whether any of our cross-signing keys
+/// differ from the public keys that exist on the server.
 #[derive(Debug, Clone)]
 pub struct DiffResult {
-    /// Does the master key differ.
+    /// Does the master key differ?
     master_differs: bool,
-    /// Does the self-signing key differ.
+    /// Does the self-signing key differ?
     self_signing_differs: bool,
-    /// DOes the user-signing key differ.
+    /// Does the user-signing key differ?
     user_signing_differs: bool,
 }
 
 impl DiffResult {
-    /// Do any of the keys differ?
+    /// Do any of the cross-signing keys differ?
     pub fn any_differ(&self) -> bool {
         self.master_differs || self.self_signing_differs || self.user_signing_differs
     }
 
-    /// Do none of them differ?
+    /// Do none of the cross-signing keys differ?
     pub fn none_differ(&self) -> bool {
         !self.master_differs && !self.self_signing_differs && !self.user_signing_differs
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -681,7 +681,7 @@ impl Store {
 
             identity
                 .import_secrets(
-                    public_identity,
+                    public_identity.to_owned(),
                     export.master_key.as_deref(),
                     export.self_signing_key.as_deref(),
                     export.user_signing_key.as_deref(),
@@ -689,10 +689,18 @@ impl Store {
                 .await?;
 
             let status = identity.status().await;
-            info!(?status, "Successfully imported the private cross signing keys");
 
-            let changes =
+            let diff = identity.get_public_identity_diff(&public_identity.inner).await;
+
+            let mut changes =
                 Changes { private_identity: Some(identity.clone()), ..Default::default() };
+
+            if diff.none_differ() {
+                public_identity.mark_as_verified();
+                changes.identities.changed.push(ReadOnlyUserIdentities::Own(public_identity.inner));
+            }
+
+            info!(?status, "Successfully imported the private cross signing keys");
 
             self.save_changes(changes).await?;
         }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -700,7 +700,7 @@ impl Store {
                 changes.identities.changed.push(ReadOnlyUserIdentities::Own(public_identity.inner));
             }
 
-            info!(?status, "Successfully imported the private cross signing keys");
+            info!(?status, "Successfully imported the private cross-signing keys");
 
             self.save_changes(changes).await?;
         }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)
