### PR TITLE
feat(sdk+ui+ffi): Implement `(SlidingSyncRoom|Room|RoomListItem)::avatar_url`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,6 @@ checksum = "1d9a8bb6c7c71d151b25936b03e012a4c00daea99e3a3797c6ead66b0a0d55e2"
 dependencies = [
  "const_panic",
  "konst_kernel",
- "konst_proc_macros",
  "typewit",
 ]
 
@@ -2375,12 +2374,6 @@ checksum = "55d2ab266022e7309df89ed712bddc753e3a3c395c3ced1bb2e4470ec2a8146d"
 dependencies = [
  "typewit",
 ]
-
-[[package]]
-name = "konst_proc_macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e28ab1dc35e09d60c2b8c90d12a9a8d9666c876c10a3739a3196db0103b6043"
 
 [[package]]
 name = "kv-log-macro"
@@ -2817,7 +2810,7 @@ dependencies = [
  "byteorder",
  "image 0.23.14",
  "qrcode",
- "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26)",
+ "ruma-common",
  "thiserror",
  "vodozemac",
 ]
@@ -4074,14 +4067,14 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+source = "git+https://github.com/ruma/ruma?rev=1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9#1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9"
 dependencies = [
  "assign",
  "js_int",
  "js_option",
  "ruma-appservice-api",
  "ruma-client-api",
- "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
+ "ruma-common",
  "ruma-federation-api",
  "ruma-push-gateway-api",
 ]
@@ -4089,10 +4082,10 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+source = "git+https://github.com/ruma/ruma?rev=1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9#1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9"
 dependencies = [
  "js_int",
- "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
+ "ruma-common",
  "serde",
  "serde_json",
 ]
