### PR TITLE
sdk+ffi: in notification settings, replace `members_count` by `is_one_to_one` for more clarity

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -137,13 +137,13 @@ impl NotificationSettings {
     ///
     /// * `room_id` - the room ID
     /// * `is_encrypted` - whether the room is encrypted
-    /// * `active_members_count` - the room's active members count (joined +
-    ///   invited)
+    /// * `is_one_to_one` - whether the room is a direct chat involving two
+    ///   people
     pub async fn get_room_notification_settings(
         &self,
         room_id: String,
         is_encrypted: bool,
-        active_members_count: u64,
+        is_one_to_one: bool,
     ) -> Result<RoomNotificationSettings, NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
         let parsed_room_id = RoomId::parse(&room_id)
@@ -158,7 +158,7 @@ impl NotificationSettings {
         // If the user has not defined a notification mode, return the default one for
         // this room
         let mode = notification_settings
-            .get_default_room_notification_mode(is_encrypted.into(), active_members_count)
+            .get_default_room_notification_mode(is_encrypted.into(), is_one_to_one.into())
             .await;
         Ok(RoomNotificationSettings::new(mode.into(), true))
     }
@@ -202,16 +202,16 @@ impl NotificationSettings {
     /// # Arguments
     ///
     /// * `is_encrypted` - whether the room is encrypted
-    /// * `active_members_count` - the room's active members count (joined +
-    ///   invited)
+    /// * `is_one_to_one` - whether the room is a direct chats involving two
+    ///   people
     pub async fn get_default_room_notification_mode(
         &self,
         is_encrypted: bool,
-        active_members_count: u64,
+        is_one_to_one: bool,
     ) -> RoomNotificationMode {
         let notification_settings = self.sdk_notification_settings.read().await;
         let mode = notification_settings
-            .get_default_room_notification_mode(is_encrypted.into(), active_members_count)
+            .get_default_room_notification_mode(is_encrypted.into(), is_one_to_one.into())
             .await;
         mode.into()
     }
@@ -344,17 +344,24 @@ impl NotificationSettings {
     }
 
     /// Unmute a room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - the room to unmute
+    /// * `is_encrypted` - whether the room is encrypted
+    /// * `is_one_to_one` - whether the room is a direct chat involving two
+    ///   people
     pub async fn unmute_room(
         &self,
         room_id: String,
         is_encrypted: bool,
-        members_count: u64,
+        is_one_to_one: bool,
     ) -> Result<(), NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
         let parsed_room_id = RoomId::parse(&room_id)
             .map_err(|_e| NotificationSettingsError::InvalidRoomId(room_id))?;
         notification_settings
-            .unmute_room(&parsed_room_id, is_encrypted.into(), members_count)
+            .unmute_room(&parsed_room_id, is_encrypted.into(), is_one_to_one.into())
             .await?;
         Ok(())
     }

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -99,17 +99,16 @@ impl Rules {
     ///
     /// # Arguments
     ///
-    /// * `is_encrypted` - `true` if the room is encrypted
-    /// * `members_count` - the room members count
+    /// * `is_encrypted` - `Yes` if the room is encrypted
+    /// * `is_one_to_one` - `Yes` if the room is a direct chat involving two
+    ///   people
     pub(crate) fn get_default_room_notification_mode(
         &self,
         is_encrypted: IsEncrypted,
-        members_count: u64,
+        is_one_to_one: IsOneToOne,
     ) -> RoomNotificationMode {
-        // get the correct default rule ID based on `is_encrypted` and `members_count`
-        let is_one_to_one = members_count == 2;
-        let predefined_rule_id =
-            get_predefined_underride_room_rule_id(is_encrypted, is_one_to_one.into());
+        // get the correct default rule ID based on `is_encrypted` and `is_one_to_one`
+        let predefined_rule_id = get_predefined_underride_room_rule_id(is_encrypted, is_one_to_one);
         let rule_id = predefined_rule_id.as_str();
 
         // If there is an `Underride` rule that should trigger a notification, the mode
@@ -264,7 +263,7 @@ impl Rules {
 /// # Arguments
 ///
 /// * `is_encrypted` - `Yes` if the room is encrypted
-/// * `is_one_to_one` - `Yes` if the room is a direct chat
+/// * `is_one_to_one` - `Yes` if the room is a direct chat involving two people
 pub(crate) fn get_predefined_underride_room_rule_id(
     is_encrypted: IsEncrypted,
     is_one_to_one: IsOneToOne,
@@ -419,7 +418,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let rules = Rules::new(ruleset);
-        let mode = rules.get_default_room_notification_mode(IsEncrypted::No, 2);
+        let mode = rules.get_default_room_notification_mode(IsEncrypted::No, IsOneToOne::Yes);
         // Then the mode should be `MentionsAndKeywordsOnly`
         assert_eq!(mode, RoomNotificationMode::MentionsAndKeywordsOnly);
     }
@@ -433,7 +432,7 @@ pub(crate) mod tests {
             .unwrap();
 
         let rules = Rules::new(ruleset);
-        let mode = rules.get_default_room_notification_mode(IsEncrypted::No, 2);
+        let mode = rules.get_default_room_notification_mode(IsEncrypted::No, IsOneToOne::Yes);
         // Then the mode should be `AllMessages`
         assert_eq!(mode, RoomNotificationMode::AllMessages);
     }


### PR DESCRIPTION
This PR removes the need to pass the active members count to the ffi layer of the notification parameters. 
The active members count was used to hide the fact that, from a push rule perspective, a `one-to-one` room is a room with exactly two members, but ultimately this adds unnecessary complexity.