### PR TITLE
feat(ui): Implement `RoomListService::sync_indicator`

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
@@ -60,6 +60,7 @@ macro_rules! sliding_sync_then_assert_request_and_fake_response {
         [$server:ident, $stream:ident]
         assert request $sign:tt { $( $request_json:tt )* },
         respond with = $( ( code $code:expr ) )? { $( $response_json:tt )* }
+        $( , after delay = $response_delay:expr )?
         $(,)?
     ) => {
         sliding_sync_then_assert_request_and_fake_response! {
@@ -67,6 +68,7 @@ macro_rules! sliding_sync_then_assert_request_and_fake_response {
             sync matches Some(Ok(_)),
             assert request $sign { $( $request_json )* },
             respond with = $( ( code $code ) )? { $( $response_json )* },
+            $( after delay = $response_delay, )?
         }
     };
 
@@ -75,6 +77,7 @@ macro_rules! sliding_sync_then_assert_request_and_fake_response {
         sync matches $sync_result:pat,
         assert request $sign:tt { $( $request_json:tt )* },
         respond with = $( ( code $code:expr ) )? { $( $response_json:tt )* }
+        $( , after delay = $response_delay:expr )?
         $(,)?
     ) => {
         {
@@ -96,6 +99,7 @@ macro_rules! sliding_sync_then_assert_request_and_fake_response {
                             $( $response_json )*
                         })
                     )
+                    $( .set_delay($response_delay) )?
                 })
                 .mount_as_scoped(&$server)
                 .await;


### PR DESCRIPTION
This patch implements a new method: `RoomListService::sync_indicator`.
It returns a `impl Stream<Item = SyncIndicator>` where `SyncIndicator`
is a new enum with 2 variants: `Show` and `Hide`.

`SyncIndicator` is the UI equivalent of a sync spinner/loader/toaster,
that the app might want to show to the user to indicate when a _first_
request is sent and might be slow, i.e. the first response is taking
a little bit of time to come. The term _first_ may be innapropriate as
it covers the actual first sync request, but also the recovering sync
request. It means that when a sync error happened, the sync indicator
will be shown too, which is a pretty useful information for the user.

It's not because a `SyncIndicator` should be shown that it must be send
immediately onto the `Stream`. In case of a normal network conditions,
without any delay, it can lead to a “blinking” visual effect. Some
constants configure how long it takes to consider that a request is
“slow”, and that the `SyncIndicator` is necessary to be shown (or
hidden).