### PR TITLE
ffi: Spawn tokio tasks for the remaining async fns

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -227,18 +227,17 @@ impl Room {
     }
 
     pub async fn add_timeline_listener(
-        &self,
+        self: Arc<Self>,
         listener: Box<dyn TimelineListener>,
     ) -> RoomTimelineListenerResult {
-        let timeline = self.timeline.clone();
-        let room = self.inner.clone();
         RUNTIME
             .spawn(async move {
-                let timeline = timeline
+                let timeline = self
+                    .timeline
                     .write()
                     .await
                     .get_or_insert_with(|| {
-                        let timeline = RUNTIME.block_on(room.timeline());
+                        let timeline = RUNTIME.block_on(self.inner.timeline());
                         Arc::new(timeline)
                     })
                     .clone();
@@ -806,50 +805,85 @@ impl Room {
         })
     }
 
-    pub async fn can_user_redact(&self, user_id: String) -> Result<bool, ClientError> {
-        let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.can_user_redact(&user_id).await?)
+    pub async fn can_user_redact(self: Arc<Self>, user_id: String) -> Result<bool, ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let user_id = UserId::parse(&user_id)?;
+                Ok(self.inner.can_user_redact(&user_id).await?)
+            })
+            .await
+            .unwrap()
     }
 
-    pub async fn can_user_ban(&self, user_id: String) -> Result<bool, ClientError> {
-        let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.can_user_ban(&user_id).await?)
+    pub async fn can_user_ban(self: Arc<Self>, user_id: String) -> Result<bool, ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let user_id = UserId::parse(&user_id)?;
+                Ok(self.inner.can_user_ban(&user_id).await?)
+            })
+            .await
+            .unwrap()
     }
 
-    pub async fn can_user_invite(&self, user_id: String) -> Result<bool, ClientError> {
-        let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.can_user_invite(&user_id).await?)
+    pub async fn can_user_invite(self: Arc<Self>, user_id: String) -> Result<bool, ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let user_id = UserId::parse(&user_id)?;
+                Ok(self.inner.can_user_invite(&user_id).await?)
+            })
+            .await
+            .unwrap()
     }
 
