### PR TITLE
Make update_timeline_item macro compatible with Rust 1.70

### DIFF
--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "matrix-sdk-ui"
 version = "0.6.0"
 edition = "2021"
+rust-version = { workspace = true }
 
 [features]
 default = ["e2e-encryption", "native-tls"]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -230,11 +230,6 @@ pub(super) struct TimelineEventHandler<'a> {
 // "see through" it, allowing borrows of TimelineEventHandler fields other than
 // `timeline_items` and `items_updated` in the update closure.
 macro_rules! update_timeline_item {
-    ($this:ident, $event_id:expr, $action:expr, $found:expr) => {
-        update_timeline_item!($this, $event_id, found: $found, not_found: || {
-            debug!("Timeline item not found, discarding {}", $action);
-        });
-    };
     ($this:ident, $event_id:expr, found: $found:expr, not_found: $not_found:expr) => {
         _update_timeline_item(
             &mut $this.state.items,
@@ -243,6 +238,11 @@ macro_rules! update_timeline_item {
             $found,
             $not_found,
         )
+    };
+    ($this:ident, $event_id:expr, $action:expr, $found:expr) => {
+        update_timeline_item!($this, $event_id, found: $found, not_found: || {
+            debug!("Timeline item not found, discarding {}", $action);
+        });
     };
 }
 


### PR DESCRIPTION
… by swapping the branches around. Previously, invocations meant to match the found + not_found branch were actually hitting the other one prior to Rust 1.71, likely due to parser supporting type ascription (even though it was an unstable feature).