### PR TITLE
Add parsing for the Capabilities/Permissions.

### DIFF
--- a/crates/matrix-sdk/src/widget/client/handler/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/client/handler/capabilities.rs
@@ -16,6 +16,7 @@ impl<'t> From<&'t Capabilities> for Permissions {
         Self {
             send: c.sender.as_ref().map(|e| e.filters().to_owned()).unwrap_or_default(),
             read: c.reader.as_ref().map(|e| e.filters().to_owned()).unwrap_or_default(),
+            ..Self::default()
         }
     }
 }

--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -1,68 +1,58 @@
 use ruma::events::{MessageLikeEventType, StateEventType, TimelineEventType};
-use serde::{Deserialize, Serialize};
+use serde::{de::Error, Deserialize};
 use tracing::warn;
 
 use super::messages::from_widget::SendEventRequest;
 
-/// Different kinds of filters that could be applied to the timeline events.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// Different kinds of filter that could be applied to the timeline events.
+#[derive(Debug, Clone)]
 pub enum EventFilter {
     /// Message-like events.
-    MessageLike {
-        /// The type of the message-like event.
-        event_type: MessageLikeEventType,
-        /// Additional filter for the msgtype, currently only used for
-        /// `m.room.message`.
-        msgtype: Option<String>,
-    },
+    MessageLike(FilterScope<MessageFilterDescriptor>),
     /// State events.
-    State {
-        /// The type of the state event.
-        event_type: StateEventType,
-        /// State key that could be `None`, `None` means "any state key".
-        state_key: Option<String>,
-    },
+    State(FilterScope<StateFilterDescriptor>),
 }
