### PR TITLE
sdk: Make RefreshTokenError authentication API-agnostic 

### DIFF
--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -76,13 +76,13 @@ where
                     res.as_ref().map_err(HttpError::client_api_error_kind)
                 {
                     if let Err(refresh_error) = client.refresh_access_token().await {
-                        match &refresh_error {
-                            HttpError::RefreshToken(RefreshTokenError::RefreshTokenRequired) => {
+                        match refresh_error {
+                            RefreshTokenError::RefreshTokenRequired => {
                                 // Refreshing access tokens is not supported by
                                 // this `Session`, ignore.
                             }
                             _ => {
-                                return Err(refresh_error);
+                                return Err(refresh_error.into());
                             }
                         }
                     } else {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -950,9 +950,9 @@ impl Client {
     ///
     /// See the documentation of the authentication API's `refresh_access_token`
     /// method for more information.
-    pub async fn refresh_access_token(&self) -> HttpResult<()> {
+    pub async fn refresh_access_token(&self) -> Result<(), RefreshTokenError> {
         let Some(auth_api) = self.auth_api() else {
-            return Err(RefreshTokenError::RefreshTokenRequired.into());
+            return Err(RefreshTokenError::RefreshTokenRequired);
         };
 
         match auth_api {
@@ -1295,12 +1295,12 @@ impl Client {
             {
                 if let Err(refresh_error) = self.refresh_access_token().await {
                     match &refresh_error {
-                        HttpError::RefreshToken(RefreshTokenError::RefreshTokenRequired) => {
+                        RefreshTokenError::RefreshTokenRequired => {
                             // Refreshing access tokens is not supported by
                             // this `Session`, ignore.
                         }
                         _ => {
-                            return Err(refresh_error);
+                            return Err(refresh_error.into());
                         }
                     }
                 } else {

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -14,7 +14,7 @@
 
 //! Error conditions.
 
-use std::io::Error as IoError;
+use std::{io::Error as IoError, sync::Arc};
 
 #[cfg(feature = "qrcode")]
 use matrix_sdk_base::crypto::ScanError;
@@ -416,18 +416,13 @@ pub enum ImageError {
 /// [handling refresh tokens]: crate::ClientBuilder::handle_refresh_tokens()
 #[derive(Debug, Error, Clone)]
 pub enum RefreshTokenError {
-    /// The Matrix endpoint returned an error.
-    #[error(transparent)]
-    ClientApi(#[from] ruma::api::client::Error),
-
     /// Tried to send a refresh token request without a refresh token.
     #[error("missing refresh token")]
     RefreshTokenRequired,
 
-    /// There was an ongoing refresh token call that failed and the error could
-    /// not be forwarded.
-    #[error("the access token could not be refreshed")]
-    UnableToRefreshToken,
+    /// An error occurred interacting with the native Matrix authentication API.
+    #[error(transparent)]
+    MatrixAuth(Arc<HttpError>),
 }
 
 /// Errors that can occur when manipulating push notification settings.

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -457,13 +457,12 @@ impl MatrixAuth {
                 *guard = Err(RefreshTokenError::RefreshTokenRequired);
                 return Err(RefreshTokenError::RefreshTokenRequired);
             };
+            let Some(refresh_token) = session_tokens.refresh_token.clone() else {
+                *guard = Err(RefreshTokenError::RefreshTokenRequired);
+                return Err(RefreshTokenError::RefreshTokenRequired);
+            };
 
-            let refresh_token = session_tokens
-                .refresh_token
-                .clone()
-                .ok_or(RefreshTokenError::RefreshTokenRequired)?;
             let request = refresh_token::v3::Request::new(refresh_token);
-
             let res = client.send_inner(request, None, None, Default::default()).await;
 
             match res {

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -154,7 +154,7 @@ async fn no_refresh_token() {
         .await;
 
     let res = client.refresh_access_token().await;
-    assert_matches!(res, Err(HttpError::RefreshToken(RefreshTokenError::RefreshTokenRequired)));
+    assert_matches!(res, Err(RefreshTokenError::RefreshTokenRequired));
 }
 
 #[async_test]
@@ -348,8 +348,9 @@ async fn refresh_token_handled_failure() {
         .mount(&server)
         .await;
 
-    let res = client.whoami().await.unwrap_err();
-    assert_matches!(res.client_api_error_kind(), Some(ErrorKind::UnknownToken { .. }))
+    let res = client.whoami().await;
+    let http_err = assert_matches!(res, Err(HttpError::RefreshToken(RefreshTokenError::MatrixAuth(http_err))) => http_err);
+    assert_matches!(http_err.client_api_error_kind(), Some(ErrorKind::UnknownToken { .. }))
 }
 
 #[async_test]


### PR DESCRIPTION
Since other authentication APIs won't interact with the Matrix API in `Client::refresh_access_token()`, it makes more sense to change the variants and use it as the return type than `HttpError`.

The second commit is just a small fix in the area.