### PR TITLE
feat(ui): Add the `none` filter

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -13,7 +13,8 @@ use matrix_sdk::{
     RoomListEntry as MatrixRoomListEntry,
 };
 use matrix_sdk_ui::room_list_service::filters::{
-    new_filter_all, new_filter_fuzzy_match_room_name, new_filter_normalized_match_room_name,
+    new_filter_all, new_filter_fuzzy_match_room_name, new_filter_none,
+    new_filter_normalized_match_room_name,
 };
 use tokio::sync::RwLock;
 
@@ -370,6 +371,7 @@ impl RoomListDynamicEntriesController {
 
         match kind {
             Kind::All => self.inner.set_filter(new_filter_all()),
+            Kind::None => self.inner.set_filter(new_filter_none()),
             Kind::NormalizedMatchRoomName { pattern } => {
                 self.inner.set_filter(new_filter_normalized_match_room_name(&self.client, &pattern))
             }
@@ -391,6 +393,7 @@ impl RoomListDynamicEntriesController {
 #[derive(uniffi::Enum)]
 pub enum RoomListEntriesDynamicFilterKind {
     All,
+    None,
     NormalizedMatchRoomName { pattern: String },
     FuzzyMatchRoomName { pattern: String },
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -59,6 +59,13 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_pattern() {
+        let matcher = FuzzyMatcher::new();
+
+        assert!(matcher.fuzzy_match("hello"));
+    }
+
+    #[test]
     fn test_literal() {
         let matcher = FuzzyMatcher::new();
 

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
@@ -1,9 +1,11 @@
 mod all;
 mod fuzzy_match_room_name;
+mod none;
 mod normalized_match_room_name;
 
 pub use all::new_filter as new_filter_all;
 pub use fuzzy_match_room_name::new_filter as new_filter_fuzzy_match_room_name;
+pub use none::new_filter as new_filter_none;
 pub use normalized_match_room_name::new_filter as new_filter_normalized_match_room_name;
 use unicode_normalization::{char::is_combining_mark, UnicodeNormalization};
 

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/none.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/none.rs
@@ -1,0 +1,25 @@
+use matrix_sdk::RoomListEntry;
+
+/// Create a new filter that will reject all entries.
+pub fn new_filter() -> impl Fn(&RoomListEntry) -> bool {
+    |_room_list_entry| -> bool { false }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not;
+
+    use matrix_sdk::RoomListEntry;
+    use ruma::room_id;
+
+    use super::new_filter;
+
+    #[test]
+    fn test_all_kind_of_room_list_entry() {
+        let none = new_filter();
+
+        assert!(none(&RoomListEntry::Empty).not());
+        assert!(none(&RoomListEntry::Filled(room_id!("!r0:bar.org").to_owned())).not());
+        assert!(none(&RoomListEntry::Invalidated(room_id!("!r0:bar.org").to_owned())).not());
+    }
+}

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
@@ -59,6 +59,13 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_pattern() {
+        let matcher = NormalizedMatcher::new();
+
+        assert!(matcher.normalized_match("hello"));
+    }
+
+    #[test]
     fn test_literal() {
         let matcher = NormalizedMatcher::new();
 


### PR DESCRIPTION
A room list can be filtered by using filters. So far, we have:

* `all` that accepts `Filled` and `Invalidated` room list entries, and rejects `Empty` entries,
* `fuzzy_match_room_name` that runs a fuzzy matcher on the room name,
* `normalized_match_room_name` that runs a normalized matcher on the room name.

When the pattern is empty, both the last filters _accept_ the room list entry. That's a long-term well-known philosophical debate. I'm glad that the behavior is the same for both of the filters.

But that's a technical problem for us. There is no way to _empty_ the room list based on a filter. It becomes a technical challenge for the client app implementors:

* When a user searches for a pattern, before any input is received, the room list must be hidden,
* When a user starts providing a pattern, the room list must be shown again,
* When the filter is changed, the client app receives a `VectorDiff::Reset { values: [] }`, but it might takes time for the app UI to remove all items from the room list, thus resulting a UI blinking glitch between the time the room list is shown, and the time the room list is actually emptied.

The solution is simple though. This patch introduces a new `none` filter. It rejects all room list entries, thus effectively emptying the room list. The client app won't hide and show the room list again, this logic is no longer necessary. Instead, the new logic is the following:

* Use the `all` filter for the “classic view”,
* User wants to search something: switch to the `none` filter,
* User has provided a non-empty pattern: switch to the `normalized_match_room_name` filter for example,
* User removes its pattern: switch back to the `none` filter,
* User goes back to the “classic view”: switch to the `all` filter.

It's a matter of switching the filter, which is more robust and deterministic than hiding or showing the room list based on some events etc.

---

* Address https://github.com/vector-im/element-x-ios/issues/1772