### PR TITLE
feat(sliding sync): optionally persist/restore the `pos` in/from DB, and use that for encryption sync

### DIFF
--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -80,7 +80,7 @@ impl EncryptionSync {
         let mut builder = client
             .sliding_sync("encryption")
             .map_err(Error::SlidingSync)?
-            .restore_pos_from_database()
+            .share_pos()
             .with_to_device_extension(
                 assign!(v4::ToDeviceConfig::default(), { enabled: Some(true)}),
             )

--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -80,6 +80,7 @@ impl EncryptionSync {
         let mut builder = client
             .sliding_sync("encryption")
             .map_err(Error::SlidingSync)?
+            .restore_pos_from_database()
             .with_to_device_extension(
                 assign!(v4::ToDeviceConfig::default(), { enabled: Some(true)}),
             )

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -40,6 +40,7 @@ pub struct SlidingSyncBuilder {
     rooms: BTreeMap<OwnedRoomId, SlidingSyncRoom>,
     poll_timeout: Duration,
     network_timeout: Duration,
+    #[cfg(feature = "e2e-encryption")]
     share_pos: bool,
 }
 
@@ -63,6 +64,7 @@ impl SlidingSyncBuilder {
                 rooms: BTreeMap::new(),
                 poll_timeout: Duration::from_secs(30),
                 network_timeout: Duration::from_secs(30),
+                #[cfg(feature = "e2e-encryption")]
                 share_pos: false,
             })
         }
