### PR TITLE
fix(crypto): don't rely on outgoing sessions being in cache when encrypting a message

### DIFF
--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -202,7 +202,8 @@ impl GroupSessionManager {
         content: Value,
         event_type: &str,
     ) -> MegolmResult<Raw<RoomEncryptedEventContent>> {
-        let session = self.sessions.get(room_id).expect("Session wasn't created nor shared");
+        let session =
+            self.sessions.get_or_load(room_id).await.expect("Session wasn't created nor shared");
 
         assert!(!session.expired(), "Session expired");
 


### PR DESCRIPTION
Because of another bug, we could have a race condition where the `OlmMachine` would get invalidated between presharing room keys and encrypting a message. This would cause the `OlmMachine` cache to be invalidated, and in particular the outgoing sessions caches, making it impossible to send messages thereafter.

This includes a regression test showing the suite of events that would lead to this, and that fails on `main` right now, with `thread 'tokio-runtime-worker' panicked at 'Session wasn't created nor shared', /Users/alfogrillo/element-projects/matrix-rust-sdk/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs:205:50`.

The fix has been contributed by @poljar, thanks!