### PR TITLE
ffi: Add `Client.remove_avatar` function

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -36,7 +36,7 @@ mime = "0.3.16"
 once_cell = { workspace = true }
 opentelemetry = { version = "0.20.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.13.0", features = ["tokio", "reqwest-client", "http-proto"] }
-ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488"] }
+ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar"] }
 sanitize-filename-reader-friendly = "2.2.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -468,6 +468,14 @@ impl Client {
         })
     }
 
+    pub fn remove_avatar(&self) -> Result<(), ClientError> {
+        let client = self.inner.clone();
+        RUNTIME.block_on(async move {
+            client.account().set_avatar_url(None).await?;
+            Ok(())
+        })
+    }
+
     pub fn avatar_url(&self) -> Result<Option<String>, ClientError> {
         let l = self.inner.clone();
         RUNTIME.block_on(async move {


### PR DESCRIPTION
When we modify the user's profile we can change the display name and the avatar, but there was no way to remove the current avatar without actually replacing it. These changes were needed:

- Added a `Client.remove_avatar` function to the FFI layer that calls `Client.account().set_avatar_url(None)`.
- Enabled [`compat-unset-avatar`](https://docs.ruma.io/ruma/api/client/profile/set_avatar_url/v3/struct.Request.html#structfield.avatar_url) feature to serialize this `None` to an empty string, otherwise we received an error saying the `avatar_url` parameter is missing from the request.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
