### PR TITLE
feat(ui): Reset `Timeline` when a user is ignored/unignored

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -48,7 +48,7 @@ use crate::{
     room_member::{MessageLikeEventType, RoomMember, StateEventType},
     timeline::{
         AudioInfo, EventTimelineItem, FileInfo, ImageInfo, PollKind, ThumbnailInfo, TimelineDiff,
-        TimelineItem, TimelineListener, VideoInfo,
+        TimelineListener, VideoInfo,
     },
     TaskHandle,
 };
@@ -253,7 +253,7 @@ impl Room {
             })
             .clone();
 
-        let (timeline_items, timeline_stream) = timeline.subscribe_batched().await;
+        let timeline_stream = timeline.subscribe_batched();
         let timeline_stream = TaskHandle::new(RUNTIME.spawn(async move {
             pin_mut!(timeline_stream);
 
@@ -263,10 +263,7 @@ impl Room {
             }
         }));
 
-        RoomTimelineListenerResult {
-            items: timeline_items.into_iter().map(TimelineItem::from_arc).collect(),
-            items_stream: Arc::new(timeline_stream),
-        }
+        RoomTimelineListenerResult { items_stream: Arc::new(timeline_stream) }
     }
 
     pub async fn room_info(&self) -> Result<RoomInfo, ClientError> {
@@ -1091,7 +1088,6 @@ impl SendAttachmentJoinHandle {
 
 #[derive(uniffi::Record)]
 pub struct RoomTimelineListenerResult {
-    pub items: Vec<Arc<TimelineItem>>,
     pub items_stream: Arc<TaskHandle>,
 }
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -929,14 +929,14 @@ impl BaseClient {
     }
 
     pub(crate) async fn apply_changes(&self, changes: &StateChanges) {
+        if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
+            self.ignore_user_list_changes.set(());
+        }
+
         for (room_id, room_info) in &changes.room_infos {
             if let Some(room) = self.store.get_room(room_id) {
                 room.update_summary(room_info.clone())
             }
-        }
-
-        if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
-            self.ignore_user_list_changes.set(());
         }
     }
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -929,14 +929,14 @@ impl BaseClient {
     }
 
     pub(crate) async fn apply_changes(&self, changes: &StateChanges) {
-        if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
-            self.ignore_user_list_changes.set(());
-        }
-
         for (room_id, room_info) in &changes.room_infos {
             if let Some(room) = self.store.get_room(room_id) {
                 room.update_summary(room_info.clone())
             }
+        }
+
+        if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
+            self.ignore_user_list_changes.set(());
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -468,12 +468,10 @@ pub enum EventItemOrigin {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use matrix_sdk::{config::RequestConfig, Client, ClientBuilder};
-    use matrix_sdk_base::{deserialized_responses::SyncTimelineEvent, BaseClient, SessionMeta};
+    use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
     use matrix_sdk_test::async_test;
     use ruma::{
-        api::{client::sync::sync_events::v4, MatrixVersion},
-        device_id,
+        api::client::sync::sync_events::v4,
         events::{
             room::message::{MessageFormat, MessageType},
             AnySyncTimelineEvent,
@@ -485,7 +483,7 @@ mod tests {
     use serde_json::json;
 
     use super::{EventTimelineItem, Profile};
-    use crate::timeline::TimelineDetails;
+    use crate::timeline::{tests::logged_in_client, TimelineDetails};
 
     #[async_test]
     async fn latest_message_event_can_be_wrapped_as_a_timeline_item() {
@@ -609,29 +607,5 @@ mod tests {
             )
             .unwrap(),
         )
-    }
-
-    /// Copied from matrix_sdk_base::sliding_sync::test
-    async fn logged_in_client(homeserver_url: Option<String>) -> Client {
-        let base_client = BaseClient::new();
-        base_client
-            .set_session_meta(SessionMeta {
-                user_id: user_id!("@u:e.uk").to_owned(),
-                device_id: device_id!("XYZ").to_owned(),
-            })
-            .await
-            .expect("Failed to set session meta");
-
-        test_client_builder(homeserver_url)
-            .request_config(RequestConfig::new().disable_retry())
-            .base_client(base_client)
-            .build()
-            .await
-            .unwrap()
-    }
-
-    fn test_client_builder(homeserver_url: Option<String>) -> ClientBuilder {
-        let homeserver = homeserver_url.as_deref().unwrap_or("http://localhost:1234");
-        Client::builder().homeserver_url(homeserver).server_versions([MatrixVersion::V1_0])
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -153,7 +153,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let state = self.state.clone();
         let ignore_user_list_stream = self.client.subscribe_to_ignore_user_list_changes();
 
-        let stream = stream! {
+        stream! {
             pin_mut!(ignore_user_list_stream);
 
             loop {
@@ -178,9 +178,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
                 state.lock().await.clear();
             }
         }
-        .switch();
-
-        stream
+        .switch()
     }
 
     pub(super) fn subscribe_batched(

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -173,6 +173,9 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
                 // When this is fired, let's loop.
                 let _ = ignore_user_list_stream.next().await;
+
+                // A user has been ignored/unignored? Let's clear the timeline.
+                state.lock().await.clear();
             }
         }
         .switch();

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -27,7 +27,7 @@ use matrix_sdk::crypto::OlmMachine;
 use matrix_sdk::{
     deserialized_responses::{SyncTimelineEvent, TimelineEvent},
     sync::{JoinedRoom, Timeline},
-    Error, Result, Room,
+    Client, Error, Result, Room,
 };
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
@@ -70,6 +70,7 @@ use self::state::{TimelineInnerStateLock, TimelineInnerStateLockGuard};
 
 #[derive(Clone, Debug)]
 pub(super) struct TimelineInner<P: RoomDataProvider = Room> {
+    client: Client,
     state: TimelineInnerStateLock,
     room_data_provider: P,
     settings: TimelineInnerSettings,
@@ -126,6 +127,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
     pub(super) fn new(room_data_provider: P) -> Self {
         let state = TimelineInnerState::new(room_data_provider.room_version());
         Self {
+            client: room_data_provider.client(),
             state: TimelineInnerStateLock::new(state),
             room_data_provider,
             settings: TimelineInnerSettings::default(),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -299,12 +299,8 @@ impl Timeline {
     ///
     /// You can poll this stream to receive updates. See
     /// [`futures_util::StreamExt`] for a high-level API on top of [`Stream`].
-    pub async fn subscribe(
-        &self,
-    ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = VectorDiff<Arc<TimelineItem>>>) {
-        let (items, stream) = self.inner.subscribe().await;
-        let stream = TimelineStream::new(stream, self.drop_handle.clone());
-        (items, stream)
+    pub fn subscribe(&self) -> impl Stream<Item = VectorDiff<Arc<TimelineItem>>> {
+        TimelineStream::new(self.inner.subscribe(), self.drop_handle.clone())
     }
 
     /// Get the current timeline items, and a batched stream of changes.
@@ -312,12 +308,8 @@ impl Timeline {
     /// In contrast to [`subscribe`](Self::subscribe), this stream can yield
     /// multiple diffs at once. The batching is done such that no arbitrary
     /// delays are added.
-    pub async fn subscribe_batched(
-        &self,
-    ) -> (Vector<Arc<TimelineItem>>, impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>>) {
-        let (items, stream) = self.inner.subscribe_batched().await;
-        let stream = TimelineStream::new(stream, self.drop_handle.clone());
-        (items, stream)
+    pub fn subscribe_batched(&self) -> impl Stream<Item = Vec<VectorDiff<Arc<TimelineItem>>>> {
+        TimelineStream::new(self.inner.subscribe_batched(), self.drop_handle.clone())
     }
 
     /// Send a message to the room, and add it to the timeline as a local echo.

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -40,7 +40,7 @@ use crate::timeline::{
 
 #[async_test]
 async fn initial_events() {
-    let mut timeline = TestTimeline::new();
+    let mut timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline
@@ -65,7 +65,7 @@ async fn initial_events() {
 
 #[async_test]
 async fn sticker() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;
 
     timeline
@@ -93,7 +93,7 @@ async fn sticker() {
 
 #[async_test]
 async fn room_member() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;
 
     let mut first_room_member_content = RoomMemberEventContent::new(MembershipState::Invite);
@@ -163,7 +163,7 @@ async fn room_member() {
 
 #[async_test]
 async fn other_state() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline
@@ -195,7 +195,7 @@ async fn other_state() {
 
 #[async_test]
 async fn dedup_pagination() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
 
     let event = timeline.make_message_event(*ALICE, RoomMessageEventContent::text_plain("o/"));
     timeline.handle_live_custom_event(event.clone()).await;
@@ -212,7 +212,7 @@ async fn dedup_pagination() {
 
 #[async_test]
 async fn dedup_initial() {
-    let mut timeline = TestTimeline::new();
+    let mut timeline = TestTimeline::new().await;
 
     let event_a = sync_timeline_event(
         timeline.make_message_event(*ALICE, RoomMessageEventContent::text_plain("A")),
@@ -259,7 +259,7 @@ async fn dedup_initial() {
 
 #[async_test]
 async fn sanitized() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline
@@ -300,7 +300,7 @@ async fn sanitized() {
 
 #[async_test]
 async fn reply() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline
@@ -355,7 +355,7 @@ async fn reply() {
 
 #[async_test]
 async fn thread() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -30,7 +30,7 @@ use crate::timeline::event_item::EventSendState;
 
 #[async_test]
 async fn remote_echo_full_trip() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     // Given a local event…
@@ -114,7 +114,7 @@ async fn remote_echo_full_trip() {
 
 #[async_test]
 async fn remote_echo_new_position() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     // Given a local event…

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -16,6 +16,7 @@ use std::{io, sync::Arc};
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
+use futures_util::pin_mut;
 use matrix_sdk::Error;
 use matrix_sdk_test::async_test;
 use ruma::{
@@ -31,7 +32,11 @@ use crate::timeline::event_item::EventSendState;
 #[async_test]
 async fn remote_echo_full_trip() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     // Given a local event…
     let txn_id = timeline
@@ -115,7 +120,11 @@ async fn remote_echo_full_trip() {
 #[async_test]
 async fn remote_echo_new_position() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     // Given a local event…
     let txn_id = timeline

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -14,6 +14,7 @@
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
+use futures_util::pin_mut;
 use matrix_sdk_test::async_test;
 use ruma::{
     assign,
@@ -35,7 +36,11 @@ use crate::timeline::TimelineItemContent;
 #[async_test]
 async fn live_redacted() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     timeline
         .handle_live_redacted_message_event(*ALICE, RedactedRoomMessageEventContent::new())
@@ -59,7 +64,11 @@ async fn live_redacted() {
 #[async_test]
 async fn live_sanitized() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     timeline
         .handle_live_message_event(
@@ -109,7 +118,11 @@ async fn live_sanitized() {
 #[async_test]
 async fn aggregated_sanitized() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     let original_event_id = EventId::new(server_name!("dummy.server"));
     let ev = json!({

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -34,7 +34,7 @@ use crate::timeline::TimelineItemContent;
 
 #[async_test]
 async fn live_redacted() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline
@@ -58,7 +58,7 @@ async fn live_redacted() {
 
 #[async_test]
 async fn live_sanitized() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline
@@ -108,7 +108,7 @@ async fn live_sanitized() {
 
 #[async_test]
 async fn aggregated_sanitized() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     let original_event_id = EventId::new(server_name!("dummy.server"));

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -18,6 +18,7 @@ use std::{io::Cursor, iter};
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
+use futures_util::pin_mut;
 use matrix_sdk::crypto::{decrypt_room_key_export, OlmMachine};
 use matrix_sdk_test::async_test;
 use ruma::{
@@ -51,7 +52,11 @@ async fn retry_message_decryption() {
         -----END MEGOLM SESSION DATA-----";
 
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     timeline
         .handle_live_message_event(
@@ -345,7 +350,11 @@ async fn retry_message_decryption_highlighted() {
         -----END MEGOLM SESSION DATA-----";
 
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     timeline
         .handle_live_message_event(

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -50,7 +50,7 @@ async fn retry_message_decryption() {
         HztoSJUr/2Y\n\
         -----END MEGOLM SESSION DATA-----";
 
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline
@@ -146,7 +146,7 @@ async fn retry_edit_decryption() {
         rHCyB4ElRjU\n\
         -----END MEGOLM SESSION DATA-----";
 
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
 
     let encrypted = EncryptedEventScheme::MegolmV1AesSha2(
         MegolmV1AesSha2ContentInit {
@@ -256,7 +256,7 @@ async fn retry_edit_and_more() {
         )
     }
 
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
 
     timeline
         .handle_live_message_event(
@@ -344,7 +344,7 @@ async fn retry_message_decryption_highlighted() {
         FM8H2PpVkKgrA+tx8LNQD+FWDfp6MyhmEJEvk9r5vU9LtTXtZl4toYvNY0UHUBbZj2xF9U9Z9A\n\
         -----END MEGOLM SESSION DATA-----";
 
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -40,7 +40,7 @@ use crate::timeline::{inner::TimelineInnerSettings, TimelineItemContent};
 
 #[async_test]
 async fn default_filter() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     // Test edits work.
@@ -103,7 +103,7 @@ async fn default_filter() {
 
 #[async_test]
 async fn filter_always_false() {
-    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+    let timeline = TestTimeline::new().await.with_settings(TimelineInnerSettings {
         event_filter: Arc::new(|_| false),
         ..Default::default()
     });
@@ -139,7 +139,7 @@ async fn filter_always_false() {
 #[async_test]
 async fn custom_filter() {
     // Filter out all state events.
-    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+    let timeline = TestTimeline::new().await.with_settings(TimelineInnerSettings {
         event_filter: Arc::new(|ev| matches!(ev, AnySyncTimelineEvent::MessageLike(_))),
         ..Default::default()
     });
@@ -178,7 +178,7 @@ async fn custom_filter() {
 
 #[async_test]
 async fn hide_failed_to_parse() {
-    let timeline = TestTimeline::new()
+    let timeline = TestTimeline::new().await
         .with_settings(TimelineInnerSettings { add_failed_to_parse: false, ..Default::default() });
 
     // m.room.message events must have a msgtype and body in content, so this

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -32,7 +32,7 @@ use crate::timeline::TimelineItemContent;
 
 #[async_test]
 async fn invalid_edit() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("test")).await;
@@ -58,7 +58,7 @@ async fn invalid_edit() {
 
 #[async_test]
 async fn invalid_event_content() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;
 
     // m.room.message events must have a msgtype and body in content, so this
@@ -114,7 +114,7 @@ async fn invalid_event_content() {
 
 #[async_test]
 async fn invalid_event() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
 
     // This event is missing the sender field which the homeserver must add to
     // all timeline events. Because the event is malformed, it will be ignored.

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -130,10 +130,7 @@ impl TestTimeline {
     }
 
     fn subscribe(&self) -> impl Stream<Item = VectorDiff<Arc<TimelineItem>>> {
-        let stream = self.inner.subscribe();
-        // assert_eq!(items.len(), 0, "Please subscribe to TestTimeline before adding
-        // items to it");
-        stream
+        self.inner.subscribe()
     }
 
     async fn subscribe_events(&self) -> impl Stream<Item = VectorDiff<EventTimelineItem>> {

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -129,9 +129,10 @@ impl TestTimeline {
         self
     }
 
-    async fn subscribe(&self) -> impl Stream<Item = VectorDiff<Arc<TimelineItem>>> {
-        let (items, stream) = self.inner.subscribe().await;
-        assert_eq!(items.len(), 0, "Please subscribe to TestTimeline before adding items to it");
+    fn subscribe(&self) -> impl Stream<Item = VectorDiff<Arc<TimelineItem>>> {
+        let stream = self.inner.subscribe();
+        // assert_eq!(items.len(), 0, "Please subscribe to TestTimeline before adding
+        // items to it");
         stream
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -22,7 +22,7 @@ use crate::timeline::{
 
 #[async_test]
 async fn poll_is_displayed() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
 
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_state = timeline.poll_state().await;
@@ -33,7 +33,7 @@ async fn poll_is_displayed() {
 
 #[async_test]
 async fn edited_poll_is_displayed() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
 
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let event = timeline.poll_event().await;
@@ -47,7 +47,7 @@ async fn edited_poll_is_displayed() {
 
 #[async_test]
 async fn voting_adds_the_vote_to_the_results() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
 
@@ -61,7 +61,7 @@ async fn voting_adds_the_vote_to_the_results() {
 
 #[async_test]
 async fn ending_a_poll_sets_end_time_to_results() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
 
@@ -74,7 +74,7 @@ async fn ending_a_poll_sets_end_time_to_results() {
 
 #[async_test]
 async fn only_the_last_vote_from_a_user_is_counted() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
 
@@ -91,7 +91,7 @@ async fn only_the_last_vote_from_a_user_is_counted() {
 
 #[async_test]
 async fn votes_after_end_are_discarded() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
 
@@ -108,7 +108,7 @@ async fn votes_after_end_are_discarded() {
 
 #[async_test]
 async fn multiple_end_events_are_discarded() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
 
@@ -128,7 +128,7 @@ async fn multiple_end_events_are_discarded() {
 
 #[async_test]
 async fn a_somewhat_complex_voting_session_yields_the_expected_outcome() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     timeline.send_poll_start(&ALICE, fakes::poll_a()).await;
     let poll_id = timeline.poll_event().await.event_id().unwrap().to_owned();
 
@@ -160,7 +160,7 @@ async fn a_somewhat_complex_voting_session_yields_the_expected_outcome() {
 
 #[async_test]
 async fn events_received_before_start_are_not_lost() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let poll_id: OwnedEventId = EventId::new(server_name!("dummy.server"));
 
     // Alice votes

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -40,7 +40,7 @@ const REACTION_KEY: &str = "👍";
 
 #[async_test]
 async fn add_reaction_failed() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
@@ -60,7 +60,7 @@ async fn add_reaction_failed() {
 
 #[async_test]
 async fn add_reaction_on_non_existent_event() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
     let msg_id = EventId::new(server_name!("example.org")); // non existent event
     let reaction = create_reaction(&msg_id);
@@ -72,7 +72,7 @@ async fn add_reaction_on_non_existent_event() {
 
 #[async_test]
 async fn add_reaction_success() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
@@ -96,7 +96,7 @@ async fn add_reaction_success() {
 
 #[async_test]
 async fn redact_reaction_success() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
@@ -118,7 +118,7 @@ async fn redact_reaction_success() {
 
 #[async_test]
 async fn redact_reaction_failure() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
@@ -144,7 +144,7 @@ async fn redact_reaction_failure() {
 
 #[async_test]
 async fn redact_reaction_from_non_existent_event() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
     let reaction_id = EventId::new(server_name!("example.org")); // non existent event
 
@@ -157,7 +157,7 @@ async fn redact_reaction_from_non_existent_event() {
 
 #[async_test]
 async fn toggle_during_request_resolves_new_action() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
@@ -208,7 +208,7 @@ async fn toggle_during_request_resolves_new_action() {
 
 #[async_test]
 async fn reactions_store_timestamp() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
@@ -241,7 +241,7 @@ async fn reactions_store_timestamp() {
 
 #[async_test]
 async fn initial_reaction_timestamp_is_stored() {
-    let mut timeline = TestTimeline::new();
+    let mut timeline = TestTimeline::new().await;
 
     let message_event_id = EventId::new(server_name!("dummy.server"));
     let reaction_timestamp = MilliSecondsSinceUnixEpoch(uint!(39845));

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -17,6 +17,7 @@ use std::{ops::RangeInclusive, sync::Arc};
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
+use futures_util::pin_mut;
 use imbl::vector;
 use matrix_sdk_test::async_test;
 use ruma::{
@@ -41,7 +42,12 @@ const REACTION_KEY: &str = "👍";
 #[async_test]
 async fn add_reaction_failed() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
 
@@ -61,7 +67,12 @@ async fn add_reaction_failed() {
 #[async_test]
 async fn add_reaction_on_non_existent_event() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
     let msg_id = EventId::new(server_name!("example.org")); // non existent event
     let reaction = create_reaction(&msg_id);
 
@@ -73,7 +84,12 @@ async fn add_reaction_on_non_existent_event() {
 #[async_test]
 async fn add_reaction_success() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
 
@@ -97,7 +113,12 @@ async fn add_reaction_success() {
 #[async_test]
 async fn redact_reaction_success() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
 
@@ -119,7 +140,12 @@ async fn redact_reaction_success() {
 #[async_test]
 async fn redact_reaction_failure() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
 
@@ -145,7 +171,12 @@ async fn redact_reaction_failure() {
 #[async_test]
 async fn redact_reaction_from_non_existent_event() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
     let reaction_id = EventId::new(server_name!("example.org")); // non existent event
 
     timeline
@@ -158,7 +189,12 @@ async fn redact_reaction_from_non_existent_event() {
 #[async_test]
 async fn toggle_during_request_resolves_new_action() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
 
@@ -209,7 +245,12 @@ async fn toggle_during_request_resolves_new_action() {
 #[async_test]
 async fn reactions_store_timestamp() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
     let reaction = create_reaction(&msg_id);
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -25,7 +25,7 @@ use crate::timeline::inner::TimelineInnerSettings;
 
 #[async_test]
 async fn read_receipts_updates() {
-    let timeline = TestTimeline::new()
+    let timeline = TestTimeline::new().await
         .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
     let mut stream = timeline.subscribe().await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -39,7 +39,7 @@ use crate::timeline::{AnyOtherFullStateEventContent, TimelineDetails, TimelineIt
 
 #[async_test]
 async fn redact_state_event() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;
 
     timeline
@@ -69,7 +69,7 @@ async fn redact_state_event() {
 
 #[async_test]
 async fn redact_replied_to_event() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;
 
     timeline
@@ -115,7 +115,7 @@ async fn redact_replied_to_event() {
 
 #[async_test]
 async fn reaction_redaction() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("hi!")).await;
@@ -140,7 +140,7 @@ async fn reaction_redaction() {
 
 #[async_test]
 async fn reaction_redaction_timeline_filter() {
-    let mut timeline = TestTimeline::new();
+    let mut timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe_events().await;
 
     // Initialise a timeline with a redacted reaction.
@@ -179,7 +179,7 @@ async fn reaction_redaction_timeline_filter() {
 
 #[async_test]
 async fn receive_unredacted() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
 
     // send two events, second one redacted
     timeline

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -27,7 +27,7 @@ use crate::timeline::{TimelineItemKind, VirtualTimelineItem};
 
 #[async_test]
 async fn day_divider() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline
@@ -100,7 +100,7 @@ async fn day_divider() {
 
 #[async_test]
 async fn update_read_marker() {
-    let timeline = TestTimeline::new();
+    let timeline = TestTimeline::new().await;
     let mut stream = timeline.subscribe().await;
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("A")).await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -15,6 +15,7 @@
 use assert_matches::assert_matches;
 use chrono::{Datelike, Local, TimeZone};
 use eyeball_im::VectorDiff;
+use futures_util::pin_mut;
 use matrix_sdk_test::async_test;
 use ruma::{
     event_id,
@@ -28,7 +29,11 @@ use crate::timeline::{TimelineItemKind, VirtualTimelineItem};
 #[async_test]
 async fn day_divider() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     timeline
         .handle_live_message_event(
@@ -101,7 +106,11 @@ async fn day_divider() {
 #[async_test]
 async fn update_read_marker() {
     let timeline = TestTimeline::new().await;
-    let mut stream = timeline.subscribe().await;
+    let stream = timeline.subscribe();
+    pin_mut!(stream);
+
+    let reset = assert_next_matches!(stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     timeline.handle_live_message_event(&ALICE, RoomMessageEventContent::text_plain("A")).await;
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -14,9 +14,9 @@
 
 use async_trait::async_trait;
 use indexmap::IndexMap;
-use matrix_sdk::Room;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk::{deserialized_responses::TimelineEvent, Result};
+use matrix_sdk::{Client, Room};
 use ruma::{
     events::receipt::{Receipt, ReceiptThread, ReceiptType},
     push::{PushConditionRoomCtx, Ruleset},
@@ -64,6 +64,7 @@ impl RoomExt for Room {
 
 #[async_trait]
 pub(super) trait RoomDataProvider: Clone + Send + Sync + 'static {
+    fn client(&self) -> Client;
     fn own_user_id(&self) -> &UserId;
     fn room_version(&self) -> RoomVersionId;
     async fn profile(&self, user_id: &UserId) -> Option<Profile>;
@@ -73,6 +74,10 @@ pub(super) trait RoomDataProvider: Clone + Send + Sync + 'static {
 
 #[async_trait]
 impl RoomDataProvider for Room {
+    fn client(&self) -> Client {
+        self.client()
+    }
+
     fn own_user_id(&self) -> &UserId {
         (**self).own_user_id()
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
-use futures_util::StreamExt;
+use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{config::SyncSettings, ruma::MilliSecondsSinceUnixEpoch};
 use matrix_sdk_test::{
     async_test, JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent, SyncResponseBuilder,
@@ -27,6 +27,7 @@ use matrix_sdk_ui::timeline::{
 };
 use ruma::{event_id, events::room::message::MessageType, room_id, uint, user_id};
 use serde_json::json;
+use stream_assert::assert_next_matches;
 use wiremock::{
     matchers::{header, method, path_regex},
     Mock, ResponseTemplate,
@@ -57,7 +58,11 @@ async fn edit() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await;
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let timeline_stream = timeline.subscribe();
+    pin_mut!(timeline_stream);
+
+    let reset = assert_next_matches!(timeline_stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
@@ -171,7 +176,11 @@ async fn reaction() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await;
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let timeline_stream = timeline.subscribe();
+    pin_mut!(timeline_stream);
+
+    let reset = assert_next_matches!(timeline_stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     ev_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
@@ -269,7 +278,11 @@ async fn redacted_message() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await;
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let timeline_stream = timeline.subscribe();
+    pin_mut!(timeline_stream);
+
+    let reset = assert_next_matches!(timeline_stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     ev_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
@@ -332,7 +345,11 @@ async fn read_marker() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await;
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let timeline_stream = timeline.subscribe();
+    pin_mut!(timeline_stream);
+
+    let reset = assert_next_matches!(timeline_stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({
@@ -407,7 +424,11 @@ async fn in_reply_to_details() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await;
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let timeline_stream = timeline.subscribe();
+    pin_mut!(timeline_stream);
+
+    let reset = assert_next_matches!(timeline_stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     // The event doesn't exist.
     assert_matches!(
@@ -568,7 +589,11 @@ async fn sync_highlighted() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = room.timeline().await;
-    let (_, mut timeline_stream) = timeline.subscribe().await;
+    let timeline_stream = timeline.subscribe();
+    pin_mut!(timeline_stream);
+
+    let reset = assert_next_matches!(timeline_stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         TimelineTestEvent::Custom(json!({

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -16,7 +16,7 @@ use std::{pin::Pin, sync::Arc};
 
 use anyhow::{Context, Result};
 use assert_matches::assert_matches;
-use eyeball_im::{Vector, VectorDiff};
+use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, FutureExt, Stream, StreamExt};
 use matrix_sdk::{
     SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -18,11 +18,14 @@ use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::config::SyncSettings;
-use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder, TimelineTestEvent};
-use matrix_sdk_ui::timeline::{RoomExt, TimelineItemContent};
+use matrix_sdk_test::{
+    async_test, GlobalAccountDataTestEvent, JoinedRoomBuilder, SyncResponseBuilder,
+    TimelineTestEvent,
+};
+use matrix_sdk_ui::timeline::{RoomExt, TimelineItemContent, VirtualTimelineItem};
 use ruma::{event_id, events::room::message::MessageType, room_id};
 use serde_json::json;
-use stream_assert::assert_next_matches;
+use stream_assert::{assert_next_matches, assert_pending};
 
 use crate::{logged_in_client, mock_sync};
 
@@ -184,4 +187,153 @@ async fn event_filter() {
     let text = assert_matches!(msg.msgtype(), MessageType::Text(text) => text);
     assert_eq!(text.body, "hi");
     assert!(msg.is_edited());
+}
+
+#[async_test]
+async fn stream_is_reset_when_a_user_is_ignored_or_unignored() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let mut ev_builder = SyncResponseBuilder::new();
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline_builder().build().await;
+    let timeline_stream = timeline.subscribe();
+    pin_mut!(timeline_stream);
+
+    let reset = assert_next_matches!(timeline_stream, VectorDiff::Reset { values } => values);
+    assert!(reset.is_empty());
+
+    let alice = "@alice:example.org";
+    let bob = "@bob:example.org";
+
+    let first_event_id = event_id!("$YTQwYl2pl1");
+    let second_event_id = event_id!("$YTQwYl2pl2");
+    let third_event_id = event_id!("$YTQwYl2pl3");
+
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                },
+                "event_id": first_event_id,
+                "origin_server_ts": 152037280,
+                "sender": alice,
+                "type": "m.room.message",
+            })))
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                },
+                "event_id": second_event_id,
+                "origin_server_ts": 152037281,
+                "sender": bob,
+                "type": "m.room.message",
+            })))
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                },
+                "event_id": third_event_id,
+                "origin_server_ts": 152037282,
+                "sender": alice,
+                "type": "m.room.message",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
+        assert_matches!(value.as_virtual(), Some(VirtualTimelineItem::DayDivider(_)));
+    });
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id(), Some(first_event_id));
+    });
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id(), Some(second_event_id));
+    });
+    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 1, value } => {
+        assert_eq!(value.as_event().unwrap().event_id(), Some(first_event_id));
+    });
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id(), Some(third_event_id));
+    });
+    assert_pending!(timeline_stream);
+
+    let fourth_event_id = event_id!("$YTQwYl2pl4");
+    let fiveth_event_id = event_id!("$YTQwYl2pl5");
+
+    ev_builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
+        "content": {
+            "ignored_users": {
+                bob: {}
+            }
+        },
+        "type": "m.ignored_user_list",
+    })));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    // The timeline has been emptied.
+    assert_next_matches!(timeline_stream, VectorDiff::Reset { values } => {
+        assert!(values.is_empty());
+    });
+    assert_pending!(timeline_stream);
+
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                },
+                "event_id": fourth_event_id,
+                "origin_server_ts": 152037283,
+                "sender": alice,
+                "type": "m.room.message",
+            })))
+            .add_timeline_event(TimelineTestEvent::Custom(json!({
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                },
+                "event_id": fiveth_event_id,
+                "origin_server_ts": 152037284,
+                "sender": alice,
+                "type": "m.room.message",
+            }))),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    // Timeline receives events as before.
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
+        assert_matches!(value.as_virtual(), Some(VirtualTimelineItem::DayDivider(_)));
+    });
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id(), Some(fourth_event_id));
+    });
+    assert_next_matches!(timeline_stream, VectorDiff::Set { index: 1, value } => {
+        assert_eq!(value.as_event().unwrap().event_id(), Some(fourth_event_id));
+    });
+    assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
+        assert_eq!(value.as_event().unwrap().event_id(), Some(fiveth_event_id));
+    });
+    assert_pending!(timeline_stream);
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -48,16 +48,10 @@ async fn batched() {
 
     let hdl = tokio::spawn(async move {
         pin_mut!(timeline_stream);
+
         let next_batch = timeline_stream.next().await.unwrap();
-        // One `VectorDiff::Reset`…
-        assert_eq!(next_batch.len(), 1);
-        assert_matches!(&next_batch[0], VectorDiff::Reset { values } => {
-            // … which is empty.
-            assert_eq!(values.len(), 0);
-        });
-        let next_batch = timeline_stream.next().await.unwrap();
-        // One day divider, and three event items.
-        assert_eq!(next_batch.len(), 4);
+        // One `VectorDiff::Reset` + one day divider + three event items.
+        assert_eq!(next_batch.len(), 5);
     });
 
     ev_builder.add_joined_room(


### PR DESCRIPTION
This PR can be reviewed commit-by-commit for more comfort.

The global idea is that the `Timeline` is cleared when a user is ignored/unignored.

This PR also splits `TimelineInnerState::lock` to `::read` and `::write`, and the lock release observer is notified only for the write lock.

---

* Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2284
* Fixes https://github.com/vector-im/element-x-ios/issues/911