### PR TITLE
chore(bindings): Handle OIDC metadata changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3422,6 +3422,7 @@ dependencies = [
  "serde",
  "serde_json",
  "stream_assert",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,6 +3428,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-normalization",
+ "url",
  "wiremock",
 ]
 

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -29,7 +29,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption", "experimental-oidc"] }
+matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption"] }
 mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -29,7 +29,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption", "experimental-oidc"] }
 mime = "0.3.16"
 # FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
 # see https://github.com/matrix-org/matrix-rust-sdk/issues/1014

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -1,9 +1,5 @@
 use std::{
     collections::HashMap,
-    fs,
-    fs::File,
-    io::{BufReader, BufWriter},
-    path::PathBuf,
     sync::{Arc, RwLock},
 };
 
@@ -22,11 +18,11 @@ use matrix_sdk::{
     },
     AuthSession,
 };
+use matrix_sdk_ui::authentication::oidc::{OidcRegistrations, OidcRegistrationsError};
 use ruma::{
     api::client::discovery::discover_homeserver::AuthenticationServerInfo, IdParseError,
     OwnedUserId,
 };
-use serde::{Deserialize, Serialize};
 use url::Url;
 use zeroize::Zeroize;
 
@@ -93,6 +89,14 @@ impl From<IdParseError> for AuthenticationError {
     }
 }
 
