### PR TITLE
fix(sdk): limit the number of retries when updating push rules.

### DIFF
--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -18,8 +18,10 @@ mod command;
 mod rule_commands;
 mod rules;
 
-use crate::{error::NotificationSettingsError, event_handler::EventHandlerHandle, Client, Result};
-use crate::config::RequestConfig;
+use crate::{
+    config::RequestConfig, error::NotificationSettingsError, event_handler::EventHandlerHandle,
+    Client, Result,
+};
 
 /// Enum representing the push notification modes for a room.
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -19,6 +19,7 @@ mod rule_commands;
 mod rules;
 
 use crate::{error::NotificationSettingsError, event_handler::EventHandlerHandle, Client, Result};
+use crate::config::RequestConfig;
 
 /// Enum representing the push notification modes for a room.
 #[derive(Debug, Clone, PartialEq)]
@@ -324,6 +325,7 @@ impl NotificationSettings {
         &self,
         rule_commands: &RuleCommands,
     ) -> Result<(), NotificationSettingsError> {
+        let request_config = Some(RequestConfig::short_retry());
         for command in &rule_commands.commands {
             match command {
                 Command::DeletePushRule { scope, kind, rule_id } => {
@@ -333,7 +335,7 @@ impl NotificationSettings {
                         rule_id.clone(),
                     );
                     self.client
-                        .send(request, None)
+                        .send(request, request_config)
                         .await
                         .map_err(|_| NotificationSettingsError::UnableToRemovePushRule)?;
                 }
@@ -341,7 +343,7 @@ impl NotificationSettings {
                     let push_rule = command.to_push_rule()?;
                     let request = set_pushrule::v3::Request::new(scope.clone(), push_rule);
                     self.client
-                        .send(request, None)
+                        .send(request, request_config)
                         .await
                         .map_err(|_| NotificationSettingsError::UnableToAddPushRule)?;
                 }
@@ -349,7 +351,7 @@ impl NotificationSettings {
                     let push_rule = command.to_push_rule()?;
                     let request = set_pushrule::v3::Request::new(scope.clone(), push_rule);
                     self.client
-                        .send(request, None)
+                        .send(request, request_config)
                         .await
                         .map_err(|_| NotificationSettingsError::UnableToAddPushRule)?;
                 }
@@ -361,7 +363,7 @@ impl NotificationSettings {
                         *enabled,
                     );
                     self.client
-                        .send(request, None)
+                        .send(request, request_config)
                         .await
                         .map_err(|_| NotificationSettingsError::UnableToUpdatePushRule)?;
                 }
@@ -373,7 +375,7 @@ impl NotificationSettings {
                         actions.clone(),
                     );
                     self.client
-                        .send(request, None)
+                        .send(request, request_config)
                         .await
                         .map_err(|_| NotificationSettingsError::UnableToUpdatePushRule)?;
                 }


### PR DESCRIPTION
This PR limits the number of retries when updating the push rules.