### PR TITLE
Add logging for `handle_redaction`

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -214,7 +214,7 @@ impl BaseRoomInfo {
         true
     }
 
-    pub fn handle_redaction(&mut self, redacts: &EventId) {
+    fn handle_redaction(&mut self, redacts: &EventId) {
         let room_version = self.room_version().unwrap_or(&RoomVersionId::V1).to_owned();
 
         // FIXME: Use let chains once available to get rid of unwrap()s


### PR DESCRIPTION
… and make the `handle_redaction` on `BaseRoomInfo` private, so it's not called directly (bypassing `RoomInfo::handle_redaction`).

This is a first step towards figuring out https://github.com/vector-im/element-x-ios/issues/1441.