### PR TITLE
Add `OlmMachine::get_room_event_encryption_info`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -61,3 +61,5 @@
 
 - Change the returned success value type of `BackupMachine::backup` from
   `OutgoingRequest` to `(OwnedTransactionId, KeysBackupRequest)`.
+
+- Expose new `OlmMachine::get_room_event_encryption_info` method.


### PR DESCRIPTION
Since the verification status of an event can change, we need to be able to
refetch the verification status without doing the whole decryption dance.

Hence, we expose a new `get_room_event_encryption_info` method.