### PR TITLE
encryption sync: disable the shared pos in the encryption sync

### DIFF
--- a/crates/matrix-sdk-ui/src/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/src/encryption_sync_service.rs
@@ -102,7 +102,7 @@ impl EncryptionSyncService {
         let mut builder = client
             .sliding_sync("encryption")
             .map_err(Error::SlidingSync)?
-            .share_pos()
+            //.share_pos() // TODO(bnjbvr) This is racy, needs cross-process lock :')
             .with_to_device_extension(
                 assign!(v4::ToDeviceConfig::default(), { enabled: Some(true)}),
             )


### PR DESCRIPTION
It is racy and would require a cross-process lock held during the whole flow (from creating the request to processing the response).