### PR TITLE
Upgrade Ruma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4848,7 +4848,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.8.2"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "assign",
  "js_int",
@@ -4864,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.16.2"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "assign",
  "bytes",
@@ -4882,7 +4882,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "as_variant",
  "base64 0.21.4",
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.26.0"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "as_variant",
  "indexmap 2.0.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4948,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.1.0"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4960,7 +4960,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.1"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.11.3"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -4984,7 +4984,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.7.1"
-source = "git+https://github.com/ruma/ruma?rev=4e8afe00229d961d206b54a61ab29f4ba1f5b2c3#4e8afe00229d961d206b54a61ab29f4ba1f5b2c3"
+source = "git+https://github.com/ruma/ruma?rev=6927393caa0fbf6dc07611e4a9cae3f281265cba#6927393caa0fbf6dc07611e4a9cae3f281265cba"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "4e8afe00229d961d206b54a61ab29f4ba1f5b2c3", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "4e8afe00229d961d206b54a61ab29f4ba1f5b2c3" }
+ruma = { git = "https://github.com/ruma/ruma", rev = "6927393caa0fbf6dc07611e4a9cae3f281265cba", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "6927393caa0fbf6dc07611e4a9cae3f281265cba" }
 once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -703,7 +703,7 @@ impl Room {
     }
 
     /// Sets a new name to the room.
