### PR TITLE
fix(ui): Try to make `RoomListService` fast for gigantic accounts with various network speeds

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -208,6 +208,7 @@ pub enum RoomListServiceState {
     // as of 2023-08-21.
     Initial,
     SettingUp,
+    Recovering,
     Running,
     Error,
     Terminated,
@@ -220,6 +221,7 @@ impl From<matrix_sdk_ui::room_list_service::State> for RoomListServiceState {
         match value {
             Init => Self::Initial,
             SettingUp => Self::SettingUp,
+            Recovering => Self::Recovering,
             Running => Self::Running,
             Error { .. } => Self::Error,
             Terminated { .. } => Self::Terminated,

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -162,7 +162,10 @@ impl RoomListService {
         let sliding_sync = builder
             .add_cached_list(configure_all_or_visible_rooms_list(
                 SlidingSyncList::builder(ALL_ROOMS_LIST_NAME)
-                    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=19))
+                    .sync_mode(
+                        SlidingSyncMode::new_selective()
+                            .add_range(ALL_ROOMS_DEFAULT_SELECTIVE_BATCH_SIZE),
+                    )
                     .timeline_limit(1)
                     .required_state(vec![
                         (StateEventType::RoomAvatar, "".to_owned()),

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -163,7 +163,7 @@ impl RoomListService {
             .add_cached_list(configure_all_or_visible_rooms_list(
                 SlidingSyncList::builder(ALL_ROOMS_LIST_NAME)
                     .sync_mode(SlidingSyncMode::new_selective().add_range(0..=19))
-                    .timeline_limit(0)
+                    .timeline_limit(1)
                     .required_state(vec![
                         (StateEventType::RoomAvatar, "".to_owned()),
                         (StateEventType::RoomEncryption, "".to_owned()),

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -71,7 +71,7 @@ impl RoomList {
 
                     match state {
                         Terminated { .. } | Error { .. } | Init => (),
-                        SettingUp | Running => break,
+                        SettingUp | Recovering | Running => break,
                     }
                 }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -133,7 +133,7 @@ struct SetAllRoomsListToGrowingSyncMode;
 
 /// Default `batch_size` for the growing sync-mode of the `ALL_ROOMS_LIST_NAME`
 /// list.
-pub const ALL_ROOMS_DEFAULT_GROWING_BATCH_SIZE: u32 = 200;
+pub const ALL_ROOMS_DEFAULT_GROWING_BATCH_SIZE: u32 = 100;
 
 #[async_trait]
 impl Action for SetAllRoomsListToGrowingSyncMode {
@@ -385,7 +385,7 @@ mod tests {
             sliding_sync
                 .on_list(ALL_ROOMS_LIST_NAME, |list| ready(matches!(
                     list.sync_mode(),
-                    SlidingSyncMode::Growing { batch_size: 200, .. }
+                    SlidingSyncMode::Growing { batch_size: 100, .. }
                 )))
                 .await,
             Some(true)

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -264,7 +264,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         "m.sticker",
                     ],
                     "sort": ["by_recency", "by_name"],
-                    "timeline_limit": 0,
+                    "timeline_limit": 1,
                 },
             },
             "extensions": {

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -702,26 +702,59 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
     // Do a regular sync from the `Error` state.
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
-        states = Error { .. } => Running,
+        states = Error { .. } => Recovering,
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // In `Running`, the sync-mode is still growing, but the range
-                    // hasn't been modified due to previous error.
-                    "ranges": [[0, 99]],
+                    // Due to previous error, the sync-mode is back to selective, with its initial range.
+                    "ranges": [[0, 19]],
                 },
                 VISIBLE_ROOMS: {
                     // We have set a viewport, which reflects here.
                     "ranges": [[5, 10]],
                 },
                 INVITES: {
-                    // The range hasn't been modified due to previous error.
+                    // Due to previous error, the range has been reset.
                     "ranges": [[0, 19]],
                 },
             },
         },
         respond with = {
             "pos": "2",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 210,
+                },
+                INVITES: {
+                    "count": 30,
+                }
+            },
+            "rooms": {},
+        },
+    };
+
+    // Do a regular sync from the `Recovering` state.
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        states = Recovering => Running,
+        assert request >= {
+            "lists": {
+                ALL_ROOMS: {
+                    // In `Running`, the sync-mode is now growing.
+                    "ranges": [[0, 99]],
+                },
+                VISIBLE_ROOMS: {
+                    // Viewport hasn't changed.
+                    "ranges": [[5, 10]],
+                },
+                INVITES: {
+                    // The range has reached its maximum.
+                    "ranges": [[0, 29]],
+                },
+            },
+        },
+        respond with = {
+            "pos": "3",
             "lists": {
                 ALL_ROOMS: {
                     "count": 210,
@@ -747,11 +780,11 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                     "ranges": [[0, 199]],
                 },
                 VISIBLE_ROOMS: {
-                    // Despites the error, the range is kept.
+                    // The range is kept.
                     "ranges": [[5, 10]],
                 },
                 INVITES: {
-                    // Despites the error, the range has made progress.
+                    // The range is kept.
                     "ranges": [[0, 29]],
                 },
             },
@@ -772,32 +805,66 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
     // Do a regular sync from the `Error` state.
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
-        states = Error { .. } => Running,
+        states = Error { .. } => Recovering,
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // Due to the error, the range is reset to its initial value.
-                    "ranges": [[0, 99]],
+                    // Due to previous error, the sync-mode is back to selective, with its initial range.
+                    "ranges": [[0, 19]],
                 },
                 VISIBLE_ROOMS: {
-                    // Despites the error, the range is kept.
+                    // We have set a viewport, which reflects here.
                     "ranges": [[5, 10]],
                 },
                 INVITES: {
-                    // Due to the error, the range is reset to its initial range.
+                    // Due to previous error, the range has been reset.
                     "ranges": [[0, 19]],
-                }
+                },
             },
         },
         respond with = {
-            "pos": "3",
+            "pos": "4",
             "lists": {
                 ALL_ROOMS: {
                     "count": 210,
                 },
                 INVITES: {
                     "count": 4,
+                }
+            },
+            "rooms": {},
+        },
+    };
+
+    // Do a regular sync from the `Recovering` state.
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        states = Recovering => Running,
+        assert request >= {
+            "lists": {
+                ALL_ROOMS: {
+                    // In `Running`, the sync-mode is now growing.
+                    "ranges": [[0, 99]],
                 },
+                VISIBLE_ROOMS: {
+                    // Viewport hasn't changed.
+                    "ranges": [[5, 10]],
+                },
+                INVITES: {
+                    // The range has reached its maximum.
+                    "ranges": [[0, 3]],
+                },
+            },
+        },
+        respond with = {
+            "pos": "5",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 210,
+                },
+                INVITES: {
+                    "count": 4,
+                }
             },
             "rooms": {},
         },
