### PR TITLE
Fix the `Room::is_encrypted` method

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -160,7 +160,7 @@ pub(crate) struct ClientInner {
     pub(crate) key_claim_lock: Mutex<()>,
     pub(crate) members_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
     /// Locks for requests on the encryption state of rooms.
-    pub(crate) encryption_state_request_locks: DashMap<OwnedRoomId, Arc<Mutex<()>>>,
+    pub(crate) encryption_state_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
     pub(crate) typing_notice_times: DashMap<OwnedRoomId, Instant>,
     /// Event handlers. See `add_event_handler`.
     pub(crate) event_handlers: EventHandlerStore,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -410,28 +410,22 @@ impl Room {
         }
     }
 
-    async fn request_encryption_state(&self) -> Result<Option<RoomEncryptionEventContent>> {
-        if let Some(mutex) = self
-            .client
-            .inner
-            .encryption_state_request_locks
-            .get(self.inner.room_id())
-            .map(|m| m.clone())
-        {
+    async fn request_encryption_state(&self) -> Result<()> {
+        let mut map = self.client.inner.encryption_state_request_locks.lock().await;
+
+        if let Some(mutex) = map.get(self.inner.room_id()).cloned() {
             // If a encryption state request is already going on, await the release of
             // the lock.
+            drop(map);
             _ = mutex.lock().await;
-
-            Ok(None)
         } else {
             let mutex = Arc::new(Mutex::new(()));
-            self.client
-                .inner
-                .encryption_state_request_locks
-                .insert(self.inner.room_id().to_owned(), mutex.clone());
+            map.insert(self.inner.room_id().to_owned(), mutex.clone());
 
             let _guard = mutex.lock().await;
+            drop(map);
 
+            // Request the event from the server.
             let request = get_state_events_for_key::v3::Request::new(
                 self.inner.room_id().to_owned(),
                 StateEventType::RoomEncryption,
@@ -446,19 +440,30 @@ impl Room {
             };
 
             let sync_lock = self.client.base_client().sync_lock().read().await;
+
+            // Persist the event and the fact that we requested it from the server in
+            // `RoomInfo`.
             let mut room_info = self.inner.clone_info();
             room_info.mark_encryption_state_synced();
             room_info.set_encryption_event(response.clone());
             let mut changes = StateChanges::default();
             changes.add_room(room_info.clone());
+
             self.client.store().save_changes(&changes).await?;
             self.update_summary(room_info);
+
+            // Alright, we're done, release the locks and let the client send an event to
+            // the room.
             drop(sync_lock);
-
-            self.client.inner.encryption_state_request_locks.remove(self.inner.room_id());
-
-            Ok(response)
+            self.client
+                .inner
+                .encryption_state_request_locks
+                .lock()
+                .await
+                .remove(self.inner.room_id());
         }
+
+        Ok(())
     }
 
     /// Check whether this room is encrypted. If the room encryption state is

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -467,11 +467,10 @@ impl Room {
     /// Returns true if the room is encrypted, otherwise false.
     pub async fn is_encrypted(&self) -> Result<bool> {
         if !self.is_encryption_state_synced() {
-            let encryption = self.request_encryption_state().await?;
-            Ok(encryption.is_some())
-        } else {
-            Ok(self.inner.is_encrypted())
+            self.request_encryption_state().await?;
         }
+
+        Ok(self.inner.is_encrypted())
     }
 
     fn are_events_visible(&self) -> bool {


### PR DESCRIPTION
This PR tackles some issues we had in our `Room::is_encrypted` method.

This PR closes: https://github.com/vector-im/crypto-internal/issues/135

Commit 1: Fixing `Room::is_encrypted` bug
We fix a bug in `Room::is_encrypted` that was messing up result. This result is
crucial to avoid the sending of unencrypted events in encrypted rooms.

Commit 2: Race-Free `Room::request_encryption_state`
We remove a minor race condition in Room::request_encryption_state. DashMap
caused issues when multiple calls stepped on each other. We switched things up
with a mutex and BTreeMap to keep things consistent.

Commit 3: Testing `Room::is_encrypted` behavior
We add a test to double-check `Room::is_encrypted` behaves now as expected.

Commit 4: Instrumenting `Room::send_raw`

The PR should be reviewed commit by commit.
