### PR TITLE
feat(bindings): OIDC in AuthenticationService.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3266,6 +3266,7 @@ dependencies = [
  "paranoid-android",
  "ruma",
  "sanitize-filename-reader-friendly",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -38,6 +38,7 @@ opentelemetry = { version = "0.20.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.13.0", features = ["tokio", "reqwest-client", "http-proto"] }
 ruma = { workspace = true, features = ["unstable-sanitize", "unstable-unspecified", "unstable-msc3488"] }
 sanitize-filename-reader-friendly = "2.2.1"
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
@@ -62,6 +63,7 @@ default-features = false
 features = [
     "anyhow",
     "e2e-encryption",
+    "experimental-oidc",
     "experimental-sliding-sync",
     "markdown",
     "rustls-tls", # note: differ from block below
@@ -75,6 +77,7 @@ default-features = false
 features = [
     "anyhow",
     "e2e-encryption",
+    "experimental-oidc",
     "experimental-sliding-sync",
     "markdown",
     "native-tls", # note: differ from block above

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -1,11 +1,31 @@
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::HashMap,
+    fs,
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
 
 use futures_util::future::join;
 use matrix_sdk::{
-    matrix_auth::{Session, SessionTokens},
-    ruma::{IdParseError, OwnedDeviceId, UserId},
-    SessionMeta,
+    oidc::{
+        types::{
+            client_credentials::ClientCredentials,
+            iana::oauth::OAuthClientAuthenticationMethod,
+            oidc::ApplicationType,
+            registration::{ClientMetadata, Localized, VerifiedClientMetadata},
+            requests::GrantType,
+        },
+        AuthorizationCode, AuthorizationResponse, Oidc, OidcError, RegisteredClientData,
+    },
+    AuthSession,
 };
+use ruma::{
+    api::client::discovery::discover_homeserver::AuthenticationServerInfo, IdParseError,
+    OwnedUserId,
+};
+use serde::{Deserialize, Serialize};
 use url::Url;
 use zeroize::Zeroize;
 
@@ -19,6 +39,7 @@ pub struct AuthenticationService {
     user_agent: Option<String>,
     client: RwLock<Option<Arc<Client>>>,
     homeserver_details: RwLock<Option<Arc<HomeserverLoginDetails>>>,
+    oidc_configuration: Option<OidcConfiguration>,
     custom_sliding_sync_proxy: RwLock<Option<String>>,
 }
 
@@ -35,10 +56,26 @@ pub enum AuthenticationError {
     ClientMissing,
     #[error("{message}")]
     InvalidServerName { message: String },
-    #[error("The homeserver doesn't provide a trusted a sliding sync proxy in its well-known configuration.")]
+    #[error("The homeserver doesn't provide a trusted sliding sync proxy in its well-known configuration.")]
     SlidingSyncNotAvailable,
     #[error("Login was successful but is missing a valid Session to configure the file store.")]
     SessionMissing,
+    #[error("Failed to use the supplied base path.")]
+    InvalidBasePath,
+    #[error(
+        "The homeserver doesn't provide an authentication issuer in its well-known configuration."
+    )]
+    OidcNotSupported,
+    #[error("Unable to use OIDC as no client metadata has been supplied.")]
+    OidcMetadataMissing,
+    #[error("Unable to use OIDC as the supplied client metadata is invalid.")]
+    OidcMetadataInvalid,
+    #[error("The supplied callback URL used to complete OIDC is invalid.")]
+    OidcCallbackUrlInvalid,
+    #[error("The OIDC login was cancelled by the user.")]
+    OidcCancelled,
+    #[error("An error occurred with OIDC: {message}")]
+    OidcError { message: String },
     #[error("An error occurred: {message}")]
     Generic { message: String },
 }
@@ -55,10 +92,120 @@ impl From<IdParseError> for AuthenticationError {
     }
 }
 
+impl From<OidcError> for AuthenticationError {
+    fn from(e: OidcError) -> AuthenticationError {
+        AuthenticationError::OidcError { message: e.to_string() }
+    }
+}
+
+/// The configuration to use when authenticating with OIDC.
+#[derive(uniffi::Record)]
+pub struct OidcConfiguration {
+    /// The name of the client that will be shown during OIDC authentication.
+    pub client_name: String,
+    /// The redirect URI that will be used when OIDC authentication is
+    /// successful.
+    pub redirect_uri: String,
+    /// A URI that contains information about the client.
+    pub client_uri: String,
+    /// A URI that contains the client's terms of service.
+    pub tos_uri: String,
+    /// A URI that contains the client's privacy policy.
+    pub policy_uri: String,
+
+    /// Pre-configured registrations for use with issuers that don't support
+    /// dynamic client registration.
+    pub static_registrations: HashMap<String, String>,
+}
+
+/// The data needed to restore an OpenID Connect session.
+#[derive(Debug, Serialize, Deserialize)]
+struct OidcRegistrations {
+    /// The URL of the OIDC Provider.
+    file_path: PathBuf,
+    /// Pre-configured registrations for use with issuers that don't support
+    /// dynamic client registration.
+    static_registrations: HashMap<String, String>,
+}
+
+/// Manages the storage of OIDC registrations.
+impl OidcRegistrations {
+    fn new(
+        base_path: &str,
+        static_registrations: HashMap<String, String>,
+    ) -> Result<Self, AuthenticationError> {
+        let oidc_directory = PathBuf::from(base_path).join("oidc");
+        fs::create_dir_all(&oidc_directory).map_err(|_| AuthenticationError::InvalidBasePath)?;
+
+        Ok(OidcRegistrations {
+            file_path: oidc_directory.join("registrations.json"),
+            static_registrations,
+        })
+    }
+
+    /// Returns all of the registrations this client has made as a HashMap of
+    /// issuer URL (as a string) to client ID (as a string).
+    fn dynamic_registrations(&self) -> HashMap<String, String> {
+        let Some(file) = File::open(&self.file_path).ok() else {
+            return HashMap::new();
+        };
+        let reader = BufReader::new(file);
+
+        let Some(registrations): Option<HashMap<String, String>> =
+            serde_json::from_reader(reader).ok()
+        else {
+            return HashMap::new();
+        };
+
+        registrations
+    }
+
+    /// Returns the client ID registered for a particular issuer or None if a
+    /// registration hasn't been made.
+    fn client_id(&self, issuer: String) -> Option<String> {
+        let mut registrations = self.dynamic_registrations();
+        registrations.extend(self.static_registrations.clone());
+        registrations.get(&issuer).cloned()
+    }
+
+    /// Stores a new client ID registration for a particular issuer. If a client
+    /// ID has already been stored, this will overwrite the old value.
+    fn set_client_id(&self, client_id: String, issuer: String) -> Result<(), AuthenticationError> {
+        let mut current = self.dynamic_registrations();
+        current.insert(issuer, client_id);
+
+        let writer = BufWriter::new(
+            File::create(&self.file_path).map_err(|_| AuthenticationError::InvalidBasePath)?,
+        );
+        serde_json::to_writer(writer, &current).map_err(|_| AuthenticationError::InvalidBasePath)
+    }
+}
+
+/// The data required to authenticate against an OIDC server.
+#[derive(uniffi::Object)]
+pub struct OidcAuthenticationData {
+    /// The underlying URL for authentication. Additional parameters may be
+    /// needed. Call `login_url()` to get the URL to be loaded in a web view.
+    url: Url,
+    /// A unique identifier for the request, used to ensure the response
+    /// originated from the authentication issuer.
+    state: String,
+}
+
+#[uniffi::export]
+impl OidcAuthenticationData {
+    /// The login URL to use for authentication.
+    pub fn login_url(&self) -> String {
+        let mut prompt_url = self.url.clone();
+        prompt_url.query_pairs_mut().append_pair("prompt", "consent");
+        prompt_url.to_string()
+    }
+}
+
 #[derive(uniffi::Object)]
 pub struct HomeserverLoginDetails {
     url: String,
-    authentication_issuer: Option<String>,
+    supports_oidc_login: bool,
     supports_password_login: bool,
 }
 
