### PR TITLE
fix(cargo): Enable `unstable-msc3381` on `ruma`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "6927393caa0fbf6dc07611e4a9cae3f281265cba", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "unstable-msc3381"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "6927393caa0fbf6dc07611e4a9cae3f281265cba", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
 ruma-common = { git = "https://github.com/ruma/ruma", rev = "6927393caa0fbf6dc07611e4a9cae3f281265cba" }
 once_cell = "1.16.0"
 serde = "1.0.151"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "6927393caa0fbf6dc07611e4a9cae3f281265cba", features = ["client-api-c", "compat-upload-signatures", "compat-user-id"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "6927393caa0fbf6dc07611e4a9cae3f281265cba", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "unstable-msc3381"] }
 ruma-common = { git = "https://github.com/ruma/ruma", rev = "6927393caa0fbf6dc07611e4a9cae3f281265cba" }
 once_cell = "1.16.0"
 serde = "1.0.151"

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -41,7 +41,7 @@ matrix-sdk-crypto = { version = "0.6.0", path = "../matrix-sdk-crypto", optional
 matrix-sdk-store-encryption = { version = "0.2.0", path = "../matrix-sdk-store-encryption" }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test", optional = true }
 once_cell = { workspace = true }
-ruma = { workspace = true, features = ["canonical-json"] }
+ruma = { workspace = true, features = ["canonical-json", "unstable-msc3381"] }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }


### PR DESCRIPTION
Without this feature:

```sh
$ cargo check -p matrix-sdk --features experimental-sliding-sync
    Checking matrix-sdk-base v0.6.1 (/Users/hwhost/Development/Element/matrix-rust-sdk/crates/matrix-sdk-base)
error[E0433]: failed to resolve: could not find `poll` in `events`
 --> crates/matrix-sdk-base/src/latest_event.rs:7:5
  |
7 |     poll::unstable_start::SyncUnstablePollStartEvent, room::message::SyncRoomMessageEvent,
  |     ^^^^ could not find `poll` in `events`

error[E0599]: no variant or associated item named `UnstablePollStart` found for enum `AnySyncMessageLikeEvent` in the current scope
  --> crates/matrix-sdk-base/src/latest_event.rs:40:68
   |
40 |         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::UnstablePollStart(poll)) => {
   |                                                                    ^^^^^^^^^^^^^^^^^ variant or associated item not found in `AnySyncMessageLikeEvent`
```

With the feature, everything goes well.