### PR TITLE
feat(ui): Create a new `normalized_match_room_name` filter

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -12,7 +12,9 @@ use matrix_sdk::{
     },
     RoomListEntry as MatrixRoomListEntry,
 };
-use matrix_sdk_ui::room_list_service::filters::{new_filter_all, new_filter_fuzzy_match_room_name};
+use matrix_sdk_ui::room_list_service::filters::{
+    new_filter_all, new_filter_fuzzy_match_room_name, new_filter_normalized_match_room_name,
+};
 use tokio::sync::RwLock;
 
 use crate::{
@@ -316,6 +318,9 @@ impl RoomListEntriesDynamicFilter {
 
         match kind {
             Kind::All => self.inner.set(new_filter_all()),
+            Kind::NormalizedMatchRoomName { pattern } => {
+                self.inner.set(new_filter_normalized_match_room_name(&self.client, &pattern))
+            }
             Kind::FuzzyMatchRoomName { pattern } => {
                 self.inner.set(new_filter_fuzzy_match_room_name(&self.client, &pattern))
             }
@@ -326,6 +331,7 @@ impl RoomListEntriesDynamicFilter {
 #[derive(uniffi::Enum)]
 pub enum RoomListEntriesDynamicFilterKind {
     All,
+    NormalizedMatchRoomName { pattern: String },
     FuzzyMatchRoomName { pattern: String },
 }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
@@ -1,8 +1,10 @@
 mod all;
 mod fuzzy_match_room_name;
+mod normalized_match_room_name;
 
 pub use all::new_filter as new_filter_all;
 pub use fuzzy_match_room_name::new_filter as new_filter_fuzzy_match_room_name;
+pub use normalized_match_room_name::new_filter as new_filter_normalized_match_room_name;
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 
 /// Normalize a string, i.e. decompose it into NFD (Normalization Form D, i.e. a

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
@@ -1,0 +1,99 @@
+use matrix_sdk::{Client, RoomListEntry};
+
+use super::normalize_string;
+
+struct NormalizedMatcher {
+    pattern: Option<String>,
+}
+
+impl NormalizedMatcher {
+    fn new() -> Self {
+        Self { pattern: None }
+    }
+
+    fn with_pattern(mut self, pattern: &str) -> Self {
+        self.pattern = Some(normalize_string(&pattern.to_lowercase()));
+
+        self
+    }
+
+    fn normalized_match(&self, subject: &str) -> bool {
+        // No pattern means there is a match.
+        let Some(pattern) = self.pattern.as_ref() else { return true };
+
+        let subject = normalize_string(&subject.to_lowercase());
+
+        subject.contains(pattern)
+    }
+}
+
+/// Create a new filter that will “normalized” match a pattern on room names.
+///
+/// Rooms are fetched from the `Client`. The pattern and the room names are
+/// normalized with `normalize_string`.
+pub fn new_filter(client: &Client, pattern: &str) -> impl Fn(&RoomListEntry) -> bool {
+    let searcher = NormalizedMatcher::new().with_pattern(pattern);
+
+    let client = client.clone();
+
+    move |room_list_entry| -> bool {
+        let Some(room_id) = room_list_entry.as_room_id() else { return false };
+        let Some(room) = client.get_room(room_id) else { return false };
+        let Some(room_name) = room.name() else { return false };
+
+        searcher.normalized_match(&room_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not;
+
+    use super::*;
+
+    #[test]
+    fn test_no_pattern() {
+        let matcher = NormalizedMatcher::new();
+
+        assert!(matcher.normalized_match("hello"));
+    }
+
+    #[test]
+    fn test_literal() {
+        let matcher = NormalizedMatcher::new();
+
+        let matcher = matcher.with_pattern("matrix");
+        assert!(matcher.normalized_match("matrix"));
+
+        let matcher = matcher.with_pattern("matrxi");
+        assert!(matcher.normalized_match("matrix").not());
+    }
+
+    #[test]
+    fn test_ignore_case() {
+        let matcher = NormalizedMatcher::new();
+
+        let matcher = matcher.with_pattern("matrix");
+        assert!(matcher.normalized_match("MaTrIX"));
+
+        let matcher = matcher.with_pattern("matrxi");
+        assert!(matcher.normalized_match("MaTrIX").not());
+    }
+
+    #[test]
+    fn test_normalization() {
+        let matcher = NormalizedMatcher::new();
+
+        let matcher = matcher.with_pattern("un été");
+
+        // First, assert that the pattern has been normalized.
+        assert_eq!(matcher.pattern, Some("un ete".to_owned()));
+
+        // Second, assert that the subject is normalized too.
+        assert!(matcher.normalized_match("un été magnifique"));
+
+        // Another concrete test.
+        let matcher = matcher.with_pattern("stefan");
+        assert!(matcher.normalized_match("Ștefan"));
+    }
+}


### PR DESCRIPTION
This patch adds a new filter for room list's entries. We had `all` and `fuzzy_match_room_name`, now this patch adds `normalized_match_room_name`. Both the pattern and the subject are normalized and lowercased, and then it's an exact match: `subject.contains(pattern)`.