### PR TITLE
Fix broken link in docs

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -257,8 +257,6 @@ impl OlmMachine {
     ///
     /// * `store` - A `Cryptostore` implementation that will be used to store
     /// the encryption keys.
-    ///
-    /// [`Cryptostore`]: trait.CryptoStore.html
     #[instrument(skip(store), fields(ed25519_key, curve25519_key))]
     pub async fn with_store(
         user_id: &UserId,


### PR DESCRIPTION
Rustdoc can link to other items by name automatically using [intra-doc link](https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html). Use that to fix a broken link in docs

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Muhammad Hamza <me@mhamza.dev>