@@ -825,11 +892,14 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
             },
         },
         respond with = {
-            "pos": "4",
+            "pos": "6",
             "lists": {
                 ALL_ROOMS: {
                     "count": 210,
                 },
+                INVITES: {
+                    "count": 30,
+                }
             },
             "rooms": {},
         },
@@ -853,7 +923,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 },
                 INVITES: {
                     // The range is kept as it was.
-                    "ranges": [[0, 3]],
+                    "ranges": [[0, 29]],
                 },
             },
         },
@@ -873,35 +943,72 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
     // Do a regular sync from the `Error` state.
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
-        states = Error { .. } => Running,
+        states = Error { .. } => Recovering,
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // An error was received at the previous sync iteration.
-                    // The list is still in growing sync-mode, but its range has
-                    // been reset.
-                    "ranges": [[0, 99]],
+                    // Due to previous error, the sync-mode is back to selective, with its initial range.
+                    "ranges": [[0, 19]],
                 },
                 VISIBLE_ROOMS: {
-                    // The range is still here.
+                    // We have set a viewport, which reflects here.
                     "ranges": [[5, 10]],
                 },
                 INVITES: {
-                    // The range is kept as it was.
+                    // Due to previous error, the range has been reset.
+                    "ranges": [[0, 19]],
+                },
+            },
+        },
+        respond with = {
+            "pos": "7",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 210,
+                },
+                INVITES: {
+                    "count": 4,
+                }
+            },
+            "rooms": {},
+        },
+    };
+
+    // Do a regular sync from the `Recovering` state.
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        states = Recovering => Running,
+        assert request >= {
+            "lists": {
+                ALL_ROOMS: {
+                    // In `Running`, the sync-mode is now growing.
+                    "ranges": [[0, 99]],
+                },
+                VISIBLE_ROOMS: {
+                    // Viewport hasn't changed.
+                    "ranges": [[5, 10]],
+                },
+                INVITES: {
+                    // The range has reached its maximum.
                     "ranges": [[0, 3]],
                 },
             },
         },
         respond with = {
-            "pos": "5",
+            "pos": "8",
             "lists": {
                 ALL_ROOMS: {
                     "count": 210,
                 },
+                INVITES: {
+                    "count": 4,
+                }
             },
             "rooms": {},
         },
     };
