### PR TITLE
feat(sliding sync): restart all_rooms in selective mode after termination/error

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -209,6 +209,7 @@ pub enum RoomListServiceState {
     Initial,
     SettingUp,
     Running,
+    Resurrecting,
     Error,
     Terminated,
 }
@@ -221,6 +222,7 @@ impl From<matrix_sdk_ui::room_list_service::State> for RoomListServiceState {
             Init => Self::Initial,
             SettingUp => Self::SettingUp,
             Running => Self::Running,
+            Resurrecting => Self::Resurrecting,
             Error { .. } => Self::Error,
             Terminated { .. } => Self::Terminated,
         }

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -162,7 +162,9 @@ impl RoomListService {
         let sliding_sync = builder
             .add_cached_list(configure_all_or_visible_rooms_list(
                 SlidingSyncList::builder(ALL_ROOMS_LIST_NAME)
-                    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=19))
+                    .sync_mode(
+                        SlidingSyncMode::new_selective().add_range(ALL_ROOMS_DEFAULT_INITIAL_RANGE),
+                    )
                     .timeline_limit(0)
                     .required_state(vec![
                         (StateEventType::RoomAvatar, "".to_owned()),

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -71,7 +71,7 @@ impl RoomList {
 
                     match state {
                         Terminated { .. } | Error { .. } | Init => (),
-                        SettingUp | Running => break,
+                        SettingUp | Running | Resurrecting => break,
                     }
                 }
 


### PR DESCRIPTION
This introduces a new state `Resurrecting`, that's reached from `Terminated`/`Error`, and that goes to the `Running` state.

Before this commit, the all_rooms list would keep on growing, after a termination/error. The `Resurrecting` mode is a new intermediary state introduced so that the all_rooms list can restart, after an error, to its initial selective mode, before getting back to the growing mode later on in `Running`. This makes the room list service faster to recovery after any kind of termination/error.