### PR TITLE
widget: add support of the client widget api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,6 +3090,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "wasm-bindgen-test",
  "wiremock",
  "zeroize",

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -55,7 +55,7 @@ experimental-sliding-sync = [
     "reqwest/gzip",
     "dep:eyeball-im-util",
 ]
-experimental-widgets = []
+experimental-widgets = [ "uuid" ]
 
 docsrs = ["e2e-encryption", "sqlite", "sso-login", "qrcode", "image-proc"]
 
@@ -97,6 +97,7 @@ thiserror = { workspace = true }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 url = "2.2.2"
+uuid = { version = "1.4.1", optional = true }
 zeroize = { workspace = true }
 
 [dependencies.image]

--- a/crates/matrix-sdk/src/widget/client/handler/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/client/handler/capabilities.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use super::Result;
+use crate::widget::{
+    messages::{
+        from_widget::{ReadEventRequest, ReadEventResponse, SendEventRequest, SendEventResponse},
+        MatrixEvent,
+    },
+    EventFilter, Permissions,
+};
+
+#[allow(missing_debug_implementations)]
+#[derive(Default)]
+pub struct Capabilities {
+    pub listener: Option<UnboundedReceiver<MatrixEvent>>,
+    pub reader: Option<Box<dyn EventReader>>,
+    pub sender: Option<Box<dyn EventSender>>,
+}
+
+#[async_trait]
+pub trait EventReader: Filtered + Send {
+    async fn read(&self, req: ReadEventRequest) -> Result<ReadEventResponse>;
+}
+
+#[async_trait]
+pub trait EventSender: Filtered + Send {
+    async fn send(&self, req: SendEventRequest) -> Result<SendEventResponse>;
+}
+
+pub trait Filtered {
+    fn filters(&self) -> &[EventFilter];
+}
+
+impl<'t> From<&'t Capabilities> for Permissions {
+    fn from(c: &'t Capabilities) -> Self {
+        Self {
+            send: c.sender.as_ref().map(|e| e.filters().to_owned()).unwrap_or_default(),
+            read: c.reader.as_ref().map(|e| e.filters().to_owned()).unwrap_or_default(),
+        }
+    }
+}

--- a/crates/matrix-sdk/src/widget/client/handler/error.rs
+++ b/crates/matrix-sdk/src/widget/client/handler/error.rs
@@ -1,0 +1,25 @@
+use std::{borrow::Cow, error::Error as StdError, result::Result as StdResult};
+
+use thiserror::Error as ThisError;
+
+pub type Result<T> = StdResult<T, Error>;
+
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("The connection to the widget has been lost")]
+    WidgetDisconnected,
+    #[error("Widget replied with an error: {0}")]
+    WidgetErrorReply(String),
+    #[error("{0}")]
+    Other(Cow<'static, str>),
+}
+
+impl Error {
+    pub fn other(err: impl StdError) -> Self {
+        Self::Other(err.to_string().into())
+    }
+
+    pub fn custom(message: impl Into<Cow<'static, str>>) -> Self {
+        Self::Other(message.into())
+    }
+}

