### PR TITLE
base: Ensure room name is not empty

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -350,6 +350,8 @@ impl Room {
     }
 
     /// Get the `m.room.name` of this room.
+    ///
+    /// The returned string is guaranteed not to be empty.
     pub fn name(&self) -> Option<String> {
         self.inner.read().name().map(ToOwned::to_owned)
     }
@@ -1022,7 +1024,8 @@ impl RoomInfo {
     }
 
     fn name(&self) -> Option<&str> {
-        Some(&self.base_info.name.as_ref()?.as_original()?.content.name)
+        let name = &self.base_info.name.as_ref()?.as_original()?.content.name;
+        (!name.is_empty()).then_some(name)
     }
 
     fn tombstone(&self) -> Option<&RoomTombstoneEventContent> {
@@ -1353,6 +1356,19 @@ mod tests {
     #[async_test]
     async fn display_name_for_invited_room_is_empty_if_no_info() {
         let (_, room) = make_room(RoomState::Invited);
+        assert_eq!(room.display_name().await.unwrap(), DisplayName::Empty);
+    }
+
+    #[async_test]
+    async fn display_name_for_invited_room_is_empty_if_room_name_empty() {
+        let (_, room) = make_room(RoomState::Invited);
+
+        let room_name = MinimalStateEvent::Original(OriginalMinimalStateEvent {
+            content: RoomNameEventContent::new(String::new()),
+            event_id: None,
+        });
+        room.inner.update(|info| info.base_info.name = Some(room_name));
+
         assert_eq!(room.display_name().await.unwrap(), DisplayName::Empty);
     }
 

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1402,7 +1402,7 @@ mod tests {
 
     fn make_name_event() -> MinimalStateEvent<RoomNameEventContent> {
         MinimalStateEvent::Original(OriginalMinimalStateEvent {
-            content: RoomNameEventContent::new("Test Room".try_into().unwrap()),
+            content: RoomNameEventContent::new("Test Room".to_owned()),
             event_id: None,
         })
     }


### PR DESCRIPTION
Ruma used to handle this during deserialization when the field was an `Option` (prior to #2588).

Especially meaningful when computing the room name, where an empty string should mean that the name is not set.
