### PR TITLE
fix(sliding sync): don't mark a room limited if we don't have cached events for that room

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -310,8 +310,10 @@ impl SlidingSync {
             }
         }
 
-        // Compute `limited`.
-        {
+        let must_process_rooms_response = self.must_process_rooms_response().await;
+
+        // Compute `limited`, if we're interested in a room list query.
+        if must_process_rooms_response {
             let known_rooms = self.inner.rooms.read().await;
             compute_limited(&known_rooms, &mut sliding_sync_response.rooms);
         }
@@ -336,7 +338,7 @@ impl SlidingSync {
         // unrelated to the current connection's parameters.
         //
         // NOTE: SS proxy workaround.
-        if self.must_process_rooms_response().await {
+        if must_process_rooms_response {
             response_processor.handle_room_response(&sliding_sync_response).await?;
         }
 


### PR DESCRIPTION
When receiving a sliding sync room response for a room that had no local events in its timeline cache,
we'd mark the room as limited before, which is incorrect. It was made worse by the fact that later in
the code, we'd clear the local cache if a room was marked as limited, so this is a problem that would
repeat itself over time (assuming empty responses for that room).

This fixes it and unifies logs so there's only one log line per room, at most.

There's also a second commit that avoids doing the `limited` flag computation if we're not interested in the rooms part of the response, according to the configuration of that sliding sync.

Related: https://github.com/vector-im/element-x-android/issues/1281 (only fixed once SDK is released and integrated)
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2540