### PR TITLE
feat: add an `EncryptionSyncPermit` and use it in the notification client

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use matrix_sdk_ui::notification_client::{
     NotificationClient as MatrixNotificationClient,
     NotificationClientBuilder as MatrixNotificationClientBuilder,
-    NotificationItem as MatrixNotificationItem,
+    NotificationItem as MatrixNotificationItem, NotificationProcessSetup,
 };
 use ruma::{EventId, RoomId};
 
@@ -80,9 +80,12 @@ pub struct NotificationClientBuilder {
 }
 
 impl NotificationClientBuilder {
-    pub(crate) fn new(client: matrix_sdk::Client) -> Result<Arc<Self>, ClientError> {
-        let builder =
-            RUNTIME.block_on(async { MatrixNotificationClient::builder(client).await })?;
+    pub(crate) fn new(
+        client: matrix_sdk::Client,
+        process_setup: NotificationProcessSetup,
+    ) -> Result<Arc<Self>, ClientError> {
+        let builder = RUNTIME
+            .block_on(async { MatrixNotificationClient::builder(client, process_setup).await })?;
         Ok(Arc::new(Self { builder }))
     }
 }
@@ -99,14 +102,9 @@ impl NotificationClientBuilder {
 
     /// Automatically retry decryption once, if the notification was received
     /// encrypted.
-    ///
-    /// The boolean indicates whether we're making use of a cross-process lock
-    /// for the crypto-store. This should be set to true, if and only if,
-    /// the notification is received in a process that's different from the
-    /// main app.
-    pub fn retry_decryption(self: Arc<Self>, with_cross_process_lock: bool) -> Arc<Self> {
+    pub fn retry_decryption(self: Arc<Self>) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
-        let builder = this.builder.retry_decryption(with_cross_process_lock);
+        let builder = this.builder.retry_decryption();
         Arc::new(Self { builder })
     }
 

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -52,7 +52,7 @@ pub trait SyncServiceStateObserver: Send + Sync + Debug {
 
 #[derive(uniffi::Object)]
 pub struct SyncService {
-    inner: MatrixSyncService,
+    pub(crate) inner: Arc<MatrixSyncService>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -107,6 +107,6 @@ impl SyncServiceBuilder {
 
     pub async fn finish(self: Arc<Self>) -> Result<Arc<SyncService>, ClientError> {
         let this = unwrap_or_clone_arc(self);
-        Ok(Arc::new(SyncService { inner: this.builder.build().await? }))
+        Ok(Arc::new(SyncService { inner: Arc::new(this.builder.build().await?) }))
     }
 }

--- a/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync/mod.rs
@@ -46,12 +46,16 @@ use tracing::{debug, trace};
 pub struct EncryptionSyncPermit(());
 
 impl EncryptionSyncPermit {
-    /// Create a new [`EncryptionSyncPermit`].
-    ///
-    /// Note: in general, you'd want to get such a permit from a [`SyncService`]
-    /// instead of creating it yourself.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self(())
+    }
+}
+
+impl EncryptionSyncPermit {
+    /// Test-only.
+    #[doc(hidden)]
+    pub fn new_for_testing() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync.rs
@@ -17,7 +17,7 @@ use crate::{
 async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
     let (client, server) = logged_in_client().await;
 
-    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
+    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
     let sync_permit_guard = sync_permit.clone().lock_owned().await;
     let encryption_sync =
         EncryptionSync::new("tests".to_owned(), client, None, WithLocking::Yes).await?;
@@ -111,7 +111,6 @@ async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
     assert!(stream.next().await.is_none());
 
     // Start a new sync.
-    drop(stream);
     let sync_permit_guard = sync_permit.clone().lock_owned().await;
     let stream = encryption_sync.sync(sync_permit_guard);
     pin_mut!(stream);
@@ -198,7 +197,7 @@ async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
 
     let _guard = setup_mocking_sliding_sync_server(&server).await;
 
-    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
+    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
     let sync_permit_guard = sync_permit.lock_owned().await;
     let encryption_sync =
         EncryptionSync::new("tests".to_owned(), client, None, WithLocking::Yes).await?;
@@ -230,7 +229,7 @@ async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
 
     let _guard = setup_mocking_sliding_sync_server(&server).await;
 
-    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
+    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
     let sync_permit_guard = sync_permit.lock_owned().await;
     let encryption_sync =
         EncryptionSync::new("tests".to_owned(), client, None, WithLocking::Yes).await?;
@@ -265,7 +264,7 @@ async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
 async fn test_encryption_sync_always_reloads_todevice_token() -> anyhow::Result<()> {
     let (client, server) = logged_in_client().await;
 
-    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new()));
+    let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
     let sync_permit_guard = sync_permit.lock_owned().await;
     let encryption_sync =
         EncryptionSync::new("tests".to_owned(), client.clone(), None, WithLocking::Yes).await?;


### PR DESCRIPTION
This introduces a new `EncryptionSyncPermit`, which is required to *run* (note: not *create*) an encryption sync. With this, we can ensure that there's at most one encryption sync running at any times, and solve #2491 in a more elegant way than what we've done: instead of asking the app to start the sync service themselves, we can take a permit and run the encryption sync a few times by ourselves, if needs be.

This aligns the behaviors of the iOS and Android apps, paving the way to always enable retrying decryption of encrypted events in notifications, for both apps.

Fixes #2491.