### PR TITLE
feat(ui): Use a dynamic limit over the `RoomList` entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,7 +1708,8 @@ dependencies = [
 [[package]]
 name = "eyeball"
 version = "0.8.6"
-source = "git+https://github.com/jplatte/eyeball?rev=9a87e72e8966b0121ca98b99c4a93133981bb8f4#9a87e72e8966b0121ca98b99c4a93133981bb8f4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a7b57c052e83f2bd8d756fc379132e43d3786f3767856026ee3757868f099f"
 dependencies = [
  "futures-core",
  "readlock",
@@ -1716,8 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im"
-version = "0.3.2"
-source = "git+https://github.com/jplatte/eyeball?rev=9a87e72e8966b0121ca98b99c4a93133981bb8f4#9a87e72e8966b0121ca98b99c4a93133981bb8f4"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5dfb21fe3514fee78a439aa917c6709150dfb5109b0d6731ef2823ed389a7dc"
 dependencies = [
  "futures-core",
  "imbl",
@@ -1728,8 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im-util"
-version = "0.3.1"
-source = "git+https://github.com/jplatte/eyeball?rev=9a87e72e8966b0121ca98b99c4a93133981bb8f4#9a87e72e8966b0121ca98b99c4a93133981bb8f4"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149c2a5da8624f3e489bcf4d0612fd659cb6cfcf4cf6aa65e1f6fc2046ee9ef2"
 dependencies = [
  "eyeball-im",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,8 +1708,7 @@ dependencies = [
 [[package]]
 name = "eyeball"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a7b57c052e83f2bd8d756fc379132e43d3786f3767856026ee3757868f099f"
+source = "git+https://github.com/jplatte/eyeball?rev=9a87e72e8966b0121ca98b99c4a93133981bb8f4#9a87e72e8966b0121ca98b99c4a93133981bb8f4"
 dependencies = [
  "futures-core",
  "readlock",
@@ -1718,8 +1717,7 @@ dependencies = [
 [[package]]
 name = "eyeball-im"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6d39e66bac9395db14e7a311c6b18477f52719ed92c07a223a7d4f2f1fa6d3"
+source = "git+https://github.com/jplatte/eyeball?rev=9a87e72e8966b0121ca98b99c4a93133981bb8f4#9a87e72e8966b0121ca98b99c4a93133981bb8f4"
 dependencies = [
  "futures-core",
  "imbl",
@@ -1731,8 +1729,7 @@ dependencies = [
 [[package]]
 name = "eyeball-im-util"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330f68ac41a164e7ad6c6ef6d3ca04790564c588a61e4480aef7ff715446baa9"
+source = "git+https://github.com/jplatte/eyeball?rev=9a87e72e8966b0121ca98b99c4a93133981bb8f4#9a87e72e8966b0121ca98b99c4a93133981bb8f4"
 dependencies = [
  "eyeball-im",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,9 @@ base64 = "0.21.0"
 byteorder = "1.4.3"
 ctor = "0.2.0"
 dashmap = "5.2.0"
-# eyeball = "0.8.3"
-# eyeball-im = { version = "0.3.2", features = ["tracing"] }
-# eyeball-im-util = "0.3.1"
-eyeball = { git = "https://github.com/jplatte/eyeball", rev = "9a87e72e8966b0121ca98b99c4a93133981bb8f4" }
-eyeball-im = { git = "https://github.com/jplatte/eyeball", rev = "9a87e72e8966b0121ca98b99c4a93133981bb8f4", features = ["tracing"] }
-eyeball-im-util = { git = "https://github.com/jplatte/eyeball", rev = "9a87e72e8966b0121ca98b99c4a93133981bb8f4" }
+eyeball = "0.8.6"
+eyeball-im = { version = "0.4.0", features = ["tracing"] }
+eyeball-im-util = "0.4.0"
 futures-core = "0.3.28"
 futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,12 @@ base64 = "0.21.0"
 byteorder = "1.4.3"
 ctor = "0.2.0"
 dashmap = "5.2.0"
-eyeball = "0.8.3"
-eyeball-im = { version = "0.3.2", features = ["tracing"] }
-eyeball-im-util = "0.3.1"
+# eyeball = "0.8.3"
+# eyeball-im = { version = "0.3.2", features = ["tracing"] }
+# eyeball-im-util = "0.3.1"
+eyeball = { git = "https://github.com/jplatte/eyeball", rev = "9a87e72e8966b0121ca98b99c4a93133981bb8f4" }
+eyeball-im = { git = "https://github.com/jplatte/eyeball", rev = "9a87e72e8966b0121ca98b99c4a93133981bb8f4", features = ["tracing"] }
+eyeball-im-util = { git = "https://github.com/jplatte/eyeball", rev = "9a87e72e8966b0121ca98b99c4a93133981bb8f4" }
 futures-core = "0.3.28"
 futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -173,15 +173,17 @@ impl RoomList {
         }
     }
 
-    fn entries_with_dynamic_filter(
+    fn entries_with_dynamic_adapters(
         &self,
+        page_size: u32,
         listener: Box<dyn RoomListEntriesListener>,
-    ) -> RoomListEntriesWithDynamicFilterResult {
-        let (entries_stream, dynamic_filter) = self.inner.entries_with_dynamic_filter();
+    ) -> RoomListEntriesWithDynamicAdaptersResult {
+        let (entries_stream, dynamic_entries_controller) =
+            self.inner.entries_with_dynamic_adapters(page_size.try_into().unwrap());
 
-        RoomListEntriesWithDynamicFilterResult {
-            dynamic_filter: Arc::new(RoomListEntriesDynamicFilter::new(
-                dynamic_filter,
+        RoomListEntriesWithDynamicAdaptersResult {
+            controller: Arc::new(RoomListDynamicEntriesController::new(
+                dynamic_entries_controller,
                 self.room_list_service.inner.client(),
             )),
             entries_stream: Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
@@ -206,8 +208,8 @@ pub struct RoomListEntriesResult {
 }
 
 #[derive(uniffi::Record)]
-pub struct RoomListEntriesWithDynamicFilterResult {
-    pub dynamic_filter: Arc<RoomListEntriesDynamicFilter>,
+pub struct RoomListEntriesWithDynamicAdaptersResult {
+    pub controller: Arc<RoomListDynamicEntriesController>,
     pub entries_stream: Arc<TaskHandle>,
 }
 
@@ -304,6 +306,7 @@ pub enum RoomListEntriesUpdate {
     Insert { index: u32, value: RoomListEntry },
     Set { index: u32, value: RoomListEntry },
     Remove { index: u32 },
+    Truncate { length: u32 },
     Reset { values: Vec<RoomListEntry> },
 }
 
@@ -325,6 +328,9 @@ impl From<VectorDiff<matrix_sdk::RoomListEntry>> for RoomListEntriesUpdate {
                 Self::Set { index: u32::try_from(index).unwrap(), value: value.into() }
             }
             VectorDiff::Remove { index } => Self::Remove { index: u32::try_from(index).unwrap() },
+            VectorDiff::Truncate { length } => {
+                Self::Truncate { length: u32::try_from(length).unwrap() }
+            }
             VectorDiff::Reset { values } => {
                 Self::Reset { values: values.into_iter().map(Into::into).collect() }
             }
@@ -338,34 +344,42 @@ pub trait RoomListEntriesListener: Send + Sync + Debug {
 }
 
 #[derive(uniffi::Object)]
-pub struct RoomListEntriesDynamicFilter {
-    inner: matrix_sdk_ui::room_list_service::DynamicRoomListFilter,
+pub struct RoomListDynamicEntriesController {
+    inner: matrix_sdk_ui::room_list_service::RoomListDynamicEntriesController,
     client: matrix_sdk::Client,
 }
 
-impl RoomListEntriesDynamicFilter {
+impl RoomListDynamicEntriesController {
     fn new(
-        dynamic_filter: matrix_sdk_ui::room_list_service::DynamicRoomListFilter,
+        dynamic_entries_controller: matrix_sdk_ui::room_list_service::RoomListDynamicEntriesController,
         client: &matrix_sdk::Client,
     ) -> Self {
-        Self { inner: dynamic_filter, client: client.clone() }
+        Self { inner: dynamic_entries_controller, client: client.clone() }
     }
 }
 
 #[uniffi::export]
-impl RoomListEntriesDynamicFilter {
-    fn set(&self, kind: RoomListEntriesDynamicFilterKind) -> bool {
+impl RoomListDynamicEntriesController {
+    fn set_filter(&self, kind: RoomListEntriesDynamicFilterKind) -> bool {
         use RoomListEntriesDynamicFilterKind as Kind;
 
         match kind {
-            Kind::All => self.inner.set(new_filter_all()),
+            Kind::All => self.inner.set_filter(new_filter_all()),
             Kind::NormalizedMatchRoomName { pattern } => {
-                self.inner.set(new_filter_normalized_match_room_name(&self.client, &pattern))
+                self.inner.set_filter(new_filter_normalized_match_room_name(&self.client, &pattern))
             }
             Kind::FuzzyMatchRoomName { pattern } => {
-                self.inner.set(new_filter_fuzzy_match_room_name(&self.client, &pattern))
+                self.inner.set_filter(new_filter_fuzzy_match_room_name(&self.client, &pattern))
             }
         }
+    }
+
+    fn add_one_page(&self) {
+        self.inner.add_one_page();
+    }
+
+    fn reset_to_one_page(&self) {
+        self.inner.reset_to_one_page();
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -83,6 +83,7 @@ pub enum TimelineDiff {
     Insert { index: usize, value: Arc<TimelineItem> },
     Set { index: usize, value: Arc<TimelineItem> },
     Remove { index: usize },
+    Truncate { length: usize },
     Reset { values: Vec<Arc<TimelineItem>> },
 }
 
@@ -99,6 +100,7 @@ impl TimelineDiff {
             VectorDiff::Set { index, value } => {
                 Self::Set { index, value: TimelineItem::from_arc(value) }
             }
+            VectorDiff::Truncate { length } => Self::Truncate { length },
             VectorDiff::Remove { index } => Self::Remove { index },
             VectorDiff::PushBack { value } => {
                 Self::PushBack { value: TimelineItem::from_arc(value) }
@@ -129,6 +131,7 @@ impl TimelineDiff {
             Self::PopBack => TimelineChange::PopBack,
             Self::PopFront => TimelineChange::PopFront,
             Self::Clear => TimelineChange::Clear,
+            Self::Truncate { .. } => TimelineChange::Truncate,
             Self::Reset { .. } => TimelineChange::Reset,
         }
     }
@@ -195,6 +198,7 @@ pub enum TimelineChange {
     PushFront,
     PopBack,
     PopFront,
+    Truncate,
     Reset,
 }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -115,7 +115,7 @@ impl RoomList {
     /// The returned stream will only start yielding diffs once a filter is set
     /// through the returned [`RoomListDynamicEntriesController`]. For every
     /// call to [`RoomListDynamicEntriesController::set_filter`], the stream
-    /// will yield a [`VectorDiff::Truncate`] followed by any updates of the
+    /// will yield a [`VectorDiff::Clear`] followed by any updates of the
     /// room list under that filter (until the next reset).
     pub fn entries_with_dynamic_adapters(
         &self,
@@ -144,8 +144,8 @@ impl RoomList {
 
                 dynamic_limit.set(page_size);
 
-                // Reset the stream by truncating it.
-                yield stream::once(ready(vec![VectorDiff::Truncate { length: 0 }]))
+                // Clearing the stream.
+                yield stream::once(ready(vec![VectorDiff::Clear]))
                     .chain(stream);
             }
         }

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -12,13 +12,14 @@
 // See the License for that specific language governing permissions and
 // limitations under the License.
 
-use std::{future::ready, sync::Arc};
+use std::{cell::RefCell, future::ready, sync::Arc};
 
 use async_cell::sync::AsyncCell;
 use async_rx::StreamExt as _;
 use async_stream::stream;
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
+use eyeball_im_util::vector::DynamicLimit;
 use futures_util::{pin_mut, stream, Stream, StreamExt as _};
 use matrix_sdk::{
     executor::{spawn, JoinHandle},
@@ -105,45 +106,49 @@ impl RoomList {
     }
 
     /// Similar to [`Self::entries`] except that it's possible to provide a
-    /// filter that will filter out room list entries.
-    pub fn entries_with_static_filter<F>(
-        &self,
-        filter: F,
-    ) -> (Vector<RoomListEntry>, impl Stream<Item = Vec<VectorDiff<RoomListEntry>>>)
-    where
-        F: Fn(&RoomListEntry) -> bool,
-    {
-        self.sliding_sync_list.room_list_filtered_stream(filter)
-    }
-
-    /// Similar to [`Self::entries_with_static_filter`] except that it's
-    /// possible to change the filter dynamically.
+    /// filter that will filter out room list entries, and that it's also
+    /// possible to “paginate” over the entries by `page_size`.
     ///
     /// The returned stream will only start yielding diffs once a filter is set
-    /// through the returned `DynamicRoomListFilter`. For every call to
-    /// [`DynamicRoomListFilter::set`], the stream will yield a
+    /// through the returned `DynamicRoomListController`. For every call to
+    /// [`DynamicRoomListController::set`], the stream will yield a
     /// [`VectorDiff::Reset`] followed by any updates of the room list under
     /// that filter (until the next reset).
-    pub fn entries_with_dynamic_filter(
+    pub fn entries_with_dynamic_adapters(
         &self,
-    ) -> (impl Stream<Item = Vec<VectorDiff<RoomListEntry>>>, DynamicRoomListFilter) {
-        let filter_fn_cell = AsyncCell::shared();
-        let dynamic_filter = DynamicRoomListFilter::new(filter_fn_cell.clone());
-
+        page_size: usize,
+    ) -> (impl Stream<Item = Vec<VectorDiff<RoomListEntry>>>, RoomListDynamicEntriesController)
+    {
         let list = self.sliding_sync_list.clone();
+
+        let filter_fn_cell = AsyncCell::shared();
+
+        let dynamic_limit = SharedObservable::<usize>::new(0);
+        let dynamic_limit_stream = dynamic_limit.subscribe();
+
+        let dynamic_entries_controller = RoomListDynamicEntriesController::new(
+            filter_fn_cell.clone(),
+            page_size,
+            dynamic_limit.clone(),
+            list.maximum_number_of_rooms_stream(),
+        );
+
         let stream = stream! {
             loop {
                 let filter_fn = filter_fn_cell.take().await;
                 let (items, stream) = list.room_list_filtered_stream(filter_fn);
+                let stream = DynamicLimit::new(items, stream, dynamic_limit_stream.clone());
 
-                // Reset the stream with all its items.
-                yield stream::once(ready(vec![VectorDiff::Reset { values: items }]))
+                dynamic_limit.set(page_size);
+
+                // Reset the stream by truncating it.
+                yield stream::once(ready(vec![VectorDiff::Truncate { length: 0 }]))
                     .chain(stream);
             }
         }
         .switch();
 
-        (stream, dynamic_filter)
+        (stream, dynamic_entries_controller)
     }
 }
 
@@ -190,31 +195,70 @@ pub enum RoomListLoadingState {
 
 type BoxedFilterFn = Box<dyn Fn(&RoomListEntry) -> bool + Send + Sync>;
 
-/// Dynamic filter for the [`RoomList`] entries.
+/// Controller for the [`RoomList`] dynamic entries.
 ///
-/// To get one value of this type, use [`RoomList::entries_with_dynamic_filter`]
-pub struct DynamicRoomListFilter {
-    inner: Arc<AsyncCell<BoxedFilterFn>>,
+/// To get one value of this type, use
+/// [`RoomList::entries_with_dynamic_adapters`]
+pub struct RoomListDynamicEntriesController {
+    filter: Arc<AsyncCell<BoxedFilterFn>>,
+    page_size: usize,
+    limit: SharedObservable<usize>,
+    maximum_number_of_rooms: RefCell<Subscriber<Option<u32>>>,
 }
 
-impl DynamicRoomListFilter {
-    fn new(inner: Arc<AsyncCell<BoxedFilterFn>>) -> Self {
-        Self { inner }
+impl RoomListDynamicEntriesController {
+    fn new(
+        filter: Arc<AsyncCell<BoxedFilterFn>>,
+        page_size: usize,
+        limit_stream: SharedObservable<usize>,
+        maximum_number_of_rooms: Subscriber<Option<u32>>,
+    ) -> Self {
+        Self {
+            filter,
+            page_size,
+            limit: limit_stream,
+            maximum_number_of_rooms: RefCell::new(maximum_number_of_rooms),
+        }
     }
 
     /// Set the filter.
     ///
     /// If the associated stream has been dropped, returns `false` to indicate
     /// the operation didn't have an effect.
-    pub fn set(&self, filter: impl Fn(&RoomListEntry) -> bool + Send + Sync + 'static) -> bool {
-        if Arc::strong_count(&self.inner) == 1 {
+    pub fn set_filter(
+        &self,
+        filter: impl Fn(&RoomListEntry) -> bool + Send + Sync + 'static,
+    ) -> bool {
+        if Arc::strong_count(&self.filter) == 1 {
             // there is no other reference to the boxed filter fn, setting it
             // would be pointless (no new references can be created from self,
             // either)
             false
         } else {
-            self.inner.set(Box::new(filter));
+            self.filter.set(Box::new(filter));
             true
         }
+    }
+
+    /// Add one page.
+    pub fn add_one_page(&self) {
+        if let Some(max) = self.maximum_number_of_rooms.borrow_mut().next_now() {
+            let max: usize = max.try_into().unwrap();
+            let limit = self.limit.get();
+
+            if limit < max {
+                // With this logic, it is possible that `limit` becomes greater than `max` if
+                // `max - limit < page_size`, and that's perfectly fine. It's OK to have a
+                // `limit` greater than `max`, but it's not OK to increase the limit
+                // indefinitely.
+                self.limit.set(limit + self.page_size);
+            }
+        }
+    }
+
+    /// Reset the one page, i.e. forget all pages and move back to the first
+    /// page.
+    pub fn reset_to_one_page(&self) {
+        self.limit.set(self.page_size);
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -12,7 +12,10 @@
 // See the License for that specific language governing permissions and
 // limitations under the License.
 
-use std::{cell::RefCell, future::ready, sync::Arc};
+use std::{
+    future::ready,
+    sync::{Arc, Mutex},
+};
 
 use async_cell::sync::AsyncCell;
 use async_rx::StreamExt as _;
@@ -203,7 +206,7 @@ pub struct RoomListDynamicEntriesController {
     filter: Arc<AsyncCell<BoxedFilterFn>>,
     page_size: usize,
     limit: SharedObservable<usize>,
-    maximum_number_of_rooms: RefCell<Subscriber<Option<u32>>>,
+    maximum_number_of_rooms: Mutex<Subscriber<Option<u32>>>,
 }
 
 impl RoomListDynamicEntriesController {
@@ -217,7 +220,7 @@ impl RoomListDynamicEntriesController {
             filter,
             page_size,
             limit: limit_stream,
-            maximum_number_of_rooms: RefCell::new(maximum_number_of_rooms),
+            maximum_number_of_rooms: Mutex::new(maximum_number_of_rooms),
         }
     }
 
@@ -243,7 +246,7 @@ impl RoomListDynamicEntriesController {
     /// Add one page, i.e. view `page_size` more entries in the room list if
     /// any.
     pub fn add_one_page(&self) {
-        if let Some(max) = self.maximum_number_of_rooms.borrow_mut().next_now() {
+        if let Some(max) = self.maximum_number_of_rooms.lock().unwrap().next_now() {
             let max: usize = max.try_into().unwrap();
             let limit = self.limit.get();
 

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -22,7 +22,7 @@ use async_rx::StreamExt as _;
 use async_stream::stream;
 use eyeball::{SharedObservable, Subscriber};
 use eyeball_im::{Vector, VectorDiff};
-use eyeball_im_util::vector::DynamicLimit;
+use eyeball_im_util::vector::Limit;
 use futures_util::{pin_mut, stream, Stream, StreamExt as _};
 use matrix_sdk::{
     executor::{spawn, JoinHandle},
@@ -140,11 +140,11 @@ impl RoomList {
             loop {
                 let filter_fn = filter_fn_cell.take().await;
                 let (items, stream) = list.room_list_filtered_stream(filter_fn);
-                let stream = DynamicLimit::new(items, stream, dynamic_limit_stream.clone());
+                let stream = Limit::dynamic(items, stream, dynamic_limit_stream.clone());
 
                 dynamic_limit.set(page_size);
 
-                // Clearing the stream.
+                // Clearing the stream before chaining with the real stream.
                 yield stream::once(ready(vec![VectorDiff::Clear]))
                     .chain(stream);
             }

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -110,10 +110,10 @@ impl RoomList {
     /// possible to “paginate” over the entries by `page_size`.
     ///
     /// The returned stream will only start yielding diffs once a filter is set
-    /// through the returned `DynamicRoomListController`. For every call to
-    /// [`DynamicRoomListController::set`], the stream will yield a
-    /// [`VectorDiff::Reset`] followed by any updates of the room list under
-    /// that filter (until the next reset).
+    /// through the returned [`RoomListDynamicEntriesController`]. For every
+    /// call to [`RoomListDynamicEntriesController::set_filter`], the stream
+    /// will yield a [`VectorDiff::Truncate`] followed by any updates of the
+    /// room list under that filter (until the next reset).
     pub fn entries_with_dynamic_adapters(
         &self,
         page_size: usize,
@@ -240,7 +240,8 @@ impl RoomListDynamicEntriesController {
         }
     }
 
-    /// Add one page.
+    /// Add one page, i.e. view `page_size` more entries in the room list if
+    /// any.
     pub fn add_one_page(&self) {
         if let Some(max) = self.maximum_number_of_rooms.borrow_mut().next_now() {
             let max: usize = max.try_into().unwrap();

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -246,17 +246,19 @@ impl RoomListDynamicEntriesController {
     /// Add one page, i.e. view `page_size` more entries in the room list if
     /// any.
     pub fn add_one_page(&self) {
-        if let Some(max) = self.maximum_number_of_rooms.lock().unwrap().next_now() {
-            let max: usize = max.try_into().unwrap();
-            let limit = self.limit.get();
+        let Some(max) = self.maximum_number_of_rooms.lock().unwrap().next_now() else {
+            return;
+        };
 
-            if limit < max {
-                // With this logic, it is possible that `limit` becomes greater than `max` if
-                // `max - limit < page_size`, and that's perfectly fine. It's OK to have a
-                // `limit` greater than `max`, but it's not OK to increase the limit
-                // indefinitely.
-                self.limit.set(limit + self.page_size);
-            }
+        let max: usize = max.try_into().unwrap();
+        let limit = self.limit.get();
+
+        if limit < max {
+            // With this logic, it is possible that `limit` becomes greater than `max` if
+            // `max - limit < page_size`, and that's perfectly fine. It's OK to have a
+            // `limit` greater than `max`, but it's not OK to increase the limit
+            // indefinitely.
+            self.limit.set(limit + self.page_size);
         }
     }
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -190,6 +190,22 @@ macro_rules! assert_entries_batch {
         )
     };
 
+    // `clear`
+    ( @_ [ $entries:ident ] [ clear ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_entries_batch!(
+            @_
+            [ $entries ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                assert_eq!(
+                    $entries.next(),
+                    Some(&VectorDiff::Clear),
+                );
+            ]
+        )
+    };
+
     // `truncate [$length]`
     ( @_ [ $entries:ident ] [ truncate [ $length:literal ] ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
         assert_entries_batch!(
@@ -1594,8 +1610,8 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
     // Assert the dynamic entries.
     assert_entries_batch! {
         [dynamic_entries_stream]
-        // Receive a `truncate` because the filter has been reset/set for the first time.
-        truncate [0];
+        // Receive a `clear` because the filter has been reset/set for the first time.
+        clear;
         end;
     };
     assert_entries_batch! {
@@ -1756,8 +1772,8 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
     // Assert the dynamic entries.
     assert_entries_batch! {
         [dynamic_entries_stream]
-        // Receive a `truncate` again because the filter has been reset.
-        truncate [0];
+        // Receive a `clear` again because the filter has been reset.
+        clear;
         end;
     }
     assert_entries_batch! {
@@ -1774,8 +1790,8 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
     // Assert the dynamic entries.
     assert_entries_batch! {
         [dynamic_entries_stream]
-        // Receive a `truncate` again because the filter has been reset.
-        truncate [0];
+        // Receive a `clear` again because the filter has been reset.
+        clear;
         end;
     }
     assert_entries_batch! {

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -119,10 +119,10 @@ macro_rules! entries {
     };
 }
 
-macro_rules! assert_entries_stream {
+macro_rules! assert_entries_batch {
     // `append [$entries]`
     ( @_ [ $entries:ident ] [ append [ $( $entry:tt )+ ] ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
-        assert_entries_stream!(
+        assert_entries_batch!(
             @_
             [ $entries ]
             [ $( $rest )* ]
@@ -140,7 +140,7 @@ macro_rules! assert_entries_stream {
 
     // `set [$nth] [$entry]`
     ( @_ [ $entries:ident ] [ set [ $index:literal ] [ $( $entry:tt )+ ] ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
-        assert_entries_stream!(
+        assert_entries_batch!(
             @_
             [ $entries ]
             [ $( $rest )* ]
@@ -158,7 +158,7 @@ macro_rules! assert_entries_stream {
 
     // `remove [$nth]`
     ( @_ [ $entries:ident ] [ remove [ $index:literal ] ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
-        assert_entries_stream!(
+        assert_entries_batch!(
             @_
             [ $entries ]
             [ $( $rest )* ]
@@ -174,7 +174,7 @@ macro_rules! assert_entries_stream {
 
     // `insert [$nth] [$entry]`
     ( @_ [ $entries:ident ] [ insert [ $index:literal ] [ $( $entry:tt )+ ] ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
-        assert_entries_stream!(
+        assert_entries_batch!(
             @_
             [ $entries ]
             [ $( $rest )* ]
@@ -190,9 +190,25 @@ macro_rules! assert_entries_stream {
         )
     };
 
+    // `truncate [$length]`
+    ( @_ [ $entries:ident ] [ truncate [ $length:literal ] ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_entries_batch!(
+            @_
+            [ $entries ]
+            [ $( $rest )* ]
+            [
+                $( $accumulator )*
+                assert_eq!(
+                    $entries.next(),
+                    Some(&VectorDiff::Truncate { length: $length }),
+                );
+            ]
+        )
+    };
+
     // `reset [$entries]`
     ( @_ [ $entries:ident ] [ reset [ $( $entry:tt )+ ] ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
-        assert_entries_stream!(
+        assert_entries_batch!(
             @_
             [ $entries ]
             [ $( $rest )* ]
@@ -208,9 +224,9 @@ macro_rules! assert_entries_stream {
         )
     };
 
-    // `pending`
-    ( @_ [ $entries:ident ] [ pending ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
-        assert_entries_stream!(
+    // `end`
+    ( @_ [ $entries:ident ] [ end ; $( $rest:tt )* ] [ $( $accumulator:tt )* ] ) => {
+        assert_entries_batch!(
             @_
             [ $entries ]
             [ $( $rest )* ]
@@ -237,7 +253,7 @@ macro_rules! assert_entries_stream {
 
         let mut entries = entries.iter();
 
-        assert_entries_stream!( @_ [ entries ] [ $( $all )* ] [] )
+        assert_entries_batch!( @_ [ entries ] [ $( $all )* ] [] )
     };
 }
 
@@ -1446,13 +1462,13 @@ async fn test_entries_stream() -> Result<(), Error> {
     };
 
     assert!(previous_entries.is_empty());
-    assert_entries_stream! {
+    assert_entries_batch! {
         [entries_stream]
         append [ E, E, E, E, E, E, E, E, E, E ];
         set[0] [ F("!r0:bar.org") ];
         set[1] [ F("!r1:bar.org") ];
         set[2] [ F("!r2:bar.org") ];
-        pending;
+        end;
     };
 
     sync_then_assert_request_and_fake_response! {
@@ -1509,19 +1525,19 @@ async fn test_entries_stream() -> Result<(), Error> {
         },
     };
 
-    assert_entries_stream! {
+    assert_entries_batch! {
         [entries_stream]
         remove[1];
         remove[0];
         insert[0] [ F("!r3:bar.org") ];
-        pending;
+        end;
     };
 
     Ok(())
 }
 
 #[async_test]
-async fn test_entries_stream_with_filters() -> Result<(), Error> {
+async fn test_dynamic_entries_stream() -> Result<(), Error> {
     let (client, server, room_list) = new_room_list_service().await?;
 
     let sync = room_list.sync();
@@ -1529,8 +1545,8 @@ async fn test_entries_stream_with_filters() -> Result<(), Error> {
 
     let all_rooms = room_list.all_rooms().await?;
 
-    let (previous_entries, entries_stream) = all_rooms.entries();
-    pin_mut!(entries_stream);
+    let (dynamic_entries_stream, dynamic_entries) = all_rooms.entries_with_dynamic_adapters(5);
+    pin_mut!(dynamic_entries_stream);
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -1568,40 +1584,27 @@ async fn test_entries_stream_with_filters() -> Result<(), Error> {
         },
     };
 
-    assert!(previous_entries.is_empty());
-    assert_entries_stream! {
-        [entries_stream]
-        append [ E, E, E, E, E, E, E, E, E, E ];
-        set[0] [ F("!r0:bar.org") ];
-        pending;
-    };
-
-    // 1. Test with a static filter.
-    let (previous_entries_static_filter, entries_stream_static_filter) =
-        all_rooms.entries_with_static_filter(new_filter_fuzzy_match_room_name(&client, "mat ba"));
-    pin_mut!(entries_stream_static_filter);
-
-    // 2. Test with a dynamic filter.
-    let (entries_stream_dynamic_filter, dynamic_filter) = all_rooms.entries_with_dynamic_filter();
-    pin_mut!(entries_stream_dynamic_filter);
-
-    // Assert the static filter.
-    assert_eq!(previous_entries_static_filter, entries![F("!r0:bar.org")]);
-
-    // Ensure the dynamic filter stream is pending because there is no filter set
+    // Ensure the dynamic entries' stream is pending because there is no filter set
     // yet.
-    assert_pending!(entries_stream_dynamic_filter);
+    assert_pending!(dynamic_entries_stream);
 
     // Now, let's define a filter.
-    dynamic_filter.set(new_filter_fuzzy_match_room_name(&client, "mat ba"));
+    dynamic_entries.set_filter(new_filter_fuzzy_match_room_name(&client, "mat ba"));
 
-    // Assert the dynamic filter.
-    assert_entries_stream! {
-        [entries_stream_dynamic_filter]
-        // Receive a `reset` because the filter has been reset/set for the first time.
-        reset [ F("!r0:bar.org") ];
-        pending;
+    // Assert the dynamic entries.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive a `truncate` because the filter has been reset/set for the first time.
+        truncate [0];
+        end;
     };
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive the initial values.
+        append [ F("!r0:bar.org") ];
+        end;
+    };
+    assert_pending!(dynamic_entries_stream);
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -1669,21 +1672,14 @@ async fn test_entries_stream_with_filters() -> Result<(), Error> {
         },
     };
 
-    // Assert the static filter.
-    assert_entries_stream! {
-        [entries_stream_static_filter]
+    // Assert the dynamic entries.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
         insert[1] [ F("!r1:bar.org") ];
         insert[2] [ F("!r4:bar.org") ];
-        pending;
+        end;
     };
-
-    // Assert the dynamic filter.
-    assert_entries_stream! {
-        [entries_stream_dynamic_filter]
-        insert[1] [ F("!r1:bar.org") ];
-        insert[2] [ F("!r4:bar.org") ];
-        pending;
-    };
+    assert_pending!(dynamic_entries_stream);
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -1745,52 +1741,73 @@ async fn test_entries_stream_with_filters() -> Result<(), Error> {
         },
     };
 
-    // Assert the static filter.
-    assert_entries_stream! {
-        [entries_stream_static_filter]
+    // Assert the dynamic entries.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
         insert[3] [ F("!r5:bar.org") ];
         insert[4] [ F("!r7:bar.org") ];
-        pending;
+        end;
     };
+    assert_pending!(dynamic_entries_stream);
 
-    // Assert the dynamic filter.
-    assert_entries_stream! {
-        [entries_stream_dynamic_filter]
-        insert[3] [ F("!r5:bar.org") ];
-        insert[4] [ F("!r7:bar.org") ];
-        pending;
+    // Now, let's change the dynamic entries!
+    dynamic_entries.set_filter(new_filter_fuzzy_match_room_name(&client, "hell"));
+
+    // Assert the dynamic entries.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive a `truncate` again because the filter has been reset.
+        truncate [0];
+        end;
+    }
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive the new initial values.
+        append [ F("!r2:bar.org"), F("!r3:bar.org"), F("!r6:bar.org") ];
+        end;
     };
-
-    // Now, let's change the dynamic filter!
-    dynamic_filter.set(new_filter_fuzzy_match_room_name(&client, "hell"));
-
-    // Assert the dynamic filter.
-    assert_entries_stream! {
-        [entries_stream_dynamic_filter]
-        // Receive a `reset` again because the filter has been reset.
-        reset [ F("!r2:bar.org"), F("!r3:bar.org"), F("!r6:bar.org") ];
-        pending;
-    };
+    assert_pending!(dynamic_entries_stream);
 
     // Now, let's change again the dynamic filter!
-    dynamic_filter.set(new_filter_all());
+    dynamic_entries.set_filter(new_filter_all());
 
-    // Assert the dynamic filter.
-    assert_entries_stream! {
-        [entries_stream_dynamic_filter]
-        // Receive a `reset` again because the filter has been reset.
-        reset [
+    // Assert the dynamic entries.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive a `truncate` again because the filter has been reset.
+        truncate [0];
+        end;
+    }
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive the new initial values.
+        append [
             F("!r0:bar.org"),
             F("!r1:bar.org"),
             F("!r2:bar.org"),
             F("!r3:bar.org"),
             F("!r4:bar.org"),
+            // Stop! The page is full :-).
+        ];
+        end;
+    };
+    assert_pending!(dynamic_entries_stream);
+
+    // Let's ask one more page.
+    dynamic_entries.add_one_page();
+
+    // Assert the dynamic entries.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive the next values.
+        append [
             F("!r5:bar.org"),
             F("!r6:bar.org"),
             F("!r7:bar.org"),
         ];
-        pending;
+        end;
     };
+    assert_pending!(dynamic_entries_stream);
 
     Ok(())
 }
@@ -1908,11 +1925,11 @@ async fn test_invites_stream() -> Result<(), Error> {
         },
     };
 
-    assert_entries_stream! {
+    assert_entries_batch! {
         [invites_stream]
         remove[0];
         insert[0] [ F("!r1:bar.org") ];
-        pending;
+        end;
     };
 
     Ok(())

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1809,6 +1809,34 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
     };
     assert_pending!(dynamic_entries_stream);
 
+    // Let's reset to one page.
+    dynamic_entries.reset_to_one_page();
+
+    // Assert the dynamic entries.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive a `truncate`.
+        truncate [5];
+        end;
+    }
+    assert_pending!(dynamic_entries_stream);
+
+    // Let's ask one more page again, because it's fun.
+    dynamic_entries.add_one_page();
+
+    // Assert the dynamic entries.
+    assert_entries_batch! {
+        [dynamic_entries_stream]
+        // Receive the next values.
+        append [
+            F("!r5:bar.org"),
+            F("!r6:bar.org"),
+            F("!r7:bar.org"),
+        ];
+        end;
+    };
+    assert_pending!(dynamic_entries_stream);
+
     Ok(())
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -279,7 +279,6 @@ mod tests {
     use std::sync::{Arc, RwLock};
 
     use assert_matches::assert_matches;
-    use futures_util::StreamExt;
     use matrix_sdk_test::async_test;
 
     use super::{

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -12,7 +12,7 @@ use std::{
     sync::{Arc, RwLock as StdRwLock},
 };
 
-use eyeball::Observable;
+use eyeball::{Observable, Subscriber};
 use eyeball_im::{ObservableVector, ObservableVectorTransaction, VectorDiff};
 use eyeball_im_util::vector;
 use futures_core::Stream;
@@ -189,7 +189,7 @@ impl SlidingSyncList {
     ///
     /// There's no guarantee of ordering between items emitted by this stream
     /// and those emitted by other streams exposed on this structure.
-    pub fn maximum_number_of_rooms_stream(&self) -> impl Stream<Item = Option<u32>> {
+    pub fn maximum_number_of_rooms_stream(&self) -> Subscriber<Option<u32>> {
         Observable::subscribe(&self.inner.maximum_number_of_rooms.read().unwrap())
     }
 


### PR DESCRIPTION
For some room lists, the number of entries can be gigantic. For example,
some accounts have 800, 2500, or even 4000 rooms! It's not necessary for
the client/app to display all the 4000 rooms. First, it can create some
performance issues, second, nobody will scroll 4000 rooms to search for
a particular room :-). Such users are more likely to use a search bar or
something equivalent. The idea is that `RoomListService` will continue
to sync all the data, but only a _limited_ view of it will be shared
to the client/app.

This patch takes `RoomList::entries_with_dynamic_filter`, and improves
it to include this (dynamic) limit.

This patch renames `RoomList::entries_with_dynamic_filter`
to `::entries_with_dynamic_adapters`. It now returns a
`RoomListDynamicEntriesController`, which is a renaming of
`DynamicRoomListFilter`. Basically, the “dynamic filter” becomes a
“dynamic controller” because `RoomList::entries_with_dynamic_adapters`
manages more than a filter. It now uses
`eyeball_im_util::vector::DynamicLimit` to dynamically limit the size
of entries. And that's the major idea behind this patch.

`RoomListDynamicEntriesController::set` is renamed `::set_filter`, and 2
new methods are introduced: `add_one_page` and `reset_to_one_page`.

A _page_ is like a chunk of room entries we want to view or add. When
doing `add_one_page`, the limit increases to `old_limit + page_size`. The
`reset_to_one_page` method resets the `limit` to `page_size` only.