### PR TITLE
feat(ffi): Improve performances of `Room::members`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/chunk_iterator.rs
+++ b/bindings/matrix-sdk-ffi/src/chunk_iterator.rs
@@ -1,0 +1,66 @@
+//! A generic `ChunkIterator` that operates over a `Vec`.
+//!
+//! This type is not designed to work over FFI, but it can be embedded inside an
+//! `uniffi::Object` for example.
+
+use std::{cell::RefCell, cmp, mem};
+
+pub struct ChunkIterator<T> {
+    items: RefCell<Vec<T>>,
+}
+
+impl<T> ChunkIterator<T> {
+    pub fn new(items: Vec<T>) -> Self {
+        Self { items: RefCell::new(items) }
+    }
+
+    pub fn len(&self) -> u32 {
+        self.items.borrow().len().try_into().unwrap()
+    }
+
+    pub fn next(&self, chunk_size: u32) -> Option<Vec<T>> {
+        if self.items.borrow().is_empty() {
+            None
+        } else if chunk_size == 0 {
+            Some(Vec::new())
+        } else {
+            let mut items = self.items.borrow_mut();
+
+            // Compute the `chunk_size`.
+            let chunk_size = cmp::min(items.len(), chunk_size.try_into().unwrap());
+            // Split the items vector.
+            let mut tail = items.split_off(chunk_size);
+            // `Vec::split_off` returns the tail, and `items` contains the head. Let's
+            // swap them.
+            mem::swap(&mut tail, &mut items);
+            // Finally, let's rename `tail` to `head`.
+            let head = tail;
+
+            Some(head)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChunkIterator;
+
+    #[test]
+    fn test_len() {
+        assert_eq!(ChunkIterator::<u8>::new(vec![1, 2, 3]).len(), 3);
+        assert_eq!(ChunkIterator::<u8>::new(vec![]).len(), 0);
+    }
+
+    #[test]
+    fn test_next() {
+        let iterator = ChunkIterator::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+        assert_eq!(iterator.next(3), Some(vec![1, 2, 3]));
+        assert_eq!(iterator.next(5), Some(vec![4, 5, 6, 7, 8]));
+        assert_eq!(iterator.next(0), Some(vec![]));
+        assert_eq!(iterator.next(1), Some(vec![9]));
+        assert_eq!(iterator.next(3), Some(vec![10, 11]));
+        assert_eq!(iterator.next(2), None);
+        assert_eq!(iterator.next(2), None);
+    }
+}

--- a/bindings/matrix-sdk-ffi/src/chunk_iterator.rs
+++ b/bindings/matrix-sdk-ffi/src/chunk_iterator.rs
@@ -3,28 +3,28 @@
 //! This type is not designed to work over FFI, but it can be embedded inside an
 //! `uniffi::Object` for example.
 
-use std::{cell::RefCell, cmp, mem};
+use std::{cmp, mem, sync::RwLock};
 
 pub struct ChunkIterator<T> {
-    items: RefCell<Vec<T>>,
+    items: RwLock<Vec<T>>,
 }
 
 impl<T> ChunkIterator<T> {
     pub fn new(items: Vec<T>) -> Self {
-        Self { items: RefCell::new(items) }
+        Self { items: RwLock::new(items) }
     }
 
     pub fn len(&self) -> u32 {
-        self.items.borrow().len().try_into().unwrap()
+        self.items.read().unwrap().len().try_into().unwrap()
     }
 
     pub fn next(&self, chunk_size: u32) -> Option<Vec<T>> {
-        if self.items.borrow().is_empty() {
+        if self.items.read().unwrap().is_empty() {
             None
         } else if chunk_size == 0 {
             Some(Vec::new())
         } else {
-            let mut items = self.items.borrow_mut();
+            let mut items = self.items.write().unwrap();
 
             // Compute the `chunk_size`.
             let chunk_size = cmp::min(items.len(), chunk_size.try_into().unwrap());

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -21,6 +21,7 @@ macro_rules! unwrap_or_clone_arc_into_variant {
 }
 
 mod authentication_service;
+mod chunk_iterator;
 mod client;
 mod client_builder;
 mod error;

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -173,7 +173,7 @@ impl Room {
         });
     }
 
-    pub async fn fetch_members(&self) -> Result<Arc<TaskHandle>, ClientError> {
+    pub async fn fetch_members(&self) -> Result<(), ClientError> {
         let timeline = self
             .timeline
             .read()
@@ -181,9 +181,7 @@ impl Room {
             .clone()
             .context("Timeline not set up, can't fetch members")?;
 
-        Ok(Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
-            timeline.fetch_members().await;
-        }))))
+        Ok(timeline.fetch_members().await)
     }
 
     pub fn display_name(&self) -> Result<String, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -182,7 +182,9 @@ impl Room {
             .clone()
             .context("Timeline not set up, can't fetch members")?;
 
-        Ok(timeline.fetch_members().await)
+        timeline.fetch_members().await;
+
+        Ok(())
     }
 
     pub fn display_name(&self) -> Result<String, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -42,6 +42,7 @@ use uuid::Uuid;
 
 use super::RUNTIME;
 use crate::{
+    chunk_iterator::ChunkIterator,
     client::ProgressWatcher,
     error::{ClientError, RoomError},
     room_info::RoomInfo,
@@ -197,14 +198,8 @@ impl Room {
         })
     }
 
-    pub async fn members(&self) -> Result<Vec<Arc<RoomMember>>, ClientError> {
-        Ok(self
-            .inner
-            .members(RoomMemberships::empty())
-            .await?
-            .iter()
-            .map(|m| Arc::new(RoomMember::new(m.clone())))
-            .collect())
+    pub async fn members(&self) -> Result<Arc<RoomMembersIterator>, ClientError> {
+        Ok(Arc::new(RoomMembersIterator::new(self.inner.members(RoomMemberships::empty()).await?)))
     }
 
     pub async fn member(&self, user_id: String) -> Result<Arc<RoomMember>, ClientError> {
@@ -1140,5 +1135,29 @@ impl From<AssetType> for RumaAssetType {
             AssetType::Sender => Self::Self_,
             AssetType::Pin => Self::Pin,
         }
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct RoomMembersIterator {
+    chunk_iterator: ChunkIterator<matrix_sdk::room::RoomMember>,
+}
+
+impl RoomMembersIterator {
+    fn new(members: Vec<matrix_sdk::room::RoomMember>) -> Self {
+        Self { chunk_iterator: ChunkIterator::new(members) }
+    }
+}
+
+#[uniffi::export]
+impl RoomMembersIterator {
+    fn len(&self) -> u32 {
+        self.chunk_iterator.len()
+    }
+
+    fn next_chunk(&self, chunk_size: u32) -> Option<Vec<Arc<RoomMember>>> {
+        self.chunk_iterator
+            .next(chunk_size)
+            .map(|members| members.into_iter().map(RoomMember::new).map(Arc::new).collect())
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -173,6 +173,8 @@ pub(crate) struct ClientInner {
     /// Lock making sure we're only doing one key claim request at a time.
     #[cfg(feature = "e2e-encryption")]
     pub(crate) key_claim_lock: Mutex<()>,
+    /// Lock to ensure that only one members request is running at a time, per
+    /// room.
     pub(crate) members_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
     /// Locks for requests on the encryption state of rooms.
     pub(crate) encryption_state_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -401,6 +401,7 @@ impl Room {
             let request = get_member_events::v3::Request::new(self.inner.room_id().to_owned());
             let response = self.client.send(request, None).await?;
 
+            // That's a large `Future`. Let's `Box::pin` to reduce its size on the stack.
             let response = Box::pin(
                 self.client.base_client().receive_members(self.inner.room_id(), &response),
             )


### PR DESCRIPTION
This PR contains several patches. It can be reviewed commit-by-commit.

The first set of patches makes `fetch_members`, `members` and `member` async. Why? Because some callers of the bindings would like to “cancel” `Room::fetch_members` or `Room::members` for example, which is easier to do when the methods are purely async.

THe second set of patches makes `members` to return a `RoomMembersIterator`, which “implements” `ChunkIterator`, a new type.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/1979