### PR TITLE
chore: remove all experimental features on the UI crate

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -29,7 +29,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption", "experimental-room-list", "experimental-encryption-sync", "experimental-notification-client", "experimental-sync-service"] }
+matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption"] }
 mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -4,36 +4,30 @@ version = "0.6.0"
 edition = "2021"
 
 [features]
-default = ["e2e-encryption", "native-tls", "experimental-room-list", "experimental-encryption-sync", "experimental-sync-service", "experimental-notification-client"]
+default = ["e2e-encryption", "native-tls"]
 
 e2e-encryption = ["matrix-sdk/e2e-encryption"]
 
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
 
-experimental-sync-service = ["experimental-room-list", "experimental-encryption-sync"]
-experimental-encryption-sync = ["experimental-sliding-sync", "dep:async-stream"]
-experimental-notification-client = ["experimental-encryption-sync"]
-experimental-room-list = ["experimental-sliding-sync", "dep:async-stream", "dep:eyeball-im-util"]
-experimental-sliding-sync = ["matrix-sdk/experimental-sliding-sync"]
-
-testing = ["dep:eyeball-im-util"]
+testing = []
 
 [dependencies]
 async-once-cell = "0.5.2"
 async-std = { version = "1.12.0", features = ["unstable"] }
-async-stream = { workspace = true, optional = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 chrono = "0.4.23"
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }
-eyeball-im-util = { workspace = true, optional = true }
+eyeball-im-util = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
 imbl = { version = "2.0.0", features = ["serde"] }
 indexmap = "2.0.0"
 itertools = { workspace = true }
-matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false }
+matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["experimental-sliding-sync"] }
 matrix-sdk-base = { version = "0.6.1", path = "../matrix-sdk-base" }
 matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto" }
 mime = "0.3.16"

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -14,19 +14,13 @@
 
 mod events;
 
-#[cfg(feature = "experimental-encryption-sync")]
 pub mod encryption_sync;
-#[cfg(feature = "experimental-notification-client")]
 pub mod notification_client;
-#[cfg(feature = "experimental-room-list")]
 pub mod room_list_service;
-#[cfg(feature = "experimental-sync-service")]
 pub mod sync_service;
 pub mod timeline;
 
-#[cfg(feature = "experimental-room-list")]
-pub use self::room_list_service::RoomListService;
-pub use self::timeline::Timeline;
+pub use self::{room_list_service::RoomListService, timeline::Timeline};
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 #[ctor::ctor]

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -57,7 +57,6 @@ impl TimelineBuilder {
     }
 
     /// Add initial events to the timeline.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) fn events(
         mut self,
         prev_token: Option<String>,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
@@ -18,10 +18,7 @@ use imbl::{vector, Vector};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use matrix_sdk::{deserialized_responses::TimelineEvent, Result};
-#[cfg(feature = "experimental-sliding-sync")]
 use matrix_sdk_base::latest_event::{is_suitable_for_latest_event, PossibleLatestEvent};
