### PR TITLE
Use uniffi-bindgen's new "library mode"

### DIFF
--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -1,4 +1,7 @@
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    env::consts::{DLL_PREFIX, DLL_SUFFIX},
+};
 
 use clap::{Args, Subcommand};
 use xshell::{cmd, pushd};
@@ -126,22 +129,22 @@ fn check_bindings() -> Result<()> {
     cmd!(
         "
         rustup run stable cargo run -p uniffi-bindgen -- generate
+            --library
             --language kotlin
             --language swift
-            --lib-file target/debug/libmatrix_sdk_ffi.a
             --out-dir target/generated-bindings
-            bindings/matrix-sdk-ffi/src/api.udl
+            target/debug/{DLL_PREFIX}matrix_sdk_ffi{DLL_SUFFIX}
         "
     )
     .run()?;
     cmd!(
         "
         rustup run stable cargo run -p uniffi-bindgen -- generate
+            --library
             --language kotlin
             --language swift
-            --lib-file target/debug/libmatrix_sdk_crypto_ffi.a
             --out-dir target/generated-bindings
-            bindings/matrix-sdk-crypto-ffi/src/olm.udl
+            target/debug/{DLL_PREFIX}matrix_sdk_crypto_ffi{DLL_SUFFIX}
         "
     )
     .run()?;

--- a/xtask/src/swift.rs
+++ b/xtask/src/swift.rs
@@ -1,8 +1,11 @@
-use std::fs::{copy, create_dir_all, remove_dir_all, remove_file, rename};
+use std::{
+    env::consts::{DLL_PREFIX, DLL_SUFFIX},
+    fs::{copy, create_dir_all, remove_dir_all, remove_file, rename},
+};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Args, Subcommand};
-use uniffi_bindgen::bindings::TargetLanguage;
+use uniffi_bindgen::{bindings::TargetLanguage, library_mode::generate_bindings};
 use xshell::{cmd, pushd};
 
 use crate::{workspace, Result};
@@ -54,29 +57,28 @@ impl SwiftArgs {
     }
 }
 
+fn matrix_sdk_ffi_dll_name() -> String {
+    format!("{DLL_PREFIX}matrix_sdk_ffi{DLL_SUFFIX}")
+}
+
 fn build_library() -> Result<()> {
     println!("Running debug library build.");
-
-    let release_type = "debug";
-    let static_lib_filename = "libmatrix_sdk_ffi.a";
 
     let root_directory = workspace::root_path()?;
     let target_directory = workspace::target_path()?;
     let ffi_directory = root_directory.join("bindings/apple/generated/matrix_sdk_ffi");
-    let library_file = ffi_directory.join(static_lib_filename);
+    let lib_output_dir = target_directory.join("debug");
 
     create_dir_all(ffi_directory.as_path())?;
 
     cmd!("cargo build -p matrix-sdk-ffi").run()?;
 
-    rename(
-        target_directory.join(release_type).join(static_lib_filename),
-        ffi_directory.join(static_lib_filename),
-    )?;
+    let static_lib_filename = "libmatrix_sdk_ffi.a";
+    rename(lib_output_dir.join(static_lib_filename), ffi_directory.join(static_lib_filename))?;
     let swift_directory = root_directory.join("bindings/apple/generated/swift");
     create_dir_all(swift_directory.as_path())?;
 
-    generate_uniffi(&library_file, &ffi_directory)?;
+    generate_uniffi(&lib_output_dir.join(matrix_sdk_ffi_dll_name()), &ffi_directory)?;
 
     let module_map_file = ffi_directory.join("module.modulemap");
     if module_map_file.exists() {
@@ -93,28 +95,25 @@ fn build_library() -> Result<()> {
     Ok(())
 }
 
-fn generate_uniffi(library_file: &Utf8Path, ffi_directory: &Utf8Path) -> Result<()> {
-    let root_directory = workspace::root_path()?;
-    let udl_file = root_directory.join("bindings/matrix-sdk-ffi/src/api.udl");
-
-    uniffi_bindgen::generate_bindings(
-        udl_file.as_path(),
-        None,
-        vec![TargetLanguage::Swift],
-        Some(ffi_directory),
-        Some(library_file),
-        false,
-    )?;
+fn generate_uniffi(library_path: &Utf8Path, ffi_directory: &Utf8Path) -> Result<()> {
+    generate_bindings(library_path, None, &[TargetLanguage::Swift], ffi_directory, false)?;
     Ok(())
 }
 
+/// Build matrix_sdk_ffi for the given target, with the given profile.
+///
+/// Returns the name of the produced shared object (a staticlib is also
+/// created).
 fn build_for_target(target: &str, profile: &str) -> Result<Utf8PathBuf> {
     cmd!("cargo build -p matrix-sdk-ffi --target {target} --profile {profile}").run()?;
 
     // The builtin dev profile has its files stored under target/debug, all
     // other targets have matching directory names
     let profile_dir_name = if profile == "dev" { "debug" } else { profile };
-    Ok(workspace::target_path()?.join(target).join(profile_dir_name).join("libmatrix_sdk_ffi.a"))
+    Ok(workspace::target_path()?
+        .join(target)
+        .join(profile_dir_name)
+        .join(matrix_sdk_ffi_dll_name()))
 }
 
 fn build_xcframework(
@@ -135,7 +134,7 @@ fn build_xcframework(
     create_dir_all(headers_dir.clone())?;
     create_dir_all(swift_dir.clone())?;
 
-    let (libs, uniff_lib_path) = if let Some(target) = only_target {
+    let (libs, uniffi_lib_path) = if let Some(target) = only_target {
         println!("-- Building for {target} 1/1");
         let build_path = build_for_target(target.as_str(), profile)?;
 
@@ -175,7 +174,7 @@ fn build_xcframework(
     };
 
     println!("-- Generating uniffi files");
-    generate_uniffi(&uniff_lib_path, &generated_dir)?;
+    generate_uniffi(&uniffi_lib_path, &generated_dir)?;
 
     rename(generated_dir.join("matrix_sdk_ffiFFI.h"), headers_dir.join("matrix_sdk_ffiFFI.h"))?;
 

--- a/xtask/src/workspace.rs
+++ b/xtask/src/workspace.rs
@@ -1,14 +1,15 @@
-use std::{env, path::PathBuf};
+use std::env;
 
+use camino::Utf8PathBuf;
 use serde::Deserialize;
 use xshell::cmd;
 
 use crate::Result;
 
-pub fn root_path() -> Result<PathBuf> {
+pub fn root_path() -> Result<Utf8PathBuf> {
     #[derive(Deserialize)]
     struct Metadata {
-        workspace_root: PathBuf,
+        workspace_root: Utf8PathBuf,
     }
 
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
@@ -16,10 +17,10 @@ pub fn root_path() -> Result<PathBuf> {
     Ok(serde_json::from_str::<Metadata>(&metadata_json)?.workspace_root)
 }
 
-pub fn target_path() -> Result<PathBuf> {
+pub fn target_path() -> Result<Utf8PathBuf> {
     #[derive(Deserialize)]
     struct Metadata {
-        target_directory: PathBuf,
+        target_directory: Utf8PathBuf,
     }
 
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());


### PR DESCRIPTION
… where we no longer need to specify the UDL file (its data is picked up automatically through the generated scaffolding).