### PR TITLE
fix(crypto): store the generation counter in the `Client`, not the `OlmMachine`

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -205,6 +205,13 @@ pub(crate) struct ClientInner {
     /// DB over time. Observing a different value than the one read in
     /// memory, when reading from the store indicates that somebody else has
     /// written into the database under our feet.
+    ///
+    /// TODO: this should live in the `OlmMachine`, since it's information
+    /// related to the lock. As of today (2023-07-28), we blow up the entire
+    /// olm machine when there's a generation mismatch. So storing the
+    /// generation in the olm machine would make the client think there's
+    /// *always* a mismatch, and that's why we need to store the generation
+    /// outside the `OlmMachine`.
     #[cfg(feature = "e2e-encryption")]
     pub(crate) crypto_store_generation: Arc<Mutex<Option<u64>>>,
 }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -880,7 +880,9 @@ impl Encryption {
         {
             let guard = lock.try_lock_once().await?;
             if guard.is_some() {
-                olm_machine.initialize_crypto_store_generation().await?;
+                olm_machine
+                    .initialize_crypto_store_generation(&self.client.inner.crypto_store_generation)
+                    .await?;
             }
         }
 
@@ -899,7 +901,10 @@ impl Encryption {
         let olm_machine_guard = self.client.olm_machine().await;
         if let Some(olm_machine) = olm_machine_guard.as_ref() {
             // If the crypto store generation has changed,
-            if olm_machine.maintain_crypto_store_generation().await? {
+            if olm_machine
+                .maintain_crypto_store_generation(&self.client.inner.crypto_store_generation)
+                .await?
+            {
                 // (get rid of the reference to the current crypto store first)
                 drop(olm_machine_guard);
                 // Recreate the OlmMachine.


### PR DESCRIPTION
In multiprocess scenarios, to know whether another process wrote in the crypto store while we were inactive/sleeping, we look at a generation counter stored in the database, comparing it against the latest value we knew about. If the latest value we knew about and the value stored in the crypto store aren't the same, we consider it a mismatch and will regenerate the entire OlmMachine (until we get finer-grained caches in the OlmMachine).

Of course, this works fine only if the generation counter lives *outside* the OlmMachine, otherwise any attempt at taking the lock will result in a mismatch, blowing up the olm machine and its generation counter, and the next time we try to lock we'll incorrectly conclude that there was a mismatch again. The only consequence should be purely about performance, but turns out this invalidates some caches in app, showing other cache-related bugs. This patch prevents the spurious reloads, and adds a regression test case that failed before the patch.