### PR TITLE
ffi: Add widget API skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,6 +3043,7 @@ dependencies = [
  "anyhow",
  "anymap2",
  "assert_matches",
+ "async-channel",
  "async-stream",
  "async-trait",
  "backoff",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -65,6 +65,7 @@ features = [
     "e2e-encryption",
     "experimental-oidc",
     "experimental-sliding-sync",
+    "experimental-widget-api",
     "markdown",
     "rustls-tls", # note: differ from block below
     "socks",
@@ -79,6 +80,7 @@ features = [
     "e2e-encryption",
     "experimental-oidc",
     "experimental-sliding-sync",
+    "experimental-widget-api",
     "markdown",
     "native-tls", # note: differ from block above
     "socks",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -65,7 +65,7 @@ features = [
     "e2e-encryption",
     "experimental-oidc",
     "experimental-sliding-sync",
-    "experimental-widget-api",
+    "experimental-widgets",
     "markdown",
     "rustls-tls", # note: differ from block below
     "socks",
@@ -80,7 +80,7 @@ features = [
     "e2e-encryption",
     "experimental-oidc",
     "experimental-sliding-sync",
-    "experimental-widget-api",
+    "experimental-widgets",
     "markdown",
     "native-tls", # note: differ from block above
     "socks",

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -38,6 +38,7 @@ mod sync_service;
 mod task_handle;
 mod timeline;
 mod tracing;
+mod widget;
 
 use async_compat::TOKIO1 as RUNTIME;
 use matrix_sdk::ruma::events::room::{message::RoomMessageEventContent, MediaSource};

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -70,7 +70,7 @@ pub(crate) type TimelineLock = Arc<RwLock<Option<Arc<Timeline>>>>;
 
 #[derive(uniffi::Object)]
 pub struct Room {
-    inner: SdkRoom,
+    pub(super) inner: SdkRoom,
     timeline: TimelineLock,
 }
 

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -1,0 +1,157 @@
+use std::sync::Arc;
+
+use matrix_sdk::async_trait;
+
+use crate::room::Room;
+
+#[derive(uniffi::Record)]
+pub struct Widget {
+    /// Information about the widget.
+    pub info: WidgetInfo,
+    /// Communication channels with a widget.
+    pub comm: Arc<WidgetComm>,
+}
+
+impl From<Widget> for matrix_sdk::widget::Widget {
+    fn from(value: Widget) -> Self {
+        let comm = &value.comm.0;
+        Self {
+            info: value.info.into(),
+            comm: matrix_sdk::widget::Comm { from: comm.from.clone(), to: comm.to.clone() },
+        }
+    }
+}
+
+/// Information about a widget.
+#[derive(uniffi::Record)]
+pub struct WidgetInfo {
+    /// Widget's unique identifier.
+    pub id: String,
+    /// Whether or not the widget should be initialized on load message
+    /// (`ContentLoad` message), or upon creation/attaching of the widget to
+    /// the SDK's state machine that drives the API.
+    pub init_on_load: bool,
+}
+
+impl From<WidgetInfo> for matrix_sdk::widget::Info {
+    fn from(value: WidgetInfo) -> Self {
+        let WidgetInfo { id, init_on_load } = value;
+        Self { id, init_on_load }
+    }
+}
+
+/// Communication "pipes" with a widget.
+#[derive(uniffi::Object)]
+pub struct WidgetComm(matrix_sdk::widget::Comm);
+
+/// Permissions that a widget can request from a client.
+#[derive(uniffi::Record)]
+pub struct WidgetPermissions {
+    /// Types of the messages that a widget wants to be able to fetch.
+    pub read: Vec<WidgetEventFilter>,
+    /// Types of the messages that a widget wants to be able to send.
+    pub send: Vec<WidgetEventFilter>,
+}
+
+impl From<WidgetPermissions> for matrix_sdk::widget::Permissions {
+    fn from(value: WidgetPermissions) -> Self {
+        Self {
+            read: value.read.into_iter().map(Into::into).collect(),
+            send: value.send.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<matrix_sdk::widget::Permissions> for WidgetPermissions {
+    fn from(value: matrix_sdk::widget::Permissions) -> Self {
+        Self {
+            read: value.read.into_iter().map(Into::into).collect(),
+            send: value.send.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// Different kinds of filters that could be applied to the timeline events.
+#[derive(uniffi::Enum)]
+pub enum WidgetEventFilter {
+    /// Message-like events.
+    MessageLike {
+        /// The type of the message-like event.
+        event_type: String,
+        /// Additional filter for the msgtype, currently only used for
+        /// `m.room.message`.
+        msgtype: Option<String>,
+    },
+    /// State events.
+    State {
+        /// The type of the state event.
+        event_type: String,
+        /// State key that could be `None`, `None` means "any state key".
+        state_key: Option<String>,
+    },
+}
+
+impl From<WidgetEventFilter> for matrix_sdk::widget::EventFilter {
+    fn from(value: WidgetEventFilter) -> Self {
+        match value {
+            WidgetEventFilter::MessageLike { event_type, msgtype } => {
+                Self::MessageLike { event_type: event_type.into(), msgtype }
+            }
+            WidgetEventFilter::State { event_type, state_key } => {
+                Self::State { event_type: event_type.into(), state_key }
+            }
+        }
+    }
+}
+
+impl From<matrix_sdk::widget::EventFilter> for WidgetEventFilter {
+    fn from(value: matrix_sdk::widget::EventFilter) -> Self {
+        use matrix_sdk::widget::EventFilter as F;
+
+        match value {
+            F::MessageLike { event_type, msgtype } => {
+                Self::MessageLike { event_type: event_type.to_string(), msgtype }
+            }
+            F::State { event_type, state_key } => {
+                Self::State { event_type: event_type.to_string(), state_key }
+            }
+        }
+    }
+}
+
+#[uniffi::export(callback_interface)]
+pub trait WidgetPermissionsProvider: Send + Sync {
+    fn acquire_permissions(&self, permissions: WidgetPermissions) -> WidgetPermissions;
+}
+
+struct PermissionsProviderWrap(Arc<dyn WidgetPermissionsProvider>);
+
+#[async_trait]
+impl matrix_sdk::widget::PermissionsProvider for PermissionsProviderWrap {
+    async fn acquire_permissions(
+        &self,
+        permissions: matrix_sdk::widget::Permissions,
+    ) -> matrix_sdk::widget::Permissions {
+        let this = self.0.clone();
+        // This could require a prompt to the user. Ideally the callback
+        // interface would just be async, but that's not supported yet so use
+        // one of tokio's blocking task threads instead.
+        tokio::task::spawn_blocking(move || this.acquire_permissions(permissions.into()).into())
+            .await
+            // propagate panics from the blocking task
+            .unwrap()
+    }
+}
+
+#[uniffi::export]
+pub async fn run_widget_api(
+    room: Arc<Room>,
+    widget: Widget,
+    permissions_provider: Box<dyn WidgetPermissionsProvider>,
+) {
+    let permissions_provider = PermissionsProviderWrap(permissions_provider.into());
+    if let Err(()) =
+        matrix_sdk::widget::run_widget_api(room.inner.clone(), widget.into(), permissions_provider)
+            .await
+    {}
+}

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -62,6 +62,7 @@ docsrs = ["e2e-encryption", "sqlite", "sso-login", "qrcode", "image-proc"]
 [dependencies]
 anyhow = { workspace = true, optional = true }
 anymap2 = "0.13.0"
+async-channel = "1.9.0"
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bytes = "1.1.0"

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -55,7 +55,7 @@ experimental-sliding-sync = [
     "reqwest/gzip",
     "dep:eyeball-im-util",
 ]
-experimental-widget-api = []
+experimental-widgets = []
 
 docsrs = ["e2e-encryption", "sqlite", "sso-login", "qrcode", "image-proc"]
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -48,7 +48,7 @@ pub mod room;
 #[cfg(feature = "experimental-sliding-sync")]
 pub mod sliding_sync;
 pub mod sync;
-#[cfg(feature = "experimental-widget-api")]
+#[cfg(feature = "experimental-widgets")]
 pub mod widget;
 
 pub use account::Account;

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -1,12 +1,12 @@
 //! Client widget API implementation.
 
-use tokio::sync::mpsc::{Receiver, Sender};
+use async_channel::{Receiver, Sender};
 
 use crate::room::Room as JoinedRoom;
 
 mod permissions;
 
-pub use self::permissions::{Permissions, PermissionsProvider};
+pub use self::permissions::{EventFilter, Permissions, PermissionsProvider};
 
 /// Describes a widget.
 #[derive(Debug)]
@@ -48,5 +48,5 @@ pub async fn run_widget_api(
     _widget: Widget,
     _permissions_provider: impl PermissionsProvider,
 ) -> Result<(), ()> {
-    todo!()
+    Err(())
 }


### PR DESCRIPTION
`run_widget_api` (better name suggestions welcome) does not do anything right now, and the `WidgetComm` type doesn't have any methods yet, but having this makes sure the API is bridge-able (after a small change to use `async_channel` where both sender and receiver are clonable).