@@ -69,10 +216,9 @@ impl HomeserverLoginDetails {
         self.url.clone()
     }
 
-    /// The OIDC Provider that is trusted by the homeserver. `None` when
-    /// not configured.
-    pub fn authentication_issuer(&self) -> Option<String> {
-        self.authentication_issuer.clone()
+    /// Whether the current homeserver supports login using OIDC.
+    pub fn supports_oidc_login(&self) -> bool {
+        self.supports_oidc_login
     }
 
     /// Whether the current homeserver supports the password login flow.
@@ -89,6 +235,7 @@ impl AuthenticationService {
         base_path: String,
         passphrase: Option<String>,
         user_agent: Option<String>,
+        oidc_configuration: Option<OidcConfiguration>,
         custom_sliding_sync_proxy: Option<String>,
     ) -> Arc<Self> {
         Arc::new(AuthenticationService {
@@ -97,6 +244,7 @@ impl AuthenticationService {
             user_agent,
             client: RwLock::new(None),
             homeserver_details: RwLock::new(None),
+            oidc_configuration,
             custom_sliding_sync_proxy: RwLock::new(custom_sliding_sync_proxy),
         })
     }
@@ -183,80 +331,94 @@ impl AuthenticationService {
             ClientError::Generic { msg } => AuthenticationError::Generic { message: msg },
         })?;
         let whoami = client.whoami()?;
-
-        // Create a new client to setup the store path now the user ID is known.
-        let homeserver_url = client.homeserver();
         let session =
             client.inner.matrix_auth().session().ok_or(AuthenticationError::SessionMissing)?;
 
-        let sliding_sync_proxy: Option<String>;
-        if let Some(custom_proxy) = self.custom_sliding_sync_proxy.read().unwrap().clone() {
-            sliding_sync_proxy = Some(custom_proxy);
-        } else if let Some(discovered_proxy) = client.discovered_sliding_sync_proxy() {
-            sliding_sync_proxy = Some(discovered_proxy.to_string());
-        } else {
-            sliding_sync_proxy = None;
-        }
-
-        let client = self
-            .new_client_builder()
-            .passphrase(self.passphrase.clone())
-            .homeserver_url(homeserver_url)
-            .sliding_sync_proxy(sliding_sync_proxy)
-            .username(whoami.user_id.to_string())
-            .build_inner()?;
-
-        // Restore the client using the session from the login request.
-        client.restore_session_inner(session)?;
-        Ok(client)
+        self.finalize_client(client, session, whoami.user_id)
     }
 
