### PR TITLE
feat(sdk): Skip Sliding Sync `Response` if it's been received already

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -403,7 +403,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             },
         },
         respond with = {
-            "pos": "2",
+            "pos": "3",
             "lists": {
                 ALL_ROOMS: {
                     "count": 1000,
@@ -444,7 +444,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             },
         },
         respond with = {
-            "pos": "2",
+            "pos": "4",
             "lists": {
                 ALL_ROOMS: {
                     "count": 1000,
@@ -914,7 +914,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
             },
         },
         respond with = {
-            "pos": "1",
+            "pos": "0",
             "lists": {
                 ALL_ROOMS: {
                     "count": 1000,
@@ -954,7 +954,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
             },
         },
         respond with = {
-            "pos": "2",
+            "pos": "1",
             "lists": {
                 ALL_ROOMS: {
                     "count": 1000,
@@ -2029,7 +2029,7 @@ async fn test_room_timeline() -> Result<(), Error> {
         [server, room_list, sync]
         assert request >= {},
         respond with = {
-            "pos": "0",
+            "pos": "1",
             "lists": {},
             "rooms": {
                 room_id: {
@@ -2110,7 +2110,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
         [server, room_list, sync]
         assert request >= {},
         respond with = {
-            "pos": "0",
+            "pos": "1",
             "lists": {},
             "rooms": {
                 room_id: {
@@ -2134,7 +2134,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
         [server, room_list, sync]
         assert request >= {},
         respond with = {
-            "pos": "0",
+            "pos": "2",
             "lists": {},
             "rooms": {
                 room_id: {
@@ -2242,7 +2242,7 @@ async fn test_input_viewport() -> Result<(), Error> {
             },
         },
         respond with = {
-            "pos": "1",
+            "pos": "2",
             "lists": {},
             "rooms": {},
         },

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, fmt::Debug, sync::RwLock as StdRwLock, time::Duration};
 
+use matrix_sdk_common::ring_buffer::RingBuffer;
 use ruma::{
     api::client::sync::sync_events::v4::{
         self, AccountDataConfig, E2EEConfig, ExtensionsConfig, ReceiptsConfig, ToDeviceConfig,
@@ -261,6 +262,7 @@ impl SlidingSyncBuilder {
             rooms,
 
             position: StdRwLock::new(SlidingSyncPositionMarkers { pos: None, delta_token }),
+            past_positions: StdRwLock::new(RingBuffer::new(20)),
 
             sticky: StdRwLock::new(SlidingSyncStickyManager::new(
                 SlidingSyncStickyParameters::new(

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -13,6 +13,14 @@ pub enum Error {
     #[error("The sliding sync response could not be handled: {0}")]
     BadResponse(String),
 
+    /// The response we've received from the server has already been received in
+    /// the past because it has a `pos` that we have recently seen.
+    #[error("The sliding sync response has already been received: `pos={pos:?}`")]
+    ResponseAlreadyReceived {
+        /// The `pos`ition that has been received.
+        pos: Option<String>,
+    },
+
     /// A `SlidingSyncListRequestGenerator` has been used without having been
     /// initialized. It happens when a response is handled before a request has
     /// been sent. It usually happens when testing.

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1489,7 +1489,7 @@ mod tests {
             // `pos` has not been updated.
             assert_eq!(sliding_sync.inner.position.read().unwrap().pos, Some("1".to_owned()));
 
-            // `past_positions` has been updated.
+            // `past_positions` has not been updated.
             let past_positions = sliding_sync.inner.past_positions.read().unwrap();
             assert_eq!(past_positions.len(), 2);
             assert_eq!(past_positions.get(0).unwrap().pos, Some("0".to_owned()));


### PR DESCRIPTION
A Sliding Sync `v4::Response` contains a `pos` value. It helps to identify progress during several requests/responses. If two requests with the same `pos` are sent, the server **must** reply with the same response, as defined in the specification.

The corollary is: If a response contains a `pos` that has already been received, the client **must** ignore it, otherwise it can create duplications. For example, let a response containing sync operations, like `DELETE` or `INSERT`, with indexes: if this pair of operations are repeated twice with the same index, it creates a broken state.

To avoid this behaviour, this patch stores the last 20 position markers received from the server. If a response contains a `pos` that has already been received, a (new) error is returned. As with all the other errors, the sync-loop is stopped, and must restarted. The past positions survive to this restart, as for the rest of the state.

When the server replies with a `M_UNKNOWN_POS`, the `pos` and the `past_positions` are all cleared.

⚠️ Note to reviewer:

* **What I am sure about**. Checking that a `pos` has not been received before running `handle_response` must be done at the beginning of the method.
* **What I am not sure about**. Right now, the `pos` and `past_positions` are saved when `handle_response` starts to execute. The rest of the code in this method can fail. If an error is raised _after_ the `pos` has been saved, the next request will pretend everything was alright, and the server will reply with a different response. It can be a problem. For example, if a list has not been updated because an error happened before (e.g. with encryption handling, or with room response handling), the next list update will be broken because the previous one didn't happen.
I was thinking of saving `pos` at the end of the method, so that we are sure that everything was done correctly, _however_ it creates new problem: if the error was raised by the update of the list, the next request will use the same `pos`, the server will reply with the same response, and list updates is likely to be broken if it has partly been updated.
👉 Actually, the place where `pos` and `past_positions` must be placed is unclear to me yet:
    * Should we consider that errors emitted during `handle_response` (apart from the `pos` check) should lead to closing the sliding sync session?
    * Should we make `list.update` infallible? Making `handle_encryption`, `handle_room_response`, and `process_and_take_response` the only fallible places (with `pos` and `past_positions` to be saved _after_ those calls)?