### PR TITLE
fix: temporarily use the pip install method for the setup-matrix-synapse action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
 
       - uses: michaelkaye/setup-matrix-synapse@main
         with:
-          installer: poetry
+          installer: venv # TODO revert to poetry once https://github.com/michaelkaye/setup-matrix-synapse/issues/95 is fixed
           uploadLogs: true
           httpPort: 8228
           disableRateLimiting: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,7 +50,7 @@ jobs:
 
     - uses: michaelkaye/setup-matrix-synapse@main
       with:
-        installer: poetry
+        installer: venv # TODO revert to poetry once https://github.com/michaelkaye/setup-matrix-synapse/issues/95 is fixed
         uploadLogs: true
         httpPort: 8228
         disableRateLimiting: true


### PR DESCRIPTION
Until https://github.com/michaelkaye/setup-matrix-synapse/issues/95 is properly resolved.