-    pub fn set_name(&self, name: Option<String>) -> Result<(), ClientError> {
+    pub fn set_name(&self, name: String) -> Result<(), ClientError> {
         RUNTIME.block_on(async move {
             self.inner.set_name(name).await?;
             Ok(())

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -1270,7 +1270,7 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherFullStateEventContent> for OtherStat
             Content::RoomJoinRules(_) => Self::RoomJoinRules,
             Content::RoomName(c) => {
                 let name = match c {
-                    FullContent::Original { content, .. } => content.name.clone(),
+                    FullContent::Original { content, .. } => Some(content.name.clone()),
                     FullContent::Redacted(_) => None,
                 };
                 Self::RoomName { name }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -909,7 +909,7 @@ impl RoomInfo {
     /// Update the room name
     pub fn update_name(&mut self, name: String) {
         self.base_info.name = Some(MinimalStateEvent::Original(OriginalMinimalStateEvent {
-            content: RoomNameEventContent::new(Some(name)),
+            content: RoomNameEventContent::new(name),
             event_id: None,
         }));
     }
@@ -1022,7 +1022,7 @@ impl RoomInfo {
     }
 
     fn name(&self) -> Option<&str> {
-        Some(self.base_info.name.as_ref()?.as_original()?.content.name.as_ref()?.as_ref())
+        Some(&self.base_info.name.as_ref()?.as_original()?.content.name)
     }
 
     fn tombstone(&self) -> Option<&RoomTombstoneEventContent> {
@@ -1386,7 +1386,7 @@ mod tests {
 
     fn make_name_event() -> MinimalStateEvent<RoomNameEventContent> {
         MinimalStateEvent::Original(OriginalMinimalStateEvent {
-            content: RoomNameEventContent::new(Some("Test Room".try_into().unwrap())),
+            content: RoomNameEventContent::new("Test Room".try_into().unwrap()),
             event_id: None,
         })
     }
@@ -1534,17 +1534,7 @@ mod tests {
 
         // And that is implemented by making a fake event
         assert_eq!(
-            room_info
-                .base_info
-                .name
-                .as_ref()
-                .unwrap()
-                .as_original()
-                .unwrap()
-                .content
-                .name
-                .as_ref()
-                .unwrap(),
+            room_info.base_info.name.as_ref().unwrap().as_original().unwrap().content.name,
             "new name"
         );
     }

--- a/crates/matrix-sdk-base/src/utils.rs
+++ b/crates/matrix-sdk-base/src/utils.rs
@@ -14,7 +14,7 @@ use ruma::{
             },
             join_rules::{RoomJoinRulesEventContent, StrippedRoomJoinRulesEvent},
             member::{MembershipState, RoomMemberEventContent},
-            name::{RoomNameEventContent, StrippedRoomNameEvent},
+            name::{RedactedRoomNameEventContent, RoomNameEventContent, StrippedRoomNameEvent},
             tombstone::{
                 RedactedRoomTombstoneEventContent, RoomTombstoneEventContent,
                 StrippedRoomTombstoneEvent,
@@ -195,8 +195,16 @@ impl From<&StrippedRoomAvatarEvent> for MinimalStateEvent<RoomAvatarEventContent
 
 impl From<&StrippedRoomNameEvent> for MinimalStateEvent<RoomNameEventContent> {
     fn from(event: &StrippedRoomNameEvent) -> Self {
-        let content = RoomNameEventContent::new(event.content.name.clone());
-        Self::Original(OriginalMinimalStateEvent { content, event_id: None })
+        match event.content.name.clone() {
+            Some(name) => {
+                let content = RoomNameEventContent::new(name);
+                Self::Original(OriginalMinimalStateEvent { content, event_id: None })
+            }
+            None => {
+                let content = RedactedRoomNameEventContent::new();
+                Self::Redacted(RedactedMinimalStateEvent { content, event_id: None })
+            }
+        }
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -167,11 +167,7 @@ async fn other_state() {
     let mut stream = timeline.subscribe().await;
 
     timeline
-        .handle_live_state_event(
-            &ALICE,
-            RoomNameEventContent::new(Some("Alice's room".to_owned())),
-            None,
-        )
+        .handle_live_state_event(&ALICE, RoomNameEventContent::new("Alice's room".to_owned()), None)
         .await;
 
     let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
@@ -181,7 +177,7 @@ async fn other_state() {
     let full_content =
         assert_matches!(ev.content(), AnyOtherFullStateEventContent::RoomName(c) => c);
     let (content, prev_content) = assert_matches!(full_content, FullStateEventContent::Original { content, prev_content } => (content, prev_content));
-    assert_eq!(content.name.as_ref().unwrap(), "Alice's room");
+    assert_eq!(content.name, "Alice's room");
     assert_matches!(prev_content, None);
 
     timeline.handle_live_redacted_state_event(&ALICE, RedactedRoomTopicEventContent::new()).await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -126,11 +126,7 @@ async fn filter_always_false() {
         .await;
 
     timeline
-        .handle_live_state_event(
-            &ALICE,
-            RoomNameEventContent::new(Some("Alice's room".to_owned())),
-            None,
-        )
+        .handle_live_state_event(&ALICE, RoomNameEventContent::new("Alice's room".to_owned()), None)
         .await;
 
     assert_eq!(timeline.inner.items().await.len(), 0);
@@ -166,11 +162,7 @@ async fn custom_filter() {
         .await;
 
     timeline
-        .handle_live_state_event(
-            &ALICE,
-            RoomNameEventContent::new(Some("Alice's room".to_owned())),
-            None,
-        )
+        .handle_live_state_event(&ALICE, RoomNameEventContent::new("Alice's room".to_owned()), None)
         .await;
 
     assert_eq!(timeline.inner.items().await.len(), 3);

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -45,7 +45,7 @@ async fn redact_state_event() {
     timeline
         .handle_live_state_event(
             &ALICE,
-            RoomNameEventContent::new(Some("Fancy room name".to_owned())),
+            RoomNameEventContent::new("Fancy room name".to_owned()),
             None,
         )
         .await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -117,7 +117,7 @@ async fn back_pagination() {
             FullStateEventContent::Original { content, prev_content }
         ) => (content, prev_content)
     );
-    assert_eq!(content.name.as_ref().unwrap(), "New room name");
+    assert_eq!(content.name, "New room name");
     assert_eq!(prev_content.as_ref().unwrap().name.as_ref().unwrap(), "Old room name");
 
     Mock::given(method("GET"))

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1760,7 +1760,7 @@ impl Room {
     }
 
     /// Sets the name of this room.
-    pub async fn set_name(&self, name: Option<String>) -> Result<send_state_event::v3::Response> {
+    pub async fn set_name(&self, name: String) -> Result<send_state_event::v3::Response> {
         self.send_state_event(RoomNameEventContent::new(name)).await
     }
 

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -588,5 +588,5 @@ async fn set_name() {
         .mount(&server)
         .await;
 
-    room.set_name(Some(name.to_owned())).await.unwrap();
+    room.set_name(name.to_owned()).await.unwrap();
 }

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 helpers = []
 
 [dependencies]
-assert_matches = { workspace = true }
+assert_matches.workspace = true
 anyhow = { workspace = true }
 assign = "1"
 ctor = { workspace = true }

--- a/testing/sliding-sync-integration-test/src/notification_client.rs
+++ b/testing/sliding-sync-integration-test/src/notification_client.rs
@@ -54,7 +54,7 @@ async fn test_notification() -> Result<()> {
     let alice_room = alice.create_room(request).await?;
 
     const ROOM_NAME: &str = "Kingdom of Integration Testing";
-    alice_room.set_name(Some(ROOM_NAME.to_owned())).await?;
+    alice_room.set_name(ROOM_NAME.to_owned()).await?;
 
     let room_id = alice_room.room_id().to_owned();
 


### PR DESCRIPTION
This changes `Room::set_name` to require a new name. We could provide `unset_name` to redact the latest room name (or post an empty one and immediately redact it?), as the spec does not provide a different mechanism for unsetting room names.