### PR TITLE
feat(auth): make the session callbacks work for the matrix auth scheme too

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{
                 ClientMetadata, ClientMetadataVerificationError, VerifiedClientMetadata,
             },
         },
-        FullSession, OidcAccountManagementAction, RegisteredClientData, SessionTokens,
+        FullSession, OidcAccountManagementAction, RegisteredClientData,
     },
     ruma::{
         api::client::{
@@ -30,7 +30,7 @@ use matrix_sdk::{
         serde::Raw,
         EventEncryptionAlgorithm, TransactionId, UInt, UserId,
     },
-    AuthApi, AuthSession, Client as MatrixClient, SessionChange,
+    AuthApi, AuthSession, Client as MatrixClient, SessionChange, SessionTokens,
 };
 use matrix_sdk_ui::notification_client::NotificationProcessSetup as MatrixNotificationProcessSetup;
 use mime::Mime;
@@ -149,7 +149,6 @@ impl From<matrix_sdk::TransmissionProgress> for TransmissionProgress {
 pub struct Client {
     pub(crate) inner: MatrixClient,
     delegate: RwLock<Option<Arc<dyn ClientDelegate>>>,
-    session_delegate: Option<Arc<dyn ClientSessionDelegate>>,
     session_verification_controller:
         Arc<tokio::sync::RwLock<Option<SessionVerificationController>>>,
 }
@@ -160,12 +159,6 @@ impl Client {
         cross_process_refresh_lock_id: Option<String>,
         session_delegate: Option<Arc<dyn ClientSessionDelegate>>,
     ) -> Result<Arc<Self>, ClientError> {
-        if cross_process_refresh_lock_id.is_some() && session_delegate.is_none() {
-            return Err(ClientError::Generic {
-                msg: "can't have a cross-process refresh lock without session delegate".to_owned(),
-            });
-        }
-
         let session_verification_controller: Arc<
             tokio::sync::RwLock<Option<SessionVerificationController>>,
         > = Default::default();
@@ -182,7 +175,6 @@ impl Client {
         let client = Arc::new(Client {
             inner: sdk_client,
             delegate: RwLock::new(None),
-            session_delegate,
             session_verification_controller,
         });
 
@@ -202,36 +194,36 @@ impl Client {
         });
 
         if let Some(process_id) = cross_process_refresh_lock_id {
-            let session_delegate = client
-                .session_delegate
-                .clone()
-                .context("missing session delegates when enabling the cross-process lock")?;
-
+            if session_delegate.is_none() {
+                return Err(anyhow::anyhow!(
+                    "missing session delegates when enabling the cross-process lock"
+                ))?;
+            }
             RUNTIME.block_on(async {
-                let oidc = client.inner.oidc();
-
-                oidc.enable_cross_process_refresh_lock(process_id.clone()).await?;
-
-                oidc.set_callbacks(
-                    {
-                        let session_delegate = session_delegate.clone();
-                        Box::new(move |client| {
-                            let session_delegate = session_delegate.clone();
-                            let user_id = client.user_id().context("user isn't logged in")?;
-                            Self::retrieve_session(session_delegate, user_id)
-                        })
-                    },
-                    {
-                        let session_delegate = session_delegate.clone();
-                        Box::new(move |client| {
-                            let session_delegate = session_delegate.clone();
-                            Box::pin(
-                                async move { Self::save_session(session_delegate, client).await },
-                            )
-                        })
-                    },
-                )
+                client.inner.oidc().enable_cross_process_refresh_lock(process_id.clone()).await
             })?;
+        }
+
+        if let Some(session_delegate) = session_delegate {
+            client.inner.set_session_callbacks(
+                {
+                    let session_delegate = session_delegate.clone();
+                    Box::new(move |client| {
+                        let session_delegate = session_delegate.clone();
+                        let user_id = client.user_id().context("user isn't logged in")?;
+                        Ok(Self::retrieve_session(session_delegate, user_id)?)
+                    })
+                },
+                {
+                    let session_delegate = session_delegate.clone();
+                    Box::new(move |client| {
+                        let session_delegate = session_delegate.clone();
+                        Box::pin(
+                            async move { Ok(Self::save_session(session_delegate, client).await?) },
+                        )
+                    })
+                },
+            )?;
         }
 
         Ok(client)
@@ -761,7 +753,8 @@ impl Client {
         let session = session_delegate.retrieve_session_from_keychain(user_id.to_string())?;
         let auth_session = TryInto::<AuthSession>::try_into(session)?;
         match auth_session {
-            AuthSession::Oidc(session) => Ok(session.user.tokens),
+            AuthSession::Oidc(session) => Ok(SessionTokens::Oidc(session.user.tokens)),
+            AuthSession::Matrix(session) => Ok(SessionTokens::Matrix(session.tokens)),
             _ => anyhow::bail!("Unexpected session kind."),
         }
     }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -42,7 +42,6 @@ image-proc = ["dep:image"]
 image-rayon = ["image-proc", "image?/jpeg_rayon"]
 
 experimental-oidc = [
-    "anyhow",
     "ruma/unstable-msc2967",
     "dep:chrono",
     "dep:language-tags",

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -431,6 +431,8 @@ impl ClientBuilder {
             refresh_token_lock: Mutex::new(Ok(())),
             session_change_sender: broadcast::Sender::new(1),
             auth_data: OnceCell::default(),
+            reload_session_callback: OnceCell::default(),
+            save_session_callback: OnceCell::default(),
         });
 
         let inner = Arc::new(ClientInner::new(

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -257,6 +257,10 @@ pub enum Error {
     #[error("The internal client state is inconsistent.")]
     InconsistentState,
 
+    /// Session callbacks have been set multiple times.
+    #[error("session callbacks have been set multiple times")]
+    MultipleSessionCallbacks,
+
     /// An error occurred interacting with the OpenID Connect API.
     #[cfg(feature = "experimental-oidc")]
     #[error(transparent)]

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -53,7 +53,7 @@ pub mod sync;
 pub mod widget;
 
 pub use account::Account;
-pub use authentication::{AuthApi, AuthSession};
+pub use authentication::{AuthApi, AuthSession, SessionTokens};
 pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, SessionChange};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -473,6 +473,12 @@ impl MatrixAuth {
 
                     self.set_session_tokens(session_tokens);
 
+                    if let Some(save_session_callback) =
+                        self.client.inner.auth_ctx.save_session_callback.get()
+                    {
+                        save_session_callback(self.client.clone());
+                    }
+
                     _ = self
                         .client
                         .inner

--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -229,6 +229,11 @@ pub enum CrossProcessRefreshLockError {
     #[error("reload session callback must be set with Oidc::set_callbacks() for the cross-process lock to work")]
     MissingReloadSession,
 
+    /// Session tokens returned by the reload_session callback were not for
+    /// OIDC.
+    #[error("session tokens returned by the reload_session callback were not for OIDC")]
+    InvalidSessionTokens,
+
     /// The store has been created twice.
     #[error(
         "the cross-process lock has been set up twice with `enable_cross_process_refresh_lock`"
@@ -292,11 +297,11 @@ mod tests {
 
         client.oidc().enable_cross_process_refresh_lock("test".to_owned()).await?;
 
-        client.oidc().set_callbacks(
+        client.set_session_callbacks(
             Box::new({
                 // This is only called because of extra checks in the code.
                 let tokens = tokens.clone();
-                move |_| Ok(tokens.clone())
+                move |_| Ok(crate::authentication::SessionTokens::Oidc(tokens.clone()))
             }),
             Box::new(|_| panic!("save_session_callback shouldn't be called here")),
         )?;


### PR DESCRIPTION
This should make it possible to use either the session change subscriber *or* the new synchronous callbacks for session changes, in both authentication schemes (Matrix Auth and OIDC). Also gets rid of the dependency to `anyhow` in OIDC, by using a wrapped dyn error type, as @jplatte suggested in the live review of the large OIDC PR.