### PR TITLE
sdk: Revert observable diff buffer capacity change

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -225,7 +225,7 @@ impl SlidingSyncListBuilder {
                 maximum_number_of_rooms: StdRwLock::new(Observable::new(None)),
                 // We want to avoid triggering `VectorDiff::Reset` too much, hence we
                 // increase the observable capacity.
-                room_list: StdRwLock::new(ObservableVector::with_capacity(64)),
+                room_list: StdRwLock::new(ObservableVector::with_capacity(4096)),
 
                 // Internal data.
                 sliding_sync_internal_channel_sender,


### PR DESCRIPTION
Resets were happening very frequently again.