### PR TITLE
sdk: Don't derive (De)serialize for AuthSession

### DIFF
--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use matrix_sdk_base::SessionMeta;
-use serde::{Deserialize, Serialize};
 
 use crate::matrix_auth::{self, MatrixAuth, MatrixAuthData};
 
@@ -26,7 +25,7 @@ pub enum AuthApi {
 }
 
 /// A user session using one of the available authentication APIs.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum AuthSession {
     /// A session using the native Matrix authentication API.


### PR DESCRIPTION
It turns out not all authentication API sessions (i.e. OIDC) are fully (de)serializable. So this removes the derive ahead of #1019.