### PR TITLE
Implement new `CryptoStoreWrapper`

### DIFF
--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -41,6 +41,8 @@
 // a lot of to-device events. This process might take some time and we should
 // support resuming it.
 
+use std::sync::Arc;
+
 use hkdf::Hkdf;
 use ruma::{
     api::client::dehydrated_device::{put_dehydrated_device, DehydratedDeviceData},
@@ -56,7 +58,7 @@ use vodozemac::LibolmPickleError;
 
 use crate::{
     olm::Account,
-    store::{IntoCryptoStore, MemoryStore, RoomKeyInfo, Store},
+    store::{CryptoStoreWrapper, MemoryStore, RoomKeyInfo, Store},
     verification::VerificationMachine,
     EncryptionSyncChanges, OlmError, OlmMachine, ReadOnlyAccount, SignatureError,
 };
@@ -89,7 +91,7 @@ impl DehydratedDevices {
         let user_identity = self.inner.store().private_identity();
 
         let account = ReadOnlyAccount::new(user_id);
-        let store = MemoryStore::new().into_crypto_store();
+        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
 
         let verification_machine =
             VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1066,7 +1066,7 @@ mod tests {
         identities::{LocalTrust, ReadOnlyDevice},
         olm::{Account, PrivateCrossSigningIdentity, ReadOnlyAccount},
         session_manager::GroupSessionCache,
-        store::{IntoCryptoStore, MemoryStore, Store},
+        store::{CryptoStoreWrapper, MemoryStore, Store},
         types::events::room::encrypted::{EncryptedEvent, RoomEncryptedEventContent},
         verification::VerificationMachine,
     };
@@ -1115,7 +1115,7 @@ mod tests {
         let device_id = DeviceId::new();
 
         let account = ReadOnlyAccount::with_device_id(&user_id, &device_id);
-        let store = MemoryStore::new().into_crypto_store();
+        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
         let store = Store::new(user_id.to_owned(), identity, store, verification);
@@ -1134,7 +1134,7 @@ mod tests {
         ))
         .await;
 
-        let store = MemoryStore::new().into_crypto_store();
+        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
 

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -45,7 +45,7 @@ use crate::{
     olm::{
         InboundGroupSession, OutboundGroupSession, Session, ShareInfo, SignedJsonObject, VerifyJson,
     },
-    store::{Changes, DeviceChanges, DynCryptoStore, Result as StoreResult},
+    store::{Changes, CryptoStoreWrapper, DeviceChanges, Result as StoreResult},
     types::{
         events::{
             forwarded_room_key::ForwardedRoomKeyContent,
@@ -709,7 +709,7 @@ impl ReadOnlyDevice {
     /// with this device.
     pub(crate) async fn get_most_recent_session(
         &self,
-        store: &DynCryptoStore,
+        store: &CryptoStoreWrapper,
     ) -> OlmResult<Option<Session>> {
         if let Some(sender_key) = self.curve25519_key() {
             if let Some(s) = store.get_sessions(&sender_key.to_base64()).await? {
@@ -794,7 +794,7 @@ impl ReadOnlyDevice {
 
     pub(crate) async fn encrypt(
         &self,
-        store: &DynCryptoStore,
+        store: &CryptoStoreWrapper,
         event_type: &str,
         content: Value,
         message_id: Option<String>,

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -764,7 +764,7 @@ pub(crate) mod testing {
         identities::IdentityManager,
         machine::testing::response_from_file,
         olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
-        store::{DynCryptoStore, IntoCryptoStore, MemoryStore, Store},
+        store::{CryptoStoreWrapper, MemoryStore, Store},
         types::DeviceKeys,
         verification::VerificationMachine,
         UploadSigningKeysRequest,
@@ -787,14 +787,9 @@ pub(crate) mod testing {
         let identity = Arc::new(Mutex::new(identity));
         let user_id = user_id().to_owned();
         let account = ReadOnlyAccount::with_device_id(&user_id, device_id());
-        let store: Arc<DynCryptoStore> = MemoryStore::new().into_crypto_store();
-        let verification = VerificationMachine::new(account, identity.clone(), store);
-        let store = Store::new(
-            user_id.clone(),
-            identity,
-            MemoryStore::new().into_crypto_store(),
-            verification,
-        );
+        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
+        let verification = VerificationMachine::new(account, identity.clone(), store.clone());
+        let store = Store::new(user_id.clone(), identity, store, verification);
         IdentityManager::new(user_id, device_id().into(), store)
     }
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -727,7 +727,7 @@ pub(crate) mod tests {
     use crate::{
         identities::{manager::testing::own_key_query, Device},
         olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
-        store::{IntoCryptoStore, MemoryStore},
+        store::{CryptoStoreWrapper, MemoryStore},
         types::{CrossSigningKey, MasterPubkey, SelfSigningPubkey, UserSigningPubkey},
         verification::VerificationMachine,
     };
@@ -771,7 +771,7 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             ReadOnlyAccount::with_device_id(second.user_id(), second.device_id()),
             private_identity,
-            MemoryStore::new().into_crypto_store(),
+            Arc::new(CryptoStoreWrapper::new(MemoryStore::new())),
         );
 
         let first = Device {
@@ -812,7 +812,7 @@ pub(crate) mod tests {
         let verification_machine = VerificationMachine::new(
             ReadOnlyAccount::with_device_id(device.user_id(), device.device_id()),
             id.clone(),
-            MemoryStore::new().into_crypto_store(),
+            Arc::new(CryptoStoreWrapper::new(MemoryStore::new())),
         );
 
         let public_identity = identity.to_public_identity().await.unwrap();

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -465,7 +465,7 @@ mod tests {
         identities::{IdentityManager, ReadOnlyDevice},
         olm::{Account, PrivateCrossSigningIdentity, ReadOnlyAccount},
         session_manager::GroupSessionCache,
-        store::{IntoCryptoStore, MemoryStore, Store},
+        store::{CryptoStoreWrapper, MemoryStore, Store},
         verification::VerificationMachine,
     };
 
@@ -514,7 +514,7 @@ mod tests {
 
         let users_for_key_claim = Arc::new(DashMap::new());
         let account = ReadOnlyAccount::with_device_id(user_id, device_id);
-        let store = MemoryStore::new().into_crypto_store();
+        let store = Arc::new(CryptoStoreWrapper::new(MemoryStore::new()));
         store.save_account(account.clone()).await.unwrap();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id)));
         let verification =

--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -1,0 +1,124 @@
+use std::{ops::Deref, sync::Arc};
+
+use futures_core::Stream;
+use futures_util::StreamExt;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+use tracing::warn;
+
+use crate::{
+    store,
+    store::{locks::CryptoStoreLock, Changes, DynCryptoStore, IntoCryptoStore, RoomKeyInfo},
+    GossippedSecret,
+};
+
+/// A wrapper for crypto store implementations that adds update notifiers.
+///
+/// This is shared between [`StoreInner`] and
+/// [`crate::verification::VerificationStore`].
+#[derive(Debug)]
+pub(crate) struct CryptoStoreWrapper {
+    store: Arc<DynCryptoStore>,
+
+    /// The sender side of a broadcast stream that is notified whenever we get
+    /// an update to an inbound group session.
+    room_keys_received_sender: broadcast::Sender<Vec<RoomKeyInfo>>,
+
+    /// The sender side of a broadcast channel which sends out secrets we
+    /// received as a `m.secret.send` event.
+    secrets_broadcaster: broadcast::Sender<GossippedSecret>,
+}
+
+impl CryptoStoreWrapper {
+    pub(crate) fn new(store: impl IntoCryptoStore) -> Self {
+        let room_keys_received_sender = broadcast::Sender::new(10);
+        let secrets_broadcaster = broadcast::Sender::new(10);
+        Self { store: store.into_crypto_store(), room_keys_received_sender, secrets_broadcaster }
+    }
+
+    /// Save the set of changes to the store.
+    ///
+    /// Also responsible for sending updates to the broadcast streams such as
+    /// `room_keys_received_sender` and `secrets_broadcaster`.
+    ///
+    /// # Arguments
+    ///
+    /// * `changes` - The set of changes that should be stored.
+    pub async fn save_changes(&self, changes: Changes) -> store::Result<()> {
+        let room_key_updates: Vec<_> =
+            changes.inbound_group_sessions.iter().map(RoomKeyInfo::from).collect();
+
+        let secrets = changes.secrets.to_owned();
+
+        self.store.save_changes(changes).await?;
+
+        if !room_key_updates.is_empty() {
+            // Ignore the result. It can only fail if there are no listeners.
+            let _ = self.room_keys_received_sender.send(room_key_updates);
+        }
+
+        for secret in secrets {
+            let _ = self.secrets_broadcaster.send(secret);
+        }
+
+        Ok(())
+    }
+
+    /// Receive notifications of room keys being received as a [`Stream`].
+    ///
+    /// Each time a room key is updated in any way, an update will be sent to
+    /// the stream. Updates that happen at the same time are batched into a
+    /// [`Vec`].
+    ///
+    /// If the reader of the stream lags too far behind, a warning will be
+    /// logged and items will be dropped.
+    pub fn room_keys_received_stream(&self) -> impl Stream<Item = Vec<RoomKeyInfo>> {
+        let stream = BroadcastStream::new(self.room_keys_received_sender.subscribe());
+
+        // the raw BroadcastStream gives us Results which can fail with
+        // BroadcastStreamRecvError if the reader falls behind. That's annoying to work
+        // with, so here we just drop the errors.
+        stream.filter_map(|result| async move {
+            match result {
+                Ok(r) => Some(r),
+                Err(BroadcastStreamRecvError::Lagged(lag)) => {
+                    warn!("room_keys_received_stream missed {} updates", lag);
+                    None
+                }
+            }
+        })
+    }
+
+    /// Receive notifications of gossipped secrets being received and stored in
+    /// the secret inbox as a [`Stream`].
+    pub fn secrets_stream(&self) -> impl Stream<Item = GossippedSecret> {
+        let stream = BroadcastStream::new(self.secrets_broadcaster.subscribe());
+
+        // the raw BroadcastStream gives us Results which can fail with
+        // BroadcastStreamRecvError if the reader falls behind. That's annoying to work
+        // with, so here we just drop the errors.
+        stream.filter_map(|result| async move {
+            match result {
+                Ok(r) => Some(r),
+                Err(BroadcastStreamRecvError::Lagged(lag)) => {
+                    warn!("secrets_stream missed {lag} updates");
+                    None
+                }
+            }
+        })
+    }
+
+    /// Creates a `CryptoStoreLock` for this store, that will contain the given
+    /// key and value when held.
+    pub fn create_store_lock(&self, lock_key: String, lock_value: String) -> CryptoStoreLock {
+        CryptoStoreLock::new(self.store.clone(), lock_key, lock_value)
+    }
+}
+
+impl Deref for CryptoStoreWrapper {
+    type Target = DynCryptoStore;
+
+    fn deref(&self) -> &Self::Target {
+        self.store.deref()
+    }
+}

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -891,7 +891,7 @@ mod tests {
 
     use crate::{
         olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
-        store::{Changes, DynCryptoStore, IntoCryptoStore, MemoryStore},
+        store::{Changes, CryptoStoreWrapper, MemoryStore},
         verification::{
             event_enums::{DoneContent, OutgoingContent, StartContent},
             FlowId, VerificationStore,
@@ -903,8 +903,8 @@ mod tests {
         user_id!("@example:localhost")
     }
 
-    fn memory_store() -> Arc<DynCryptoStore> {
-        MemoryStore::new().into_crypto_store()
+    fn memory_store() -> Arc<CryptoStoreWrapper> {
+        Arc::new(CryptoStoreWrapper::new(MemoryStore::new()))
     }
 
     fn device_id() -> &'static DeviceId {

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -864,6 +864,8 @@ impl AcceptSettings {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use assert_matches::assert_matches;
     use matrix_sdk_test::async_test;
     use ruma::{
@@ -876,7 +878,7 @@ mod tests {
     use super::Sas;
     use crate::{
         olm::PrivateCrossSigningIdentity,
-        store::{IntoCryptoStore, MemoryStore},
+        store::{CryptoStoreWrapper, MemoryStore},
         verification::{
             event_enums::{AcceptContent, KeyContent, MacContent, OutgoingContent, StartContent},
             VerificationStore,
@@ -910,7 +912,7 @@ mod tests {
 
         let alice_store = VerificationStore {
             account: alice.clone(),
-            inner: MemoryStore::new().into_crypto_store(),
+            inner: Arc::new(CryptoStoreWrapper::new(MemoryStore::new())),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())).into(),
         };
 
@@ -919,7 +921,7 @@ mod tests {
 
         let bob_store = VerificationStore {
             account: bob.clone(),
-            inner: bob_store.into_crypto_store(),
+            inner: Arc::new(CryptoStoreWrapper::new(bob_store)),
             private_identity: Mutex::new(PrivateCrossSigningIdentity::empty(bob_id())).into(),
         };
 


### PR DESCRIPTION
... so that `VerificationStore` and `StoreInner` can share the same `save_changes` impl which broadcasts updates to the broadcast channels.