### PR TITLE
Add support to broadcast devices and user identities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,6 +3176,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "stream_assert",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5548,9 +5549,9 @@ checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "stream_assert"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58491272dc90918dba713fd9e3556a67a09e067621143f3616754788286489f1"
+checksum = "7fab678a73c9013f0427c63cfb42d98bd459a465194e7e583df486f679684b96"
 dependencies = [
  "futures-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"
+stream_assert = "0.1.1"
 thiserror = "1.0.38"
 tokio = { version = "1.30.0", default-features = false, features = ["sync"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -79,5 +79,6 @@ matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 olm-rs = { version = "2.2.0", features = ["serde"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 # required for async_test macro
+stream_assert = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -91,7 +91,7 @@ impl DehydratedDevices {
         let user_identity = self.inner.store().private_identity();
 
         let account = ReadOnlyAccount::new(user_id);
-        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
 
         let verification_machine =
             VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1115,7 +1115,7 @@ mod tests {
         let device_id = DeviceId::new();
 
         let account = ReadOnlyAccount::with_device_id(&user_id, &device_id);
-        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
         let store = Store::new(user_id.to_owned(), identity, store, verification);
@@ -1134,7 +1134,7 @@ mod tests {
         ))
         .await;
 
-        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1214,6 +1214,20 @@ pub(crate) mod tests {
     }
 
     #[async_test]
+    async fn devices_stream() {
+        let manager = manager().await;
+        let (request_id, _) = manager.build_key_query_for_users(vec![user_id()]);
+
+        let stream = manager.store.devices_stream();
+        pin_mut!(stream);
+
+        manager.receive_keys_query_response(&request_id, &own_key_query()).await.unwrap();
+
+        let update = assert_ready!(stream);
+        assert!(!update.new.is_empty(), "The device update should contain some devices");
+    }
+
+    #[async_test]
     async fn identities_stream() {
         let manager = manager().await;
         let (request_id, _) = manager.build_key_query_for_users(vec![user_id()]);

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -787,7 +787,7 @@ pub(crate) mod testing {
         let identity = Arc::new(Mutex::new(identity));
         let user_id = user_id().to_owned();
         let account = ReadOnlyAccount::with_device_id(&user_id, device_id());
-        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
         let store = Store::new(user_id.clone(), identity, store, verification);
         IdentityManager::new(user_id, device_id().into(), store)

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -67,6 +67,29 @@ impl UserIdentities {
             _ => None,
         }
     }
+
+    /// Get the ID of the user this identity belongs to.
+    pub fn user_id(&self) -> &UserId {
+        match self {
+            UserIdentities::Own(u) => u.user_id(),
+            UserIdentities::Other(u) => u.user_id(),
+        }
+    }
+
+    pub(crate) fn new(
+        identity: ReadOnlyUserIdentities,
+        verification_machine: VerificationMachine,
+        own_identity: Option<ReadOnlyOwnUserIdentity>,
+    ) -> Self {
+        match identity {
+            ReadOnlyUserIdentities::Own(i) => {
+                Self::Own(OwnUserIdentity { inner: i, verification_machine })
+            }
+            ReadOnlyUserIdentities::Other(i) => {
+                Self::Other(UserIdentity { inner: i, own_identity, verification_machine })
+            }
+        }
+    }
 }
 
 impl From<OwnUserIdentity> for UserIdentities {

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -771,7 +771,7 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             ReadOnlyAccount::with_device_id(second.user_id(), second.device_id()),
             private_identity,
-            Arc::new(CryptoStoreWrapper::new(MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(second.user_id(), MemoryStore::new())),
         );
 
         let first = Device {
@@ -812,7 +812,7 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             ReadOnlyAccount::with_device_id(device.user_id(), device.device_id()),
             id.clone(),
-            Arc::new(CryptoStoreWrapper::new(MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(device.user_id(), MemoryStore::new())),
         );
 
         let public_identity = identity.to_public_identity().await.unwrap();

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -171,7 +171,7 @@ impl OlmMachine {
         let account =
             ReadOnlyAccount::rehydrate(pickle_key, self.user_id(), device_id, device_data).await?;
 
-        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(self.user_id(), MemoryStore::new()));
 
         Ok(Self::new_helper(
             self.user_id(),
@@ -325,7 +325,7 @@ impl OlmMachine {
         };
 
         let identity = Arc::new(Mutex::new(identity));
-        let store = Arc::new(CryptoStoreWrapper::new(store));
+        let store = Arc::new(CryptoStoreWrapper::new(user_id, store));
         Ok(OlmMachine::new_helper(user_id, device_id, store, account, identity))
     }
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -514,7 +514,7 @@ mod tests {
 
         let users_for_key_claim = Arc::new(DashMap::new());
         let account = ReadOnlyAccount::with_device_id(user_id, device_id);
-        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
+        let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
         store.save_account(account.clone()).await.unwrap();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id)));
         let verification =

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -582,7 +582,7 @@ mod tests {
         let _ = VerificationMachine::new(
             alice,
             identity,
-            Arc::new(CryptoStoreWrapper::new(MemoryStore::new())),
+            Arc::new(CryptoStoreWrapper::new(alice_id(), MemoryStore::new())),
         );
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -876,14 +876,14 @@ pub(crate) mod tests {
         bob_store.save_devices(vec![alice_device]).await;
 
         let alice_store = VerificationStore {
+            inner: Arc::new(CryptoStoreWrapper::new(alice.user_id(), alice_store)),
             account: alice,
-            inner: Arc::new(CryptoStoreWrapper::new(alice_store)),
             private_identity: alice_private_identity.into(),
         };
 
         let bob_store = VerificationStore {
             account: bob.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(bob_store)),
+            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_store)),
             private_identity: bob_private_identity.into(),
         };
 

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -903,8 +903,8 @@ mod tests {
         user_id!("@example:localhost")
     }
 
-    fn memory_store() -> Arc<CryptoStoreWrapper> {
-        Arc::new(CryptoStoreWrapper::new(MemoryStore::new()))
+    fn memory_store(user_id: &UserId) -> Arc<CryptoStoreWrapper> {
+        Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()))
     }
 
     fn device_id() -> &'static DeviceId {
@@ -913,8 +913,8 @@ mod tests {
 
     #[async_test]
     async fn test_verification_creation() {
-        let store = memory_store();
         let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
+        let store = memory_store(account.user_id());
 
         let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
         let master_key = private_identity.master_public_key().await.unwrap();
@@ -979,7 +979,7 @@ mod tests {
     async fn test_reciprocate_receival() {
         let test = |flow_id: FlowId| async move {
             let alice_account = ReadOnlyAccount::with_device_id(user_id(), device_id());
-            let store = memory_store();
+            let store = memory_store(alice_account.user_id());
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
 
@@ -1018,7 +1018,7 @@ mod tests {
             );
             assert_matches!(alice_verification.state(), QrVerificationState::Started);
 
-            let bob_store = memory_store();
+            let bob_store = memory_store(bob_account.user_id());
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
             let bob_store = VerificationStore {

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -912,7 +912,7 @@ mod tests {
 
         let alice_store = VerificationStore {
             account: alice.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(MemoryStore::new())),
+            inner: Arc::new(CryptoStoreWrapper::new(alice.user_id(), MemoryStore::new())),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())).into(),
         };
 
@@ -921,7 +921,7 @@ mod tests {
 
         let bob_store = VerificationStore {
             account: bob.clone(),
-            inner: Arc::new(CryptoStoreWrapper::new(bob_store)),
+            inner: Arc::new(CryptoStoreWrapper::new(bob.user_id(), bob_store)),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(bob_id())).into(),
         };
 

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -51,6 +51,6 @@ ctor = { workspace = true }
 eyeball-im-util = { workspace = true }
 matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
-stream_assert = "0.1.0"
+stream_assert = { workspace = true }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 wiremock = "0.5.13"

--- a/crates/matrix-sdk/src/encryption/identities/mod.rs
+++ b/crates/matrix-sdk/src/encryption/identities/mod.rs
@@ -87,9 +87,9 @@
 mod devices;
 mod users;
 
-pub use devices::{Device, UserDevices};
+pub use devices::{Device, DeviceUpdates, UserDevices};
 pub use matrix_sdk_base::crypto::types::MasterPubkey;
-pub use users::UserIdentity;
+pub use users::{IdentityUpdates, UserIdentity};
 
 /// Error for the manual verification step, when we manually sign users or
 /// devices.


### PR DESCRIPTION
This PR adds a way for users to listen for devices and user identities that were added or updated in our store.

This becomes useful if and when users try to implement a page which displays a list of devices a user has, or if they want to warn about newly added devices.