### PR TITLE
ui: Ignore flaky test

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2549,6 +2549,7 @@ async fn test_input_viewport() -> Result<(), Error> {
 }
 
 #[async_test]
+#[ignore] // flaky
 async fn test_sync_indicator() -> Result<(), Error> {
     let (_, server, room_list) = new_room_list_service().await?;
 


### PR DESCRIPTION
It's still compiled, but not run unless `--ignored` or `--include-ignored` is passed on the commandline.