### PR TITLE
feat(bindings): Add logo_uri to OidcConfiguration.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -109,6 +109,8 @@ pub struct OidcConfiguration {
     pub redirect_uri: String,
     /// A URI that contains information about the client.
     pub client_uri: String,
+    /// A URI that contains the client's logo.
+    pub logo_uri: String,
     /// A URI that contains the client's terms of service.
     pub tos_uri: String,
     /// A URI that contains the client's privacy policy.
@@ -556,6 +558,7 @@ impl AuthenticationService {
             .map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
         let client_name = Some(Localized::new(configuration.client_name.to_owned(), []));
         let client_uri = Url::parse(&configuration.client_uri).ok().map(|u| Localized::new(u, []));
+        let logo_uri = Url::parse(&configuration.logo_uri).ok().map(|u| Localized::new(u, []));
         let policy_uri = Url::parse(&configuration.policy_uri).ok().map(|u| Localized::new(u, []));
         let tos_uri = Url::parse(&configuration.tos_uri).ok().map(|u| Localized::new(u, []));
 
@@ -569,6 +572,7 @@ impl AuthenticationService {
             client_name,
             contacts: None,
             client_uri,
+            logo_uri,
             policy_uri,
             tos_uri,
             ..Default::default()

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -558,46 +558,10 @@ impl AuthenticationService {
             .map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
         let client_name =
             configuration.client_name.as_ref().map(|n| Localized::new(n.to_owned(), []));
-        let client_uri = configuration
-            .client_uri
-            .as_deref()
-            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
-                Ok(Localized::new(
-                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
-                    [],
-                ))
-            })
-            .transpose()?;
-        let logo_uri = configuration
-            .logo_uri
-            .as_deref()
-            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
-                Ok(Localized::new(
-                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
-                    [],
-                ))
-            })
-            .transpose()?;
-        let policy_uri = configuration
-            .policy_uri
-            .as_deref()
-            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
-                Ok(Localized::new(
-                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
-                    [],
-                ))
-            })
-            .transpose()?;
-        let tos_uri = configuration
-            .tos_uri
-            .as_deref()
-            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
-                Ok(Localized::new(
-                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
-                    [],
-                ))
-            })
-            .transpose()?;
+        let client_uri = configuration.client_uri.localized_url()?;
+        let logo_uri = configuration.logo_uri.localized_url()?;
+        let policy_uri = configuration.policy_uri.localized_url()?;
+        let tos_uri = configuration.tos_uri.localized_url()?;
 
         ClientMetadata {
             application_type: Some(ApplicationType::Native),
@@ -648,5 +612,24 @@ impl AuthenticationService {
         client.restore_session_inner(session)?;
 
         Ok(client)
+    }
+}
+
+trait OptionExt {
+    /// Convenience method to convert a string to a URL and returns it as a
+    /// Localized URL. No localization is actually performed.
+    fn localized_url(&self) -> Result<Option<Localized<Url>>, AuthenticationError>;
+}
+
+impl OptionExt for Option<String> {
+    fn localized_url(&self) -> Result<Option<Localized<Url>>, AuthenticationError> {
+        self.as_deref()
+            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
+                Ok(Localized::new(
+                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
+                    [],
+                ))
+            })
+            .transpose()
     }
 }

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -561,31 +561,43 @@ impl AuthenticationService {
         let client_uri = configuration
             .client_uri
             .as_deref()
-            .map(Url::parse)
-            .transpose()
-            .map_err(|_| AuthenticationError::OidcMetadataInvalid)?
-            .map(|u| Localized::new(u, []));
+            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
+                Ok(Localized::new(
+                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
+                    [],
+                ))
+            })
+            .transpose()?;
         let logo_uri = configuration
             .logo_uri
             .as_deref()
-            .map(Url::parse)
-            .transpose()
-            .map_err(|_| AuthenticationError::OidcMetadataInvalid)?
-            .map(|u| Localized::new(u, []));
+            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
+                Ok(Localized::new(
+                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
+                    [],
+                ))
+            })
+            .transpose()?;
         let policy_uri = configuration
             .policy_uri
             .as_deref()
-            .map(Url::parse)
-            .transpose()
-            .map_err(|_| AuthenticationError::OidcMetadataInvalid)?
-            .map(|u| Localized::new(u, []));
+            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
+                Ok(Localized::new(
+                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
+                    [],
+                ))
+            })
+            .transpose()?;
         let tos_uri = configuration
             .tos_uri
             .as_deref()
-            .map(Url::parse)
-            .transpose()
-            .map_err(|_| AuthenticationError::OidcMetadataInvalid)?
-            .map(|u| Localized::new(u, []));
+            .map(|uri| -> Result<Localized<Url>, AuthenticationError> {
+                Ok(Localized::new(
+                    Url::parse(uri).map_err(|_| AuthenticationError::OidcMetadataInvalid)?,
+                    [],
+                ))
+            })
+            .transpose()?;
 
         ClientMetadata {
             application_type: Some(ApplicationType::Native),


### PR DESCRIPTION
Part of https://github.com/vector-im/element-x-ios/issues/1547 this PR updates the `OidcConfiguration` to take a logo URL that will be displayed in the Consent prompt.

Whilst this property is optional in the request, without it MAS displays a big white square so I chose to not make it an optional property on the configuration.