### PR TITLE
feat(sliding sync): include the connection id in the tracing context

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -496,7 +496,7 @@ impl SlidingSync {
             || !self.inner.lists.read().await.is_empty()
     }
 
-    #[instrument(skip_all, fields(pos))]
+    #[instrument(skip_all, fields(pos, conn_id = self.inner.id))]
     async fn sync_once(&self) -> Result<UpdateSummary> {
         let (request, request_config, requested_room_unsubscriptions) =
             self.generate_sync_request(&mut LazyTransactionId::new()).await?;


### PR DESCRIPTION
Due to popular request, we're adding this; it would also make debugging sliding sync requests likely easier for everyone.