### PR TITLE
Workaround uniffi kotlin bug with empty structs

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -803,7 +803,7 @@ impl From<RumaUnstableAudioDetailsContentBlock> for UnstableAudioDetailsContent 
 
 #[derive(Clone, uniffi::Record)]
 pub struct UnstableVoiceContent {
-    // DO NOT USE: Dummy prop to work around https://github.com/mozilla/uniffi-rs/issues/1760
+    // DO NOT USE: Dummy field to work around https://github.com/mozilla/uniffi-rs/issues/1760
     do_not_use: bool,
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -802,11 +802,14 @@ impl From<RumaUnstableAudioDetailsContentBlock> for UnstableAudioDetailsContent 
 }
 
 #[derive(Clone, uniffi::Record)]
-pub struct UnstableVoiceContent {}
+pub struct UnstableVoiceContent {
+    // DO NOT USE: Dummy prop to work around https://github.com/mozilla/uniffi-rs/issues/1760
+    do_not_use: bool,
+}
 
 impl From<RumaUnstableVoiceContentBlock> for UnstableVoiceContent {
     fn from(_details: RumaUnstableVoiceContentBlock) -> Self {
-        Self {}
+        Self { do_not_use: false }
     }
 }
 


### PR DESCRIPTION
Adds a dummy field to `UnstableVoiceContent` otherwise uniffi will generate an empty Kotlin data class which breaks compilation (Kotlin data classes must have at least 1 prop). Upstream bug: https://github.com/mozilla/uniffi-rs/issues/1760
