### PR TITLE
fix(ui): The `invites` sliding sync is no longer cached

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -194,7 +194,7 @@ impl RoomListService {
             ))
             .await
             .map_err(Error::SlidingSync)?
-            .add_cached_list(
+            .add_list(
                 SlidingSyncList::builder(INVITES_LIST_NAME)
                     .sync_mode(
                         SlidingSyncMode::new_selective().add_range(INVITES_DEFAULT_SELECTIVE_RANGE),
@@ -213,8 +213,6 @@ impl RoomListService {
 
                     }))),
             )
-            .await
-            .map_err(Error::SlidingSync)?
             .build()
             .await
             .map(Arc::new)


### PR DESCRIPTION
`RoomListService::new_internal` were creating the `invites` sliding sync list, with a cache. It is not a good idea. It should not be cached. Let's remove that :-).

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/2548.