### PR TITLE
chore(ui): Improve error description for `Error::SlidingSync`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -384,7 +384,7 @@ fn configure_all_or_visible_rooms_list(
 #[derive(Debug, Error)]
 pub enum Error {
     /// Error from [`matrix_sdk::SlidingSync`].
-    #[error("SlidingSync failed")]
+    #[error("SlidingSync failed: {0}")]
     SlidingSync(SlidingSyncError),
 
     /// An operation has been requested on an unknown list.


### PR DESCRIPTION
`matrix_sdk_ui::room_list_service::Error` has a `SlidingSync` variant to report errors from `matrix_sdk::sliding_sync::Error` (to be more exact, from `matrix_sdk::Error::SlidingSync`).

This patch updates the error message from `SlidingSync failed` to `SlidingSync failed: <explanation>`, where `<explanation>` is the `Display` representation of the inner error.

It will help to provide more details to the end-user when looking at logs.