### PR TITLE
feat: Share the authentication data between a parent `Client` and all its children

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -328,7 +328,7 @@ impl Client {
     /// OpenID Connect and this `Client` was constructed using auto-discovery by
     /// setting the homeserver with [`ClientBuilder::server_name()`].
     pub(crate) fn discovered_authentication_server(&self) -> Option<AuthenticationServerInfo> {
-        self.inner.authentication_server_info().cloned()
+        self.inner.oidc().authentication_server_info().cloned()
     }
 
     /// The sliding sync proxy that is trusted by the homeserver. `None` when

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -14,7 +14,7 @@
 
 use matrix_sdk_base::SessionMeta;
 use ruma::api::client::discovery::discover_homeserver::AuthenticationServerInfo;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, OnceCell};
 
 #[cfg(feature = "experimental-oidc")]
 use crate::oidc::{self, Oidc, OidcAuthData};
@@ -41,6 +41,9 @@ pub(crate) struct AuthCtx {
     /// session such as logging out when the access token is invalid or
     /// persisting updates to the access/refresh tokens.
     pub(crate) session_change_sender: broadcast::Sender<SessionChange>,
+
+    /// Authentication data to keep in memory.
+    pub(crate) auth_data: OnceCell<AuthData>,
 }
 
 /// An enum over all the possible authentication APIs.

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -25,6 +25,10 @@ pub(crate) struct AuthCtx {
     /// The authentication server info discovered from the homeserver.
     #[cfg_attr(not(feature = "experimental-oidc"), allow(dead_code))]
     pub(crate) authentication_server_info: Option<AuthenticationServerInfo>,
+
+    /// Whether to try to refresh the access token automatically when an
+    /// `M_UNKNOWN_TOKEN` error is encountered.
+    pub(crate) handle_refresh_tokens: bool,
 }
 
 /// An enum over all the possible authentication APIs.

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -13,10 +13,18 @@
 // limitations under the License.
 
 use matrix_sdk_base::SessionMeta;
+use ruma::api::client::discovery::discover_homeserver::AuthenticationServerInfo;
 
 use crate::matrix_auth::{self, MatrixAuth, MatrixAuthData};
 #[cfg(feature = "experimental-oidc")]
 use crate::oidc::{self, Oidc, OidcAuthData};
+
+/// All the data relative to authentication, and that must be shared between a client and all its
+/// children.
+pub(crate) struct AuthCtx {
+    /// The authentication server info discovered from the homeserver.
+    pub(crate) authentication_server_info: Option<AuthenticationServerInfo>,
+}
 
 /// An enum over all the possible authentication APIs.
 #[derive(Debug, Clone)]

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -23,8 +23,8 @@ use crate::{
     RefreshTokenError, SessionChange,
 };
 
-/// All the data relative to authentication, and that must be shared between a client and all its
-/// children.
+/// All the data relative to authentication, and that must be shared between a
+/// client and all its children.
 pub(crate) struct AuthCtx {
     /// The authentication server info discovered from the homeserver.
     #[cfg_attr(not(feature = "experimental-oidc"), allow(dead_code))]
@@ -127,14 +127,6 @@ impl AuthData {
         match self {
             AuthData::Matrix(d) => Some(d),
             #[cfg(feature = "experimental-oidc")]
-            _ => None,
-        }
-    }
-
-    #[cfg(feature = "experimental-oidc")]
-    pub(crate) fn as_oidc(&self) -> Option<&OidcAuthData> {
-        match self {
-            AuthData::Oidc(d) => Some(d),
             _ => None,
         }
     }

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -14,13 +14,13 @@
 
 use matrix_sdk_base::SessionMeta;
 use ruma::api::client::discovery::discover_homeserver::AuthenticationServerInfo;
-use tokio::sync::Mutex;
+use tokio::sync::{broadcast, Mutex};
 
 #[cfg(feature = "experimental-oidc")]
 use crate::oidc::{self, Oidc, OidcAuthData};
 use crate::{
     matrix_auth::{self, MatrixAuth, MatrixAuthData},
-    RefreshTokenError,
+    RefreshTokenError, SessionChange,
 };
 
 /// All the data relative to authentication, and that must be shared between a client and all its
@@ -36,6 +36,11 @@ pub(crate) struct AuthCtx {
 
     /// Lock making sure we're only doing one token refresh at a time.
     pub(crate) refresh_token_lock: Mutex<Result<(), RefreshTokenError>>,
+
+    /// Session change publisher. Allows the subscriber to handle changes to the
+    /// session such as logging out when the access token is invalid or
+    /// persisting updates to the access/refresh tokens.
+    pub(crate) session_change_sender: broadcast::Sender<SessionChange>,
 }
 
 /// An enum over all the possible authentication APIs.

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -23,6 +23,7 @@ use crate::oidc::{self, Oidc, OidcAuthData};
 /// children.
 pub(crate) struct AuthCtx {
     /// The authentication server info discovered from the homeserver.
+    #[cfg_attr(not(feature = "experimental-oidc"), allow(dead_code))]
     pub(crate) authentication_server_info: Option<AuthenticationServerInfo>,
 }
 

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -80,6 +80,15 @@ impl AuthSession {
         }
     }
 
