### PR TITLE
Reuse base64 encoding/decoding methods from vodozemac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,6 @@ dependencies = [
  "async-std",
  "async-trait",
  "atomic",
- "base64 0.21.2",
  "bs58",
  "byteorder",
  "cbc",
@@ -6431,7 +6430,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vodozemac"
 version = "0.4.0"
-source = "git+https://github.com/matrix-org/vodozemac/?rev=e3b658526f6f1dd0a9065c1c96346b796712c425#e3b658526f6f1dd0a9065c1c96346b796712c425"
+source = "git+https://github.com/matrix-org/vodozemac/?rev=23098d391d9a91db7d72a0ce19e69559b4340b13#23098d391d9a91db7d72a0ce19e69559b4340b13"
 dependencies = [
  "aes",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "base64 0.21.2",
  "futures-util",
  "hmac",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-core = "0.1.30"
 uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "e20b9c2b72144ef51a381c6b321ac810a4fbfdbe" }
 uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "e20b9c2b72144ef51a381c6b321ac810a4fbfdbe" }
-vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "e3b658526f6f1dd0a9065c1c96346b796712c425" }
+vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "23098d391d9a91db7d72a0ce19e69559b4340b13" }
 zeroize = "1.6.0"
 
 # Default release profile, select with `--release`

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -18,7 +18,6 @@ bundled-sqlite = ["matrix-sdk-sqlite/bundled"]
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = { workspace = true }
 futures-util = "0.3.25"
 hmac = "0.12.1"
 http = { workspace = true }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -31,7 +31,6 @@ aes = "0.8.1"
 atomic = "0.5.1"
 async-std = { version = "1.12.0", features = ["unstable"] }
 async-trait = { workspace = true }
-base64 = { workspace = true }
 bs58 = { version = "0.5.0", optional = true }
 byteorder = { workspace = true }
 cbc = { version = "0.1.2", features = ["std"], optional = true }

--- a/crates/matrix-sdk-crypto/src/backups/keys/compat.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/compat.rs
@@ -25,9 +25,7 @@ use hkdf::Hkdf;
 use hmac::{digest::MacError, Hmac, Mac as MacT};
 use sha2::Sha256;
 use thiserror::Error;
-use vodozemac::{Curve25519PublicKey, Curve25519SecretKey, KeyError, SharedSecret};
-
-use crate::utilities::base64_decode;
+use vodozemac::{base64_decode, Curve25519PublicKey, Curve25519SecretKey, KeyError, SharedSecret};
 
 type Aes256CbcEnc = cbc::Encryptor<Aes256>;
 type Aes256CbcDec = cbc::Decryptor<Aes256>;
