### PR TITLE
Silence clippy lint `arc_with_non_send_sync` on wasm

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -35,6 +35,14 @@ rustflags = [
     "-Wclippy::todo",
 ]
 
+[target.'cfg(target_arch = "wasm32")']
+rustflags = [
+    # We have some types that are !Send and/or !Sync only on wasm, it would be
+    # slightly more efficient, but also pretty annoying, to wrap them in Rc
+    # where we would use Arc on other platforms.
+    "-Aclippy::arc_with_non_send_sync",
+]
+
 # activate the target-applies-to-host feature.
 # Required for `target-applies-to-host` at the top to take effect.
 [unstable]

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -468,7 +468,7 @@ pub enum EventItemOrigin {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use matrix_sdk::{config::RequestConfig, Client, ClientBuilder, SlidingSyncRoom};
+    use matrix_sdk::{config::RequestConfig, Client, ClientBuilder};
     use matrix_sdk_base::{deserialized_responses::SyncTimelineEvent, BaseClient, SessionMeta};
     use matrix_sdk_test::async_test;
     use ruma::{


### PR DESCRIPTION
We have some types that are !Send and/or !Sync only on wasm, it would be slightly more efficient, but also pretty annoying, to wrap them in Rc where we would use Arc on other platforms.