### PR TITLE
Add binding to create message events from HTML

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -52,6 +52,14 @@ pub fn message_event_content_from_markdown(md: String) -> Arc<RoomMessageEventCo
     Arc::new(RoomMessageEventContent::text_markdown(md))
 }
 
+#[uniffi::export]
+pub fn message_event_content_from_html(
+    body: String,
+    html_body: String,
+) -> Arc<RoomMessageEventContent> {
+    Arc::new(RoomMessageEventContent::text_html(body, html_body))
+}
+
 #[uniffi::export(callback_interface)]
 pub trait TimelineListener: Sync + Send {
     fn on_update(&self, diff: Vec<Arc<TimelineDiff>>);


### PR DESCRIPTION
## Changes

Add FFI binding to create message events with custom HTML.

## Context

We currently have `message_event_content_from_markdown()` which can detect markdown and produce a message event containing formatted HTML content. However, markdown detection is limited and can lead to bugs such as vector-im/element-x-android#1070.

Hence the need for apps to create message events from a custom plain text body and formatted HTML body.
