### PR TITLE
feat(sliding sync): store the to-device `next_batch` token in the crypto store

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -519,6 +519,7 @@ impl OlmMachine {
         device_changes: DeviceLists,
         key_counts: HashMap<String, i32>,
         unused_fallback_keys: Option<Vec<String>>,
+        next_batch_token: String,
     ) -> Result<SyncChangesResult, CryptoStoreError> {
         let to_device: ToDevice = serde_json::from_str(&events)?;
         let device_changes: RumaDeviceLists = device_changes.into();
@@ -543,6 +544,7 @@ impl OlmMachine {
                 changed_devices: &device_changes,
                 one_time_keys_counts: &key_counts,
                 unused_fallback_keys: unused_fallback_keys.as_deref(),
+                next_batch_token: Some(next_batch_token),
             }),
         )?;
 

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -537,13 +537,14 @@ impl OlmMachine {
         let unused_fallback_keys: Option<Vec<DeviceKeyAlgorithm>> =
             unused_fallback_keys.map(|u| u.into_iter().map(DeviceKeyAlgorithm::from).collect());
 
-        let (to_device_events, room_key_infos) =
-            self.runtime.block_on(self.inner.receive_sync_changes(
-                to_device.events,
-                &device_changes,
-                &key_counts,
-                unused_fallback_keys.as_deref(),
-            ))?;
+        let (to_device_events, room_key_infos) = self.runtime.block_on(
+            self.inner.receive_sync_changes(matrix_sdk_crypto::EncryptionSyncChanges {
+                to_device_events: to_device.events,
+                changed_devices: &device_changes,
+                one_time_keys_counts: &key_counts,
+                unused_fallback_keys: unused_fallback_keys.as_deref(),
+            }),
+        )?;
 
         let to_device_events =
             to_device_events.into_iter().map(|event| event.json().get().to_owned()).collect();

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -730,6 +730,7 @@ impl BaseClient {
                     changed_devices: &response.device_lists,
                     one_time_keys_counts: &response.device_one_time_keys_count,
                     unused_fallback_keys: response.device_unused_fallback_key_types.as_deref(),
+                    next_batch_token: Some(response.next_batch.clone()),
                 },
                 &mut changes,
             )

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -60,10 +60,10 @@ impl BaseClient {
 
         let v4::Extensions { to_device, e2ee, .. } = extensions;
 
-        let to_device = to_device.as_ref().map(|v4| v4.events.clone()).unwrap_or_default();
+        let to_device_events = to_device.as_ref().map(|v4| v4.events.clone()).unwrap_or_default();
 
         trace!(
-            to_device_events = to_device.len(),
+            to_device_events = to_device_events.len(),
             device_one_time_keys_count = e2ee.device_one_time_keys_count.len(),
             device_unused_fallback_key_types =
                 e2ee.device_unused_fallback_key_types.as_ref().map(|v| v.len()),
@@ -81,10 +81,13 @@ impl BaseClient {
         let to_device = self
             .preprocess_to_device_events(
                 matrix_sdk_crypto::EncryptionSyncChanges {
-                    to_device_events: to_device,
+                    to_device_events,
                     changed_devices: &e2ee.device_lists,
                     one_time_keys_counts: &e2ee.device_one_time_keys_count,
                     unused_fallback_keys: e2ee.device_unused_fallback_key_types.as_deref(),
+                    next_batch_token: to_device
+                        .as_ref()
+                        .map(|to_device| to_device.next_batch.clone()),
                 },
                 &mut changes,
             )

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -80,10 +80,12 @@ impl BaseClient {
         // counts.
         let to_device = self
             .preprocess_to_device_events(
-                to_device,
-                &e2ee.device_lists,
-                &e2ee.device_one_time_keys_count,
-                e2ee.device_unused_fallback_key_types.as_deref(),
+                matrix_sdk_crypto::EncryptionSyncChanges {
+                    to_device_events: to_device,
+                    changed_devices: &e2ee.device_lists,
+                    one_time_keys_counts: &e2ee.device_one_time_keys_count,
+                    unused_fallback_keys: e2ee.device_unused_fallback_key_types.as_deref(),
+                },
                 &mut changes,
             )
             .await?;

--- a/crates/matrix-sdk-crypto/README.md
+++ b/crates/matrix-sdk-crypto/README.md
@@ -19,7 +19,7 @@ The state machine works in a push/pull manner:
 ```rust,no_run
 use std::collections::BTreeMap;
 
-use matrix_sdk_crypto::{OlmMachine, OlmError};
+use matrix_sdk_crypto::{EncryptionSyncChanges, OlmMachine, OlmError};
 use ruma::{
     api::client::sync::sync_events::{v3::ToDevice, DeviceLists},
     device_id, user_id,
@@ -33,14 +33,16 @@ async fn main() -> Result<(), OlmError> {
     let changed_devices = DeviceLists::default();
     let one_time_key_counts = BTreeMap::default();
     let unused_fallback_keys = Some(Vec::new());
+    let next_batch_token = "T0K3N".to_owned();
 
     // Push changes that the server sent to us in a sync response.
-    let decrypted_to_device = machine.receive_sync_changes(
-        vec![],
-        &changed_devices,
-        &one_time_key_counts,
-        unused_fallback_keys.as_deref(),
-    ).await?;
+    let decrypted_to_device = machine.receive_sync_changes(EncryptionSyncChanges {
+        to_device_events: vec![],
+        changed_devices: &changed_devices,
+        one_time_keys_counts: &one_time_key_counts,
+        unused_fallback_keys: unused_fallback_keys.as_deref(),
+        next_batch_token: Some(next_batch_token),
+    }).await?;
 
     // Pull requests that we need to send out.
     let outgoing_requests = machine.outgoing_requests().await?;

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1761,7 +1761,7 @@ mod tests {
         use serde_json::value::to_raw_value;
         use tokio_stream::StreamExt;
 
-        use crate::machine::tests::get_machine_pair_with_setup_sessions;
+        use crate::{machine::tests::get_machine_pair_with_setup_sessions, EncryptionSyncChanges};
 
         let alice_id = user_id!("@alice:localhost");
 
@@ -1832,7 +1832,12 @@ mod tests {
         pin_mut!(stream);
 
         bob_machine
-            .receive_sync_changes(vec![event], &Default::default(), &Default::default(), None)
+            .receive_sync_changes(EncryptionSyncChanges {
+                to_device_events: vec![event],
+                changed_devices: &Default::default(),
+                one_time_keys_counts: &Default::default(),
+                unused_fallback_keys: None,
+            })
             .await
             .unwrap();
 

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1837,6 +1837,7 @@ mod tests {
                 changed_devices: &Default::default(),
                 one_time_keys_counts: &Default::default(),
                 unused_fallback_keys: None,
+                next_batch_token: None,
             })
             .await
             .unwrap();

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -78,7 +78,7 @@ pub use identities::{
     Device, LocalTrust, OwnUserIdentity, ReadOnlyDevice, ReadOnlyOwnUserIdentity,
     ReadOnlyUserIdentities, ReadOnlyUserIdentity, UserDevices, UserIdentities, UserIdentity,
 };
-pub use machine::OlmMachine;
+pub use machine::{EncryptionSyncChanges, OlmMachine};
 #[cfg(feature = "qrcode")]
 pub use matrix_sdk_qrcode;
 pub use olm::{CrossSigningStatus, EncryptionSettings, ReadOnlyAccount, Session};

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -184,20 +184,13 @@ pub struct KeysQueryRequest {
     /// The keys to be downloaded. An empty list indicates all devices for
     /// the corresponding user.
     pub device_keys: BTreeMap<OwnedUserId, Vec<OwnedDeviceId>>,
-
-    /// If the client is fetching keys as a result of a device update
-    /// received in a sync request, this should be the 'since' token of that
-    /// sync request, or any later sync token. This allows the server to
-    /// ensure its response contains the keys advertised by the notification
-    /// in that sync.
-    pub token: Option<String>,
 }
 
 impl KeysQueryRequest {
     pub(crate) fn new(users: impl Iterator<Item = OwnedUserId>) -> Self {
         let device_keys = users.map(|u| (u, Vec::new())).collect();
 
-        Self { timeout: None, device_keys, token: None }
+        Self { timeout: None, device_keys }
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -190,9 +190,8 @@ impl CryptoStore for MemoryStore {
             }
         }
 
-        if let Some(next_batch) = changes.next_batch_token {
-            *self.next_batch_token.write().await = Some(next_batch);
-        }
+        // Note: this will save an empty next_batch token, if provided an empty one.
+        *self.next_batch_token.write().await = changes.next_batch_token;
 
         Ok(())
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -139,6 +139,9 @@ struct StoreInner {
     secrets_broadcaster: broadcast::Sender<GossippedSecret>,
 }
 
+/// Aggregated changes to be saved in the database.
+///
+// If you ever add a field here, make sure to update `Changes::is_empty` too.
 #[derive(Default, Debug)]
 #[allow(missing_docs)]
 pub struct Changes {
@@ -176,6 +179,8 @@ impl Changes {
     pub fn is_empty(&self) -> bool {
         self.account.is_none()
             && self.private_identity.is_none()
+            && self.backup_version.is_none()
+            && self.backup_decryption_key.is_none()
             && self.sessions.is_empty()
             && self.message_hashes.is_empty()
             && self.inbound_group_sessions.is_empty()
@@ -183,6 +188,9 @@ impl Changes {
             && self.key_requests.is_empty()
             && self.identities.is_empty()
             && self.devices.is_empty()
+            && self.withheld_session_info.is_empty()
+            && self.room_settings.is_empty()
+            && self.secrets.is_empty()
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -140,7 +140,6 @@ struct StoreInner {
 }
 
 /// Aggregated changes to be saved in the database.
-///
 // If you ever add a field here, make sure to update `Changes::is_empty` too.
 #[derive(Default, Debug)]
 #[allow(missing_docs)]
@@ -160,6 +159,7 @@ pub struct Changes {
     pub withheld_session_info: BTreeMap<OwnedRoomId, BTreeMap<String, RoomKeyWithheldEvent>>,
     pub room_settings: HashMap<OwnedRoomId, RoomSettings>,
     pub secrets: Vec<GossippedSecret>,
+    pub next_batch_token: Option<String>,
 }
 
 /// A user for which we are tracking the list of devices.
@@ -191,6 +191,7 @@ impl Changes {
             && self.withheld_session_info.is_empty()
             && self.room_settings.is_empty()
             && self.secrets.is_empty()
+            && self.next_batch_token.is_none()
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -257,6 +257,9 @@ pub trait CryptoStore: AsyncTraitDeps {
         key: &str,
         holder: &str,
     ) -> Result<bool, Self::Error>;
+
+    /// Load the next-batch token for a to-device query, if any.
+    async fn next_batch_token(&self) -> Result<Option<String>, Self::Error>;
 }
 
 #[repr(transparent)]
@@ -422,6 +425,10 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
         holder: &str,
     ) -> Result<bool, Self::Error> {
         self.0.try_take_leased_lock(lease_duration_ms, key, holder).await.map_err(Into::into)
+    }
+
+    async fn next_batch_token(&self) -> Result<Option<String>, Self::Error> {
+        self.0.next_batch_token().await.map_err(Into::into)
     }
 }
 

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -763,9 +763,9 @@ impl CryptoStore for SqliteCryptoStore {
                     txn.set_kv("identity", &serialized_private_identity)?;
                 }
 
-                if let Some(next_batch) = &changes.next_batch_token {
-                    let serialized_next_batch = this.serialize_value(next_batch)?;
-                    txn.set_kv("next_batch_token", &serialized_next_batch)?;
+                if let Some(token) = &changes.next_batch_token {
+                    let serialized_token = this.serialize_value(token)?;
+                    txn.set_kv("next_batch_token", &serialized_token)?;
                 }
 
                 if let Some(decryption_key) = &changes.backup_decryption_key {
@@ -1218,8 +1218,8 @@ impl CryptoStore for SqliteCryptoStore {
     async fn next_batch_token(&self) -> Result<Option<String>, Self::Error> {
         let conn = self.acquire().await?;
         if let Some(token) = conn.get_kv("next_batch_token").await? {
-            let token = self.deserialize_value(&token)?;
-            Ok(Some(token))
+            let maybe_token: Option<String> = self.deserialize_value(&token)?;
+            Ok(maybe_token)
         } else {
             Ok(None)
         }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -452,6 +452,14 @@ impl Client {
     }
 }
 
+#[cfg(any(feature = "testing", test))]
+impl Client {
+    /// Get the olm machine, for testing purposes only.
+    pub async fn olm_machine_for_testing(&self) -> RwLockReadGuard<'_, Option<OlmMachine>> {
+        self.olm_machine().await
+    }
+}
+
 /// A high-level API to manage the client's encryption.
 ///
 /// To get this, use [`Client::encryption()`].


### PR DESCRIPTION
Before this, it was saved in the state store. Because Element iOS can read and write to it from different processes (b/o the notification process), we did write it into the state store and reload it *on every single request*. With the sliding sync happening in notifications in https://github.com/matrix-org/matrix-rust-sdk/pull/2252, an in-memory state store will be used in place of the on-disk one; that means we'd lose access to the previous delta tokens, if we kept the current scheme.

This PR makes it so that the delta-token is now stored in the crypto store. As an "in-app" migration path, if we find it was missing from the crypto-store, we try to read it from the state-store. Later writes will put it into the crypto-store anyways, where it's preferably read from.