### PR TITLE
ffi: Only ever call ClientDelegate methods in a blocking task

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -200,9 +200,7 @@ impl ClientBuilder {
             sdk_client.set_sliding_sync_proxy(Some(Url::parse(&sliding_sync_proxy)?));
         }
 
-        let client = Client::new(sdk_client);
-
-        Ok(Arc::new(client))
+        Ok(Client::new(sdk_client))
     }
 }
 


### PR DESCRIPTION
… and clean up a few unnecessary Arc's.
