### PR TITLE
chore: get rid of `Client::inherit_session`

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1987,13 +1987,9 @@ impl Client {
             )),
         };
 
-        // Now inherit the session without restarting the crypto machine.
+        // Copy the parent's session into the child.
         if let Some(session) = self.session() {
-            match session {
-                AuthSession::Matrix(s) => {
-                    client.matrix_auth().inherit_session(s).await?;
-                }
-            }
+            client.restore_session(session).await?;
         }
 
         Ok(client)

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -798,20 +798,8 @@ impl MatrixAuth {
     #[instrument(skip_all)]
     pub async fn restore_session(&self, session: Session) -> Result<()> {
         debug!("Restoring Matrix auth session");
-
         self.set_session(session).await?;
-
         debug!("Done restoring Matrix auth session");
-
-        Ok(())
-    }
-
-    /// Same as [`Self::restore_session`], but doesn't regenerate the Olm
-    /// machine automatically.
-    pub(crate) async fn inherit_session(&self, session: Session) -> Result<()> {
-        debug!("Inheriting Matrix auth session");
-        self.set_session(session).await?;
-        debug!("Done inheriting Matrix auth session");
         Ok(())
     }
 


### PR DESCRIPTION
It does the same as `restore_session` now. Thanks @zecakeh for finding this out!