### PR TITLE
Fix original content of messages being retained in JSON form on redaction

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -694,7 +694,7 @@ impl<'a> TimelineEventHandler<'a> {
                     is_own: self.ctx.is_own_event,
                     is_highlighted: self.ctx.is_highlighted,
                     encryption_info: self.ctx.encryption_info.clone(),
-                    original_json: raw_event.clone(),
+                    original_json: Some(raw_event.clone()),
                     latest_edit_json: None,
                     origin,
                 }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -555,11 +555,13 @@ impl<'a> TimelineEventHandler<'a> {
                     warn!("reaction_map out of sync with timeline items");
                 }
             }
+
+            // Even if the event being redacted is a reaction (found in
+            // `reaction_map`), it can still be present in the timeline items
+            // directly with the raw event timeline feature (not yet
+            // implemented) => no early return here.
         }
 
-        // Even if the event being redacted is a reaction (found in
-        // `reaction_map`), it can still be present in the timeline items
-        // directly with the raw event timeline feature (not yet implemented).
         update_timeline_item!(self, &redacts, "redaction", |event_item| {
             if event_item.as_remote().is_none() {
                 error!("inconsistent state: redaction received on a non-remote event item");

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -97,7 +97,6 @@ impl EventTimelineItem {
         use super::traits::RoomDataProvider;
 
         let raw_sync_event = sync_event.event;
-
         let encryption_info = sync_event.encryption_info;
 
         let Ok(event) = raw_sync_event.deserialize_as::<AnySyncTimelineEvent>() else {
@@ -138,7 +137,7 @@ impl EventTimelineItem {
             is_own,
             is_highlighted,
             encryption_info,
-            original_json: raw_sync_event,
+            original_json: Some(raw_sync_event),
             latest_edit_json,
             origin,
         }
@@ -317,7 +316,7 @@ impl EventTimelineItem {
     pub fn original_json(&self) -> Option<&Raw<AnySyncTimelineEvent>> {
         match &self.kind {
             EventTimelineItemKind::Local(_local_event) => None,
-            EventTimelineItemKind::Remote(remote_event) => Some(&remote_event.original_json),
+            EventTimelineItemKind::Remote(remote_event) => remote_event.original_json.as_ref(),
         }
     }
 
@@ -379,9 +378,7 @@ impl EventTimelineItem {
         let content = self.content.redact(room_version);
         let kind = match &self.kind {
             EventTimelineItemKind::Local(l) => EventTimelineItemKind::Local(l.clone()),
-            EventTimelineItemKind::Remote(r) => {
-                EventTimelineItemKind::Remote(r.without_reactions())
-            }
+            EventTimelineItemKind::Remote(r) => EventTimelineItemKind::Remote(r.redact()),
         };
         Self {
             sender: self.sender.clone(),

--- a/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
@@ -46,9 +46,15 @@ pub(in crate::timeline) struct RemoteEventTimelineItem {
     pub encryption_info: Option<EncryptionInfo>,
     /// JSON of the original event.
     ///
-    /// If the message is edited, this *won't* change, instead
-    /// `latest_edit_json` will be updated.
-    pub original_json: Raw<AnySyncTimelineEvent>,
+    /// If the event is edited, this *won't* change, instead `latest_edit_json`
+    /// will be updated.
+    ///
+    /// This field always starts out as `Some(_)`, but is set to `None` when the
+    /// event is redacted. The redacted form of the event could be computed
+    /// locally instead (at least when the redaction came from the server and
+    /// thus the whole event is available), but it's not clear whether there is
+    /// a clear need for that.
+    pub original_json: Option<Raw<AnySyncTimelineEvent>>,
     /// JSON of the latest edit to this item.
     pub latest_edit_json: Option<Raw<AnySyncTimelineEvent>>,
     /// Where we got this event from: A sync response or pagination.
@@ -72,9 +78,15 @@ impl RemoteEventTimelineItem {
         Self { reactions, ..self.clone() }
     }
 
-    /// Clone the current event item, and reset its `reactions`.
-    pub fn without_reactions(&self) -> Self {
-        Self { reactions: BundledReactions::default(), ..self.clone() }
+    /// Clone the current event item, and clear its `reactions` as well as the
+    /// JSON representation fields.
+    pub fn redact(&self) -> Self {
+        Self {
+            reactions: BundledReactions::default(),
+            original_json: None,
+            latest_edit_json: None,
+            ..self.clone()
+        }
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -730,7 +730,12 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
                     tracing::Span::current().record("event_id", debug(&remote_event.event_id));
 
-                    match decryptor.decrypt_event_impl(&remote_event.original_json).await {
+                    let Some(original_json) = &remote_event.original_json else {
+                        error!("UTD item must contain original JSON");
+                        return None;
+                    };
+
+                    match decryptor.decrypt_event_impl(original_json).await {
                         Ok(event) => {
                             trace!(
                                 "Successfully decrypted event that previously failed to decrypt"

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -102,6 +102,7 @@ async fn redact_replied_to_event() {
     let first_item_again =
         assert_next_matches!(stream, VectorDiff::Set { index: 0, value } => value);
     assert_matches!(first_item_again.content(), TimelineItemContent::RedactedMessage);
+    assert_matches!(first_item_again.original_json(), None);
 
     let second_item_again =
         assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);


### PR DESCRIPTION
The original JSON will just be removed entirely. There might be edge cases where this is unfortunate for debugging, but it fixes the immediate problem in a simple manner. Computing the redacted JSON locally seems error-prone, but if there are debugging needs, we could probably offer users to update the JSON by re-requesting the event after redaction.

Resolves #2417.