### PR TITLE
feat(sdk): Remove `SlidingSyncList::room_list_filtered_stream`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -143,7 +143,8 @@ impl RoomList {
             loop {
                 let filter_fn = filter_fn_cell.take().await;
                 let (values, stream) = list
-                    .room_list_filtered_stream(filter_fn)
+                    .room_list_stream()
+                    .filter(filter_fn)
                     .dynamic_limit_with_initial_value(page_size, limit_stream.clone());
 
                 // Clearing the stream before chaining with the real stream.

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -14,7 +14,6 @@ use std::{
 
 use eyeball::{Observable, Subscriber};
 use eyeball_im::{ObservableVector, ObservableVectorTransaction, VectorDiff};
-use eyeball_im_util::vector::{VectorObserverExt, VectorSubscriberExt};
 use futures_core::Stream;
 use imbl::Vector;
 use ruma::{api::client::sync::sync_events::v4, assign, OwnedRoomId, TransactionId};
@@ -156,20 +155,6 @@ impl SlidingSyncList {
         let subscriber = ObservableVector::subscribe(&read_lock);
 
         (values, subscriber.into_batched_stream())
-    }
-
-    /// Get a stream of room list, but filtered.
-    ///
-    /// It's similar to [`Self::room_list_stream`] but the room list is filtered
-    /// by `filter`.
-    pub fn room_list_filtered_stream<F>(
-        &self,
-        filter: F,
-    ) -> (Vector<RoomListEntry>, impl Stream<Item = Vec<VectorDiff<RoomListEntry>>>)
-    where
-        F: Fn(&RoomListEntry) -> bool,
-    {
-        self.inner.room_list.read().unwrap().subscribe().batched().filter(filter)
     }
 
     /// Get the maximum number of rooms. See [`Self::maximum_number_of_rooms`]


### PR DESCRIPTION
This patch removes `SlidingSyncList::room_list_filtered_stream. Of course, the only place where it was used,
`RoomList::entries_with_dynamic_adapters` now use `.filter` from `VectorSubscriberExt`. It's basically less code.