### PR TITLE
fix(base): Detect left room in `SlidingSyncResponse`

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -229,7 +229,7 @@ impl BaseClient {
         ambiguity_cache: &mut AmbiguityCache,
         account_data: &AccountData,
     ) -> Result<(RoomInfo, Option<JoinedRoom>, Option<InvitedRoom>)> {
-        let required_state = Self::deserialize_events(&room_data.required_state);
+        let required_state = Self::deserialize_state_events(&room_data.required_state);
 
         // Find or create the room in the store
         #[allow(unused_mut)] // Required for some feature flag combinations
@@ -331,7 +331,7 @@ impl BaseClient {
     fn process_sliding_sync_room_membership(
         &self,
         room_data: &v4::SlidingSyncRoom,
-        required_state: &[Option<AnySyncStateEvent>],
+        required_state: &[AnySyncStateEvent],
         store: &Store,
         room_id: &RoomId,
         changes: &mut StateChanges,
@@ -385,11 +385,11 @@ impl BaseClient {
     /// the state in room_info to reflect the "membership" property.
     pub(crate) fn handle_own_room_membership(
         &self,
-        required_state: &[Option<AnySyncStateEvent>],
+        required_state: &[AnySyncStateEvent],
         room_info: &mut RoomInfo,
     ) {
         for event in required_state {
-            if let Some(AnySyncStateEvent::RoomMember(member)) = &event {
+            if let AnySyncStateEvent::RoomMember(member) = &event {
                 // If this event updates the current user's membership, record that in the
                 // room_info.
                 if let Some(meta) = self.session_meta() {

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -17,16 +17,17 @@ use std::ops::Deref;
 
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
+#[cfg(feature = "e2e-encryption")]
+use ruma::events::AnyToDeviceEvent;
 use ruma::{
     api::client::sync::sync_events::{
         v3::{self, InvitedRoom, RoomSummary},
         v4::{self, AccountData},
     },
     events::{AnySyncStateEvent, AnySyncTimelineEvent},
+    serde::Raw,
     RoomId,
 };
-#[cfg(feature = "e2e-encryption")]
-use ruma::{events::AnyToDeviceEvent, serde::Raw};
 use tracing::{instrument, trace, warn};
 
 use super::BaseClient;

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -9,6 +9,7 @@ use matrix_sdk::{
     config::SyncSettings,
     room::Receipts,
 };
+use matrix_sdk_base::RoomState;
 use matrix_sdk_test::{async_test, test_json};
 use ruma::{
     api::client::{membership::Invite3pidInit, receipt::create_receipt::v3::ReceiptType},
@@ -80,7 +81,7 @@ async fn invite_user_by_3pid() {
 }
 
 #[async_test]
-async fn leave_room() {
+async fn leave_room() -> Result<(), anyhow::Error> {
     let (client, server) = logged_in_client().await;
 
     Mock::given(method("POST"))
@@ -94,11 +95,15 @@ async fn leave_room() {
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let _response = client.sync_once(sync_settings).await.unwrap();
+    let _response = client.sync_once(sync_settings).await?;
 
     let room = client.get_room(&test_json::DEFAULT_SYNC_ROOM_ID).unwrap();
 
-    room.leave().await.unwrap();
+    room.leave().await?;
+
+    assert_eq!(room.state(), RoomState::Left);
+
+    Ok(())
 }
 
 #[async_test]


### PR DESCRIPTION
OK so here is the story.

In `matrix_sdk_base`, we extend the `BaseClient` to add `SlidingSync` feature. Among many things, we map a `SlidingSyncResponse` into a `SyncResponse`, and we update all the inner types like `Room` etc.

In #2300, @poljar [has noticed that we have a `FIXME` in our code](https://github.com/matrix-org/matrix-rust-sdk/issues/2300#issuecomment-1661836252) saying that any room that isn't in an `Invite` state is considered `Join`. It misses one case: `Left`. Technically, what the code does is: either the room is in `Invite` state, and we do our stuff, or we create a new room in a `Join` state, and update the room's state based on the `required_state` provided in the `SlidingSyncResponse`.

From here, I've started to investigate with @pixlwave (thanks!). We have noticed that the server send the same event twice (tracked https://github.com/matrix-org/sliding-sync/issues/250). But we have also noticed that the state event containing the `"membership": "leave"` value was not sent as part of the `required_state` events as it happens most of the time, but this time as part of the `timeline` events!

This patch then updates the code to look for state events in the `required_state` as before, but _also_ in `timeline`.

I recommend to review this PR commit-by-commit. I tried to make commit standalone with useful descriptions as much as possible.

---

* Fixes #2300
* Partly address https://github.com/matrix-org/matrix-rust-sdk/issues/2078, another patch might be needed to fix all issues raised there.