### PR TITLE
Allow redacted events as latest event

### DIFF
--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -5,7 +5,7 @@
 
 use ruma::events::{
     room::message::RoomMessageEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-    OriginalSyncMessageLikeEvent, SyncMessageLikeEvent,
+    SyncMessageLikeEvent,
 };
 
 /// Represents a decision about whether an event could be stored as the latest
@@ -15,7 +15,7 @@ use ruma::events::{
 #[derive(Debug)]
 pub enum PossibleLatestEvent<'a> {
     /// This message is suitable - it is an m.room.message
-    YesMessageLike(&'a OriginalSyncMessageLikeEvent<RoomMessageEventContent>),
+    YesMessageLike(&'a SyncMessageLikeEvent<RoomMessageEventContent>),
     // Later: YesState(),
     // Later: YesReaction(),
     /// Not suitable - it's a state event
@@ -24,8 +24,6 @@ pub enum PossibleLatestEvent<'a> {
     NoUnsupportedMessageLikeType,
     /// Not suitable - it's encrypted
     NoEncrypted,
-    /// Not suitable - it's redacted (might we want to include these?)
-    NoRedacted,
 }
 
 /// Decide whether an event could be stored as the latest event in a room.
@@ -33,9 +31,9 @@ pub enum PossibleLatestEvent<'a> {
 pub fn is_suitable_for_latest_event(event: &AnySyncTimelineEvent) -> PossibleLatestEvent<'_> {
     match event {
         // Suitable - we have an m.room.message that was not redacted
-        AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
-            SyncMessageLikeEvent::Original(message),
-        )) => PossibleLatestEvent::YesMessageLike(message),
+        AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(message)) => {
+            PossibleLatestEvent::YesMessageLike(message)
+        }
 
         // Encrypted events are not suitable
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomEncrypted(_)) => {
@@ -44,11 +42,6 @@ pub fn is_suitable_for_latest_event(event: &AnySyncTimelineEvent) -> PossibleLat
 
         // Later, if we support reactions:
         // AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::Reaction(_))
-
-        // Redacted events are not suitable
-        AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
-            SyncMessageLikeEvent::Redacted(_),
-        )) => PossibleLatestEvent::NoRedacted,
 
         // MessageLike, but not one of the types we want to show in message previews, so not
         // suitable
@@ -81,7 +74,7 @@ mod tests {
             sticker::{StickerEventContent, SyncStickerEvent},
             AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent, EmptyStateKey,
             MessageLikeUnsigned, OriginalSyncMessageLikeEvent, OriginalSyncStateEvent,
-            RedactedSyncMessageLikeEvent, RedactedUnsigned, StateUnsigned,
+            RedactedSyncMessageLikeEvent, RedactedUnsigned, StateUnsigned, SyncMessageLikeEvent,
             UnsignedRoomRedactionEvent,
         },
         owned_event_id, owned_mxc_uri, owned_user_id, MilliSecondsSinceUnixEpoch, UInt,
@@ -106,9 +99,9 @@ mod tests {
                 unsigned: MessageLikeUnsigned::new(),
             }),
         ));
-        let m = assert_matches::assert_matches!(
+        let m = assert_matches!(
             is_suitable_for_latest_event(&event),
-            PossibleLatestEvent::YesMessageLike(m) => m
+            PossibleLatestEvent::YesMessageLike(SyncMessageLikeEvent::Original(m)) => m
         );
 
         assert_eq!(m.content.msgtype.msgtype(), "m.image");
@@ -137,7 +130,7 @@ mod tests {
     }
 
     #[test]
-    fn redacted_messages_are_unsuitable() {
+    fn redacted_messages_are_suitable() {
         // Ruma does not allow constructing UnsignedRoomRedactionEvent instances.
         let room_redaction_event: UnsignedRoomRedactionEvent = serde_json::from_value(json!({
             "content": {},
@@ -158,7 +151,10 @@ mod tests {
             }),
         ));
 
-        assert_matches!(is_suitable_for_latest_event(&event), PossibleLatestEvent::NoRedacted);
+        assert_matches!(
+            is_suitable_for_latest_event(&event),
+            PossibleLatestEvent::YesMessageLike(SyncMessageLikeEvent::Redacted(_))
+        );
     }
 
     #[test]

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content.rs
@@ -122,7 +122,9 @@ impl TimelineItemContent {
         event: AnySyncTimelineEvent,
     ) -> Option<TimelineItemContent> {
         match is_suitable_for_latest_event(&event) {
-            PossibleLatestEvent::YesMessageLike(m) => Self::from_suitable_latest_event_content(m),
+            PossibleLatestEvent::YesMessageLike(m) => {
+                Some(Self::from_suitable_latest_event_content(m))
+            }
             PossibleLatestEvent::NoUnsupportedEventType => {
                 // TODO: when we support state events in message previews, this will need change
                 warn!("Found a state event cached as latest_event! ID={}", event.event_id());
@@ -148,9 +150,7 @@ impl TimelineItemContent {
     /// Given some message content that is from an event that we have already
     /// determined is suitable for use as a latest event in a message preview,
     /// extract its contents and wrap it as a TimelineItemContent.
-    fn from_suitable_latest_event_content(
-        event: &SyncRoomMessageEvent,
-    ) -> Option<TimelineItemContent> {
+    fn from_suitable_latest_event_content(event: &SyncRoomMessageEvent) -> TimelineItemContent {
         match event {
             SyncRoomMessageEvent::Original(event) => {
                 // Grab the content of this event
@@ -167,13 +167,13 @@ impl TimelineItemContent {
                 // Message::from_event marks the original event as Unavailable if it can't be
                 // found inside the timeline_items.
                 let timeline_items = Vector::new();
-                Some(TimelineItemContent::Message(Message::from_event(
+                TimelineItemContent::Message(Message::from_event(
                     event_content,
                     relations,
                     &timeline_items,
-                )))
+                ))
             }
-            SyncRoomMessageEvent::Redacted(_) => Some(TimelineItemContent::RedactedMessage),
+            SyncRoomMessageEvent::Redacted(_) => TimelineItemContent::RedactedMessage,
         }
     }
 


### PR DESCRIPTION
*Maybe* a fix for https://github.com/vector-im/element-x-ios/issues/1441, I'm really not sure 😅

We've always wanted to include redacted events AFAICT, it was likely just a misunderstanding that we might want to exclude them.