+impl From<OidcRegistrationsError> for AuthenticationError {
+    fn from(e: OidcRegistrationsError) -> AuthenticationError {
+        match e {
+            OidcRegistrationsError::InvalidBasePath => AuthenticationError::InvalidBasePath,
+        }
+    }
+}
+
 impl From<OidcError> for AuthenticationError {
     fn from(e: OidcError) -> AuthenticationError {
         AuthenticationError::OidcError { message: e.to_string() }
@@ -119,69 +123,6 @@ pub struct OidcConfiguration {
     /// Pre-configured registrations for use with issuers that don't support
     /// dynamic client registration.
     pub static_registrations: HashMap<String, String>,
-}
-
-/// The data needed to restore an OpenID Connect session.
-#[derive(Debug, Serialize, Deserialize)]
-struct OidcRegistrations {
-    /// The path of the file where the registrations are stored.
-    file_path: PathBuf,
-    /// Pre-configured registrations for use with issuers that don't support
-    /// dynamic client registration.
-    static_registrations: HashMap<String, String>,
-}
-
-/// Manages the storage of OIDC registrations.
-impl OidcRegistrations {
-    fn new(
-        base_path: &str,
-        static_registrations: HashMap<String, String>,
-    ) -> Result<Self, AuthenticationError> {
-        let oidc_directory = PathBuf::from(base_path).join("oidc");
-        fs::create_dir_all(&oidc_directory).map_err(|_| AuthenticationError::InvalidBasePath)?;
-
-        Ok(OidcRegistrations {
-            file_path: oidc_directory.join("registrations.json"),
-            static_registrations,
-        })
-    }
-
-    /// Returns all of the registrations this client has made as a HashMap of
-    /// issuer URL (as a string) to client ID (as a string).
-    fn dynamic_registrations(&self) -> HashMap<String, String> {
-        let reader = match File::open(&self.file_path) {
-            Ok(file) => BufReader::new(file),
-            Err(e) => {
-                tracing::error!("Failed to open registrations file: {e}");
-                return HashMap::new();
-            }
-        };
-
-        serde_json::from_reader(reader).unwrap_or_else(|e| {
-            tracing::error!("Failed to parse registrations file: {e}");
-            HashMap::new()
-        })
-    }
-
-    /// Returns the client ID registered for a particular issuer or None if a
-    /// registration hasn't been made.
-    fn client_id(&self, issuer: &str) -> Option<String> {
-        let mut registrations = self.dynamic_registrations();
-        registrations.extend(self.static_registrations.clone());
-        registrations.get(issuer).cloned()
-    }
-
-    /// Stores a new client ID registration for a particular issuer. If a client
-    /// ID has already been stored, this will overwrite the old value.
-    fn set_client_id(&self, client_id: String, issuer: String) -> Result<(), AuthenticationError> {
-        let mut current = self.dynamic_registrations();
-        current.insert(issuer, client_id);
-
-        let writer = BufWriter::new(
-            File::create(&self.file_path).map_err(|_| AuthenticationError::InvalidBasePath)?,
-        );
-        serde_json::to_writer(writer, &current).map_err(|_| AuthenticationError::InvalidBasePath)
-    }
 }
 
 /// The data required to authenticate against an OIDC server.
@@ -503,8 +444,13 @@ impl AuthenticationService {
             .client_id()
             .to_owned();
 
+        let metadata = oidc.client_metadata().ok_or(AuthenticationError::OidcError {
+            message: String::from("Missing client metadata."),
+        })?;
+
         let registrations = OidcRegistrations::new(
             &self.base_path,
+            metadata,
             self.oidc_configuration
                 .as_ref()
                 .map(|c| c.static_registrations.clone())
@@ -526,6 +472,7 @@ impl AuthenticationService {
         let issuer = &authentication_server.issuer;
         let Some(registrations) = OidcRegistrations::new(
             &self.base_path,
+            &oidc_metadata,
             self.oidc_configuration
                 .as_ref()
                 .map(|c| c.static_registrations.clone())

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -93,6 +93,7 @@ impl From<OidcRegistrationsError> for AuthenticationError {
     fn from(e: OidcRegistrationsError) -> AuthenticationError {
         match e {
             OidcRegistrationsError::InvalidBasePath => AuthenticationError::InvalidBasePath,
+            _ => AuthenticationError::OidcError { message: e.to_string() },
         }
     }
 }
@@ -486,7 +487,7 @@ impl AuthenticationService {
         };
 
         let client_data = RegisteredClientData {
-            credentials: ClientCredentials::None { client_id: client_id.to_string() },
+            credentials: ClientCredentials::None { client_id: client_id.0 },
             metadata: oidc_metadata,
         };
 

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -451,8 +451,11 @@ impl AuthenticationService {
             message: String::from("Missing client metadata."),
         })?;
 
-        let registrations =
-            OidcRegistrations::new(&self.base_path, metadata, self.oidc_static_registrations())?;
+        let registrations = OidcRegistrations::new(
+            &self.base_path,
+            metadata.clone(),
+            self.oidc_static_registrations(),
+        )?;
         registrations.set_and_write_client_id(ClientId(client_id), issuer)?;
 
         Ok(())
@@ -472,7 +475,7 @@ impl AuthenticationService {
         };
         let Some(registrations) = OidcRegistrations::new(
             &self.base_path,
-            &oidc_metadata,
+            oidc_metadata.clone(),
             self.oidc_static_registrations(),
         )
         .ok() else {

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -29,7 +29,7 @@ fuzzy-matcher = "0.3.7"
 imbl = { version = "2.0.0", features = ["serde"] }
 indexmap = "2.0.0"
 itertools = { workspace = true }
-matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["experimental-sliding-sync"] }
+matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["experimental-oidc", "experimental-sliding-sync"] }
 matrix-sdk-base = { version = "0.6.1", path = "../matrix-sdk-base" }
 matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto" }
 mime = "0.3.16"
@@ -50,7 +50,7 @@ assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 ctor = { workspace = true }
 eyeball-im-util = { workspace = true }
-matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing", "experimental-oidc"] }
+matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 stream_assert = "0.1.0"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 unicode-normalization = "0.1.22"
+url = "2.2.2"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -8,7 +8,6 @@ rust-version = { workspace = true }
 default = ["e2e-encryption", "native-tls"]
 
 e2e-encryption = ["matrix-sdk/e2e-encryption"]
-experimental-oidc = ["matrix-sdk/experimental-oidc"]
 
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
@@ -50,7 +49,7 @@ assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 ctor = { workspace = true }
 eyeball-im-util = { workspace = true }
-matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing"] }
+matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing", "experimental-oidc"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 stream_assert = "0.1.0"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = { workspace = true }
 default = ["e2e-encryption", "native-tls"]
 
 e2e-encryption = ["matrix-sdk/e2e-encryption"]
+experimental-oidc = ["matrix-sdk/experimental-oidc"]
 
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
@@ -49,7 +50,7 @@ assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 ctor = { workspace = true }
 eyeball-im-util = { workspace = true }
-matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing", "experimental-oidc"] }
+matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 stream_assert = "0.1.0"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -49,8 +49,9 @@ assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 ctor = { workspace = true }
 eyeball-im-util = { workspace = true }
-matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing"] }
+matrix-sdk = { version = "0.6.2", path = "../matrix-sdk", default-features = false, features = ["testing", "experimental-oidc"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 stream_assert = "0.1.0"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+tempfile = "3.3.0"
 wiremock = "0.5.13"

--- a/crates/matrix-sdk-ui/src/authentication/mod.rs
+++ b/crates/matrix-sdk-ui/src/authentication/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod oidc;
 
-// Move AuthenticationService from the FFI into here.
+// TODO(pixlwave) Move AuthenticationService from the FFI into here.

--- a/crates/matrix-sdk-ui/src/authentication/mod.rs
+++ b/crates/matrix-sdk-ui/src/authentication/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "experimental-oidc")]
 pub mod oidc;
 
 // Move AuthenticationService from the FFI into here.

--- a/crates/matrix-sdk-ui/src/authentication/mod.rs
+++ b/crates/matrix-sdk-ui/src/authentication/mod.rs
@@ -1,0 +1,3 @@
+pub mod oidc;
+
+// Move AuthenticationService from the FFI into here.

--- a/crates/matrix-sdk-ui/src/authentication/mod.rs
+++ b/crates/matrix-sdk-ui/src/authentication/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "experimental-oidc")]
 pub mod oidc;
 
 // Move AuthenticationService from the FFI into here.

--- a/crates/matrix-sdk-ui/src/authentication/oidc.rs
+++ b/crates/matrix-sdk-ui/src/authentication/oidc.rs
@@ -1,0 +1,214 @@
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    fs,
+    fs::File,
+    hash::{Hash, Hasher},
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+};
+
+use matrix_sdk::oidc::types::registration::VerifiedClientMetadata;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, thiserror::Error)]
+pub enum OidcRegistrationsError {
+    #[error("Failed to use the supplied base path.")]
+    InvalidBasePath,
+}
+
+/// The data needed to restore an OpenID Connect session.
+#[derive(Debug)]
+pub struct OidcRegistrations {
+    /// The path of the file where the registrations are stored.
+    file_path: PathBuf,
+    /// The hash for the metadata used to register the client.
+    /// This is used to check if the client needs to be re-registered.
+    metadata_hash: u64,
+    /// Pre-configured registrations for use with issuers that don't support
+    /// dynamic client registration.
+    static_registrations: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RegistrationData {
+    /// The hash for the metadata used to register the client.
+    metadata_hash: u64,
+    /// All of the registrations this client has made as a HashMap of issuer URL
+    /// (as a string) to client ID (as a string).
+    dynamic_registrations: HashMap<String, String>,
+}
+
+/// Manages the storage of OIDC registrations.
+impl OidcRegistrations {
+    pub fn new(
+        base_path: &str,
+        metadata: &VerifiedClientMetadata,
+        static_registrations: HashMap<String, String>,
+    ) -> Result<Self, OidcRegistrationsError> {
+        let oidc_directory = PathBuf::from(base_path).join("oidc");
+        fs::create_dir_all(&oidc_directory).map_err(|_| OidcRegistrationsError::InvalidBasePath)?;
+
+        let metadata_hash = {
+            let mut hasher = DefaultHasher::new();
+            let metadata_string = serde_json::to_string(metadata).unwrap();
+            metadata_string.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        Ok(OidcRegistrations {
+            file_path: oidc_directory.join("registrations.json"),
+            metadata_hash,
+            static_registrations,
+        })
+    }
+
+    /// Returns the underlying registration data.
+    fn registration_data(&self) -> RegistrationData {
+        let reader = match File::open(&self.file_path) {
+            Ok(file) => BufReader::new(file),
+            Err(e) => {
+                tracing::warn!("Failed to open registrations file: {e}");
+                return RegistrationData {
+                    metadata_hash: self.metadata_hash,
+                    dynamic_registrations: Default::default(),
+                };
+            }
+        };
+
+        let registration_data = match serde_json::from_reader::<_, RegistrationData>(reader) {
+            Ok(data) => data,
+            Err(e) => {
+                tracing::error!("Failed to parse registrations file: {e}");
+                return RegistrationData {
+                    metadata_hash: self.metadata_hash,
+                    dynamic_registrations: Default::default(),
+                };
+            }
+        };
+
+        if registration_data.metadata_hash != self.metadata_hash {
+            tracing::warn!("Metadata hash mismatch, clearing registrations");
+            return RegistrationData {
+                metadata_hash: self.metadata_hash,
+                dynamic_registrations: Default::default(),
+            };
+        }
+
+        registration_data
+    }
+
+    /// Returns the client ID registered for a particular issuer or None if a
+    /// registration hasn't been made.
+    pub fn client_id(&self, issuer: &str) -> Option<String> {
+        let mut data = self.registration_data();
+        data.dynamic_registrations.extend(self.static_registrations.clone());
+        data.dynamic_registrations.get(issuer).cloned()
+    }
+
+    /// Stores a new client ID registration for a particular issuer. If a client
+    /// ID has already been stored, this will overwrite the old value.
+    pub fn set_client_id(
+        &self,
+        client_id: String,
+        issuer: String,
+    ) -> Result<(), OidcRegistrationsError> {
+        let mut data = self.registration_data();
+        data.dynamic_registrations.insert(issuer, client_id);
+
+        let writer = BufWriter::new(
+            File::create(&self.file_path).map_err(|_| OidcRegistrationsError::InvalidBasePath)?,
+        );
+        serde_json::to_writer(writer, &data).map_err(|_| OidcRegistrationsError::InvalidBasePath)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, default::Default};
+
+    use matrix_sdk::oidc::types::registration::{ClientMetadata, Localized};
+    use tempfile::tempdir;
+    use wiremock::http::Url;
+
+    use super::*;
+
+    #[test]
+    fn test_oidc_registrations() {
+        // Given a fresh registration store with a single static registration.
+        let dir = tempdir().unwrap();
+        let base_path = dir.path().to_str().unwrap();
+
+        let mut static_registrations = HashMap::new();
+        static_registrations
+            .insert("https://example.com".to_owned(), "static_client_id".to_owned());
+
+        let oidc_metadata = mock_metadata("Example".to_owned());
+
+        let registrations =
+            OidcRegistrations::new(base_path, &oidc_metadata, static_registrations).unwrap();
+
+        assert_eq!(
+            registrations.client_id("https://example.com"),
+            Some("static_client_id".to_owned())
+        );
+        assert_eq!(registrations.client_id("https://example.org"), None);
+
+        // When a dynamic registration is added.
+        registrations
+            .set_client_id("dynamic_client_id".to_owned(), "https://example.org".to_owned())
+            .unwrap();
+
+        // Then the dynamic registration should be stored and the static registration
+        // should be unaffected.
+        assert_eq!(
+            registrations.client_id("https://example.com"),
+            Some("static_client_id".to_owned())
+        );
+        assert_eq!(
+            registrations.client_id("https://example.org"),
+            Some("dynamic_client_id".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_change_of_metadata() {
+        // Given a single registration with an example app name.
+        let dir = tempdir().unwrap();
+        let base_path = dir.path().to_str().unwrap();
+
+        let oidc_metadata = mock_metadata("Example".to_owned());
+
+        let registrations =
+            OidcRegistrations::new(base_path, &oidc_metadata, HashMap::new()).unwrap();
+        registrations
+            .set_client_id("dynamic_client_id".to_owned(), "https://example.org".to_owned())
+            .unwrap();
+
+        assert_eq!(
+            registrations.client_id("https://example.org"),
+            Some("dynamic_client_id".to_owned())
+        );
+
+        // When the app name changes.
+        let new_oidc_metadata = mock_metadata("New App".to_owned());
+
+        let registrations =
+            OidcRegistrations::new(base_path, &new_oidc_metadata, HashMap::new()).unwrap();
+
+        // Then the registration is cleared.
+        assert_eq!(registrations.client_id("https://example.org"), None);
+    }
+
+    fn mock_metadata(client_name: String) -> VerifiedClientMetadata {
+        let callback_url = Url::parse("https://example.org/login/callback").unwrap();
+        let client_name = Some(Localized::new(client_name, None));
+
+        ClientMetadata {
+            redirect_uris: Some(vec![callback_url]),
+            client_name,
+            ..Default::default()
+        }
+        .validate()
+        .unwrap()
+    }
+}

--- a/crates/matrix-sdk-ui/src/authentication/oidc.rs
+++ b/crates/matrix-sdk-ui/src/authentication/oidc.rs
@@ -1,6 +1,20 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
-    fs,
+    fmt, fs,
     fs::File,
     hash::{Hash, Hasher},
     io::{BufReader, BufWriter},
@@ -9,11 +23,22 @@ use std::{
 
 use matrix_sdk::oidc::types::registration::VerifiedClientMetadata;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 #[derive(Debug, thiserror::Error)]
 pub enum OidcRegistrationsError {
     #[error("Failed to use the supplied base path.")]
     InvalidBasePath,
+}
+
+/// A client ID that has been registered with an OpenID Connect provider.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct ClientId(pub String);
+
+impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 /// The data needed to restore an OpenID Connect session.
@@ -26,24 +51,39 @@ pub struct OidcRegistrations {
     metadata_hash: u64,
     /// Pre-configured registrations for use with issuers that don't support
     /// dynamic client registration.
-    static_registrations: HashMap<String, String>,
+    static_registrations: HashMap<Url, ClientId>,
 }
 
+/// The underlying data that is stored in the registration file.
 #[derive(Debug, Serialize, Deserialize)]
-struct RegistrationData {
+struct FrozenRegistrationData {
     /// The hash for the metadata used to register the client.
     metadata_hash: u64,
     /// All of the registrations this client has made as a HashMap of issuer URL
     /// (as a string) to client ID (as a string).
-    dynamic_registrations: HashMap<String, String>,
+    dynamic_registrations: HashMap<Url, ClientId>,
 }
 
 /// Manages the storage of OIDC registrations.
 impl OidcRegistrations {
+    /// Creates a new registration store.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_path` - A directory where the registrations file can be stored.
+    ///   It will be nested inside of a directory called `oidc` as
+    ///   `registrations.json`.
+    ///
+    /// * `metadata` - The metadata used to register the client. If this
+    ///   changes, any stored registrations will be lost so the client can
+    ///   re-register with the new data.
+    ///
+    /// * `static_registrations` - Pre-configured registrations for use with
+    ///   issuers that don't support dynamic client registration.
     pub fn new(
         base_path: &str,
         metadata: &VerifiedClientMetadata,
-        static_registrations: HashMap<String, String>,
+        static_registrations: HashMap<Url, ClientId>,
     ) -> Result<Self, OidcRegistrationsError> {
         let oidc_directory = PathBuf::from(base_path).join("oidc");
         fs::create_dir_all(&oidc_directory).map_err(|_| OidcRegistrationsError::InvalidBasePath)?;
@@ -63,23 +103,23 @@ impl OidcRegistrations {
     }
 
     /// Returns the underlying registration data.
-    fn registration_data(&self) -> RegistrationData {
+    fn read_registration_data(&self) -> FrozenRegistrationData {
         let reader = match File::open(&self.file_path) {
             Ok(file) => BufReader::new(file),
             Err(e) => {
                 tracing::warn!("Failed to open registrations file: {e}");
-                return RegistrationData {
+                return FrozenRegistrationData {
                     metadata_hash: self.metadata_hash,
                     dynamic_registrations: Default::default(),
                 };
             }
         };
 
-        let registration_data = match serde_json::from_reader::<_, RegistrationData>(reader) {
+        let registration_data = match serde_json::from_reader::<_, FrozenRegistrationData>(reader) {
             Ok(data) => data,
             Err(e) => {
                 tracing::error!("Failed to parse registrations file: {e}");
-                return RegistrationData {
+                return FrozenRegistrationData {
                     metadata_hash: self.metadata_hash,
                     dynamic_registrations: Default::default(),
                 };
@@ -88,7 +128,7 @@ impl OidcRegistrations {
 
         if registration_data.metadata_hash != self.metadata_hash {
             tracing::warn!("Metadata hash mismatch, clearing registrations");
-            return RegistrationData {
+            return FrozenRegistrationData {
                 metadata_hash: self.metadata_hash,
                 dynamic_registrations: Default::default(),
             };
@@ -99,20 +139,20 @@ impl OidcRegistrations {
 
     /// Returns the client ID registered for a particular issuer or None if a
     /// registration hasn't been made.
-    pub fn client_id(&self, issuer: &str) -> Option<String> {
-        let mut data = self.registration_data();
+    pub fn client_id(&self, issuer: &Url) -> Option<ClientId> {
+        let mut data = self.read_registration_data();
         data.dynamic_registrations.extend(self.static_registrations.clone());
         data.dynamic_registrations.get(issuer).cloned()
     }
 
     /// Stores a new client ID registration for a particular issuer. If a client
     /// ID has already been stored, this will overwrite the old value.
-    pub fn set_client_id(
+    pub fn set_and_write_client_id(
         &self,
-        client_id: String,
-        issuer: String,
+        client_id: ClientId,
+        issuer: Url,
     ) -> Result<(), OidcRegistrationsError> {
-        let mut data = self.registration_data();
+        let mut data = self.read_registration_data();
         data.dynamic_registrations.insert(issuer, client_id);
 
         let writer = BufWriter::new(
@@ -138,36 +178,29 @@ mod tests {
         let dir = tempdir().unwrap();
         let base_path = dir.path().to_str().unwrap();
 
+        let static_url = Url::parse("https://example.com").unwrap();
+        let static_id = ClientId("static_client_id".to_owned());
+        let dynamic_url = Url::parse("https://example.org").unwrap();
+        let dynamic_id = ClientId("dynamic_client_id".to_owned());
+
         let mut static_registrations = HashMap::new();
-        static_registrations
-            .insert("https://example.com".to_owned(), "static_client_id".to_owned());
+        static_registrations.insert(static_url.clone(), static_id.clone());
 
         let oidc_metadata = mock_metadata("Example".to_owned());
 
         let registrations =
             OidcRegistrations::new(base_path, &oidc_metadata, static_registrations).unwrap();
 
-        assert_eq!(
-            registrations.client_id("https://example.com"),
-            Some("static_client_id".to_owned())
-        );
-        assert_eq!(registrations.client_id("https://example.org"), None);
+        assert_eq!(registrations.client_id(&static_url), Some(static_id.clone()));
+        assert_eq!(registrations.client_id(&dynamic_url), None);
 
         // When a dynamic registration is added.
-        registrations
-            .set_client_id("dynamic_client_id".to_owned(), "https://example.org".to_owned())
-            .unwrap();
+        registrations.set_and_write_client_id(dynamic_id.clone(), dynamic_url.clone()).unwrap();
 
         // Then the dynamic registration should be stored and the static registration
         // should be unaffected.
-        assert_eq!(
-            registrations.client_id("https://example.com"),
-            Some("static_client_id".to_owned())
-        );
-        assert_eq!(
-            registrations.client_id("https://example.org"),
-            Some("dynamic_client_id".to_owned())
-        );
+        assert_eq!(registrations.client_id(&static_url), Some(static_id));
+        assert_eq!(registrations.client_id(&dynamic_url), Some(dynamic_id));
     }
 
     #[test]
@@ -176,27 +209,33 @@ mod tests {
         let dir = tempdir().unwrap();
         let base_path = dir.path().to_str().unwrap();
 
+        let static_url = Url::parse("https://example.com").unwrap();
+        let static_id = ClientId("static_client_id".to_owned());
+        let dynamic_url = Url::parse("https://example.org").unwrap();
+        let dynamic_id = ClientId("dynamic_client_id".to_owned());
+
         let oidc_metadata = mock_metadata("Example".to_owned());
 
-        let registrations =
-            OidcRegistrations::new(base_path, &oidc_metadata, HashMap::new()).unwrap();
-        registrations
-            .set_client_id("dynamic_client_id".to_owned(), "https://example.org".to_owned())
-            .unwrap();
+        let mut static_registrations = HashMap::new();
+        static_registrations.insert(static_url.clone(), static_id.clone());
 
-        assert_eq!(
-            registrations.client_id("https://example.org"),
-            Some("dynamic_client_id".to_owned())
-        );
+        let registrations =
+            OidcRegistrations::new(base_path, &oidc_metadata, static_registrations.clone())
+                .unwrap();
+        registrations.set_and_write_client_id(dynamic_id.clone(), dynamic_url.clone()).unwrap();
+
+        assert_eq!(registrations.client_id(&static_url), Some(static_id.clone()));
+        assert_eq!(registrations.client_id(&dynamic_url), Some(dynamic_id));
 
         // When the app name changes.
         let new_oidc_metadata = mock_metadata("New App".to_owned());
 
         let registrations =
-            OidcRegistrations::new(base_path, &new_oidc_metadata, HashMap::new()).unwrap();
+            OidcRegistrations::new(base_path, &new_oidc_metadata, static_registrations).unwrap();
 
-        // Then the registration is cleared.
-        assert_eq!(registrations.client_id("https://example.org"), None);
+        // Then the dynamic registrations are cleared.
+        assert_eq!(registrations.client_id(&dynamic_url), None);
+        assert_eq!(registrations.client_id(&static_url), Some(static_id));
     }
 
     fn mock_metadata(client_name: String) -> VerifiedClientMetadata {

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod events;
 
+pub mod authentication;
 pub mod encryption_sync_service;
 pub mod notification_client;
 pub mod room_list_service;

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -390,8 +390,8 @@ impl Oidc {
     /// ```no_run
     /// use futures_util::StreamExt;
     /// use matrix_sdk::Client;
-    /// # fn persist_session(_: &matrix_sdk::matrix_auth::Session) {};
-    /// # async {
+    /// # fn persist_session(_: &matrix_sdk::oidc::FullSession) {}
+    /// # _ = async {
     /// let homeserver = "http://example.com";
     /// let client = Client::builder()
     ///     .homeserver_url(homeserver)
@@ -402,16 +402,17 @@ impl Oidc {
     /// // Login with the OpenID Connect API…
     ///
     /// let oidc = client.oidc();
-    /// let session = oidc.session().expect("Client should be logged in");
-    /// persist_session(session);
+    /// let session = oidc.full_session().expect("Client should be logged in");
+    /// persist_session(&session);
     ///
     /// // Handle when at least one of the tokens changed.
     /// let mut tokens_stream =
     ///     oidc.session_tokens_stream().expect("Client should be logged in");
     /// loop {
     ///     if tokens_stream.next().await.is_some() {
-    ///         let session = oidc.session().expect("Client should be logged in");
-    ///         persist_session(session);
+    ///         let session =
+    ///             oidc.full_session().expect("Client should be logged in");
+    ///         persist_session(&session);
     ///     }
     /// }
     /// # anyhow::Ok(()) };
@@ -502,13 +503,15 @@ impl Oidc {
     /// # Example
     ///
     /// ```no_run
-    /// use matrix_sdk::Client;
+    /// use matrix_sdk::{Client, ServerName};
     /// use matrix_sdk::oidc::types::client_credentials::ClientCredentials;
+    /// use matrix_sdk::oidc::RegisteredClientData;
     /// # use matrix_sdk::oidc::types::registration::{ClientMetadata, VerifiedClientMetadata};
     /// # let metadata = ClientMetadata::default().validate().unwrap();
-    /// # fn persist_client_registration (_: &str, _: &VerifiedClientMetadata, _: &ClientCredentials) {};
-    /// # async {
-    /// let client = Client::builder().server_name("my_homeserver.org").build().await?;
+    /// # fn persist_client_registration (_: &str, _: &RegisteredClientData) {}
+    /// # _ = async {
+    /// let server_name = ServerName::parse("my_homeserver.org").unwrap();
+    /// let client = Client::builder().server_name(&server_name).build().await?;
     /// let oidc = client.oidc();
     ///
     /// if let Some(info) = oidc.authentication_server_info() {
@@ -533,7 +536,7 @@ impl Oidc {
     ///
     ///     persist_client_registration(&info.issuer, &client_data);
     /// }
-    /// # anyhow::Ok(()) }
+    /// # anyhow::Ok(()) };
     /// ```
     ///
     /// [software statement]: https://datatracker.ietf.org/doc/html/rfc7591#autoid-8
@@ -663,14 +666,16 @@ impl Oidc {
     /// # Example
     ///
     /// ```no_run
-    /// # use matrix_sdk::{Client};
+    /// # use anyhow::anyhow;
+    /// use matrix_sdk::{Client};
+    /// # use matrix_sdk::oidc::AuthorizationResponse;
     /// # use url::Url;
     /// # let homeserver = Url::parse("https://example.com").unwrap();
     /// # let redirect_uri = Url::parse("http://127.0.0.1/oidc").unwrap();
     /// # let redirected_to_uri = Url::parse("http://127.0.0.1/oidc").unwrap();
     /// # let issuer_info = unimplemented!();
     /// # let client_data = unimplemented!();
-    /// # async {
+    /// # _ = async {
     /// # let client = Client::new(homeserver).await?;
     /// let oidc = client.oidc();
     ///
@@ -679,7 +684,7 @@ impl Oidc {
     ///     client_data,
     /// ).await;
     ///
-    /// let auth_data = oidc.login(redirect_uri, None).build().await?;
+    /// let auth_data = oidc.login(redirect_uri, None)?.build().await?;
     ///
     /// // Open auth_data.url and wait for response at the redirect URI.
     /// // The full URL obtained is called here `redirected_to_uri`.
@@ -689,7 +694,7 @@ impl Oidc {
     /// let code = match auth_response {
     ///     AuthorizationResponse::Success(code) => code,
     ///     AuthorizationResponse::Error(error) => {
-    ///         return Err(format!("Authorization failed: {error}").into());
+    ///         return Err(anyhow!("Authorization failed: {:?}", error));
     ///     }
     /// };
     ///


### PR DESCRIPTION
Currently when the AuthenticationService is given updated metadata, it is ignored if a dynamic registration has already been made for a selected issuer. This PR fixes that by storing the metadata's hash and resetting the store when there is a mis-match.

Additionally it moves `OidcRegistrations` out of the FFI into a new `authentication` module in the UI crate and adds some tests.