### PR TITLE
Define FFI API for `m.poll.start` and `m.poll.end`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -126,8 +126,6 @@ pub enum MessageLikeEventContent {
     KeyVerificationKey,
     KeyVerificationMac,
     KeyVerificationDone,
-    PollStart,
-    PollEnd,
     ReactionContent { related_event_id: String },
     RoomEncrypted,
     RoomMessage { message_type: MessageType },

--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -126,6 +126,8 @@ pub enum MessageLikeEventContent {
     KeyVerificationKey,
     KeyVerificationMac,
     KeyVerificationDone,
+    PollStart,
+    PollEnd,
     ReactionContent { related_event_id: String },
     RoomEncrypted,
     RoomMessage { message_type: MessageType },

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -474,6 +474,17 @@ pub enum TimelineItemContentKind {
         info: ImageInfo,
         url: String,
     },
+    Poll {
+        question: String,
+        kind: PollKind,
+        max_selections: u64,
+        answers: Vec<PollAnswer>,
+        votes: HashMap<String, Vec<String>>,
+        end_time: Option<u64>,
+    },
+    PollEnd {
+        start_event_id: String,
+    },
     UnableToDecrypt {
         msg: EncryptedMessage,
     },
@@ -1251,4 +1262,16 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherFullStateEventContent> for OtherStat
             Content::_Custom { event_type, .. } => Self::Custom { event_type: event_type.clone() },
         }
     }
+}
+
+#[derive(Clone, uniffi::Enum)]
+pub enum PollKind {
+    Disclosed,
+    Undisclosed,
+}
+
+#[derive(Clone, uniffi::Record)]
+pub struct PollAnswer {
+    pub id: String,
+    pub text: String,
 }


### PR DESCRIPTION
Simply adds FFI message types and their associated structs for poll events

---

We already have a working implementation based on this, but it needs the [ruma PR](https://github.com/ruma/ruma/pull/1589) landed etc. Committing just these binding stubs will unblock the client-side development that is relying on this functionality.