### PR TITLE
base: Make `BaseRoomInfo` compatible with room version 11

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -43,7 +43,8 @@ pub use http;
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{
-    DisplayName, Room, RoomInfo, RoomMember, RoomMemberships, RoomState, RoomStateFilter,
+    DisplayName, Room, RoomCreateWithCreatorEventContent, RoomInfo, RoomMember, RoomMemberships,
+    RoomState, RoomStateFilter,
 };
 pub use store::{StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError};
 pub use utils::{

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -11,18 +11,24 @@ pub use normal::{Room, RoomInfo, RoomState, RoomStateFilter};
 use ruma::{
     assign,
     events::{
+        macros::EventContent,
         room::{
-            avatar::RoomAvatarEventContent, canonical_alias::RoomCanonicalAliasEventContent,
-            create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
+            avatar::RoomAvatarEventContent,
+            canonical_alias::RoomCanonicalAliasEventContent,
+            create::{PreviousRoom, RoomCreateEventContent},
+            encryption::RoomEncryptionEventContent,
             guest_access::RoomGuestAccessEventContent,
             history_visibility::RoomHistoryVisibilityEventContent,
-            join_rules::RoomJoinRulesEventContent, member::MembershipState,
-            name::RoomNameEventContent, tombstone::RoomTombstoneEventContent,
+            join_rules::RoomJoinRulesEventContent,
+            member::MembershipState,
+            name::RoomNameEventContent,
+            tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
         },
-        AnyStrippedStateEvent, AnySyncStateEvent, RedactContent, RedactedStateEventContent,
-        StaticStateEventContent, SyncStateEvent,
+        AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
+        RedactedStateEventContent, StaticStateEventContent, SyncStateEvent,
     },
+    room::RoomType,
     EventId, OwnedUserId, RoomVersionId,
 };
 use serde::{Deserialize, Serialize};
@@ -69,7 +75,7 @@ pub struct BaseRoomInfo {
     /// The canonical alias of this room.
     canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
     /// The `m.room.create` event content of this room.
-    create: Option<MinimalStateEvent<RoomCreateEventContent>>,
+    create: Option<MinimalStateEvent<RoomCreateWithCreatorEventContent>>,
     /// A list of user ids this room is considered as direct message, if this
     /// room is a DM.
     pub(crate) dm_targets: HashSet<OwnedUserId>,
@@ -309,6 +315,99 @@ fn calculate_room_name(
     } else {
         DisplayName::Calculated(names)
     }
+}
+
+/// The content of an `m.room.create` event, with a required `creator` field.
+///
+/// Starting with room version 11, the `creator` field should be removed and the
+/// `sender` field of the event should be used instead. This is reflected on
+/// [`RoomCreateEventContent`].
+///
+/// This type was created as an alternative for ease of use. When it is used in
+/// the SDK, it is constructed by copying the `sender` of the original event as
+/// the `creator`.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "m.room.create", kind = State, state_key_type = EmptyStateKey, custom_redacted)]
+pub struct RoomCreateWithCreatorEventContent {
+    /// The `user_id` of the room creator.
+    ///
+    /// This is set by the homeserver.
+    ///
+    /// While this should be optional since room version 11, we copy the sender
+    /// of the event so we can still access it.
+    pub creator: OwnedUserId,
+
+    /// Whether or not this room's data should be transferred to other
+    /// homeservers.
+    #[serde(
+        rename = "m.federate",
+        default = "ruma::serde::default_true",
+        skip_serializing_if = "ruma::serde::is_true"
+    )]
+    pub federate: bool,
+
+    /// The version of the room.
+    ///
+    /// Defaults to `RoomVersionId::V1`.
+    #[serde(default = "default_create_room_version_id")]
+    pub room_version: RoomVersionId,
+
+    /// A reference to the room this room replaces, if the previous room was
+    /// upgraded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub predecessor: Option<PreviousRoom>,
+
+    /// The room type.
+    ///
+    /// This is currently only used for spaces.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    pub room_type: Option<RoomType>,
+}
+
+impl RoomCreateWithCreatorEventContent {
+    /// Constructs a `RoomCreateWithCreatorEventContent` with the given original
+    /// content and sender.
+    pub fn from_event_content(content: RoomCreateEventContent, sender: OwnedUserId) -> Self {
+        let RoomCreateEventContent { federate, room_version, predecessor, room_type, .. } = content;
+        Self { creator: sender, federate, room_version, predecessor, room_type }
+    }
+
+    fn into_event_content(self) -> (RoomCreateEventContent, OwnedUserId) {
+        let Self { creator, federate, room_version, predecessor, room_type } = self;
+
+        #[allow(deprecated)]
+        let content = assign!(RoomCreateEventContent::new_v11(), {
+            creator: Some(creator.clone()),
+            federate,
+            room_version,
+            predecessor,
+            room_type,
+        });
+
+        (content, creator)
+    }
+}
+
+/// Redacted form of [`RoomCreateWithCreatorEventContent`].
+pub type RedactedRoomCreateWithCreatorEventContent = RoomCreateWithCreatorEventContent;
+
+impl RedactedStateEventContent for RedactedRoomCreateWithCreatorEventContent {
+    type StateKey = EmptyStateKey;
+}
+
+impl RedactContent for RoomCreateWithCreatorEventContent {
+    type Redacted = RedactedRoomCreateWithCreatorEventContent;
+
+    fn redact(self, version: &RoomVersionId) -> Self::Redacted {
+        let (content, sender) = self.into_event_content();
+        // Use Ruma's redaction algorithm.
+        let content = content.redact(version);
+        Self::from_event_content(content, sender)
+    }
+}
+
+fn default_create_room_version_id() -> RoomVersionId {
+    RoomVersionId::V1
 }
 
 bitflags! {

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -117,8 +117,14 @@ impl BaseRoomInfo {
     }
 
     /// Get the room version of this room.
+    ///
+    /// For room versions earlier than room version 11, if the event is
+    /// redacted, this will return the default of [`RoomVersionId::V1`].
     pub fn room_version(&self) -> Option<&RoomVersionId> {
-        Some(&self.create.as_ref()?.as_original()?.content.room_version)
+        match self.create.as_ref()? {
+            MinimalStateEvent::Original(ev) => Some(&ev.content.room_version),
+            MinimalStateEvent::Redacted(ev) => Some(&ev.content.room_version),
+        }
     }
 
     /// Handle a state event for this room and update our info accordingly.

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -23,8 +23,9 @@ pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
     deserialized_responses,
     store::{DynStateStore, MemoryStore, StateStoreExt},
-    DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomMemberships,
-    RoomState, SessionMeta, StateChanges, StateStore, StoreError,
+    DisplayName, Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomInfo,
+    RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
+    StateStore, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;


### PR DESCRIPTION
Closes #2439.

See commits messages for details.

The question is: do we need to write database migrations? It should only be necessary if a client already encountered a room version 11 `m.room.create` event.