### PR TITLE
feat: query keys for newly sync'd members when sending encrypted message

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -12,6 +12,7 @@ use matrix_sdk_base::{
     store::StateStoreExt,
     RoomMemberships, StateChanges,
 };
+use matrix_sdk_common::timeout::timeout;
 use mime::Mime;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::{
@@ -1313,13 +1314,16 @@ impl Room {
     ///
     /// This method makes sure the room that was returned when joining a room
     /// has been echoed back in the sync.
+    ///
     /// Warning: This waits until a sync happens and does not return if no sync
-    /// is happening! It can also return early when the room is not a joined
-    /// room anymore!
+    /// is happening. It can also return early when the room is not a joined
+    /// room anymore.
     #[instrument(skip_all)]
     pub async fn sync_up(&self) {
         while !self.is_synced() && self.state() == RoomState::Joined {
-            self.client.inner.sync_beat.listen().wait_timeout(Duration::from_secs(1));
+            let wait_for_beat = self.client.inner.sync_beat.listen();
+            // We don't care whether it's a timeout or a sync beat.
+            let _ = timeout(wait_for_beat, Duration::from_millis(1000)).await;
         }
     }
 

--- a/testing/matrix-sdk-integration-testing/assets/ci-start.sh
+++ b/testing/matrix-sdk-integration-testing/assets/ci-start.sh
@@ -4,6 +4,8 @@ export SYNAPSE_SERVER_NAME=matrix-sdk.rs
 export SYNAPSE_REPORT_STATS=no
 echo " ====== Generating config  ====== "
 /start.py generate
+
+# Courtesy of https://github.com/michaelkaye/setup-matrix-synapse/blob/e2067245b5265640f94d310fc79a1d388cc70452/create.js#L99
 echo " ====== Patching for CI  ====== "
 echo """
 enable_registration: true
@@ -16,9 +18,31 @@ rc_message:
 rc_registration:
  per_second: 1000
  burst_count: 1000
- 
+
+rc_login:
+ address:
+  per_second: 1000
+  burst_count: 1000
+ account:
+  per_second: 1000
+  burst_count: 1000
+ failed_attempts:
+  per_second: 1000
+  burst_count: 1000
+
+rc_admin_redaction:
+  per_second: 1000
+  burst_count: 1000
+
 rc_joins:
  local:
+  per_second: 1000
+  burst_count: 1000
+ remote:
+  per_second: 1000
+  burst_count: 1000
+
+rc_3pid_validation:
   per_second: 1000
   burst_count: 1000
 
@@ -32,18 +56,6 @@ rc_invites:
  per_issuer:
   per_second: 1000
   burst_count: 1000
-
-rc_login:
- address:
-   per_second: 1000
-   burst_count: 1000
-#  account:
-#    per_second: 0.17
-#    burst_count: 3
-#  failed_attempts:
-#    per_second: 0.17
-#    burst_count: 3
-
 """ >>  /data/homeserver.yaml
 
 echo " ====== Starting server with:  ====== "

--- a/testing/matrix-sdk-integration-testing/assets/docker-compose.yml
+++ b/testing/matrix-sdk-integration-testing/assets/docker-compose.yml
@@ -2,7 +2,6 @@
 version: '3'
 
 services:
-
   synapse:
     build: .
     restart: "no"
@@ -10,7 +9,6 @@ services:
       disable: true
     volumes:
       - matrix-rust-sdk-ci-data:/data
-      
     ports:
       - 8228:8008/tcp
 

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, option_env};
+use std::{collections::HashMap, ops::Deref, option_env, sync::Mutex as StdMutex, time::Duration};
 
 use anyhow::Result;
 use assign::assign;
 use matrix_sdk::{
-    config::RequestConfig,
+    config::{RequestConfig, SyncSettings},
     ruma::api::client::{account::register::v3::Request as RegistrationRequest, uiaa},
     Client,
 };
@@ -73,4 +73,38 @@ pub async fn get_client_for_user(username: String, use_sqlite_store: bool) -> Re
     users.insert(username, (client.clone(), tmp_dir)); // keeping temp dir around so it doesn't get destroyed yet
 
     Ok(client)
+}
+
+/// Client that correctly maintains and propagates sync token values.
+pub struct SyncTokenAwareClient {
+    client: Client,
+    token: StdMutex<Option<String>>,
+}
+
+impl SyncTokenAwareClient {
+    pub async fn sync_once(&self) -> Result<()> {
+        let mut settings = SyncSettings::default().timeout(Duration::from_secs(1));
+
+        let token = { self.token.lock().unwrap().clone() };
+        if let Some(token) = token {
+            settings = settings.token(token);
+        }
+
+        let response = self.client.sync_once(settings).await?;
+        *self.token.lock().unwrap() = Some(response.next_batch);
+        Ok(())
+    }
+}
+
+impl Deref for SyncTokenAwareClient {
+    type Target = Client;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+pub async fn get_sync_aware_client_for_user(username: String) -> Result<SyncTokenAwareClient> {
+    let client = get_client_for_user(username, true).await?;
+    Ok(SyncTokenAwareClient { client, token: None.into() })
 }

--- a/testing/matrix-sdk-integration-testing/src/tests.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests.rs
@@ -1,3 +1,4 @@
+mod e2ee;
 mod invitations;
 mod reactions;
 mod redaction;

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -1,0 +1,122 @@
+use std::{
+    ops::Deref,
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::Result;
+use assign::assign;
+use matrix_sdk::{
+    config::SyncSettings,
+    ruma::{
+        api::client::room::create_room::v3::Request as CreateRoomRequest,
+        events::room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
+    },
+    Client,
+};
+use tracing::warn;
+
+use crate::helpers::get_client_for_user;
+
+struct SyncAwareClient {
+    client: Client,
+    token: Mutex<Option<String>>,
+}
+
+impl SyncAwareClient {
+    async fn sync_once(&self) -> Result<()> {
+        let mut settings = SyncSettings::default().timeout(Duration::from_secs(1));
+
+        let token = { self.token.lock().unwrap().clone() };
+        if let Some(token) = token {
+            settings = settings.token(token);
+        }
+
+        let response = self.client.sync_once(settings).await?;
+        *self.token.lock().unwrap() = Some(response.next_batch);
+        Ok(())
+    }
+}
+
+impl Deref for SyncAwareClient {
+    type Target = Client;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+async fn get_sync_aware_client_for_user(username: String) -> Result<SyncAwareClient> {
+    let client = get_client_for_user(username, true).await?;
+    Ok(SyncAwareClient { client, token: None.into() })
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_encryption_missing_member_keys() -> Result<()> {
+    let time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+    let alice = get_sync_aware_client_for_user(format!("alice{time}")).await?;
+    let bob = get_sync_aware_client_for_user(format!("bob{time}")).await?;
+
+    let invite = vec![bob.user_id().unwrap().to_owned()];
+    let request = assign!(CreateRoomRequest::new(), {
+        invite,
+        is_direct: true,
+    });
+
+    let alice_room = alice.create_room(request).await?;
+    alice_room.enable_encryption().await?;
+    alice.sync_once().await?;
+
+    warn!("alice has created and enabled encryption in the room");
+
+    bob.sync_once().await?;
+    bob.get_room(alice_room.room_id()).unwrap().join().await?;
+    bob.sync_once().await?; // TODO poljar says this shouldn't be required, but it is in practice?
+
+    warn!("bob has joined");
+
+    // New person joins the room.
+    let carl = get_sync_aware_client_for_user(format!("carl{time}").to_owned()).await?;
+    alice_room.invite_user_by_id(carl.user_id().unwrap()).await?;
+
+    carl.sync_once().await?;
+    carl.get_room(alice_room.room_id()).unwrap().join().await?;
+    carl.sync_once().await?;
+
+    warn!("carl has joined");
+
+    // Bob sends message WITHOUT syncing.
+    warn!("bob sends message...");
+    let bob_room = bob.get_room(alice_room.room_id()).unwrap();
+    bob_room.send(RoomMessageEventContent::text_plain("Hello world!"), None).await?;
+    warn!("bob is done sending the message");
+
+    // All the other uses get to decrypt the message.
+    for user in [alice, carl] {
+        warn!("{} is looking for decrypted message", user.user_id().unwrap());
+
+        let found_event = Arc::new(Mutex::new(false));
+
+        let found_event_handler = found_event.clone();
+        user.add_event_handler(move |event: SyncRoomMessageEvent| {
+            warn!("Found a message \\o/ {:?}", event);
+            let found_event = found_event_handler.clone();
+            async move {
+                let MessageType::Text(text_content) = &event.as_original().unwrap().content.msgtype
+                else {
+                    return;
+                };
+                if text_content.body == "Hello world!" {
+                    *found_event.lock().unwrap() = true;
+                }
+            }
+        });
+
+        user.sync_once().await?;
+
+        let found = *found_event.lock().unwrap();
+        assert!(found, "event has not been found for {}", user.user_id().unwrap());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
When sending an encrypted message, we'll sync members of the room, if we never did that before. That means we might discover new accounts for which we don't have any encryption keys; in that case, we'd need to send the queries for missing users. This PR implements that.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2236
Fixes https://github.com/vector-im/element-x-ios/issues/1275