### PR TITLE
feat(ui): Do not propagate sliding sync session expiration inside `SyncService`

### DIFF
--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -259,10 +259,6 @@ impl EncryptionSync {
 
         Ok(())
     }
-
-    pub(crate) async fn expire_sync_session(&self) {
-        self.sliding_sync.expire_session().await;
-    }
 }
 
 /// Errors for the [`EncryptionSync`].

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -274,26 +274,6 @@ impl RoomListService {
         self.sliding_sync.stop_sync().map_err(Error::SlidingSync)
     }
 
-    /// Force the sliding sync session to expire.
-    ///
-    /// This is used by [`SyncService`][crate::SyncService].
-    ///
-    /// **Warning**: This method **must not** be called while the sync loop is
-    /// running!
-    pub(crate) async fn expire_sync_session(&self) {
-        self.sliding_sync.expire_session().await;
-
-        // Usually, when the session expires, it leads the state to be `Error`,
-        // thus some actions (like refreshing the lists) are executed. However,
-        // if the sync loop has been stopped manually, the state is `Terminated`, and
-        // when the session is forced to expire, the state remains `Terminated`, thus
-        // the actions aren't executed as expected. Consequently, let's update the
-        // state.
-        if let State::Terminated { from } = self.state.get() {
-            self.state.set(State::Error { from });
-        }
-    }
-
     /// Get the [`Client`] that has been used to create [`Self`].
     pub fn client(&self) -> &Client {
         &self.client
@@ -455,8 +435,7 @@ mod tests {
     use matrix_sdk_base::SessionMeta;
     use matrix_sdk_test::async_test;
     use ruma::{api::MatrixVersion, device_id, user_id};
-    use serde_json::json;
-    use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
+    use wiremock::MockServer;
 
     use super::*;
 
@@ -486,15 +465,6 @@ mod tests {
         let (client, _) = new_client().await;
 
         RoomListService::new(client).await
-    }
-
-    struct SlidingSyncMatcher;
-
-    impl Match for SlidingSyncMatcher {
-        fn matches(&self, request: &Request) -> bool {
-            request.url.path() == "/_matrix/client/unstable/org.matrix.msc3575/sync"
-                && request.method == Method::Post
-        }
     }
 
     #[async_test]
@@ -551,56 +521,6 @@ mod tests {
         let extensions = with_encryption.sliding_sync.extensions_config();
         assert_eq!(extensions.e2ee.enabled, Some(true));
         assert_eq!(extensions.to_device.enabled, Some(true));
-
-        Ok(())
-    }
-
-    #[async_test]
-    async fn test_expire_sliding_sync_session_manually() -> Result<(), Error> {
-        let (client, server) = new_client().await;
-
-        let room_list = RoomListService::new(client).await?;
-
-        let sync = room_list.sync();
-        pin_mut!(sync);
-
-        // Run a first sync.
-        {
-            let _mock_guard = Mock::given(SlidingSyncMatcher)
-                .respond_with(move |_request: &Request| {
-                    ResponseTemplate::new(200).set_body_json(json!({
-                        "pos": "0",
-                        "lists": {
-                            ALL_ROOMS_LIST_NAME: {
-                                "count": 0,
-                                "ops": [],
-                            },
-                        },
-                        "rooms": {},
-                    }))
-                })
-                .mount_as_scoped(&server)
-                .await;
-
-            let _ = sync.next().await;
-        }
-
-        assert_eq!(room_list.state().get(), State::SettingUp);
-
-        // Stop the sync.
-        room_list.stop_sync()?;
-
-        // Do another sync.
-        let _ = sync.next().await;
-
-        // State is `Terminated`, as expected!
-        assert_eq!(room_list.state.get(), State::Terminated { from: Box::new(State::Running) });
-
-        // Now, let's make the sliding sync session to expire.
-        room_list.expire_sync_session().await;
-
-        // State is `Error`, as a regular session expiration would generate!
-        assert_eq!(room_list.state.get(), State::Error { from: Box::new(State::Running) });
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -758,10 +758,7 @@ impl SlidingSync {
     /// expire anyways, and should be used only in very specific cases (e.g.
     /// multiple sliding syncs being run in parallel, and one of them has
     /// expired).
-    ///
-    /// This method **MUST** be called when the sync loop is stopped.
-    #[doc(hidden)]
-    pub async fn expire_session(&self) {
+    async fn expire_session(&self) {
         info!("Session expired; resetting `pos` and sticky parameters");
 
         {


### PR DESCRIPTION
When `SlidingSync` receives a `M_UNKNOWN_POS`, it means its session has expired. It can happen for various reasons.

`SyncService` manipulates 2 sync mechanisms: `EncryptionSync` and `RoomListService`. Both are using `SlidingSync`. Prior to this patch, we had an heuristics that: when a sync' session has expired, it forces the other sync to expire its session. Why? Because we wanted to save roundtrips between the client and the server as we supposed that hitting a session expiration on one sync is highly likely to see another session expiration for the other sync. Indeed, both sync loops are supposed to run at same pace and to behave almost the same. We did introduce this heuristic because the server was taking 1.4s to respond `M_UNKNOW_POS`, i.e. to respond that the session has expired.

This patch removes this heuristics for the following reasons:

* _A priori_, this 1.4s lag might no longer be present. Thus, the roundtrip impact is no longer really relevant, and can be acceptable.
* Sometimes there is false positive. One session can expire for _reason_ and will make the other one to expire while it wasn't necessary.
* With the above items in mind, handling this heuristics on our side makes _us responsible_ of handling session expirations pro-actively. In addition, it adds quite a lot of complexity, code, documentation, and tests on our side (recent example is https://github.com/matrix-org/matrix-rust-sdk/pull/2446 which solves a broken state because of this _manual_ session expiration).
* Exposing this API across multiple crates was a mix of `#[doc(hidden)]` and feature flag, something that was unpleasant to write and to read. It was dangerous and error-prone.

`SyncService` keeps stopping both syncs if one stops, thus they continue to have a synchronized state, but each sync mechanism continues to handle session expiration on its own, secretly, privately.