### PR TITLE
sdk: Fix unit tests not compiling without testing feature

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -141,6 +141,7 @@ assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 dirs = "5.0.1"
 futures-executor = { workspace = true }
+matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base", default_features = false, features = ["testing"] }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 


### PR DESCRIPTION
Some unit tests in the SDK use matrix-sdk-crypto functionality that's only available with `cfg(feature = "testing")`. Enable that feature (in sdk-base and implicitly sdk-crypto, though only sdk-crypto would have been possible too) for test builds of the sdk crate.

This allows `cargo test -p matrix-sdk` to work.