### PR TITLE
ui: Convert most integration tests from wiremock to axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,9 +459,11 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -477,6 +479,30 @@ dependencies = [
  "http-body",
  "mime",
  "rustversion",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cebbcd90f811f93fc2a993024caecc1e8270d9d1eb9d3359edb3069c2096ea6f"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -2002,6 +2028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+
+[[package]]
 name = "http-types"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2928,11 +2960,14 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "assert_matches",
+ "async-channel",
  "async-once-cell",
  "async-rx",
  "async-std",
  "async-stream",
  "async-trait",
+ "axum",
+ "axum-extra",
  "chrono",
  "ctor",
  "eyeball",
@@ -2957,6 +2992,7 @@ dependencies = [
  "stream_assert",
  "thiserror",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
@@ -5149,6 +5185,25 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
+dependencies = [
+ "bitflags 2.3.3",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -463,7 +463,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -481,14 +480,13 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
 name = "axum-extra"
-version = "0.7.5"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cebbcd90f811f93fc2a993024caecc1e8270d9d1eb9d3359edb3069c2096ea6f"
+checksum = "a93e433be9382c737320af3924f7d5fc6f89c155cf2bf88949d8f5126fab283f"
 dependencies = [
  "axum",
  "axum-core",
@@ -502,7 +500,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -2028,12 +2025,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
-
-[[package]]
 name = "http-types"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,7 +2983,6 @@ dependencies = [
  "stream_assert",
  "thiserror",
  "tokio",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
@@ -5185,25 +5175,6 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
-dependencies = [
- "bitflags 2.3.3",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ assert_matches = "1.5.0"
 async-rx = "0.1.3"
 async-stream = "0.3.3"
 async-trait = "0.1.60"
+axum = { version = "0.6.20", default-features = false, features = ["json"] }
+axum-extra = "0.7.7"
 base64 = "0.21.0"
 byteorder = "1.4.3"
 ctor = "0.2.0"

--- a/crates/matrix-sdk-appservice/Cargo.toml
+++ b/crates/matrix-sdk-appservice/Cargo.toml
@@ -30,7 +30,7 @@ sso-login = ["matrix-sdk/sso-login"]
 docs = []
 
 [dependencies]
-axum = { version = "0.6.1", default-features = false, features = ["json"] }
+axum = { workspace = true }
 dashmap = { workspace = true }
 http = { workspace = true }
 hyper = { version = "0.14.20", features = ["http1", "http2", "server"] }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1318,7 +1318,7 @@ mod tests {
 
         let client = logged_in_client(user_id).await;
 
-        let mut ev_builder = SyncResponseBuilder::new();
+        let ev_builder = SyncResponseBuilder::new();
 
         let response = ev_builder
             .add_left_room(LeftRoomBuilder::new(room_id).add_timeline_event(
@@ -1492,7 +1492,7 @@ mod tests {
         event_id: &str,
         user_id: &UserId,
     ) -> Room {
-        let mut ev_builder = SyncResponseBuilder::new();
+        let ev_builder = SyncResponseBuilder::new();
         let response = ev_builder
             .add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
                 TimelineTestEvent::Custom(json!({

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1318,9 +1318,9 @@ mod tests {
 
         let client = logged_in_client(user_id).await;
 
-        let ev_builder = SyncResponseBuilder::new();
+        let sync_builder = SyncResponseBuilder::new();
 
-        let response = ev_builder
+        let response = sync_builder
             .add_left_room(LeftRoomBuilder::new(room_id).add_timeline_event(
                 TimelineTestEvent::Custom(json!({
                     "content": {
@@ -1338,7 +1338,7 @@ mod tests {
         client.receive_sync_response(response).await.unwrap();
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Left);
 
-        let response = ev_builder
+        let response = sync_builder
             .add_invited_room(InvitedRoomBuilder::new(room_id).add_state_event(
                 StrippedStateTestEvent::Custom(json!({
                     "content": {
@@ -1492,8 +1492,8 @@ mod tests {
         event_id: &str,
         user_id: &UserId,
     ) -> Room {
-        let ev_builder = SyncResponseBuilder::new();
-        let response = ev_builder
+        let sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
             .add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
                 TimelineTestEvent::Custom(json!({
                     "content": {

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -48,14 +48,13 @@ anyhow = { workspace = true }
 assert-json-diff = "2.0"
 assert_matches = { workspace = true }
 async-channel = "1.9.0"
-axum = { version = "0.6.19", default-features = false, features = ["json", "tokio", "tracing"] }
-axum-extra = { version = "0.7.5", features = ["erased-json"] }
+axum = { workspace = true, features = ["tokio"] }
+axum-extra = { workspace = true, features = ["erased-json"] }
 ctor = { workspace = true }
 eyeball-im-util = { workspace = true }
 matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 stream_assert = "0.1.0"
-tower-http = { version = "0.4.3", features = ["trace"] }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 wiremock = "0.5.13"
 

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -47,11 +47,15 @@ unicode-normalization = "0.1.22"
 anyhow = { workspace = true }
 assert-json-diff = "2.0"
 assert_matches = { workspace = true }
+async-channel = "1.9.0"
+axum = { version = "0.6.19", default-features = false, features = ["json", "tokio", "tracing"] }
+axum-extra = { version = "0.7.5", features = ["erased-json"] }
 ctor = { workspace = true }
 eyeball-im-util = { workspace = true }
 matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 stream_assert = "0.1.0"
+tower-http = { version = "0.4.3", features = ["trace"] }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 wiremock = "0.5.13"
 

--- a/crates/matrix-sdk-ui/tests/integration/axum.rs
+++ b/crates/matrix-sdk-ui/tests/integration/axum.rs
@@ -1,0 +1,91 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::{Ipv4Addr, SocketAddr};
+
+use axum::{http::StatusCode, routing::get, Json};
+use axum_extra::response::ErasedJson;
+use matrix_sdk::{
+    config::RequestConfig,
+    matrix_auth::{Session, SessionTokens},
+    Client, ClientBuilder,
+};
+use matrix_sdk_base::SessionMeta;
+use matrix_sdk_test::{test_json, SyncResponseBuilder};
+use ruma::{api::MatrixVersion, device_id, user_id};
+use tokio::spawn;
+use tower_http::trace::TraceLayer;
+
+pub fn test_client_builder(routes: axum::Router) -> ClientBuilder {
+    let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0);
+    let server = axum::Server::bind(&addr)
+        .serve(routes.layer(TraceLayer::new_for_http()).into_make_service());
+
+    let client_builder = Client::builder()
+        .homeserver_url(format!("http://{}", server.local_addr()))
+        .server_versions([MatrixVersion::V1_7]);
+
+    spawn(async move {
+        server.await.unwrap();
+    });
+
+    client_builder
+}
+
+pub async fn no_retry_test_client(routes: axum::Router) -> Client {
+    test_client_builder(routes)
+        .request_config(RequestConfig::new().disable_retry())
+        .build()
+        .await
+        .unwrap()
+}
+
+pub async fn logged_in_client(routes: axum::Router) -> Client {
+    let session = Session {
+        meta: SessionMeta {
+            user_id: user_id!("@example:localhost").to_owned(),
+            device_id: device_id!("DEVICEID").to_owned(),
+        },
+        tokens: SessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+
+    let client = no_retry_test_client(routes).await;
+    client.restore_session(session).await.unwrap();
+    client
+}
+
+pub trait RouterExt: Sized {
+    fn mock_encryption_state(self, is_encrypted: bool) -> Self;
+    fn mock_sync_responses(self, sync_builder: SyncResponseBuilder) -> Self;
+}
+
+impl<S: Clone + Send + Sync + 'static> RouterExt for axum::Router<S> {
+    fn mock_encryption_state(self, is_encrypted: bool) -> Self {
+        self.route(
+            "/_matrix/client/v3/rooms/:room_id/state/m.room.encryption/",
+            if is_encrypted {
+                get(|| async { ErasedJson::new(&*test_json::sync_events::ENCRYPTION_CONTENT) })
+            } else {
+                get(|| async { (StatusCode::NOT_FOUND, ErasedJson::new(&*test_json::NOT_FOUND)) })
+            },
+        )
+    }
+
+    fn mock_sync_responses(self, sync_builder: SyncResponseBuilder) -> Self {
+        self.route(
+            "/_matrix/client/v3/sync",
+            get(|| async move { Json(sync_builder.build_json_sync_response()) }),
+        )
+    }
+}

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -26,6 +26,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
+mod axum;
 mod encryption_sync;
 mod notification_client;
 mod room_list_service;

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -37,7 +37,7 @@ async fn test_notification_client_with_context() {
         "type": "m.room.message",
     });
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id.clone())
             .add_timeline_event(TimelineTestEvent::Custom(event_json.clone())),

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -37,14 +37,14 @@ async fn test_notification_client_with_context() {
         "type": "m.room.message",
     });
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id.clone())
             .add_timeline_event(TimelineTestEvent::Custom(event_json.clone())),
     );
 
     // First, mock a sync that contains a text message.
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -42,10 +42,10 @@ async fn echo() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -93,7 +93,7 @@ async fn echo() {
     let item = sent_confirmation.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::Sent { .. }));
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "Hello, World!",
@@ -107,7 +107,7 @@ async fn echo() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -139,10 +139,10 @@ async fn retry_failed() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -194,10 +194,10 @@ async fn dedup_by_event_id_late() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -230,7 +230,7 @@ async fn dedup_by_event_id_late() {
     let item = local_echo.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::NotSentYet));
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "Hello, World!",
@@ -244,7 +244,7 @@ async fn dedup_by_event_id_late() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
     assert_next_matches!(timeline_stream, VectorDiff::Insert { index: 0, .. }); // day divider
@@ -264,10 +264,10 @@ async fn cancel_failed() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -42,7 +42,7 @@ async fn echo() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -139,7 +139,7 @@ async fn retry_failed() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -194,7 +194,7 @@ async fn dedup_by_event_id_late() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -264,7 +264,7 @@ async fn cancel_failed() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -48,10 +48,10 @@ async fn edit() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -59,7 +59,7 @@ async fn edit() {
     let timeline = room.timeline().await;
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "hello",
@@ -72,7 +72,7 @@ async fn edit() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -92,7 +92,7 @@ async fn edit() {
     assert_matches!(msg.in_reply_to(), None);
     assert!(!msg.is_edited());
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
                 "content": {
@@ -126,7 +126,7 @@ async fn edit() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -162,10 +162,10 @@ async fn reaction() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -173,7 +173,7 @@ async fn reaction() {
     let timeline = room.timeline().await;
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
                 "content": {
@@ -200,7 +200,7 @@ async fn reaction() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -229,7 +229,7 @@ async fn reaction() {
 
     // TODO: After adding raw timeline items, check for one here
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {},
             "redacts": "$031IXQRi27504",
@@ -240,7 +240,7 @@ async fn reaction() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -260,10 +260,10 @@ async fn redacted_message() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -271,7 +271,7 @@ async fn redacted_message() {
     let timeline = room.timeline().await;
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
                 "content": {},
@@ -300,7 +300,7 @@ async fn redacted_message() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -323,10 +323,10 @@ async fn read_marker() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -334,7 +334,7 @@ async fn read_marker() {
     let timeline = room.timeline().await;
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "hello",
@@ -347,7 +347,7 @@ async fn read_marker() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -355,17 +355,17 @@ async fn read_marker() {
     let message = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
     assert_matches!(message.as_event().unwrap().content(), TimelineItemContent::Message(_));
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id).add_account_data(RoomAccountDataTestEvent::FullyRead),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
     // Nothing should happen, the marker cannot be added at the end.
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "hello to you!",
@@ -378,7 +378,7 @@ async fn read_marker() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -398,10 +398,10 @@ async fn in_reply_to_details() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -415,7 +415,7 @@ async fn in_reply_to_details() {
         Err(TimelineError::RemoteEventNotInTimeline)
     );
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
                 "content": {
@@ -444,7 +444,7 @@ async fn in_reply_to_details() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -459,7 +459,7 @@ async fn in_reply_to_details() {
     assert_eq!(in_reply_to.event_id, event_id!("$event1"));
     assert_matches!(in_reply_to.event, TimelineDetails::Ready(_));
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "you were right",
@@ -477,7 +477,7 @@ async fn in_reply_to_details() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -553,8 +553,8 @@ async fn sync_highlighted() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder
         // We need the member event and power levels locally so the push rules processor works.
         .add_joined_room(
             JoinedRoomBuilder::new(room_id)
@@ -562,7 +562,7 @@ async fn sync_highlighted() {
                 .add_state_event(StateTestEvent::PowerLevels),
         );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -570,7 +570,7 @@ async fn sync_highlighted() {
     let timeline = room.timeline().await;
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "hello",
@@ -583,7 +583,7 @@ async fn sync_highlighted() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -599,7 +599,7 @@ async fn sync_highlighted() {
     // Own events don't trigger push rules.
     assert!(!remote_event.is_highlighted());
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "This room has been replaced",
@@ -613,7 +613,7 @@ async fn sync_highlighted() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -48,7 +48,7 @@ async fn edit() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -162,7 +162,7 @@ async fn reaction() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -260,7 +260,7 @@ async fn redacted_message() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -323,7 +323,7 @@ async fn read_marker() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -398,7 +398,7 @@ async fn in_reply_to_details() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -553,7 +553,7 @@ async fn sync_highlighted() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder
         // We need the member event and power levels locally so the push rules processor works.
         .add_joined_room(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -44,7 +44,7 @@ async fn back_pagination() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -144,7 +144,7 @@ async fn back_pagination_highlighted() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder
         // We need the member event and power levels locally so the push rules processor works.
         .add_joined_room(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -44,10 +44,10 @@ async fn back_pagination() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -144,8 +144,8 @@ async fn back_pagination_highlighted() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder
         // We need the member event and power levels locally so the push rules processor works.
         .add_joined_room(
             JoinedRoomBuilder::new(room_id)
@@ -153,7 +153,7 @@ async fn back_pagination_highlighted() {
                 .add_state_event(StateTestEvent::PowerLevels),
         );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -12,9 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    future::pending,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use assert_matches::assert_matches;
+use axum::{http::StatusCode, response::IntoResponse, routing::put, Json};
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
 use matrix_sdk::config::SyncSettings;
@@ -23,58 +31,49 @@ use matrix_sdk_ui::timeline::{EventItemOrigin, EventSendState, RoomExt};
 use ruma::{events::room::message::RoomMessageEventContent, room_id};
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
-use tokio::time::sleep;
-use wiremock::{
-    matchers::{body_string_contains, method, path_regex},
-    Mock, ResponseTemplate,
+use tokio::{
+    task::yield_now,
+    time::{sleep, timeout},
 };
 
-use crate::{logged_in_client, mock_encryption_state, mock_sync};
+use crate::axum::{logged_in_client, RouterExt};
 
 #[async_test]
 async fn message_order() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let sync_builder = SyncResponseBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let sync_builder = SyncResponseBuilder::new();
+    let (fst_tx, fst_rx) = async_channel::bounded(1);
+    let (snd_tx, snd_rx) = async_channel::bounded(1);
+    let client = logged_in_client(
+        axum::Router::new()
+            .route(
+                "/_matrix/client/v3/rooms/:room_id/send/*rest",
+                put(move |body: String| async move {
+                    if body.contains("First!") {
+                        fst_rx.recv().await.unwrap();
+                        Json(json!({ "event_id": "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP" }))
+                    } else if body.contains("Second.") {
+                        snd_rx.recv().await.unwrap();
+                        Json(json!({ "event_id": "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ" }))
+                    } else {
+                        unreachable!()
+                    }
+                }),
+            )
+            .mock_encryption_state(false)
+            .mock_sync_responses(sync_builder.clone()),
+    )
+    .await;
+
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
+    client.sync_once(sync_settings.clone()).await.unwrap();
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = room.timeline().await;
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
-
-    // Response for first message takes 200ms to respond
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
-        .and(body_string_contains("First!"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(&json!({ "event_id": "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP" }))
-                .set_delay(Duration::from_millis(200)),
-        )
-        .mount(&server)
-        .await;
-
-    // Response for second message only takes 100ms to respond, so should come
-    // back first if we don't serialize requests
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
-        .and(body_string_contains("Second."))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(&json!({ "event_id": "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ" }))
-                .set_delay(Duration::from_millis(100)),
-        )
-        .mount(&server)
-        .await;
 
     timeline.send(RoomMessageEventContent::text_plain("First!").into(), None).await;
     timeline.send(RoomMessageEventContent::text_plain("Second.").into(), None).await;
@@ -87,44 +86,79 @@ async fn message_order() {
         assert_eq!(value.content().as_message().unwrap().body(), "Second.");
     });
 
-    // Wait 200ms for the first msg, 100ms for the second, 200ms for overhead
-    sleep(Duration::from_millis(500)).await;
+    // Make both requests succeed at this point, but in reverse order.
+    snd_tx.send(()).await.unwrap();
+    yield_now().await;
+    fst_tx.send(()).await.unwrap();
 
-    // The first item should be updated first
-    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 0, value } => {
-        assert_eq!(value.content().as_message().unwrap().body(), "First!");
-        assert_eq!(value.event_id().unwrap(), "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP");
-    });
-    // Then the second one
-    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 1, value } => {
-        assert_eq!(value.content().as_message().unwrap().body(), "Second.");
-        assert_eq!(value.event_id().unwrap(), "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ");
-    });
-    assert_pending!(timeline_stream);
+    let retries = async move {
+        // The first item should be updated first
+        assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 0, value }) => {
+            assert_eq!(value.content().as_message().unwrap().body(), "First!");
+            assert_eq!(value.event_id().unwrap(), "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP");
+        });
+        // Then the second one
+        assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 1, value }) => {
+            assert_eq!(value.content().as_message().unwrap().body(), "Second.");
+            assert_eq!(value.event_id().unwrap(), "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ");
+        });
+        assert_pending!(timeline_stream);
+    };
+
+    timeout(Duration::from_millis(500), retries).await.unwrap();
 }
 
 #[async_test]
 async fn retry_order() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let sync_builder = SyncResponseBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let sync_builder = SyncResponseBuilder::new();
+    let num_requests = Arc::new(AtomicU8::new(0));
+    let client = logged_in_client(
+        axum::Router::new()
+            .route(
+                "/_matrix/client/v3/rooms/:room_id/send/*rest",
+                put(move |body: String| async move {
+                    // The first request fails
+                    if num_requests.fetch_add(1, Ordering::AcqRel) < 1 {
+                        // Make sure not to return immediately, so both requests have made it to
+                        // the queue before the first one fails.
+                        sleep(Duration::from_millis(50)).await;
+                        return StatusCode::BAD_REQUEST.into_response();
+                    }
+
+                    // Following requests succeed
+                    if body.contains("First!") {
+                        // Response for first message retry takes 50ms to respond
+                        sleep(Duration::from_millis(50)).await;
+                        Json(json!({ "event_id": "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP" }))
+                            .into_response()
+                    } else if body.contains("Second.") {
+                        // Response for second message retry takes 100ms to respond,
+                        // so should come back after first if we don't serialize retries
+                        sleep(Duration::from_millis(100)).await;
+                        Json(json!({ "event_id": "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ" }))
+                            .into_response()
+                    } else {
+                        unreachable!()
+                    }
+                }),
+            )
+            .mock_encryption_state(false)
+            .mock_sync_responses(sync_builder.clone()),
+    )
+    .await;
+
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
+    client.sync_once(sync_settings.clone()).await.unwrap();
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await);
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
-    // Send two messages without mocking the server response.
-    // It will respond with a 404, resulting in a failed-to-send state.
+    // Try sending two messages
     timeline.send(RoomMessageEventContent::text_plain("First!").into(), Some("1".into())).await;
     timeline.send(RoomMessageEventContent::text_plain("Second.").into(), Some("2".into())).await;
 
@@ -137,7 +171,7 @@ async fn retry_order() {
     });
 
     // Local echoes are updated with the failed send state as soon as
-    // the 404 response is received
+    // the error response is received
     assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 0, value }) => {
         assert_matches!(value.send_state().unwrap(), EventSendState::SendingFailed { .. });
     });
@@ -146,32 +180,7 @@ async fn retry_order() {
         assert_matches!(value.send_state().unwrap(), EventSendState::Cancelled);
     });
 
-    // Response for first message takes 100ms to respond
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
-        .and(body_string_contains("First!"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(&json!({ "event_id": "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP" }))
-                .set_delay(Duration::from_millis(100)),
-        )
-        .mount(&server)
-        .await;
-
-    // Response for second message takes 200ms to respond, so should come back
-    // after first if we don't serialize retries
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
-        .and(body_string_contains("Second."))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(&json!({ "event_id": "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ" }))
-                .set_delay(Duration::from_millis(200)),
-        )
-        .mount(&server)
-        .await;
-
-    // Retry the second message first
+    // Retry both messages, but the second one first
     timeline.retry_send("2".into()).await.unwrap();
     timeline.retry_send("1".into()).await.unwrap();
 
@@ -188,47 +197,61 @@ async fn retry_order() {
         assert_eq!(value.content().as_message().unwrap().body(), "First!");
     });
 
-    // Wait 200ms for the first msg, 100ms for the second, 300ms for overhead
-    sleep(Duration::from_millis(600)).await;
+    let retries = async move {
+        // The second item (now at index 0) should be updated first, since it was
+        // retried first
+        assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 0, value }) => {
+            assert_eq!(value.content().as_message().unwrap().body(), "Second.");
+            assert_matches!(value.send_state().unwrap(), EventSendState::Sent { .. });
+            assert_eq!(value.event_id().unwrap(), "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ");
+        });
+        // Then the first one
+        assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 1, value }) => {
+            assert_eq!(value.content().as_message().unwrap().body(), "First!");
+            assert_matches!(value.send_state().unwrap(), EventSendState::Sent { .. });
+            assert_eq!(value.event_id().unwrap(), "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP");
+        });
+    };
 
-    // The second item (now at index 0) should be updated first, since it was
-    // retried first
-    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 0, value } => {
-        assert_eq!(value.content().as_message().unwrap().body(), "Second.");
-        assert_matches!(value.send_state().unwrap(), EventSendState::Sent { .. });
-        assert_eq!(value.event_id().unwrap(), "$5E2kLK/Sg342bgBU9ceEIEPYpbFaqJpZ");
-    });
-    // Then the first one
-    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 1, value } => {
-        assert_eq!(value.content().as_message().unwrap().body(), "First!");
-        assert_matches!(value.send_state().unwrap(), EventSendState::Sent { .. });
-        assert_eq!(value.event_id().unwrap(), "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP");
-    });
-    assert_pending!(timeline_stream);
+    timeout(Duration::from_millis(500), retries).await.unwrap();
 }
 
 #[async_test]
 async fn clear_with_echoes() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let sync_builder = SyncResponseBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let sync_builder = SyncResponseBuilder::new();
+    let num_requests = Arc::new(AtomicU8::new(0));
+    let client = logged_in_client(
+        axum::Router::new()
+            .route(
+                "/_matrix/client/v3/rooms/:room_id/send/*rest",
+                put(|| async move {
+                    if num_requests.fetch_add(1, Ordering::AcqRel) < 1 {
+                        // First request fails
+                        StatusCode::BAD_REQUEST
+                    } else {
+                        // Second request stalls forever
+                        pending().await
+                    }
+                }),
+            )
+            .mock_encryption_state(false)
+            .mock_sync_responses(sync_builder.clone()),
+    )
+    .await;
+
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
-    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
-    server.reset().await;
-
-    mock_encryption_state(&server, false).await;
+    client.sync_once(sync_settings.clone()).await.unwrap();
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await;
 
-    // Send a message without mocking the server response.
     {
         let (_, mut timeline_stream) = timeline.subscribe().await;
 
+        // Send the first message (will fail)
         timeline.send(RoomMessageEventContent::text_plain("Send failure").into(), None).await;
 
         // Wait for the first message to fail. Don't use time, but listen for the first
@@ -238,25 +261,13 @@ async fn clear_with_echoes() {
         let _local_echo_replaced_with_failure = timeline_stream.next().await;
     }
 
-    // Next message will take "forever" to send.
-    Mock::given(method("PUT"))
-        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_json(&json!({ "event_id": "$PyHxV5mYzjetBUT3qZq7V95GOzxb02EP" }))
-                .set_delay(Duration::from_secs(3600)),
-        )
-        .mount(&server)
-        .await;
-
-    // (this one)
+    // Send the second message (will stall forever in the server)
     timeline.send(RoomMessageEventContent::text_plain("Pending").into(), None).await;
 
     // Another message comes in.
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id).add_timeline_event(TimelineTestEvent::MessageText),
     );
-    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     client.sync_once(sync_settings.clone()).await.unwrap();
 
     // At this point, there should be three timeline items:

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -37,10 +37,10 @@ async fn message_order() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -109,10 +109,10 @@ async fn retry_order() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -37,7 +37,7 @@ async fn message_order() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -109,7 +109,7 @@ async fn retry_order() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -213,7 +213,7 @@ async fn clear_with_echoes() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut sync_builder = SyncResponseBuilder::new();
+    let sync_builder = SyncResponseBuilder::new();
     sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -48,7 +48,7 @@ async fn read_receipts_updates() {
     let second_event_id = event_id!("$e32037280er453l:localhost");
     let third_event_id = event_id!("$Sg2037280074GZr34:localhost");
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -245,7 +245,7 @@ async fn send_single_receipt() {
 
     let own_user_id = client.user_id().unwrap();
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -592,7 +592,7 @@ async fn send_multiple_receipts() {
 
     let own_user_id = client.user_id().unwrap();
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -48,10 +48,10 @@ async fn read_receipts_updates() {
     let second_event_id = event_id!("$e32037280er453l:localhost");
     let third_event_id = event_id!("$Sg2037280074GZr34:localhost");
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -68,7 +68,7 @@ async fn read_receipts_updates() {
     let bob_receipt = timeline.latest_user_read_receipt(bob).await;
     assert_matches!(bob_receipt, None);
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::MessageText)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
@@ -93,7 +93,7 @@ async fn read_receipts_updates() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -125,7 +125,7 @@ async fn read_receipts_updates() {
     assert_eq!(alice_receipt_event_id, third_event_id);
 
     // Read receipt on unknown event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 "$unknowneventid": {
@@ -140,7 +140,7 @@ async fn read_receipts_updates() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -148,7 +148,7 @@ async fn read_receipts_updates() {
     assert_eq!(alice_receipt_event_id, third_event.event_id().unwrap());
 
     // Read receipt on older event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 second_event_id: {
@@ -167,7 +167,7 @@ async fn read_receipts_updates() {
     assert_eq!(alice_receipt_event_id, third_event_id);
 
     // Read receipt on same event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 third_event_id: {
@@ -186,7 +186,7 @@ async fn read_receipts_updates() {
     assert_eq!(alice_receipt_event_id, third_event_id);
 
     // New user with explicit read receipt.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 third_event_id: {
@@ -201,7 +201,7 @@ async fn read_receipts_updates() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -213,7 +213,7 @@ async fn read_receipts_updates() {
     assert_eq!(bob_receipt_event_id, third_event_id);
 
     // Private read receipt is updated.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 second_event_id: {
@@ -228,7 +228,7 @@ async fn read_receipts_updates() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -245,10 +245,10 @@ async fn send_single_receipt() {
 
     let own_user_id = client.user_id().unwrap();
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -310,7 +310,7 @@ async fn send_single_receipt() {
     server.reset().await;
 
     // Unchanged receipts are not sent.
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
                 "content": {
@@ -337,7 +337,7 @@ async fn send_single_receipt() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -424,7 +424,7 @@ async fn send_single_receipt() {
     // Newer receipts in the timeline are sent.
     let third_receipts_event_id = event_id!("$third_receipts_event_id");
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
                 "content": {
@@ -471,7 +471,7 @@ async fn send_single_receipt() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -527,7 +527,7 @@ async fn send_single_receipt() {
     server.reset().await;
 
     // Older receipts in the timeline are not sent.
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
                 "content": {
@@ -554,7 +554,7 @@ async fn send_single_receipt() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -592,10 +592,10 @@ async fn send_multiple_receipts() {
 
     let own_user_id = client.user_id().unwrap();
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -626,7 +626,7 @@ async fn send_multiple_receipts() {
     server.reset().await;
 
     // Unchanged receipts are not sent.
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
                 "content": {
@@ -653,7 +653,7 @@ async fn send_multiple_receipts() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -690,7 +690,7 @@ async fn send_multiple_receipts() {
         .public_read_receipt(Some(third_receipts_event_id.to_owned()))
         .private_read_receipt(Some(third_receipts_event_id.to_owned()));
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
                 "content": {
@@ -737,7 +737,7 @@ async fn send_multiple_receipts() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -758,7 +758,7 @@ async fn send_multiple_receipts() {
     server.reset().await;
 
     // Older receipts in the timeline are not sent.
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
                 "content": {
@@ -785,7 +785,7 @@ async fn send_multiple_receipts() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -31,7 +31,7 @@ async fn batched() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
@@ -67,7 +67,7 @@ async fn event_filter() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -31,10 +31,10 @@ async fn batched() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -48,14 +48,14 @@ async fn batched() {
         assert_eq!(next_batch.len(), 4);
     });
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::MessageText)
             .add_timeline_event(TimelineTestEvent::Member)
             .add_timeline_event(TimelineTestEvent::MessageNotice),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
     tokio::time::timeout(Duration::from_millis(500), hdl).await.unwrap().unwrap();
@@ -67,10 +67,10 @@ async fn event_filter() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -79,7 +79,7 @@ async fn event_filter() {
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let first_event_id = event_id!("$YTQwYl2ply");
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "body": "hello",
@@ -92,7 +92,7 @@ async fn event_filter() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -115,7 +115,7 @@ async fn event_filter() {
 
     let second_event_id = event_id!("$Ga6Y2l0gKY");
     let edit_event_id = event_id!("$7i9In0gEmB");
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
                 "content": {
@@ -149,7 +149,7 @@ async fn event_filter() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -180,11 +180,11 @@ async fn test_state_event_getting() {
 #[async_test]
 async fn room_route() {
     let (client, server) = logged_in_client().await;
-    let ev_builder = SyncResponseBuilder::new();
+    let sync_builder = SyncResponseBuilder::new();
     let room_id = room_id!("!test_room:127.0.0.1");
 
     // Without elligible server
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(TimelineTestEvent::Custom(json!({
                 "content": {
@@ -209,7 +209,7 @@ async fn room_route() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let sync_token = client.sync_once(SyncSettings::new()).await.unwrap().next_batch;
     let room = client.get_room(room_id).unwrap();
 
@@ -218,10 +218,10 @@ async fn room_route() {
 
     // With a single elligible server
     let mut batch = 0;
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
         bulk_room_members(batch, 0..1, "localhost", &MembershipState::Join),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     let sync_token =
         client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
@@ -231,10 +231,10 @@ async fn room_route() {
 
     // With two elligible servers
     batch += 1;
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
         bulk_room_members(batch, 0..15, "notarealhs", &MembershipState::Join),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     let sync_token =
         client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
@@ -245,10 +245,10 @@ async fn room_route() {
 
     // With three elligible servers
     batch += 1;
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
         bulk_room_members(batch, 0..5, "mymatrix", &MembershipState::Join),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     let sync_token =
         client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
@@ -260,10 +260,10 @@ async fn room_route() {
 
     // With four elligible servers
     batch += 1;
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_state_bulk(
         bulk_room_members(batch, 0..10, "yourmatrix", &MembershipState::Join),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     let sync_token =
         client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
@@ -274,7 +274,7 @@ async fn room_route() {
     assert_eq!(route[2], "mymatrix");
 
     // With power levels
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "users": {
@@ -288,7 +288,7 @@ async fn room_route() {
             "type": "m.room.power_levels",
         })),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     let sync_token =
         client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
@@ -299,7 +299,7 @@ async fn room_route() {
     assert_eq!(route[2], "yourmatrix");
 
     // With higher power levels
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "users": {
@@ -314,7 +314,7 @@ async fn room_route() {
             "type": "m.room.power_levels",
         })),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     let sync_token =
         client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
@@ -325,7 +325,7 @@ async fn room_route() {
     assert_eq!(route[2], "yourmatrix");
 
     // With server ACLs
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "allow": ["*"],
@@ -339,7 +339,7 @@ async fn room_route() {
             "type": "m.room.server_acl",
         })),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
 
     let route = room.route().await.unwrap();
@@ -352,11 +352,11 @@ async fn room_route() {
 #[async_test]
 async fn room_permalink() {
     let (client, server) = logged_in_client().await;
-    let ev_builder = SyncResponseBuilder::new();
+    let sync_builder = SyncResponseBuilder::new();
     let room_id = room_id!("!test_room:127.0.0.1");
 
     // Without aliases
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_state_bulk(bulk_room_members(
                 0,
@@ -371,7 +371,7 @@ async fn room_permalink() {
                 &MembershipState::Join,
             )),
     );
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let sync_token = client.sync_once(SyncSettings::new()).await.unwrap().next_batch;
     let room = client.get_room(room_id).unwrap();
 
@@ -385,7 +385,7 @@ async fn room_permalink() {
     );
 
     // With an alternative alias
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "alt_aliases": ["#alias:localhost"],
@@ -397,7 +397,7 @@ async fn room_permalink() {
             "type": "m.room.canonical_alias",
         })),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     let sync_token =
         client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap().next_batch;
 
@@ -408,7 +408,7 @@ async fn room_permalink() {
     assert_eq!(room.matrix_permalink(false).await.unwrap().to_string(), "matrix:r/alias:localhost");
 
     // With a canonical alias
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "alias": "#canonical:localhost",
@@ -421,7 +421,7 @@ async fn room_permalink() {
             "type": "m.room.canonical_alias",
         })),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
 
     assert_eq!(
@@ -441,12 +441,12 @@ async fn room_permalink() {
 #[async_test]
 async fn room_event_permalink() {
     let (client, server) = logged_in_client().await;
-    let ev_builder = SyncResponseBuilder::new();
+    let sync_builder = SyncResponseBuilder::new();
     let room_id = room_id!("!test_room:127.0.0.1");
     let event_id = event_id!("$15139375512JaHAW");
 
     // Without aliases
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_state_bulk(bulk_room_members(
                 0,
@@ -461,7 +461,7 @@ async fn room_event_permalink() {
                 &MembershipState::Join,
             )),
     );
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let sync_token = client.sync_once(SyncSettings::new()).await.unwrap().next_batch;
     let room = client.get_room(room_id).unwrap();
 
@@ -475,7 +475,7 @@ async fn room_event_permalink() {
     );
 
     // Adding an alias doesn't change anything
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
             "content": {
                 "alias": "#canonical:localhost",
@@ -488,7 +488,7 @@ async fn room_event_permalink() {
             "type": "m.room.canonical_alias",
         })),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), Some(sync_token.clone())).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), Some(sync_token.clone())).await;
     client.sync_once(SyncSettings::new().token(sync_token)).await.unwrap();
 
     assert_eq!(
@@ -509,8 +509,8 @@ async fn event() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let ev_builder = SyncResponseBuilder::new();
-    ev_builder
+    let sync_builder = SyncResponseBuilder::new();
+    sync_builder
         // We need the member event and power levels locally so the push rules processor works.
         .add_joined_room(
             JoinedRoomBuilder::new(room_id)
@@ -518,7 +518,7 @@ async fn event() {
                 .add_state_event(StateTestEvent::PowerLevels),
         );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -180,7 +180,7 @@ async fn test_state_event_getting() {
 #[async_test]
 async fn room_route() {
     let (client, server) = logged_in_client().await;
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     let room_id = room_id!("!test_room:127.0.0.1");
 
     // Without elligible server
@@ -352,7 +352,7 @@ async fn room_route() {
 #[async_test]
 async fn room_permalink() {
     let (client, server) = logged_in_client().await;
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     let room_id = room_id!("!test_room:127.0.0.1");
 
     // Without aliases
@@ -441,7 +441,7 @@ async fn room_permalink() {
 #[async_test]
 async fn room_event_permalink() {
     let (client, server) = logged_in_client().await;
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     let room_id = room_id!("!test_room:127.0.0.1");
     let event_id = event_id!("$15139375512JaHAW");
 
@@ -509,7 +509,7 @@ async fn event() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
+    let ev_builder = SyncResponseBuilder::new();
     ev_builder
         // We need the member event and power levels locally so the push rules processor works.
         .add_joined_room(


### PR DESCRIPTION
Seems to be about the same amount of boilerplate but we can use channels and other things to delay responses now.
