### PR TITLE
Allow to define the default notification mode for a given room type

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -158,7 +158,7 @@ impl NotificationSettings {
         // If the user has not defined a notification mode, return the default one for
         // this room
         let mode = notification_settings
-            .get_default_room_notification_mode(is_encrypted, active_members_count)
+            .get_default_room_notification_mode(is_encrypted.into(), active_members_count)
             .await;
         Ok(RoomNotificationSettings::new(mode.into(), true))
     }
@@ -193,7 +193,7 @@ impl NotificationSettings {
     ) -> RoomNotificationMode {
         let notification_settings = self.sdk_notification_settings.read().await;
         let mode = notification_settings
-            .get_default_room_notification_mode(is_encrypted, active_members_count)
+            .get_default_room_notification_mode(is_encrypted.into(), active_members_count)
             .await;
         mode.into()
     }
@@ -213,7 +213,7 @@ impl NotificationSettings {
     ) -> Result<(), NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
         notification_settings
-            .set_default_room_notification_mode(encrypted, one_to_one, mode.into())
+            .set_default_room_notification_mode(encrypted.into(), one_to_one.into(), mode.into())
             .await?;
         Ok(())
     }
@@ -325,7 +325,7 @@ impl NotificationSettings {
         let parsed_room_idom_id = RoomId::parse(&room_id)
             .map_err(|_e| NotificationSettingsError::InvalidRoomId(room_id))?;
         notification_settings
-            .unmute_room(&parsed_room_idom_id, is_encrypted, members_count)
+            .unmute_room(&parsed_room_idom_id, is_encrypted.into(), members_count)
             .await?;
         Ok(())
     }

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -131,7 +131,7 @@ impl NotificationSettings {
         }
     }
 
-    /// Gets the notification settings for a room.
+    /// Get the notification settings for a room.
     ///
     /// # Arguments
     ///
@@ -163,7 +163,7 @@ impl NotificationSettings {
         Ok(RoomNotificationSettings::new(mode.into(), true))
     }
 
-    /// Sets the notification mode for a room.
+    /// Set the notification mode for a room.
     pub async fn set_room_notification_mode(
         &self,
         room_id: String,
@@ -198,7 +198,27 @@ impl NotificationSettings {
         mode.into()
     }
 
-    /// Restores the default notification mode for a room
+    /// Set the default room notification mode
+    ///
+    /// # Arguments
+    ///
+    /// * `encrypted` - whether the mode is for encrypted rooms
+    /// * `one_to_one` - whether the mode is for direct chats
+    /// * `mode` - the new default mode
+    pub async fn set_default_room_notification_mode(
+        &self,
+        encrypted: bool,
+        one_to_one: bool,
+        mode: RoomNotificationMode,
+    ) -> Result<(), NotificationSettingsError> {
+        let notification_settings = self.sdk_notification_settings.read().await;
+        notification_settings
+            .set_default_room_notification_mode(encrypted, one_to_one, mode.into())
+            .await?;
+        Ok(())
+    }
+
+    /// Restore the default notification mode for a room
     pub async fn restore_default_room_notification_mode(
         &self,
         room_id: String,

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -170,9 +170,9 @@ impl NotificationSettings {
         mode: RoomNotificationMode,
     ) -> Result<(), NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
-        let parsed_room_idom_id = RoomId::parse(&room_id)
+        let parsed_room_id = RoomId::parse(&room_id)
             .map_err(|_e| NotificationSettingsError::InvalidRoomId(room_id))?;
-        notification_settings.set_room_notification_mode(&parsed_room_idom_id, mode.into()).await?;
+        notification_settings.set_room_notification_mode(&parsed_room_id, mode.into()).await?;
         Ok(())
     }
 
@@ -202,18 +202,23 @@ impl NotificationSettings {
     ///
     /// # Arguments
     ///
-    /// * `encrypted` - whether the mode is for encrypted rooms
-    /// * `one_to_one` - whether the mode is for direct chats
+    /// * `is_encrypted` - whether the mode is for encrypted rooms
+    /// * `is_one_to_one` - whether the mode is for direct chats involving two
+    ///   people
     /// * `mode` - the new default mode
     pub async fn set_default_room_notification_mode(
         &self,
-        encrypted: bool,
-        one_to_one: bool,
+        is_encrypted: bool,
+        is_one_to_one: bool,
         mode: RoomNotificationMode,
     ) -> Result<(), NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
         notification_settings
-            .set_default_room_notification_mode(encrypted.into(), one_to_one.into(), mode.into())
+            .set_default_room_notification_mode(
+                is_encrypted.into(),
+                is_one_to_one.into(),
+                mode.into(),
+            )
             .await?;
         Ok(())
     }
@@ -224,9 +229,9 @@ impl NotificationSettings {
         room_id: String,
     ) -> Result<(), NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
-        let parsed_room_idom_id = RoomId::parse(&room_id)
+        let parsed_room_id = RoomId::parse(&room_id)
             .map_err(|_e| NotificationSettingsError::InvalidRoomId(room_id))?;
-        notification_settings.delete_user_defined_room_rules(&parsed_room_idom_id).await?;
+        notification_settings.delete_user_defined_room_rules(&parsed_room_id).await?;
         Ok(())
     }
 
