### PR TITLE
feat(ui): `Room::latest_event` returns the `Timeline` local event if any

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -139,21 +139,24 @@ impl Room {
 
     /// Get the latest event in the timeline.
     ///
-    /// The latest event comes first from the `Timeline` if it exists.
-    /// Otherwise, it comes from the cache. This method does not fetch any
-    /// events or calculate anything — if it's not already available, we
-    /// return `None`.
+    /// The latest event comes first from the `Timeline` if it exists and if it
+    /// contains a local event. Otherwise, it comes from the cache. This method
+    /// does not fetch any events or calculate anything — if it's not
+    /// already available, we return `None`.
     ///
     /// It's different from `Self::timeline().latest_event()` as it won't track
     /// the read marker and receipts.
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
-        // Look for a remote or **local** event in the `Timeline`.
+        // Look for a local event in the `Timeline`.
         //
         // First off, let's see if a `Timeline` exists…
         if let Some(timeline) = self.inner.timeline.get() {
             // If it contains a `latest_event`…
             if let Some(timeline_last_event) = timeline.latest_event().await {
-                return Some(timeline_last_event);
+                // If it's a local echo…
+                if timeline_last_event.is_local_echo() {
+                    return Some(timeline_last_event);
+                }
             }
         }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -139,24 +139,21 @@ impl Room {
 
     /// Get the latest event in the timeline.
     ///
-    /// The latest event comes first from the `Timeline` if it exists and if it
-    /// contains a local event. Otherwise, it comes from the cache. This method
-    /// does not fetch any events or calculate anything — if it's not
-    /// already available, we return `None`.
+    /// The latest event comes first from the `Timeline` if it exists.
+    /// Otherwise, it comes from the cache. This method does not fetch any
+    /// events or calculate anything — if it's not already available, we
+    /// return `None`.
     ///
     /// It's different from `Self::timeline().latest_event()` as it won't track
     /// the read marker and receipts.
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
-        // Look for a local event in the `Timeline`.
+        // Look for a remote or **local** event in the `Timeline`.
         //
         // First off, let's see if a `Timeline` exists…
         if let Some(timeline) = self.inner.timeline.get() {
             // If it contains a `latest_event`…
             if let Some(timeline_last_event) = timeline.latest_event().await {
-                // If it's a local echo…
-                if timeline_last_event.is_local_echo() {
-                    return Some(timeline_last_event);
-                }
+                return Some(timeline_last_event);
             }
         }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -137,13 +137,30 @@ impl Room {
             .clone()
     }
 
-    /// Get the latest event in the timeline, if we already have it cached. Does
-    /// not fetch any events or calculate anything - if it's not already
-    /// available, we return None.
+    /// Get the latest event in the timeline.
+    ///
+    /// The latest event comes first from the `Timeline` if it exists and if it
+    /// contains a local event. Otherwise, it comes from the cache. This method
+    /// does not fetch any events or calculate anything — if it's not
+    /// already available, we return `None`.
     ///
     /// It's different from `Self::timeline().latest_event()` as it won't track
     /// the read marker and receipts.
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
+        // Look for a local event in the `Timeline`.
+        //
+        // First off, let's see if a `Timeline` exists…
+        if let Some(timeline) = self.inner.timeline.get() {
+            // If it contains a `latest_event`…
+            if let Some(timeline_last_event) = timeline.latest_event().await {
+                // If it's a local echo…
+                if timeline_last_event.is_local_echo() {
+                    return Some(timeline_last_event);
+                }
+            }
+        }
+
+        // Otherwise, fallback to the classical path.
         self.inner.sliding_sync_room.latest_timeline_item().await
     }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -143,9 +143,6 @@ impl Room {
     /// contains a local event. Otherwise, it comes from the cache. This method
     /// does not fetch any events or calculate anything — if it's not
     /// already available, we return `None`.
-    ///
-    /// It's different from `Self::timeline().latest_event()` as it won't track
-    /// the read marker and receipts.
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
         // Look for a local event in the `Timeline`.
         //

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -19,8 +19,8 @@ use matrix_sdk_ui::{
 use ruma::{
     api::client::sync::sync_events::{v4::RoomSubscription, UnreadNotificationsCount},
     assign, event_id,
-    events::StateEventType,
-    mxc_uri, room_id, uint,
+    events::{room::message::RoomMessageEventContent, StateEventType},
+    mxc_uri, room_id, uint, TransactionId,
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
@@ -2283,6 +2283,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
     assert_matches!(
         room.latest_event().await,
         Some(event) => {
+            assert!(event.is_local_echo().not());
             assert_eq!(event.event_id(), Some(event_id!("$x0:bar.org")));
         }
     );
@@ -2304,10 +2305,49 @@ async fn test_room_latest_event() -> Result<(), Error> {
     };
 
     // The latest event has been updated.
+    let latest_event = assert_matches!(
+        room.latest_event().await,
+        Some(event) => {
+            assert!(event.is_local_echo().not());
+            assert_eq!(event.event_id(), Some(event_id!("$x1:bar.org")));
+
+            event
+        }
+    );
+
+    // Now let's compare with the result of the `Timeline`.
+    let timeline = room.timeline().await;
+
+    // The latest event matches the latest event of the `Timeline`.
+    assert_matches!(
+        timeline.latest_event().await,
+        Some(timeline_event) => {
+            assert_eq!(timeline_event.event_id(), latest_event.event_id());
+        }
+    );
+
+    // Insert a local event in the `Timeline`.
+    let txn_id: &TransactionId = "foobar-txn-id".into();
+
+    timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into(), Some(txn_id)).await;
+
+    // The latest event of the `Timeline` is a local event.
+    assert_matches!(
+        timeline.latest_event().await,
+        Some(timeline_event) => {
+            assert!(timeline_event.is_local_echo());
+            assert_eq!(timeline_event.event_id(), None);
+            assert_eq!(timeline_event.transaction_id(), Some(txn_id));
+        }
+    );
+
+    // The latest event is a local event.
     assert_matches!(
         room.latest_event().await,
         Some(event) => {
-            assert_eq!(event.event_id(), Some(event_id!("$x1:bar.org")));
+            assert!(event.is_local_echo());
+            assert_eq!(event.event_id(), None);
+            assert_eq!(event.transaction_id(), Some(txn_id));
         }
     );
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2303.
Closes https://github.com/vector-im/element-x-ios/issues/1294.

This patch updates `Room::latest_event` to return the `Timeline` local event if any.

First off, it starts by checking if a `Timeline` exists. It won't create it if it doesn't exist! Second, it checks whether a latest event exists.

This patch also updates the tests accordingly.