### PR TITLE
fix: `&` without an explicit lifetime name cannot be used here

### DIFF
--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -824,10 +824,10 @@ pub enum StateStoreDataKey<'a> {
 
 impl StateStoreDataKey<'_> {
     /// Key to use for the [`SyncToken`][Self::SyncToken] variant.
-    pub const SYNC_TOKEN: &str = "sync_token";
+    pub const SYNC_TOKEN: &'static str = "sync_token";
     /// Key prefix to use for the [`Filter`][Self::Filter] variant.
-    pub const FILTER: &str = "filter";
+    pub const FILTER: &'static str = "filter";
     /// Key prefix to use for the [`UserAvatarUrl`][Self::UserAvatarUrl]
     /// variant.
-    pub const USER_AVATAR_URL: &str = "user_avatar_url";
+    pub const USER_AVATAR_URL: &'static str = "user_avatar_url";
 }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -144,7 +144,7 @@ impl std::fmt::Debug for OlmMachine {
 }
 
 impl OlmMachine {
-    const CURRENT_GENERATION_STORE_KEY: &str = "generation-counter";
+    const CURRENT_GENERATION_STORE_KEY: &'static str = "generation-counter";
 
     /// Create a new memory based OlmMachine.
     ///

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -98,8 +98,8 @@ pub struct NotificationClient {
 }
 
 impl NotificationClient {
-    const CONNECTION_ID: &str = "notifications";
-    const LOCK_ID: &str = "notifications";
+    const CONNECTION_ID: &'static str = "notifications";
+    const LOCK_ID: &'static str = "notifications";
 
     /// Create a new builder for a notification client.
     pub async fn builder(


### PR DESCRIPTION
This was previously accepted by the compiler but is being phased out; it will become a hard error in a future release! See https://github.com/ rust-lang/rust/issues/115010.