-#[cfg(feature = "experimental-sliding-sync")]
-use ruma::events::{AnySyncTimelineEvent, OriginalSyncMessageLikeEvent};
 use ruma::{
     assign,
     events::{
@@ -56,15 +53,13 @@ use ruma::{
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         sticker::StickerEventContent,
         AnyFullStateEventContent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent,
-        AnyTimelineEvent, BundledMessageLikeRelations, FullStateEventContent, MessageLikeEventType,
-        StateEventType,
+        AnySyncTimelineEvent, AnyTimelineEvent, BundledMessageLikeRelations, FullStateEventContent,
+        MessageLikeEventType, OriginalSyncMessageLikeEvent, StateEventType,
     },
     OwnedDeviceId, OwnedEventId, OwnedMxcUri, OwnedTransactionId, OwnedUserId, RoomVersionId,
     UserId,
 };
-use tracing::error;
-#[cfg(feature = "experimental-sliding-sync")]
-use tracing::warn;
+use tracing::{error, warn};
 
 use super::{EventItemIdentifier, EventTimelineItem, Profile, TimelineDetails};
 use crate::timeline::{
@@ -122,7 +117,6 @@ impl TimelineItemContent {
     /// If the supplied event is suitable to be used as a latest_event in a
     /// message preview, extract its contents and wrap it as a
     /// TimelineItemContent.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) fn from_latest_event_content(
         event: AnySyncTimelineEvent,
     ) -> Option<TimelineItemContent> {
@@ -157,7 +151,6 @@ impl TimelineItemContent {
     /// Given some message content that is from an event that we have already
     /// determined is suitable for use as a latest event in a message preview,
     /// extract its contents and wrap it as a TimelineItemContent.
-    #[cfg(feature = "experimental-sliding-sync")]
     fn from_suitable_latest_event_content(
         message: &OriginalSyncMessageLikeEvent<RoomMessageEventContent>,
     ) -> Option<TimelineItemContent> {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -15,10 +15,7 @@
 use std::sync::Arc;
 
 use indexmap::IndexMap;
-#[cfg(feature = "experimental-sliding-sync")]
-use matrix_sdk::SlidingSyncRoom;
-use matrix_sdk::{deserialized_responses::EncryptionInfo, Error};
-#[cfg(feature = "experimental-sliding-sync")]
+use matrix_sdk::{deserialized_responses::EncryptionInfo, Error, SlidingSyncRoom};
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use once_cell::sync::Lazy;
 use ruma::{
@@ -27,7 +24,6 @@ use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedMxcUri, OwnedTransactionId,
     OwnedUserId, RoomVersionId, TransactionId, UserId,
 };
-#[cfg(feature = "experimental-sliding-sync")]
 use tracing::warn;
 
 mod content;
@@ -94,7 +90,6 @@ impl EventTimelineItem {
 
     /// If the supplied low-level SyncTimelineEventy is suitable for use as the
     /// latest_event in a message preview, wrap it as an EventTimelineItem,
-    #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) async fn from_latest_event(
         room: &SlidingSyncRoom,
         sync_event: SyncTimelineEvent,
@@ -488,7 +483,6 @@ mod test {
     use super::*;
 
     #[async_test]
-    #[cfg(feature = "experimental-sliding-sync")]
     async fn latest_message_event_can_be_wrapped_as_a_timeline_item() {
         // Given a sync event that is suitable to be used as a latest_event
 
@@ -520,7 +514,6 @@ mod test {
     }
 
     #[async_test]
-    #[cfg(feature = "experimental-sliding-sync")]
     async fn latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender() {
         // Given a sync event that is suitable to be used as a latest_event, and a room
         // with a member event for the sender
@@ -584,14 +577,12 @@ mod test {
         .unwrap()
     }
 
-    #[cfg(feature = "experimental-sliding-sync")]
     async fn response_with_room(room_id: &RoomId, room: v4::SlidingSyncRoom) -> v4::Response {
         let mut response = v4::Response::new("6".to_owned());
         response.rooms.insert(room_id.to_owned(), room);
         response
     }
 
-    #[cfg(feature = "experimental-sliding-sync")]
     fn message_event(
         room_id: &RoomId,
         user_id: &UserId,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -59,7 +59,6 @@ mod pagination;
 mod queue;
 mod reactions;
 mod read_receipts;
-#[cfg(feature = "experimental-sliding-sync")]
 mod sliding_sync_ext;
 #[cfg(test)]
 mod tests;
@@ -68,8 +67,6 @@ mod to_device;
 mod traits;
 mod virtual_item;
 
-#[cfg(feature = "experimental-sliding-sync")]
-pub use self::sliding_sync_ext::SlidingSyncRoomExt;
 pub use self::{
     builder::TimelineBuilder,
     event_item::{
@@ -82,6 +79,7 @@ pub use self::{
     item::{TimelineItem, TimelineItemKind},
     pagination::{PaginationOptions, PaginationOutcome},
     reactions::ReactionSenderData,
+    sliding_sync_ext::SlidingSyncRoomExt,
     traits::RoomExt,
     virtual_item::VirtualTimelineItem,
 };
@@ -137,7 +135,6 @@ impl Timeline {
     }
 
     /// Clear all timeline items, and reset pagination parameters.
-    #[cfg(feature = "experimental-sliding-sync")]
     pub async fn clear(&self) {
         let mut start_lock = self.start_token.lock().await;
         let mut end_lock = self._end_token.lock().await;

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -26,11 +26,8 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-#[cfg(feature = "experimental-encryption-sync")]
 mod encryption_sync;
-#[cfg(feature = "experimental-notification-client")]
 mod notification_client;
-#[cfg(feature = "experimental-room-list")]
 mod room_list_service;
 mod sliding_sync;
 mod timeline;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -36,7 +36,7 @@ mod echo;
 mod pagination;
 mod queue;
 mod read_receipts;
-#[cfg(feature = "experimental-sliding-sync")]
+
 pub(crate) mod sliding_sync;
 
 use crate::{logged_in_client, mock_sync};


### PR DESCRIPTION
As discussed, we think the entire UI crate should be considered experimental. We've also observed a proliferation of feature flags there (many of those are my wrong doings, sorry). Since the one internal user (FFI) of that crate enabled all experimental features, it seems fine to make them all default, while not providing any extra stability guarantee based on that action.