-    pub async fn can_user_kick(&self, user_id: String) -> Result<bool, ClientError> {
-        let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.can_user_kick(&user_id).await?)
+    pub async fn can_user_kick(self: Arc<Self>, user_id: String) -> Result<bool, ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let user_id = UserId::parse(&user_id)?;
+                Ok(self.inner.can_user_kick(&user_id).await?)
+            })
+            .await
+            .unwrap()
     }
 
     pub async fn can_user_send_state(
-        &self,
+        self: Arc<Self>,
         user_id: String,
         state_event: StateEventType,
     ) -> Result<bool, ClientError> {
-        let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.can_user_send_state(&user_id, state_event.into()).await?)
+        RUNTIME
+            .spawn(async move {
+                let user_id = UserId::parse(&user_id)?;
+                Ok(self.inner.can_user_send_state(&user_id, state_event.into()).await?)
+            })
+            .await
+            .unwrap()
     }
 
     pub async fn can_user_send_message(
-        &self,
+        self: Arc<Self>,
         user_id: String,
         message: MessageLikeEventType,
     ) -> Result<bool, ClientError> {
-        let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.can_user_send_message(&user_id, message.into()).await?)
+        RUNTIME
+            .spawn(async move {
+                let user_id = UserId::parse(&user_id)?;
+                Ok(self.inner.can_user_send_message(&user_id, message.into()).await?)
+            })
+            .await
+            .unwrap()
     }
 
     pub async fn can_user_trigger_room_notification(
-        &self,
+        self: Arc<Self>,
         user_id: String,
     ) -> Result<bool, ClientError> {
-        let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.can_user_trigger_room_notification(&user_id).await?)
+        RUNTIME
+            .spawn(async move {
+                let user_id = UserId::parse(&user_id)?;
+                Ok(self.inner.can_user_trigger_room_notification(&user_id).await?)
+            })
+            .await
+            .unwrap()
     }
 
     pub fn own_user_id(&self) -> String {
@@ -914,23 +948,25 @@ impl Room {
 
 #[derive(uniffi::Object)]
 pub struct SendAttachmentJoinHandle {
-    join_hdl: Arc<Mutex<JoinHandle<Result<(), RoomError>>>>,
+    join_hdl: Mutex<JoinHandle<Result<(), RoomError>>>,
     abort_hdl: AbortHandle,
 }
 
 impl SendAttachmentJoinHandle {
     fn new(join_hdl: JoinHandle<Result<(), RoomError>>) -> Arc<Self> {
         let abort_hdl = join_hdl.abort_handle();
-        let join_hdl = Arc::new(Mutex::new(join_hdl));
+        let join_hdl = Mutex::new(join_hdl);
         Arc::new(Self { join_hdl, abort_hdl })
     }
 }
 
 #[uniffi::export(async_runtime = "tokio")]
 impl SendAttachmentJoinHandle {
-    pub async fn join(&self) -> Result<(), RoomError> {
-        let join_hdl = self.join_hdl.clone();
-        RUNTIME.spawn(async move { (&mut *join_hdl.lock().await).await.unwrap() }).await.unwrap()
+    pub async fn join(self: Arc<Self>) -> Result<(), RoomError> {
+        RUNTIME
+            .spawn(async move { (&mut *self.join_hdl.lock().await).await.unwrap() })
+            .await
+            .unwrap()
     }
 
     pub fn cancel(&self) {

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -93,21 +93,36 @@ impl RoomListService {
     }
 
     async fn all_rooms(self: Arc<Self>) -> Result<Arc<RoomList>, RoomListError> {
-        Ok(Arc::new(RoomList {
-            room_list_service: self.clone(),
-            inner: Arc::new(self.inner.all_rooms().await.map_err(RoomListError::from)?),
-        }))
+        RUNTIME
+            .spawn(async move {
+                Ok(Arc::new(RoomList {
+                    room_list_service: self.clone(),
+                    inner: Arc::new(self.inner.all_rooms().await.map_err(RoomListError::from)?),
+                }))
+            })
+            .await
+            .unwrap()
     }
 
     async fn invites(self: Arc<Self>) -> Result<Arc<RoomList>, RoomListError> {
-        Ok(Arc::new(RoomList {
-            room_list_service: self.clone(),
-            inner: Arc::new(self.inner.invites().await.map_err(RoomListError::from)?),
-        }))
+        RUNTIME
+            .spawn(async move {
+                Ok(Arc::new(RoomList {
+                    room_list_service: self.clone(),
+                    inner: Arc::new(self.inner.invites().await.map_err(RoomListError::from)?),
+                }))
+            })
+            .await
+            .unwrap()
     }
 
-    async fn apply_input(&self, input: RoomListInput) -> Result<(), RoomListError> {
-        self.inner.apply_input(input.into()).await.map(|_| ()).map_err(Into::into)
+    async fn apply_input(self: Arc<Self>, input: RoomListInput) -> Result<(), RoomListError> {
+        RUNTIME
+            .spawn(async move {
+                self.inner.apply_input(input.into()).await.map(|_| ()).map_err(Into::into)
+            })
+            .await
+            .unwrap()
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -61,69 +61,94 @@ impl SessionVerificationController {
         *self.delegate.write().unwrap() = delegate;
     }
 
-    pub async fn request_verification(&self) -> Result<(), ClientError> {
-        let methods = vec![VerificationMethod::SasV1];
-        let verification_request = self
-            .user_identity
-            .request_verification_with_methods(methods)
+    pub async fn request_verification(self: Arc<Self>) -> Result<(), ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let methods = vec![VerificationMethod::SasV1];
+                let verification_request = self
+                    .user_identity
+                    .request_verification_with_methods(methods)
+                    .await
+                    .map_err(anyhow::Error::from)?;
+                *self.verification_request.write().unwrap() = Some(verification_request);
+
+                Ok(())
+            })
             .await
-            .map_err(anyhow::Error::from)?;
-        *self.verification_request.write().unwrap() = Some(verification_request);
-
-        Ok(())
+            .unwrap()
     }
 
-    pub async fn start_sas_verification(&self) -> Result<(), ClientError> {
-        let verification_request = self.verification_request.read().unwrap().clone();
+    pub async fn start_sas_verification(self: Arc<Self>) -> Result<(), ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let verification_request = self.verification_request.read().unwrap().clone();
 
-        if let Some(verification) = verification_request {
-            match verification.start_sas().await {
-                Ok(Some(verification)) => {
-                    *self.sas_verification.write().unwrap() = Some(verification.clone());
+                if let Some(verification) = verification_request {
+                    match verification.start_sas().await {
+                        Ok(Some(verification)) => {
+                            *self.sas_verification.write().unwrap() = Some(verification.clone());
 
-                    if let Some(delegate) = &*self.delegate.read().unwrap() {
-                        delegate.did_start_sas_verification()
+                            if let Some(delegate) = &*self.delegate.read().unwrap() {
+                                delegate.did_start_sas_verification()
+                            }
+
+                            let delegate = self.delegate.clone();
+                            RUNTIME.spawn(Self::listen_to_changes(delegate, verification));
+                        }
+                        _ => {
+                            if let Some(delegate) = &*self.delegate.read().unwrap() {
+                                delegate.did_fail()
+                            }
+                        }
                     }
-
-                    let delegate = self.delegate.clone();
-                    RUNTIME.spawn(Self::listen_to_changes(delegate, verification));
                 }
-                _ => {
-                    if let Some(delegate) = &*self.delegate.read().unwrap() {
-                        delegate.did_fail()
-                    }
+
+                Ok(())
+            })
+            .await
+            .unwrap()
+    }
+
+    pub async fn approve_verification(self: Arc<Self>) -> Result<(), ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let sas_verification = self.sas_verification.read().unwrap().clone();
+                if let Some(sas_verification) = sas_verification {
+                    sas_verification.confirm().await?;
                 }
-            }
-        }
 
-        Ok(())
+                Ok(())
+            })
+            .await
+            .unwrap()
     }
 
-    pub async fn approve_verification(&self) -> Result<(), ClientError> {
-        let sas_verification = self.sas_verification.read().unwrap().clone();
-        if let Some(sas_verification) = sas_verification {
-            sas_verification.confirm().await?;
-        }
+    pub async fn decline_verification(self: Arc<Self>) -> Result<(), ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let sas_verification = self.sas_verification.read().unwrap().clone();
+                if let Some(sas_verification) = sas_verification {
+                    sas_verification.mismatch().await?;
+                }
 
-        Ok(())
+                Ok(())
+            })
+            .await
+            .unwrap()
     }
 
-    pub async fn decline_verification(&self) -> Result<(), ClientError> {
-        let sas_verification = self.sas_verification.read().unwrap().clone();
-        if let Some(sas_verification) = sas_verification {
-            sas_verification.mismatch().await?;
-        }
+    pub async fn cancel_verification(self: Arc<Self>) -> Result<(), ClientError> {
+        RUNTIME
+            .spawn(async move {
+                let verification_request = self.verification_request.read().unwrap().clone();
+                if let Some(verification) = verification_request {
+                    verification.cancel().await?;
+                }
 
-        Ok(())
-    }
-
-    pub async fn cancel_verification(&self) -> Result<(), ClientError> {
-        let verification_request = self.verification_request.read().unwrap().clone();
-        if let Some(verification) = verification_request {
-            verification.cancel().await?;
-        }
-
-        Ok(())
+                Ok(())
+            })
+            .await
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
… as a workaround for cancellation being broken in UniFFI.

Specifically:

- Before this change, cancelling a future from the foreign code would (apparently) **leak** it, meaning that it would no longer be polled but it wouldn't be dropped either, so any shared resources held by that future would never be released.
- After this change, cancelling a future from the foreign code will only leak a join handle and possibly some UniFFI state, but the main Rust future will just continue running. This is not ideal, but avoids deadlocks.
