### PR TITLE
feat(ui): Implement `RoomList::entries_with_dynamic_filter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,6 +2958,7 @@ dependencies = [
  "stream_assert",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_cell"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834eee9ce518130a3b4d5af09ecc43e9d6b57ee76613f227a1ddd6b77c7a62bc"
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,6 +2940,7 @@ dependencies = [
  "async-std",
  "async-stream",
  "async-trait",
+ "async_cell",
  "chrono",
  "ctor",
  "eyeball",
@@ -2958,7 +2965,6 @@ dependencies = [
  "stream_assert",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -313,7 +313,9 @@ impl RoomListEntriesDynamicFilter {
 
         match kind {
             Kind::All => self.inner.set(new_filter_all()),
-            Kind::FuzzyMatchRoomName { pattern } => self.inner.set(new_filter_fuzzy_match_room_name(&self.client, &pattern)),
+            Kind::FuzzyMatchRoomName { pattern } => {
+                self.inner.set(new_filter_fuzzy_match_room_name(&self.client, &pattern))
+            }
         }
     }
 }
@@ -321,9 +323,7 @@ impl RoomListEntriesDynamicFilter {
 #[derive(uniffi::Enum)]
 pub enum RoomListEntriesDynamicFilterKind {
     All,
-    FuzzyMatchRoomName {
-        pattern: String,
-    }
+    FuzzyMatchRoomName { pattern: String },
 }
 
 #[derive(uniffi::Object)]

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -12,7 +12,7 @@ use matrix_sdk::{
     },
     RoomListEntry as MatrixRoomListEntry,
 };
-use matrix_sdk_ui::room_list_service::filters::new_filter_fuzzy_match_room_name;
+use matrix_sdk_ui::room_list_service::filters::{new_filter_all, new_filter_fuzzy_match_room_name};
 use tokio::sync::RwLock;
 
 use crate::{room::Room, timeline::EventTimelineItem, TaskHandle, RUNTIME};
@@ -308,8 +308,21 @@ impl RoomListEntriesDynamicFilter {
 
 #[uniffi::export]
 impl RoomListEntriesDynamicFilter {
-    fn set_with_fuzzy_match_pattern(&self, pattern: String) -> bool {
-        self.inner.set(new_filter_fuzzy_match_room_name(&self.client, &pattern))
+    fn set(&self, kind: RoomListEntriesDynamicFilterKind) -> bool {
+        use RoomListEntriesDynamicFilterKind as Kind;
+
+        match kind {
+            Kind::All => self.inner.set(new_filter_all()),
+            Kind::FuzzyMatchRoomName { pattern } => self.inner.set(new_filter_fuzzy_match_room_name(&self.client, &pattern)),
+        }
+    }
+}
+
+#[derive(uniffi::Enum)]
+pub enum RoomListEntriesDynamicFilterKind {
+    All,
+    FuzzyMatchRoomName {
+        pattern: String,
     }
 }
 

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -12,6 +12,7 @@ native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
 
 [dependencies]
+async_cell = "0.2.2"
 async-once-cell = "0.5.2"
 async-rx = { workspace = true }
 async-std = { version = "1.12.0", features = ["unstable"] }
@@ -38,7 +39,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = "0.1.14"
 tracing = { workspace = true, features = ["attributes"] }
 unicode-normalization = "0.1.22"
 

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -38,6 +38,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-stream = "0.1.14"
 tracing = { workspace = true, features = ["attributes"] }
 unicode-normalization = "0.1.22"
 

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/all.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/all.rs
@@ -1,7 +1,7 @@
 use matrix_sdk::RoomListEntry;
 
 /// Create a new filter that will accept all filled or invalidated entries.
-pub fn new_filter() -> impl Fn(&RoomListEntry) -> bool + Send + Sync + 'static {
+pub fn new_filter() -> impl Fn(&RoomListEntry) -> bool {
     |room_list_entry| -> bool {
         matches!(room_list_entry, RoomListEntry::Filled(_) | RoomListEntry::Invalidated(_))
     }

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/all.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/all.rs
@@ -1,0 +1,26 @@
+use matrix_sdk::RoomListEntry;
+
+/// Create a new filter that will accept all filled or invalidated entries.
+pub fn new_filter() -> impl Fn(&RoomListEntry) -> bool + Send + Sync + 'static {
+    |room_list_entry| -> bool {
+        matches!(room_list_entry, RoomListEntry::Filled(_) | RoomListEntry::Invalidated(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not;
+
+    use ruma::room_id;
+
+    use super::*;
+
+    #[test]
+    fn test_all_kind_of_room_list_entry() {
+        let all = new_filter();
+
+        assert!(all(&RoomListEntry::Empty).not());
+        assert!(all(&RoomListEntry::Filled(room_id!("!r0:bar.org").to_owned())));
+        assert!(all(&RoomListEntry::Invalidated(room_id!("!r0:bar.org").to_owned())));
+    }
+}

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -88,11 +88,12 @@ mod tests {
         let matcher = FuzzyMatcher::new();
 
         let matcher = matcher.with_pattern("mtx");
-        assert!(matcher.fuzzy_match("Matrix"));
+        assert!(matcher.fuzzy_match("matrix"));
         assert!(matcher.fuzzy_match("Matrix"));
 
         let matcher = matcher.with_pattern("Mtx");
-        assert!(matcher.fuzzy_match("MatriX").not());
+        assert!(matcher.fuzzy_match("matrix").not());
+        assert!(matcher.fuzzy_match("Matrix"));
     }
 
     #[test]

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -31,10 +31,7 @@ impl FuzzyMatcher {
 ///
 /// Rooms are fetched from the `Client`. The pattern and the room names are
 /// normalized with `normalize_string`.
-pub fn new_filter(
-    client: &Client,
-    pattern: &str,
-) -> impl Fn(&RoomListEntry) -> bool + Send + Sync + 'static {
+pub fn new_filter(client: &Client, pattern: &str) -> impl Fn(&RoomListEntry) -> bool {
     let searcher = FuzzyMatcher::new().with_pattern(pattern);
 
     let client = client.clone();

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
@@ -1,5 +1,7 @@
+mod all;
 mod fuzzy_match_room_name;
 
+pub use all::new_filter as new_filter_all;
 pub use fuzzy_match_room_name::new_filter as new_filter_fuzzy_match_room_name;
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -95,6 +95,9 @@ use tokio::sync::{Mutex, RwLock};
 /// The [`RoomListService`] type. See the module's documentation to learn more.
 #[derive(Debug)]
 pub struct RoomListService {
+    /// Client that has created this [`RoomListService`].
+    client: Client,
+
     /// The Sliding Sync instance.
     sliding_sync: Arc<SlidingSync>,
 
@@ -175,6 +178,7 @@ impl RoomListService {
             .map_err(Error::SlidingSync)?;
 
         Ok(Self {
+            client,
             sliding_sync,
             state: SharedObservable::new(State::Init),
             rooms: Arc::new(RwLock::new(RingBuffer::new(Self::ROOM_OBJECT_CACHE_SIZE))),
@@ -256,6 +260,11 @@ impl RoomListService {
     /// state-machine into the [`State::Terminated`] state.
     pub fn stop_sync(&self) -> Result<(), Error> {
         self.sliding_sync.stop_sync().map_err(Error::SlidingSync)
+    }
+
+    /// Get the [`Client`] that has been used to create [`Self`].
+    pub fn client(&self) -> &Client {
+        &self.client
     }
 
     /// Get a subscriber to the state.

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -12,9 +12,11 @@
 // See the License for that specific language governing permissions and
 // limitations under the License.
 
-use std::future::ready;
+use std::{future::ready, sync::Arc};
 
+use async_cell::sync::AsyncCell;
 use async_rx::StreamExt as _;
+use async_stream::stream;
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
 use futures_util::{pin_mut, stream, Stream, StreamExt as _};
@@ -22,8 +24,6 @@ use matrix_sdk::{
     executor::{spawn, JoinHandle},
     RoomListEntry, SlidingSync, SlidingSyncList,
 };
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
 
 use super::{Error, State};
 
@@ -142,15 +142,17 @@ impl RoomList {
     pub fn entries_with_dynamic_filter(
         &self,
     ) -> (impl Stream<Item = Vec<VectorDiff<RoomListEntry>>>, DynamicRoomListFilter) {
-        // FIXME: Should ideally be a single-consumer watch channel / observable.
-        let (tx, rx) = mpsc::channel(1);
+        let filter_fn_cell = AsyncCell::shared();
+        let dynamic_filter = DynamicRoomListFilter::new(filter_fn_cell.clone());
 
         let list = self.sliding_sync_list.clone();
         let room_list_service_state = self.room_list_service_state.clone();
-        let stream = ReceiverStream::new(rx)
-            .map(move |filter_fn| {
+        let stream = stream! {
+            loop {
+                let filter_fn = filter_fn_cell.take().await;
                 let (items, stream) = list.room_list_filtered_stream(filter_fn);
-                stream::once(
+
+                yield stream::once(
                     // Reset the stream with all its items.
                     ready(vec![VectorDiff::Reset { values: items }]),
                 )
@@ -159,12 +161,11 @@ impl RoomList {
                     // `room_list_service_state` is changed.
                     stream.batch_with(room_list_service_state.clone().map(|_| ())),
                 )
-            })
-            .switch();
+            }
+        }
+        .switch();
 
-        let filter = DynamicRoomListFilter::new(tx);
-
-        (stream, filter)
+        (stream, dynamic_filter)
     }
 }
 
@@ -211,27 +212,31 @@ pub enum RoomListLoadingState {
 
 type BoxedFilterFn = Box<dyn Fn(&RoomListEntry) -> bool + Send + Sync>;
 
+/// Dynamic filter for the [`RoomList`] entries.
+///
+/// To get one value of this type, use [`RoomList::entries_with_dynamic_filter`]
 pub struct DynamicRoomListFilter {
-    tx: mpsc::Sender<BoxedFilterFn>,
+    inner: Arc<AsyncCell<BoxedFilterFn>>,
 }
 
 impl DynamicRoomListFilter {
-    fn new(tx: mpsc::Sender<BoxedFilterFn>) -> Self {
-        Self { tx }
+    fn new(inner: Arc<AsyncCell<BoxedFilterFn>>) -> Self {
+        Self { inner }
     }
 
     /// Set the filter.
     ///
     /// If the associated stream has been dropped, returns `false` to indicate
     /// the operation didn't have an effect.
-    ///
-    /// The future returned by this should usually resolve immediately. The only
-    /// case where it doesn't is when the associated stream is polled less
-    /// frequently than the filter is being set.
-    pub async fn set(
-        &self,
-        filter: impl Fn(&RoomListEntry) -> bool + Send + Sync + 'static,
-    ) -> bool {
-        self.tx.send(Box::new(filter)).await.is_ok()
+    pub fn set(&self, filter: impl Fn(&RoomListEntry) -> bool + Send + Sync + 'static) -> bool {
+        if Arc::strong_count(&self.inner) == 1 {
+            // there is no other reference to the boxed filter fn, setting it
+            // would be pointless (no new references can be created from self,
+            // either)
+            false
+        } else {
+            self.inner.set(Box::new(filter));
+            true
+        }
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -120,7 +120,7 @@ impl RoomList {
         filter: F,
     ) -> (Vector<RoomListEntry>, impl Stream<Item = Vec<VectorDiff<RoomListEntry>>>)
     where
-        F: Fn(&RoomListEntry) -> bool + Send + Sync + 'static,
+        F: Fn(&RoomListEntry) -> bool,
     {
         let (entries, entries_stream) = self.sliding_sync_list.room_list_filtered_stream(filter);
 
@@ -149,7 +149,6 @@ impl RoomList {
         let room_list_service_state = self.room_list_service_state.clone();
         let stream = ReceiverStream::new(rx)
             .map(move |filter_fn| {
-                // FIXME: filter_fn is already boxed, we box it again here
                 let (items, stream) = list.room_list_filtered_stream(filter_fn);
                 stream::once(
                     // Reset the stream with all its items.

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -115,7 +115,7 @@ impl RoomList {
 
     /// Similar to [`Self::entries`] except that it's possible to provide a
     /// filter that will filter out room list entries.
-    pub fn entries_filtered<F>(
+    pub fn entries_with_static_filter<F>(
         &self,
         filter: F,
     ) -> (Vector<RoomListEntry>, impl Stream<Item = Vec<VectorDiff<RoomListEntry>>>)
@@ -132,7 +132,8 @@ impl RoomList {
         )
     }
 
-    /// Get a stream of room list entries, filtered dynamically.
+    /// Similar to [`Self::entries_with_static_filter`] except that it's
+    /// possible to change the filter dynamically.
     ///
     /// The returned stream will only start yielding diffs once a filter is set
     /// through the returned `DynamicRoomListFilter`. For every call to

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -8,7 +8,7 @@ use matrix_sdk::Client;
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::{
     room_list_service::{
-        filters::new_filter_fuzzy_match_room_name, Error, Input, InputResult, RoomListEntry,
+        filters::{new_filter_all, new_filter_fuzzy_match_room_name}, Error, Input, InputResult, RoomListEntry,
         RoomListLoadingState, State, ALL_ROOMS_LIST_NAME as ALL_ROOMS,
         INVITES_LIST_NAME as INVITES, VISIBLE_ROOMS_LIST_NAME as VISIBLE_ROOMS,
     },
@@ -1638,6 +1638,26 @@ async fn test_entries_stream_with_filters() -> Result<(), Error> {
         [entries_stream_dynamic_filter]
         // Receive a `reset` again because the filter has been reset.
         reset [ F("!r2:bar.org"), F("!r3:bar.org"), F("!r6:bar.org") ];
+        pending;
+    };
+
+    // Now, let's change again the dynamic filter!
+    dynamic_filter.set(new_filter_all());
+
+    // Assert the dynamic filter.
+    assert_entries_stream! {
+        [entries_stream_dynamic_filter]
+        // Receive a `reset` again because the filter has been reset.
+        reset [
+            F("!r0:bar.org"),
+            F("!r1:bar.org"),
+            F("!r2:bar.org"),
+            F("!r3:bar.org"),
+            F("!r4:bar.org"),
+            F("!r5:bar.org"),
+            F("!r6:bar.org"),
+            F("!r7:bar.org"),
+        ];
         pending;
     };
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -8,9 +8,10 @@ use matrix_sdk::Client;
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::{
     room_list_service::{
-        filters::{new_filter_all, new_filter_fuzzy_match_room_name}, Error, Input, InputResult, RoomListEntry,
-        RoomListLoadingState, State, ALL_ROOMS_LIST_NAME as ALL_ROOMS,
-        INVITES_LIST_NAME as INVITES, VISIBLE_ROOMS_LIST_NAME as VISIBLE_ROOMS,
+        filters::{new_filter_all, new_filter_fuzzy_match_room_name},
+        Error, Input, InputResult, RoomListEntry, RoomListLoadingState, State,
+        ALL_ROOMS_LIST_NAME as ALL_ROOMS, INVITES_LIST_NAME as INVITES,
+        VISIBLE_ROOMS_LIST_NAME as VISIBLE_ROOMS,
     },
     timeline::{TimelineItemKind, VirtualTimelineItem},
     RoomListService,

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -61,8 +61,6 @@ pub struct SlidingSyncList {
     inner: Arc<SlidingSyncListInner>,
 }
 
-type BoxedRoomListEntryFilter = Box<dyn Fn(&RoomListEntry) -> bool + Sync + Send>;
-
 impl SlidingSyncList {
     /// Create a new [`SlidingSyncListBuilder`] with the given name.
     pub fn builder(name: impl Into<String>) -> SlidingSyncListBuilder {
@@ -169,11 +167,11 @@ impl SlidingSyncList {
     pub fn room_list_filtered_stream<F>(
         &self,
         filter: F,
-    ) -> (Vector<RoomListEntry>, FilterVectorSubscriber<RoomListEntry, BoxedRoomListEntryFilter>)
+    ) -> (Vector<RoomListEntry>, FilterVectorSubscriber<RoomListEntry, F>)
     where
-        F: Fn(&RoomListEntry) -> bool + Sync + Send + 'static,
+        F: Fn(&RoomListEntry) -> bool,
     {
-        ObservableVector::subscribe_filter(&self.inner.room_list.read().unwrap(), Box::new(filter))
+        ObservableVector::subscribe_filter(&self.inner.room_list.read().unwrap(), filter)
     }
 
     /// Get the maximum number of rooms. See [`Self::maximum_number_of_rooms`]


### PR DESCRIPTION
Address #1911.

Thanks for @jplatte for his collaboration on this patch.

This patch can be reviewed commit-by-commit, but a one-diff review is also doable I guess.

On FFI side:

* `RoomList::entries` is now infallible,
* `RoomList::entries_with_dynamic_filter` has been implemented. It returns a stream + a `RoomListDynamicFilter` object, which has a single method: `set`. It accepts `RoomListDynamicFilterKind` value, which is an enum with `All` or `FuzzyMatchRoomName` variants.

Why this design? Because it allows the client-app to use `entries` if it provides a single “static” room list, or `entries_with_dynamic_filter` if it considers to filter the list with various filters. The client-app doesn't have to call `entries` or `entries_with_dynamic_filter` alternatively, it can just switch between `All` or other variants depending of the filters.

On the Rust side:

* This patch implements the new `all` filter, which returns `true` for all `RoomListEntry` that are `Filled` or `Invalidated`,
* This patch implements the new `RoomList::entries_with_dynamic_filter` method,
* This patch renames the `RoomList::entries_filtered` method to `::entries_with_static_filter`.