### PR TITLE
feat(ffi): Add support for voice messages sent as `m.room.message`

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -36,7 +36,7 @@ mime = "0.3.16"
 once_cell = { workspace = true }
 opentelemetry = { version = "0.20.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.13.0", features = ["tokio", "reqwest-client", "http-proto"] }
-ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar"] }
+ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat"] }
 sanitize-filename-reader-friendly = "2.2.1"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -21,7 +21,10 @@ use matrix_sdk::{
                 MessageType as RumaMessageType,
                 NoticeMessageEventContent as RumaNoticeMessageEventContent,
                 RoomMessageEventContentWithoutRelation,
-                TextMessageEventContent as RumaTextMessageEventContent, VideoInfo as RumaVideoInfo,
+                TextMessageEventContent as RumaTextMessageEventContent,
+                UnstableAudioDetailsContentBlock as RumaUnstableAudioDetailsContentBlock,
+                UnstableVoiceContentBlock as RumaUnstableVoiceContentBlock,
+                VideoInfo as RumaVideoInfo,
                 VideoMessageEventContent as RumaVideoMessageEventContent,
             },
             ImageInfo as RumaImageInfo, MediaSource, ThumbnailInfo as RumaThumbnailInfo,
@@ -613,6 +616,8 @@ impl TryFrom<RumaMessageType> for MessageType {
                     body: c.body.clone(),
                     source: Arc::new(c.source.clone()),
                     info: c.info.as_deref().map(Into::into),
+                    audio: c.audio.map(Into::into),
+                    voice: c.voice.map(Into::into),
                 },
             },
             RumaMessageType::Video(c) => MessageType::Video {
@@ -683,6 +688,8 @@ pub struct AudioMessageContent {
     pub body: String,
     pub source: Arc<MediaSource>,
     pub info: Option<AudioInfo>,
+    pub audio: Option<AudioDetailsContent>,
+    pub voice: Option<VoiceContent>,
 }
 
 #[derive(Clone, uniffi::Record)]
@@ -772,6 +779,34 @@ impl TryFrom<&AudioInfo> for BaseAudioInfo {
             .map_err(|_| TimelineError::InvalidMediaInfoField)?;
 
         Ok(BaseAudioInfo { duration: Some(duration), size: Some(size) })
+    }
+}
+
+#[derive(Clone, uniffi::Record)]
+pub struct AudioDetailsContent {
+    pub duration: Duration,
+    pub waveform: Vec<u16>,
+}
+
+impl From<RumaUnstableAudioDetailsContentBlock> for AudioDetailsContent {
+    fn from(details: RumaUnstableAudioDetailsContentBlock) -> Self {
+        Self {
+            duration: details.duration,
+            waveform: details
+                .waveform
+                .iter()
+                .map(|x| u16::try_from(x.get()).unwrap_or(0))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, uniffi::Record)]
+pub struct VoiceContent {}
+
+impl From<RumaUnstableVoiceContentBlock> for VoiceContent {
+    fn from(_details: RumaUnstableVoiceContentBlock) -> Self {
+        Self {}
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -688,8 +688,8 @@ pub struct AudioMessageContent {
     pub body: String,
     pub source: Arc<MediaSource>,
     pub info: Option<AudioInfo>,
-    pub audio: Option<AudioDetailsContent>,
-    pub voice: Option<VoiceContent>,
+    pub audio: Option<UnstableAudioDetailsContent>,
+    pub voice: Option<UnstableVoiceContent>,
 }
 
 #[derive(Clone, uniffi::Record)]
@@ -783,12 +783,12 @@ impl TryFrom<&AudioInfo> for BaseAudioInfo {
 }
 
 #[derive(Clone, uniffi::Record)]
-pub struct AudioDetailsContent {
+pub struct UnstableAudioDetailsContent {
     pub duration: Duration,
     pub waveform: Vec<u16>,
 }
 
-impl From<RumaUnstableAudioDetailsContentBlock> for AudioDetailsContent {
+impl From<RumaUnstableAudioDetailsContentBlock> for UnstableAudioDetailsContent {
     fn from(details: RumaUnstableAudioDetailsContentBlock) -> Self {
         Self {
             duration: details.duration,
@@ -802,9 +802,9 @@ impl From<RumaUnstableAudioDetailsContentBlock> for AudioDetailsContent {
 }
 
 #[derive(Clone, uniffi::Record)]
-pub struct VoiceContent {}
+pub struct UnstableVoiceContent {}
 
-impl From<RumaUnstableVoiceContentBlock> for VoiceContent {
+impl From<RumaUnstableVoiceContentBlock> for UnstableVoiceContent {
     fn from(_details: RumaUnstableVoiceContentBlock) -> Self {
         Self {}
     }


### PR DESCRIPTION
This PR adds support for voice messages sent as `m.room.message`  (as implemented by Element Web)