-    /// Restore an existing session on the current homeserver using an access
-    /// token issued by an authentication server.
-    /// # Arguments
-    ///
-    /// * `token` - The access token issued by the authentication server.
-    ///
-    /// * `device_id` - The device ID that the access token was scoped for.
-    pub fn restore_with_access_token(
+    /// Requests the URL needed for login in a web view using OIDC. Once the web
+    /// view has succeeded, call `login_with_oidc_callback` with the callback it
+    /// returns.
+    pub fn url_for_oidc_login(&self) -> Result<Arc<OidcAuthenticationData>, AuthenticationError> {
+        let Some(client) = self.client.read().unwrap().clone() else {
+            return Err(AuthenticationError::ClientMissing);
+        };
+
+        let Some(authentication_server) = client.authentication_server() else {
+            return Err(AuthenticationError::OidcNotSupported);
+        };
+
+        let Some(oidc_configuration) = &self.oidc_configuration else {
+            return Err(AuthenticationError::OidcMetadataMissing);
+        };
+
+        let redirect_url = Url::parse(&oidc_configuration.redirect_uri)
+            .map_err(|_e| AuthenticationError::OidcMetadataInvalid)?;
+
+        let oidc = client.inner.oidc();
+
+        RUNTIME.block_on(async {
+            self.configure_oidc(&oidc, authentication_server, oidc_configuration).await?;
+
+            let data = oidc.login(redirect_url, None)?.build().await?;
+
+            Ok(Arc::new(OidcAuthenticationData { url: data.url, state: data.state }))
+        })
+    }
+
+    /// Completes the OIDC login process.
+    pub fn login_with_oidc_callback(
         &self,
-        token: String,
-        device_id: String,
+        authentication_data: Arc<OidcAuthenticationData>,
+        callback_url: String,
     ) -> Result<Arc<Client>, AuthenticationError> {
         let Some(client) = self.client.read().unwrap().clone() else {
             return Err(AuthenticationError::ClientMissing);
         };
 
-        // Restore the client and ask the server for the full user ID as this
-        // could be different from the username that was entered.
-        let discovery_user_id = UserId::parse("@unknown:unknown")
-            .map_err(|e| AuthenticationError::Generic { message: e.to_string() })?;
-        let device_id: OwnedDeviceId = device_id.as_str().into();
+        let oidc = client.inner.oidc();
 
-        let discovery_session = Session {
-            meta: SessionMeta { user_id: discovery_user_id, device_id: device_id.clone() },
-            tokens: SessionTokens { access_token: token.clone(), refresh_token: None },
+        let url =
+            Url::parse(&callback_url).map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
+
+        let response = AuthorizationResponse::parse_uri(&url)
+            .map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
+
+        let code = match response {
+            AuthorizationResponse::Success(code) => code,
+            AuthorizationResponse::Error(err) => {
+                // TODO: This doesn't work, cancel doesn't include a description it seems.
+                let Some(error) = err.error.error_description else {
+                    return Err(AuthenticationError::OidcCallbackUrlInvalid);
+                };
+                if error == "access_denied" {
+                    return Err(AuthenticationError::OidcCancelled);
+                }
+                return Err(AuthenticationError::OidcError { message: error.to_string() });
+            }
         };
 
-        client.restore_session_inner(discovery_session)?;
-        let whoami = client.whoami()?;
-
-        // Create the actual client with a store path from the user ID.
-        let homeserver_url = client.homeserver();
-        let session = Session {
-            meta: SessionMeta { user_id: whoami.user_id.clone(), device_id },
-            tokens: SessionTokens { access_token: token, refresh_token: None },
+        if code.state != authentication_data.state {
+            return Err(AuthenticationError::OidcCallbackUrlInvalid);
         };
-        let client = self
-            .new_client_builder()
-            .passphrase(self.passphrase.clone())
-            .homeserver_url(homeserver_url)
-            .username(whoami.user_id.to_string())
-            .build_inner()?;
 
-        // Restore the client using the session.
-        client.restore_session_inner(session)?;
-        Ok(client)
+        RUNTIME.block_on(async move {
+            oidc.finish_authorization(AuthorizationCode {
+                code: code.code,
+                state: code.state.to_string(),
+            })
+            .await?;
+
+            oidc.finish_login()
+                .await
+                .map_err(|e| AuthenticationError::OidcError { message: e.to_string() })
+        })?;
+
+        let user_id = client.inner.user_id().unwrap().to_owned();
+        let session =
+            client.inner.oidc().full_session().ok_or(AuthenticationError::SessionMissing)?;
+        self.finalize_client(client, session, user_id)
     }
 }
 
@@ -281,9 +443,174 @@ impl AuthenticationService {
         let login_details = join(client.async_homeserver(), client.supports_password_login()).await;
 
         let url = login_details.0;
-        let supports_password_login = login_details.1?;
-        let authentication_issuer = client.authentication_issuer();
+        let supports_oidc_login = client.authentication_server().is_some();
+        let supports_password_login = login_details.1.ok().unwrap_or(false);
 
-        Ok(HomeserverLoginDetails { url, authentication_issuer, supports_password_login })
+        Ok(HomeserverLoginDetails { url, supports_oidc_login, supports_password_login })
+    }
+
+    /// Handle any necessary configuration in order for login via OIDC to
+    /// succeed. This includes performing dynamic client registration against
+    /// the homeserver's issuer or restoring a previous registration if one has
+    /// been stored.
+    async fn configure_oidc(
+        &self,
+        oidc: &Oidc,
+        authentication_server: AuthenticationServerInfo,
+        configuration: &OidcConfiguration,
+    ) -> Result<(), AuthenticationError> {
+        if oidc.client_credentials().is_some() {
+            tracing::info!("OIDC is already configured.");
+            return Ok(());
+        };
+
+        let oidc_metadata = self.oidc_metadata(configuration)?;
+
+        if self.load_client_registration(oidc, oidc_metadata.clone()).await {
+            tracing::info!("OIDC configuration loaded from disk.");
+            return Ok(());
+        }
+
+        tracing::info!("Registering this client for OIDC.");
+        let registration_response = oidc
+            .register_client(&authentication_server.issuer, oidc_metadata.clone(), None)
+            .await?;
+
+        let client_data = RegisteredClientData {
+            // The format of the credentials changes according to the client metadata that was sent.
+            // Public clients only get a client ID.
+            credentials: ClientCredentials::None {
+                client_id: registration_response.client_id.clone(),
+            },
+            metadata: oidc_metadata,
+        };
+        oidc.restore_registered_client(authentication_server, client_data).await;
+
+        tracing::info!("Persisting OIDC registration data.");
+        self.store_client_registration(oidc).await?;
+
+        Ok(())
+    }
+
+    /// Stores the current OIDC dynamic client registration so it can be re-used
+    /// if we ever log in via the same issuer again.
+    async fn store_client_registration(&self, oidc: &Oidc) -> Result<(), AuthenticationError> {
+        let issuer = oidc.issuer().ok_or(AuthenticationError::OidcNotSupported)?;
+        let client_id = oidc
+            .client_credentials()
+            .ok_or(AuthenticationError::OidcError {
+                message: String::from("Missing client registration."),
+            })?
+            .client_id()
+            .to_owned();
+
+        let registrations = OidcRegistrations::new(
+            &self.base_path,
+            self.oidc_configuration
+                .as_ref()
+                .map(|c| c.static_registrations.clone())
+                .unwrap_or_default(),
+        )?;
+        registrations.set_client_id(client_id, issuer.to_owned())?;
+
+        Ok(())
+    }
+
+    /// Attempts to load an existing OIDC dynamic client registration for the
+    /// currently configured issuer.
+    async fn load_client_registration(
+        &self,
+        oidc: &Oidc,
+        oidc_metadata: VerifiedClientMetadata,
+    ) -> bool {
+        let Some(issuer) = oidc.issuer() else {
+            return false;
+        };
+        let Some(registrations) = OidcRegistrations::new(
+            &self.base_path,
+            self.oidc_configuration
+                .as_ref()
+                .map(|c| c.static_registrations.clone())
+                .unwrap_or_default(),
+        )
+        .ok() else {
+            return false;
+        };
+        let Some(client_id) = registrations.client_id(issuer.to_owned()) else {
+            return false;
+        };
+
+        let client_data = RegisteredClientData {
+            credentials: ClientCredentials::None { client_id: client_id.clone() },
+            metadata: oidc_metadata,
+        };
+
+        let authentication_server = AuthenticationServerInfo::new(issuer.to_owned(), None);
+        oidc.restore_registered_client(authentication_server, client_data).await;
+
+        true
+    }
+
+    /// Creates and verifies OIDC client metadata for the supplied OIDC
+    /// configuration.
+    fn oidc_metadata(
+        &self,
+        configuration: &OidcConfiguration,
+    ) -> Result<VerifiedClientMetadata, AuthenticationError> {
+        let redirect_uri = Url::parse(&configuration.redirect_uri)
+            .map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
+        let client_name = Some(Localized::new(configuration.client_name.to_owned(), []));
+        let client_uri = Url::parse(&configuration.client_uri).ok().map(|u| Localized::new(u, []));
+        let policy_uri = Url::parse(&configuration.policy_uri).ok().map(|u| Localized::new(u, []));
+        let tos_uri = Url::parse(&configuration.tos_uri).ok().map(|u| Localized::new(u, []));
+
+        ClientMetadata {
+            application_type: Some(ApplicationType::Native),
+            redirect_uris: Some(vec![redirect_uri]),
+            grant_types: Some(vec![GrantType::RefreshToken, GrantType::AuthorizationCode]),
+            // A native client shouldn't use authentication as the credentials could be intercepted.
+            token_endpoint_auth_method: Some(OAuthClientAuthenticationMethod::None),
+            // The server should display the following fields when getting the user's consent.
+            client_name,
+            contacts: None,
+            client_uri,
+            policy_uri,
+            tos_uri,
+            ..Default::default()
+        }
+        .validate()
+        .map_err(|_| AuthenticationError::OidcMetadataInvalid)
+    }
+
+    /// Creates a new client to setup the store path now the user ID is known.
+    fn finalize_client(
+        &self,
+        client: Arc<Client>,
+        session: impl Into<AuthSession>,
+        user_id: OwnedUserId,
+    ) -> Result<Arc<Client>, AuthenticationError> {
+        let homeserver_url = client.homeserver();
+
+        let sliding_sync_proxy: Option<String>;
+        if let Some(custom_proxy) = self.custom_sliding_sync_proxy.read().unwrap().clone() {
+            sliding_sync_proxy = Some(custom_proxy);
+        } else if let Some(discovered_proxy) = client.discovered_sliding_sync_proxy() {
+            sliding_sync_proxy = Some(discovered_proxy.to_string());
+        } else {
+            sliding_sync_proxy = None;
+        }
+
+        let client = self
+            .new_client_builder()
+            .passphrase(self.passphrase.clone())
+            .homeserver_url(homeserver_url)
+            .sliding_sync_proxy(sliding_sync_proxy)
+            .username(user_id.to_string())
+            .build_inner()?;
+
+        // Restore the client using the session from the login request.
+        client.restore_session_inner(session)?;
+
+        Ok(client)
     }
 }

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -360,17 +360,8 @@ impl AuthenticationService {
             self.configure_oidc(&oidc, authentication_server, oidc_configuration).await?;
 
             let mut data_builder = oidc.login(redirect_url, None)?;
-
-            if let Ok(provider_metadata) = oidc.provider_metadata().await {
-                if provider_metadata
-                    .prompt_values_supported
-                    .as_ref()
-                    .is_some_and(|p| p.contains(&Prompt::Consent))
-                {
-                    data_builder = data_builder.prompt(vec![Prompt::Consent]);
-                }
-            }
-
+            // TODO: Add a check for the Consent prompt when MAS is updated.
+            data_builder = data_builder.prompt(vec![Prompt::Consent]);
             let data = data_builder.build().await?;
 
             Ok(Arc::new(OidcAuthenticationData { url: data.url, state: data.state }))

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -420,6 +420,10 @@ impl Client {
         })
     }
 
