### PR TITLE
ffi: Simplify regular (non-OTLP) tracing initialization

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -56,7 +56,6 @@ tracing-android = { git = "https://github.com/jmartinesp/tracing-android", rev =
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [target.'cfg(target_os = "android")'.dependencies.matrix-sdk]
 path = "../../crates/matrix-sdk"


### PR DESCRIPTION
Wanted to switch from tracing-android to paranoid-android, ran out of time for today.