### PR TITLE
ui: Keep local echoes when clearing timeline

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -165,6 +165,10 @@ impl EventTimelineItem {
         matches!(self.kind, EventTimelineItemKind::Local(_))
     }
 
+    pub(super) fn is_remote_event(&self) -> bool {
+        matches!(self.kind, EventTimelineItemKind::Remote(_))
+    }
+
     /// Get the `LocalEventTimelineItem` if `self` is `Local`.
     pub(super) fn as_local(&self) -> Option<&LocalEventTimelineItem> {
         match &self.kind {

--- a/crates/matrix-sdk-ui/src/timeline/item.rs
+++ b/crates/matrix-sdk-ui/src/timeline/item.rs
@@ -80,6 +80,14 @@ impl TimelineItem {
         })
     }
 
+    pub(crate) fn is_local_echo(&self) -> bool {
+        matches!(&self.kind, TimelineItemKind::Event(ev) if ev.is_local_echo())
+    }
+
+    pub(crate) fn is_remote_event(&self) -> bool {
+        matches!(&self.kind, TimelineItemKind::Event(ev) if ev.is_remote_event())
+    }
+
     pub(crate) fn is_virtual(&self) -> bool {
         matches!(self.kind, TimelineItemKind::Virtual(_))
     }


### PR DESCRIPTION
This is especially important for ones that failed to send (or ones that fail post timeline clearing), since there is no way to retry them otherwise.

Closes #2334.