@@ -322,10 +327,10 @@ impl NotificationSettings {
         members_count: u64,
     ) -> Result<(), NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
-        let parsed_room_idom_id = RoomId::parse(&room_id)
+        let parsed_room_id = RoomId::parse(&room_id)
             .map_err(|_e| NotificationSettingsError::InvalidRoomId(room_id))?;
         notification_settings
-            .unmute_room(&parsed_room_idom_id, is_encrypted.into(), members_count)
+            .unmute_room(&parsed_room_id, is_encrypted.into(), members_count)
             .await?;
         Ok(())
     }

--- a/crates/matrix-sdk/src/notification_settings/command.rs
+++ b/crates/matrix-sdk/src/notification_settings/command.rs
@@ -22,6 +22,8 @@ pub(crate) enum Command {
     SetPushRuleEnabled { scope: RuleScope, kind: RuleKind, rule_id: String, enabled: bool },
     /// Delete a push rule
     DeletePushRule { scope: RuleScope, kind: RuleKind, rule_id: String },
+    /// Set a list of actions
+    SetPushRuleActions { scope: RuleScope, kind: RuleKind, rule_id: String, actions: Vec<Action> },
 }
 
 fn get_notify_actions(notify: bool) -> Vec<Action> {
@@ -55,11 +57,11 @@ impl Command {
                 Ok(NewPushRule::Override(new_rule))
             }
 
-            Self::SetPushRuleEnabled { .. } | Self::DeletePushRule { .. } => {
-                Err(NotificationSettingsError::InvalidParameter(
-                    "cannot create a push rule from this command.".to_owned(),
-                ))
-            }
+            Self::SetPushRuleEnabled { .. }
+            | Self::DeletePushRule { .. }
+            | Self::SetPushRuleActions { .. } => Err(NotificationSettingsError::InvalidParameter(
+                "cannot create a push rule from this command.".to_owned(),
+            )),
         }
     }
 }

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -1,7 +1,8 @@
 use ruma::{
     api::client::push::RuleScope,
     push::{
-        PredefinedContentRuleId, PredefinedOverrideRuleId, RemovePushRuleError, RuleKind, Ruleset,
+        Action, PredefinedContentRuleId, PredefinedOverrideRuleId, RemovePushRuleError, RuleKind,
+        Ruleset,
     },
     RoomId,
 };
@@ -153,6 +154,24 @@ impl RuleCommands {
 
         Ok(())
     }
