### PR TITLE
ffi: Add custom tracing log formatter

### DIFF
--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -177,7 +177,7 @@ where
             }
 
             if let Some(scope) = ctx.event_scope() {
-                writer.write_str(" | stack: ")?;
+                writer.write_str(" | spans: ")?;
                 let mut first = true;
 
                 for span in scope.from_root() {

--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -10,7 +10,11 @@ use opentelemetry_otlp::{Protocol, WithExportConfig};
 use tokio::runtime::Handle;
 use tracing_core::Subscriber;
 use tracing_subscriber::{
-    fmt, layer::SubscriberExt, registry::LookupSpan, util::SubscriberInitExt, EnvFilter, Layer,
+    fmt::{self, time::FormatTime, FormatEvent, FormatFields, FormattedFields},
+    layer::SubscriberExt,
+    registry::LookupSpan,
+    util::SubscriberInitExt,
+    EnvFilter, Layer,
 };
 
 use crate::RUNTIME;
@@ -94,36 +98,126 @@ fn text_layers<S>(config: TracingConfiguration) -> impl Layer<S>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    fn fmt_layer<S>() -> fmt::Layer<S> {
-        fmt::layer()
-            .with_file(true)
-            .with_line_number(true)
-            .with_ansi(cfg!(not(any(target_os = "android", target_os = "ios"))))
+    // Adjusted version of tracing_subscriber::fmt::Format
+    struct EventFormatter {
+        display_timestamp: bool,
+        display_level: bool,
     }
 
-    let file_layer = config
-        .write_to_files
-        .map(|c| fmt_layer().with_writer(tracing_appender::rolling::hourly(c.path, c.file_prefix)));
+    impl EventFormatter {
+        fn new() -> Self {
+            Self { display_timestamp: true, display_level: true }
+        }
 
-    #[cfg(not(target_os = "android"))]
-    return Layer::and_then(
-        file_layer,
-        config.write_to_stdout_or_system.then(|| fmt_layer().with_writer(std::io::stderr)),
-    );
+        #[cfg(target_os = "android")]
+        fn for_logcat() -> Self {
+            // Level and time are already captured by logcat separately
+            Self { display_timestamp: false, display_level: false }
+        }
 
-    #[cfg(target_os = "android")]
-    return Layer::and_then(
+        fn format_timestamp(&self, writer: &mut fmt::format::Writer<'_>) -> std::fmt::Result {
+            if fmt::time::SystemTime.format_time(writer).is_err() {
+                writer.write_str("<unknown time>")?;
+            }
+            Ok(())
+        }
+
+        fn write_filename(
+            &self,
+            writer: &mut fmt::format::Writer<'_>,
+            filename: &str,
+        ) -> std::fmt::Result {
+            const CRATES_IO_PATH_MATCHER: &str = ".cargo/registry/src/index.crates.io";
+            let crates_io_filename = filename
+                .split_once(CRATES_IO_PATH_MATCHER)
+                .and_then(|(_, rest)| rest.split_once('/').map(|(_, rest)| rest));
+
+            if let Some(filename) = crates_io_filename {
+                writer.write_str("<crates.io>/")?;
+                writer.write_str(filename)
+            } else {
+                writer.write_str(filename)
+            }
+        }
+    }
+
+    impl<S, N> FormatEvent<S, N> for EventFormatter
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+        N: for<'a> FormatFields<'a> + 'static,
+    {
+        fn format_event(
+            &self,
+            ctx: &fmt::FmtContext<'_, S, N>,
+            mut writer: fmt::format::Writer<'_>,
+            event: &tracing_core::Event<'_>,
+        ) -> std::fmt::Result {
+            let meta = event.metadata();
+
+            if self.display_timestamp {
+                self.format_timestamp(&mut writer)?;
+                writer.write_char(' ')?;
+            }
+
+            if self.display_level {
+                // For info and warn, add a padding space to the left
+                write!(writer, "{:>5} ", meta.level())?;
+            }
+
+            write!(writer, "{}: ", meta.target())?;
+
+            ctx.format_fields(writer.by_ref(), event)?;
+
+            if let Some(filename) = meta.file() {
+                writer.write_str(" | ")?;
+                self.write_filename(&mut writer, filename)?;
+                if let Some(line_number) = meta.line() {
+                    write!(writer, ":{line_number}")?;
+                }
+            }
+
+            if let Some(scope) = ctx.event_scope() {
+                writer.write_str(" | stack: ")?;
+                let mut first = true;
+
+                for span in scope.from_root() {
+                    if !first {
+                        writer.write_str(" > ")?;
+                    }
+                    first = false;
+                    write!(writer, "{}", span.metadata().name())?;
+
+                    let ext = span.extensions();
+                    if let Some(fields) = &ext.get::<FormattedFields<N>>() {
+                        if !fields.is_empty() {
+                            write!(writer, "{{{fields}}}")?;
+                        }
+                    }
+                }
+            }
+
+            writeln!(writer)
+        }
+    }
+
+    let file_layer = config.write_to_files.map(|c| {
+        fmt::layer()
+            .event_format(EventFormatter::new())
+            .with_writer(tracing_appender::rolling::hourly(c.path, c.file_prefix))
+    });
+
+    Layer::and_then(
         file_layer,
         config.write_to_stdout_or_system.then(|| {
-            fmt_layer()
-                // Level and time are already captured by logcat separately
-                .with_level(false)
-                .without_time()
-                .with_writer(paranoid_android::AndroidLogMakeWriter::new(
-                    "org.matrix.rust.sdk".to_owned(),
-                ))
+            #[cfg(not(target_os = "android"))]
+            return fmt::layer().event_format(EventFormatter::new()).with_writer(std::io::stderr);
+
+            #[cfg(target_os = "android")]
+            return fmt::layer().event_format(EventFormatter::for_logcat()).with_writer(
+                paranoid_android::AndroidLogMakeWriter::new("org.matrix.rust.sdk".to_owned()),
+            );
         }),
-    );
+    )
 }
 
 #[derive(uniffi::Record)]


### PR DESCRIPTION
Example output:

```
2023-08-25T12:20:29.337610Z TRACE matrix_sdk_ui::timeline::event_handler: Handling event | crates/matrix-sdk-ui/src/timeline/event_handler.rs:284 | stack: handle_event{event_id="$FuRWqHfOu949TacuzF:dummy.server" position=Update(2)}
2023-08-25T12:20:29.337642Z TRACE matrix_sdk_ui::timeline::event_handler: Found timeline item to update | crates/matrix-sdk-ui/src/timeline/event_handler.rs:1205 | stack: handle_event{event_id="$FuRWqHfOu949TacuzF:dummy.server" position=Update(2)} > handle_room_message_edit{replacement_event_id="$QJ8GvVn5PDehujg61h:dummy.server"}
2023-08-25T12:20:29.337659Z TRACE matrix_sdk_ui::timeline::event_handler: Applying edit | crates/matrix-sdk-ui/src/timeline/event_handler.rs:443 | stack: handle_event{event_id="$FuRWqHfOu949TacuzF:dummy.server" position=Update(2)} > handle_room_message_edit{replacement_event_id="$QJ8GvVn5PDehujg61h:dummy.server"}
2023-08-25T12:20:29.337683Z TRACE matrix_sdk_ui::timeline::event_handler: Updating item | crates/matrix-sdk-ui/src/timeline/event_handler.rs:1207 | stack: handle_event{event_id="$FuRWqHfOu949TacuzF:dummy.server" position=Update(2)} > handle_room_message_edit{replacement_event_id="$QJ8GvVn5PDehujg61h:dummy.server"}
2023-08-25T12:20:29.337698Z DEBUG eyeball::vector::update: set(index = 1) | <crates.io>/eyeball-im-0.2.6/src/vector.rs:171 | stack: handle_event{event_id="$FuRWqHfOu949TacuzF:dummy.server" position=Update(2)} > handle_room_message_edit{replacement_event_id="$QJ8GvVn5PDehujg61h:dummy.server"}
```