+
+    // etc.
 
     Ok(())
 }
@@ -933,7 +1040,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
             "pos": "0",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 1000,
+                    "count": 150,
                 },
             },
             "rooms": {},
@@ -951,13 +1058,12 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
     // Do a regular sync from the `Terminated` state.
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
-        states = Terminated { .. } => Running,
+        states = Terminated { .. } => Recovering,
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // In `SettingUp`, the sync-mode has changed to growing, with
-                    // its initial range.
-                    "ranges": [[0, 99]],
+                    // Due to previous error, the sync-mode is back to selective with its initial range.
+                    "ranges": [[0, 19]],
                 },
                 VISIBLE_ROOMS: {
                     // Hello new list.
@@ -973,7 +1079,38 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
             "pos": "1",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 1000,
+                    "count": 150,
+                },
+            },
+            "rooms": {},
+        },
+    };
+
+    // Do a regular sync from the `Recovering` state.
+    sync_then_assert_request_and_fake_response! {
+        [server, room_list, sync]
+        states = Recovering => Running,
+        assert request >= {
+            "lists": {
+                ALL_ROOMS: {
+                    // In `Running`, the sync-mode is now growing, with its initial range.
+                    "ranges": [[0, 99]],
+                },
+                VISIBLE_ROOMS: {
+                    // Hello new list.
+                    "ranges": [[0, 19]],
+                },
+                INVITES: {
+                    // Hello new list.
+                    "ranges": [[0, 19]],
+                },
+            },
+        },
+        respond with = {
+            "pos": "2",
+            "lists": {
+                ALL_ROOMS: {
+                    "count": 150,
                 },
             },
             "rooms": {},
@@ -994,64 +1131,20 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
     // Do a regular sync from the `Terminated` state.
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
-        states = Terminated { .. } => Running,
+        states = Terminated { .. } => Recovering,
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // In `Running`, the sync-mode is still growing, the previous termination
-                    // didn't restart the whole growing.
-                    "ranges": [[0, 199]],
+                    // Due to the previous termination, the sync-mode is back to selective.
+                    "ranges": [[0, 19]],
                 },
                 VISIBLE_ROOMS: {
                     // We have set a viewport, which reflects here.
                     "ranges": [[5, 10]],
                 },
                 INVITES: {
-                    // The range hasn't been modified due to previous termination.
+                    // Due to the previous termination, the range is reset.
                     "ranges": [[0, 19]],
-                },
-            },
-        },
-        respond with = {
-            "pos": "2",
-            "lists": {
-                ALL_ROOMS: {
-                    "count": 1000,
-                },
-                INVITES: {
-                    "count": 3,
-                }
-            },
-            "rooms": {},
-        },
-    };
-
-    // Stop the sync.
-    room_list.stop_sync()?;
-    assert!(sync.next().await.is_none());
-
-    // Start a new sync.
-    let sync = room_list.sync();
-    pin_mut!(sync);
-
-    // Do a regular sync from the `Terminated` state.
-    sync_then_assert_request_and_fake_response! {
-        [server, room_list, sync]
-        states = Terminated { .. } => Running,
-        assert request >= {
-            "lists": {
-                ALL_ROOMS: {
-                    // In `Running`, the sync-mode is still growing, the previous termination
-                    // didn't restart the whole growing.
-                    "ranges": [[0, 299]],
-                },
-                VISIBLE_ROOMS: {
-                    // Despites the termination, the range is kept.
-                    "ranges": [[5, 10]],
-                },
-                INVITES: {
-                    // Despites the error, the range has made progress.
-                    "ranges": [[0, 2]],
                 },
             },
         },
@@ -1059,34 +1152,33 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
             "pos": "3",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 1000,
+                    "count": 150,
                 },
                 INVITES: {
-                    "count": 0,
+                    "count": 4,
                 }
             },
             "rooms": {},
         },
     };
 
