### PR TITLE
fix: save the OIDC refresh token from the response (!)

### DIFF
--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -913,6 +913,8 @@ impl Oidc {
             latest_id_token: id_token.or_else(|| latest_id_token.cloned()),
         });
 
+        _ = self.client.inner.session_change_sender.send(SessionChange::TokensRefreshed);
+
         Ok(response)
     }
 
@@ -954,11 +956,6 @@ impl Oidc {
             {
                 Ok(response) => {
                     *guard = Ok(());
-                    _ = self
-                        .client
-                        .inner
-                        .session_change_sender
-                        .send(SessionChange::TokensRefreshed);
                     Ok(Some(response))
                 }
                 Err(error) => {


### PR DESCRIPTION
Save the OIDC refresh token obtained from the response (that was removed in an attempt to debug further invalid grant issues), and add some logs to help with debugging in the future.