### PR TITLE
chore(sdk): Remove one `TODO` in Sliding Sync

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -223,8 +223,8 @@ impl SlidingSyncListBuilder {
                 // otherwise.
                 state: StdRwLock::new(Observable::new(Default::default())),
                 maximum_number_of_rooms: StdRwLock::new(Observable::new(None)),
-                // TODO: We need to do batching here instead of increasing the capacity. We want to
-                // avoid triggering `VectorDiff::Reset` as much as possible.
+                // We want to avoid triggering `VectorDiff::Reset` as much as possible, hence we
+                // increase the observable capacity.
                 room_list: StdRwLock::new(ObservableVector::with_capacity(4096)),
 
                 // Internal data.


### PR DESCRIPTION
Address #1911.

The batch subscriber exists in `matrix_sdk_ui::RoomList` (https://github.com/matrix-org/matrix-rust-sdk/pull/2322) instead of being added here.

We must keep the observable capacity to 4096, but the `TODO` is no longer relevant.

Why keeping the capacity to 4096? Because if the batch subscriber (in `RoomList`) isn't “listened” quickly, we don't want to get a `Reset`.