-
-// TODO: all-message-like and all-state?
-
 impl EventFilter {
-    pub(super) fn matches(&self, de_helper: &EventDeHelperForFilter) -> bool {
-        match (self, &de_helper.state_key) {
+    pub(super) fn matches(&self, matrix_event: &MatrixEventFilterInput) -> bool {
+        match (self, &matrix_event.state_key) {
             // message-like filter, message-like event
-            (
-                EventFilter::MessageLike { event_type: filter_type, msgtype: filter_msgtype },
-                None,
-            ) => {
-                if de_helper.event_type != TimelineEventType::from(filter_type.clone()) {
-                    return false;
-                }
-
-                if *filter_type != MessageLikeEventType::RoomMessage {
-                    if filter_msgtype.is_some() {
-                        warn!("Invalid filter: msgtype specified for a non-room-message filter");
+            (EventFilter::MessageLike(message_filter), None) => match message_filter {
+                FilterScope::All => true,
+                FilterScope::Custom(filter) => {
+                    if matrix_event.event_type != TimelineEventType::from(filter.event_type.clone())
+                    {
                         return false;
                     }
-                    return true;
-                }
 
-                match (filter_msgtype, &de_helper.content.msgtype) {
-                    (Some(a), Some(b)) => a == b,
-                    (Some(_), None) => false,
-                    (None, Some(_)) | (None, None) => true,
+                    if filter.event_type != MessageLikeEventType::RoomMessage {
+                        if filter.msgtype.is_some() {
+                            warn!(
+                                "Invalid filter: msgtype specified for a non-room-message filter"
+                            );
+                            return false;
+                        }
+                        return true;
+                    }
+
+                    match (filter.msgtype.clone(), matrix_event.content.msgtype.clone()) {
+                        (Some(a), Some(b)) => a == b,
+                        (Some(_), None) => false,
+                        (None, Some(_)) | (None, None) => true,
+                    }
                 }
-            }
+            },
 
             // state filter, state event
-            (
-                EventFilter::State { event_type: filter_type, state_key: filter_key },
-                Some(state_key),
-            ) => {
-                de_helper.event_type == TimelineEventType::from(filter_type.clone())
-                    && filter_key
-                        .as_ref()
-                        .map_or(true, |filter_state_key| filter_state_key == state_key)
-            }
+            (EventFilter::State(state_filter), Some(state_key)) => match state_filter {
+                FilterScope::All => true,
+                FilterScope::Custom(filter) => {
+                    matrix_event.event_type == TimelineEventType::from(filter.event_type.clone())
+                        && filter
+                            .state_key
+                            .as_ref()
+                            .map_or(true, |filter_state_key| filter_state_key == state_key)
+                }
+            },
 
             // something else
             _ => false,
@@ -70,10 +60,87 @@ impl EventFilter {
     }
 }
 
-// TODO: Custom (de)serialize impls for EventFilter
+#[derive(Debug, Clone)]
+pub enum FilterScope<T: FilterDescriptor> {
+    All,
+    Custom(T),
+}
+impl<T: FilterDescriptor> FilterScope<T> {
+    /// Convert a `FilterScope` into an extension string.
+    /// Example:
+    /// ```
+    /// FilterScope::Custom(
+    ///     StateFilterDescriptor{
+    ///         event_type:"m.room.member",
+    ///         state_key: Some("@username:server.domain")
+    ///     }
+    /// )
+    /// ```
+    /// has the extension `m.room.member#@username:server.domain`
+    pub(crate) fn get_ext(&self) -> String {
+        match self {
+            FilterScope::All => "".to_owned(),
+            FilterScope::Custom(descriptor) => {
+                let (p, s) = descriptor.get_prefix_suffix();
+                let s = s.map(|s| format!("#{}", s)).unwrap_or("".to_owned());
+                format!("{}{}", p, s)
+            }
+        }
+    }
+
+    /// Creates a `FilterScope` from an extension string.
+    /// Example:
+    /// `org.matrix.msc2762.m.send.event:m.room.message#m.text` has the extension `m.room.message#m.text`
+    pub(crate) fn from_ext(ext: &str) -> Result<Self, serde_json::Error> {
+        match ext.clone().split("#").collect::<Vec<_>>().as_slice() {
+            [""] => Ok(FilterScope::All),
+            [perfix] => Ok(FilterScope::Custom(T::from_prefix_suffix((*perfix).to_owned(), None))),
+            [perfix, suffix] => Ok(FilterScope::Custom(T::from_prefix_suffix(
+                (*perfix).to_owned(),
+                Some((*suffix).to_owned()),
+            ))),
+            _ => Err(serde_json::Error::custom("could not parse capability")),
+        }
+    }
+}
+pub trait FilterDescriptor {
+    fn get_prefix_suffix(&self) ->  (String, Option<String>);
+    fn from_prefix_suffix(prefix: String, suffix: Option<String>) -> Self;
+}
+#[derive(Debug, Clone)]
+pub struct StateFilterDescriptor {
+    /// The type of the state event.
+    event_type: StateEventType,
+    /// State key that could be `None`, `None` means "any state key".
+    state_key: Option<String>,
+}
+impl FilterDescriptor for StateFilterDescriptor {
+    fn get_prefix_suffix(&self) -> (String, Option<String>) {
+        (self.event_type.to_string(), self.state_key.as_ref().map(|s|s.clone()))
+    }
+    fn from_prefix_suffix(prefix: String, suffix: Option<String>) -> Self {
+        StateFilterDescriptor { event_type: prefix.into(), state_key: suffix }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct MessageFilterDescriptor {
+    /// The type of the message-like event.
+    event_type: MessageLikeEventType,
+    /// Additional filter for the msgtype, currently only used for
+    /// `m.room.message`. `None` means "any msgtype"
+    msgtype: Option<String>,
+}
+impl FilterDescriptor for MessageFilterDescriptor {
+    fn get_prefix_suffix(&self) ->  (String, Option<String>) {
+        (self.event_type.to_string(), self.msgtype.as_ref().map(|s|s.clone()))
+    }
+    fn from_prefix_suffix(prefix: String, suffix: Option<String>) -> Self {
+        MessageFilterDescriptor { event_type: prefix.into(), msgtype: suffix }
+    }
+}
 
 #[derive(Debug, Deserialize)]
-pub(super) struct EventDeHelperForFilter {
+pub(super) struct MatrixEventFilterInput {
     #[serde(rename = "type")]
     pub(super) event_type: TimelineEventType,
     pub(super) state_key: Option<String>,
@@ -85,7 +152,7 @@ pub(super) struct MatrixEventContent {
     pub(super) msgtype: Option<String>,
 }
 
-impl EventDeHelperForFilter {
+impl MatrixEventFilterInput {
     pub(super) fn from_send_event_request(req: SendEventRequest) -> Self {
         let SendEventRequest { event_type, state_key, content } = req;
         Self {

--- a/crates/matrix-sdk/src/widget/permissions.rs
+++ b/crates/matrix-sdk/src/widget/permissions.rs
@@ -2,9 +2,18 @@
 //! client.
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use super::filter::EventFilter;
+use super::filter::{
+    EventFilter::{self, MessageLike, State},
+    FilterScope,
+};
+
+const SEND_EVENT: &str = "org.matrix.msc2762.m.send.event";
+const READ_EVENT: &str = "org.matrix.msc2762.m.receive.event";
+const SEND_STATE: &str = "org.matrix.msc2762.m.send.state_event";
+const READ_STATE: &str = "org.matrix.msc2762.m.receive.state_event";
+const REQUIRES_CLIENT: &str = "io.element.requires_client";
 
 /// Must be implemented by a component that provides functionality of deciding
 /// whether a widget is allowed to use certain capabilities (typically by
@@ -18,10 +27,84 @@ pub trait PermissionsProvider: Send + Sync + 'static {
 }
 
 /// Permissions that a widget can request from a client.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default)]
 pub struct Permissions {
     /// Types of the messages that a widget wants to be able to fetch.
     pub read: Vec<EventFilter>,
     /// Types of the messages that a widget wants to be able to send.
     pub send: Vec<EventFilter>,
+    /// If a widget requests this capability the client is not allowed
+    /// to open the widget in a seperated browser.
+    pub requires_client: bool,
+}
+
+impl Serialize for Permissions {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut capability_list: Vec<String> = vec![];
+        let caps = vec![self.requires_client];
+        let strs = vec![REQUIRES_CLIENT];
+
+        caps.iter()
+            .zip(strs.iter())
+            .filter(|(c, _)| **c)
+            .for_each(|(_, s)| capability_list.push((*s).to_owned()));
+
+        let send = self.send.clone().into_iter().map(|filter| match filter {
+            State(scope) => (SEND_STATE, scope.get_ext()),
+            MessageLike(scope) => (SEND_EVENT, scope.get_ext()),
+        });
+
+        let read = self.read.clone().into_iter().map(|f| match f {
+            State(scope) => (READ_STATE, scope.get_ext()),
+            MessageLike(scope) => (READ_EVENT, scope.get_ext()),
+        });
+
+        for (base, ext) in send.chain(read) {
+            capability_list.push(format!("{}{}", base, ext));
+        }
+
+        capability_list.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Permissions {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let capability_list = Vec::<String>::deserialize(deserializer)?;
+        let mut permissions = Permissions::default();
+
+        let err_m = |e: serde_json::Error| de::Error::custom(e.to_string());
+
+        for capability in capability_list {
+            match &capability.split(":").collect::<Vec<_>>().as_slice() {
+                [REQUIRES_CLIENT] => permissions.requires_client = true,
+
+                [SEND_EVENT] => permissions.send.push(MessageLike(FilterScope::All)),
+                [READ_EVENT] => permissions.read.push(MessageLike(FilterScope::All)),
+                [SEND_EVENT, rest] => {
+                    permissions.send.push(MessageLike(FilterScope::from_ext(rest).map_err(err_m)?))
+                }
+                [READ_EVENT, rest] => {
+                    permissions.read.push(MessageLike(FilterScope::from_ext(rest).map_err(err_m)?))
+                }
+
+                [SEND_STATE] => permissions.send.push(State(FilterScope::All)),
+                [READ_STATE] => permissions.read.push(State(FilterScope::All)),
+                [SEND_STATE, rest] => {
+                    permissions.send.push(State(FilterScope::from_ext(rest).map_err(err_m)?))
+                }
+                [READ_STATE, rest] => {
+                    permissions.read.push(State(FilterScope::from_ext(rest).map_err(err_m)?))
+                }
+                _ => {}
+            }
+        }
+
+        Ok(permissions)
+    }
 }


### PR DESCRIPTION
This does not include the FFI.
Changes to the FFI are required however to support the `All` scope.
@jplatte 
I changed the `EventDeHelperForFilter` -> `MatrixEventFilterInput` let me know if you want this to be reverted (Because we decided for EventDeHelperForFilter in our sync but now I very much prefer MatrixEventFilterInput but at the end its just a preference thing so I dont mind.)

I am not sure about the structure of the EventFilter there are two obvious solutions:
```rust
enum EventFilter{
  AllState,
  AllMessageLike,
  State(StateFilterDescriptor),
  MessageLike(MessageFilterDescriptor),
}
```
or
```rust
enum EventFilter{
  State(FilterScope<StateFilterDescriptor>),
  MessageLike(FilterScope<MessageFilterDescriptor>),
}
enum FilterScope<T>{
  All,
  Custom<T>
}
```

I decided for the second solution since this seems to be the one which is more aligned with the actual logic. We first decided if its a state or message filter and than think about the scope. AllState is not an actually different enum state.
This might make the FFI more complicated however and also in the implementation there might be more helper functions than what would be required with the first option.