### PR TITLE
sdk: Make use of clonable FnOnce in event handlers

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -149,14 +149,11 @@ impl Client {
         > = Default::default();
         let ctrl = session_verification_controller.clone();
 
-        sdk_client.add_event_handler(move |ev: AnyToDeviceEvent| {
-            let ctrl = ctrl.clone();
-            async move {
-                if let Some(session_verification_controller) = &*ctrl.clone().read().await {
-                    session_verification_controller.process_to_device_message(ev).await;
-                } else {
-                    debug!("received to-device message, but verification controller isn't ready");
-                }
+        sdk_client.add_event_handler(move |ev: AnyToDeviceEvent| async move {
+            if let Some(session_verification_controller) = &*ctrl.clone().read().await {
+                session_verification_controller.process_to_device_message(ev).await;
+            } else {
+                debug!("received to-device message, but verification controller isn't ready");
             }
         });
 

--- a/crates/matrix-sdk-appservice/src/lib.rs
+++ b/crates/matrix-sdk-appservice/src/lib.rs
@@ -539,10 +539,7 @@ impl AppService {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        future,
-        sync::{Arc, Mutex},
-    };
+    use std::sync::{Arc, Mutex};
 
     use http::{Method, Request};
     use hyper::Body;
@@ -664,9 +661,8 @@ mod tests {
         let on_state_member = Arc::new(Mutex::new(false));
         appservice.user(None).await?.add_event_handler({
             let on_state_member = on_state_member.clone();
-            move |_ev: OriginalSyncRoomMemberEvent| {
+            move |_ev: OriginalSyncRoomMemberEvent| async move {
                 *on_state_member.lock().unwrap() = true;
-                future::ready(())
             }
         });
 
@@ -816,9 +812,8 @@ mod tests {
         let on_state_member = Arc::new(Mutex::new(false));
         appservice.user(None).await?.add_event_handler({
             let on_state_member = on_state_member.clone();
-            move |_ev: OriginalSyncRoomMemberEvent| {
+            move |_ev: OriginalSyncRoomMemberEvent| async move {
                 *on_state_member.lock().unwrap() = true;
-                future::ready(())
             }
         });
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -17,7 +17,7 @@ use std::{
     time::Duration,
 };
 
-use futures_util::{future::ready, pin_mut, StreamExt as _};
+use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::{room::Room, Client, ClientBuildError, SlidingSyncList, SlidingSyncMode};
 use matrix_sdk_base::{deserialized_responses::TimelineEvent, RoomState, StoreError};
 use ruma::{
@@ -206,7 +206,7 @@ impl NotificationClient {
         let cloned_notif = notification.clone();
         let target_event_id = event_id.to_owned();
         let timeline_event_handler =
-            self.client.add_event_handler(move |raw: Raw<AnySyncTimelineEvent>| {
+            self.client.add_event_handler(move |raw: Raw<AnySyncTimelineEvent>| async move {
                 match raw.get_field::<OwnedEventId>("event_id") {
                     Ok(Some(event_id)) => {
                         if event_id == target_event_id {
@@ -220,13 +220,12 @@ impl NotificationClient {
                         tracing::warn!("could not get event id");
                     }
                 }
-                ready(())
             });
 
         let cloned_notif = notification.clone();
         let target_event_id = event_id.to_owned();
         let stripped_member_handler =
-            self.client.add_event_handler(move |raw: Raw<StrippedRoomMemberEvent>| {
+            self.client.add_event_handler(move |raw: Raw<StrippedRoomMemberEvent>| async move {
                 match raw.get_field::<OwnedEventId>("event_id") {
                     Ok(Some(event_id)) => {
                         if event_id == target_event_id {
@@ -239,7 +238,6 @@ impl NotificationClient {
                         tracing::warn!("could not get event id");
                     }
                 }
-                ready(())
             });
 
         // Room power levels are necessary to build the push context.

--- a/crates/matrix-sdk-ui/src/timeline/to_device.rs
+++ b/crates/matrix-sdk-ui/src/timeline/to_device.rs
@@ -28,8 +28,6 @@ pub(super) fn handle_room_key_event(
     room_id: OwnedRoomId,
 ) -> impl EventHandler<ToDeviceRoomKeyEvent, (Client,)> {
     move |event: ToDeviceRoomKeyEvent, client: Client| {
-        let inner = inner.clone();
-        let room_id = room_id.clone();
         async move {
             let event_room_id = event.content.room_id;
             let session_id = event.content.session_id;
@@ -44,8 +42,6 @@ pub(super) fn handle_forwarded_room_key_event(
     room_id: OwnedRoomId,
 ) -> impl EventHandler<ToDeviceForwardedRoomKeyEvent, (Client,)> {
     move |event: ToDeviceForwardedRoomKeyEvent, client: Client| {
-        let inner = inner.clone();
-        let room_id = room_id.clone();
         async move {
             let event_room_id = event.content.room_id;
             let session_id = event.content.session_id;

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -20,6 +20,9 @@ Breaking changes:
   - Removed the previous `Room`, `Joined`, `Invited` and `Left` types
   - Merged all of the functionality from `Joined`, `Invited` and `Left` into `room::Common`
   - Renamed `room::Common` to just `Room` and made it accessible as `matrix_sdk::Room`
+- Event handler closures now need to implement `FnOnce` + `Clone` instead of `Fn`
+  - As a consequence, you no longer need to explicitly need to `clone` variables they capture
+    before constructing an `async move {}` block inside
 
 Bug fixes:
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -674,17 +674,13 @@ impl Client {
     ///     todo!("Display the token");
     /// });
     ///
-    /// // Adding your custom data to the handler can be done as well
-    /// let data = "MyCustomIdentifier".to_owned();
+    /// // Event handler closures can also capture local variables.
+    /// // Make sure they are cheap to clone though, because they will be cloned
+    /// // every time the closure is called.
+    /// let data: std::sync::Arc<str> = "MyCustomIdentifier".into();
     ///
-    /// client.add_event_handler({
-    ///     let data = data.clone();
-    ///     move |ev: SyncRoomMessageEvent | {
-    ///         let data = data.clone();
-    ///         async move {
-    ///             println!("Calling the handler with identifier {data}");
-    ///         }
-    ///     }
+    /// client.add_event_handler(move |ev: SyncRoomMessageEvent | async move {
+    ///     println!("Calling the handler with identifier {data}");
     /// });
     /// # });
     /// ```

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -100,10 +100,9 @@ impl NotificationSettings {
         let rules = Arc::new(RwLock::new(Rules::new(ruleset)));
 
         // Listen for PushRulesEvent
-        let rules_clone = rules.clone();
-        let push_rules_event_handler = client.add_event_handler(move |ev: PushRulesEvent| {
-            let rules = rules_clone.to_owned();
-            async move {
+        let push_rules_event_handler = client.add_event_handler({
+            let rules = Arc::clone(&rules);
+            move |ev: PushRulesEvent| async move {
                 *rules.write().await = Rules::new(ev.content.global);
             }
         });

--- a/examples/image_bot/src/main.rs
+++ b/examples/image_bot/src/main.rs
@@ -42,7 +42,7 @@ async fn login_and_sync(
 
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
 
-    client.add_event_handler(move |ev, room| on_room_message(ev, room, image.clone()));
+    client.add_event_handler(move |ev, room| on_room_message(ev, room, image));
 
     let settings = SyncSettings::default().token(response.next_batch);
     client.sync(settings).await?;

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -60,17 +60,14 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
         let found_event = Arc::new(Mutex::new(false));
 
         let found_event_handler = found_event.clone();
-        user.add_event_handler(move |event: SyncRoomMessageEvent| {
-            warn!("Found a message \\o/ {:?}", event);
-            let found_event = found_event_handler.clone();
-            async move {
-                let MessageType::Text(text_content) = &event.as_original().unwrap().content.msgtype
-                else {
-                    return;
-                };
-                if text_content.body == "Hello world!" {
-                    *found_event.lock().unwrap() = true;
-                }
+        user.add_event_handler(move |event: SyncRoomMessageEvent| async move {
+            warn!("Found a message \\o/ {event:?}");
+            let MessageType::Text(text_content) = &event.as_original().unwrap().content.msgtype
+            else {
+                return;
+            };
+            if text_content.body == "Hello world!" {
+                *found_event_handler.lock().unwrap() = true;
             }
         });
 


### PR DESCRIPTION
Technically a breaking change I think, but realistically event handler closures were always clonable.