### PR TITLE
chore(uniffi): Update `uniffi` to another branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5344,7 +5344,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "uniffi"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "anyhow",
  "camino",
@@ -5365,7 +5365,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "anyhow",
  "askama",
@@ -5389,7 +5389,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "anyhow",
  "camino",
@@ -5399,7 +5399,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "quote",
  "syn 2.0.28",
@@ -5408,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5424,7 +5424,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "bincode",
  "camino",
@@ -5442,7 +5442,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "anyhow",
  "camino",
@@ -5468,7 +5468,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.24.1"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "anyhow",
  "uniffi_meta",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5344,7 +5344,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "uniffi"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "anyhow",
  "camino",
@@ -5365,7 +5365,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "anyhow",
  "askama",
@@ -5389,7 +5389,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "anyhow",
  "camino",
@@ -5399,7 +5399,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "quote",
  "syn 2.0.28",
@@ -5408,7 +5408,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5424,7 +5424,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "bincode",
  "camino",
@@ -5442,7 +5442,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5454,7 +5454,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "anyhow",
  "camino",
@@ -5468,7 +5468,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "anyhow",
  "uniffi_meta",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8#6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ thiserror = "1.0.38"
 tokio = { version = "1.24", default-features = false, features = ["sync"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-core = "0.1.30"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749" }
 vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "cedc9a08fdd8d0931ea778acf68c619a8298ee70" }
 zeroize = "1.6.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ thiserror = "1.0.38"
 tokio = { version = "1.24", default-features = false, features = ["sync"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-core = "0.1.30"
-uniffi = { git = "https://github.com/Hywan/uniffi-rs", rev = "9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b" }
-uniffi_bindgen = { git = "https://github.com/Hywan/uniffi-rs", rev = "9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "6bdfdceaf51fbfac9b41e0688fece6a4e384c3b8" }
 vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "cedc9a08fdd8d0931ea778acf68c619a8298ee70" }
 zeroize = "1.6.0"
 


### PR DESCRIPTION
This patch switches UniFFI from
https://github.com/mozilla/uniffi-rs/pull/1684 to
https://github.com/mozilla/uniffi-rs/pull/1697.

Tested by @ganfra, and it works.