### PR TITLE
Fix `is_user_mention_enabled` and `is_room_mention_enabled`

### DIFF
--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -120,7 +120,7 @@ impl Rules {
 
     /// Get whether the `IsUserMention` rule is enabled.
     fn is_user_mention_enabled(&self) -> bool {
-        // Search for an enabled `Override` rule `IsUserMention` (MSC3952).
+        // Search for an `Override` rule `IsUserMention` (MSC3952).
         // This is a new push rule that may not yet be present.
         if let Some(rule) =
             self.ruleset.get(RuleKind::Override, PredefinedOverrideRuleId::IsUserMention)
@@ -152,7 +152,7 @@ impl Rules {
 
     /// Get whether the `IsRoomMention` rule is enabled.
     fn is_room_mention_enabled(&self) -> bool {
-        // Search for an enabled `Override` rule `IsRoomMention` (MSC3952).
+        // Search for an `Override` rule `IsRoomMention` (MSC3952).
         // This is a new push rule that may not yet be present.
         if let Some(rule) =
             self.ruleset.get(RuleKind::Override, PredefinedOverrideRuleId::IsRoomMention)

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -6,6 +6,7 @@ use serde_json::Value as JsonValue;
 #[cfg(feature = "appservice")]
 pub mod appservice;
 mod event_builder;
+pub mod notification_settings;
 pub mod test_json;
 
 pub use event_builder::{

--- a/testing/matrix-sdk-test/src/notification_settings/mod.rs
+++ b/testing/matrix-sdk-test/src/notification_settings/mod.rs
@@ -1,0 +1,49 @@
+use ruma::{
+    push::{
+        Action, NewConditionalPushRule, NewPushRule, NewSimplePushRule, PushCondition, RuleKind,
+        Ruleset, Tweak,
+    },
+    RoomId, UserId,
+};
+
+pub fn get_server_default_ruleset() -> Ruleset {
+    let user_id = UserId::parse("@user:matrix.org").unwrap();
+    Ruleset::server_default(&user_id)
+}
+
+/// Build a new ruleset based on the server's default ruleset, by inserting a
+/// list of rules
+pub fn build_ruleset(rule_list: Vec<(RuleKind, &RoomId, bool)>) -> Ruleset {
+    let mut ruleset = get_server_default_ruleset();
+    for (kind, room_id, notify) in rule_list {
+        let actions = if notify {
+            vec![Action::Notify, Action::SetTweak(Tweak::Sound("default".into()))]
+        } else {
+            vec![]
+        };
+        match kind {
+            RuleKind::Room => {
+                let new_rule = NewSimplePushRule::new(room_id.to_owned(), actions);
+                ruleset.insert(NewPushRule::Room(new_rule), None, None).unwrap();
+            }
+            RuleKind::Override | RuleKind::Underride => {
+                let new_rule = NewConditionalPushRule::new(
+                    room_id.into(),
+                    vec![PushCondition::EventMatch {
+                        key: "room_id".to_owned(),
+                        pattern: room_id.to_string(),
+                    }],
+                    actions,
+                );
+                let new_push_rule = match kind {
+                    RuleKind::Override => NewPushRule::Override(new_rule),
+                    _ => NewPushRule::Underride(new_rule),
+                };
+                ruleset.insert(new_push_rule, None, None).unwrap();
+            }
+            _ => {}
+        }
+    }
+
+    ruleset
+}


### PR DESCRIPTION
With this PR:
- `is_user_mention_enabled()` now returns the value of the new push rule `.m.rule.is_user_mention` if the rule exists. Previously, the value of the new push rule was only returned if it was enabled.
- `is_room_mention_enabled()` now returns the value of the new push rule `.m.rule.is_room_mention` if the rule exists. Previously, the value of the new push rule was only returned if it was enabled.

The previous implementation was problematic because setting `is_room_mention_enabled()` to `false` actually makes 2 API calls:
- One disabling the new push rule `.m.rule.is_room_mention`
- One disabling the deprecated rule `.m.rule.roomnotif` 

And the client app was seeing the room mention enabled after the first call because the previous implementation was returning the state of the deprecated rule if the new one was disabled.
In this way, the new push rule is the one used if it exists.

This PR also fixes some UnitTests for `notification_settings` crate.