### PR TITLE
test(sliding sync): skipping b/o mode change doesn't change parameters in other lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,6 +3042,7 @@ version = "0.6.2"
 dependencies = [
  "anyhow",
  "anymap2",
+ "assert-json-diff",
  "assert_matches",
  "async-channel",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.70"
 
 [workspace.dependencies]
 anyhow = "1.0.68"
+assert-json-diff = "2"
 assert_matches = "1.5.0"
 async-rx = "0.1.3"
 async-stream = "0.3.3"

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -45,7 +45,7 @@ unicode-normalization = "0.1.22"
 
 [dev-dependencies]
 anyhow = { workspace = true }
-assert-json-diff = "2.0"
+assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 ctor = { workspace = true }
 eyeball-im-util = { workspace = true }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -138,6 +138,7 @@ tokio = { workspace = true, features = ["fs", "rt", "macros"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+assert-json-diff = "2.0"
 assert_matches = { workspace = true }
 dirs = "5.0.1"
 futures-executor = { workspace = true }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -138,7 +138,7 @@ tokio = { workspace = true, features = ["fs", "rt", "macros"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-assert-json-diff = "2.0"
+assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 dirs = "5.0.1"
 futures-executor = { workspace = true }


### PR DESCRIPTION
This is a hunch I had when reading some rageshakes, but my hunch was wrong. At least that makes for a new test that I don't think we had somewhere else in the code base: make sure that if we skip a stream iteration because of a change in list A, list B parameters don't get updated.