### PR TITLE
ffi: use `RoomMessageEventContentWithoutRelation` for send / reply / edit

### DIFF
--- a/bindings/matrix-sdk-ffi/src/api.udl
+++ b/bindings/matrix-sdk-ffi/src/api.udl
@@ -1,6 +1,6 @@
 namespace matrix_sdk_ffi {};
 
-interface RoomMessageEventContent {};
+interface RoomMessageEventContentWithoutRelation {};
 
 [Error]
 interface ClientError {

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -41,7 +41,9 @@ mod tracing;
 mod widget;
 
 use async_compat::TOKIO1 as RUNTIME;
-use matrix_sdk::ruma::events::room::{message::RoomMessageEventContent, MediaSource};
+use matrix_sdk::ruma::events::room::{
+    message::RoomMessageEventContentWithoutRelation, MediaSource,
+};
 use matrix_sdk_ui::timeline::{BackPaginationStatus, EventItemOrigin};
 
 use self::{error::ClientError, task_handle::TaskHandle, timeline::MediaSourceExt};

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -19,8 +19,8 @@ use matrix_sdk::{
                 LocationMessageEventContent as RumaLocationMessageEventContent,
                 MessageType as RumaMessageType,
                 NoticeMessageEventContent as RumaNoticeMessageEventContent,
-                RoomMessageEventContent, TextMessageEventContent as RumaTextMessageEventContent,
-                VideoInfo as RumaVideoInfo,
+                RoomMessageEventContentWithoutRelation,
+                TextMessageEventContent as RumaTextMessageEventContent, VideoInfo as RumaVideoInfo,
                 VideoMessageEventContent as RumaVideoMessageEventContent,
             },
             ImageInfo as RumaImageInfo, MediaSource, ThumbnailInfo as RumaThumbnailInfo,
@@ -43,21 +43,27 @@ pub fn media_source_from_url(url: String) -> Arc<MediaSource> {
 }
 
 #[uniffi::export]
-pub fn message_event_content_new(msgtype: MessageType) -> Arc<RoomMessageEventContent> {
-    Arc::new(RoomMessageEventContent::new(msgtype.into()))
+pub fn message_event_content_new(
+    msgtype: MessageType,
+) -> Arc<RoomMessageEventContentWithoutRelation> {
+    Arc::new(RoomMessageEventContentWithoutRelation::new(msgtype.into()))
 }
 
 #[uniffi::export]
-pub fn message_event_content_from_markdown(md: String) -> Arc<RoomMessageEventContent> {
-    Arc::new(RoomMessageEventContent::text_markdown(md))
+pub fn message_event_content_from_markdown(
+    md: String,
+) -> Arc<RoomMessageEventContentWithoutRelation> {
+    Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_markdown(md)))
 }
 
 #[uniffi::export]
 pub fn message_event_content_from_html(
     body: String,
     html_body: String,
-) -> Arc<RoomMessageEventContent> {
-    Arc::new(RoomMessageEventContent::text_html(body, html_body))
+) -> Arc<RoomMessageEventContentWithoutRelation> {
+    Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_html(
+        body, html_body,
+    )))
 }
 
 #[uniffi::export(callback_interface)]


### PR DESCRIPTION
Allow using `RoomMessageEventContent` instead of strings in order to edit or reply to events.

Main use case: an app that uses an advanced composer such as Matrix Rich Text Editor, might need to provide HTML + Markdown instead of just Markdown. 

Also actually moves from using `RoomMessageEventContent` to `RoomMessageEventContentWithoutRelation` in order to avoid having to "downcast" when attaching a replacement. 