### PR TITLE
ci: Use taiki-e/install-action to install protoc

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tool: protoc@3.20.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -67,10 +67,10 @@ jobs:
         uses: actions/checkout@v3
 
       # install protoc in case we end up rebuilding opentelemetry-proto
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tool: protoc@3.20.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,10 +163,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tool: protoc@3.20.3
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -354,10 +354,10 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tool: protoc@3.20.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tool: protoc@3.20.3
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
This is what tonic, the dependency that needs `protoc`, does in its CI.
The action previously used was generating warnings.