### PR TITLE
Add method to fetch account data and fetch the m.direct account data from the server when marking rooms as DMs

### DIFF
--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -809,11 +809,7 @@ impl Account {
     ///
     /// * `room_id` - The room id of the DM room.
     /// * `user_ids` - The user ids of the invitees for the DM room.
-    pub(crate) async fn mark_as_dm(
-        &self,
-        room_id: &RoomId,
-        user_ids: &[OwnedUserId],
-    ) -> Result<()> {
+    pub async fn mark_as_dm(&self, room_id: &RoomId, user_ids: &[OwnedUserId]) -> Result<()> {
         use ruma::events::direct::DirectEventContent;
 
         // Now we need to mark the room as a DM for ourselves, we fetch the

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -695,7 +695,7 @@ impl Account {
         get_raw_content(self.client.store().get_account_data_event(event_type).await?)
     }
 
-    /// Fetch an global account data event from the server.
+    /// Fetch a global account data event from the server.
     ///
     /// The content from the response will not be persisted in the store.
     ///


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
