### PR TITLE
chore(sdk): Log the OIDC refresh token (hashed).

### DIFF
--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -60,6 +60,15 @@ impl AuthSession {
             AuthSession::Oidc(session) => &session.user.tokens.access_token,
         }
     }
+
+    /// Get the refresh token of this session.
+    pub fn refresh_token(&self) -> &Option<String> {
+        match self {
+            AuthSession::Matrix(session) => &session.tokens.refresh_token,
+            #[cfg(feature = "experimental-oidc")]
+            AuthSession::Oidc(session) => &session.user.tokens.refresh_token,
+        }
+    }
 }
 
 impl From<matrix_auth::Session> for AuthSession {

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -62,11 +62,11 @@ impl AuthSession {
     }
 
     /// Get the refresh token of this session.
-    pub fn refresh_token(&self) -> &Option<String> {
+    pub fn get_refresh_token(&self) -> Option<&str> {
         match self {
-            AuthSession::Matrix(session) => &session.tokens.refresh_token,
+            AuthSession::Matrix(session) => session.tokens.refresh_token.as_deref(),
             #[cfg(feature = "experimental-oidc")]
-            AuthSession::Oidc(session) => &session.user.tokens.refresh_token,
+            AuthSession::Oidc(session) => session.user.tokens.refresh_token.as_deref(),
         }
     }
 }


### PR DESCRIPTION
To help track down why an `InvalidGrant` error is unexpectedly being thrown, this PR logs the OIDC refresh token (in hashed form) in the following instances:
- After a successful refresh.
- After a failed refresh.

As `InvalidGrant` is thrown when a token is reused, this will allow the ability to track in the logs whether the token isn't being updated properly by the app or whether the issue may be on the backend. First part of #2476.