### PR TITLE
chore(sliding sync): Tweak tracing logs and context

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -66,7 +66,8 @@ impl BaseClient {
             to_device_events = to_device.len(),
             device_one_time_keys_count = e2ee.device_one_time_keys_count.len(),
             device_unused_fallback_key_types =
-                e2ee.device_unused_fallback_key_types.as_ref().map(|v| v.len())
+                e2ee.device_unused_fallback_key_types.as_ref().map(|v| v.len()),
+            "Processing sliding sync e2ee events",
         );
 
         let mut changes = StateChanges::default();
@@ -115,7 +116,12 @@ impl BaseClient {
             ..
         } = response;
 
-        trace!(rooms = rooms.len(), lists = lists.len(), extensions = !extensions.is_empty());
+        trace!(
+            rooms = rooms.len(),
+            lists = lists.len(),
+            extensions = !extensions.is_empty(),
+            "Processing sliding sync room events"
+        );
 
         if rooms.is_empty() && extensions.is_empty() {
             // we received a room reshuffling event only, there won't be anything for us to

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -199,7 +199,7 @@ pub(super) async fn restore_sliding_sync_state(
         }
 
         None => {
-            trace!("Failed to find the `SlidingSync` object in the cache");
+            trace!("No Sliding Sync object in the cache");
         }
     }
 


### PR DESCRIPTION
This reduces log levels in the sdk-base crate when processing a sliding sync, and also changes a bit the sliding sync logs:

- include the `conn_id` at the stream level, not the `sync_once` level (that's a child scope of the stream)
- also include whether e2ee is enabled at the stream level
- shorten most static logs
- remove duplicate "sending request" logs