### PR TITLE
Support for MSC3814 - Dehydrated devices v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -716,9 +716,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1229,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
 
 [[package]]
 name = "digest"
@@ -1499,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc044aac1d046f7563f43906f57c9b0bb4a1cc35bd2363fa3cc68e3e072c5743"
+checksum = "78a7b57c052e83f2bd8d756fc379132e43d3786f3767856026ee3757868f099f"
 dependencies = [
  "futures-core",
  "readlock",
@@ -2306,7 +2309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys",
 ]
 
@@ -2387,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "konst"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9a8bb6c7c71d151b25936b03e012a4c00daea99e3a3797c6ead66b0a0d55e2"
+checksum = "030400e39b2dff8beaa55986a17e0014ad657f569ca92426aafcb5e8e71faee7"
 dependencies = [
  "const_panic",
  "konst_kernel",
@@ -2398,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "konst_kernel"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d2ab266022e7309df89ed712bddc753e3a3c395c3ced1bb2e4470ec2a8146d"
+checksum = "3376133edc39f027d551eb77b077c2865a0ef252b2e7d0dd6b6dc303db95d8b5"
 dependencies = [
  "typewit",
 ]
@@ -2451,9 +2454,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -2521,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67827e6ea8ee8a7c4a72227ef4fc08957040acffdb5f122733b24fa12daff41b"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "matrix-pickle"
@@ -4178,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=8b4ece2b0fa31be21eb1273a6e6bf32e09909480#8b4ece2b0fa31be21eb1273a6e6bf32e09909480"
+source = "git+https://github.com/ruma/ruma?rev=f1772ae5bc1d849655498f51b0fec7b0ef10e339#f1772ae5bc1d849655498f51b0fec7b0ef10e339"
 dependencies = [
  "assign",
  "js_int",
@@ -4193,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=8b4ece2b0fa31be21eb1273a6e6bf32e09909480#8b4ece2b0fa31be21eb1273a6e6bf32e09909480"
+source = "git+https://github.com/ruma/ruma?rev=f1772ae5bc1d849655498f51b0fec7b0ef10e339#f1772ae5bc1d849655498f51b0fec7b0ef10e339"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4204,7 +4207,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=8b4ece2b0fa31be21eb1273a6e6bf32e09909480#8b4ece2b0fa31be21eb1273a6e6bf32e09909480"
+source = "git+https://github.com/ruma/ruma?rev=f1772ae5bc1d849655498f51b0fec7b0ef10e339#f1772ae5bc1d849655498f51b0fec7b0ef10e339"
 dependencies = [
  "assign",
  "bytes",
@@ -4221,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=8b4ece2b0fa31be21eb1273a6e6bf32e09909480#8b4ece2b0fa31be21eb1273a6e6bf32e09909480"
+source = "git+https://github.com/ruma/ruma?rev=f1772ae5bc1d849655498f51b0fec7b0ef10e339#f1772ae5bc1d849655498f51b0fec7b0ef10e339"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -4254,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=8b4ece2b0fa31be21eb1273a6e6bf32e09909480#8b4ece2b0fa31be21eb1273a6e6bf32e09909480"
+source = "git+https://github.com/ruma/ruma?rev=f1772ae5bc1d849655498f51b0fec7b0ef10e339#f1772ae5bc1d849655498f51b0fec7b0ef10e339"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4265,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=8b4ece2b0fa31be21eb1273a6e6bf32e09909480#8b4ece2b0fa31be21eb1273a6e6bf32e09909480"
+source = "git+https://github.com/ruma/ruma?rev=f1772ae5bc1d849655498f51b0fec7b0ef10e339#f1772ae5bc1d849655498f51b0fec7b0ef10e339"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4274,7 +4277,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=8b4ece2b0fa31be21eb1273a6e6bf32e09909480#8b4ece2b0fa31be21eb1273a6e6bf32e09909480"
+source = "git+https://github.com/ruma/ruma?rev=f1772ae5bc1d849655498f51b0fec7b0ef10e339#f1772ae5bc1d849655498f51b0fec7b0ef10e339"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4289,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=8b4ece2b0fa31be21eb1273a6e6bf32e09909480#8b4ece2b0fa31be21eb1273a6e6bf32e09909480"
+source = "git+https://github.com/ruma/ruma?rev=f1772ae5bc1d849655498f51b0fec7b0ef10e339#f1772ae5bc1d849655498f51b0fec7b0ef10e339"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4342,22 +4345,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -4505,9 +4508,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.179"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
@@ -4523,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.179"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4851,7 +4854,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys",
 ]
 
@@ -4931,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
  "deranged",
  "itoa",
@@ -5204,7 +5207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.24",
+ "time 0.3.25",
  "tracing-subscriber",
 ]
 
@@ -5564,7 +5567,7 @@ checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
 dependencies = [
  "anyhow",
  "rustversion",
- "time 0.3.24",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -5576,7 +5579,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vodozemac"
 version = "0.4.0"
-source = "git+https://github.com/matrix-org/vodozemac/?rev=cedc9a08fdd8d0931ea778acf68c619a8298ee70#cedc9a08fdd8d0931ea778acf68c619a8298ee70"
+source = "git+https://github.com/matrix-org/vodozemac/?rev=e3b658526f6f1dd0a9065c1c96346b796712c425#e3b658526f6f1dd0a9065c1c96346b796712c425"
 dependencies = [
  "aes",
  "arrayvec",
@@ -5904,9 +5907,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd122eb777186e60c3fdf765a58ac76e41c582f1f535fbf3314434c6b58f3f7"
+checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "8b4ece2b0fa31be21eb1273a6e6bf32e09909480", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "8b4ece2b0fa31be21eb1273a6e6bf32e09909480" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "f1772ae5bc1d849655498f51b0fec7b0ef10e339", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "f1772ae5bc1d849655498f51b0fec7b0ef10e339" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"
@@ -46,7 +46,7 @@ tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-core = "0.1.30"
 uniffi = { git = "https://github.com/Hywan/uniffi-rs", rev = "9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b" }
 uniffi_bindgen = { git = "https://github.com/Hywan/uniffi-rs", rev = "9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b" }
-vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "cedc9a08fdd8d0931ea778acf68c619a8298ee70" }
+vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "e3b658526f6f1dd0a9065c1c96346b796712c425" }
 zeroize = "1.6.0"
 
 # Default release profile, select with `--release`

--- a/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
@@ -1,0 +1,184 @@
+use std::{mem::ManuallyDrop, sync::Arc};
+
+use matrix_sdk_crypto::dehydrated_devices::{
+    DehydratedDevice as InnerDehydratedDevice, DehydratedDevices as InnerDehydratedDevices,
+    RehydratedDevice as InnerRehydratedDevice,
+};
+use ruma::{api::client::dehydrated_device, events::AnyToDeviceEvent, serde::Raw, OwnedDeviceId};
+use serde_json::json;
+use tokio::runtime::Handle;
+use zeroize::Zeroize;
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+#[uniffi(flat_error)]
+pub enum DehydrationError {
+    #[error(transparent)]
+    Pickle(#[from] matrix_sdk_crypto::vodozemac::LibolmPickleError),
+    #[error(transparent)]
+    MissingSigningKey(#[from] matrix_sdk_crypto::SignatureError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("The pickle key has an invalid length, expected 32 bytes, got {0}")]
+    PickleKeyLength(usize),
+}
+
+impl From<matrix_sdk_crypto::dehydrated_devices::DehydrationError> for DehydrationError {
+    fn from(value: matrix_sdk_crypto::dehydrated_devices::DehydrationError) -> Self {
+        match value {
+            matrix_sdk_crypto::dehydrated_devices::DehydrationError::Json(e) => Self::Json(e),
+            matrix_sdk_crypto::dehydrated_devices::DehydrationError::Pickle(e) => Self::Pickle(e),
+            matrix_sdk_crypto::dehydrated_devices::DehydrationError::MissingSigningKey(e) => {
+                Self::MissingSigningKey(e)
+            }
+        }
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct DehydratedDevices {
+    pub(crate) runtime: Handle,
+    pub(crate) inner: ManuallyDrop<InnerDehydratedDevices>,
+}
+
+impl Drop for DehydratedDevices {
+    fn drop(&mut self) {
+        // See the drop implementation for the `crate::OlmMachine` for an explanation.
+        let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
+        let _guard = self.runtime.enter();
+        drop(inner);
+    }
+}
+
+#[uniffi::export]
+impl DehydratedDevices {
+    pub fn create(&self) -> Arc<DehydratedDevice> {
+        DehydratedDevice {
+            inner: ManuallyDrop::new(self.inner.create()),
+            runtime: self.runtime.to_owned(),
+        }
+        .into()
+    }
+
+    pub fn rehydrate(
+        &self,
+        pickle_key: Vec<u8>,
+        device_id: String,
+        device_data: String,
+    ) -> Result<Arc<RehydratedDevice>, DehydrationError> {
+        let device_data: Raw<_> = serde_json::from_str(&device_data)?;
+        let device_id: OwnedDeviceId = device_id.into();
+
+        let mut key = get_pickle_key(&pickle_key)?;
+
+        let ret = RehydratedDevice {
+            runtime: self.runtime.to_owned(),
+            inner: ManuallyDrop::new(self.runtime.block_on(self.inner.rehydrate(
+                &key,
+                &device_id,
+                device_data,
+            ))?),
+        }
+        .into();
+
+        key.zeroize();
+
+        Ok(ret)
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct RehydratedDevice {
+    inner: ManuallyDrop<InnerRehydratedDevice>,
+    runtime: Handle,
+}
+
+impl Drop for RehydratedDevice {
+    fn drop(&mut self) {
+        // See the drop implementation for the `crate::OlmMachine` for an explanation.
+        let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
+        let _guard = self.runtime.enter();
+        drop(inner);
+    }
+}
+
+#[uniffi::export]
+impl RehydratedDevice {
+    pub fn receive_events(&self, events: String) -> Result<(), crate::CryptoStoreError> {
+        let events: Vec<Raw<AnyToDeviceEvent>> = serde_json::from_str(&events)?;
+        self.runtime.block_on(self.inner.receive_events(events))?;
+
+        Ok(())
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct DehydratedDevice {
+    pub(crate) runtime: Handle,
+    pub(crate) inner: ManuallyDrop<InnerDehydratedDevice>,
+}
+
+impl Drop for DehydratedDevice {
+    fn drop(&mut self) {
+        // See the drop implementation for the `crate::OlmMachine` for an explanation.
+        let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
+        let _guard = self.runtime.enter();
+        drop(inner);
+    }
+}
+
+#[uniffi::export]
+impl DehydratedDevice {
+    pub fn keys_for_upload(
+        &self,
+        device_display_name: String,
+        pickle_key: Vec<u8>,
+    ) -> Result<UploadDehydratedDeviceRequest, DehydrationError> {
+        let mut key = get_pickle_key(&pickle_key)?;
+
+        let request =
+            self.runtime.block_on(self.inner.keys_for_upload(device_display_name, &key))?;
+
+        key.zeroize();
+
+        Ok(request.into())
+    }
+}
+
+#[derive(Debug, uniffi::Record)]
+pub struct UploadDehydratedDeviceRequest {
+    /// The serialized JSON body of the request.
+    body: String,
+}
+
+impl From<dehydrated_device::put_dehydrated_device::unstable::Request>
+    for UploadDehydratedDeviceRequest
+{
+    fn from(value: dehydrated_device::put_dehydrated_device::unstable::Request) -> Self {
+        let body = json!({
+            "device_id": value.device_id,
+            "device_data": value.device_data,
+            "initial_device_display_name": value.initial_device_display_name,
+            "device_keys": value.device_keys,
+            "one_time_keys": value.one_time_keys,
+            "fallback_keys": value.fallback_keys,
+        });
+
+        let body = serde_json::to_string(&body)
+            .expect("We should be able to serialize the PUT dehydrated devices request body");
+
+        Self { body }
+    }
+}
+
+fn get_pickle_key(pickle_key: &[u8]) -> Result<Box<[u8; 32]>, DehydrationError> {
+    let pickle_key_length = pickle_key.len();
+
+    if pickle_key_length == 32 {
+        let mut key = Box::new([0u8; 32]);
+        key.copy_from_slice(pickle_key);
+
+        Ok(key)
+    } else {
+        Err(DehydrationError::PickleKeyLength(pickle_key_length))
+    }
+}

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(unused_qualifications)]
 
 mod backup_recovery_key;
+mod dehydrated_devices;
 mod device;
 mod error;
 mod logger;

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -48,6 +48,7 @@ use tokio::runtime::Runtime;
 use zeroize::Zeroize;
 
 use crate::{
+    dehydrated_devices::DehydratedDevices,
     error::{CryptoStoreError, DecryptionError, SecretImportError, SignatureError},
     parse_user_id,
     responses::{response_from_string, OwnedResponse},
@@ -1426,6 +1427,15 @@ impl OlmMachine {
             .runtime
             .block_on(self.inner.backup_machine().verify_backup(backup_info, false))?
             .into())
+    }
+
+    /// Manage dehydrated devices.
+    pub fn dehydrated_devices(&self) -> Arc<DehydratedDevices> {
+        DehydratedDevices {
+            inner: ManuallyDrop::new(self.inner.dehydrated_devices()),
+            runtime: self.runtime.handle().to_owned(),
+        }
+        .into()
     }
 }
 

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,7 @@
 # unreleased
 
+- Add initial support for MSC3814 - dehydrated devices.
+
 - Mark our `OwnUserIdentity` as verified if we successfully import the matching
   private keys.
 

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 automatic-room-key-forwarding = []
 js = ["ruma/js", "vodozemac/js"]
 qrcode = ["dep:matrix-sdk-qrcode"]
-backups_v1 = ["dep:bs58", "dep:cbc", "dep:hkdf"]
+backups_v1 = ["dep:bs58", "dep:cbc"]
 message-ids = ["dep:ulid"]
 experimental-algorithms = []
 
@@ -41,7 +41,7 @@ dashmap = { workspace = true }
 eyeball = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-hkdf = { version = "0.12.3", optional = true }
+hkdf = "0.12.3"
 hmac = "0.12.1"
 http = { workspace = true, optional = true } # feature = testing only
 itertools = { workspace = true }
@@ -50,7 +50,7 @@ matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 pbkdf2 = { version = "0.11.0", default-features = false }
 rand = "0.8.5"
 rmp-serde = "1.1.1"
-ruma = { workspace = true, features = ["rand", "canonical-json"] }
+ruma = { workspace = true, features = ["rand", "canonical-json", "unstable-msc3814"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 sha2 = "0.10.2"

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -1,0 +1,531 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Submodule for device dehydration support.
+//!
+//! Dehydrated devices intend to solve the use-case where users might want to
+//! frequently delete their device, in which case other users won't be able to
+//! send end-to-end encrypted messages to them as no device exists to receive
+//! and decrypt them.
+//!
+//! A dehydrated device is a kind-of omnipresent virtual device that lives on
+//! the homeserver. A dehydrated device acts as a normal device from the
+//! point of view of other devices. It uploads device and one-time keys to
+//! the homeserver which other devices can download and start 1-to-1 encrypted
+//! sessions with the device just like with any other device.
+//!
+//! The one important difference is that the private parts of the uploaded
+//! device and one-time keys are encrypted and uploaded to the homeserver as
+//! well.
+//!
+//! Once the user creates a new real device, the real device can download the
+//! private keys of the dehydrated device from the homeserver, decrypt them and
+//! download all the encrypted to-device events the dehydrated device has
+//! received. This process is called rehydration.
+//!
+//! After the rehydration process is completed, the user's real device should
+//! create a new dehydrated device.
+
+// TODO: Once a device has been rehydrated it might need to download and decrypt
+// a lot of to-device events. This process might take some time and we should
+// support resuming it.
+
+use hkdf::Hkdf;
+use ruma::{
+    api::client::dehydrated_device::{put_dehydrated_device, DehydratedDeviceData},
+    assign,
+    events::AnyToDeviceEvent,
+    serde::Raw,
+    DeviceId,
+};
+use sha2::Sha256;
+use thiserror::Error;
+use tracing::{instrument, trace};
+use vodozemac::LibolmPickleError;
+
+use crate::{
+    olm::Account,
+    store::{IntoCryptoStore, MemoryStore, RoomKeyInfo, Store},
+    verification::VerificationMachine,
+    EncryptionSyncChanges, OlmError, OlmMachine, ReadOnlyAccount, SignatureError,
+};
+
+/// Error type for device dehydration issues.
+#[derive(Debug, Error)]
+pub enum DehydrationError {
+    /// The dehydrated device could not be unpickled.
+    #[error(transparent)]
+    Pickle(#[from] LibolmPickleError),
+    /// The dehydrated device could not be signed by our user identity,
+    /// we're missing the self-signing key.
+    #[error("The self-signing key is missing, can't create a dehydrated device")]
+    MissingSigningKey(#[from] SignatureError),
+    /// We could not deserialize the dehydrated device data.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+/// Struct collecting methods to create and rehydrate dehydrated devices.
+#[derive(Debug)]
+pub struct DehydratedDevices {
+    pub(crate) inner: OlmMachine,
+}
+
+impl DehydratedDevices {
+    /// Create a new [`DehydratedDevice`] which can be uploaded to the server.
+    pub fn create(&self) -> DehydratedDevice {
+        let user_id = self.inner.user_id();
+        let user_identity = self.inner.store().private_identity();
+
+        let account = ReadOnlyAccount::new(user_id);
+        let store = MemoryStore::new().into_crypto_store();
+
+        let verification_machine =
+            VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
+        let store = Store::new(user_id.into(), user_identity, store, verification_machine);
+
+        let account = Account { inner: account, store };
+
+        DehydratedDevice { account }
+    }
+
+    /// Rehydrate the dehydrated device.
+    ///
+    /// Once rehydrated, to-device events can be pushed into the
+    /// [`RehydratedDevice`] to collect the room keys the device has
+    /// received.
+    ///
+    /// For more info see the example for the
+    /// [`RehydratedDevice::receive_events()`] method.
+    ///
+    /// # Arguments
+    ///
+    /// * `pickle_key` - The encryption key that was used to encrypt the private
+    ///   parts of the identity keys, and one-time keys of the device.
+    ///
+    /// * `device_id` - The unique identifier of the device.
+    ///
+    /// * `device_data` - The encrypted data of the device, containing the
+    ///   private keys of the device.
+    pub async fn rehydrate(
+        &self,
+        pickle_key: &[u8; 32],
+        device_id: &DeviceId,
+        device_data: Raw<DehydratedDeviceData>,
+    ) -> Result<RehydratedDevice, DehydrationError> {
+        let pickle_key = expand_pickle_key(pickle_key, device_id);
+        let rehydrated = self.inner.rehydrate(&pickle_key, device_id, device_data).await?;
+
+        Ok(RehydratedDevice { rehydrated, original: self.inner.to_owned() })
+    }
+}
+
+/// A rehydraded device.
+///
+/// This device can now receive to-device events to decrypt and gather room keys
+/// which were sent to the dehydrated device.
+#[derive(Debug)]
+pub struct RehydratedDevice {
+    rehydrated: OlmMachine,
+    original: OlmMachine,
+}
+
+impl RehydratedDevice {
+    /// Feed to-device events the device was supposed to receive into the
+    /// [`RehydratedDevice`].
+    ///
+    /// Most to-device events we feed into the [`RehydratedDevice`] will contain
+    /// room keys, the rehydrated device will pass these room keys into our
+    /// own [`OlmMachine`] which will persist them and make the room keys
+    /// available for use using the usual
+    /// [`OlmMachine::decrypt_room_event()`] method.
+    ///
+    /// Once the homeserver returns a response without any to-device events, we
+    /// can safely delete the current dehydrated device and create a new one.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use anyhow::Result;
+    /// # use matrix_sdk_crypto::OlmMachine;
+    /// # use ruma::{api::client::dehydrated_device, DeviceId};
+    /// # async fn example() -> Result<()> {
+    /// # let machine: OlmMachine = unimplemented!();
+    /// async fn get_dehydrated_device() -> Result<dehydrated_device::get_dehydrated_device::unstable::Response> {
+    ///     todo!("Download the dehydrated device");
+    /// }
+    ///
+    /// async fn get_events(
+    ///     device_id: &DeviceId,
+    ///     since_token: Option<&str>
+    /// ) -> Result<dehydrated_device::get_events::unstable::Response> {
+    ///     todo!("Download the to-device events of the dehydrated device");
+    /// }
+    ///
+    /// // Don't use a zero key for real.
+    /// let pickle_key = [0u8; 32];
+    ///
+    /// // Fetch the dehydrated device from the server.
+    /// let response = get_dehydrated_device().await?;
+    /// let device_id = response.device_id;
+    ///
+    /// // Rehydrate the device.
+    /// let rehydrated = machine
+    ///     .dehydrated_devices()
+    ///     .rehydrate(&pickle_key, &device_id, response.device_data)
+    ///     .await?;
+    ///
+    /// let mut since_token = None;
+    /// let mut imported_room_keys = 0;
+    ///
+    /// loop {
+    ///     let response =
+    ///         get_events(&device_id, since_token).await?;
+    ///
+    ///     if response.events.is_empty() {
+    ///         break;
+    ///     }
+    ///
+    ///     since_token = response.next_batch.as_deref();
+    ///     imported_room_keys += rehydrated.receive_events(response.events).await?.len();
+    /// }
+    ///
+    /// println!("Successfully imported {imported_room_keys} from the dehydrated device.");
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[instrument(
+        skip_all,
+        fields(
+            user_id = ?self.original.user_id(),
+            rehydrated_device_id = ?self.rehydrated.device_id(),
+            original_device_id = ?self.original.device_id()
+        )
+    )]
+    pub async fn receive_events(
+        &self,
+        events: Vec<Raw<AnyToDeviceEvent>>,
+    ) -> Result<Vec<RoomKeyInfo>, OlmError> {
+        trace!("Receiving events for a rehydrated Device");
+
+        let sync_changes = EncryptionSyncChanges {
+            to_device_events: events,
+            next_batch_token: None,
+            one_time_keys_counts: &Default::default(),
+            changed_devices: &Default::default(),
+            unused_fallback_keys: None,
+        };
+
+        // Let us first give the events to the rehydrated device, this will decrypt any
+        // encrypted to-device events and fetch out the room keys.
+        let (_, changes) = self.rehydrated.preprocess_sync_changes(sync_changes).await?;
+
+        // Now take the room keys and persist them in our original `OlmMachine`.
+        let room_keys = &changes.inbound_group_sessions;
+        let updates = room_keys.iter().map(Into::into).collect();
+
+        trace!(room_key_count = room_keys.len(), "Collected room keys from the rehydrated device");
+
+        self.original.store().save_inbound_group_sessions(room_keys).await?;
+        self.rehydrated.store().save_changes(changes).await?;
+
+        Ok(updates)
+    }
+}
+
+/// A dehydrated device that can uploaded to the homeserver.
+///
+/// To upload the dehydrated device take a look at the
+/// [`DehydratedDevice::keys_for_upload()`] method.
+#[derive(Debug)]
+pub struct DehydratedDevice {
+    account: Account,
+}
+
+impl DehydratedDevice {
+    /// Get the request to upload the dehydrated device.
+    ///
+    /// # Arguments
+    ///
+    /// * `initial_device_display_name` - The human-readable name this device
+    ///   should have.
+    /// * `pickle_key` - The encryption key that should be used to encrypt the
+    ///   private parts of the identity keys, and one-time keys of the device.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use matrix_sdk_crypto::OlmMachine;
+    /// # async fn example() -> anyhow::Result<()> {
+    /// # let machine: OlmMachine = unimplemented!();
+    /// // Don't use a zero key for real.
+    /// let pickle_key = [0u8; 32];
+    ///
+    /// // Create the dehydrated device.
+    /// let device = machine.dehydrated_devices().create();
+    ///
+    /// // Create the request that should upload the device.
+    /// let request = device
+    ///     .keys_for_upload("Dehydrated device".to_owned(), &pickle_key)
+    ///     .await?;
+    ///
+    /// // Send the request out using your HTTP client.
+    /// // client.send(request).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[instrument(
+        skip_all, fields(
+            user_id = ?self.account.user_id(),
+            device_id = ?self.account.device_id(),
+            identity_keys = ?self.account.identity_keys,
+        )
+    )]
+    pub async fn keys_for_upload(
+        &self,
+        initial_device_display_name: String,
+        pickle_key: &[u8; 32],
+    ) -> Result<put_dehydrated_device::unstable::Request, DehydrationError> {
+        self.account.generate_fallback_key_helper().await;
+        let (device_keys, one_time_keys, fallback_keys) = self.account.keys_for_upload().await;
+
+        let mut device_keys = device_keys
+            .expect("We should always try to upload device keys for a dehydrated device.");
+
+        self.account
+            .store
+            .private_identity()
+            .lock()
+            .await
+            .sign_device_keys(&mut device_keys)
+            .await?;
+
+        trace!("Creating an upload request for a dehydrated device");
+
+        let pickle_key = expand_pickle_key(pickle_key, self.account.device_id());
+        let device_id = self.account.device_id().to_owned();
+        let device_data = self.account.dehydrate(&pickle_key).await;
+        let initial_device_display_name = Some(initial_device_display_name);
+
+        Ok(
+            assign!(put_dehydrated_device::unstable::Request::new(device_id, device_data, device_keys.to_raw()), {
+                one_time_keys, fallback_keys, initial_device_display_name
+            }),
+        )
+    }
+}
+
+/// We're using the libolm-compatible pickle format and its encryption scheme.
+///
+/// The libolm pickle encryption scheme uses HKDF to deterministically expand an
+/// input key material, usually 32 bytes, into a AES key, MAC key, and the
+/// initialization vector (IV).
+///
+/// This means that the same input key material will always end up producing the
+/// same AES key, and IV.
+///
+/// This encryption scheme is used in the Olm double ratchet and was designed to
+/// minimize the size of the ciphertext. As a tradeof, it requires a unique
+/// input key material for each plaintext that gets encrypted, otherwise IV
+/// reuse happens.
+///
+/// To combat the IV reuse, we're going to create a per-dehydrated-device unique
+/// pickle key by expanding the key itself with the device ID used as the salt.
+fn expand_pickle_key(key: &[u8; 32], device_id: &DeviceId) -> Box<[u8; 32]> {
+    // TODO: Perhaps we should put this into vodozemac with a new pickle
+    // minimalistic pickle format using the [`matrix_pickle`] crate.
+    //
+    // [`matrix_pickle`]: https://docs.rs/matrix-pickle/latest/matrix_pickle/
+    let kdf: Hkdf<Sha256> = Hkdf::new(Some(device_id.as_bytes()), key);
+    let mut key = Box::new([0u8; 32]);
+
+    kdf.expand(b"dehydrated-device-pickle-key", key.as_mut_slice())
+        .expect("We should be able to expand the 32 byte pickle key");
+
+    key
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::BTreeMap, iter};
+
+    use matrix_sdk_test::async_test;
+    use ruma::{
+        api::client::keys::get_keys::v3::Response as KeysQueryResponse, assign,
+        encryption::DeviceKeys, events::AnyToDeviceEvent, room_id, serde::Raw, user_id, DeviceId,
+        RoomId, TransactionId, UserId,
+    };
+
+    use crate::{
+        machine::tests::{create_session, get_prepared_machine, to_device_requests_to_content},
+        olm::OutboundGroupSession,
+        types::events::ToDeviceEvent,
+        utilities::json_convert,
+        EncryptionSettings, OlmMachine,
+    };
+
+    const PICKLE_KEY: &[u8; 32] = &[0u8; 32];
+
+    fn user_id() -> &'static UserId {
+        user_id!("@alice:localhost")
+    }
+
+    async fn get_olm_machine() -> OlmMachine {
+        let (olm_machine, _) = get_prepared_machine(user_id(), false).await;
+        olm_machine.bootstrap_cross_signing(false).await.unwrap();
+
+        olm_machine
+    }
+
+    // Insert some device keys into a [`OlmMachine`] making the [`Device`] available
+    // to the [`OlmMachine`].
+    async fn receive_device_keys(
+        olm_machine: &OlmMachine,
+        user_id: &UserId,
+        device_id: &DeviceId,
+        device_keys: Raw<DeviceKeys>,
+    ) {
+        let device_keys = BTreeMap::from([(device_id.to_owned(), device_keys)]);
+
+        let keys_query_response = assign!(
+            KeysQueryResponse::new(), {
+                device_keys: BTreeMap::from([(user_id.to_owned(), device_keys)]),
+            }
+        );
+
+        olm_machine
+            .mark_request_as_sent(&TransactionId::new(), &keys_query_response)
+            .await
+            .unwrap();
+    }
+
+    async fn send_room_key(
+        machine: &OlmMachine,
+        room_id: &RoomId,
+        recipient: &UserId,
+    ) -> (Raw<AnyToDeviceEvent>, OutboundGroupSession) {
+        let to_device_requests = machine
+            .share_room_key(room_id, iter::once(recipient), EncryptionSettings::default())
+            .await
+            .unwrap();
+
+        let event = ToDeviceEvent::new(
+            user_id().to_owned(),
+            to_device_requests_to_content(to_device_requests),
+        );
+
+        let session =
+            machine.inner.group_session_manager.get_outbound_group_session(room_id).expect(
+                "An outbound group session should have been created when the room key was shared",
+            );
+
+        (
+            json_convert(&event)
+                .expect("We should be able to convert the to-device event into it's Raw variatn"),
+            session,
+        )
+    }
+
+    #[async_test]
+    async fn dehydrated_device_creation() {
+        let olm_machine = get_olm_machine().await;
+
+        let dehydrated_device = olm_machine.dehydrated_devices().create();
+
+        let request = dehydrated_device
+            .keys_for_upload("Foo".to_owned(), PICKLE_KEY)
+            .await
+            .expect("We should be able to create a request to upload a dehydrated device");
+
+        assert!(
+            !request.one_time_keys.is_empty(),
+            "The dehydrated device creation request should contain some one-time keys"
+        );
+
+        assert!(
+            !request.fallback_keys.is_empty(),
+            "The dehydrated device creation request should contain some fallback keys"
+        );
+    }
+
+    #[async_test]
+    async fn dehydrated_device_rehydration() {
+        let room_id = room_id!("!test:example.org");
+        let alice = get_olm_machine().await;
+
+        let dehydrated_device = alice.dehydrated_devices().create();
+
+        let mut request = dehydrated_device
+            .keys_for_upload("Foo".to_owned(), PICKLE_KEY)
+            .await
+            .expect("We should be able to create a request to upload a dehydrated device");
+
+        let (key_id, one_time_key) = request
+            .one_time_keys
+            .pop_first()
+            .expect("The dehydrated device creation request should contain a one-time key");
+
+        // Ensure that we know about the public keys of the dehydrated device.
+        receive_device_keys(&alice, user_id(), &request.device_id, request.device_keys).await;
+        // Create a 1-to-1 Olm session with the dehydrated device.
+        create_session(&alice, user_id(), &request.device_id, key_id, one_time_key).await;
+
+        // Send a room key to the dehydrated device.
+        let (event, group_session) = send_room_key(&alice, room_id, user_id()).await;
+
+        // Let's now create a new `OlmMachine` which doesn't know about the room key.
+        let bob = get_olm_machine().await;
+
+        let room_key = bob
+            .store()
+            .get_inbound_group_session(room_id, group_session.session_id())
+            .await
+            .unwrap();
+
+        assert!(
+            room_key.is_none(),
+            "We should not have access to the room key that was only sent to the dehydrated device"
+        );
+
+        // Rehydrate the device.
+        let rehydrated = bob
+            .dehydrated_devices()
+            .rehydrate(PICKLE_KEY, &request.device_id, request.device_data)
+            .await
+            .expect("We should be able to rehydrate the device");
+
+        // Push the to-device event containing the room key into the rehydrated device.
+        let ret = rehydrated
+            .receive_events(vec![event])
+            .await
+            .expect("We should be able to push to-device events into the rehydrated device");
+
+        assert_eq!(ret.len(), 1, "The rehydrated device should have imported a room key");
+
+        // The `OlmMachine` now does know about the room key since the rehydrated device
+        // shared it with us.
+        let room_key = bob
+            .store()
+            .get_inbound_group_session(room_id, group_session.session_id())
+            .await
+            .unwrap()
+            .expect("We should now have access to the room key, since the rehydrated device imported it for us");
+
+        assert_eq!(
+            room_key.session_id(),
+            group_session.session_id(),
+            "The session ids of the imported room key and the outbound group session should match"
+        );
+    }
+}

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1098,15 +1098,15 @@ mod tests {
     }
 
     fn account() -> ReadOnlyAccount {
-        ReadOnlyAccount::new(alice_id(), alice_device_id())
+        ReadOnlyAccount::with_device_id(alice_id(), alice_device_id())
     }
 
     fn bob_account() -> ReadOnlyAccount {
-        ReadOnlyAccount::new(bob_id(), bob_device_id())
+        ReadOnlyAccount::with_device_id(bob_id(), bob_device_id())
     }
 
     fn alice_2_account() -> ReadOnlyAccount {
-        ReadOnlyAccount::new(alice_id(), alice2_device_id())
+        ReadOnlyAccount::with_device_id(alice_id(), alice2_device_id())
     }
 
     #[cfg(feature = "automatic-room-key-forwarding")]
@@ -1114,7 +1114,7 @@ mod tests {
         let user_id = user_id.to_owned();
         let device_id = DeviceId::new();
 
-        let account = ReadOnlyAccount::new(&user_id, &device_id);
+        let account = ReadOnlyAccount::with_device_id(&user_id, &device_id);
         let store = MemoryStore::new().into_crypto_store();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
@@ -1126,10 +1126,13 @@ mod tests {
 
     async fn get_machine() -> GossipMachine {
         let user_id = alice_id().to_owned();
-        let account = ReadOnlyAccount::new(&user_id, alice_device_id());
+        let account = ReadOnlyAccount::with_device_id(&user_id, alice_device_id());
         let device = ReadOnlyDevice::from_account(&account).await;
-        let another_device =
-            ReadOnlyDevice::from_account(&ReadOnlyAccount::new(&user_id, alice2_device_id())).await;
+        let another_device = ReadOnlyDevice::from_account(&ReadOnlyAccount::with_device_id(
+            &user_id,
+            alice2_device_id(),
+        ))
+        .await;
 
         let store = MemoryStore::new().into_crypto_store();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -786,7 +786,7 @@ pub(crate) mod testing {
         let identity = PrivateCrossSigningIdentity::new(user_id().into()).await;
         let identity = Arc::new(Mutex::new(identity));
         let user_id = user_id().to_owned();
-        let account = ReadOnlyAccount::new(&user_id, device_id());
+        let account = ReadOnlyAccount::with_device_id(&user_id, device_id());
         let store: Arc<DynCryptoStore> = MemoryStore::new().into_crypto_store();
         let verification = VerificationMachine::new(account, identity.clone(), store);
         let store = Store::new(

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -769,7 +769,7 @@ pub(crate) mod tests {
         let private_identity =
             Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(second.user_id())));
         let verification_machine = VerificationMachine::new(
-            ReadOnlyAccount::new(second.user_id(), second.device_id()),
+            ReadOnlyAccount::with_device_id(second.user_id(), second.device_id()),
             private_identity,
             MemoryStore::new().into_crypto_store(),
         );
@@ -804,13 +804,13 @@ pub(crate) mod tests {
         let response = own_key_query();
         let (_, device) = device(&response);
 
-        let account = ReadOnlyAccount::new(device.user_id(), device.device_id());
+        let account = ReadOnlyAccount::with_device_id(device.user_id(), device.device_id());
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
 
         let id = Arc::new(Mutex::new(identity.clone()));
 
         let verification_machine = VerificationMachine::new(
-            ReadOnlyAccount::new(device.user_id(), device.device_id()),
+            ReadOnlyAccount::with_device_id(device.user_id(), device.device_id()),
             id.clone(),
             MemoryStore::new().into_crypto_store(),
         );

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -18,6 +18,7 @@
 
 #[cfg(feature = "backups_v1")]
 pub mod backups;
+pub mod dehydrated_devices;
 mod error;
 mod file_encryption;
 mod gossiping;

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -165,10 +165,9 @@ impl OlmMachine {
         device_id: &DeviceId,
         store: Arc<DynCryptoStore>,
         account: ReadOnlyAccount,
-        user_identity: PrivateCrossSigningIdentity,
+        user_identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
     ) -> Self {
         let user_id: OwnedUserId = user_id.into();
-        let user_identity = Arc::new(Mutex::new(user_identity));
 
         let verification_machine =
             VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
@@ -262,7 +261,7 @@ impl OlmMachine {
                 account
             }
             None => {
-                let account = ReadOnlyAccount::new(user_id, device_id);
+                let account = ReadOnlyAccount::with_device_id(user_id, device_id);
 
                 Span::current()
                     .record("ed25519_key", display(account.identity_keys().ed25519))
@@ -302,6 +301,8 @@ impl OlmMachine {
                 PrivateCrossSigningIdentity::empty(user_id)
             }
         };
+
+        let identity = Arc::new(Mutex::new(identity));
 
         Ok(OlmMachine::new_helper(user_id, device_id, store, account, identity))
     }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -557,10 +557,7 @@ impl ReadOnlyAccount {
         &EventEncryptionAlgorithm::MegolmV2AesSha2,
     ];
 
-    /// Create a fresh new account, this will generate the identity key-pair.
-    #[allow(clippy::ptr_arg)]
-    pub fn new(user_id: &UserId, device_id: &DeviceId) -> Self {
-        let mut account = InnerAccount::new();
+    fn new_helper(mut account: InnerAccount, user_id: &UserId, device_id: &DeviceId) -> Self {
         let identity_keys = account.identity_keys();
 
         // Let's generate some initial one-time keys while we're here. Since we know
@@ -585,6 +582,22 @@ impl ReadOnlyAccount {
             uploaded_signed_key_count: Arc::new(AtomicU64::new(0)),
             creation_local_time: MilliSecondsSinceUnixEpoch::now(),
         }
+    }
+
+    /// Create a fresh new account, this will generate the identity key-pair.
+    pub fn with_device_id(user_id: &UserId, device_id: &DeviceId) -> Self {
+        let account = InnerAccount::new();
+
+        Self::new_helper(account, user_id, device_id)
+    }
+
+    /// Create a new random Olm Account, the long-term Curve25519 identity key
+    /// encoded as base64 will be used for the device ID.
+    pub fn new(user_id: &UserId) -> Self {
+        let account = InnerAccount::new();
+        let device_id: OwnedDeviceId = encode(account.identity_keys().curve25519.as_bytes()).into();
+
+        Self::new_helper(account, user_id, &device_id)
     }
 
     /// Get the user id of the owner of the account.
@@ -1329,7 +1342,7 @@ mod tests {
 
     #[async_test]
     async fn one_time_key_creation() -> Result<()> {
-        let account = ReadOnlyAccount::new(user_id(), device_id());
+        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
 
         let (_, one_time_keys, _) = account.keys_for_upload().await;
         assert!(!one_time_keys.is_empty());
@@ -1366,7 +1379,7 @@ mod tests {
 
     #[async_test]
     async fn fallback_key_creation() -> Result<()> {
-        let account = ReadOnlyAccount::new(user_id(), device_id());
+        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
 
         let (_, _, fallback_keys) = account.keys_for_upload().await;
 
@@ -1406,7 +1419,7 @@ mod tests {
         let key = vodozemac::Curve25519PublicKey::from_base64(
             "7PUPP6Ijt5R8qLwK2c8uK5hqCNF9tOzWYgGaAay5JBs",
         )?;
-        let account = ReadOnlyAccount::new(user_id(), device_id());
+        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
 
         let key = account.sign_key(key, true).await;
 
@@ -1430,7 +1443,7 @@ mod tests {
     #[async_test]
     async fn test_account_and_device_creation_timestamp() -> Result<()> {
         let now = MilliSecondsSinceUnixEpoch::now();
-        let account = ReadOnlyAccount::new(user_id(), device_id());
+        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
         let then = MilliSecondsSinceUnixEpoch::now();
 
         assert!(account.creation_local_time() >= now);

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -667,7 +667,7 @@ mod test {
 
     #[async_test]
     async fn session_comparison() {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
 
         let (_, inbound) = alice.create_group_session_pair_with_defaults(room_id).await;

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -778,7 +778,8 @@ mod tests {
 
         let settings = EncryptionSettings { rotation_period_msgs: 1, ..Default::default() };
 
-        let account = ReadOnlyAccount::new(user_id!("@alice:example.org"), device_id!("DEVICEID"));
+        let account =
+            ReadOnlyAccount::with_device_id(user_id!("@alice:example.org"), device_id!("DEVICEID"));
         let (session, _) = account
             .create_group_session_pair(room_id!("!test_room:example.org"), settings)
             .await

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -80,8 +80,8 @@ pub(crate) mod tests {
     }
 
     pub(crate) async fn get_account_and_session() -> (ReadOnlyAccount, Session) {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
-        let bob = ReadOnlyAccount::new(bob_id(), bob_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
 
         bob.generate_one_time_keys_helper(1).await;
         let one_time_key = *bob.one_time_keys().await.values().next().unwrap();
@@ -100,7 +100,7 @@ pub(crate) mod tests {
 
     #[test]
     fn account_creation() {
-        let account = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let account = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
 
         assert!(!account.shared());
 
@@ -110,7 +110,10 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn one_time_keys_creation() {
-        let account = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let account = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let one_time_keys = account.one_time_keys().await;
+
+        assert!(!one_time_keys.is_empty());
         assert_ne!(account.max_one_time_keys().await, 0);
 
         account.generate_one_time_keys_helper(10).await;
@@ -127,8 +130,8 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn session_creation() {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
-        let bob = ReadOnlyAccount::new(bob_id(), bob_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
         let alice_keys = alice.identity_keys();
         alice.generate_one_time_keys_helper(1).await;
         let one_time_keys = alice.one_time_keys().await;
@@ -165,7 +168,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn group_session_creation() {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
 
         let (outbound, _) = alice.create_group_session_pair_with_defaults(room_id).await;
@@ -201,7 +204,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn edit_decryption() {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
         let event_id = event_id!("$1234adfad:asdf");
 
@@ -260,7 +263,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn relates_to_decryption() {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
         let event_id = event_id!("$1234adfad:asdf");
 
@@ -332,7 +335,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn group_session_export() {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
 
         let (_, inbound) = alice.create_group_session_pair_with_defaults(room_id).await;

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -745,7 +745,7 @@ mod tests {
 
     #[async_test]
     async fn private_identity_signed_by_account() {
-        let account = ReadOnlyAccount::new(user_id(), device_id!("DEVICEID"));
+        let account = ReadOnlyAccount::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
         let master = identity.master_key.lock().await;
         let master = master.as_ref().unwrap();
@@ -768,7 +768,7 @@ mod tests {
 
     #[async_test]
     async fn sign_device() {
-        let account = ReadOnlyAccount::new(user_id(), device_id!("DEVICEID"));
+        let account = ReadOnlyAccount::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
 
         let mut device = ReadOnlyDevice::from_account(&account).await;
@@ -785,10 +785,11 @@ mod tests {
 
     #[async_test]
     async fn sign_user_identity() {
-        let account = ReadOnlyAccount::new(user_id(), device_id!("DEVICEID"));
+        let account = ReadOnlyAccount::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
 
-        let bob_account = ReadOnlyAccount::new(user_id!("@bob:localhost"), device_id!("DEVICEID"));
+        let bob_account =
+            ReadOnlyAccount::with_device_id(user_id!("@bob:localhost"), device_id!("DEVICEID"));
         let (bob_private, _, _) = PrivateCrossSigningIdentity::with_account(&bob_account).await;
         let mut bob_public = ReadOnlyUserIdentity::from_private(&bob_private).await;
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -478,7 +478,7 @@ mod tests {
     }
 
     fn bob_account() -> ReadOnlyAccount {
-        ReadOnlyAccount::new(user_id!("@bob:localhost"), device_id!("BOBDEVICE"))
+        ReadOnlyAccount::with_device_id(user_id!("@bob:localhost"), device_id!("BOBDEVICE"))
     }
 
     fn keys_claim_with_failure() -> KeyClaimResponse {
@@ -513,7 +513,7 @@ mod tests {
         let device_id = device_id();
 
         let users_for_key_claim = Arc::new(DashMap::new());
-        let account = ReadOnlyAccount::new(user_id, device_id);
+        let account = ReadOnlyAccount::with_device_id(user_id, device_id);
         let store = MemoryStore::new().into_crypto_store();
         store.save_account(account.clone()).await.unwrap();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id)));
@@ -689,7 +689,7 @@ mod tests {
     #[async_test]
     async fn failure_handling() {
         let alice = user_id!("@alice:example.org");
-        let alice_account = ReadOnlyAccount::new(alice, "DEVICEID".into());
+        let alice_account = ReadOnlyAccount::with_device_id(alice, "DEVICEID".into());
         let alice_device = ReadOnlyDevice::from_account(&alice_account).await;
 
         let manager = session_manager().await;
@@ -732,7 +732,7 @@ mod tests {
         let response = KeyClaimResponse::try_from_http_response(response).unwrap();
 
         let alice = user_id!("@alice:example.org");
-        let alice_account = ReadOnlyAccount::new(alice, "DEVICEID".into());
+        let alice_account = ReadOnlyAccount::with_device_id(alice, "DEVICEID".into());
         let alice_device = ReadOnlyDevice::from_account(&alice_account).await;
 
         let manager = session_manager().await;

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -71,12 +71,12 @@ macro_rules! cryptostore_integration_tests {
             }
 
             fn get_account() -> ReadOnlyAccount {
-                ReadOnlyAccount::new(&alice_id(), &alice_device_id())
+                ReadOnlyAccount::with_device_id(alice_id(), alice_device_id())
             }
 
             async fn get_account_and_session() -> (ReadOnlyAccount, Session) {
-                let alice = ReadOnlyAccount::new(&alice_id(), &alice_device_id());
-                let bob = ReadOnlyAccount::new(&bob_id(), &bob_device_id());
+                let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+                let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
 
                 bob.generate_one_time_keys_helper(1).await;
                 let one_time_key = *bob.one_time_keys().await.values().next().unwrap();
@@ -402,13 +402,13 @@ macro_rules! cryptostore_integration_tests {
                 let dir = "device_saving";
                 let (_account, store) = get_loaded_store(dir.clone()).await;
 
-                let alice_device_1 = ReadOnlyDevice::from_account(&ReadOnlyAccount::new(
+                let alice_device_1 = ReadOnlyDevice::from_account(&ReadOnlyAccount::with_device_id(
                     "@alice:localhost".try_into().unwrap(),
                     "FIRSTDEVICE".into(),
                 ))
                 .await;
 
-                let alice_device_2 = ReadOnlyDevice::from_account(&ReadOnlyAccount::new(
+                let alice_device_2 = ReadOnlyDevice::from_account(&ReadOnlyAccount::with_device_id(
                     "@alice:localhost".try_into().unwrap(),
                     "SECONDDEVICE".into(),
                 ))
@@ -488,7 +488,7 @@ macro_rules! cryptostore_integration_tests {
 
                 let store = get_store(dir, None).await;
 
-                let account = ReadOnlyAccount::new(&user_id, device_id);
+                let account = ReadOnlyAccount::with_device_id(&user_id, device_id);
 
                 store.save_account(account.clone()).await.expect("Can't save account");
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -508,8 +508,7 @@ impl Store {
         self.save_changes(changes).await
     }
 
-    #[cfg(test)]
-    /// Testing helper to allow to save only a set of InboundGroupSession
+    /// Convenience helper to persist an array of [`InboundGroupSession`]s.
     pub(crate) async fn save_inbound_group_sessions(
         &self,
         sessions: &[InboundGroupSession],

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -578,7 +578,7 @@ mod tests {
 
     #[async_test]
     async fn create() {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let store = MemoryStore::new();
         let _ = VerificationMachine::new(alice, identity, store.into_crypto_store());

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -839,13 +839,13 @@ mod test {
     }
 
     pub(crate) async fn setup_stores() -> (VerificationStore, VerificationStore) {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let alice_store = MemoryStore::new();
         let (alice_private_identity, _, _) =
             PrivateCrossSigningIdentity::with_account(&alice).await;
         let alice_private_identity = Mutex::new(alice_private_identity);
 
-        let bob = ReadOnlyAccount::new(bob_id(), bob_device_id());
+        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
         let bob_store = MemoryStore::new();
         let (bob_private_identity, _, _) = PrivateCrossSigningIdentity::with_account(&bob).await;
         let bob_private_identity = Mutex::new(bob_private_identity);

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -914,7 +914,7 @@ mod tests {
     #[async_test]
     async fn test_verification_creation() {
         let store = memory_store();
-        let account = ReadOnlyAccount::new(user_id(), device_id());
+        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
 
         let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
         let master_key = private_identity.master_public_key().await.unwrap();
@@ -978,7 +978,7 @@ mod tests {
     #[async_test]
     async fn test_reciprocate_receival() {
         let test = |flow_id: FlowId| async move {
-            let alice_account = ReadOnlyAccount::new(user_id(), device_id());
+            let alice_account = ReadOnlyAccount::with_device_id(user_id(), device_id());
             let store = memory_store();
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
@@ -990,7 +990,7 @@ mod tests {
             };
 
             let bob_account =
-                ReadOnlyAccount::new(alice_account.user_id(), device_id!("BOBDEVICE"));
+                ReadOnlyAccount::with_device_id(alice_account.user_id(), device_id!("BOBDEVICE"));
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
             let identity = private_identity.to_public_identity().await.unwrap();

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -902,10 +902,10 @@ mod tests {
 
     async fn machine_pair() -> (VerificationStore, ReadOnlyDevice, VerificationStore, ReadOnlyDevice)
     {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let alice_device = ReadOnlyDevice::from_account(&alice).await;
 
-        let bob = ReadOnlyAccount::new(bob_id(), bob_device_id());
+        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
         let alice_store = VerificationStore {

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -1559,10 +1559,10 @@ mod tests {
     async fn get_sas_pair(
         mac_method: Option<SupportedMacMethod>,
     ) -> (SasState<Created>, SasState<WeAccepted>) {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let alice_device = ReadOnlyDevice::from_account(&alice).await;
 
-        let bob = ReadOnlyAccount::new(bob_id(), bob_device_id());
+        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
         let flow_id = TransactionId::new().into();
@@ -1825,10 +1825,10 @@ mod tests {
 
     #[async_test]
     async fn sas_from_start_unknown_method() {
-        let alice = ReadOnlyAccount::new(alice_id(), alice_device_id());
+        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
         let alice_device = ReadOnlyDevice::from_account(&alice).await;
 
-        let bob = ReadOnlyAccount::new(bob_id(), bob_device_id());
+        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
         let flow_id = TransactionId::new().into();


### PR DESCRIPTION
This PR adds initial support for [MSC3814]. This is best reviewed commit by
commit.

It's best to get an overview of the MSC first, the docs in the
`dehydrated_devices` submodule attempt to explain dehydrated devices as well.

- [x] Public API changes documented in changelogs (optional)

This closes: #401.

[MSC3814]: https://github.com/uhoreg/matrix-doc/blob/shrivelled_sessions/proposals/3814-dehydrated-devices-with-ssss.md
