### PR TITLE
Use ObservableVectorTransaction from eyeball-im 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d999ff633cd7243e8b9efc2a1e35846517f16ce4c3c87a70e0a829d8fb29af3"
+checksum = "8c6d39e66bac9395db14e7a311c6b18477f52719ed92c07a223a7d4f2f1fa6d3"
 dependencies = [
  "futures-core",
  "imbl",
@@ -1734,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im-util"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a51602d13a284f2241af1d8dc020dd22f49a6bbbf420a5eccbea6c399069a45"
+checksum = "d1207bf28748211f9c446f4c8a629a41683ea77e4be8456483fc7ee087062946"
 dependencies = [
  "eyeball-im",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ byteorder = "1.4.3"
 ctor = "0.2.0"
 dashmap = "5.2.0"
 eyeball = "0.8.3"
-eyeball-im = { version = "0.2.5", features = ["tracing"] }
-eyeball-im-util = "0.2.1"
+eyeball-im = { version = "0.3.2", features = ["tracing"] }
+eyeball-im-util = "0.3.0"
 futures-core = "0.3.28"
 futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This replaces our use of `batch_with` from `async-rx`, which was batching things reasonably most of the time, but not all of the time due to timing issues. There was a misunderstanding in why we needed to batch things in the first place (it was not just performance, but also correctness).