### PR TITLE
Remove the 'testing' feature from matrix-sdk-ui

### DIFF
--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -11,8 +11,6 @@ e2e-encryption = ["matrix-sdk/e2e-encryption"]
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
 
-testing = []
-
 [dependencies]
 async-once-cell = "0.5.2"
 async-rx = { workspace = true }
@@ -54,7 +52,3 @@ matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 stream_assert = "0.1.0"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 wiremock = "0.5.13"
-
-[[test]]
-name = "integration"
-required-features = ["testing"]

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -102,7 +102,7 @@ mod tests {
         let matcher = matcher.with_pattern("ubété");
 
         // First, assert that the pattern has been normalized.
-        assert_eq!(matcher.pattern, Some("ubete".to_string()));
+        assert_eq!(matcher.pattern, Some("ubete".to_owned()));
 
         // Second, assert that the subject is normalized too.
         assert!(matcher.fuzzy_match("un bel été"));

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -330,7 +330,7 @@ impl RoomListService {
         Ok(room)
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     pub fn sliding_sync(&self) -> &SlidingSync {
         &self.sliding_sync
     }

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -18,7 +18,6 @@ use std::{fmt, sync::Arc};
 
 use async_rx::StreamExt as _;
 use eyeball_im::{ObservableVectorEntry, VectorDiff, VectorSubscriber};
-#[cfg(any(test, feature = "testing"))]
 use eyeball_im_util::{FilterMapVectorSubscriber, VectorExt};
 use futures_core::Stream;
 use imbl::Vector;
@@ -164,7 +163,6 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         (items, stream)
     }
 
-    #[cfg(any(test, feature = "testing"))]
     pub(super) async fn subscribe_filter_map<U, F>(
         &self,
         f: F,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -645,6 +645,7 @@ impl Timeline {
 }
 
 /// Test helpers, likely not very useful in production.
+#[doc(hidden)]
 impl Timeline {
     /// Get the current list of timeline items.
     pub async fn items(&self) -> Vector<Arc<TimelineItem>> {

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1670,7 +1670,7 @@ mod tests {
                     device_one_time_keys_count: BTreeMap::from([(DeviceKeyAlgorithm::SignedCurve25519, uint!(42))])
                 }),
                 to_device: Some(assign!(v4::ToDevice::default(), {
-                    next_batch: "to-device-token".to_string()
+                    next_batch: "to-device-token".to_owned(),
                 })),
             })
         });

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -19,7 +19,7 @@ eyeball-im = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
 matrix-sdk = { path = "../../crates/matrix-sdk", features = ["testing"] }
-matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", features = ["testing"] }
+matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui" }
 once_cell = { workspace = true }
 tempfile = "3.3.0"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
I wanted to do more than this, but it's really not clear how to proceed.

This allows running matrix-sdk-ui integration tests with just `cargo test -p matrix-sdk-ui`, instead of `cargo test -p matrix-sdk-ui --features testing`.

An alternative to just making these functions public would be to make them public and `#[doc(hidden)]`.