### PR TITLE
Add the x86-64 Android workaround to the Crypto SDK too

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/build.rs
+++ b/bindings/matrix-sdk-crypto-ffi/build.rs
@@ -1,8 +1,37 @@
+use std::env;
 use std::error::Error;
 
 use vergen::EmitBuilder;
 
+/// Adds a temporary workaround for an issue with the Rust compiler and Android
+/// in x86_64 devices: https://github.com/rust-lang/rust/issues/109717.
+/// The workaround comes from: https://github.com/mozilla/application-services/pull/5442
+fn setup_x86_64_android_workaround() {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
+    if target_arch == "x86_64" && target_os == "android" {
+        let android_ndk_home = env::var("ANDROID_NDK_HOME").expect("ANDROID_NDK_HOME not set");
+        let build_os = match env::consts::OS {
+            "linux" => "linux",
+            "macos" => "darwin",
+            "windows" => "windows",
+            _ => panic!(
+                "Unsupported OS. You must use either Linux, MacOS or Windows to build the crate."
+            ),
+        };
+        const DEFAULT_CLANG_VERSION: &str = "14.0.7";
+        let clang_version =
+            env::var("NDK_CLANG_VERSION").unwrap_or_else(|_| DEFAULT_CLANG_VERSION.to_owned());
+        let linux_x86_64_lib_dir = format!(
+            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib64/clang/{clang_version}/lib/linux/"
+        );
+        println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
+        println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
+    }
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
+    setup_x86_64_android_workaround();
     uniffi::generate_scaffolding("./src/olm.udl")?;
 
     EmitBuilder::builder().git_sha(true).git_describe(true, false, None).emit()?;

--- a/bindings/matrix-sdk-crypto-ffi/build.rs
+++ b/bindings/matrix-sdk-crypto-ffi/build.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::error::Error;
+use std::{env, error::Error};
 
 use vergen::EmitBuilder;
 


### PR DESCRIPTION
Some time ago [we found an issue](https://github.com/matrix-org/matrix-rust-sdk/pull/1782) with x86-64 binaries generated from the Rust SDK using NDK 25 lacking some symbols and instantly crashing any apps that used the library in x86-64 devices. The Crypto SDK is also affected by this issue, as seen in https://github.com/vector-im/element-android/issues/8546.

In this PR I added the same workaround to the crypto SDK FFI crate.