@@ -232,6 +234,7 @@ impl SlidingSyncBuilder {
     /// multi-process scenarios, to save it into some shared storage so that one
     /// sliding sync instance running across two different processes can
     /// continue with the same sync position it had before being stopped.
+    #[cfg(feature = "e2e-encryption")]
     pub fn share_pos(mut self) -> Self {
         self.share_pos = true;
         self
@@ -257,13 +260,22 @@ impl SlidingSyncBuilder {
         // Reload existing state from the cache.
         let restored_fields =
             restore_sliding_sync_state(&client, &self.storage_key, &lists).await?;
+
         let (delta_token, pos) = if let Some(fields) = restored_fields {
-            (fields.delta_token, fields.pos)
+            #[cfg(feature = "e2e-encryption")]
+            let pos = if self.share_pos { fields.pos } else { None };
+            #[cfg(not(feature = "e2e-encryption"))]
+            let pos = None;
+
+            (fields.delta_token, pos)
         } else {
             (None, None)
         };
 
-        let pos = if self.share_pos { pos } else { None };
+        #[cfg(feature = "e2e-encryption")]
+        let share_pos = self.share_pos;
+        #[cfg(not(feature = "e2e-encryption"))]
+        let share_pos = false;
 
         let rooms = AsyncRwLock::new(self.rooms);
         let lists = AsyncRwLock::new(lists);
@@ -278,7 +290,7 @@ impl SlidingSyncBuilder {
 
             client,
             storage_key: self.storage_key,
-            share_pos: self.share_pos,
+            share_pos,
 
             lists,
             rooms,

--- a/crates/matrix-sdk/src/sliding_sync/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/builder.rs
@@ -224,11 +224,13 @@ impl SlidingSyncBuilder {
         self
     }
 
-    /// Should the sliding sync instance restore its stream position from the database?
+    /// Should the sliding sync instance restore its stream position from the
+    /// database?
     ///
-    /// In general, sliding sync instances will cache the stream position (`pos` field in the
-    /// request) in internal fields. It can be useful, in multi-process scenarios, to save it into
-    /// the database so that one sliding sync instance running across two different processes can
+    /// In general, sliding sync instances will cache the stream position (`pos`
+    /// field in the request) in internal fields. It can be useful, in
+    /// multi-process scenarios, to save it into the database so that one
+    /// sliding sync instance running across two different processes can
     /// continue with the same stream position it had before being stopped.
     pub fn restore_pos_from_database(mut self) -> Self {
         self.restore_pos_from_database = true;

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -490,8 +490,8 @@ mod tests {
             .await?
             .expect("must have restored fields");
 
-        // After restoring, the delta token, the to-device since token, and stream position could
-        // be read from the state store.
+        // After restoring, the delta token, the to-device since token, and stream
+        // position could be read from the state store.
         assert_eq!(restored_fields.delta_token.unwrap(), delta_token);
         assert_eq!(restored_fields.to_device_token.unwrap(), to_device_token);
         assert_eq!(restored_fields.pos.unwrap(), pos);

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -201,7 +201,7 @@ pub(super) async fn restore_sliding_sync_state(
         Some(Ok(FrozenSlidingSync {
             to_device_since,
             delta_token: frozen_delta_token,
-            previous_pos: frozen_pos,
+            pos: frozen_pos,
         })) => {
             trace!("Successfully read the `SlidingSync` from the cache");
             // Only update the to-device token if we failed to read it from the crypto store
@@ -445,7 +445,7 @@ mod tests {
             Some(bytes) => {
                 let deserialized: FrozenSlidingSync = serde_json::from_slice(&bytes)?;
                 assert_eq!(deserialized.delta_token, Some(delta_token.clone()));
-                assert_eq!(deserialized.previous_pos, Some(pos.clone()));
+                assert_eq!(deserialized.pos, Some(pos.clone()));
                 assert!(deserialized.to_device_since.is_none());
             }
         );
@@ -481,7 +481,7 @@ mod tests {
                 serde_json::to_vec(&FrozenSlidingSync {
                     to_device_since: Some(to_device_token.clone()),
                     delta_token: Some(delta_token.clone()),
-                    previous_pos: Some(pos.clone()),
+                    pos: Some(pos.clone()),
                 })?,
             )
             .await?;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -91,7 +91,8 @@ pub(super) struct SlidingSyncInner {
     /// The storage key to keep this cache at and load it from.
     storage_key: String,
 
-    /// Should this sliding sync instance try to restore its stream position from the database?
+    /// Should this sliding sync instance try to restore its stream position
+    /// from the database?
     restore_pos_from_database: bool,
 
     /// Position markers.
@@ -475,8 +476,8 @@ impl SlidingSync {
             None
         };
 
-        // Update pos: either the one restored from the database, if any and the sliding sync was
-        // configured so, or read it from the memory cache.
+        // Update pos: either the one restored from the database, if any and the sliding
+        // sync was configured so, or read it from the memory cache.
         let pos = if self.inner.restore_pos_from_database {
             if let Some(fields) = &restored_fields {
                 // Override the memory one with the database one, for consistency.
@@ -1629,7 +1630,7 @@ mod tests {
                 let pos = {
                     let mut pos = server_pos.lock().unwrap();
                     let prev = *pos;
-                    *pos = *pos + 1;
+                    *pos += 1;
                     prev
                 };
 
@@ -1657,8 +1658,8 @@ mod tests {
         let sync = sliding_sync.sync();
         pin_mut!(sync);
 
-        // Sync goes well, and then the position is saved both into the internal memory and the
-        // database.
+        // Sync goes well, and then the position is saved both into the internal memory
+        // and the database.
         let next = sync.next().await;
         assert_matches!(next, Some(Ok(_update_summary)));
 
@@ -1672,12 +1673,13 @@ mod tests {
         .await?
         .expect("must have restored fields");
 
-        // While it has been saved into the database, it's not necessarily going to be used later!
+        // While it has been saved into the database, it's not necessarily going to be
+        // used later!
         assert_eq!(restored_fields.pos.as_deref(), Some("0"));
 
-        // Now, even if we mess with the position stored in the database, the sliding sync instance
-        // isn't configured to reload the stream position from the database, so it won't be
-        // changed.
+        // Now, even if we mess with the position stored in the database, the sliding
+        // sync instance isn't configured to reload the stream position from the
+        // database, so it won't be changed.
         {
             let other_sync = client.sliding_sync("forgetful-sync")?.build().await?;
 
@@ -1695,7 +1697,8 @@ mod tests {
             assert_eq!(request.pos.as_deref(), Some("0"));
         }
 
-        // Recreating a sliding sync with the same ID doesn't preload the pos, if not asked to.
+        // Recreating a sliding sync with the same ID doesn't preload the pos, if not
+        // asked to.
         {
             let sliding_sync = client.sliding_sync("forgetful-sync")?.build().await?;
             assert!(sliding_sync.inner.position.lock().await.pos.is_none());
@@ -1721,7 +1724,7 @@ mod tests {
                 let pos = {
                     let mut pos = server_pos.lock().unwrap();
                     let prev = *pos;
-                    *pos = *pos + 1;
+                    *pos += 1;
                     prev
                 };
 
@@ -1750,8 +1753,8 @@ mod tests {
         let sync = sliding_sync.sync();
         pin_mut!(sync);
 
-        // Sync goes well, and then the position is saved both into the internal memory and the
-        // database.
+        // Sync goes well, and then the position is saved both into the internal memory
+        // and the database.
         let next = sync.next().await;
         assert_matches!(next, Some(Ok(_update_summary)));
 
@@ -1765,7 +1768,8 @@ mod tests {
         .await?
         .expect("must have restored fields");
 
-        // While it has been saved into the database, it's not necessarily going to be used later!
+        // While it has been saved into the database, it's not necessarily going to be
+        // used later!
         assert_eq!(restored_fields.pos.as_deref(), Some("0"));
 
         // Another process modifies the stream position under our feet...
@@ -1797,7 +1801,8 @@ mod tests {
             assert_eq!(request.pos.as_deref(), Some("42"));
         }
 
-        // Invalidating the session will remove the in-memory value AND the database value.
+        // Invalidating the session will remove the in-memory value AND the database
+        // value.
         sliding_sync.expire_session().await;
 
         {

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -877,19 +877,19 @@ struct FrozenSlidingSync {
     to_device_since: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     delta_token: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pos: Option<String>,
 }
 
 impl FrozenSlidingSync {
     async fn new(position: &SlidingSyncPositionMarkers) -> Self {
         // The to-device token must be saved in the `FrozenCryptoSlidingSync` now.
-        Self {
-            delta_token: position.delta_token.clone(),
-            to_device_since: None,
-            pos: position.pos.clone(),
-        }
+        Self { delta_token: position.delta_token.clone(), to_device_since: None }
     }
+}
+
+#[derive(Serialize, Deserialize)]
+struct FrozenSlidingSyncPos {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pos: Option<String>,
 }
 
 /// A summary of the updates received after a sync (like in
@@ -1613,6 +1613,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[async_test]
     async fn test_sliding_sync_doesnt_remember_pos() -> Result<()> {
         let server = MockServer::start().await;
@@ -1707,6 +1708,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "e2e-encryption")]
     #[async_test]
     async fn test_sliding_sync_does_remember_pos() -> Result<()> {
         let server = MockServer::start().await;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -852,12 +852,18 @@ struct FrozenSlidingSync {
     to_device_since: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     delta_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    previous_pos: Option<String>,
 }
 
 impl FrozenSlidingSync {
     async fn new(position: &SlidingSyncPositionMarkers) -> Self {
         // The to-device token must be saved in the `FrozenCryptoSlidingSync` now.
-        Self { delta_token: position.delta_token.clone(), to_device_since: None }
+        Self {
+            delta_token: position.delta_token.clone(),
+            to_device_since: None,
+            previous_pos: position.pos.clone(),
+        }
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -878,7 +878,7 @@ struct FrozenSlidingSync {
     #[serde(skip_serializing_if = "Option::is_none")]
     delta_token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    previous_pos: Option<String>,
+    pos: Option<String>,
 }
 
 impl FrozenSlidingSync {
@@ -887,7 +887,7 @@ impl FrozenSlidingSync {
         Self {
             delta_token: position.delta_token.clone(),
             to_device_since: None,
-            previous_pos: position.pos.clone(),
+            pos: position.pos.clone(),
         }
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -93,6 +93,10 @@ pub(super) struct SlidingSyncInner {
 
     /// Should this sliding sync instance try to restore its sync position
     /// from the database?
+    ///
+    /// Note: in non-cfg(e2e-encryption) builds, it's always set to false. We
+    /// keep it even so, to avoid sparkling cfg statements everywhere
+    /// throughout this file.
     share_pos: bool,
 
     /// Position markers.

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -489,17 +489,12 @@ impl SlidingSync {
         if to_device_enabled {
             let lists = self.inner.lists.read().await;
 
-            let mut to_device_token = None;
-            restore_sliding_sync_state(
-                &self.inner.client,
-                &self.inner.storage_key,
-                &lists,
-                &mut None,
-                &mut to_device_token,
-            )
-            .await?;
-
-            request.extensions.to_device.since = to_device_token;
+            if let Some(restored_fields) =
+                restore_sliding_sync_state(&self.inner.client, &self.inner.storage_key, &lists)
+                    .await?
+            {
+                request.extensions.to_device.since = restored_fields.to_device_token;
+            }
         }
 
         // Apply the transaction id if one was generated.


### PR DESCRIPTION
This introduces a new `SlidingSyncBuilder` method, `restore_pos_from_database()`, that when enabled, will save the `pos` values into the database, and restore them just before running another request.

This will show useful in contexts where multiple processes can spawn a sliding sync, and we'd like continuity over the range of `pos` values that are sent, given a fixed `conn_id`. In particular, this will prevent spurious session expirations, when alternating between the sliding sync running in one process or the other. An example of that is the iOS setup, where we have the main app running as its own process, and a separate process running to decrypt notifications.

This can be reviewed commit by commit; the latest commit includes extensive tests, including some for session expiration (as well as some changes to maintain the invariant that `pos` is always the same in memory and in DB).