### PR TITLE
test(ci): Exponential backoff when retrying flaky tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,4 @@
-
 [profile.default]
-retries = 2
+retries = { backoff = "exponential", count = 3, delay = "1s", jitter = true }
 # kill the slow tests if they still aren't up after 180s
 slow-timeout = { period = "60s", terminate-after = 3 }


### PR DESCRIPTION
This patch changes the backoff strategy from `fixed` to `exponential` when a flaky test is retried. The `count` value is also updated to 3. Finally, we try to avoid the thundering herd problems with `jitter = true`.