### PR TITLE
feat: Make `latest_event` faster regarding member profile

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -315,10 +315,10 @@ impl Room {
 
         // Otherwise, fallback to the classical path.
         let latest_event = match self.inner.latest_event() {
-            Some(ev) => matrix_sdk_ui::timeline::EventTimelineItem::from_latest_event(
+            Some(latest_event) => matrix_sdk_ui::timeline::EventTimelineItem::from_latest_event(
                 self.inner.client(),
                 self.inner.room_id(),
-                ev,
+                latest_event,
             )
             .await
             .map(EventTimelineItem)

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -54,7 +54,7 @@ use tokio::sync::RwLockReadGuard;
 use tracing::{debug, info, instrument, trace, warn};
 
 #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
-use crate::latest_event::{is_suitable_for_latest_event, PossibleLatestEvent};
+use crate::latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent};
 use crate::{
     deserialized_responses::{AmbiguityChanges, MembersResponse, SyncTimelineEvent},
     error::Result,
@@ -620,10 +620,7 @@ impl BaseClient {
     /// decrypted event if we found one, along with its index in the
     /// latest_encrypted_events list, or None if we didn't find one.
     #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
-    async fn decrypt_latest_suitable_event(
-        &self,
-        room: &Room,
-    ) -> Option<(SyncTimelineEvent, usize)> {
+    async fn decrypt_latest_suitable_event(&self, room: &Room) -> Option<(LatestEvent, usize)> {
         let enc_events = room.latest_encrypted_events();
 
         // Walk backwards through the encrypted events, looking for one we can decrypt
@@ -636,7 +633,7 @@ impl BaseClient {
                         is_suitable_for_latest_event(&any_sync_event)
                     {
                         // The event is the right type for us to use as latest_event
-                        return Some((decrypted, i));
+                        return Some((LatestEvent::new(decrypted), i));
                     }
                 }
             }

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -13,7 +13,7 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::RoomMember;
+use crate::MinimalRoomMemberEvent;
 
 /// Represents a decision about whether an event could be stored as the latest
 /// event in a room. Variants starting with Yes indicate that this message could
@@ -65,39 +65,56 @@ pub fn is_suitable_for_latest_event(event: &AnySyncTimelineEvent) -> PossibleLat
     }
 }
 
+/// Represent all information required to represent a latest event in an
+/// efficient way.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct LatestEvent {
+    /// The actual event.
     event: SyncTimelineEvent,
-    // member: Option<RoomMember>,
+
+    /// The member profile of the event' sender.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sender_profile: Option<MinimalRoomMemberEvent>,
 }
 
 impl LatestEvent {
+    /// Create a new [`LatestEvent`] without the sender's profile.
     pub fn new(event: SyncTimelineEvent) -> Self {
-        Self { event }
+        Self { event, sender_profile: None }
     }
 
-    // pub fn new_with_member(event: SyncTimelineEvent, member: RoomMember) -> Self
-    // {     Self { event, member: Some(member) }
-    // }
+    /// Create a new [`LatestEvent`] with maybe the sender's profile.
+    pub fn new_with_sender_profile(
+        event: SyncTimelineEvent,
+        sender_profile: Option<MinimalRoomMemberEvent>,
+    ) -> Self {
+        Self { event, sender_profile }
+    }
 
+    /// Transform [`Self`] into an event.
     pub fn into_event(self) -> SyncTimelineEvent {
         self.event
     }
 
+    /// Get a reference to the event.
     pub fn event(&self) -> &SyncTimelineEvent {
         &self.event
     }
 
+    /// Get a mutable reference to the event.
     pub fn event_mut(&mut self) -> &mut SyncTimelineEvent {
         &mut self.event
     }
 
+    /// Get the event ID.
     pub fn event_id(&self) -> Option<OwnedEventId> {
         self.event.event_id()
     }
-    // pub fn member(&self) -> Option<&RoomMember> {
-    //     self.member.as_ref()
-    // }
+
+    /// Get a reference to the sender profile if any.
+    pub fn sender_profile(&self) -> Option<&MinimalRoomMemberEvent> {
+        self.sender_profile.as_ref()
+    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -3,10 +3,17 @@
 
 #![cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
 
-use ruma::events::{
-    poll::unstable_start::SyncUnstablePollStartEvent, room::message::SyncRoomMessageEvent,
-    AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
+use ruma::{
+    events::{
+        poll::unstable_start::SyncUnstablePollStartEvent, room::message::SyncRoomMessageEvent,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+    },
+    OwnedEventId,
 };
+use serde::{Deserialize, Serialize};
+
+use crate::RoomMember;
 
 /// Represents a decision about whether an event could be stored as the latest
 /// event in a room. Variants starting with Yes indicate that this message could
@@ -56,6 +63,41 @@ pub fn is_suitable_for_latest_event(event: &AnySyncTimelineEvent) -> PossibleLat
         // We don't currently support state events
         AnySyncTimelineEvent::State(_) => PossibleLatestEvent::NoUnsupportedEventType,
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct LatestEvent {
+    event: SyncTimelineEvent,
+    // member: Option<RoomMember>,
+}
+
+impl LatestEvent {
+    pub fn new(event: SyncTimelineEvent) -> Self {
+        Self { event }
+    }
+
+    // pub fn new_with_member(event: SyncTimelineEvent, member: RoomMember) -> Self
+    // {     Self { event, member: Some(member) }
+    // }
+
+    pub fn into_event(self) -> SyncTimelineEvent {
+        self.event
+    }
+
+    pub fn event(&self) -> &SyncTimelineEvent {
+        &self.event
+    }
+
+    pub fn event_mut(&mut self) -> &mut SyncTimelineEvent {
+        &mut self.event
+    }
+
+    pub fn event_id(&self) -> Option<OwnedEventId> {
+        self.event.event_id()
+    }
+    // pub fn member(&self) -> Option<&RoomMember> {
+    //     self.member.as_ref()
+    // }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -117,9 +117,9 @@ impl LatestEvent {
         self.event.event_id()
     }
 
-    /// Get a reference to the sender profile if any.
-    pub fn sender_profile(&self) -> Option<&MinimalRoomMemberEvent> {
-        self.sender_profile.as_ref()
+    /// Check whether [`Self`] has a sender a profile.
+    pub fn has_sender_profile(&self) -> bool {
+        self.sender_profile.is_some()
     }
 
     /// Return the sender's display name if it was known at the time [`Self`]

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -1,16 +1,15 @@
 //! Utilities for working with events to decide whether they are suitable for
 //! use as a [crate::Room::latest_event].
 
-#![cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
+#![cfg(feature = "experimental-sliding-sync")]
 
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
-use ruma::{
-    events::{
-        poll::unstable_start::SyncUnstablePollStartEvent, room::message::SyncRoomMessageEvent,
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
-    },
-    MxcUri, OwnedEventId,
+#[cfg(feature = "e2e-encryption")]
+use ruma::events::{
+    poll::unstable_start::SyncUnstablePollStartEvent, room::message::SyncRoomMessageEvent,
+    AnySyncMessageLikeEvent, AnySyncTimelineEvent,
 };
+use ruma::{MxcUri, OwnedEventId};
 use serde::{Deserialize, Serialize};
 
 use crate::MinimalRoomMemberEvent;
@@ -19,6 +18,7 @@ use crate::MinimalRoomMemberEvent;
 /// event in a room. Variants starting with Yes indicate that this message could
 /// be stored, and provide the inner event information, and those starting with
 /// a No indicate that it could not, and give a reason.
+#[cfg(feature = "e2e-encryption")]
 #[derive(Debug)]
 pub enum PossibleLatestEvent<'a> {
     /// This message is suitable - it is an m.room.message
@@ -37,6 +37,7 @@ pub enum PossibleLatestEvent<'a> {
 
 /// Decide whether an event could be stored as the latest event in a room.
 /// Returns a LatestEvent representing our decision.
+#[cfg(feature = "e2e-encryption")]
 pub fn is_suitable_for_latest_event(event: &AnySyncTimelineEvent) -> PossibleLatestEvent<'_> {
     match event {
         // Suitable - we have an m.room.message that was not redacted

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -118,7 +118,7 @@ impl LatestEvent {
         self.event.event_id()
     }
 
-    /// Check whether [`Self`] has a sender a profile.
+    /// Check whether [`Self`] has a sender profile.
     pub fn has_sender_profile(&self) -> bool {
         self.sender_profile.is_some()
     }

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -77,7 +77,6 @@ pub struct LatestEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     sender_profile: Option<MinimalRoomMemberEvent>,
 
-    // sender_room_member_event: Option<RoomMemberEvent
     /// The name of the event' sender is ambiguous.
     #[serde(skip_serializing_if = "Option::is_none")]
     sender_name_is_ambiguous: Option<bool>,

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -58,9 +58,10 @@ use super::{
     members::{MemberInfo, MemberRoomInfo},
     BaseRoomInfo, DisplayName, RoomCreateWithCreatorEventContent, RoomMember,
 };
+#[cfg(feature = "experimental-sliding-sync")]
+use crate::latest_event::LatestEvent;
 use crate::{
     deserialized_responses::MemberEvent,
-    latest_event::LatestEvent,
     store::{DynStateStore, Result as StoreResult, StateStoreExt},
     sync::UnreadNotificationsCount,
     MinimalStateEvent, OriginalMinimalStateEvent, RoomMemberships,

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -23,8 +23,6 @@ use std::{
 use bitflags::bitflags;
 use eyeball::{SharedObservable, Subscriber};
 use futures_util::stream::{self, StreamExt};
-#[cfg(feature = "experimental-sliding-sync")]
-use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
 use matrix_sdk_common::ring_buffer::RingBuffer;
 #[cfg(feature = "experimental-sliding-sync")]

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     deserialized_responses::SyncOrStrippedState,
+    latest_event::LatestEvent,
     rooms::{
         normal::{RoomSummary, SyncInfo},
         BaseRoomInfo,
@@ -115,7 +116,7 @@ impl RoomInfoV1 {
             sync_info,
             encryption_state_synced,
             #[cfg(feature = "experimental-sliding-sync")]
-            latest_event,
+            latest_event: latest_event.map(LatestEvent::new),
             base_info: base_info.migrate(create),
         }
     }

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -38,9 +38,10 @@ use ruma::{
 };
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "experimental-sliding-sync")]
+use crate::latest_event::LatestEvent;
 use crate::{
     deserialized_responses::SyncOrStrippedState,
-    latest_event::LatestEvent,
     rooms::{
         normal::{RoomSummary, SyncInfo},
         BaseRoomInfo,

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -177,6 +177,7 @@ impl RoomListService {
                     .required_state(vec![
                         (StateEventType::RoomAvatar, "".to_owned()),
                         (StateEventType::RoomEncryption, "".to_owned()),
+                        (StateEventType::RoomMember, "$LAZY".to_owned()),
                         (StateEventType::RoomPowerLevels, "".to_owned()),
                     ]),
             ))

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -268,8 +268,9 @@ impl RepliedToEvent {
         let content =
             TimelineItemContent::Message(Message::from_event(c, event.relations(), &vector![]));
         let sender = event.sender().to_owned();
-        let sender_profile =
-            TimelineDetails::from_initial_value(room_data_provider.profile(&sender).await);
+        let sender_profile = TimelineDetails::from_initial_value(
+            room_data_provider.profile_from_user_id(&sender).await,
+        );
 
         Ok(Self { content, sender, sender_profile })
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -109,9 +109,9 @@ pub enum TimelineItemContent {
 }
 
 impl TimelineItemContent {
-    /// If the supplied event is suitable to be used as a latest_event in a
+    /// If the supplied event is suitable to be used as a `latest_event` in a
     /// message preview, extract its contents and wrap it as a
-    /// TimelineItemContent.
+    /// `TimelineItemContent`.
     pub(crate) fn from_latest_event_content(
         event: AnySyncTimelineEvent,
     ) -> Option<TimelineItemContent> {
@@ -146,23 +146,23 @@ impl TimelineItemContent {
 
     /// Given some message content that is from an event that we have already
     /// determined is suitable for use as a latest event in a message preview,
-    /// extract its contents and wrap it as a TimelineItemContent.
+    /// extract its contents and wrap it as a `TimelineItemContent`.
     fn from_suitable_latest_event_content(event: &SyncRoomMessageEvent) -> TimelineItemContent {
         match event {
             SyncRoomMessageEvent::Original(event) => {
                 // Grab the content of this event
                 let event_content = event.content.clone();
 
-                // We don't have access to any relations via the AnySyncTimelineEvent (I think -
-                // andyb) so we pretend there are none. This might be OK for the message preview
-                // use case.
+                // We don't have access to any relations via the `AnySyncTimelineEvent` (I think
+                // - andyb) so we pretend there are none. This might be OK for
+                // the message preview use case.
                 let relations = BundledMessageLikeRelations::new();
 
                 // If this message is a reply, we would look up in this list the message it was
                 // replying to. Since we probably won't show this in the message preview,
                 // it's probably OK to supply an empty list here.
-                // Message::from_event marks the original event as Unavailable if it can't be
-                // found inside the timeline_items.
+                // `Message::from_event` marks the original event as `Unavailable` if it can't
+                // be found inside the timeline_items.
                 let timeline_items = Vector::new();
                 TimelineItemContent::Message(Message::from_event(
                     event_content,
@@ -174,7 +174,7 @@ impl TimelineItemContent {
         }
     }
 
-    /// extracts a TimelineItemContent from a poll start event for use as a
+    /// Extracts a `TimelineItemContent` from a poll start event for use as a
     /// latest event in a message preview.
     fn from_suitable_latest_poll_event_content(
         event: &SyncUnstablePollStartEvent,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -90,8 +90,9 @@ impl EventTimelineItem {
         Self { sender, sender_profile, timestamp, content, kind }
     }
 
-    /// If the supplied low-level SyncTimelineEventy is suitable for use as the
-    /// latest_event in a message preview, wrap it as an EventTimelineItem,
+    /// If the supplied low-level `SyncTimelineEventy` is suitable for use as
+    /// the `latest_event `` in a message preview, wrap it as an
+    /// `EventTimelineItem`.
     pub async fn from_latest_event(
         client: Client,
         room_id: &RoomId,
@@ -112,8 +113,8 @@ impl EventTimelineItem {
         let event_id = event.event_id().to_owned();
         let is_own = client.user_id().map(|uid| uid == sender).unwrap_or(false);
 
-        // If we don't (yet) know how to handle this type of message, return None here.
-        // If we do, convert it into a TimelineItemContent.
+        // If we don't (yet) know how to handle this type of message, return `None`
+        // here. If we do, convert it into a `TimelineItemContent`.
         let item_content = TimelineItemContent::from_latest_event_content(event)?;
 
         // We don't currently bundle any reactions with the main event. This could

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -522,7 +522,6 @@ mod tests {
         serde::Raw,
         user_id, RoomId, UInt, UserId,
     };
-    use serde_json::json;
 
     use super::{EventTimelineItem, Profile};
     use crate::timeline::TimelineDetails;
@@ -676,25 +675,20 @@ mod tests {
         formatted_body: &str,
         ts: u64,
     ) -> SyncTimelineEvent {
-        SyncTimelineEvent::new(
-            Raw::from_json_string(
-                json!({
-                    "event_id": "$eventid6",
-                    "sender": user_id,
-                    "origin_server_ts": ts,
-                    "type": "m.room.message",
-                    "room_id": room_id.to_string(),
-                    "content": {
-                        "body": body,
-                        "format": "org.matrix.custom.html",
-                        "formatted_body": formatted_body,
-                        "msgtype": "m.text"
-                    },
-                })
-                .to_string(),
-            )
-            .unwrap(),
-        )
+        sync_timeline_event!({
+            "event_id": "$eventid6",
+            "sender": user_id,
+            "origin_server_ts": ts,
+            "type": "m.room.message",
+            "room_id": room_id.to_string(),
+            "content": {
+                "body": body,
+                "format": "org.matrix.custom.html",
+                "formatted_body": formatted_body,
+                "msgtype": "m.text"
+            },
+        })
+        .into()
     }
 
     /// Copied from matrix_sdk_base::sliding_sync::test

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -434,7 +434,7 @@ impl From<RemoteEventTimelineItem> for EventTimelineItemKind {
 }
 
 /// The display name and avatar URL of a room member.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Profile {
     /// The display name, if set.
     pub display_name: Option<String>,

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -161,7 +161,7 @@ impl EventTimelineItem {
             TimelineDetails::Unavailable
         };
 
-        Some(EventTimelineItem::new(sender, sender_profile, timestamp, item_content, event_kind))
+        Some(Self::new(sender, sender_profile, timestamp, item_content, event_kind))
     }
 
     /// Check whether this item is a local echo.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -593,7 +593,7 @@ mod tests {
     #[async_test]
     async fn latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_cache() {
         // Given a sync event that is suitable to be used as a latest_event, a room, and
-        // a member even for the sender (which isn't part of the room yet).
+        // a member event for the sender (which isn't part of the room yet).
 
         use ruma::owned_mxc_uri;
         let room_id = room_id!("!q:x.uk");

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -91,7 +91,7 @@ impl EventTimelineItem {
     }
 
     /// If the supplied low-level `SyncTimelineEventy` is suitable for use as
-    /// the `latest_event `` in a message preview, wrap it as an
+    /// the `latest_event` in a message preview, wrap it as an
     /// `EventTimelineItem`.
     pub async fn from_latest_event(
         client: Client,

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -205,7 +205,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         };
 
         let sender = self.room_data_provider.own_user_id().to_owned();
-        let sender_profile = self.room_data_provider.profile(&sender).await;
+        let sender_profile = self.room_data_provider.profile_from_user_id(&sender).await;
         let reaction_state = match (to_redact_local, to_redact_remote) {
             (None, None) => {
                 // No record of the reaction, create a local echo
@@ -343,7 +343,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         content: AnyMessageLikeEventContent,
     ) {
         let sender = self.room_data_provider.own_user_id().to_owned();
-        let profile = self.room_data_provider.profile(&sender).await;
+        let profile = self.room_data_provider.profile_from_user_id(&sender).await;
 
         let mut state = self.state.write().await;
         state.handle_local_event(sender, profile, txn_id, content, &self.settings);
@@ -358,7 +358,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         content: RoomRedactionEventContent,
     ) {
         let sender = self.room_data_provider.own_user_id().to_owned();
-        let profile = self.room_data_provider.profile(&sender).await;
+        let profile = self.room_data_provider.profile_from_user_id(&sender).await;
 
         let mut state = self.state.write().await;
         state.handle_local_redaction(sender, profile, txn_id, to_redact, content, &self.settings);
@@ -738,7 +738,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
                 continue;
             }
 
-            match self.room_data_provider.profile(event_item.sender()).await {
+            match self.room_data_provider.profile_from_user_id(event_item.sender()).await {
                 Some(profile) => {
                     trace!(event_id, transaction_id, "Adding profile");
                     let updated_item =

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -544,7 +544,7 @@ impl TimelineInnerStateTransaction<'_> {
         };
 
         let is_own_event = sender == room_data_provider.own_user_id();
-        let sender_profile = room_data_provider.profile(&sender).await;
+        let sender_profile = room_data_provider.profile_from_user_id(&sender).await;
         let ctx = TimelineEventContext {
             sender,
             sender_profile,

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -23,6 +23,7 @@ use futures_core::Stream;
 use futures_util::{FutureExt, StreamExt};
 use indexmap::IndexMap;
 use matrix_sdk::deserialized_responses::{SyncTimelineEvent, TimelineEvent};
+use matrix_sdk_base::latest_event::LatestEvent;
 use matrix_sdk_test::{EventBuilder, ALICE};
 use ruma::{
     events::{
@@ -238,7 +239,11 @@ impl RoomDataProvider for TestRoomDataProvider {
         RoomVersionId::V10
     }
 
-    async fn profile(&self, _user_id: &UserId) -> Option<Profile> {
+    async fn profile_from_user_id(&self, _user_id: &UserId) -> Option<Profile> {
+        None
+    }
+
+    async fn profile_from_latest_event(&self, _latest_event: &LatestEvent) -> Option<Profile> {
         None
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -93,11 +93,7 @@ impl RoomDataProvider for Room {
                 display_name_ambiguous: member.name_ambiguous(),
                 avatar_url: member.avatar_url().map(ToOwned::to_owned),
             }),
-            Ok(None) if self.are_members_synced() => Some(Profile {
-                display_name: None,
-                display_name_ambiguous: false,
-                avatar_url: None,
-            }),
+            Ok(None) if self.are_members_synced() => Some(Profile::default()),
             Ok(None) => None,
             Err(e) => {
                 error!(%user_id, "Failed to fetch room member information: {e}");
@@ -113,7 +109,7 @@ impl RoomDataProvider for Room {
 
         Some(Profile {
             display_name: latest_event.sender_display_name().map(ToOwned::to_owned),
-            display_name_ambiguous: latest_event.sender_name_ambiguous().unwrap_or(false),
+            display_name_ambiguous: latest_event.sender_name_ambiguous().unwrap_or_default(),
             avatar_url: latest_event.sender_avatar_url().map(ToOwned::to_owned),
         })
     }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -17,6 +17,7 @@ use indexmap::IndexMap;
 use matrix_sdk::Room;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk::{deserialized_responses::TimelineEvent, Result};
+use matrix_sdk_base::latest_event::LatestEvent;
 use ruma::{
     events::receipt::{Receipt, ReceiptThread, ReceiptType},
     push::{PushConditionRoomCtx, Ruleset},
@@ -66,7 +67,8 @@ impl RoomExt for Room {
 pub(super) trait RoomDataProvider: Clone + Send + Sync + 'static {
     fn own_user_id(&self) -> &UserId;
     fn room_version(&self) -> RoomVersionId;
-    async fn profile(&self, user_id: &UserId) -> Option<Profile>;
+    async fn profile_from_user_id(&self, user_id: &UserId) -> Option<Profile>;
+    async fn profile_from_latest_event(&self, latest_event: &LatestEvent) -> Option<Profile>;
     async fn read_receipts_for_event(&self, event_id: &EventId) -> IndexMap<OwnedUserId, Receipt>;
     async fn push_rules_and_context(&self) -> Option<(Ruleset, PushConditionRoomCtx)>;
 }
@@ -84,7 +86,7 @@ impl RoomDataProvider for Room {
         })
     }
 
-    async fn profile(&self, user_id: &UserId) -> Option<Profile> {
+    async fn profile_from_user_id(&self, user_id: &UserId) -> Option<Profile> {
         match self.get_member_no_sync(user_id).await {
             Ok(Some(member)) => Some(Profile {
                 display_name: member.display_name().map(ToOwned::to_owned),
@@ -102,6 +104,18 @@ impl RoomDataProvider for Room {
                 None
             }
         }
+    }
+
+    async fn profile_from_latest_event(&self, latest_event: &LatestEvent) -> Option<Profile> {
+        if !latest_event.has_sender_profile() {
+            return None;
+        }
+
+        Some(Profile {
+            display_name: latest_event.sender_display_name().map(ToOwned::to_owned),
+            display_name_ambiguous: latest_event.sender_name_ambiguous().unwrap_or(false),
+            avatar_url: latest_event.sender_avatar_url().map(ToOwned::to_owned),
+        })
     }
 
     async fn read_receipts_for_event(&self, event_id: &EventId) -> IndexMap<OwnedUserId, Receipt> {

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -109,7 +109,7 @@ impl RoomDataProvider for Room {
 
         Some(Profile {
             display_name: latest_event.sender_display_name().map(ToOwned::to_owned),
-            display_name_ambiguous: latest_event.sender_name_ambiguous().unwrap_or_default(),
+            display_name_ambiguous: latest_event.sender_name_ambiguous().unwrap_or(false),
             avatar_url: latest_event.sender_avatar_url().map(ToOwned::to_owned),
         })
     }

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -274,6 +274,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                     "required_state": [
                         ["m.room.avatar", ""],
                         ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
                         ["m.room.power_levels", ""],
                     ],
                     "filters": {

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -15,10 +15,9 @@ use super::{
     FrozenSlidingSync, FrozenSlidingSyncList, SlidingSync, SlidingSyncList,
     SlidingSyncPositionMarkers,
 };
-use crate::{
-    sliding_sync::{FrozenSlidingSyncPos, SlidingSyncListCachePolicy},
-    Client, Result,
-};
+#[cfg(feature = "e2e-encryption")]
+use crate::sliding_sync::FrozenSlidingSyncPos;
+use crate::{sliding_sync::SlidingSyncListCachePolicy, Client, Result};
 
 /// Be careful: as this is used as a storage key; changing it requires migrating
 /// data!

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -50,12 +50,13 @@ use tokio::{
 use tracing::{debug, error, info, instrument, trace, warn, Instrument, Span};
 use url::Url;
 
+#[cfg(feature = "e2e-encryption")]
+use self::utils::JoinHandleExt as _;
 pub use self::{builder::*, error::*, list::*, room::*};
 use self::{
     cache::restore_sliding_sync_state,
     client::SlidingSyncResponseProcessor,
     sticky_parameters::{LazyTransactionId, SlidingSyncStickyManager, StickyData},
-    utils::JoinHandleExt as _,
 };
 use crate::{config::RequestConfig, Client, Result};
 

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use eyeball_im::Vector;
-use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
+use matrix_sdk_base::{deserialized_responses::SyncTimelineEvent, latest_event::LatestEvent};
 use ruma::{
     api::client::sync::sync_events::{v4, UnreadNotificationsCount},
     events::AnySyncStateEvent,
@@ -133,7 +133,7 @@ impl SlidingSyncRoom {
     }
 
     /// Find the latest event in this room
-    pub fn latest_event(&self) -> Option<SyncTimelineEvent> {
+    pub fn latest_event(&self) -> Option<LatestEvent> {
         self.inner.client.get_room(&self.inner.room_id).and_then(|room| room.latest_event())
     }
 


### PR DESCRIPTION
This patch wants to address https://github.com/matrix-org/matrix-rust-sdk/issues/2535.

The underlying idea behind this PR is to make `Timeline::latest_event` faster. How? By storing the member profile along with the `SyncTimelineEvent` which represents the latest event.

To achieve that, the `RoomList` configures the `all_rooms` sliding sync list to require `m.room.member: $LAZY`. That way, we hope that we receive the member information related to the events, so that we can create a “tiny” profile that skips any access to the storage.

If such a “tiny” profile cannot be generated, `EventTimelineItem::from_latest_event` will simply fallback to the “slow” path.

This PR must be reviewed commit-by-commit, otherwise it's going to be quite complex as it involves a little bit of refactoring (like introducing the `LatestEvent` type).

What's left to do: add more tests. Actual tests are passing, which means we don't have any regressions, plus the fallback to the “slow” path works. That's great. I need to add tests to ensure the “fast” path works too. Edit: It's done.

---

* Fix https://github.com/matrix-org/matrix-rust-sdk/issues/2535