### PR TITLE
Revert upgrade to uniffi since it broke generation of swift bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6213,7 +6213,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "uniffi"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "anyhow",
  "camino",
@@ -6234,7 +6234,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "anyhow",
  "askama",
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "anyhow",
  "camino",
@@ -6268,7 +6268,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "quote",
  "syn 2.0.28",
@@ -6277,7 +6277,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -6293,7 +6293,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "bincode",
  "camino",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6323,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "anyhow",
  "camino",
@@ -6337,7 +6337,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.24.1"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "anyhow",
  "uniffi_meta",
@@ -6658,7 +6658,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749#f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749"
+source = "git+https://github.com/Hywan/uniffi-rs?rev=9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b#9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ thiserror = "1.0.38"
 tokio = { version = "1.30.0", default-features = false, features = ["sync"] }
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-core = "0.1.30"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "f2ca3ba6117696ecae1c1ec3b6cdee0e53ff0749" }
+uniffi = { git = "https://github.com/Hywan/uniffi-rs", rev = "9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b" }
+uniffi_bindgen = { git = "https://github.com/Hywan/uniffi-rs", rev = "9e2ffac3e6c8dbad4dcd9c6339069ef31ef87a7b" }
 vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "e3b658526f6f1dd0a9065c1c96346b796712c425" }
 zeroize = "1.6.0"
 


### PR DESCRIPTION
See CI task failure in https://github.com/matrix-org/matrix-rust-sdk/pull/2404.