### PR TITLE
Show polls in timeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
+source = "git+https://github.com/ruma/ruma?rev=eeef5555238c6ee38bee5711930b256d0255e627#eeef5555238c6ee38bee5711930b256d0255e627"
 dependencies = [
  "assign",
  "js_int",
@@ -4885,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
+source = "git+https://github.com/ruma/ruma?rev=eeef5555238c6ee38bee5711930b256d0255e627#eeef5555238c6ee38bee5711930b256d0255e627"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
+source = "git+https://github.com/ruma/ruma?rev=eeef5555238c6ee38bee5711930b256d0255e627#eeef5555238c6ee38bee5711930b256d0255e627"
 dependencies = [
  "assign",
  "bytes",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
+source = "git+https://github.com/ruma/ruma?rev=eeef5555238c6ee38bee5711930b256d0255e627#eeef5555238c6ee38bee5711930b256d0255e627"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
+source = "git+https://github.com/ruma/ruma?rev=eeef5555238c6ee38bee5711930b256d0255e627#eeef5555238c6ee38bee5711930b256d0255e627"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
+source = "git+https://github.com/ruma/ruma?rev=eeef5555238c6ee38bee5711930b256d0255e627#eeef5555238c6ee38bee5711930b256d0255e627"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
+source = "git+https://github.com/ruma/ruma?rev=eeef5555238c6ee38bee5711930b256d0255e627#eeef5555238c6ee38bee5711930b256d0255e627"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
+source = "git+https://github.com/ruma/ruma?rev=eeef5555238c6ee38bee5711930b256d0255e627#eeef5555238c6ee38bee5711930b256d0255e627"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4870,7 +4870,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=f59652b94086a5733cc741cf8e21d90bd56e05b1#f59652b94086a5733cc741cf8e21d90bd56e05b1"
+source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
 dependencies = [
  "assign",
  "js_int",
@@ -4885,7 +4885,7 @@ dependencies = [
 [[package]]
 name = "ruma-appservice-api"
 version = "0.8.1"
-source = "git+https://github.com/ruma/ruma?rev=f59652b94086a5733cc741cf8e21d90bd56e05b1#f59652b94086a5733cc741cf8e21d90bd56e05b1"
+source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=f59652b94086a5733cc741cf8e21d90bd56e05b1#f59652b94086a5733cc741cf8e21d90bd56e05b1"
+source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
 dependencies = [
  "assign",
  "bytes",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=f59652b94086a5733cc741cf8e21d90bd56e05b1#f59652b94086a5733cc741cf8e21d90bd56e05b1"
+source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=f59652b94086a5733cc741cf8e21d90bd56e05b1#f59652b94086a5733cc741cf8e21d90bd56e05b1"
+source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=f59652b94086a5733cc741cf8e21d90bd56e05b1#f59652b94086a5733cc741cf8e21d90bd56e05b1"
+source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=f59652b94086a5733cc741cf8e21d90bd56e05b1#f59652b94086a5733cc741cf8e21d90bd56e05b1"
+source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=f59652b94086a5733cc741cf8e21d90bd56e05b1#f59652b94086a5733cc741cf8e21d90bd56e05b1"
+source = "git+https://github.com/ruma/ruma?rev=10a0443f6e7c912d71b087c579205b0c110c2049#10a0443f6e7c912d71b087c579205b0c110c2049"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "f59652b94086a5733cc741cf8e21d90bd56e05b1", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "f59652b94086a5733cc741cf8e21d90bd56e05b1" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "10a0443f6e7c912d71b087c579205b0c110c2049", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "10a0443f6e7c912d71b087c579205b0c110c2049" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "10a0443f6e7c912d71b087c579205b0c110c2049", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "10a0443f6e7c912d71b087c579205b0c110c2049" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "eeef5555238c6ee38bee5711930b256d0255e627", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "eeef5555238c6ee38bee5711930b256d0255e627" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -29,7 +29,7 @@ use matrix_sdk::{
 };
 use matrix_sdk_ui::timeline::{EventItemOrigin, PollResult, Profile, TimelineDetails};
 use ruma::{assign, UInt};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::{
     error::{ClientError, TimelineError},
@@ -1291,7 +1291,10 @@ impl From<RumaPollKind> for PollKind {
         match value {
             RumaPollKind::Disclosed => Self::Disclosed,
             RumaPollKind::Undisclosed => Self::Undisclosed,
-            _ => Self::Undisclosed, // TODO Safe default. Should we keep it?
+            _ => {
+                info!("Unknown poll kind, defaulting to undisclosed");
+                Self::Undisclosed
+            }
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -1313,8 +1313,8 @@ impl From<PollResult> for TimelineItemContentKind {
             max_selections: value.max_selections,
             answers: value
                 .answers
-                .iter()
-                .map(|i| PollAnswer { id: i.id.clone(), text: i.text.clone() })
+                .into_iter()
+                .map(|i| PollAnswer { id: i.id, text: i.text })
                 .collect(),
             votes: value.votes,
             end_time: value.end_time,

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -27,7 +27,7 @@ use matrix_sdk::{
         },
     },
 };
-use matrix_sdk_ui::timeline::{polls::FfiPollKind, EventItemOrigin, Profile, TimelineDetails};
+use matrix_sdk_ui::timeline::{EventItemOrigin, FfiPollKind, Profile, TimelineDetails};
 use ruma::{assign, UInt};
 use tracing::warn;
 

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -1316,8 +1316,7 @@ impl From<PollResult> for TimelineItemContentKind {
                 .iter()
                 .map(|i| PollAnswer { id: i.id.clone(), text: i.text.clone() })
                 .collect(),
-            // TODO Why is this iter needed? If using into_iter() I can remove the clone()s, why?
-            votes: value.votes.iter().map(|i| (i.0.clone(), i.1.clone())).collect(),
+            votes: value.votes,
             end_time: value.end_time,
         }
     }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -420,6 +420,9 @@ impl TimelineItemContent {
                     url: content.url.to_string(),
                 }
             }
+            Content::Poll(_) => {
+                // TODO("Map TimelineItemContent::Poll to TimelineItemContentKind::Poll")
+            }
             Content::UnableToDecrypt(msg) => {
                 TimelineItemContentKind::UnableToDecrypt { msg: EncryptedMessage::new(msg) }
             }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -574,8 +574,9 @@ impl<'a> TimelineEventHandler<'a> {
 
     fn handle_poll_start(&mut self, c: UnstablePollStartEventContent, should_add: bool) {
         let mut poll_state = PollState::new(c);
+        // TODO: If the flow is not remote we're not able to apply the pending events. Is this a problem?
         if let Flow::Remote { event_id, .. } = self.ctx.flow.clone() {
-            self.state.poll_cache.apply(&event_id, &mut poll_state);
+            self.state.poll_pending_events.apply(&event_id, &mut poll_state);
         };
         self.add(should_add, TimelineItemContent::Poll(poll_state));
     }
@@ -596,7 +597,7 @@ impl<'a> TimelineEventHandler<'a> {
                 _ => None,
             },
             not_found: || {
-                self.state.poll_cache.add_response(
+                self.state.poll_pending_events.add_response(
                     &c.relates_to.event_id,
                     &self.ctx.sender,
                     &self.ctx.timestamp,
@@ -618,7 +619,7 @@ impl<'a> TimelineEventHandler<'a> {
                 _ => None,
             },
             not_found: || {
-                self.state.poll_cache.add_end(&c.relates_to.event_id, &self.ctx.timestamp);
+                self.state.poll_pending_events.add_end(&c.relates_to.event_id, &self.ctx.timestamp);
             }
         );
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -542,12 +542,12 @@ impl<'a> TimelineEventHandler<'a> {
             }
 
             let TimelineItemContent::Poll(poll_state) = &event_item.content() else {
-                        info!(
-                            original_sender = ?event_item.sender(), edit_sender = ?self.ctx.sender,
-                            "Can't edit a poll that is not of type TimelineItemContent::Poll, discarding"
-                        );
-                        return None;
-                    };
+                info!(
+                    original_sender = ?event_item.sender(), edit_sender = ?self.ctx.sender,
+                    "Can't edit a poll that is not of type TimelineItemContent::Poll, discarding"
+                );
+                return None;
+            };
 
             let new_content = match poll_state.edit(&replacement.new_content) {
                 Ok(edited_poll_state) => TimelineItemContent::Poll(edited_poll_state),
@@ -573,9 +573,9 @@ impl<'a> TimelineEventHandler<'a> {
     fn handle_poll_start(&mut self, c: UnstablePollStartEventContent, should_add: bool) {
         let mut poll_state = PollState::new(c);
         if let Flow::Remote { event_id, .. } = self.ctx.flow.clone() {
+            // Applying the cache to remote events only because local echoes
+            // don't have an event ID that could be referenced by responses yet.
             self.state.poll_pending_events.apply(&event_id, &mut poll_state);
-        } else {
-            info!("Can't apply poll pending events to non remote event, discarding");
         }
         self.add(should_add, TimelineItemContent::Poll(poll_state));
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -637,6 +637,9 @@ impl<'a> TimelineEventHandler<'a> {
     // Redacted redactions are no-ops (unfortunately)
     #[instrument(skip_all, fields(redacts_event_id = ?redacts))]
     fn handle_redaction(&mut self, redacts: OwnedEventId, _content: RoomRedactionEventContent) {
+        // TODO: Apply local redaction of PollReponse and PollEnd events.
+        // https://github.com/matrix-org/matrix-rust-sdk/pull/2381#issuecomment-1689647825
+
         let id = EventItemIdentifier::EventId(redacts.clone());
         if let Some((_, rel)) = self.state.reactions.map.remove(&id) {
             update_timeline_item!(self, &rel.event_id, "redaction", |event_item| {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -528,24 +528,29 @@ impl<'a> TimelineEventHandler<'a> {
 
     fn handle_poll_response(&mut self, c: UnstablePollResponseEventContent) {
         // TODO(polls): what if the event isn't found? Cache this for later?
-        update_timeline_item!(self, &c.relates_to.event_id.clone(), "vote", |event_item| {
-            match event_item.content() {
-                TimelineItemContent::Poll(poll_state) => Some(event_item.with_content(
-                    TimelineItemContent::Poll(poll_state.add_response(
-                        self.ctx.sender.clone(),
-                        self.ctx.timestamp,
-                        c,
+        update_timeline_item!(
+            self,
+            &c.relates_to.event_id.clone(),
+            "poll response",
+            |event_item| {
+                match event_item.content() {
+                    TimelineItemContent::Poll(poll_state) => Some(event_item.with_content(
+                        TimelineItemContent::Poll(poll_state.add_response(
+                            self.ctx.sender.clone(),
+                            self.ctx.timestamp,
+                            c,
+                        )),
+                        None,
                     )),
-                    None,
-                )),
-                _ => None,
+                    _ => None,
+                }
             }
-        });
+        );
     }
 
     fn handle_poll_end(&mut self, c: UnstablePollEndEventContent) {
         // TODO(polls): what if the event isn't found? Cache this for later?
-        update_timeline_item!(self, &c.relates_to.event_id.clone(), "ended", |event_item| {
+        update_timeline_item!(self, &c.relates_to.event_id.clone(), "poll end", |event_item| {
             match event_item.content() {
                 TimelineItemContent::Poll(poll_state) => Some(event_item.with_content(
                     TimelineItemContent::Poll(poll_state.end(

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -572,9 +572,10 @@ impl<'a> TimelineEventHandler<'a> {
 
     fn handle_poll_start(&mut self, c: UnstablePollStartEventContent, should_add: bool) {
         let mut poll_state = PollState::new(c);
-        // TODO: If the flow is not remote we're not able to apply the pending events. Is this a problem?
         if let Flow::Remote { event_id, .. } = self.ctx.flow.clone() {
             self.state.poll_pending_events.apply(&event_id, &mut poll_state);
+        } else {
+            info!("Can't apply poll pending events to non remote event, discarding");
         }
         self.add(should_add, TimelineItemContent::Poll(poll_state));
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -292,6 +292,15 @@ impl<'a> TimelineEventHandler<'a> {
                 AnyMessageLikeEventContent::Sticker(content) => {
                     self.add(should_add, TimelineItemContent::Sticker(Sticker { content }));
                 }
+                AnyMessageLikeEventContent::UnstablePollStart(c) => {
+                    self.add(should_add, TimelineItemContent::poll(c));
+                }
+                AnyMessageLikeEventContent::UnstablePollResponse(c) => {
+                    // TODO("run aggregation logic?")
+                }
+                AnyMessageLikeEventContent::UnstablePollEnd(c) => {
+                    // TODO("run aggregation logic?")
+                }
                 // TODO
                 _ => {
                     debug!(
@@ -397,6 +406,9 @@ impl<'a> TimelineEventHandler<'a> {
                 | TimelineItemContent::FailedToParseState { .. } => {
                     info!("Edit event applies to event that couldn't be parsed, discarding");
                     return None;
+                }
+                TimelineItemContent::Poll(_) => {
+                    todo!("Implement poll edit.")
                 }
             };
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -637,7 +637,7 @@ impl<'a> TimelineEventHandler<'a> {
     // Redacted redactions are no-ops (unfortunately)
     #[instrument(skip_all, fields(redacts_event_id = ?redacts))]
     fn handle_redaction(&mut self, redacts: OwnedEventId, _content: RoomRedactionEventContent) {
-        // TODO: Apply local redaction of PollReponse and PollEnd events.
+        // TODO: Apply local redaction of PollResponse and PollEnd events.
         // https://github.com/matrix-org/matrix-rust-sdk/pull/2381#issuecomment-1689647825
 
         let id = EventItemIdentifier::EventId(redacts.clone());

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -588,7 +588,7 @@ impl<'a> TimelineEventHandler<'a> {
                 TimelineItemContent::Poll(poll_state) => Some(event_item.with_content(
                     TimelineItemContent::Poll(poll_state.add_response(
                         &self.ctx.sender,
-                        &self.ctx.timestamp,
+                        self.ctx.timestamp,
                         &c,
                     )),
                     None,
@@ -599,7 +599,7 @@ impl<'a> TimelineEventHandler<'a> {
                 self.state.poll_pending_events.add_response(
                     &c.relates_to.event_id,
                     &self.ctx.sender,
-                    &self.ctx.timestamp,
+                    self.ctx.timestamp,
                     &c,
                 );
             }
@@ -612,13 +612,13 @@ impl<'a> TimelineEventHandler<'a> {
             &c.relates_to.event_id,
             found: |event_item| match event_item.content() {
                 TimelineItemContent::Poll(poll_state) => Some(event_item.with_content(
-                    TimelineItemContent::Poll(poll_state.end(&self.ctx.timestamp)),
+                    TimelineItemContent::Poll(poll_state.end(self.ctx.timestamp)),
                     None,
                 )),
                 _ => None,
             },
             not_found: || {
-                self.state.poll_pending_events.add_end(&c.relates_to.event_id, &self.ctx.timestamp);
+                self.state.poll_pending_events.add_end(&c.relates_to.event_id, self.ctx.timestamp);
             }
         );
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -609,7 +609,7 @@ impl<'a> TimelineEventHandler<'a> {
     fn handle_poll_end(&mut self, c: UnstablePollEndEventContent) {
         update_timeline_item!(
             self,
-            &c.relates_to.event_id.clone(),
+            &c.relates_to.event_id,
             found: |event_item| match event_item.content() {
                 TimelineItemContent::Poll(poll_state) => Some(event_item.with_content(
                     TimelineItemContent::Poll(poll_state.end(&self.ctx.timestamp)),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
@@ -62,10 +62,9 @@ use ruma::{
 use tracing::{error, warn};
 
 use super::{EventItemIdentifier, EventTimelineItem, Profile, TimelineDetails};
-use crate::timeline::polls::PollState;
 use crate::timeline::{
-    traits::RoomDataProvider, Error as TimelineError, ReactionSenderData, TimelineItem,
-    DEFAULT_SANITIZER_MODE,
+    polls::PollState, traits::RoomDataProvider, Error as TimelineError, ReactionSenderData,
+    TimelineItem, DEFAULT_SANITIZER_MODE,
 };
 
 /// The content of an [`EventTimelineItem`][super::EventTimelineItem].

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
@@ -19,7 +19,6 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use matrix_sdk::{deserialized_responses::TimelineEvent, Result};
 use matrix_sdk_base::latest_event::{is_suitable_for_latest_event, PossibleLatestEvent};
-use ruma::events::poll::unstable_start::UnstablePollStartEventContent;
 use ruma::{
     assign,
     events::{
@@ -63,6 +62,7 @@ use ruma::{
 use tracing::{error, warn};
 
 use super::{EventItemIdentifier, EventTimelineItem, Profile, TimelineDetails};
+use crate::timeline::polls::PollState;
 use crate::timeline::{
     traits::RoomDataProvider, Error as TimelineError, ReactionSenderData, TimelineItem,
     DEFAULT_SANITIZER_MODE,
@@ -113,7 +113,7 @@ pub enum TimelineItemContent {
         error: Arc<serde_json::Error>,
     },
 
-    /// A poll event.
+    /// An `m.poll.start` event.
     Poll(PollState),
 }
 
@@ -209,13 +209,6 @@ impl TimelineItemContent {
         timeline_items: &Vector<Arc<TimelineItem>>,
     ) -> Self {
         Self::Message(Message::from_event(c, relations, timeline_items))
-    }
-
-    pub(crate) fn poll(content: UnstablePollStartEventContent) -> Self {
-        Self::Poll(PollState {
-            // TODO("Fill up the content)
-            question: String::from("Question of the poll"),
-        })
     }
 
     pub(crate) fn unable_to_decrypt(content: RoomEncryptedEventContent) -> Self {
@@ -967,10 +960,4 @@ impl OtherState {
     fn redact(&self, room_version: &RoomVersionId) -> Self {
         Self { state_key: self.state_key.clone(), content: self.content.redact(room_version) }
     }
-}
-
-#[derive(Clone, Debug)]
-pub struct PollState {
-    // TODO: Put current state of the poll here.
-    pub(in crate::timeline) question: String,
 }

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -47,7 +47,7 @@ use crate::{
         },
         event_item::EventItemIdentifier,
         item::timeline_item,
-        polls::PollCache,
+        polls::PollPendingEvents,
         reactions::{ReactionToggleResult, Reactions},
         traits::RoomDataProvider,
         util::{rfind_event_item, timestamp_to_date},
@@ -98,7 +98,7 @@ pub(in crate::timeline) struct TimelineInnerState {
     pub items: ObservableVector<Arc<TimelineItem>>,
     next_internal_id: u64,
     pub reactions: Reactions,
-    pub poll_cache: PollCache,
+    pub poll_pending_events: PollPendingEvents,
     pub fully_read_event: Option<OwnedEventId>,
     /// Whether the fully-read marker item should try to be updated when an
     /// event is added.
@@ -125,7 +125,7 @@ impl TimelineInnerState {
             items: ObservableVector::with_capacity(32),
             next_internal_id: Default::default(),
             reactions: Default::default(),
-            poll_cache: Default::default(),
+            poll_pending_events: Default::default(),
             fully_read_event: Default::default(),
             event_should_update_fully_read_marker: Default::default(),
             users_read_receipts: Default::default(),

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -47,6 +47,7 @@ use crate::{
         },
         event_item::EventItemIdentifier,
         item::timeline_item,
+        polls::PollCache,
         reactions::{ReactionToggleResult, Reactions},
         traits::RoomDataProvider,
         util::{rfind_event_item, timestamp_to_date},
@@ -97,6 +98,7 @@ pub(in crate::timeline) struct TimelineInnerState {
     pub items: ObservableVector<Arc<TimelineItem>>,
     next_internal_id: u64,
     pub reactions: Reactions,
+    pub poll_cache: PollCache,
     pub fully_read_event: Option<OwnedEventId>,
     /// Whether the fully-read marker item should try to be updated when an
     /// event is added.
@@ -123,6 +125,7 @@ impl TimelineInnerState {
             items: ObservableVector::with_capacity(32),
             next_internal_id: Default::default(),
             reactions: Default::default(),
+            poll_cache: Default::default(),
             fully_read_event: Default::default(),
             event_should_update_fully_read_marker: Default::default(),
             users_read_receipts: Default::default(),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -495,8 +495,8 @@ impl Timeline {
             | TimelineItemContent::FailedToParseState { .. } => {
                 error_return!("Invalid state: attempting to retry a failed-to-parse item");
             }
-            TimelineItemContent::Poll(_) => {
-                todo!("Implement retry for polls.");
+            TimelineItemContent::Poll(poll_state) => {
+                AnyMessageLikeEventContent::UnstablePollStart(poll_state.into())
             }
         };
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -56,7 +56,7 @@ mod futures;
 mod inner;
 mod item;
 mod pagination;
-pub mod polls;
+mod polls;
 mod queue;
 mod reactions;
 mod read_receipts;
@@ -80,6 +80,7 @@ pub use self::{
     futures::SendAttachment,
     item::{TimelineItem, TimelineItemKind},
     pagination::{PaginationOptions, PaginationOutcome},
+    polls::FfiPollKind,
     reactions::ReactionSenderData,
     sliding_sync_ext::SlidingSyncRoomExt,
     traits::RoomExt,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -56,6 +56,7 @@ mod futures;
 mod inner;
 mod item;
 mod pagination;
+pub mod polls;
 mod queue;
 mod reactions;
 mod read_receipts;

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -80,7 +80,7 @@ pub use self::{
     futures::SendAttachment,
     item::{TimelineItem, TimelineItemKind},
     pagination::{PaginationOptions, PaginationOutcome},
-    polls::FfiPollKind,
+    polls::PollResult,
     reactions::ReactionSenderData,
     sliding_sync_ext::SlidingSyncRoomExt,
     traits::RoomExt,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -493,6 +493,9 @@ impl Timeline {
             | TimelineItemContent::FailedToParseState { .. } => {
                 error_return!("Invalid state: attempting to retry a failed-to-parse item");
             }
+            TimelineItemContent::Poll(_) => {
+                todo!("Implement retry for polls.");
+            }
         };
 
         let txn_id = txn_id.to_owned();

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -1,0 +1,169 @@
+/// Polls module.
+///
+/// This module handles rendering of MSC3381 polls in the timeline.
+use imbl::HashMap;
+use ruma::{
+    events::{
+        poll::{
+            compile_unstable_poll_results,
+            unstable_end::UnstablePollEndEventContent,
+            unstable_response::{
+                OriginalSyncUnstablePollResponseEvent, UnstablePollResponseEventContent,
+            },
+            unstable_start::UnstablePollStartEventContent,
+        },
+        MessageLikeUnsigned,
+    },
+    EventId, MilliSecondsSinceUnixEpoch, OwnedUserId, ServerName,
+};
+
+use super::TimelineItemContent;
+
+/// Holds the state of a poll.
+///
+/// This struct should be created for each poll start event received and then
+/// updated whenever any other poll response or poll end event is received
+/// that relates to the same poll start event.
+#[derive(Clone, Debug)]
+pub struct PollState {
+    pub(super) start_event: StartEvent,
+    pub(super) response_events: Vec<ResponseEvent>,
+    pub(super) end_event: Option<EndEvent>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct StartEvent {
+    pub(super) sender: OwnedUserId,
+    pub(super) timestamp: MilliSecondsSinceUnixEpoch,
+    pub(super) content: UnstablePollStartEventContent,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ResponseEvent {
+    pub(super) sender: OwnedUserId,
+    pub(super) timestamp: MilliSecondsSinceUnixEpoch,
+    pub(super) content: UnstablePollResponseEventContent,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct EndEvent {
+    pub(super) sender: OwnedUserId,
+    pub(super) timestamp: MilliSecondsSinceUnixEpoch,
+    pub(super) content: UnstablePollEndEventContent,
+}
+
+impl PollState {
+    pub(super) fn new(
+        sender: OwnedUserId,
+        timestamp: MilliSecondsSinceUnixEpoch,
+        content: UnstablePollStartEventContent,
+    ) -> PollState {
+        PollState {
+            start_event: StartEvent { sender, timestamp, content },
+            response_events: Vec::new(),
+            end_event: None,
+        }
+    }
+
+    pub(super) fn add_response(
+        &self,
+        sender: OwnedUserId,
+        timestamp: MilliSecondsSinceUnixEpoch,
+        content: UnstablePollResponseEventContent,
+    ) -> Self {
+        let mut clone = self.clone();
+        clone.response_events.push(ResponseEvent { sender, timestamp, content });
+        clone
+    }
+
+    pub(super) fn end(
+        &self,
+        sender: OwnedUserId,
+        timestamp: MilliSecondsSinceUnixEpoch,
+        content: UnstablePollEndEventContent,
+    ) -> Self {
+        let mut clone = self.clone();
+        clone.end_event = Some(EndEvent { sender, timestamp, content });
+        clone
+    }
+
+    pub fn results(&self) -> FfiPoll {
+        let responses = self
+            .response_events
+            .iter()
+            .map(|e| OriginalSyncUnstablePollResponseEvent {
+                // Concocting an OriginalSyncUnstablePollResponseEvent as I'm not able to get it from the handle_event() fn.
+                content: e.content.clone(),
+                event_id: EventId::new(<&ServerName>::try_from("example.com").unwrap()), // TODO Remove example.com
+                sender: e.sender.clone(),
+                origin_server_ts: e.timestamp,
+                unsigned: MessageLikeUnsigned::new(),
+            })
+            .collect::<Vec<OriginalSyncUnstablePollResponseEvent>>();
+
+        let results = compile_unstable_poll_results(
+            &self.start_event.content.poll_start,
+            responses.iter().map(|i| i).collect::<Vec<&OriginalSyncUnstablePollResponseEvent>>(),
+            None,
+        );
+
+        FfiPoll {
+            question: self.start_event.content.poll_start.question.text.clone(),
+            kind: match self.start_event.content.poll_start.kind {
+                ruma::events::poll::start::PollKind::Undisclosed => FfiPollKind::Undisclosed,
+                ruma::events::poll::start::PollKind::Disclosed => FfiPollKind::Disclosed,
+                _ => FfiPollKind::Undisclosed, // Safe default. Should we keep it?
+            },
+            max_selections: self.start_event.content.poll_start.max_selections.into(),
+            answers: self
+                .start_event
+                .content
+                .poll_start
+                .answers
+                .iter()
+                .map(|i| FfiPollAnswer { id: i.id.clone(), text: i.text.clone() })
+                .collect(),
+            votes: results
+                .iter()
+                .map(|i| (i.0.to_string(), i.1.into_iter().map(|i| i.to_string()).collect()))
+                .collect(),
+            end_time: if let Some(e) = self.end_event.clone() {
+                Some(e.timestamp.0.into())
+            } else {
+                None
+            },
+        }
+    }
+}
+
+impl TryFrom<&TimelineItemContent> for PollState {
+    type Error = ();
+
+    fn try_from(value: &TimelineItemContent) -> Result<PollState, Self::Error> {
+        match value {
+            TimelineItemContent::Poll(poll_state) => Ok(poll_state.clone()),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub struct PollAnswerId(pub String);
+
+pub struct FfiPoll {
+    pub question: String,
+    pub kind: FfiPollKind,
+    pub max_selections: u64,
+    pub answers: Vec<FfiPollAnswer>,
+    pub votes: HashMap<String, Vec<String>>,
+    pub end_time: Option<u64>,
+}
+
+pub enum FfiPollKind {
+    Disclosed,
+    Undisclosed,
+}
+pub struct FfiPollAnswer {
+    pub id: String,
+    pub text: String,
+}

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -10,7 +10,7 @@ use ruma::{
             unstable_response::{
                 OriginalSyncUnstablePollResponseEvent, UnstablePollResponseEventContent,
             },
-            unstable_start::UnstablePollStartEventContent,
+            unstable_start::{UnstablePollStartContentBlock, UnstablePollStartEventContent},
         },
         MessageLikeUnsigned,
     },
@@ -85,6 +85,10 @@ impl PollState {
         clone
     }
 
+    pub fn fallback_text(&self) -> Option<String> {
+        self.start_event.content.text.clone()
+    }
+
     pub fn results(&self) -> FfiPoll {
         let responses = self
             .response_events
@@ -130,6 +134,20 @@ impl PollState {
             } else {
                 None
             },
+        }
+    }
+}
+
+impl Into<UnstablePollStartEventContent> for PollState {
+    fn into(self) -> UnstablePollStartEventContent {
+        let content = UnstablePollStartContentBlock::new(
+            self.start_event.content.poll_start.question.text.clone(),
+            self.start_event.content.poll_start.answers.clone(),
+        );
+        if let Some(text) = self.fallback_text() {
+            UnstablePollStartEventContent::plain_text(text, content)
+        } else {
+            UnstablePollStartEventContent::new(content)
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -87,7 +87,7 @@ impl PollState {
                 origin_server_ts: response_data.timestamp,
                 selections: &response_data.answers,
             }),
-            None,
+            self.end_event_timestamp,
         );
 
         PollResult {
@@ -165,6 +165,7 @@ impl PollPendingEvents {
     }
 }
 
+#[derive(Debug)]
 pub struct PollResult {
     pub question: String,
     pub kind: PollKind,
@@ -174,6 +175,7 @@ pub struct PollResult {
     pub end_time: Option<u64>,
 }
 
+#[derive(Debug)]
 pub struct PollResultAnswer {
     pub id: String,
     pub text: String,

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -17,8 +17,6 @@ use ruma::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedUserId, ServerName,
 };
 
-use super::TimelineItemContent;
-
 /// Holds the state of a poll.
 ///
 /// This struct should be created for each poll start event received and then
@@ -132,17 +130,6 @@ impl PollState {
             } else {
                 None
             },
-        }
-    }
-}
-
-impl TryFrom<&TimelineItemContent> for PollState {
-    type Error = ();
-
-    fn try_from(value: &TimelineItemContent) -> Result<PollState, Self::Error> {
-        match value {
-            TimelineItemContent::Poll(poll_state) => Ok(poll_state.clone()),
-            _ => Err(()),
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -1,6 +1,7 @@
 //! This module handles rendering of MSC3381 polls in the timeline.
 
-use imbl::HashMap;
+use std::collections::HashMap;
+
 use ruma::{
     events::{
         poll::{

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -69,10 +69,16 @@ impl PollState {
         clone
     }
 
-    pub(super) fn end(&self, timestamp: MilliSecondsSinceUnixEpoch) -> Self {
-        let mut clone = self.clone();
-        clone.end_event_timestamp = Some(timestamp);
-        clone
+    /// Marks the poll as ended.
+    /// NB: If the poll has already ended it will return an error.
+    pub(super) fn end(&self, timestamp: MilliSecondsSinceUnixEpoch) -> Result<Self, ()> {
+        if self.end_event_timestamp.is_none() {
+            let mut clone = self.clone();
+            clone.end_event_timestamp = Some(timestamp);
+            Ok(clone)
+        } else {
+            Err(())
+        }
     }
 
     pub fn fallback_text(&self) -> Option<String> {

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -110,7 +110,7 @@ impl PollState {
                 .collect(),
             votes: results
                 .iter()
-                .map(|i| (i.0.to_string(), i.1.into_iter().map(|i| i.to_string()).collect()))
+                .map(|i| ((*i.0).to_owned(), i.1.iter().map(|i| i.to_string()).collect()))
                 .collect(),
             end_time: self.end_event_timestamp.map(|millis| millis.0.into()),
         }
@@ -164,8 +164,8 @@ impl PollPendingEvents {
         if let Some(pending_responses) = self.pending_poll_responses.get_mut(start_event_id) {
             poll_state.response_data.append(pending_responses);
         }
-        if let Some(pending_end) = self.pending_poll_ends.get_mut(start_event_id) {
-            poll_state.end_event_timestamp = Some(pending_end.clone());
+        if let Some(pending_end) = self.pending_poll_ends.get(start_event_id) {
+            poll_state.end_event_timestamp = Some(*pending_end)
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -1,6 +1,5 @@
-/// Polls module.
-///
-/// This module handles rendering of MSC3381 polls in the timeline.
+//! This module handles rendering of MSC3381 polls in the timeline.
+
 use imbl::HashMap;
 use ruma::{
     events::{

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -64,6 +64,7 @@ mod edit;
 mod encryption;
 mod event_filter;
 mod invalid;
+mod polls;
 mod reaction_group;
 mod reactions;
 mod read_receipts;

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -207,10 +207,11 @@ fn assert_poll_start_eq(a: &UnstablePollStartContentBlock, b: &UnstablePollStart
     assert_eq!(a.kind, b.kind);
     assert_eq!(a.max_selections, b.max_selections);
     assert_eq!(a.answers.len(), a.answers.len());
-    assert_eq!(a.answers[0].id, a.answers[0].id);
-    assert_eq!(a.answers[0].text, a.answers[0].text);
-    assert_eq!(a.answers[1].id, a.answers[1].id);
-    assert_eq!(a.answers[1].text, a.answers[1].text);
+    a.answers.iter().zip(b.answers.iter()).all(|(a, b)| {
+        assert_eq!(a.id, b.id);
+        assert_eq!(a.text, b.text);
+        true
+    });
 }
 
 mod fakes {

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -21,7 +21,7 @@ async fn poll_is_displayed() {
     let poll_state = timeline.poll_state().await;
 
     assert_poll_start_eq(&poll_state.start_event_content.poll_start, &fakes::poll_a());
-    assert_eq!(poll_state.response_data.is_empty(), true);
+    assert!(poll_state.response_data.is_empty());
 }
 
 #[async_test]
@@ -108,7 +108,7 @@ async fn multiple_end_events_are_discarded() {
     // Poll finishes
     timeline.send_poll_end(&ALICE, "ENDED", &poll_id).await;
     let results = timeline.poll_state().await.results();
-    assert_eq!(results.end_time.is_some(), true);
+    assert!(results.end_time.is_some());
 
     let first_end_time = results.end_time.unwrap();
 
@@ -181,15 +181,7 @@ async fn events_received_before_start_are_not_lost() {
 
 impl TestTimeline {
     async fn events(&self) -> Vec<EventTimelineItem> {
-        self.inner
-            .items()
-            .await
-            .iter()
-            .filter_map(|item| match item.as_event() {
-                Some(event) => Some(event.clone()),
-                None => None,
-            })
-            .collect()
+        self.inner.items().await.iter().filter_map(|item| item.as_event().cloned()).collect()
     }
 
     async fn poll_event(&self) -> EventTimelineItem {

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -21,7 +21,7 @@ async fn poll_is_displayed() {
     let poll_state = timeline.poll_state().await;
 
     assert_poll_start_eq(&poll_state.start_event_content.poll_start, &fakes::poll_a());
-    assert_eq!(poll_state.response_events.is_empty(), true);
+    assert_eq!(poll_state.response_data.is_empty(), true);
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -243,7 +243,7 @@ fn get_updated_poll_event(
 }
 
 fn assert_poll_description(poll_state: &PollState) {
-    let start_content = poll_state.start_event.content.poll_start.clone();
+    let start_content = poll_state.start_event_content.poll_start.clone();
     assert_eq!(start_content.question.text, "Up or down?");
     assert_eq!(start_content.kind, PollKind::Disclosed);
     assert_eq!(start_content.max_selections, UInt::new(1).unwrap());
@@ -255,7 +255,7 @@ fn assert_poll_description(poll_state: &PollState) {
 }
 
 fn assert_edited_poll_description(poll_state: &PollState) {
-    let start_content = poll_state.start_event.content.poll_start.clone();
+    let start_content = poll_state.start_event_content.poll_start.clone();
     assert_eq!(start_content.question.text, "Up or down edited?");
     assert_eq!(start_content.kind, PollKind::Disclosed);
     assert_eq!(start_content.max_selections, UInt::new(1).unwrap());

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -63,8 +63,8 @@ async fn voting_does_update_a_poll() {
     // Poll finishes
     timeline.send_poll_end(&ALICE, "ENDED", &poll_id).await;
 
-    // Now Bob votes again but his vote won't count
-    timeline.send_poll_response(&BOB, vec!["id_up"], &poll_id).await;
+    // Now Bob also changes his mind but it's too late, his vote won't count
+    timeline.send_poll_response(&BOB, vec!["id_down"], &poll_id).await;
     let results = timeline.poll_state().await.results();
     assert_eq!(results.votes["id_up"], vec![BOB.to_string()]);
     assert_eq!(results.votes["id_down"], vec![ALICE.to_string()]);

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -180,16 +180,16 @@ async fn events_received_before_start_are_not_lost() {
 }
 
 impl TestTimeline {
-    async fn events(&self) -> Vec<EventTimelineItem> {
+    async fn event_items(&self) -> Vec<EventTimelineItem> {
         self.inner.items().await.iter().filter_map(|item| item.as_event().cloned()).collect()
     }
 
     async fn poll_event(&self) -> EventTimelineItem {
-        self.events().await.first().unwrap().clone()
+        self.event_items().await.first().unwrap().clone()
     }
 
     async fn poll_state(&self) -> PollState {
-        self.events().await.first().unwrap().clone().poll_state()
+        self.event_items().await.first().unwrap().clone().poll_state()
     }
 
     async fn send_poll_start(&self, sender: &UserId, content: UnstablePollStartContentBlock) {

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::timeline::polls::PollState;
 use crate::timeline::tests::{assert_no_more_updates, TestTimeline, ALICE, BOB};
-use crate::timeline::{EventTimelineItem, TimelineItem};
+use crate::timeline::{EventTimelineItem, TimelineItem, TimelineItemContent};
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
 use futures_util::{FutureExt, StreamExt};
@@ -187,4 +187,15 @@ fn assert_poll_description(poll_state: &PollState) {
     assert_eq!(start_content.answers[0].text, "Up");
     assert_eq!(start_content.answers[1].id, "id_down");
     assert_eq!(start_content.answers[1].text, "Down");
+}
+
+impl TryFrom<&TimelineItemContent> for PollState {
+    type Error = ();
+
+    fn try_from(value: &TimelineItemContent) -> Result<PollState, Self::Error> {
+        match value {
+            TimelineItemContent::Poll(poll_state) => Ok(poll_state.clone()),
+            _ => Err(()),
+        }
+    }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -1,0 +1,190 @@
+use std::sync::Arc;
+
+use crate::timeline::polls::PollState;
+use crate::timeline::tests::{assert_no_more_updates, TestTimeline, ALICE, BOB};
+use crate::timeline::{EventTimelineItem, TimelineItem};
+use eyeball_im::VectorDiff;
+use futures_core::Stream;
+use futures_util::{FutureExt, StreamExt};
+use matrix_sdk_test::async_test;
+use ruma::events::poll::start::PollKind;
+use ruma::events::poll::unstable_response::UnstablePollResponseEventContent;
+use ruma::events::poll::unstable_start::{
+    UnstablePollAnswer, UnstablePollAnswers, UnstablePollStartContentBlock,
+    UnstablePollStartEventContent,
+};
+use ruma::events::AnyMessageLikeEventContent;
+use ruma::{OwnedEventId, UInt, UserId};
+
+#[async_test]
+async fn start_poll_event_should_have_initial_poll_state() {
+    let (_timeline, mut stream) = create_timeline_with_start_poll_event().await;
+    let start_event = get_poll_start_event(&mut stream);
+    let poll_state = PollState::try_from(start_event.content()).unwrap();
+
+    assert_poll_description(&poll_state);
+    assert_eq!(poll_state.response_events.is_empty(), true);
+
+    assert_no_more_updates(&mut stream).await;
+}
+
+#[async_test]
+async fn poll_response_event_should_update_poll_state() {
+    let (timeline, mut stream) = create_timeline_with_start_poll_event().await;
+    let start_event = get_poll_start_event(&mut stream);
+    timeline
+        .send_poll_response_event(
+            &ALICE,
+            vec!["id_up".to_string()],
+            start_event.event_id().unwrap().to_owned(),
+        )
+        .await;
+    let updated_start_event = get_updated_poll_event(&mut stream);
+    let poll_state = PollState::try_from(updated_start_event.content()).unwrap();
+
+    assert_poll_description(&poll_state);
+    assert_eq!(poll_state.response_events.len(), 1);
+    assert_eq!(poll_state.response_events[0].sender, ALICE.to_owned());
+    assert_eq!(poll_state.response_events[0].timestamp.0, UInt::new(1).unwrap());
+    assert_eq!(
+        poll_state.response_events[0].content.poll_response.answers.first().unwrap(),
+        "id_up"
+    );
+
+    let poll = poll_state.results();
+    assert_eq!(poll.votes["id_up"], vec!["@alice:server.name"]);
+
+    assert_no_more_updates(&mut stream).await;
+}
+
+#[async_test]
+async fn two_poll_response_events_should_update_poll_state() {
+    let (timeline, mut stream) = create_timeline_with_start_poll_event().await;
+    let start_event = get_poll_start_event(&mut stream);
+    timeline
+        .send_poll_response_event(
+            &ALICE,
+            vec!["id_up".to_string()],
+            start_event.event_id().unwrap().to_owned(),
+        )
+        .await;
+    let start_event_after_1st_vote = get_updated_poll_event(&mut stream);
+    let _poll_state_after_first_vote =
+        PollState::try_from(start_event_after_1st_vote.content()).unwrap();
+    timeline
+        .send_poll_response_event(
+            &BOB,
+            vec!["id_up".to_string()],
+            start_event.event_id().unwrap().to_owned(),
+        )
+        .await;
+    let start_event_after_2nd_vote = get_updated_poll_event(&mut stream);
+    let _poll_state_after_2nd_vote =
+        PollState::try_from(start_event_after_2nd_vote.content()).unwrap();
+
+    assert_poll_description(&_poll_state_after_2nd_vote);
+    assert_eq!(_poll_state_after_2nd_vote.response_events.len(), 2);
+    assert_eq!(_poll_state_after_2nd_vote.response_events[0].sender, ALICE.to_owned());
+    assert_eq!(_poll_state_after_2nd_vote.response_events[0].timestamp.0, UInt::new(1).unwrap());
+    assert_eq!(
+        _poll_state_after_2nd_vote.response_events[0]
+            .content
+            .poll_response
+            .answers
+            .first()
+            .unwrap(),
+        "id_up"
+    );
+    assert_eq!(_poll_state_after_2nd_vote.response_events[1].sender, BOB.to_owned());
+    assert_eq!(_poll_state_after_2nd_vote.response_events[1].timestamp.0, UInt::new(2).unwrap());
+    assert_eq!(
+        _poll_state_after_2nd_vote.response_events[1]
+            .content
+            .poll_response
+            .answers
+            .first()
+            .unwrap(),
+        "id_up"
+    );
+
+    let poll = _poll_state_after_2nd_vote.results();
+    assert_eq!(poll.votes["id_up"], vec!["@alice:server.name", "@bob:other.server"]);
+
+    assert_no_more_updates(&mut stream).await;
+}
+
+impl TestTimeline {
+    async fn send_poll_start_event(self: &Self) {
+        let mut content = UnstablePollStartContentBlock::new(
+            "Up or down?",
+            UnstablePollAnswers::try_from(vec![
+                UnstablePollAnswer::new("id_up".to_string(), "Up".to_string()),
+                UnstablePollAnswer::new("id_down".to_string(), "Down".to_string()),
+            ])
+            .unwrap(),
+        );
+        content.kind = PollKind::Disclosed;
+
+        self.handle_live_message_event(
+            &ALICE,
+            AnyMessageLikeEventContent::UnstablePollStart(UnstablePollStartEventContent::new(
+                content,
+            )),
+        )
+        .await
+    }
+
+    async fn send_poll_response_event(
+        self: &Self,
+        sender: &UserId,
+        answers: Vec<String>,
+        poll_id: OwnedEventId,
+    ) {
+        self.handle_live_message_event(
+            sender,
+            AnyMessageLikeEventContent::UnstablePollResponse(
+                UnstablePollResponseEventContent::new(answers, poll_id),
+            ),
+        )
+        .await
+    }
+}
+
+async fn create_timeline_with_start_poll_event(
+) -> (TestTimeline, impl Stream<Item = VectorDiff<Arc<TimelineItem>>>) {
+    let timeline = TestTimeline::new();
+    let stream = timeline.subscribe().await;
+    timeline.send_poll_start_event().await;
+    (timeline, stream)
+}
+
+fn get_poll_start_event(
+    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
+) -> EventTimelineItem {
+    let _day_divider = stream.next().now_or_never().unwrap();
+    match stream.next().now_or_never().unwrap().unwrap() {
+        VectorDiff::PushBack { value } => value.as_event().unwrap().clone(),
+        _ => panic!("Not a pushback"),
+    }
+}
+
+fn get_updated_poll_event(
+    stream: &mut (impl Stream<Item = VectorDiff<Arc<TimelineItem>>> + Unpin),
+) -> EventTimelineItem {
+    match stream.next().now_or_never().unwrap().unwrap() {
+        VectorDiff::Set { value, .. } => value.as_event().unwrap().clone(),
+        _ => panic!("Not a set"),
+    }
+}
+
+fn assert_poll_description(poll_state: &PollState) {
+    let start_content = poll_state.start_event.content.poll_start.clone();
+    assert_eq!(start_content.question.text, "Up or down?");
+    assert_eq!(start_content.kind, PollKind::Disclosed);
+    assert_eq!(start_content.max_selections, UInt::new(1).unwrap());
+    assert_eq!(start_content.answers.len(), 2);
+    assert_eq!(start_content.answers[0].id, "id_up");
+    assert_eq!(start_content.answers[0].text, "Up");
+    assert_eq!(start_content.answers[1].id, "id_down");
+    assert_eq!(start_content.answers[1].text, "Down");
+}

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -1,17 +1,24 @@
-use crate::timeline::polls::PollState;
-use crate::timeline::tests::{TestTimeline, ALICE, BOB};
-use crate::timeline::{EventTimelineItem, TimelineItemContent};
 use matrix_sdk_test::async_test;
-use ruma::events::poll::unstable_end::UnstablePollEndEventContent;
-use ruma::events::poll::unstable_response::UnstablePollResponseEventContent;
-use ruma::events::poll::unstable_start::{
-    UnstablePollStartContentBlock, UnstablePollStartEventContent,
+use ruma::{
+    events::{
+        poll::{
+            unstable_end::UnstablePollEndEventContent,
+            unstable_response::UnstablePollResponseEventContent,
+            unstable_start::{UnstablePollStartContentBlock, UnstablePollStartEventContent},
+        },
+        relation::Replacement,
+        room::message::Relation,
+        AnyMessageLikeEventContent,
+    },
+    serde::Raw,
+    server_name, EventId, OwnedEventId, UserId,
 };
-use ruma::events::relation::Replacement;
-use ruma::events::room::message::Relation;
-use ruma::events::AnyMessageLikeEventContent;
-use ruma::serde::Raw;
-use ruma::{server_name, EventId, OwnedEventId, UserId};
+
+use crate::timeline::{
+    polls::PollState,
+    tests::{TestTimeline, ALICE, BOB},
+    EventTimelineItem, TimelineItemContent,
+};
 
 #[async_test]
 async fn poll_is_displayed() {


### PR DESCRIPTION
- Creates `polls` module in `timeline` to hold all related logic.
  - `PollState` holds ruma types directly to keep it simple and reuse ruma’s existing aggregation logic.
  - `PollPendingEvents` acts as a cache for response/end events that are handled before their start event has been handled. 
- Handles ruma's `UnstablePoll{Start, Response, End}` events.
  - When a start event arrives it computes the starting `PollState`.
    - If there are responses/end events in the `PollPendingEvents` cache it will move them from the cache to the state.
  - When a response event arrives it updates the `PollState`.
    - Or it is added to the `PollPendingEvents` if no start event is found yet.
  - When an end event arrives it updates the `PollState`
    - Or it is added to the `PollPendingEvents` if no start event is found yet. 
- Handles retries.
- Handles edit events for the poll start event. 
- Adds timeline tests in `matrix_sdk_ui::timeline::tests::polls` (still to be improved).
- BREAKING: Removes the `matrix_sdk_ffi::timeline::TimelineItemContentKind::PollEnd` variant because the timeline won't show end events.