### PR TITLE
fix(ui): Add `m.room.member: $LAZY` in the require states of `visible_rooms`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -117,7 +117,10 @@ impl Action for AddVisibleRoomsList {
                         SlidingSyncMode::new_selective().add_range(VISIBLE_ROOMS_DEFAULT_RANGE),
                     )
                     .timeline_limit(20)
-                    .required_state(vec![(StateEventType::RoomEncryption, "".to_owned())]),
+                    .required_state(vec![
+                        (StateEventType::RoomEncryption, "".to_owned()),
+                        (StateEventType::RoomMember, "$LAZY".to_owned()),
+                    ]),
             ))
             .await
             .map_err(Error::SlidingSync)?;

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -288,6 +288,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                     "ranges": [[0, 19]],
                     "required_state": [
                         ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
                     ],
                     "filters": {
                         "is_invite": false,


### PR DESCRIPTION
This patch tries to fix https://github.com/vector-im/element-x-ios/issues/1204 by adding the following required states in the `visible_rooms` sliding sync list: `m.room.member: $LAZY`.