### PR TITLE
feat(polls): cache events if the poll start isn't found locally

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -40,6 +40,7 @@ pub use self::{
     local::EventSendState,
 };
 pub(super) use self::{
+    content::PollResponse,
     local::LocalEventTimelineItem,
     remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };

--- a/crates/matrix-sdk-ui/src/timeline/inner.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner.rs
@@ -71,6 +71,7 @@ use super::{
     TimelineItemContent, TimelineItemKind,
 };
 use crate::events::SyncTimelineEventWithoutContent;
+use crate::timeline::event_item::PollResponse;
 
 #[derive(Clone, Debug)]
 pub(super) struct TimelineInner<P: RoomDataProvider = Room> {
@@ -84,6 +85,7 @@ pub(super) struct TimelineInnerState {
     pub(super) items: ObservableVector<Arc<TimelineItem>>,
     pub(super) next_internal_id: u64,
     pub(super) reactions: Reactions,
+    pub(super) pending_poll_events: HashMap<OwnedEventId, (Option<MilliSecondsSinceUnixEpoch>, Vec<PollResponse>)>,
     pub(super) fully_read_event: Option<OwnedEventId>,
     /// Whether the fully-read marker item should try to be updated when an
     /// event is added.
@@ -1125,6 +1127,7 @@ impl TimelineInnerState {
             items: Default::default(),
             next_internal_id: Default::default(),
             reactions: Default::default(),
+            pending_poll_events: Default::default(),
             fully_read_event: Default::default(),
             event_should_update_fully_read_marker: Default::default(),
             users_read_receipts: Default::default(),


### PR DESCRIPTION
Handles the case where we receive a poll response or end event but don't have the corresponding start event in the timeline. Simply stores the details in the event handler and uses them when/if the start event is received (basically the same as how reactions are handled).

Introduces a PollResponse type that replaces the `(UserId, Vec<PollAnswerId>, Option<Timestamp>)` tuple because the types were getting a bit unwieldy.

---

What needs to happen for this to not be a draft:

- [ ] The [plumbing PR](https://github.com/matrix-org/matrix-rust-sdk/pull/2331) lands, as this is based on top of it (they could be merged into one PR, but I figured it was helpful to review the logic separately)