### PR TITLE
Polls: use new event replacement types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "assign",
  "js_int",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "assign",
  "bytes",
@@ -4879,7 +4879,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "as_variant",
  "base64 0.21.3",
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.26.0"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "as_variant",
  "indexmap 2.0.0",
@@ -4933,7 +4933,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.1.0"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
+source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "assign",
  "js_int",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "assign",
  "bytes",
@@ -4879,7 +4879,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "as_variant",
  "base64 0.21.3",
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.26.0"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "as_variant",
  "indexmap 2.0.0",
@@ -4933,7 +4933,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.1.0"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4957,7 +4957,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4981,7 +4981,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6#f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6"
+source = "git+https://github.com/ruma/ruma?rev=18195e0a6e242f4b38fa7ae66a063ed62c9205eb#18195e0a6e242f4b38fa7ae66a063ed62c9205eb"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "18195e0a6e242f4b38fa7ae66a063ed62c9205eb", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "18195e0a6e242f4b38fa7ae66a063ed62c9205eb" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "4e8afe00229d961d206b54a61ab29f4ba1f5b2c3", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "4e8afe00229d961d206b54a61ab29f4ba1f5b2c3" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "f271cd28f5a0cae2c9eda8ebc36834f5b3ecc6f6" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "18195e0a6e242f4b38fa7ae66a063ed62c9205eb", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "18195e0a6e242f4b38fa7ae66a063ed62c9205eb" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -30,9 +30,8 @@ use matrix_sdk::{
 use matrix_sdk_ui::timeline::{BackPaginationStatus, RoomExt, Timeline};
 use mime::Mime;
 use ruma::events::poll::{
-    unstable_end::UnstablePollEndEventContent,
-    unstable_response::UnstablePollResponseEventContent,
-    unstable_start::{NewUnstablePollStartEventContent, UnstablePollStartEventContent},
+    unstable_end::UnstablePollEndEventContent, unstable_response::UnstablePollResponseEventContent,
+    unstable_start::NewUnstablePollStartEventContent,
 };
 use tokio::{
     sync::{Mutex, RwLock},
@@ -447,9 +446,8 @@ impl Room {
 
         let poll_start_event_content =
             NewUnstablePollStartEventContent::plain_text(fallback_text, poll_content_block);
-        let event_content = AnyMessageLikeEventContent::UnstablePollStart(
-            UnstablePollStartEventContent::New(poll_start_event_content),
-        );
+        let event_content =
+            AnyMessageLikeEventContent::UnstablePollStart(poll_start_event_content.into());
 
         RUNTIME.spawn(async move {
             timeline.send(event_content, txn_id.as_deref().map(Into::into)).await;

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -14,7 +14,6 @@ use matrix_sdk::{
             location::{AssetType as RumaAssetType, LocationContent, ZoomLevel},
             poll::unstable_start::{
                 UnstablePollAnswer, UnstablePollAnswers, UnstablePollStartContentBlock,
-                UnstablePollStartEventContent,
             },
             receipt::ReceiptThread,
             relation::{Annotation, Replacement},
@@ -31,7 +30,9 @@ use matrix_sdk::{
 use matrix_sdk_ui::timeline::{BackPaginationStatus, RoomExt, Timeline};
 use mime::Mime;
 use ruma::events::poll::{
-    unstable_end::UnstablePollEndEventContent, unstable_response::UnstablePollResponseEventContent,
+    unstable_end::UnstablePollEndEventContent,
+    unstable_response::UnstablePollResponseEventContent,
+    unstable_start::{NewUnstablePollStartEventContent, UnstablePollStartEventContent},
 };
 use tokio::{
     sync::{Mutex, RwLock},
@@ -445,8 +446,10 @@ impl Room {
             .fold(question, |acc, (index, answer)| format!("{acc}\n{}. {answer}", index + 1));
 
         let poll_start_event_content =
-            UnstablePollStartEventContent::plain_text(fallback_text, poll_content_block);
-        let event_content = AnyMessageLikeEventContent::UnstablePollStart(poll_start_event_content);
+            NewUnstablePollStartEventContent::plain_text(fallback_text, poll_content_block);
+        let event_content = AnyMessageLikeEventContent::UnstablePollStart(
+            UnstablePollStartEventContent::New(poll_start_event_content),
+        );
 
         RUNTIME.spawn(async move {
             timeline.send(event_content, txn_id.as_deref().map(Into::into)).await;

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -37,6 +37,7 @@ use ruma::{
     api::client::receipt::create_receipt::v3::ReceiptType,
     assign,
     events::{
+        poll::unstable_start::UnstablePollStartEventContent,
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptThread},
         relation::Annotation,
@@ -492,9 +493,9 @@ impl Timeline {
             | TimelineItemContent::FailedToParseState { .. } => {
                 error_return!("Invalid state: attempting to retry a failed-to-parse item");
             }
-            TimelineItemContent::Poll(poll_state) => {
-                AnyMessageLikeEventContent::UnstablePollStart(poll_state.into())
-            }
+            TimelineItemContent::Poll(poll_state) => AnyMessageLikeEventContent::UnstablePollStart(
+                UnstablePollStartEventContent::New(poll_state.into()),
+            ),
         };
 
         let txn_id = txn_id.to_owned();

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -8,8 +8,8 @@ use ruma::{
         start::PollKind,
         unstable_response::UnstablePollResponseEventContent,
         unstable_start::{
-            UnstablePollStartContentBlock, UnstablePollStartEventContent,
-            UnstablePollStartEventContentWithoutRelation,
+            NewUnstablePollStartEventContent, NewUnstablePollStartEventContentWithoutRelation,
+            UnstablePollStartContentBlock,
         },
         PollResponseData,
     },
@@ -23,7 +23,7 @@ use ruma::{
 /// to the same poll start event.
 #[derive(Clone, Debug)]
 pub struct PollState {
-    pub(super) start_event_content: UnstablePollStartEventContent,
+    pub(super) start_event_content: NewUnstablePollStartEventContent,
     pub(super) response_data: Vec<ResponseData>,
     pub(super) end_event_timestamp: Option<MilliSecondsSinceUnixEpoch>,
 }
@@ -36,13 +36,13 @@ pub(super) struct ResponseData {
 }
 
 impl PollState {
-    pub(super) fn new(content: UnstablePollStartEventContent) -> Self {
+    pub(super) fn new(content: NewUnstablePollStartEventContent) -> Self {
         Self { start_event_content: content, response_data: vec![], end_event_timestamp: None }
     }
 
     pub(super) fn edit(
         &self,
-        replacement: &UnstablePollStartEventContentWithoutRelation,
+        replacement: &NewUnstablePollStartEventContentWithoutRelation,
     ) -> Result<Self, ()> {
         if self.response_data.is_empty() && self.end_event_timestamp.is_none() {
             let mut clone = self.clone();
@@ -117,16 +117,16 @@ impl PollState {
     }
 }
 
-impl From<PollState> for UnstablePollStartEventContent {
+impl From<PollState> for NewUnstablePollStartEventContent {
     fn from(value: PollState) -> Self {
         let content = UnstablePollStartContentBlock::new(
             value.start_event_content.poll_start.question.text.clone(),
             value.start_event_content.poll_start.answers.clone(),
         );
         if let Some(text) = value.fallback_text() {
-            UnstablePollStartEventContent::plain_text(text, content)
+            NewUnstablePollStartEventContent::plain_text(text, content)
         } else {
-            UnstablePollStartEventContent::new(content)
+            NewUnstablePollStartEventContent::new(content)
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -4,10 +4,11 @@ use ruma::{
         poll::{
             unstable_end::UnstablePollEndEventContent,
             unstable_response::UnstablePollResponseEventContent,
-            unstable_start::{UnstablePollStartContentBlock, UnstablePollStartEventContent},
+            unstable_start::{
+                NewUnstablePollStartEventContent, ReplacementUnstablePollStartEventContent,
+                UnstablePollStartContentBlock, UnstablePollStartEventContent,
+            },
         },
-        relation::Replacement,
-        room::message::Relation,
         AnyMessageLikeEventContent,
     },
     serde::Raw,
@@ -201,7 +202,7 @@ impl TestTimeline {
 
     async fn send_poll_start(&self, sender: &UserId, content: UnstablePollStartContentBlock) {
         let event_content = AnyMessageLikeEventContent::UnstablePollStart(
-            UnstablePollStartEventContent::new(content),
+            UnstablePollStartEventContent::New(NewUnstablePollStartEventContent::new(content)),
         );
         self.handle_live_message_event(sender, event_content).await;
     }
@@ -213,7 +214,7 @@ impl TestTimeline {
         content: UnstablePollStartContentBlock,
     ) {
         let event_content = AnyMessageLikeEventContent::UnstablePollStart(
-            UnstablePollStartEventContent::new(content),
+            UnstablePollStartEventContent::New(NewUnstablePollStartEventContent::new(content)),
         );
         let event = self.make_message_event_with_id(sender, event_content, event_id.to_owned());
         let raw = Raw::new(&event).unwrap().cast();
@@ -243,12 +244,11 @@ impl TestTimeline {
         original_id: &EventId,
         content: UnstablePollStartContentBlock,
     ) {
-        let mut content = UnstablePollStartEventContent::new(content);
-        content.relates_to = Some(Relation::Replacement(Replacement::new(
-            original_id.to_owned(),
-            content.clone().into(),
-        )));
-        let event_content = AnyMessageLikeEventContent::UnstablePollStart(content);
+        let content =
+            ReplacementUnstablePollStartEventContent::new(content, original_id.to_owned());
+        let event_content = AnyMessageLikeEventContent::UnstablePollStart(
+            UnstablePollStartEventContent::Replacement(content),
+        );
         self.handle_live_message_event(sender, event_content).await
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -6,7 +6,7 @@ use ruma::{
             unstable_response::UnstablePollResponseEventContent,
             unstable_start::{
                 NewUnstablePollStartEventContent, ReplacementUnstablePollStartEventContent,
-                UnstablePollStartContentBlock, UnstablePollStartEventContent,
+                UnstablePollStartContentBlock,
             },
         },
         AnyMessageLikeEventContent,
@@ -202,7 +202,7 @@ impl TestTimeline {
 
     async fn send_poll_start(&self, sender: &UserId, content: UnstablePollStartContentBlock) {
         let event_content = AnyMessageLikeEventContent::UnstablePollStart(
-            UnstablePollStartEventContent::New(NewUnstablePollStartEventContent::new(content)),
+            NewUnstablePollStartEventContent::new(content).into(),
         );
         self.handle_live_message_event(sender, event_content).await;
     }
@@ -214,7 +214,7 @@ impl TestTimeline {
         content: UnstablePollStartContentBlock,
     ) {
         let event_content = AnyMessageLikeEventContent::UnstablePollStart(
-            UnstablePollStartEventContent::New(NewUnstablePollStartEventContent::new(content)),
+            NewUnstablePollStartEventContent::new(content).into(),
         );
         let event = self.make_message_event_with_id(sender, event_content, event_id.to_owned());
         let raw = Raw::new(&event).unwrap().cast();
@@ -246,9 +246,7 @@ impl TestTimeline {
     ) {
         let content =
             ReplacementUnstablePollStartEventContent::new(content, original_id.to_owned());
-        let event_content = AnyMessageLikeEventContent::UnstablePollStart(
-            UnstablePollStartEventContent::Replacement(content),
-        );
+        let event_content = AnyMessageLikeEventContent::UnstablePollStart(content.into());
         self.handle_live_message_event(sender, event_content).await
     }
 }


### PR DESCRIPTION
From the changes in: https://github.com/ruma/ruma/pull/1638

Will allow polls edited from legacy Elements to be read rust-sdk based clients.