### PR TITLE
ffi: RoomInfo notification mode must reflect the user-defined mode

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -63,7 +63,7 @@ impl RoomInfo {
             joined_members_count: room.joined_members_count(),
             highlight_count: unread_notification_counts.highlight_count,
             notification_count: unread_notification_counts.notification_count,
-            notification_mode: room.notification_mode().await.map(Into::into),
+            notification_mode: room.notification_mode(true).await.map(Into::into),
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -63,7 +63,10 @@ impl RoomInfo {
             joined_members_count: room.joined_members_count(),
             highlight_count: unread_notification_counts.highlight_count,
             notification_count: unread_notification_counts.notification_count,
-            user_defined_notification_mode: room.user_defined_notification_mode().await.map(Into::into),
+            user_defined_notification_mode: room
+                .user_defined_notification_mode()
+                .await
+                .map(Into::into),
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -28,7 +28,7 @@ pub struct RoomInfo {
     joined_members_count: u64,
     highlight_count: u64,
     notification_count: u64,
-    notification_mode: Option<RoomNotificationMode>,
+    user_defined_notification_mode: Option<RoomNotificationMode>,
 }
 
 impl RoomInfo {
@@ -63,7 +63,7 @@ impl RoomInfo {
             joined_members_count: room.joined_members_count(),
             highlight_count: unread_notification_counts.highlight_count,
             notification_count: unread_notification_counts.notification_count,
-            notification_mode: room.user_defined_notification_mode().await.map(Into::into),
+            user_defined_notification_mode: room.user_defined_notification_mode().await.map(Into::into),
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -63,7 +63,7 @@ impl RoomInfo {
             joined_members_count: room.joined_members_count(),
             highlight_count: unread_notification_counts.highlight_count,
             notification_count: unread_notification_counts.notification_count,
-            notification_mode: room.notification_mode(true).await.map(Into::into),
+            notification_mode: room.user_defined_notification_mode().await.map(Into::into),
         })
     }
 }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2362,7 +2362,11 @@ impl Room {
     }
 
     /// Get the notification mode
-    pub async fn notification_mode(&self) -> Option<RoomNotificationMode> {
+    ///
+    /// # Arguments
+    ///
+    /// * `user_defined_only` - Whether to get only the user-defined mode.
+    pub async fn notification_mode(&self, user_defined_only: bool) -> Option<RoomNotificationMode> {
         if !matches!(self.state(), RoomState::Joined) {
             return None;
         }
@@ -2371,7 +2375,7 @@ impl Room {
         // Get the user-defined mode if available
         let notification_mode =
             notification_settings.get_user_defined_room_notification_mode(self.room_id()).await;
-        if notification_mode.is_some() {
+        if user_defined_only || notification_mode.is_some() {
             notification_mode
         } else if let Ok(is_encrypted) = self.is_encrypted().await {
             // Otherwise, if encrypted status is available, get the default mode for this

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2362,11 +2362,7 @@ impl Room {
     }
 
     /// Get the notification mode
-    ///
-    /// # Arguments
-    ///
-    /// * `user_defined_only` - Whether to get only the user-defined mode.
-    pub async fn notification_mode(&self, user_defined_only: bool) -> Option<RoomNotificationMode> {
+    pub async fn notification_mode(&self) -> Option<RoomNotificationMode> {
         if !matches!(self.state(), RoomState::Joined) {
             return None;
         }
@@ -2375,7 +2371,7 @@ impl Room {
         // Get the user-defined mode if available
         let notification_mode =
             notification_settings.get_user_defined_room_notification_mode(self.room_id()).await;
-        if user_defined_only || notification_mode.is_some() {
+        if notification_mode.is_some() {
             notification_mode
         } else if let Ok(is_encrypted) = self.is_encrypted().await {
             // Otherwise, if encrypted status is available, get the default mode for this
@@ -2390,6 +2386,17 @@ impl Room {
         } else {
             None
         }
+    }
+
+    /// Get the user-defined notification mode
+    pub async fn user_defined_notification_mode(&self) -> Option<RoomNotificationMode> {
+        if !matches!(self.state(), RoomState::Joined) {
+            return None;
+        }
+        let notification_settings = self.client().notification_settings().await;
+
+        // Get the user-defined mode if available
+        notification_settings.get_user_defined_room_notification_mode(self.room_id()).await
     }
 }
 

--- a/crates/matrix-sdk/tests/integration/room/notification_mode.rs
+++ b/crates/matrix-sdk/tests/integration/room/notification_mode.rs
@@ -39,7 +39,7 @@ async fn get_notification_mode() {
     // Joined room with a user-defined rule
     let room = client.get_room(room_id).unwrap();
     assert_eq!(room.state(), RoomState::Joined);
-    let mode = room.notification_mode().await;
+    let mode = room.notification_mode(false).await;
     assert_matches!(mode, Some(RoomNotificationMode::AllMessages));
 
     // Joined room without user-defined rules
@@ -63,12 +63,15 @@ async fn get_notification_mode() {
 
     let room = client.get_room(room_no_rules_id).unwrap();
     assert_eq!(room.state(), RoomState::Joined);
-    let mode = room.notification_mode().await;
+    let mode = room.notification_mode(false).await;
     assert_matches!(mode, Some(RoomNotificationMode::MentionsAndKeywordsOnly));
+
+    let mode = room.notification_mode(true).await;
+    assert_matches!(mode, None);
 
     // Room not joined
     let room = client.get_room(room_not_joined_id).unwrap();
     assert_eq!(room.state(), RoomState::Invited);
-    let mode = room.notification_mode().await;
+    let mode = room.notification_mode(false).await;
     assert_eq!(mode, None);
 }

--- a/crates/matrix-sdk/tests/integration/room/notification_mode.rs
+++ b/crates/matrix-sdk/tests/integration/room/notification_mode.rs
@@ -39,7 +39,7 @@ async fn get_notification_mode() {
     // Joined room with a user-defined rule
     let room = client.get_room(room_id).unwrap();
     assert_eq!(room.state(), RoomState::Joined);
-    let mode = room.notification_mode(false).await;
+    let mode = room.notification_mode().await;
     assert_matches!(mode, Some(RoomNotificationMode::AllMessages));
 
     // Joined room without user-defined rules
@@ -61,17 +61,20 @@ async fn get_notification_mode() {
         .mount(&server)
         .await;
 
+    // With a room without specific notification rules
     let room = client.get_room(room_no_rules_id).unwrap();
     assert_eq!(room.state(), RoomState::Joined);
-    let mode = room.notification_mode(false).await;
+    // getting the mode should return the default one
+    let mode = room.notification_mode().await;
     assert_matches!(mode, Some(RoomNotificationMode::MentionsAndKeywordsOnly));
 
-    let mode = room.notification_mode(true).await;
+    // getting the user-defined mode must return None
+    let mode = room.user_defined_notification_mode().await;
     assert_matches!(mode, None);
 
     // Room not joined
     let room = client.get_room(room_not_joined_id).unwrap();
     assert_eq!(room.state(), RoomState::Invited);
-    let mode = room.notification_mode(false).await;
+    let mode = room.notification_mode().await;
     assert_eq!(mode, None);
 }


### PR DESCRIPTION
With this PR, the notification mode in `RoomInfo` now reflects the user-defined mode.