+    pub fn account_url(&self) -> Option<String> {
+        self.authentication_server().and_then(|a| a.account)
+    }
+
     pub fn user_id(&self) -> Result<String, ClientError> {
         let user_id = self.inner.user_id().context("No User ID found")?;
         Ok(user_id.to_string())

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -3,6 +3,15 @@ use std::sync::{Arc, RwLock};
 use anyhow::{anyhow, Context};
 use matrix_sdk::{
     media::{MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSize},
+    oidc::{
+        types::{
+            client_credentials::ClientCredentials,
+            registration::{
+                ClientMetadata, ClientMetadataVerificationError, VerifiedClientMetadata,
+            },
+        },
+        FullSession, RegisteredClientData,
+    },
     ruma::{
         api::client::{
             account::whoami,
@@ -21,9 +30,13 @@ use matrix_sdk::{
         serde::Raw,
         EventEncryptionAlgorithm, TransactionId, UInt, UserId,
     },
-    Client as MatrixClient,
+    AuthApi, AuthSession, Client as MatrixClient, SessionChange,
 };
-use ruma::push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat};
+use ruma::{
+    api::client::discovery::discover_homeserver::AuthenticationServerInfo,
+    push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat},
+};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, error};
@@ -98,6 +111,7 @@ impl From<PushFormat> for RumaPushFormat {
 #[uniffi::export(callback_interface)]
 pub trait ClientDelegate: Sync + Send {
     fn did_receive_auth_error(&self, is_soft_logout: bool);
+    fn did_refresh_tokens(&self);
 }
 
 #[uniffi::export(callback_interface)]
@@ -152,12 +166,12 @@ impl Client {
             session_verification_controller,
         };
 
-        let mut unknown_token_error_receiver = client.inner.subscribe_to_unknown_token_errors();
+        let mut session_change_receiver = client.inner.subscribe_to_session_changes();
         let client_clone = client.clone();
         RUNTIME.spawn(async move {
             loop {
-                match unknown_token_error_receiver.recv().await {
-                    Ok(unknown_token) => client_clone.process_unknown_token_error(unknown_token),
+                match session_change_receiver.recv().await {
+                    Ok(session_change) => client_clone.process_session_change(session_change),
                     Err(receive_error) => {
                         if let RecvError::Closed = receive_error {
                             break;
@@ -229,18 +243,51 @@ impl Client {
             user_id,
             device_id,
             homeserver_url: _,
+            oidc_data,
             sliding_sync_proxy,
         } = session;
 
-        let session = matrix_sdk::matrix_auth::Session {
-            meta: matrix_sdk::SessionMeta {
-                user_id: user_id.try_into()?,
-                device_id: device_id.into(),
-            },
-            tokens: matrix_sdk::matrix_auth::SessionTokens { access_token, refresh_token },
-        };
+        if let Some(oidc_data) = oidc_data {
+            // Restore using an OIDC FullSession.
+            let oidc_data = serde_json::from_str::<OidcUnvalidatedSessionData>(&oidc_data)?
+                .validate()
+                .context("OIDC metadata validation failed.")?;
+            let latest_id_token = oidc_data.latest_id_token.and_then(|s| s.try_into().ok());
 
-        self.restore_session_inner(session)?;
+            let user_session = matrix_sdk::oidc::UserSession {
+                meta: matrix_sdk::SessionMeta {
+                    user_id: user_id.try_into()?,
+                    device_id: device_id.into(),
+                },
+                tokens: matrix_sdk::oidc::SessionTokens {
+                    access_token,
+                    refresh_token,
+                    latest_id_token,
+                },
+                issuer_info: oidc_data.issuer_info,
+            };
+
+            let session = FullSession {
+                client: RegisteredClientData {
+                    credentials: ClientCredentials::None { client_id: oidc_data.client_id },
+                    metadata: oidc_data.client_metadata,
+                },
+                user: user_session,
+            };
+
+            self.restore_session_inner(session)?;
+        } else {
+            // Restore using a regular Matrix Session.
+            let session = matrix_sdk::matrix_auth::Session {
+                meta: matrix_sdk::SessionMeta {
+                    user_id: user_id.try_into()?,
+                    device_id: device_id.into(),
+                },
+                tokens: matrix_sdk::matrix_auth::SessionTokens { access_token, refresh_token },
+            };
+
+            self.restore_session_inner(session)?;
+        }
 
         if let Some(sliding_sync_proxy) = sliding_sync_proxy {
             let sliding_sync_proxy = Url::parse(&sliding_sync_proxy)
@@ -254,10 +301,10 @@ impl Client {
 }
 
 impl Client {
-    /// Restores the client from a `matrix_sdk::matrix_auth::Session`.
+    /// Restores the client from an `AuthSession`.
     pub(crate) fn restore_session_inner(
         &self,
-        session: matrix_sdk::matrix_auth::Session,
+        session: impl Into<AuthSession>,
     ) -> anyhow::Result<()> {
         RUNTIME.block_on(async move {
             self.inner.restore_session(session).await?;
@@ -271,8 +318,8 @@ impl Client {
 
     /// The OIDC Provider that is trusted by the homeserver. `None` when
     /// not configured.
-    pub(crate) fn authentication_issuer(&self) -> Option<String> {
-        self.inner.authentication_server_info().map(|i| i.issuer.clone())
+    pub(crate) fn authentication_server(&self) -> Option<AuthenticationServerInfo> {
+        self.inner.authentication_server_info().cloned()
     }
 
     /// The sliding sync proxy that is trusted by the homeserver. `None` when
@@ -306,22 +353,70 @@ impl Client {
 
     pub fn session(&self) -> Result<Session, ClientError> {
         RUNTIME.block_on(async move {
-            let matrix_sdk::matrix_auth::Session {
-                meta: matrix_sdk::SessionMeta { user_id, device_id },
-                tokens: matrix_sdk::matrix_auth::SessionTokens { access_token, refresh_token },
-            } = self.inner.matrix_auth().session().context("Missing session")?;
+            let auth_api = self.inner.auth_api().context("Missing authentication API")?;
+
             let homeserver_url = self.inner.homeserver().await.into();
             let sliding_sync_proxy =
                 self.discovered_sliding_sync_proxy().map(|url| url.to_string());
 
-            Ok(Session {
-                access_token,
-                refresh_token,
-                user_id: user_id.to_string(),
-                device_id: device_id.to_string(),
-                homeserver_url,
-                sliding_sync_proxy,
-            })
+            match auth_api {
+                // Build the session from the regular Matrix Auth Session.
+                AuthApi::Matrix(a) => {
+                    let matrix_sdk::matrix_auth::Session {
+                        meta: matrix_sdk::SessionMeta { user_id, device_id },
+                        tokens:
+                            matrix_sdk::matrix_auth::SessionTokens { access_token, refresh_token },
+                    } = a.session().context("Missing session")?;
+
+                    Ok(Session {
+                        access_token,
+                        refresh_token,
+                        user_id: user_id.to_string(),
+                        device_id: device_id.to_string(),
+                        homeserver_url,
+                        oidc_data: None,
+                        sliding_sync_proxy,
+                    })
+                }
+                // Build the session from the OIDC UserSession.
+                AuthApi::Oidc(api) => {
+                    let matrix_sdk::oidc::UserSession {
+                        meta: matrix_sdk::SessionMeta { user_id, device_id },
+                        tokens:
+                            matrix_sdk::oidc::SessionTokens {
+                                access_token,
+                                refresh_token,
+                                latest_id_token,
+                            },
+                        issuer_info,
+                    } = api.user_session().context("Missing session")?;
+                    let client_id = api
+                        .client_credentials()
+                        .context("OIDC client credentials are missing.")?
+                        .client_id()
+                        .to_owned();
+                    let client_metadata =
+                        api.client_metadata().context("OIDC client metadata is missing.")?.clone();
+                    let oidc_data = OidcSessionData {
+                        client_id,
+                        client_metadata,
+                        latest_id_token: latest_id_token.map(|t| t.to_string()),
+                        issuer_info,
+                    };
+
+                    let oidc_data = serde_json::to_string(&oidc_data).ok();
+                    Ok(Session {
+                        access_token,
+                        refresh_token,
+                        user_id: user_id.to_string(),
+                        device_id: device_id.to_string(),
+                        homeserver_url,
+                        oidc_data,
+                        sliding_sync_proxy,
+                    })
+                }
+                _ => Err(anyhow!("Unknown authentication API").into()),
+            }
         })
     }
 
@@ -495,7 +590,24 @@ impl Client {
 
     /// Log out the current user
     pub fn logout(&self) -> Result<(), ClientError> {
-        RUNTIME.block_on(self.inner.matrix_auth().logout())?;
+        let Some(auth_api) = self.inner.auth_api() else {
+            return Err(anyhow!("Missing authentication API").into());
+        };
+
+        match auth_api {
+            AuthApi::Matrix(a) => {
+                tracing::info!("Logging out via the homeserver.");
+                RUNTIME.block_on(a.logout())?;
+            }
+            AuthApi::Oidc(api) => {
+                tracing::info!("Logging out via OIDC.");
+                RUNTIME.block_on(api.logout())?;
+            }
+            _ => {
+                return Err(anyhow!("Unknown authentication API").into());
+            }
+        }
+
         Ok(())
     }
 
@@ -632,9 +744,16 @@ impl From<&search_users::v3::User> for UserProfile {
 }
 
 impl Client {
-    fn process_unknown_token_error(&self, unknown_token: matrix_sdk::UnknownToken) {
+    fn process_session_change(&self, session_change: SessionChange) {
         if let Some(delegate) = &*self.delegate.read().unwrap() {
-            delegate.did_receive_auth_error(unknown_token.soft_logout);
+            match session_change {
+                SessionChange::UnknownToken { soft_logout } => {
+                    delegate.did_receive_auth_error(soft_logout);
+                }
+                SessionChange::TokensRefreshed => {
+                    delegate.did_refresh_tokens();
+                }
+            }
         }
     }
 }
@@ -756,8 +875,45 @@ pub struct Session {
     pub device_id: String,
 
     // FFI-only fields (for now)
+    /// The URL for the homeserver used for this session.
     pub homeserver_url: String,
+    /// Additional data for this session session if OpenID Connect was used
+    /// for authentication.
+    pub oidc_data: Option<String>,
+    /// The URL for the sliding sync proxy used for this session.
     pub sliding_sync_proxy: Option<String>,
+}
+
+/// Represents a client registration against an OpenID Connect authentication
+/// issuer.
+#[derive(Serialize)]
+pub(crate) struct OidcSessionData {
+    client_id: String,
+    client_metadata: VerifiedClientMetadata,
+    latest_id_token: Option<String>,
+    issuer_info: AuthenticationServerInfo,
+}
+
+/// Represents an unverified client registration against an OpenID Connect
+/// authentication issuer. Call `validate` on this to use it for restoration.
+#[derive(Deserialize)]
+pub(crate) struct OidcUnvalidatedSessionData {
+    client_id: String,
+    client_metadata: ClientMetadata,
+    latest_id_token: Option<String>,
+    issuer_info: AuthenticationServerInfo,
+}
+
+impl OidcUnvalidatedSessionData {
+    /// Validates the data so that it can be used.
+    fn validate(self) -> Result<OidcSessionData, ClientMetadataVerificationError> {
+        Ok(OidcSessionData {
+            client_id: self.client_id,
+            client_metadata: self.client_metadata.validate()?,
+            latest_id_token: self.latest_id_token,
+            issuer_info: self.issuer_info,
+        })
+    }
 }
 
 #[uniffi::export]

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -316,9 +316,13 @@ impl Client {
         self.inner.homeserver().await.to_string()
     }
 
-    /// The OIDC Provider that is trusted by the homeserver. `None` when
-    /// not configured.
-    pub(crate) fn authentication_server(&self) -> Option<AuthenticationServerInfo> {
+    /// The homeserver's trusted OIDC Provider that was discovered in the
+    /// well-known.
+    ///
+    /// This will only be set if the homeserver supports authenticating via
+    /// OpenID Connect and this `Client` was constructed using auto-discovery by
+    /// setting the homeserver with [`ClientBuilder::server_name()`].
+    pub(crate) fn discovered_authentication_server(&self) -> Option<AuthenticationServerInfo> {
         self.inner.authentication_server_info().cloned()
     }
 
@@ -421,7 +425,7 @@ impl Client {
     }
 
     pub fn account_url(&self) -> Option<String> {
-        self.authentication_server().and_then(|a| a.account)
+        self.inner.oidc().account_management_url().unwrap_or(None).map(|url| url.to_string())
     }
 
     pub fn user_id(&self) -> Result<String, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -252,7 +252,11 @@ impl Client {
             let oidc_data = serde_json::from_str::<OidcUnvalidatedSessionData>(&oidc_data)?
                 .validate()
                 .context("OIDC metadata validation failed.")?;
-            let latest_id_token = oidc_data.latest_id_token.and_then(|s| s.try_into().ok());
+            let latest_id_token = oidc_data
+                .latest_id_token
+                .map(TryInto::try_into)
+                .transpose()
+                .context("OIDC latest_id_token is invalid.")?;
 
             let user_session = matrix_sdk::oidc::UserSession {
                 meta: matrix_sdk::SessionMeta {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -425,7 +425,7 @@ impl Client {
     }
 
     pub fn account_url(&self) -> Option<String> {
-        self.inner.oidc().account_management_url().unwrap_or(None).map(|url| url.to_string())
+        self.inner.oidc().account_management_url().ok().flatten().map(|url| url.to_string())
     }
 
     pub fn user_id(&self) -> Result<String, ClientError> {
@@ -891,8 +891,8 @@ pub struct Session {
     // FFI-only fields (for now)
     /// The URL for the homeserver used for this session.
     pub homeserver_url: String,
-    /// Additional data for this session session if OpenID Connect was used
-    /// for authentication.
+    /// Additional data for this session if OpenID Connect was used for
+    /// authentication.
     pub oidc_data: Option<String>,
     /// The URL for the sliding sync proxy used for this session.
     pub sliding_sync_proxy: Option<String>,

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -208,7 +208,7 @@ impl Default for ClientBuilder {
             sliding_sync_proxy: None,
             proxy: None,
             disable_ssl_verification: false,
-            inner: MatrixClient::builder(),
+            inner: MatrixClient::builder().handle_refresh_tokens(),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -32,6 +32,7 @@ pub struct ClientBuilder {
     sliding_sync_proxy: Option<String>,
     proxy: Option<String>,
     disable_ssl_verification: bool,
+    disable_automatic_token_refresh: bool,
     inner: MatrixClientBuilder,
 }
 
@@ -103,6 +104,12 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
+    pub fn disable_automatic_token_refresh(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.disable_automatic_token_refresh = true;
+        Arc::new(builder)
+    }
+
     pub fn build(self: Arc<Self>) -> Result<Arc<Client>, ClientError> {
         Ok(self.build_inner()?)
     }
@@ -157,6 +164,10 @@ impl ClientBuilder {
             inner_builder = inner_builder.disable_ssl_verification();
         }
 
+        if !builder.disable_automatic_token_refresh {
+            inner_builder = inner_builder.handle_refresh_tokens();
+        }
+
         if let Some(user_agent) = builder.user_agent {
             inner_builder = inner_builder.user_agent(user_agent);
         }
@@ -208,7 +219,8 @@ impl Default for ClientBuilder {
             sliding_sync_proxy: None,
             proxy: None,
             disable_ssl_verification: false,
-            inner: MatrixClient::builder().handle_refresh_tokens(),
+            disable_automatic_token_refresh: false,
+            inner: MatrixClient::builder(),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use matrix_sdk::{
-    self, encryption::CryptoStoreError, HttpError, IdParseError,
+    self, encryption::CryptoStoreError, oidc::OidcError, HttpError, IdParseError,
     NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
 use matrix_sdk_ui::{encryption_sync, notification_client, sync_service, timeline};
@@ -92,6 +92,12 @@ impl From<notification_client::Error> for ClientError {
 
 impl From<sync_service::Error> for ClientError {
     fn from(e: sync_service::Error) -> Self {
+        Self::new(e)
+    }
+}
+
+impl From<OidcError> for ClientError {
+    fn from(e: OidcError) -> Self {
         Self::new(e)
     }
 }

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::Debug,
     future::{Future, IntoFuture},
+    ops::Deref,
     pin::Pin,
 };
 
@@ -8,12 +9,22 @@ use cfg_vis::cfg_vis;
 use eyeball::SharedObservable;
 #[cfg(not(target_arch = "wasm32"))]
 use eyeball::Subscriber;
+use mas_oidc_client::{
+    error::{
+        Error as OidcClientError, ErrorBody as OidcErrorBody, HttpError as OidcHttpError,
+        TokenRefreshError, TokenRequestError,
+    },
+    requests::authorization_code::AuthorizationValidationData,
+    types::errors::ClientErrorCode,
+};
 use ruma::api::{client::error::ErrorKind, error::FromHttpResponseError, OutgoingRequest};
+use tracing::trace;
 
 use super::super::Client;
 use crate::{
     config::RequestConfig,
     error::{HttpError, HttpResult},
+    oidc::OidcError,
     RefreshTokenError, TransmissionProgress,
 };
 
@@ -69,26 +80,61 @@ where
                 Box::pin(client.send_inner(request.clone(), config, None, send_progress.clone()))
                     .await;
 
-            // If this is an `M_UNKNOWN_TOKEN` error and refresh token handling is active,
-            // try to refresh the token and retry the request.
-            if client.inner.handle_refresh_tokens {
-                if let Err(Some(ErrorKind::UnknownToken { .. })) =
-                    res.as_ref().map_err(HttpError::client_api_error_kind)
-                {
-                    if let Err(refresh_error) = client.refresh_access_token().await {
-                        match refresh_error {
-                            RefreshTokenError::RefreshTokenRequired => {
-                                // Refreshing access tokens is not supported by
-                                // this `Session`, ignore.
-                            }
-                            _ => {
-                                return Err(refresh_error.into());
-                            }
+            // An `M_UNKNOWN_TOKEN` error can potentially be fixed with a token refresh.
+            if let Err(Some(ErrorKind::UnknownToken { soft_logout })) =
+                res.as_ref().map_err(HttpError::client_api_error_kind)
+            {
+                trace!("Token refresh: Unknown token error received.");
+                // If automatic token refresh isn't supported, there is nothing more to do.
+                if !client.inner.handle_refresh_tokens {
+                    trace!("Token refresh: Automatic refresh disabled.");
+                    client.broadcast_unknown_token(soft_logout);
+                    return res;
+                }
+
+                // Try to refresh the token and retry the request.
+                if let Err(refresh_error) = client.refresh_access_token().await {
+                    match &refresh_error {
+                        RefreshTokenError::RefreshTokenRequired => {
+                            trace!("Token refresh: The session doesn't have a refresh token.");
+                            // Refreshing access tokens is not supported by this `Session`, ignore.
+                            client.broadcast_unknown_token(soft_logout);
                         }
-                    } else {
-                        return Box::pin(client.send_inner(request, config, None, send_progress))
-                            .await;
+                        RefreshTokenError::Oidc(oidc_error) => {
+                            let oidc_error = oidc_error.deref();
+                            match oidc_error {
+                                OidcError::Oidc(OidcClientError::TokenRefresh(
+                                    TokenRefreshError::Token(TokenRequestError::Http(
+                                        OidcHttpError {
+                                            body:
+                                                Some(OidcErrorBody {
+                                                    error: ClientErrorCode::InvalidGrant,
+                                                    ..
+                                                }),
+                                            ..
+                                        },
+                                    )),
+                                )) => {
+                                    trace!("Token refresh: OIDC refresh denied.");
+                                    // The refresh was denied, signal to sign out the user.
+                                    client.broadcast_unknown_token(soft_logout);
+                                }
+                                _ => {
+                                    trace!("Token refresh: OIDC refresh encountered a problem.");
+                                    // The refresh failed for other reasons, no
+                                    // need to sign out.
+                                }
+                            };
+                            return Err(refresh_error.into());
+                        }
+                        _ => {
+                            trace!("Token refresh: Token refresh failed.");
+                            return Err(refresh_error.into());
+                        }
                     }
+                } else {
+                    trace!("Token refresh: Refresh succeeded, retrying request.");
+                    return Box::pin(client.send_inner(request, config, None, send_progress)).await;
                 }
             }
 

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -1,7 +1,8 @@
+#[cfg(feature = "experimental-oidc")]
+use std::ops::Deref;
 use std::{
     fmt::Debug,
     future::{Future, IntoFuture},
-    ops::Deref,
     pin::Pin,
 };
 
@@ -9,22 +10,23 @@ use cfg_vis::cfg_vis;
 use eyeball::SharedObservable;
 #[cfg(not(target_arch = "wasm32"))]
 use eyeball::Subscriber;
+#[cfg(feature = "experimental-oidc")]
 use mas_oidc_client::{
     error::{
         Error as OidcClientError, ErrorBody as OidcErrorBody, HttpError as OidcHttpError,
         TokenRefreshError, TokenRequestError,
     },
-    requests::authorization_code::AuthorizationValidationData,
     types::errors::ClientErrorCode,
 };
 use ruma::api::{client::error::ErrorKind, error::FromHttpResponseError, OutgoingRequest};
 use tracing::trace;
 
 use super::super::Client;
+#[cfg(feature = "experimental-oidc")]
+use crate::oidc::OidcError;
 use crate::{
     config::RequestConfig,
     error::{HttpError, HttpResult},
-    oidc::OidcError,
     RefreshTokenError, TransmissionProgress,
 };
 
@@ -100,6 +102,7 @@ where
                             // Refreshing access tokens is not supported by this `Session`, ignore.
                             client.broadcast_unknown_token(soft_logout);
                         }
+                        #[cfg(feature = "experimental-oidc")]
                         RefreshTokenError::Oidc(oidc_error) => {
                             let oidc_error = oidc_error.deref();
                             match oidc_error {

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -132,6 +132,9 @@ where
                         }
                         _ => {
                             trace!("Token refresh: Token refresh failed.");
+                            // This isn't necessarily correct, but matches the behaviour when
+                            // implementing OIDC.
+                            client.broadcast_unknown_token(soft_logout);
                             return Err(refresh_error.into());
                         }
                     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -424,13 +424,17 @@ impl Client {
     /// The authentication server info discovered from the homeserver.
     ///
     /// This will only be set if the homeserver supports authenticating via
-    /// OpenID Connect ([MSC3861]) and this `Client` was constructed using
-    /// auto-discovery by setting the homeserver with
-    /// [`ClientBuilder::server_name()`].
+    /// OpenID Connect ([MSC3861]) and either this `Client` was constructed
+    /// using auto-discovery by setting the homeserver with
+    /// [`ClientBuilder::server_name()`] or it is authenticated using said
+    /// authentication server.
     ///
     /// [MSC3861]: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
     pub fn authentication_server_info(&self) -> Option<&AuthenticationServerInfo> {
-        self.inner.authentication_server_info.as_ref()
+        if let Some(discovered_server) = &self.inner.authentication_server_info {
+            return Some(discovered_server);
+        };
+        self.inner.auth_data.get().and_then(|d| d.as_oidc().map(|o| &o.issuer_info))
     }
 
     /// The sliding sync proxy that is trusted by the homeserver.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1371,6 +1371,9 @@ impl Client {
                     }
                     _ => {
                         trace!("Token refresh: Token refresh failed.");
+                        // This isn't necessarily correct, but matches the behaviour when
+                        // implementing OIDC.
+                        self.broadcast_unknown_token(soft_logout);
                         return Err(refresh_error.into());
                     }
                 }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -52,7 +52,7 @@ pub mod sliding_sync;
 pub mod encryption;
 pub use account::Account;
 pub use authentication::{AuthApi, AuthSession};
-pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, UnknownToken};
+pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, SessionChange};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;
 pub use error::{

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -42,6 +42,7 @@ use tracing::{debug, info, instrument};
 
 use crate::{
     authentication::AuthData,
+    client::SessionChange,
     config::RequestConfig,
     error::{HttpError, HttpResult},
     Client, Error, RefreshTokenError, Result,
@@ -473,7 +474,11 @@ impl MatrixAuth {
 
                     self.set_session_tokens(session_tokens);
 
-                    // TODO: Let ffi client to know that tokens have changed
+                    _ = self
+                        .client
+                        .inner
+                        .session_change_sender
+                        .send(SessionChange::TokensRefreshed);
 
                     Ok(Some(res))
                 }

--- a/crates/matrix-sdk/src/oidc/data_serde.rs
+++ b/crates/matrix-sdk/src/oidc/data_serde.rs
@@ -17,7 +17,7 @@ use serde::{de, ser::SerializeStruct, Deserialize, Serialize};
 use super::SessionTokens;
 
 impl Serialize for SessionTokens {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -741,7 +741,7 @@ impl Oidc {
         // Get the user ID.
         let whoami_res = self.client.whoami().await.map_err(crate::Error::from)?;
 
-        let session = matrix_sdk_base::SessionMeta {
+        let session = SessionMeta {
             user_id: whoami_res.user_id,
             device_id: whoami_res.device_id.ok_or(OidcError::MissingDeviceId)?,
         };

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -209,7 +209,7 @@ pub use self::{
     auth_code_builder::{OidcAuthCodeUrlBuilder, OidcAuthorizationData},
     end_session_builder::{OidcEndSessionData, OidcEndSessionUrlBuilder},
 };
-use crate::{authentication::AuthData, Client, RefreshTokenError, Result};
+use crate::{authentication::AuthData, client::SessionChange, Client, RefreshTokenError, Result};
 
 pub(crate) struct OidcAuthData {
     pub(crate) issuer_info: AuthenticationServerInfo,
@@ -929,6 +929,11 @@ impl Oidc {
             match self.refresh_access_token_inner(session_tokens, refresh_token).await {
                 Ok(response) => {
                     *guard = Ok(());
+                    _ = self
+                        .client
+                        .inner
+                        .session_change_sender
+                        .send(SessionChange::TokensRefreshed);
                     Ok(Some(response))
                 }
                 Err(error) => {


### PR DESCRIPTION
This PR builds on top of #1019 exposing OIDC to the bindings.

- The authentication service can be configured for OIDC (performing dynamic registration) and supports login via OIDC.
- The FFI client now converts `Session` to/from the OIDC Sessions when necessary.
- `UnknownToken` errors are now broadcast from the refresh logic depending on the errors encountered.
- `SessionChange`s are also broadcast to indicate that the app should update the session in whatever secure storage is being used.

Left todo in this PR:

- [x] Check if the account URL needs to be stored or is already part of the `Session` (for use later).
- [x] Detect cancellation from the WebView properly.
- [x] Return the URL for RP initiated sign out when calling `logout()`.
