### PR TITLE
feat(notification client): bump sliding sync timeouts

### DIFF
--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -153,7 +153,7 @@ impl NotificationClient {
         let encryption_sync = EncryptionSync::new(
             Self::LOCK_ID.to_owned(),
             self.client.clone(),
-            Some((Duration::from_secs(3), Duration::from_secs(1))),
+            Some((Duration::from_secs(3), Duration::from_secs(4))),
             with_locking,
         )
         .await;
@@ -268,7 +268,7 @@ impl NotificationClient {
             .client
             .sliding_sync(Self::CONNECTION_ID)?
             .poll_timeout(Duration::from_secs(1))
-            .network_timeout(Duration::from_secs(1))
+            .network_timeout(Duration::from_secs(3))
             .with_account_data_extension(
                 assign!(AccountDataConfig::default(), { enabled: Some(true) }),
             )


### PR DESCRIPTION
The timeouts were a bit too agressive, according to some user logs, resulting in failing to load the event mentioned in the notification.

Here's the rationale for the new timeouts: we're only limited by the iOS process which has *at most* 30 seconds to process a notification.

- We're running at most 3 requests of the notification sliding sync, so that will be (1+3)*3 = 12 seconds allocated for that.
- If we've found an event but it required decryption, we're running the encryption sync up to 2 times, (3+4) seconds each => 14 seconds.

At most we're eating up 26 seconds of the entire time, leaving some ballast for the rest of the program.