@@ -171,7 +169,7 @@ impl PkEncryption {
 #[derive(Debug, Error)]
 pub enum MessageDecodeError {
     #[error(transparent)]
-    Base64(#[from] base64::DecodeError),
+    Base64(#[from] vodozemac::Base64DecodeError),
     #[error(transparent)]
     Key(#[from] KeyError),
 }
@@ -214,10 +212,9 @@ pub enum Error {
 #[cfg(test)]
 mod tests {
     use olm_rs::pk::{OlmPkDecryption, OlmPkEncryption, PkMessage};
-    use vodozemac::Curve25519PublicKey;
+    use vodozemac::{base64_encode, Curve25519PublicKey};
 
     use super::{Message, MessageDecodeError, PkDecryption, PkEncryption};
-    use crate::utilities::base64_encode;
 
     impl TryFrom<PkMessage> for Message {
         type Error = MessageDecodeError;

--- a/crates/matrix-sdk-crypto/src/backups/keys/compat.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/compat.rs
@@ -27,7 +27,7 @@ use sha2::Sha256;
 use thiserror::Error;
 use vodozemac::{Curve25519PublicKey, Curve25519SecretKey, KeyError, SharedSecret};
 
-use crate::utilities::decode;
+use crate::utilities::base64_decode;
 
 type Aes256CbcEnc = cbc::Encryptor<Aes256>;
 type Aes256CbcDec = cbc::Decryptor<Aes256>;
@@ -190,8 +190,8 @@ impl Message {
         ephemeral_key: &str,
     ) -> Result<Self, MessageDecodeError> {
         Ok(Self {
-            ciphertext: decode(ciphertext)?,
-            mac: decode(mac)?,
+            ciphertext: base64_decode(ciphertext)?,
+            mac: base64_decode(mac)?,
             ephemeral_key: Curve25519PublicKey::from_base64(ephemeral_key)?,
         })
     }
@@ -217,7 +217,7 @@ mod tests {
     use vodozemac::Curve25519PublicKey;
 
     use super::{Message, MessageDecodeError, PkDecryption, PkEncryption};
-    use crate::utilities::encode;
+    use crate::utilities::base64_encode;
 
     impl TryFrom<PkMessage> for Message {
         type Error = MessageDecodeError;
@@ -230,8 +230,8 @@ mod tests {
     impl From<Message> for PkMessage {
         fn from(val: Message) -> Self {
             PkMessage {
-                ciphertext: encode(val.ciphertext),
-                mac: encode(val.mac),
+                ciphertext: base64_encode(val.ciphertext),
+                mac: base64_encode(val.mac),
                 ephemeral_key: val.ephemeral_key.to_base64(),
             }
         }

--- a/crates/matrix-sdk-crypto/src/backups/keys/decryption.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/decryption.rs
@@ -44,7 +44,7 @@ pub enum DecodeError {
     Base58(#[from] bs58::decode::Error),
     /// The  recovery key isn't valid base64.
     #[error(transparent)]
-    Base64(#[from] base64::DecodeError),
+    Base64(#[from] vodozemac::Base64DecodeError),
     /// The recovery key is too short, we couldn't read enough data.
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -121,7 +121,7 @@ impl BackupDecryptionKey {
 
     /// Try to create a [`BackupDecryptionKey`] from a base64 export.
     pub fn from_base64(key: &str) -> Result<Self, DecodeError> {
-        let decoded = Zeroizing::new(crate::utilities::base64_decode(key)?);
+        let decoded = Zeroizing::new(vodozemac::base64_decode(key)?);
 
         if decoded.len() != Self::KEY_SIZE {
             Err(DecodeError::Length(Self::KEY_SIZE, decoded.len()))

--- a/crates/matrix-sdk-crypto/src/backups/keys/decryption.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/decryption.rs
@@ -121,7 +121,7 @@ impl BackupDecryptionKey {
 
     /// Try to create a [`BackupDecryptionKey`] from a base64 export.
     pub fn from_base64(key: &str) -> Result<Self, DecodeError> {
-        let decoded = Zeroizing::new(crate::utilities::decode(key)?);
+        let decoded = Zeroizing::new(crate::utilities::base64_decode(key)?);
 
         if decoded.len() != Self::KEY_SIZE {
             Err(DecodeError::Length(Self::KEY_SIZE, decoded.len()))

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -21,7 +21,6 @@ use aes::{
     cipher::{generic_array::GenericArray, KeyIvInit, StreamCipher},
     Aes256,
 };
-use base64::DecodeError;
 use rand::{thread_rng, RngCore};
 use ruma::{
     events::room::{EncryptedFile, JsonWebKey, JsonWebKeyInit},
@@ -83,7 +82,7 @@ pub enum DecryptorError {
     /// Some data in the encrypted attachment coldn't be decoded, this may be a
     /// hash, the secret key, or the initialization vector.
     #[error(transparent)]
-    Decode(#[from] DecodeError),
+    Decode(#[from] vodozemac::Base64DecodeError),
     /// A hash is missing from the encryption info.
     #[error("The encryption info is missing a hash")]
     MissingHash,

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -25,12 +25,10 @@ use rand::{thread_rng, RngCore};
 use serde_json::Error as SerdeError;
 use sha2::{Sha256, Sha512};
 use thiserror::Error;
+use vodozemac::{base64_decode, base64_encode};
 use zeroize::Zeroize;
 
-use crate::{
-    olm::ExportedRoomKey,
-    utilities::{base64_decode, base64_encode, DecodeError},
-};
+use crate::olm::ExportedRoomKey;
 
 type Aes256Ctr = ctr::Ctr128BE<Aes256>;
 
@@ -63,7 +61,7 @@ pub enum KeyExportError {
     Json(#[from] SerdeError),
     /// The key export string isn't valid base64.
     #[error(transparent)]
-    Decode(#[from] DecodeError),
+    Decode(#[from] vodozemac::Base64DecodeError),
     /// The key export doesn't all the required fields.
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -29,7 +29,7 @@ use zeroize::Zeroize;
 
 use crate::{
     olm::ExportedRoomKey,
-    utilities::{decode, encode, DecodeError},
+    utilities::{base64_decode, base64_encode, DecodeError},
 };
 
 type Aes256Ctr = ctr::Ctr128BE<Aes256>;
@@ -199,11 +199,11 @@ fn encrypt_helper(plaintext: &mut [u8], passphrase: &str, rounds: u32) -> String
 
     derived_keys.zeroize();
 
-    encode(payload)
+    base64_encode(payload)
 }
 
 fn decrypt_helper(ciphertext: &str, passphrase: &str) -> Result<String, KeyExportError> {
-    let decoded = decode(ciphertext)?;
+    let decoded = base64_decode(ciphertext)?;
 
     let mut decoded = Cursor::new(decoded);
 
@@ -284,7 +284,8 @@ mod tests {
     use ruma::{room_id, user_id};
 
     use super::{
-        decode, decrypt_helper, decrypt_room_key_export, encrypt_helper, encrypt_room_key_export,
+        base64_decode, decrypt_helper, decrypt_room_key_export, encrypt_helper,
+        encrypt_room_key_export,
     };
     use crate::{error::OlmResult, machine::tests::get_prepared_machine, RoomKeyImportResult};
 
@@ -314,7 +315,7 @@ mod tests {
     #[test]
     fn test_decode() {
         let export = export_without_headers();
-        decode(export).unwrap();
+        base64_decode(export).unwrap();
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -44,6 +44,7 @@ use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use tracing::{debug, field::debug, info, instrument, trace, warn, Span};
 use vodozemac::{
+    base64_encode,
     olm::{
         Account as InnerAccount, AccountPickle, IdentityKeys, OlmMessage,
         OneTimeKeyGenerationResult, PreKeyMessage, SessionConfig,
@@ -73,7 +74,6 @@ use crate::{
         },
         CrossSigningKey, DeviceKeys, EventEncryptionAlgorithm, MasterPubkey, OneTimeKey, SignedKey,
     },
-    utilities::base64_encode,
     CryptoStoreError, OlmError, SignatureError,
 };
 
@@ -602,7 +602,8 @@ impl ReadOnlyAccount {
     /// encoded as base64 will be used for the device ID.
     pub fn new(user_id: &UserId) -> Self {
         let account = InnerAccount::new();
-        let device_id: OwnedDeviceId = base64_encode(account.identity_keys().curve25519.as_bytes()).into();
+        let device_id: OwnedDeviceId =
+            base64_encode(account.identity_keys().curve25519.as_bytes()).into();
 
         Self::new_helper(account, user_id, &device_id)
     }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -73,7 +73,7 @@ use crate::{
         },
         CrossSigningKey, DeviceKeys, EventEncryptionAlgorithm, MasterPubkey, OneTimeKey, SignedKey,
     },
-    utilities::encode,
+    utilities::base64_encode,
     CryptoStoreError, OlmError, SignatureError,
 };
 
@@ -148,7 +148,7 @@ impl OlmMessageHash {
             .chain_update(ciphertext)
             .finalize();
 
-        Self { sender_key, hash: encode(sha.as_slice()) }
+        Self { sender_key, hash: base64_encode(sha.as_slice()) }
     }
 }
 
@@ -602,7 +602,7 @@ impl ReadOnlyAccount {
     /// encoded as base64 will be used for the device ID.
     pub fn new(user_id: &UserId) -> Self {
         let account = InnerAccount::new();
-        let device_id: OwnedDeviceId = encode(account.identity_keys().curve25519.as_bytes()).into();
+        let device_id: OwnedDeviceId = base64_encode(account.identity_keys().curve25519.as_bytes()).into();
 
         Self::new_helper(account, user_id, &device_id)
     }

--- a/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
@@ -16,7 +16,7 @@ use ruma::{encryption::KeyUsage, DeviceKeyAlgorithm, DeviceKeyId, OwnedUserId};
 use serde::{Deserialize, Serialize};
 use serde_json::{Error as JsonError, Value};
 use thiserror::Error;
-use vodozemac::{Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, KeyError};
+use vodozemac::{DecodeError, Ed25519PublicKey, Ed25519SecretKey, Ed25519Signature, KeyError};
 use zeroize::Zeroize;
 
 use crate::{
@@ -26,7 +26,6 @@ use crate::{
         CrossSigningKey, DeviceKeys, MasterPubkey, SelfSigningPubkey, Signatures, SigningKeys,
         UserSigningPubkey,
     },
-    utilities::DecodeError,
     ReadOnlyUserIdentity,
 };
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -58,7 +58,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
-use vodozemac::{megolm::SessionOrdering, Curve25519PublicKey};
+use vodozemac::{base64_encode, megolm::SessionOrdering, Curve25519PublicKey};
 use zeroize::Zeroize;
 
 use crate::{
@@ -71,7 +71,6 @@ use crate::{
         ReadOnlyAccount, Session,
     },
     types::{events::room_key_withheld::RoomKeyWithheldEvent, EventEncryptionAlgorithm},
-    utilities::base64_encode,
     verification::VerificationMachine,
     CrossSigningStatus, ReadOnlyOwnUserIdentity,
 };

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -71,7 +71,7 @@ use crate::{
         ReadOnlyAccount, Session,
     },
     types::{events::room_key_withheld::RoomKeyWithheldEvent, EventEncryptionAlgorithm},
-    utilities::encode,
+    utilities::base64_encode,
     verification::VerificationMachine,
     CrossSigningStatus, ReadOnlyOwnUserIdentity,
 };
@@ -339,7 +339,7 @@ impl BackupDecryptionKey {
 
     /// Export the [`BackupDecryptionKey`] as a base64 encoded string.
     pub fn to_base64(&self) -> String {
-        encode(self.inner.as_slice())
+        base64_encode(self.inner.as_slice())
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/utilities.rs
+++ b/crates/matrix-sdk-crypto/src/utilities.rs
@@ -20,29 +20,7 @@ use std::{
     time::Duration,
 };
 
-pub use base64::DecodeError;
-use base64::{
-    alphabet,
-    engine::{general_purpose, GeneralPurpose},
-    Engine,
-};
 use matrix_sdk_common::instant::Instant;
-
-const STANDARD_NO_PAD: GeneralPurpose = GeneralPurpose::new(
-    &alphabet::STANDARD,
-    general_purpose::NO_PAD
-        .with_decode_padding_mode(base64::engine::DecodePaddingMode::Indifferent),
-);
-
-/// Decode the input as base64 with no padding.
-pub fn base64_decode(input: impl AsRef<[u8]>) -> Result<Vec<u8>, DecodeError> {
-    STANDARD_NO_PAD.decode(input)
-}
-
-/// Encode the input as base64 with no padding.
-pub fn base64_encode(input: impl AsRef<[u8]>) -> String {
-    STANDARD_NO_PAD.encode(input)
-}
 
 #[cfg(test)]
 pub(crate) fn json_convert<T, U>(value: &T) -> serde_json::Result<U>

--- a/crates/matrix-sdk-crypto/src/utilities.rs
+++ b/crates/matrix-sdk-crypto/src/utilities.rs
@@ -35,12 +35,12 @@ const STANDARD_NO_PAD: GeneralPurpose = GeneralPurpose::new(
 );
 
 /// Decode the input as base64 with no padding.
-pub fn decode(input: impl AsRef<[u8]>) -> Result<Vec<u8>, DecodeError> {
+pub fn base64_decode(input: impl AsRef<[u8]>) -> Result<Vec<u8>, DecodeError> {
     STANDARD_NO_PAD.decode(input)
 }
 
 /// Encode the input as base64 with no padding.
-pub fn encode(input: impl AsRef<[u8]>) -> String {
+pub fn base64_encode(input: impl AsRef<[u8]>) -> String {
     STANDARD_NO_PAD.encode(input)
 }
 


### PR DESCRIPTION
We have those same base64 decoding/encoding methods defined in multiple places and it's annoying to keep them in sync. Let's define them once and reuse them instead.

Closes: https://github.com/matrix-org/matrix-rust-sdk/issues/2531.

@BillCarsonFr if you have a unit test for the bindings feel free to push a commit or pass the commit to me over Matrix.