+    /// Take the matrix user information of this session.
+    pub fn into_meta(self) -> SessionMeta {
+        match self {
+            AuthSession::Matrix(session) => session.meta,
+            #[cfg(feature = "experimental-oidc")]
+            AuthSession::Oidc(session) => session.user.meta,
+        }
+    }
+
     /// Get the access token of this session.
     pub fn access_token(&self) -> &str {
         match self {

--- a/crates/matrix-sdk/src/authentication.rs
+++ b/crates/matrix-sdk/src/authentication.rs
@@ -14,10 +14,14 @@
 
 use matrix_sdk_base::SessionMeta;
 use ruma::api::client::discovery::discover_homeserver::AuthenticationServerInfo;
+use tokio::sync::Mutex;
 
-use crate::matrix_auth::{self, MatrixAuth, MatrixAuthData};
 #[cfg(feature = "experimental-oidc")]
 use crate::oidc::{self, Oidc, OidcAuthData};
+use crate::{
+    matrix_auth::{self, MatrixAuth, MatrixAuthData},
+    RefreshTokenError,
+};
 
 /// All the data relative to authentication, and that must be shared between a client and all its
 /// children.
@@ -29,6 +33,9 @@ pub(crate) struct AuthCtx {
     /// Whether to try to refresh the access token automatically when an
     /// `M_UNKNOWN_TOKEN` error is encountered.
     pub(crate) handle_refresh_tokens: bool,
+
+    /// Lock making sure we're only doing one token refresh at a time.
+    pub(crate) refresh_token_lock: Mutex<Result<(), RefreshTokenError>>,
 }
 
 /// An enum over all the possible authentication APIs.

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -422,7 +422,10 @@ impl ClientBuilder {
 
         let homeserver = Url::parse(&homeserver)?;
 
-        let auth_ctx = Arc::new(AuthCtx { authentication_server_info });
+        let auth_ctx = Arc::new(AuthCtx {
+            authentication_server_info,
+            handle_refresh_tokens: self.handle_refresh_tokens,
+        });
 
         let inner = Arc::new(ClientInner::new(
             auth_ctx,
@@ -433,7 +436,6 @@ impl ClientBuilder {
             base_client,
             self.server_versions,
             self.respect_login_well_known,
-            self.handle_refresh_tokens,
         ));
 
         debug!("Done building the Client");

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -21,7 +21,7 @@ use ruma::{
     OwnedServerName, ServerName,
 };
 use thiserror::Error;
-use tokio::sync::Mutex;
+use tokio::sync::{broadcast, Mutex};
 use tracing::{debug, field::debug, instrument, Span};
 use url::Url;
 
@@ -427,6 +427,7 @@ impl ClientBuilder {
             authentication_server_info,
             handle_refresh_tokens: self.handle_refresh_tokens,
             refresh_token_lock: Mutex::new(Ok(())),
+            session_change_sender: broadcast::Sender::new(1),
         });
 
         let inner = Arc::new(ClientInner::new(

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -21,7 +21,7 @@ use ruma::{
     OwnedServerName, ServerName,
 };
 use thiserror::Error;
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, OnceCell};
 use tracing::{debug, field::debug, instrument, Span};
 use url::Url;
 
@@ -428,6 +428,7 @@ impl ClientBuilder {
             handle_refresh_tokens: self.handle_refresh_tokens,
             refresh_token_lock: Mutex::new(Ok(())),
             session_change_sender: broadcast::Sender::new(1),
+            auth_data: OnceCell::default(),
         });
 
         let inner = Arc::new(ClientInner::new(

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -21,6 +21,7 @@ use ruma::{
     OwnedServerName, ServerName,
 };
 use thiserror::Error;
+use tokio::sync::Mutex;
 use tracing::{debug, field::debug, instrument, Span};
 use url::Url;
 
@@ -425,6 +426,7 @@ impl ClientBuilder {
         let auth_ctx = Arc::new(AuthCtx {
             authentication_server_info,
             handle_refresh_tokens: self.handle_refresh_tokens,
+            refresh_token_lock: Mutex::new(Ok(())),
         });
 
         let inner = Arc::new(ClientInner::new(

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -27,7 +27,10 @@ use url::Url;
 use super::{Client, ClientInner};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::http_client::HttpSettings;
-use crate::{config::RequestConfig, error::RumaApiError, http_client::HttpClient, HttpError};
+use crate::{
+    authentication::AuthCtx, config::RequestConfig, error::RumaApiError, http_client::HttpClient,
+    HttpError,
+};
 
 /// Builder that allows creating and configuring various parts of a [`Client`].
 ///
@@ -419,9 +422,11 @@ impl ClientBuilder {
 
         let homeserver = Url::parse(&homeserver)?;
 
+        let auth_ctx = Arc::new(AuthCtx { authentication_server_info });
+
         let inner = Arc::new(ClientInner::new(
+            auth_ctx,
             homeserver,
-            authentication_server_info,
             #[cfg(feature = "experimental-sliding-sync")]
             sliding_sync_proxy,
             http_client,

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -40,6 +40,7 @@ use crate::{
 #[allow(missing_debug_implementations)]
 pub struct SendRequest<R> {
     pub(crate) client: Client,
+    pub(crate) sliding_sync_proxy_url: Option<String>,
     pub(crate) request: R,
     pub(crate) config: Option<RequestConfig>,
     pub(crate) send_progress: SharedObservable<TransmissionProgress>,
@@ -82,17 +83,23 @@ where
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
-        let Self { client, request, config, send_progress } = self;
+        let Self { client, request, config, send_progress, sliding_sync_proxy_url } = self;
+
         Box::pin(async move {
-            let res =
-                Box::pin(client.send_inner(request.clone(), config, None, send_progress.clone()))
-                    .await;
+            let res = Box::pin(client.send_inner(
+                request.clone(),
+                config,
+                sliding_sync_proxy_url.clone(),
+                send_progress.clone(),
+            ))
+            .await;
 
             // An `M_UNKNOWN_TOKEN` error can potentially be fixed with a token refresh.
             if let Err(Some(ErrorKind::UnknownToken { soft_logout })) =
                 res.as_ref().map_err(HttpError::client_api_error_kind)
             {
                 trace!("Token refresh: Unknown token error received.");
+
                 // If automatic token refresh isn't supported, there is nothing more to do.
                 if !client.inner.auth_ctx.handle_refresh_tokens {
                     trace!("Token refresh: Automatic refresh disabled.");
@@ -114,6 +121,7 @@ where
                             // Refreshing access tokens is not supported by this `Session`, ignore.
                             client.broadcast_unknown_token(soft_logout);
                         }
+
                         #[cfg(feature = "experimental-oidc")]
                         RefreshTokenError::Oidc(oidc_error) => {
                             let oidc_error = oidc_error.deref();
@@ -148,6 +156,7 @@ where
                             };
                             return Err(refresh_error.into());
                         }
+
                         _ => {
                             trace!("Token refresh: Token refresh failed.");
                             // This isn't necessarily correct, but matches the behaviour when
@@ -158,7 +167,13 @@ where
                     }
                 } else {
                     trace!("Token refresh: Refresh succeeded, retrying request.");
-                    return Box::pin(client.send_inner(request, config, None, send_progress)).await;
+                    return Box::pin(client.send_inner(
+                        request,
+                        config,
+                        sliding_sync_proxy_url,
+                        send_progress,
+                    ))
+                    .await;
                 }
             }
 

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -94,7 +94,7 @@ where
             {
                 trace!("Token refresh: Unknown token error received.");
                 // If automatic token refresh isn't supported, there is nothing more to do.
-                if !client.inner.handle_refresh_tokens {
+                if !client.inner.auth_ctx.handle_refresh_tokens {
                     trace!("Token refresh: Automatic refresh disabled.");
                     client.broadcast_unknown_token(soft_logout);
                     return res;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -192,8 +192,6 @@ pub(crate) struct ClientInner {
     /// wait for the sync to get the data to fetch a room object from the state
     /// store.
     pub(crate) sync_beat: event_listener::Event,
-    /// Authentication data to keep in memory.
-    pub(crate) auth_data: OnceCell<AuthData>,
 
     #[cfg(feature = "e2e-encryption")]
     pub(crate) cross_process_crypto_store_lock: OnceCell<CryptoStoreLock>,
@@ -251,7 +249,6 @@ impl ClientInner {
             sync_gap_broadcast_txs: Default::default(),
             respect_login_well_known,
             sync_beat: event_listener::Event::new(),
-            auth_data: Default::default(),
             #[cfg(feature = "e2e-encryption")]
             cross_process_crypto_store_lock: OnceCell::new(),
             #[cfg(feature = "e2e-encryption")]
@@ -416,14 +413,14 @@ impl Client {
     ///
     /// Will be `None` if the client has not been logged in.
     pub fn access_token(&self) -> Option<String> {
-        self.inner.auth_data.get()?.access_token()
+        self.inner.auth_ctx.auth_data.get()?.access_token()
     }
 
     /// Access the authentication API used to log in this client.
     ///
     /// Will be `None` if the client has not been logged in.
     pub fn auth_api(&self) -> Option<AuthApi> {
-        match self.inner.auth_data.get()? {
+        match self.inner.auth_ctx.auth_data.get()? {
             AuthData::Matrix(_) => Some(AuthApi::Matrix(self.matrix_auth())),
             #[cfg(feature = "experimental-oidc")]
             AuthData::Oidc(_) => Some(AuthApi::Oidc(self.oidc())),

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1905,9 +1905,15 @@ impl Client {
             )),
         };
 
-        // Copy the parent's session into the child.
+        // Copy the parent's session meta into the child. This initializes the in-memory
+        // state store of the child client with `SessionMeta`, and regenerates
+        // the `OlmMachine` if needs be.
+        //
+        // Note: we don't need to do a full `restore_session`, because this would
+        // overwrite the session information shared with the parent too, and it
+        // must be initialized at most once.
         if let Some(session) = self.session() {
-            client.restore_session(session).await?;
+            client.base_client().set_session_meta(session.into_meta()).await?;
         }
 
         Ok(client)

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -53,7 +53,6 @@ use ruma::{
             device::{delete_devices, get_devices, update_device},
             directory::{get_public_rooms, get_public_rooms_filtered},
             discovery::{
-                discover_homeserver::AuthenticationServerInfo,
                 get_capabilities::{self, Capabilities},
                 get_supported_versions,
             },
@@ -369,18 +368,6 @@ impl Client {
     /// The Homeserver of the client.
     pub async fn homeserver(&self) -> Url {
         self.inner.homeserver.read().await.clone()
-    }
-
-    /// The authentication server info discovered from the homeserver.
-    ///
-    /// This will only be set if the homeserver supports authenticating via
-    /// OpenID Connect ([MSC3861]) and this `Client` was constructed using
-    /// auto-discovery by setting the homeserver with
-    /// [`ClientBuilder::server_name()`].
-    ///
-    /// [MSC3861]: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
-    pub fn authentication_server_info(&self) -> Option<&AuthenticationServerInfo> {
-        self.inner.auth_ctx.authentication_server_info.as_ref()
     }
 
     /// The sliding sync proxy that is trusted by the homeserver.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -186,8 +186,6 @@ pub(crate) struct ClientInner {
     /// Whether the client should update its homeserver URL with the discovery
     /// information present in the login response.
     respect_login_well_known: bool,
-    /// Lock making sure we're only doing one token refresh at a time.
-    pub(crate) refresh_token_lock: Mutex<Result<(), RefreshTokenError>>,
     /// An event that can be listened on to wait for a successful sync. The
     /// event will only be fired if a sync loop is running. Can be used for
     /// synchronization, e.g. if we send out a request to create a room, we can
@@ -259,7 +257,6 @@ impl ClientInner {
             sync_gap_broadcast_txs: Default::default(),
             respect_login_well_known,
             sync_beat: event_listener::Event::new(),
-            refresh_token_lock: Mutex::new(Ok(())),
             session_change_sender,
             auth_data: Default::default(),
             #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -450,7 +450,7 @@ impl MatrixAuth {
         &self,
     ) -> Result<Option<refresh_token::v3::Response>, RefreshTokenError> {
         let client = &self.client;
-        let lock = client.inner.refresh_token_lock.try_lock();
+        let lock = client.inner.auth_ctx.refresh_token_lock.try_lock();
 
         if let Ok(mut guard) = lock {
             let Some(mut session_tokens) = self.session_tokens() else {
@@ -489,7 +489,7 @@ impl MatrixAuth {
                 }
             }
         } else {
-            match client.inner.refresh_token_lock.lock().await.as_ref() {
+            match client.inner.auth_ctx.refresh_token_lock.lock().await.as_ref() {
                 Ok(_) => Ok(None),
                 Err(error) => Err(error.clone()),
             }

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -476,6 +476,7 @@ impl MatrixAuth {
                     _ = self
                         .client
                         .inner
+                        .auth_ctx
                         .session_change_sender
                         .send(SessionChange::TokensRefreshed);
 

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -78,7 +78,7 @@ impl MatrixAuth {
     }
 
     fn data(&self) -> Option<&MatrixAuthData> {
-        self.client.inner.auth_data.get()?.as_matrix()
+        self.client.inner.auth_ctx.auth_data.get()?.as_matrix()
     }
 
     /// Gets the homeserver’s supported login types.
@@ -560,7 +560,7 @@ impl MatrixAuth {
 
     /// Set the current session tokens
     pub(crate) fn set_session_tokens(&self, tokens: SessionTokens) {
-        if let Some(auth_data) = self.client.inner.auth_data.get() {
+        if let Some(auth_data) = self.client.inner.auth_ctx.auth_data.get() {
             let Some(data) = auth_data.as_matrix() else {
                 panic!("Cannot call native Matrix authentication API after logging in with another API");
             };
@@ -569,6 +569,7 @@ impl MatrixAuth {
         } else {
             self.client
                 .inner
+                .auth_ctx
                 .auth_data
                 .set(AuthData::Matrix(MatrixAuthData { tokens: SharedObservable::new(tokens) }))
                 .expect("We just checked the value was not set");

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -352,20 +352,18 @@ impl Oidc {
     }
 
     /// Set the current session tokens.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the `auth_data` field hasn't been set before with an OIDC
+    /// session.
     fn set_session_tokens(&self, session_tokens: SessionTokens) {
-        if let Some(auth_data) = self.client.inner.auth_ctx.auth_data.get() {
-            let Some(data) = auth_data.as_oidc() else {
-                panic!("Cannot call OpenID Connect API after logging in with another API");
-            };
-
-            if let Some(tokens) = data.tokens.get() {
-                tokens.set_if_not_eq(session_tokens);
-            } else {
-                let _ = data.tokens.set(SharedObservable::new(session_tokens));
-            }
+        let data =
+            self.data().expect("Cannot call OpenID Connect API after logging in with another API");
+        if let Some(tokens) = data.tokens.get() {
+            tokens.set_if_not_eq(session_tokens);
         } else {
-            // Other OIDC auth data should have already been set before the session tokens.
-            unreachable!()
+            let _ = data.tokens.set(SharedObservable::new(session_tokens));
         }
     }
 

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -903,7 +903,7 @@ impl Oidc {
             latest_id_token,
         });
 
-        _ = self.client.inner.session_change_sender.send(SessionChange::TokensRefreshed);
+        _ = self.client.inner.auth_ctx.session_change_sender.send(SessionChange::TokensRefreshed);
 
         Ok(response)
     }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -253,7 +253,7 @@ impl Oidc {
     ///
     /// Returns `None` if the client's registration was not restored yet.
     fn data(&self) -> Option<&OidcAuthData> {
-        match self.client.inner.auth_data.get()? {
+        match self.client.inner.auth_ctx.auth_data.get()? {
             AuthData::Oidc(data) => Some(data),
             _ => None,
         }
@@ -353,7 +353,7 @@ impl Oidc {
 
     /// Set the current session tokens.
     fn set_session_tokens(&self, session_tokens: SessionTokens) {
-        if let Some(auth_data) = self.client.inner.auth_data.get() {
+        if let Some(auth_data) = self.client.inner.auth_ctx.auth_data.get() {
             let Some(data) = auth_data.as_oidc() else {
                 panic!("Cannot call OpenID Connect API after logging in with another API");
             };
@@ -594,6 +594,7 @@ impl Oidc {
 
         self.client
             .inner
+            .auth_ctx
             .auth_data
             .set(AuthData::Oidc(data))
             .expect("Client authentication data was already set");
@@ -629,6 +630,7 @@ impl Oidc {
         self.client.base_client().set_session_meta(meta).await?;
         self.client
             .inner
+            .auth_ctx
             .auth_data
             .set(AuthData::Oidc(data))
             .expect("Client authentication data was already set");

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -269,7 +269,7 @@ impl Oidc {
     /// [MSC3861]: https://github.com/matrix-org/matrix-spec-proposals/pull/3861
     /// [`ClientBuilder::server_name()`]: crate::ClientBuilder::server_name()
     pub fn authentication_server_info(&self) -> Option<&AuthenticationServerInfo> {
-        self.client.inner.authentication_server_info.as_ref()
+        self.client.inner.auth_ctx.authentication_server_info.as_ref()
     }
 
     /// The OpenID Connect Provider used for authorization.

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -926,7 +926,7 @@ impl Oidc {
         &self,
     ) -> Result<Option<AccessTokenResponse>, RefreshTokenError> {
         let client = &self.client;
-        let lock = client.inner.refresh_token_lock.try_lock();
+        let lock = client.inner.auth_ctx.refresh_token_lock.try_lock();
 
         macro_rules! fail {
             ($lock:expr, $error:expr) => {
@@ -957,7 +957,7 @@ impl Oidc {
                 }
             }
         } else {
-            match client.inner.refresh_token_lock.lock().await.as_ref() {
+            match client.inner.auth_ctx.refresh_token_lock.lock().await.as_ref() {
                 Ok(_) => Ok(None),
                 Err(error) => Err(error.clone()),
             }

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -552,7 +552,7 @@ async fn build_client(
                 // Check if the homeserver advertises an OIDC Provider with auto-discovery.
                 // This can be bypassed by providing the issuer manually, but it should be the
                 // most common case for public homeservers.
-                if let Some(issuer_info) = client.authentication_server_info().cloned() {
+                if let Some(issuer_info) = client.oidc().authentication_server_info().cloned() {
                     println!("Found issuer: {}", issuer_info.issuer);
 
                     let homeserver = client.homeserver().await.to_string();


### PR DESCRIPTION
This fixes two things:

- for one, the authentication information was *duplicated* but not shared across a parent `Client` and its children. It means that any attempt to refresh an access token could happen in both the parent in the child, independently, leading in at least one of those failing. With OIDC the problem is much more frequent, since refreshes happen every 5 minutes at the moment.
- once we've fixed the above and shared that state, then when creating a child `Client`, we don't need to restore the full session, as it could overwrite the current session tokens (leading to some gnarly race conditions, observed during the implementation of #2440). Instead, we need to restore only the session metadata (user id and device id), which also recreates a fresh `OlmMachine`.

Includes also some misc refactorings, including a glorious removal of 100% duplicated code in the inner logic to send requests :heart_on_fire: 

Part of #2440.