### PR TITLE
ui: Deduplicate in-reply-to fetching

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -879,6 +879,10 @@ impl TimelineInner {
             info!("Event is not a reply");
             return Ok(());
         };
+        if let TimelineDetails::Pending = &in_reply_to.event {
+            info!("Replied-to event is already being fetched");
+            return Ok(());
+        }
         if let TimelineDetails::Ready(_) = &in_reply_to.event {
             info!("Replied-to event has already been fetched");
             return Ok(());


### PR DESCRIPTION
Currently EX-ios is a bit over-eager with calling this, this is a quick fix so we don't do pointless extra work (though ideally the app would also make sure not to call this function too often).