### PR TITLE
feat(ui): Look for `Room` in the ring buffer from the newest instead of the oldest

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -313,7 +313,8 @@ impl RoomListService {
     pub async fn room(&self, room_id: &RoomId) -> Result<Room, Error> {
         {
             let rooms = self.rooms.read().await;
-            if let Some(room) = rooms.iter().find(|room| room.id() == room_id) {
+
+            if let Some(room) = rooms.iter().rfind(|room| room.id() == room_id) {
                 return Ok(room.clone());
             }
         }


### PR DESCRIPTION
In `RoomListService`, there is a cache over the `Room`s to avoid re- computing them every time the user calls `RoomListService::room`. It also allows async operations to have time to finish while the user jumps back to the room list and so on.

When reading this cache, which is `matrix_sdk_common::RingBuffer`, `RingBuffer::iter` is used with `Iter::find` to find if the `Room` exists in the cache. The cache has a size of 128 (given by `ROOM_OBJECT_CACHE_SIZE`), which is quite large.

`Iter::find` will iterate from the oldest to the newest room in the cache, but realistically, I reckon we need to iterate from the newest to the oldest room. Indeed, the app user is more likely to jump between recently opened rooms more frequently, thus saving quite a lot of iterations for usual cases.

One may argue than in practice, a user won't open 128 rooms anyway… :-p.