+
+    /// Set the actions of the rule from the given kind and with the given
+    /// `rule_id`
+    pub(crate) fn set_rule_actions(
+        &mut self,
+        kind: RuleKind,
+        rule_id: &str,
+        actions: Vec<Action>,
+    ) -> Result<(), NotificationSettingsError> {
+        self.rules.set_actions(kind.clone(), rule_id, actions.clone())?;
+        self.commands.push(Command::SetPushRuleActions {
+            scope: RuleScope::Global,
+            kind,
+            rule_id: rule_id.to_owned(),
+            actions,
+        });
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -162,8 +181,9 @@ mod tests {
     use ruma::{
         api::client::push::RuleScope,
         push::{
-            NewPushRule, NewSimplePushRule, PredefinedContentRuleId, PredefinedOverrideRuleId,
-            RemovePushRuleError, RuleKind, Ruleset,
+            Action, NewPushRule, NewSimplePushRule, PredefinedContentRuleId,
+            PredefinedOverrideRuleId, PredefinedUnderrideRuleId, RemovePushRuleError, RuleKind,
+            Ruleset, Tweak,
         },
         OwnedRoomId, RoomId, UserId,
     };
@@ -481,5 +501,50 @@ mod tests {
                 }
             );
         }
+    }
+
+    #[async_test]
+    async fn test_set_rule_actions() {
+        let mut ruleset = get_server_default_ruleset();
+        let mut rule_commands = RuleCommands::new(ruleset.clone());
+
+        // Starting with an empty action list for `PredefinedUnderrideRuleId::Message`.
+        ruleset
+            .set_actions(RuleKind::Underride, PredefinedUnderrideRuleId::Message, vec![])
+            .unwrap();
+
+        // After setting a list of actions
+        rule_commands
+            .set_rule_actions(
+                RuleKind::Underride,
+                PredefinedUnderrideRuleId::Message.as_str(),
+                vec![Action::Notify, Action::SetTweak(Tweak::Sound("default".into()))],
+            )
+            .unwrap();
+
+        // The ruleset must have been updated
+        let actions = rule_commands
+            .rules
+            .get(RuleKind::Underride, PredefinedUnderrideRuleId::Message)
+            .unwrap()
+            .actions();
+        assert_eq!(actions.len(), 2);
+
+        // and a `SetPushRuleActions` command must have been added
+        assert_eq!(rule_commands.commands.len(), 1);
+        assert_matches!(&rule_commands.commands[0],
+            Command::SetPushRuleActions { scope, kind, rule_id, actions } => {
+                assert_eq!(scope, &RuleScope::Global);
+                assert_eq!(kind, &RuleKind::Underride);
+                assert_eq!(rule_id, PredefinedUnderrideRuleId::Message.as_str());
+                assert_eq!(actions.len(), 2);
+                assert_matches!(&actions[0], Action::Notify);
+                assert_matches!(&actions[1], Action::SetTweak(tweak) => {
+                    assert_matches!(tweak, Tweak::Sound(sound) => {
+                        assert_eq!(sound, "default");
+                    });
+                });
+            }
+        );
     }
 }

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -539,10 +539,8 @@ mod tests {
                 assert_eq!(rule_id, PredefinedUnderrideRuleId::Message.as_str());
                 assert_eq!(actions.len(), 2);
                 assert_matches!(&actions[0], Action::Notify);
-                assert_matches!(&actions[1], Action::SetTweak(tweak) => {
-                    assert_matches!(tweak, Tweak::Sound(sound) => {
-                        assert_eq!(sound, "default");
-                    });
+                assert_matches!(&actions[1], Action::SetTweak(Tweak::Sound(sound)) => {
+                    assert_eq!(sound, "default");
                 });
             }
         );

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -9,7 +9,10 @@ use ruma::{
 };
 
 use super::{command::Command, rule_commands::RuleCommands, RoomNotificationMode};
-use crate::error::NotificationSettingsError;
+use crate::{
+    error::NotificationSettingsError,
+    notification_settings::{IsEncrypted, IsOneToOne},
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct Rules {
@@ -99,12 +102,13 @@ impl Rules {
     /// * `members_count` - the room members count
     pub(crate) fn get_default_room_notification_mode(
         &self,
-        is_encrypted: bool,
+        is_encrypted: IsEncrypted,
         members_count: u64,
     ) -> RoomNotificationMode {
         // get the correct default rule ID based on `is_encrypted` and `members_count`
+        let is_one_to_one = members_count == 2;
         let predefined_rule_id =
-            get_predefined_underride_room_rule_id(is_encrypted, members_count == 2);
+            get_predefined_underride_room_rule_id(is_encrypted, is_one_to_one.into());
         let rule_id = predefined_rule_id.as_str();
 
         // If there is an `Underride` rule that should trigger a notification, the mode
@@ -225,17 +229,17 @@ impl Rules {
 ///
 /// # Arguments
 ///
-/// * `is_encrypted` - `true` if the room is encrypted
-/// * `is_one_to_one` - `true` if the room is a direct chat
+/// * `is_encrypted` - `Yes` if the room is encrypted
+/// * `is_one_to_one` - `Yes` if the room is a direct chat
 pub(crate) fn get_predefined_underride_room_rule_id(
-    is_encrypted: bool,
-    is_one_to_one: bool,
+    is_encrypted: IsEncrypted,
+    is_one_to_one: IsOneToOne,
 ) -> PredefinedUnderrideRuleId {
     match (is_encrypted, is_one_to_one) {
-        (true, true) => PredefinedUnderrideRuleId::EncryptedRoomOneToOne,
-        (false, true) => PredefinedUnderrideRuleId::RoomOneToOne,
-        (true, false) => PredefinedUnderrideRuleId::Encrypted,
-        (false, false) => PredefinedUnderrideRuleId::Message,
+        (IsEncrypted::Yes, IsOneToOne::Yes) => PredefinedUnderrideRuleId::EncryptedRoomOneToOne,
+        (IsEncrypted::No, IsOneToOne::Yes) => PredefinedUnderrideRuleId::RoomOneToOne,
+        (IsEncrypted::Yes, IsOneToOne::No) => PredefinedUnderrideRuleId::Encrypted,
+        (IsEncrypted::No, IsOneToOne::No) => PredefinedUnderrideRuleId::Message,
     }
 }
 
@@ -258,7 +262,7 @@ pub(crate) mod tests {
         error::NotificationSettingsError,
         notification_settings::{
             rules::{self, Rules},
-            RoomNotificationMode,
+            IsEncrypted, IsOneToOne, RoomNotificationMode,
         },
     };
 
@@ -354,19 +358,19 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_get_predefined_underride_room_rule_id() {
         assert_eq!(
-            rules::get_predefined_underride_room_rule_id(false, false),
+            rules::get_predefined_underride_room_rule_id(IsEncrypted::No, IsOneToOne::No),
             PredefinedUnderrideRuleId::Message
         );
         assert_eq!(
-            rules::get_predefined_underride_room_rule_id(false, true),
+            rules::get_predefined_underride_room_rule_id(IsEncrypted::No, IsOneToOne::Yes),
             PredefinedUnderrideRuleId::RoomOneToOne
         );
         assert_eq!(
-            rules::get_predefined_underride_room_rule_id(true, false),
+            rules::get_predefined_underride_room_rule_id(IsEncrypted::Yes, IsOneToOne::No),
             PredefinedUnderrideRuleId::Encrypted
         );
         assert_eq!(
-            rules::get_predefined_underride_room_rule_id(true, true),
+            rules::get_predefined_underride_room_rule_id(IsEncrypted::Yes, IsOneToOne::Yes),
             PredefinedUnderrideRuleId::EncryptedRoomOneToOne
         );
     }
@@ -380,7 +384,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let rules = Rules::new(ruleset);
-        let mode = rules.get_default_room_notification_mode(false, 2);
+        let mode = rules.get_default_room_notification_mode(IsEncrypted::No, 2);
         // Then the mode should be `MentionsAndKeywordsOnly`
         assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly);
     }
@@ -394,7 +398,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let rules = Rules::new(ruleset);
-        let mode = rules.get_default_room_notification_mode(false, 2);
+        let mode = rules.get_default_room_notification_mode(IsEncrypted::No, 2);
         // Then the mode should be `AllMessages`
         assert_eq!(mode, RoomNotificationMode::AllMessages);
     }


### PR DESCRIPTION
This PR is part of https://github.com/matrix-org/matrix-rust-sdk/issues/1959 implementation.

It exposes, in the `notification_settings` crate, a function to define the default notification mode for a given room type (the type is defined by whether the room is encrypted or a direct discussion).
