### PR TITLE
feat(FFI): allow specifying a protocol along a server name

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -10,7 +10,7 @@ use url::Url;
 use zeroize::Zeroize;
 
 use super::{client::Client, client_builder::ClientBuilder, RUNTIME};
-use crate::{client_builder::Protocol, error::ClientError};
+use crate::{client_builder::UrlScheme, error::ClientError};
 
 #[derive(uniffi::Object)]
 pub struct AuthenticationService {
@@ -119,9 +119,9 @@ impl AuthenticationService {
         match result {
             Ok(server_name) => {
                 let protocol = if server_name_or_homeserver_url.starts_with("http://") {
-                    Protocol::Http
+                    UrlScheme::Http
                 } else {
-                    Protocol::Https
+                    UrlScheme::Https
                 };
                 builder = builder.server_name_with_protocol(server_name.to_string(), protocol);
             }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -93,7 +93,7 @@ mod builder;
 mod futures;
 
 pub use self::{
-    builder::{ClientBuildError, ClientBuilder},
+    builder::{ClientBuildError, ClientBuilder, ServerNameProtocol},
     futures::SendRequest,
 };
 
@@ -1923,6 +1923,7 @@ pub(crate) mod tests {
 
     use super::Client;
     use crate::{
+        client::builder::ServerNameProtocol,
         config::{RequestConfig, SyncSettings},
         test_utils::{logged_in_client, no_retry_test_client, test_client_builder},
     };
@@ -1975,7 +1976,11 @@ pub(crate) mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::VERSIONS))
             .mount(&server)
             .await;
-        let client = Client::builder().server_name(alice.server_name()).build().await.unwrap();
+        let client = Client::builder()
+            .server_name_with_protocol(alice.server_name(), ServerNameProtocol::Http)
+            .build()
+            .await
+            .unwrap();
 
         assert_eq!(client.homeserver().await, Url::parse(server_url.as_ref()).unwrap());
     }
@@ -1994,7 +1999,11 @@ pub(crate) mod tests {
             .await;
 
         assert!(
-            Client::builder().server_name(alice.server_name()).build().await.is_err(),
+            Client::builder()
+                .server_name_with_protocol(alice.server_name(), ServerNameProtocol::Http)
+                .build()
+                .await
+                .is_err(),
             "Creating a client from a user ID should fail when the .well-known request fails."
         );
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -93,7 +93,7 @@ mod builder;
 mod futures;
 
 pub use self::{
-    builder::{ClientBuildError, ClientBuilder, ServerNameProtocol},
+    builder::{ClientBuildError, ClientBuilder},
     futures::SendRequest,
 };
 
@@ -1923,7 +1923,6 @@ pub(crate) mod tests {
 
     use super::Client;
     use crate::{
-        client::builder::ServerNameProtocol,
         config::{RequestConfig, SyncSettings},
         test_utils::{logged_in_client, no_retry_test_client, test_client_builder},
     };
@@ -1977,7 +1976,7 @@ pub(crate) mod tests {
             .mount(&server)
             .await;
         let client = Client::builder()
-            .server_name_with_protocol(alice.server_name(), ServerNameProtocol::Http)
+            .insecure_server_name_no_tls(alice.server_name())
             .build()
             .await
             .unwrap();
@@ -2000,7 +1999,7 @@ pub(crate) mod tests {
 
         assert!(
             Client::builder()
-                .server_name_with_protocol(alice.server_name(), ServerNameProtocol::Http)
+                .insecure_server_name_no_tls(alice.server_name())
                 .build()
                 .await
                 .is_err(),

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -50,7 +50,10 @@ pub mod sliding_sync;
 pub mod encryption;
 pub use account::Account;
 pub use authentication::{AuthApi, AuthSession};
-pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, UnknownToken};
+pub use client::{
+    Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, ServerNameProtocol,
+    UnknownToken,
+};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;
 pub use error::{

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -50,10 +50,7 @@ pub mod sliding_sync;
 pub mod encryption;
 pub use account::Account;
 pub use authentication::{AuthApi, AuthSession};
-pub use client::{
-    Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, ServerNameProtocol,
-    UnknownToken,
-};
+pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, UnknownToken};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;
 pub use error::{


### PR DESCRIPTION
This slightly changes the public API of `ClientBuilder` to introduce a new method `server_name_with_protocol`, that allows specifying the protocol along the server name.

As a reminder: `homeserver_url` will use the URL as is, while `server_name` does the well-known fetching and discover the actual underlying homeserver based on that. The server name didn't include the protocol, and it was assumed that the server would be reachable via HTTPS all the time... except for testing purposes, where we assumed we always tested with Wiremock which only does HTTP.

This makes the whole setup more explicit by allowing (optionally) to set the protocol along the server name. This is also wired in FFI, and as such should fix #2312.