-    // Do a regular sync from the `Running` state to update the `ALL_ROOMS` list
-    // again.
+    // Do a regular sync from the `Recovering` state.
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
-        states = Running => Running,
+        states = Recovering => Running,
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // No termination.
-                    "ranges": [[0, 399]],
+                    // Now, back to growing sync-mode with its initial range.
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
-                    // No termination. The range is still here.
+                    // We have set a viewport, which reflects here.
                     "ranges": [[5, 10]],
                 },
                 INVITES: {
-                    // The range is making progress.
-                    "ranges": [[0, 0]],
+                    // Range has reached its maximum.
+                    "ranges": [[0, 3]],
                 },
             },
         },
@@ -1094,39 +1186,33 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
             "pos": "4",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 1000,
+                    "count": 150,
                 },
+                INVITES: {
+                    "count": 4,
+                }
             },
             "rooms": {},
         },
     };
 
-    // Stop the sync.
-    room_list.stop_sync()?;
-    assert!(sync.next().await.is_none());
-
-    // Start a new sync.
-    let sync = room_list.sync();
-    pin_mut!(sync);
-
-    // Do a regular sync from the `Terminated` state.
+    // Do a regular sync from the `Running` state.
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
-        states = Terminated { .. } => Running,
+        states = Running => Running,
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    // The termination doesn't invalidate the range, we're still in the stable
-                    // state.
-                    "ranges": [[0, 499]],
+                    // Range is making progress, and has reached its maximum.
+                    "ranges": [[0, 149]],
                 },
                 VISIBLE_ROOMS: {
-                    // The range is still here.
+                    // We have set a viewport, which reflects here.
                     "ranges": [[5, 10]],
                 },
                 INVITES: {
-                    // The range is kept as it was.
-                    "ranges": [[0, 0]],
+                    // Range has reached its maximum.
+                    "ranges": [[0, 3]],
                 },
             },
         },
@@ -1134,8 +1220,11 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
             "pos": "5",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 1000,
+                    "count": 150,
                 },
