### PR TITLE
feat: log the x-sentry-event-id if we receive it from the server

### DIFF
--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -94,7 +94,16 @@ impl HttpClient {
     #[allow(clippy::too_many_arguments)]
     #[instrument(
         skip(self, access_token, config, request, send_progress),
-        fields(config, path, request_size, request_body, request_id, status, response_size,)
+        fields(
+            config,
+            path,
+            request_size,
+            request_body,
+            request_id,
+            status,
+            response_size,
+            sentry_event_id,
+        )
     )]
     pub async fn send<R>(
         &self,


### PR DESCRIPTION
Extracted of https://github.com/matrix-org/matrix-rust-sdk/pull/2440.

Whenever there's an OIDC logout, our OIDC server (MAS) will log some information to Sentry to understand why a token has been rejected, and include some Sentry ID in the response, so we may correlate the Sentry log with our custom logs. This adds logging of that ID, if it's present in the request.