### PR TITLE
feat(sdk): Adjust `room_list` observable capacity

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -223,9 +223,9 @@ impl SlidingSyncListBuilder {
                 // otherwise.
                 state: StdRwLock::new(Observable::new(Default::default())),
                 maximum_number_of_rooms: StdRwLock::new(Observable::new(None)),
-                // We want to avoid triggering `VectorDiff::Reset` as much as possible, hence we
+                // We want to avoid triggering `VectorDiff::Reset` too much, hence we
                 // increase the observable capacity.
-                room_list: StdRwLock::new(ObservableVector::with_capacity(4096)),
+                room_list: StdRwLock::new(ObservableVector::with_capacity(64)),
 
                 // Internal data.
                 sliding_sync_internal_channel_sender,


### PR DESCRIPTION
Prior to this patch, we have increased the
`SlidingSyncListInner::room_list` capacity, to avoid trigger `VectorDiff::Reset` as much as possible. Now that Element X is optimised to handle larger diff, we can discrease this number, yeeeee :-).