### PR TITLE
feat(sliding sync): remove `response_handling_lock` and extend the position's lock responsibilities

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -281,7 +281,6 @@ impl SlidingSyncBuilder {
             room_unsubscriptions: Default::default(),
 
             internal_channel: internal_channel_sender,
-            response_handling_lock: Arc::new(AsyncMutex::new(())),
 
             poll_timeout: self.poll_timeout,
             network_timeout: self.network_timeout,

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -283,7 +283,7 @@ mod tests {
             }
 
             let position_guard = sliding_sync.inner.position.lock().await;
-            assert!(sliding_sync.cache_to_storage(&*position_guard).await.is_ok());
+            assert!(sliding_sync.cache_to_storage(&position_guard).await.is_ok());
 
             storage_key
         };
@@ -408,7 +408,7 @@ mod tests {
             position_guard.delta_token = Some(delta_token.clone());
 
             // Then, we can correctly cache the sliding sync instance.
-            store_sliding_sync_state(&sliding_sync, &*position_guard).await?;
+            store_sliding_sync_state(&sliding_sync, &position_guard).await?;
         }
 
         // The delta token has been correctly written to the state store (but not the

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -644,9 +644,9 @@ impl SlidingSync {
             }
 
             // Handle the response.
-            let updates = this.handle_response(response, &mut *position_guard).await?;
+            let updates = this.handle_response(response, &mut position_guard).await?;
 
-            this.cache_to_storage(&*position_guard).await?;
+            this.cache_to_storage(&position_guard).await?;
 
             // Release the position guard lock.
             // It means that other responses can be generated and then handled later.
@@ -1157,7 +1157,7 @@ mod tests {
         // FrozenSlidingSync doesn't contain the to_device_token anymore, as it's saved
         // in the crypto store since PR #2323.
         let position_guard = sliding_sync.inner.position.lock().await;
-        let frozen = FrozenSlidingSync::new(&*position_guard).await;
+        let frozen = FrozenSlidingSync::new(&position_guard).await;
         assert!(frozen.to_device_since.is_none());
 
         Ok(())
@@ -1842,7 +1842,7 @@ mod tests {
         {
             let mut position_guard = sliding_sync.inner.position.clone().lock_owned().await;
 
-            sliding_sync.handle_response(server_response.clone(), &mut *position_guard).await?;
+            sliding_sync.handle_response(server_response.clone(), &mut position_guard).await?;
         }
 
         // E2EE has been properly handled.
@@ -1873,7 +1873,7 @@ mod tests {
         {
             let mut position_guard = sliding_sync.inner.position.clone().lock_owned().await;
 
-            sliding_sync.handle_response(server_response.clone(), &mut *position_guard).await?;
+            sliding_sync.handle_response(server_response.clone(), &mut position_guard).await?;
         }
 
         // E2EE response has been ignored.
@@ -1907,7 +1907,7 @@ mod tests {
         {
             let mut position_guard = sliding_sync.inner.position.clone().lock_owned().await;
 
-            sliding_sync.handle_response(server_response.clone(), &mut *position_guard).await?;
+            sliding_sync.handle_response(server_response.clone(), &mut position_guard).await?;
         }
 
         // E2EE has been properly handled.


### PR DESCRIPTION
In the previous situation, we had two locks with similar responsibilities, the `response_handling_lock` and the `position` lock. The latter *almost* covered the former's critical zone, albeit for a single function call, which left room for a deadlock situation (latter taken, then former, then latter).

This removes the former, and extends the critical zone of the latter up to the end of the response handling, removing the possibility of the deadlock entirely.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2426.