### PR TITLE
feat(ui): Change `all_rooms` to `timeline_limit=0`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -163,7 +163,7 @@ impl RoomListService {
             .add_cached_list(configure_all_or_visible_rooms_list(
                 SlidingSyncList::builder(ALL_ROOMS_LIST_NAME)
                     .sync_mode(SlidingSyncMode::new_selective().add_range(0..=19))
-                    .timeline_limit(1)
+                    .timeline_limit(0)
                     .required_state(vec![
                         (StateEventType::RoomAvatar, "".to_owned()),
                         (StateEventType::RoomEncryption, "".to_owned()),

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -247,9 +247,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "conn_id": "room-list",
             "lists": {
                 ALL_ROOMS: {
-                    "ranges": [
-                        [0, 19],
-                    ],
+                    "ranges": [[0, 19]],
                     "required_state": [
                         ["m.room.avatar", ""],
                         ["m.room.encryption", ""],
@@ -266,7 +264,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         "m.sticker",
                     ],
                     "sort": ["by_recency", "by_name"],
-                    "timeline_limit": 1,
+                    "timeline_limit": 0,
                 },
             },
             "extensions": {
@@ -299,9 +297,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "conn_id": "room-list",
             "lists": {
                 ALL_ROOMS: {
-                    "ranges": [
-                        [0, 199],
-                    ],
+                    "ranges": [[0, 199]],
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [[0, 19]],


### PR DESCRIPTION
When a user has hundreds of rooms, `RoomListService` will fetch at worst one event per room, which can generate large responses. Let's use a `timeline_limit=0`.