@@ -4100,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+source = "git+https://github.com/ruma/ruma?rev=1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9#1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9"
 dependencies = [
  "assign",
  "bytes",
@@ -4108,7 +4101,7 @@ dependencies = [
  "js_int",
  "js_option",
  "maplit",
- "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
+ "ruma-common",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -4117,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+source = "git+https://github.com/ruma/ruma?rev=1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9#1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -4135,8 +4128,8 @@ dependencies = [
  "pulldown-cmark",
  "rand 0.8.5",
  "regex",
- "ruma-identifiers-validation 0.9.1 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
- "ruma-macros 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
+ "ruma-identifiers-validation",
+ "ruma-macros",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -4148,37 +4141,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruma-common"
-version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
-dependencies = [
- "base64 0.21.2",
- "bytes",
- "form_urlencoded",
- "indexmap 2.0.0",
- "js_int",
- "js_option",
- "konst",
- "percent-encoding",
- "regex",
- "ruma-identifiers-validation 0.9.1 (git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26)",
- "ruma-macros 0.11.3 (git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26)",
- "serde",
- "serde_html_form",
- "serde_json",
- "thiserror",
- "tracing",
- "url",
- "wildmatch",
-]
-
-[[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+source = "git+https://github.com/ruma/ruma?rev=1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9#1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9"
 dependencies = [
  "js_int",
- "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
+ "ruma-common",
  "serde",
  "serde_json",
 ]
@@ -4186,16 +4154,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
-dependencies = [
- "js_int",
- "thiserror",
-]
-
-[[package]]
-name = "ruma-identifiers-validation"
-version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
+source = "git+https://github.com/ruma/ruma?rev=1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9#1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4204,28 +4163,13 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+source = "git+https://github.com/ruma/ruma?rev=1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9#1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "ruma-identifiers-validation 0.9.1 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
- "serde",
- "syn 2.0.22",
- "toml 0.7.5",
-]
-
-[[package]]
-name = "ruma-macros"
-version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
-dependencies = [
- "once_cell",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "ruma-identifiers-validation 0.9.1 (git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26)",
+ "ruma-identifiers-validation",
  "serde",
  "syn 2.0.22",
  "toml 0.7.5",
@@ -4234,10 +4178,10 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+source = "git+https://github.com/ruma/ruma?rev=1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9#1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9"
 dependencies = [
  "js_int",
- "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
+ "ruma-common",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,7 +2817,7 @@ dependencies = [
  "byteorder",
  "image 0.23.14",
  "qrcode",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26)",
  "thiserror",
  "vodozemac",
 ]
@@ -4074,14 +4074,14 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
+source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
 dependencies = [
  "assign",
  "js_int",
  "js_option",
  "ruma-appservice-api",
  "ruma-client-api",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
  "ruma-federation-api",
  "ruma-push-gateway-api",
 ]
@@ -4089,10 +4089,10 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
+source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
 dependencies = [
  "js_int",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
  "serde",
  "serde_json",
 ]
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
+source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
 dependencies = [
  "assign",
  "bytes",
@@ -4108,7 +4108,7 @@ dependencies = [
  "js_int",
  "js_option",
  "maplit",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
+source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -4135,8 +4135,8 @@ dependencies = [
  "pulldown-cmark",
  "rand 0.8.5",
  "regex",
- "ruma-identifiers-validation",
- "ruma-macros",
+ "ruma-identifiers-validation 0.9.1 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
+ "ruma-macros 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -4148,14 +4148,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruma-federation-api"
-version = "0.7.1"
+name = "ruma-common"
+version = "0.11.3"
 source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
 dependencies = [
+ "base64 0.21.2",
+ "bytes",
+ "form_urlencoded",
+ "indexmap 2.0.0",
  "js_int",
- "ruma-common",
+ "js_option",
+ "konst",
+ "percent-encoding",
+ "regex",
+ "ruma-identifiers-validation 0.9.1 (git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26)",
+ "ruma-macros 0.11.3 (git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26)",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "url",
+ "wildmatch",
+]
+
+[[package]]
+name = "ruma-federation-api"
+version = "0.7.1"
+source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+dependencies = [
+ "js_int",
+ "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ruma-identifiers-validation"
+version = "0.9.1"
+source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+dependencies = [
+ "js_int",
+ "thiserror",
 ]
 
 [[package]]
@@ -4170,13 +4204,28 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
+source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "ruma-identifiers-validation 0.9.1 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
+ "serde",
+ "syn 2.0.22",
+ "toml 0.7.5",
+]
+
+[[package]]
+name = "ruma-macros"
+version = "0.11.3"
 source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "ruma-identifiers-validation",
+ "ruma-identifiers-validation 0.9.1 (git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26)",
  "serde",
  "syn 2.0.22",
  "toml 0.7.5",
@@ -4185,10 +4234,10 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=a641adb4287267ba9c4778ac1ee83b4ecab11e26#a641adb4287267ba9c4778ac1ee83b4ecab11e26"
+source = "git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096#201f0027d4e8be1716096c4a700eff211313c096"
 dependencies = [
  "js_int",
- "ruma-common",
+ "ruma-common 0.11.3 (git+https://github.com/ruma/ruma?rev=201f0027d4e8be1716096c4a700eff211313c096)",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "a641adb4287267ba9c4778ac1ee83b4ecab11e26", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "201f0027d4e8be1716096c4a700eff211313c096", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
 ruma-common = { git = "https://github.com/ruma/ruma", rev = "a641adb4287267ba9c4778ac1ee83b4ecab11e26" }
 once_cell = "1.16.0"
 serde = "1.0.151"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "201f0027d4e8be1716096c4a700eff211313c096", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "a641adb4287267ba9c4778ac1ee83b4ecab11e26" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "1d81c7c6d49aec053d5b84441bc5a4e62d8cc8a9" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -296,15 +296,15 @@ impl RoomListItem {
         RUNTIME.block_on(async { self.inner.name().await })
     }
 
-    pub fn is_direct(&self) -> bool {
+    fn avatar_url(&self) -> Option<String> {
+        self.inner.avatar_url().map(|uri| uri.to_string())
+    }
+
+    fn is_direct(&self) -> bool {
         RUNTIME.block_on(async { self.inner.inner_room().is_direct().await.unwrap_or(false) })
     }
 
-    pub fn avatar_url(&self) -> Option<String> {
-        self.inner.inner_room().avatar_url().map(|uri| uri.to_string())
-    }
-
-    pub fn canonical_alias(&self) -> Option<String> {
+    fn canonical_alias(&self) -> Option<String> {
         self.inner.inner_room().canonical_alias().map(|alias| alias.to_string())
     }
 
@@ -399,13 +399,15 @@ pub struct UnreadNotificationsCount {
 
 #[uniffi::export]
 impl UnreadNotificationsCount {
-    pub fn highlight_count(&self) -> u32 {
+    fn highlight_count(&self) -> u32 {
         self.highlight_count
     }
-    pub fn notification_count(&self) -> u32 {
+
+    fn notification_count(&self) -> u32 {
         self.notification_count
     }
-    pub fn has_notifications(&self) -> bool {
+
+    fn has_notifications(&self) -> bool {
         self.notification_count != 0 || self.highlight_count != 0
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -20,7 +20,7 @@ use async_once_cell::OnceCell as AsyncOnceCell;
 use matrix_sdk::{SlidingSync, SlidingSyncRoom};
 use ruma::{
     api::client::sync::sync_events::{v4::RoomSubscription, UnreadNotificationsCount},
-    RoomId,
+    OwnedMxcUri, RoomId,
 };
 
 use super::Error;
@@ -87,6 +87,14 @@ impl Room {
             Some(name) => name,
             None => self.inner.room.display_name().await.ok()?.to_string(),
         })
+    }
+
+    /// Get the best possible avatar for the room.
+    ///
+    /// If the sliding sync room has received an avatar from the server, then
+    /// use it, otherwise, let's try to find one from `Room`.
+    pub fn avatar_url(&self) -> Option<OwnedMxcUri> {
+        self.inner.sliding_sync_room.avatar_url().or_else(|| self.inner.room.avatar_url())
     }
 
     /// Get the underlying [`matrix_sdk::Room`].

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -18,7 +18,7 @@ use ruma::{
     api::client::sync::sync_events::{v4::RoomSubscription, UnreadNotificationsCount},
     assign, event_id,
     events::StateEventType,
-    room_id, uint,
+    mxc_uri, room_id, uint,
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
@@ -1697,6 +1697,7 @@ async fn test_room() -> Result<(), Error> {
             "rooms": {
                 room_id_0: {
                     "name": "Room #0",
+                    "avatar": "mxc://homeserver/media",
                     "initial": true,
                 },
                 room_id_1: {
@@ -1706,13 +1707,22 @@ async fn test_room() -> Result<(), Error> {
         },
     };
 
-    // Room has received a name from sliding sync.
     let room0 = room_list.room(room_id_0).await?;
+
+    // Room has received a name from sliding sync.
     assert_eq!(room0.name().await, Some("Room #0".to_owned()));
 
-    // Room has not received a name from sliding sync, then it's calculated.
+    // Room has received an avatar from sliding sync.
+    assert_eq!(room0.avatar_url(), Some(mxc_uri!("mxc://homeserver/media").to_owned()));
+
     let room1 = room_list.room(room_id_1).await?;
+
+    // Room has not received a name from sliding sync, then it's calculated.
     assert_eq!(room1.name().await, Some("Empty Room".to_owned()));
+
+    // Room has not received an avatar from sliding sync, then it's calculated, but
+    // there is nothing to calculate from, so there is no URL.
+    assert_eq!(room1.avatar_url(), None);
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -1736,6 +1746,7 @@ async fn test_room() -> Result<(), Error> {
             "rooms": {
                 room_id_1: {
                     "name": "Room #1",
+                    "avatar": "mxc://homeserver/other-media",
                 },
             },
         },
@@ -1743,6 +1754,9 @@ async fn test_room() -> Result<(), Error> {
 
     // Room has _now_ received a name from sliding sync!
     assert_eq!(room1.name().await, Some("Room #1".to_owned()));
+
+    // Room has _now_ received an avatar URL from sliding sync!
+    assert_eq!(room1.avatar_url(), Some(mxc_uri!("mxc://homeserver/other-media").to_owned()));
 
     Ok(())
 }


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2306.

Blocked by:
* https://github.com/ruma/ruma/pull/1607.

This patch can be reviewed commit-by-commit.

This patch implements `matrix_sdk::SlidingSyncRoom::avatar_url`. Then it implements `matrix_sdk_ui::room_list_service::Room::avatar_url`. Finally, it updates `matrix_sdk_ffi::RoomListItem::avatar_url`.

This avatar URL comes from a Sliding Sync room response.
