### PR TITLE
feat(sdk): Add an action parameter to the OIDC account URL.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -431,7 +431,7 @@ impl Client {
     }
 
     pub fn account_url(&self) -> Option<String> {
-        self.inner.oidc().account_management_url().ok().flatten().map(|url| url.to_string())
+        self.inner.oidc().account_management_url(None).ok().flatten().map(|url| url.to_string())
     }
 
     pub fn user_id(&self) -> Result<String, ClientError> {

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -35,8 +35,8 @@ use matrix_sdk::{
             requests::GrantType,
             scope::{Scope, ScopeToken},
         },
-        AuthorizationCode, AuthorizationResponse, FullSession, OidcAuthorizationData,
-        RegisteredClientData, UserSession,
+        AuthorizationCode, AuthorizationResponse, FullSession, OidcAccountManagementAction,
+        OidcAuthorizationData, RegisteredClientData, UserSession,
     },
     room::Room,
     ruma::{
@@ -322,7 +322,13 @@ impl OidcCli {
                     self.whoami().await;
                 }
                 Some("account") => {
-                    self.account();
+                    self.account(None);
+                }
+                Some("profile") => {
+                    self.account(Some(OidcAccountManagementAction::Profile));
+                }
+                Some("sessions") => {
+                    self.account(Some(OidcAccountManagementAction::SessionsList));
                 }
                 Some("watch") => {
                     self.watch().await?;
@@ -379,8 +385,8 @@ impl OidcCli {
     }
 
     /// Get the account management URL.
-    fn account(&self) {
-        match self.client.oidc().account_management_url() {
+    fn account(&self, action: Option<OidcAccountManagementAction>) {
+        match self.client.oidc().account_management_url(action) {
             Ok(Some(url)) => {
                 println!("\nTo manage your account, visit: {url}");
             }


### PR DESCRIPTION
This PR adds the `action` and `device_id` account management URL parameters to OIDC and the FFI as detailed here:

https://github.com/sandhose/matrix-doc/blob/msc/sandhose/oidc-discovery/proposals/2965-oidc-discovery.md#account-management-url-parameters

Unsure if its possible to test these currently, I'm hoping @bnjbvr will add enough mocks to make that possible. For now I have checked they're all working against a server.

Part of https://github.com/vector-im/element-internal/issues/487