+                INVITES: {
+                    "count": 4,
+                }
             },
             "rooms": {},
         },

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -297,7 +297,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "conn_id": "room-list",
             "lists": {
                 ALL_ROOMS: {
-                    "ranges": [[0, 199]],
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [[0, 19]],
@@ -367,7 +367,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "conn_id": "room-list",
             "lists": {
                 ALL_ROOMS: {
-                    "ranges": [[0, 399]],
+                    "ranges": [[0, 199]],
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [[0, 19]],
@@ -408,7 +408,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "conn_id": "room-list",
             "lists": {
                 ALL_ROOMS: {
-                    "ranges": [[0, 599]],
+                    "ranges": [[0, 299]],
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [[0, 19]],
@@ -449,7 +449,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
             "conn_id": "room-list",
             "lists": {
                 ALL_ROOMS: {
-                    "ranges": [[0, 799]],
+                    "ranges": [[0, 399]],
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [[0, 19]],
@@ -654,7 +654,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
             "pos": "1",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 410,
+                    "count": 210,
                 },
             },
             "rooms": {},
@@ -671,7 +671,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // In `SettingUp`, the sync-mode has changed to growing, with
                     // its initial range.
-                    "ranges": [[0, 199]],
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     // Hello new list.
@@ -708,7 +708,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // In `Running`, the sync-mode is still growing, but the range
                     // hasn't been modified due to previous error.
-                    "ranges": [[0, 199]],
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     // We have set a viewport, which reflects here.
@@ -724,7 +724,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
             "pos": "2",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 410,
+                    "count": 210,
                 },
                 INVITES: {
                     "count": 30,
@@ -744,7 +744,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // In `Running`, the sync-mode is still growing, and the range
                     // has made progress.
-                    "ranges": [[0, 399]],
+                    "ranges": [[0, 199]],
                 },
                 VISIBLE_ROOMS: {
                     // Despites the error, the range is kept.
@@ -777,7 +777,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     // Due to the error, the range is reset to its initial value.
-                    "ranges": [[0, 199]],
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     // Despites the error, the range is kept.
@@ -793,7 +793,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
             "pos": "3",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 410,
+                    "count": 210,
                 },
                 INVITES: {
                     "count": 4,
@@ -812,7 +812,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     // No error. The range is making progress.
-                    "ranges": [[0, 399]],
+                    "ranges": [[0, 199]],
                 },
                 VISIBLE_ROOMS: {
                     // No error. The range is still here.
@@ -828,7 +828,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
             "pos": "4",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 410,
+                    "count": 210,
                 },
             },
             "rooms": {},
@@ -845,7 +845,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // Range is making progress and is even reaching the maximum
                     // number of rooms.
-                    "ranges": [[0, 409]],
+                    "ranges": [[0, 209]],
                 },
                 VISIBLE_ROOMS: {
                     // The range is still here.
@@ -880,7 +880,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
                     // An error was received at the previous sync iteration.
                     // The list is still in growing sync-mode, but its range has
                     // been reset.
-                    "ranges": [[0, 199]],
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     // The range is still here.
@@ -896,7 +896,7 @@ async fn test_sync_resumes_from_error() -> Result<(), Error> {
             "pos": "5",
             "lists": {
                 ALL_ROOMS: {
-                    "count": 410,
+                    "count": 210,
                 },
             },
             "rooms": {},
@@ -957,7 +957,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // In `SettingUp`, the sync-mode has changed to growing, with
                     // its initial range.
-                    "ranges": [[0, 199]],
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     // Hello new list.
@@ -1000,7 +1000,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // In `Running`, the sync-mode is still growing, the previous termination
                     // didn't restart the whole growing.
-                    "ranges": [[0, 399]],
+                    "ranges": [[0, 199]],
                 },
                 VISIBLE_ROOMS: {
                     // We have set a viewport, which reflects here.
@@ -1043,7 +1043,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // In `Running`, the sync-mode is still growing, the previous termination
                     // didn't restart the whole growing.
-                    "ranges": [[0, 599]],
+                    "ranges": [[0, 299]],
                 },
                 VISIBLE_ROOMS: {
                     // Despites the termination, the range is kept.
@@ -1078,7 +1078,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     // No termination.
-                    "ranges": [[0, 799]],
+                    "ranges": [[0, 399]],
                 },
                 VISIBLE_ROOMS: {
                     // No termination. The range is still here.
@@ -1118,7 +1118,7 @@ async fn test_sync_resumes_from_terminated() -> Result<(), Error> {
                 ALL_ROOMS: {
                     // The termination doesn't invalidate the range, we're still in the stable
                     // state.
-                    "ranges": [[0, 999]],
+                    "ranges": [[0, 499]],
                 },
                 VISIBLE_ROOMS: {
                     // The range is still here.
@@ -2388,7 +2388,7 @@ async fn test_input_viewport() -> Result<(), Error> {
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    "ranges": [[0, 199]],
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [[0, 19]],
@@ -2425,7 +2425,7 @@ async fn test_input_viewport() -> Result<(), Error> {
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
-                    "ranges": [[0, 199]],
+                    "ranges": [[0, 99]],
                 },
                 VISIBLE_ROOMS: {
                     "ranges": [[10, 15], [20, 25]],


### PR DESCRIPTION
This PR must be reviewed commit-by-commit. It tries to make `RoomListService` fast for gigantic accounts with various network speeds and stability. It's basically fine-tuning.