--- a/crates/matrix-sdk/src/widget/client/handler/mod.rs
+++ b/crates/matrix-sdk/src/widget/client/handler/mod.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::{
+    mpsc::{unbounded_channel, UnboundedSender},
+    oneshot::Receiver,
+};
+
+use self::state::{State, Task as StateTask};
+pub use self::{
+    capabilities::{Capabilities, EventReader, EventSender, Filtered},
+    error::{Error, Result},
+    openid::{OpenIDDecision, OpenIDStatus},
+    outgoing::{Request as Outgoing, Response},
+    state::IncomingRequest,
+};
+use crate::widget::{
+    messages::{
+        from_widget::{Action, SupportedApiVersionsResponse},
+        Header, MessageKind, OpenIDRequest, OpenIDResponse, OpenIDState,
+    },
+    Permissions,
+};
+
+mod capabilities;
+mod error;
+mod outgoing;
+mod state;
+
+#[async_trait]
+pub trait WidgetProxy: Send + Sync + 'static {
+    async fn send<T: Outgoing>(&self, req: T) -> Result<Response<T::Response>>;
+    fn reply(&self, reply: Reply) -> Result<()>;
+    fn init_on_load(&self) -> bool;
+}
+
+#[async_trait]
+pub trait Client: Send + Sync + 'static {
+    async fn initialise(&mut self, req: Permissions) -> Capabilities;
+    fn get_openid(&self, req: OpenIDRequest) -> OpenIDStatus;
+}
+
+#[allow(missing_debug_implementations)]
+pub struct MessageHandler<W> {
+    state_tx: UnboundedSender<StateTask>,
+    widget: Arc<W>,
+}
+
+impl<W: WidgetProxy> MessageHandler<W> {
+    pub fn new(client: impl Client, widget: W) -> Self {
+        let widget = Arc::new(widget);
+
+        let (state_tx, state_rx) = unbounded_channel();
+        tokio::spawn(State::new(widget.clone(), client).listen(state_rx));
+
+        if !widget.init_on_load() {
+            let _ = state_tx.send(StateTask::NegotiateCapabilities);
+        }
+
+        Self { widget, state_tx }
+    }
+
+    pub fn handle(&self, req: IncomingRequest) -> Result<()> {
+        match req.action {
+            Action::GetSupportedApiVersion(MessageKind::Request(r)) => {
+                let response = r.map(Ok(SupportedApiVersionsResponse::new()));
+                self.widget.reply(Reply {
+                    header: req.header,
+                    action: Action::GetSupportedApiVersion(response),
+                })?;
+            }
+
+            _ => {
+                self.state_tx
+                    .send(StateTask::HandleIncoming(req))
+                    .map_err(|_| Error::WidgetDisconnected)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub struct Reply {
+    pub header: Header,
+    // TODO: Define a new type, so that we can guarantee on compile time that we can only send
+    // `Action(Kind::Response)` here and not `Action(Kind::Request)`.
+    pub action: Action,
+}
+
+mod openid {
+    use super::{OpenIDResponse, OpenIDState, Receiver};
+
+    #[derive(Debug)]
+    pub enum OpenIDStatus {
+        #[allow(dead_code)]
+        Resolved(OpenIDDecision),
+        Pending(Receiver<OpenIDDecision>),
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum OpenIDDecision {
+        Blocked,
+        Allowed(OpenIDState),
+    }
+
+    impl From<OpenIDDecision> for OpenIDResponse {
+        fn from(decision: OpenIDDecision) -> Self {
+            match decision {
+                OpenIDDecision::Allowed(resolved) => OpenIDResponse::Allowed(resolved),
+                OpenIDDecision::Blocked => OpenIDResponse::Blocked,
+            }
+        }
+    }
+}

--- a/crates/matrix-sdk/src/widget/client/handler/outgoing.rs
+++ b/crates/matrix-sdk/src/widget/client/handler/outgoing.rs
@@ -1,0 +1,70 @@
+use crate::widget::messages::{
+    to_widget::{Action, CapabilitiesResponse, CapabilitiesUpdatedRequest},
+    Empty, MessageKind as Kind, OpenIDResponse,
+};
+
+pub type Response<T> = Result<T, String>;
+
+pub trait Request: Sized + Send + Sync + 'static {
+    type Response;
+
+    // TODO: Nothing stops the implementor to to generate an `Action` that is
+    // `Action(Kind::Response)` inside an `into_action()` implementation which is
+    // bad, because we **actually** want to enforce that only an
+    // `Action(Kind::Request)` could be used here. Define a special trait and
+    // newtype for each possible outgoing requset and further restrict the types
+    // that we can use. The response must match the action defined above. We can
+    // further restrict types here for more compile time safety. This would also
+    // eliminate a boilerplate copy-paste here and/or will allow to create a
+    // more elegant macro for it.
+    fn into_action(self) -> Action;
+    fn extract_response(reply: Action) -> Option<Response<Self::Response>>;
+}
+
+pub struct CapabilitiesRequest;
+impl Request for CapabilitiesRequest {
+    type Response = CapabilitiesResponse;
+
+    fn into_action(self) -> Action {
+        Action::CapabilitiesRequest(Kind::empty())
+    }
+
+    fn extract_response(reply: Action) -> Option<Response<Self::Response>> {
+        match reply {
+            Action::CapabilitiesRequest(Kind::Response(r)) => Some(r.response()),
+            _ => None,
+        }
+    }
+}
+
+pub struct CapabilitiesUpdate(pub CapabilitiesUpdatedRequest);
+impl Request for CapabilitiesUpdate {
+    type Response = Empty;
+
+    fn into_action(self) -> Action {
+        Action::CapabilitiesUpdate(Kind::request(self.0))
+    }
+
+    fn extract_response(reply: Action) -> Option<Response<Self::Response>> {
+        match reply {
+            Action::CapabilitiesUpdate(Kind::Response(r)) => Some(r.response()),
+            _ => None,
+        }
+    }
+}
+
+pub struct OpenIDUpdated(pub OpenIDResponse);
+impl Request for OpenIDUpdated {
+    type Response = Empty;
+
+    fn into_action(self) -> Action {
+        Action::OpenIdCredentialsUpdate(Kind::request(self.0))
+    }
+
+    fn extract_response(reply: Action) -> Option<Response<Self::Response>> {
+        match reply {
+            Action::OpenIdCredentialsUpdate(Kind::Response(r)) => Some(r.response()),
+            _ => None,
+        }
+    }
+}

--- a/crates/matrix-sdk/src/widget/client/handler/state.rs
+++ b/crates/matrix-sdk/src/widget/client/handler/state.rs
@@ -1,0 +1,184 @@
+use std::sync::Arc;
+
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use super::{
+    outgoing, Capabilities, Client, Error, OpenIDResponse, OpenIDStatus, Reply, Result, WidgetProxy,
+};
+use crate::widget::{
+    messages::{
+        from_widget::{Action, ApiVersion, SupportedApiVersionsResponse},
+        to_widget::{CapabilitiesResponse, CapabilitiesUpdatedRequest},
+        Empty, Header, MessageKind as Kind,
+    },
+    Permissions,
+};
+
+pub struct State<W, C> {
+    capabilities: Option<Capabilities>,
+    widget: Arc<W>,
+    client: C,
+}
+
+impl<W, C> State<W, C> {
+    pub fn new(widget: Arc<W>, client: C) -> Self {
+        Self { capabilities: None, widget, client }
+    }
+}
+
+pub enum Task {
+    NegotiateCapabilities,
+    HandleIncoming(IncomingRequest),
+}
+
+#[derive(Debug, Clone)]
+pub struct IncomingRequest {
+    pub header: Header,
+    pub action: Action,
+}
+
+impl<W: WidgetProxy, C: Client> State<W, C> {
+    pub async fn listen(mut self, mut rx: UnboundedReceiver<Task>) {
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                Task::HandleIncoming(req) => {
+                    if let Err(..) = self.handle(req.clone()).await {
+                        // TODO: We need to send an error to the widget if the
+                        // error was "normal",
+                        // i.e. a `Error::Other`. However, a
+                        // `WidgetDisconnected` is a terminal
+                        // error (we can get it if we try to send a message to
+                        // the widget as a response to
+                        // the incoming request and the widget's sink is dead at
+                        // the moment (widget
+                        // disconnected). Such terminal errors don't require any
+                        // specific action except for logging (?), use tracing
+                        // to log it here later.
+                    }
+                }
+                Task::NegotiateCapabilities => {
+                    let _ = self.initialise().await;
+                }
+            }
+        }
+    }
+
+    async fn handle(&mut self, IncomingRequest { header, action }: IncomingRequest) -> Result<()> {
+        match action {
+            Action::ContentLoaded(Kind::Request(req)) => {
+                let (response, negotiate) =
+                    match (self.widget.init_on_load(), self.capabilities.as_ref()) {
+                        (true, None) => (Ok(Empty {}), true),
+                        (true, Some(..)) => (Err("Already loaded".into()), false),
+                        _ => (Ok(Empty {}), false),
+                    };
+
+                self.reply(header, Action::ContentLoaded(req.map(response)))?;
+                if negotiate {
+                    self.initialise().await?;
+                }
+            }
+
+            Action::GetSupportedApiVersion(Kind::Request(req)) => {
+                let response = req.map(Ok(SupportedApiVersionsResponse::new()));
+                self.reply(header, Action::GetSupportedApiVersion(response))?;
+            }
+
+            Action::GetOpenID(Kind::Request(req)) => {
+                let (reply, handle) = match self.client.get_openid(req.content.clone()) {
+                    OpenIDStatus::Resolved(decision) => (decision.into(), None),
+                    OpenIDStatus::Pending(handle) => (OpenIDResponse::Pending, Some(handle)),
+                };
+
+                let response = req.map(Ok(reply));
+                self.reply(header, Action::GetOpenID(response))?;
+                if let Some(handle) = handle {
+                    let status = handle.await.map_err(|_| Error::WidgetDisconnected)?;
+                    self.widget
+                        .send(outgoing::OpenIDUpdated(status.into()))
+                        .await?
+                        .map_err(Error::WidgetErrorReply)?;
+                }
+            }
+
+            Action::ReadEvent(Kind::Request(req)) => {
+                let fut = self
+                    .caps()?
+                    .reader
+                    .as_ref()
+                    .ok_or(Error::custom("No permissions to read events"))?
+                    .read(req.content.clone());
+                let response = req.map(Ok(fut.await?));
+                self.reply(header, Action::ReadEvent(response))?;
+            }
+
+            Action::SendEvent(Kind::Request(req)) => {
+                let fut = self
+                    .caps()?
+                    .sender
+                    .as_ref()
+                    .ok_or(Error::custom("No permissions to send events"))?
+                    .send(req.content.clone());
+                let response = req.map(Ok(fut.await?));
+                self.reply(header, Action::SendEvent(response))?;
+            }
+
+            _ => {
+                // TODO: Widget sent:
+                // - A `FromWidget` response instead of sending a request. This
+                //   is
+                // actually not correct and widgets should not do this. We
+                // probably need to send an error in this case,
+                // clarify the format of this error later.
+                // - A new message kind that we don't support yet. We need to
+                //   send an error to the
+                // widget informing the widget that the message is not
+                // supported.
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn initialise(&mut self) -> Result<()> {
+        let CapabilitiesResponse { capabilities: desired } = self
+            .widget
+            .send(outgoing::CapabilitiesRequest)
+            .await?
+            .map_err(Error::WidgetErrorReply)?;
+
+        let capabilities = self.client.initialise(desired.clone()).await;
+        let approved: Permissions = (&capabilities).into();
+        self.capabilities = Some(capabilities);
+
+        let update = CapabilitiesUpdatedRequest { requested: desired, approved };
+        self.widget
+            .send(outgoing::CapabilitiesUpdate(update))
+            .await?
+            .map_err(Error::WidgetErrorReply)?;
+
+        Ok(())
+    }
+
+    fn reply(&self, header: Header, action: Action) -> Result<()> {
+        self.widget.reply(Reply { header, action })
+    }
+
+    fn caps(&mut self) -> Result<&mut Capabilities> {
+        self.capabilities.as_mut().ok_or(Error::custom("Capabilities have not been negotiated"))
+    }
+}
+
+impl SupportedApiVersionsResponse {
+    pub fn new() -> Self {
+        Self {
+            versions: vec![
+                ApiVersion::V0_0_1,
+                ApiVersion::V0_0_2,
+                ApiVersion::MSC2762,
+                ApiVersion::MSC2871,
+                ApiVersion::MSC3819,
+            ],
+        }
+    }
+}

--- a/crates/matrix-sdk/src/widget/client/matrix/mod.rs
+++ b/crates/matrix-sdk/src/widget/client/matrix/mod.rs
@@ -1,0 +1,217 @@
+use std::result::Result as StdResult;
+
+use async_trait::async_trait;
+use ruma::{
+    api::client::{
+        account::request_openid_token::v3::Request as MatrixOpenIDRequest, filter::RoomEventFilter,
+    },
+    events::AnySyncTimelineEvent,
+    serde::Raw,
+};
+use tokio::sync::{mpsc, oneshot};
+
+use super::handler::{
+    Capabilities, Client, Error, EventReader as Reader, EventSender as Sender, Filtered,
+    OpenIDDecision, OpenIDStatus, Result,
+};
+use crate::{
+    event_handler::EventHandlerDropGuard,
+    room::{MessagesOptions, Room as Joined},
+    widget::{
+        messages::{
+            from_widget::{
+                ReadEventRequest, ReadEventResponse, SendEventRequest, SendEventResponse,
+            },
+            EventType, MatrixEvent, OpenIDRequest, OpenIDState,
+        },
+        EventFilter, Permissions, PermissionsProvider,
+    },
+};
+
+#[derive(Debug)]
+pub struct Driver<T> {
+    room: Joined,
+    permissions_provider: T,
+    event_handler_handle: Option<EventHandlerDropGuard>,
+}
+
+impl<T> Driver<T> {
+    pub fn new(room: Joined, permissions_provider: T) -> Self {
+        Self { room, permissions_provider, event_handler_handle: None }
+    }
+}
+
+#[async_trait]
+impl<T: PermissionsProvider> Client for Driver<T> {
+    async fn initialise(&mut self, permissions: Permissions) -> Capabilities {
+        let permissions = self.permissions_provider.acquire_permissions(permissions).await;
+
+        Capabilities {
+            listener: Filters::new(permissions.read.clone())
+                .map(|filters| self.setup_event_listener(filters)),
+            reader: Filters::new(permissions.read).map(|filters| {
+                let reader: Box<dyn Reader> =
+                    Box::new(EventServerProxy::new(self.room.clone(), filters));
+                reader
+            }),
+            sender: Filters::new(permissions.send).map(|filters| {
+                let sender: Box<dyn Sender> =
+                    Box::new(EventServerProxy::new(self.room.clone(), filters));
+                sender
+            }),
+        }
+    }
+
+    fn get_openid(&self, req: OpenIDRequest) -> OpenIDStatus {
+        let user_id = self.room.own_user_id().to_owned();
+        let client = self.room.client.clone();
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let _ = tx.send(
+                client
+                    .send(MatrixOpenIDRequest::new(user_id), None)
+                    .await
+                    .map(|res| {
+                        OpenIDDecision::Allowed(OpenIDState {
+                            id: req.id,
+                            token: res.access_token,
+                            expires_in_seconds: res.expires_in.as_secs() as usize,
+                            server: res.matrix_server_name.to_string(),
+                            kind: res.token_type.to_string(),
+                        })
+                    })
+                    .unwrap_or(OpenIDDecision::Blocked),
+            );
+        });
+
+        // TODO: getting an OpenID token generally has multiple phases as per the JS
+        // implementation of the `ClientWidgetAPI`, e.g. the `MatrixDriver`
+        // would normally have some state, so that if a token is requested
+        // multiple times, it may return/resolve the token right away.
+        // Currently, we assume that we always request a new token. Fix it later.
+        OpenIDStatus::Pending(rx)
+    }
+}
+
+impl<W> Driver<W> {
+    fn setup_event_listener(&mut self, filter: Filters) -> mpsc::UnboundedReceiver<MatrixEvent> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let callback = move |ev: Raw<AnySyncTimelineEvent>| {
+            let (filter, tx) = (filter.clone(), tx.clone());
+            if let Ok(msg) = ev.deserialize_as::<MatrixEvent>() {
+                filter.allow(&msg.event_type).then(|| tx.send(msg));
+            }
+            async {}
+        };
+
+        let handle = self.room.add_event_handler(callback);
+        let drop_guard = self.room.client().event_handler_drop_guard(handle);
+        self.event_handler_handle.replace(drop_guard);
+        rx
+    }
+}
+
+#[derive(Debug)]
+pub struct EventServerProxy {
+    room: Joined,
+    filter: Filters,
+}
+
+impl EventServerProxy {
+    fn new(room: Joined, filter: Filters) -> Self {
+        Self { room, filter }
+    }
+}
+
+#[async_trait]
+impl Reader for EventServerProxy {
+    async fn read(&self, req: ReadEventRequest) -> Result<ReadEventResponse> {
+        let options = {
+            let mut o = MessagesOptions::backward();
+            o.limit = req.limit.into();
+            o.filter = {
+                let mut f = RoomEventFilter::default();
+                f.types = Some(vec![req.event_type.event_type().to_string()]);
+                f
+            };
+            o
+        };
+
+        // Fetch messages from the server.
+        let messages = self.room.messages(options).await.map_err(Error::other)?;
+
+        // Iterator over deserialized state messages.
+        let state = messages.state.into_iter().map(|s| s.deserialize_as::<MatrixEvent>());
+
+        // Iterator over deserialized timeline messages.
+        let timeline = messages.chunk.into_iter().map(|m| m.event.deserialize_as());
+
+        // Chain two iterators together and run them through the filter.
+        Ok(ReadEventResponse {
+            events: state
+                .chain(timeline)
+                .filter_map(StdResult::ok)
+                .filter(|m| self.filter.allow(&m.event_type))
+                .collect(),
+        })
+    }
+}
+
+#[async_trait]
+impl Sender for EventServerProxy {
+    async fn send(&self, req: SendEventRequest) -> Result<SendEventResponse> {
+        // Run the request through the filter.
+        if !self.filter.allow(&req.event_type) {
+            return Err(Error::custom("Message not allowed by filter"));
+        }
+
+        // Send the request based on whether the state key is set or not.
+        //
+        // TODO: not sure about the `*_raw` methods here, same goes for
+        // the `MatrixEvent`. I feel like stronger types would suit better here,
+        // but that's how it was originally implemented by @toger5, clarify it
+        // later once @jplatte reviews it.
+        let event_id = match req.event_type {
+            EventType::State { event_type, state_key } => {
+                self.room
+                    .send_state_event_raw(req.content, &event_type.to_string(), &state_key)
+                    .await
+                    .map_err(Error::other)?
+                    .event_id
+            }
+            EventType::MessageLike { event_type, .. } => {
+                self.room
+                    .send_raw(req.content, &event_type.to_string(), None)
+                    .await
+                    .map_err(Error::other)?
+                    .event_id
+            }
+        };
+
+        Ok(SendEventResponse {
+            room_id: self.room.room_id().to_string(),
+            event_id: event_id.to_string(),
+        })
+    }
+}
+
+impl Filtered for EventServerProxy {
+    fn filters(&self) -> &[EventFilter] {
+        &self.filter.filters
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Filters {
+    filters: Vec<EventFilter>,
+}
+
+impl Filters {
+    fn new(filters: Vec<EventFilter>) -> Option<Self> {
+        (!filters.is_empty()).then_some(Self { filters })
+    }
+
+    fn allow(&self, event_type: &EventType) -> bool {
+        self.filters.iter().any(|f| event_type.matches(f))
+    }
+}

--- a/crates/matrix-sdk/src/widget/client/mod.rs
+++ b/crates/matrix-sdk/src/widget/client/mod.rs
@@ -1,0 +1,127 @@
+//! Client widget API implementation.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use serde_json::{from_str as from_json, to_string as to_json};
+use tokio::sync::{mpsc::UnboundedSender, oneshot};
+use uuid::Uuid;
+
+use self::handler::{
+    Client, IncomingRequest, MessageHandler, Outgoing, Reply, Response, WidgetProxy,
+};
+pub use self::{
+    handler::{Error, Result},
+    matrix::Driver as MatrixDriver,
+};
+use super::{
+    messages::{to_widget::Action as ToWidgetAction, Action, Header, Message},
+    Info as WidgetInfo, Widget,
+};
+
+mod handler;
+mod matrix;
+
+/// Runs the client widget API handler for a given widget with a provided
+/// `client`. Returns once the widget is disconnected or some terminal error
+/// occurs.
+pub async fn run<T: Client>(client: T, mut widget: Widget) -> Result<()> {
+    // A map of outgoing requests that we are waiting a response for, i.e. a
+    // requests that we sent to the widget and that we're expecting an answer
+    // from.
+    let state: PendingResponses = Arc::new(Mutex::new(HashMap::new()));
+
+    // Create a message handler (handles incoming requests from the widget).
+    let handler = {
+        let widget = WidgetSink::new(widget.info, widget.comm.to, state.clone());
+        MessageHandler::new(client, widget)
+    };
+
+    // Receives plain JSON string messages from a widget, parses it and passes it to
+    // the handler.
+    while let Some(raw) = widget.comm.from.recv().await {
+        match from_json::<Message>(&raw) {
+            Ok(msg) => match msg.action {
+                // This is an incoming request from a widget.
+                Action::FromWidget(a) => {
+                    handler.handle(IncomingRequest { header: msg.header, action: a })?;
+                }
+                // This is a response from the widget to our request (i.e. response to the outgoing
+                // request from our perspective).
+                Action::ToWidget(a) => {
+                    let pending = state
+                        .lock()
+                        .expect("Pending mutex poisoned")
+                        .remove(&msg.header.request_id);
+
+                    if let Some(tx) = pending {
+                        // It's ok if it fails here, it just means that the handler died and the
+                        // handler only dies once the widget disconnects.
+                        let _ = tx.send(a);
+                    }
+
+                    // TODO: We don't seem to have an error response for the
+                    // unexpected **responses** to our requests. Only for errors
+                    // that occur during the processing of the **incoming
+                    // requests**, not the **outgoing requests** (requests sent
+                    // by us **to** the widget). Clarify that later.
+                }
+            },
+            Err(..) => {
+                // TODO: We need to construct a message to inform the widget
+                // about the incorrectly formatted message, but it does not look
+                // like we have a well-defined error mechanism for such cases.
+                // Clarify that later.
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Map that stores pending responses for the outgoing requests (requests that
+/// **we** send to the widget).
+type PendingResponses = Arc<Mutex<HashMap<String, oneshot::Sender<ToWidgetAction>>>>;
+
+struct WidgetSink {
+    info: WidgetInfo,
+    sink: UnboundedSender<String>,
+    pending: PendingResponses,
+}
+
+impl WidgetSink {
+    fn new(info: WidgetInfo, sink: UnboundedSender<String>, pending: PendingResponses) -> Self {
+        Self { info, sink, pending }
+    }
+}
+
+#[async_trait]
+impl WidgetProxy for WidgetSink {
+    async fn send<T: Outgoing>(&self, msg: T) -> Result<Response<T::Response>> {
+        let id = Uuid::new_v4().to_string();
+        let message = {
+            let header = Header::new(&id, &self.info.id);
+            let action = Action::ToWidget(msg.into_action());
+            to_json(&Message::new(header, action)).expect("Bug: can't serialise a message")
+        };
+        self.sink.send(message).map_err(|_| Error::WidgetDisconnected)?;
+
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().expect("Pending mutex poisoned").insert(id, tx);
+        let reply = rx.await.map_err(|_| Error::WidgetDisconnected)?;
+        Ok(T::extract_response(reply).ok_or(Error::custom("Widget sent invalid response"))?)
+    }
+
+    fn reply(&self, reply: Reply) -> Result<()> {
+        let message = to_json(&Message::new(reply.header, Action::FromWidget(reply.action)))
+            .expect("Bug: can't serialise a message");
+        self.sink.send(message).map_err(|_| Error::WidgetDisconnected)
+    }
+
+    fn init_on_load(&self) -> bool {
+        self.info.init_on_load
+    }
+}

--- a/crates/matrix-sdk/src/widget/messages/actions/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/messages/actions/from_widget.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+use crate::widget::messages::{
+    Empty, EventType, MatrixEvent, MessageKind, OpenIDRequest, OpenIDResponse,
+};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "action")]
+pub enum Action {
+    #[serde(rename = "supported_api_versions")]
+    GetSupportedApiVersion(MessageKind<Empty, SupportedApiVersionsResponse>),
+    #[serde(rename = "content_loaded")]
+    ContentLoaded(MessageKind<Empty, Empty>),
+    #[serde(rename = "get_openid")]
+    GetOpenID(MessageKind<OpenIDRequest, OpenIDResponse>),
+    #[serde(rename = "send_events")]
+    SendEvent(MessageKind<SendEventRequest, SendEventResponse>),
+    #[serde(rename = "org.matrix.msc2876.read_events")]
+    ReadEvent(MessageKind<ReadEventRequest, ReadEventResponse>),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SupportedApiVersionsResponse {
+    pub versions: Vec<ApiVersion>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum ApiVersion {
+    /// First stable version.
+    #[serde(rename = "0.0.1")]
+    V0_0_1,
+    /// Second stable version.
+    #[serde(rename = "0.0.2")]
+    V0_0_2,
+    /// Supports sending and receiving of events.
+    #[serde(rename = "org.matrix.msc2762")]
+    MSC2762,
+    /// Supports sending of approved capabilities back to the widget.
+    #[serde(rename = "org.matrix.msc2871")]
+    MSC2871,
+    /// Supports navigating to a URI.
+    #[serde(rename = "org.matrix.msc2931")]
+    MSC2931,
+    /// Supports capabilities renegotiation.
+    #[serde(rename = "org.matrix.msc2974")]
+    MSC2974,
+    /// Supports reading eventsi in a room (deprecated).
+    #[serde(rename = "org.matrix.msc2876")]
+    MSC2876,
+    /// Supports sending and receiving of to-device events.
+    #[serde(rename = "org.matrix.msc3819")]
+    MSC3819,
+    /// Supports access to the TURN servers.
+    #[serde(rename = "town.robin.msc3846")]
+    MSC3846,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SendEventRequest {
+    #[serde(flatten)]
+    pub event_type: EventType,
+    pub content: serde_json::Value,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SendEventResponse {
+    pub room_id: String,
+    pub event_id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReadEventRequest {
+    #[serde(flatten)]
+    pub event_type: EventType,
+    pub limit: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReadEventResponse {
+    pub events: Vec<MatrixEvent>,
+}

--- a/crates/matrix-sdk/src/widget/messages/actions/message.rs
+++ b/crates/matrix-sdk/src/widget/messages/actions/message.rs
@@ -1,0 +1,98 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum Kind<Req, Resp> {
+    Request(Request<Req>),
+    Response(Response<Req, Resp>),
+}
+
+impl<T> Kind<Empty, T> {
+    pub fn empty() -> Self {
+        Kind::Request(Request::empty())
+    }
+}
+
+impl<Req, Resp> Kind<Req, Resp> {
+    pub fn request(content: Req) -> Self {
+        Kind::Request(Request::new(content))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Request<T> {
+    #[serde(rename = "data")]
+    pub content: T,
+}
+
+impl<T> Request<T> {
+    pub fn new(content: T) -> Self {
+        Self { content }
+    }
+}
+
+impl Request<Empty> {
+    pub const fn empty() -> Self {
+        Self { content: Empty }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Response<Req, Resp> {
+    #[serde(flatten)]
+    pub request: Request<Req>,
+    pub response: ResponseBody<Resp>,
+}
+
+impl<Req, Resp: Clone> Response<Req, Resp> {
+    pub fn response(&self) -> Result<Resp, String> {
+        match &self.response {
+            ResponseBody::Success(resp) => Ok(resp.clone()),
+            ResponseBody::Failure(err) => Err(err.as_ref().to_owned()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ResponseBody<T> {
+    Success(T),
+    Failure(ErrorBody),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ErrorBody {
+    pub error: ErrorMessage,
+}
+
+impl ErrorBody {
+    pub fn new(message: impl AsRef<str>) -> Self {
+        Self { error: ErrorMessage { message: message.as_ref().to_owned() } }
+    }
+}
+
+impl AsRef<str> for ErrorBody {
+    fn as_ref(&self) -> &str {
+        &self.error.message
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ErrorMessage {
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Empty;
+
+impl<T> Request<T> {
+    pub fn map<R>(self, response: Result<R, String>) -> Kind<T, R> {
+        Kind::Response(Response {
+            request: self,
+            response: match response {
+                Ok(response) => ResponseBody::Success(response),
+                Err(error) => ResponseBody::Failure(ErrorBody::new(error)),
+            },
+        })
+    }
+}

--- a/crates/matrix-sdk/src/widget/messages/actions/mod.rs
+++ b/crates/matrix-sdk/src/widget/messages/actions/mod.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+pub mod from_widget;
+mod message;
+pub mod to_widget;
+
+pub use self::message::{Empty, Kind as MessageKind, Request, Response};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "api")]
+pub enum Action {
+    FromWidget(from_widget::Action),
+    ToWidget(to_widget::Action),
+}

--- a/crates/matrix-sdk/src/widget/messages/actions/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/messages/actions/to_widget.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+use crate::widget::{
+    messages::{Empty, MatrixEvent, MessageKind, OpenIDResponse},
+    Permissions as Capabilities,
+};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "action")]
+pub enum Action {
+    #[serde(rename = "capabilities")]
+    CapabilitiesRequest(MessageKind<Empty, CapabilitiesResponse>),
+    #[serde(rename = "notify_capabilities")]
+    CapabilitiesUpdate(MessageKind<CapabilitiesUpdatedRequest, Empty>),
+    #[serde(rename = "openid_credentials")]
+    OpenIdCredentialsUpdate(MessageKind<OpenIDResponse, Empty>),
+    #[serde(rename = "send_event")]
+    SendEvent(MessageKind<MatrixEvent, Empty>),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CapabilitiesResponse {
+    pub capabilities: Capabilities,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CapabilitiesUpdatedRequest {
+    pub requested: Capabilities,
+    pub approved: Capabilities,
+}

--- a/crates/matrix-sdk/src/widget/messages/event.rs
+++ b/crates/matrix-sdk/src/widget/messages/event.rs
@@ -1,0 +1,79 @@
+use ruma::events::{MessageLikeEventType, StateEventType, TimelineEventType};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::widget::EventFilter;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MatrixEvent {
+    #[serde(flatten)]
+    pub event_type: EventType,
+    pub sender: String,
+    pub event_id: String,
+    pub room_id: String,
+    pub origin_server_ts: u32,
+    pub unsigned: Unsigned,
+    // TODO: Really not sure about this one, I feel like it should be a `AnyTimelineEvent` or
+    // something like this. But @toger5 implemented it with this type originally, so let's
+    // clarify it better.
+    pub content: Value,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Unsigned {
+    age: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum EventType {
+    /// Message-like events.
+    MessageLike {
+        /// The type of the message-like event.
+        #[serde(rename = "type")]
+        event_type: MessageLikeEventType,
+        /// An optional `msgtype` of the event.
+        msgtype: Option<String>,
+    },
+    /// State events.
+    State {
+        /// The type of the state event.
+        #[serde(rename = "type")]
+        event_type: StateEventType,
+        /// State key.
+        state_key: String,
+    },
+}
+
+impl EventType {
+    pub fn event_type(&self) -> TimelineEventType {
+        match self {
+            EventType::MessageLike { event_type, .. } => event_type.clone().into(),
+            EventType::State { event_type, .. } => event_type.clone().into(),
+        }
+    }
+}
+
+impl EventType {
+    pub fn matches(&self, filter: &EventFilter) -> bool {
+        match (self, filter) {
+            (
+                EventType::MessageLike { event_type, msgtype },
+                EventFilter::MessageLike { event_type: filter_type, msgtype: filter_msgtype },
+            ) => {
+                event_type == filter_type
+                    && msgtype.as_ref().zip(filter_msgtype.as_ref()).map_or(true, |(a, b)| a == b)
+            }
+            (
+                EventType::State { event_type, state_key },
+                EventFilter::State { event_type: filter_type, state_key: filter_key },
+            ) => {
+                event_type == filter_type
+                    && filter_key
+                        .as_ref()
+                        .map_or(true, |filter_state_key| filter_state_key == state_key)
+            }
+            _ => false,
+        }
+    }
+}

--- a/crates/matrix-sdk/src/widget/messages/mod.rs
+++ b/crates/matrix-sdk/src/widget/messages/mod.rs
@@ -1,0 +1,39 @@
+//! Events that are used by the Widget API.
+
+use serde::{Deserialize, Serialize};
+
+pub use self::{
+    actions::{from_widget, to_widget, Action, Empty, MessageKind, Request, Response},
+    event::{EventType, MatrixEvent},
+    openid::{Request as OpenIDRequest, Response as OpenIDResponse, State as OpenIDState},
+};
+
+mod actions;
+mod event;
+mod openid;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Message {
+    #[serde(flatten)]
+    pub header: Header,
+    pub action: Action,
+}
+
+impl Message {
+    pub fn new(header: Header, action: Action) -> Self {
+        Self { header, action }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Header {
+    pub request_id: String,
+    pub widget_id: String,
+}
+
+impl Header {
+    pub fn new(request_id: impl Into<String>, widget_id: impl Into<String>) -> Self {
+        Self { request_id: request_id.into(), widget_id: widget_id.into() }
+    }
+}

--- a/crates/matrix-sdk/src/widget/messages/openid.rs
+++ b/crates/matrix-sdk/src/widget/messages/openid.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Request {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct State {
+    #[serde(rename = "original_request_id")]
+    pub id: String,
+    #[serde(rename = "access_token")]
+    pub token: String,
+    #[serde(rename = "expires_in")]
+    pub expires_in_seconds: usize,
+    #[serde(rename = "matrix_server_name")]
+    pub server: String,
+    #[serde(rename = "token_type")]
+    pub kind: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Response {
+    Allowed(State),
+    Blocked,
+    Pending,
+}

--- a/crates/matrix-sdk/src/widget/permissions.rs
+++ b/crates/matrix-sdk/src/widget/permissions.rs
@@ -2,6 +2,7 @@
 //! client.
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use crate::ruma::events::{MessageLikeEventType, StateEventType};
 
@@ -17,7 +18,7 @@ pub trait PermissionsProvider: Send + Sync + 'static {
 }
 
 /// Permissions that a widget can request from a client.
-#[derive(Debug)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Permissions {
     /// Types of the messages that a widget wants to be able to fetch.
     pub read: Vec<EventFilter>,
@@ -26,7 +27,7 @@ pub struct Permissions {
 }
 
 /// Different kinds of filters that could be applied to the timeline events.
-#[derive(Debug)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub enum EventFilter {
     /// Message-like events.
     MessageLike {


### PR DESCRIPTION
Hey @jplatte,

here is a preliminary implementation of the client widget API that is necessary for the Element Call integration into Element X that we (@daniel-abramov and @toger5) have been working on in the last couple of weeks (@toger5 additionally performed some smoke tests of certain things). It's mostly finished, but requires some further tests this week and there are a couple of things that could be improved (the improvement vector is known :slightly_smiling_face:). I decided to submit the PR in its current state, so that others can start with review and verify things, also it would enable us to start with the first integration attempts if other things are ready this week (CC @stefanceriu).

Some notable known improvement points for this PR, hopefully I did not miss anything:
1. It has some unresolved TODOs, primarily related to the user of the stronger types (that would give us more compile-time safety), error handling and a couple widget API specific questions.
2. A couple of places with some boilerplate that could be eliminated.
3. A Missing **proper** implementation of serialisation and deserialisation for the event filters that the Widget API sends (@toger5 would you like to add it based on your former PRs and a recent implementation or should I? I believe you've implemented it here: https://github.com/toger5/matrix-rust-sdk/pull/26/files).
4. Logging/tracing and some additional comments would not harm.

PS: I was a bit in a rush while trying to 'finalise' the PR within the week (I remember you wanted to see code / PR ASAP), so there is a probability that I might have missed something, but I believe that there shouldn't be any *massive* changes to the existing implementations.