### PR TITLE
base & stores: Migrate `RoomInfo` to new format

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -43,7 +43,8 @@ pub use http;
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{
-    DisplayName, Room, RoomInfo, RoomMember, RoomMemberships, RoomState, RoomStateFilter,
+    DisplayName, Room, RoomCreateWithCreatorEventContent, RoomInfo, RoomMember, RoomMemberships,
+    RoomState, RoomStateFilter,
 };
 pub use store::{StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError};
 pub use utils::{

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::assign_op_pattern)] // triggered by bitflags! usage
 
 mod members;
-mod normal;
+pub(crate) mod normal;
 
 use std::{collections::HashSet, fmt};
 
@@ -71,30 +71,30 @@ impl fmt::Display for DisplayName {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BaseRoomInfo {
     /// The avatar URL of this room.
-    avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
+    pub(crate) avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
     /// The canonical alias of this room.
-    canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
+    pub(crate) canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
     /// The `m.room.create` event content of this room.
-    create: Option<MinimalStateEvent<RoomCreateWithCreatorEventContent>>,
+    pub(crate) create: Option<MinimalStateEvent<RoomCreateWithCreatorEventContent>>,
     /// A list of user ids this room is considered as direct message, if this
     /// room is a DM.
     pub(crate) dm_targets: HashSet<OwnedUserId>,
     /// The `m.room.encryption` event content that enabled E2EE in this room.
     pub(crate) encryption: Option<RoomEncryptionEventContent>,
     /// The guest access policy of this room.
-    guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
+    pub(crate) guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
     /// The history visibility policy of this room.
-    history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
+    pub(crate) history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
     /// The join rule policy of this room.
-    join_rules: Option<MinimalStateEvent<RoomJoinRulesEventContent>>,
+    pub(crate) join_rules: Option<MinimalStateEvent<RoomJoinRulesEventContent>>,
     /// The maximal power level that can be found in this room.
     pub(crate) max_power_level: i64,
     /// The `m.room.name` of this room.
-    name: Option<MinimalStateEvent<RoomNameEventContent>>,
+    pub(crate) name: Option<MinimalStateEvent<RoomNameEventContent>>,
     /// The `m.room.tombstone` event content of this room.
-    tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
+    pub(crate) tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
     /// The topic of this room.
-    topic: Option<MinimalStateEvent<RoomTopicEventContent>>,
+    pub(crate) topic: Option<MinimalStateEvent<RoomTopicEventContent>>,
 }
 
 impl BaseRoomInfo {

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -11,18 +11,24 @@ pub use normal::{Room, RoomInfo, RoomState, RoomStateFilter};
 use ruma::{
     assign,
     events::{
+        macros::EventContent,
         room::{
-            avatar::RoomAvatarEventContent, canonical_alias::RoomCanonicalAliasEventContent,
-            create::RoomCreateEventContent, encryption::RoomEncryptionEventContent,
+            avatar::RoomAvatarEventContent,
+            canonical_alias::RoomCanonicalAliasEventContent,
+            create::{PreviousRoom, RoomCreateEventContent},
+            encryption::RoomEncryptionEventContent,
             guest_access::RoomGuestAccessEventContent,
             history_visibility::RoomHistoryVisibilityEventContent,
-            join_rules::RoomJoinRulesEventContent, member::MembershipState,
-            name::RoomNameEventContent, tombstone::RoomTombstoneEventContent,
+            join_rules::RoomJoinRulesEventContent,
+            member::MembershipState,
+            name::RoomNameEventContent,
+            tombstone::RoomTombstoneEventContent,
             topic::RoomTopicEventContent,
         },
-        AnyStrippedStateEvent, AnySyncStateEvent, RedactContent, RedactedStateEventContent,
-        StaticStateEventContent, SyncStateEvent,
+        AnyStrippedStateEvent, AnySyncStateEvent, EmptyStateKey, RedactContent,
+        RedactedStateEventContent, StaticStateEventContent, SyncStateEvent,
     },
+    room::RoomType,
     EventId, OwnedUserId, RoomVersionId,
 };
 use serde::{Deserialize, Serialize};
@@ -69,7 +75,7 @@ pub struct BaseRoomInfo {
     /// The canonical alias of this room.
     canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
     /// The `m.room.create` event content of this room.
-    create: Option<MinimalStateEvent<RoomCreateEventContent>>,
+    create: Option<MinimalStateEvent<RoomCreateWithCreatorEventContent>>,
     /// A list of user ids this room is considered as direct message, if this
     /// room is a DM.
     pub(crate) dm_targets: HashSet<OwnedUserId>,
@@ -309,6 +315,99 @@ fn calculate_room_name(
     } else {
         DisplayName::Calculated(names)
     }
+}
+
+/// The content of an `m.room.create` event, with a required `creator` field.
+///
+/// Starting with room version 11, the `creator` field should be removed and the
+/// `sender` field of the event should be used instead. This is reflected on
+/// [`RoomCreateEventContent`].
+///
+/// This type was created as an alternative for ease of use. When it is used in
+/// the SDK, it is constructed by copying the `sender` of the original event as
+/// the `creator`.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "m.room.create", kind = State, state_key_type = EmptyStateKey, custom_redacted)]
+pub struct RoomCreateWithCreatorEventContent {
+    /// The `user_id` of the room creator.
+    ///
+    /// This is set by the homeserver.
+    ///
+    /// While this should be optional since room version 11, we copy the sender
+    /// of the event so we can still access it.
+    pub creator: OwnedUserId,
+
+    /// Whether or not this room's data should be transferred to other
+    /// homeservers.
+    #[serde(
+        rename = "m.federate",
+        default = "ruma::serde::default_true",
+        skip_serializing_if = "ruma::serde::is_true"
+    )]
+    pub federate: bool,
+
+    /// The version of the room.
+    ///
+    /// Defaults to `RoomVersionId::V1`.
+    #[serde(default = "default_create_room_version_id")]
+    pub room_version: RoomVersionId,
+
+    /// A reference to the room this room replaces, if the previous room was
+    /// upgraded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub predecessor: Option<PreviousRoom>,
+
+    /// The room type.
+    ///
+    /// This is currently only used for spaces.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    pub room_type: Option<RoomType>,
+}
+
+impl RoomCreateWithCreatorEventContent {
+    /// Constructs a `RoomCreateWithCreatorEventContent` with the given original
+    /// content and sender.
+    pub fn from_event_content(content: RoomCreateEventContent, sender: OwnedUserId) -> Self {
+        let RoomCreateEventContent { federate, room_version, predecessor, room_type, .. } = content;
+        Self { creator: sender, federate, room_version, predecessor, room_type }
+    }
+
+    fn into_event_content(self) -> (RoomCreateEventContent, OwnedUserId) {
+        let Self { creator, federate, room_version, predecessor, room_type } = self;
+
+        #[allow(deprecated)]
+        let content = assign!(RoomCreateEventContent::new_v11(), {
+            creator: Some(creator.clone()),
+            federate,
+            room_version,
+            predecessor,
+            room_type,
+        });
+
+        (content, creator)
+    }
+}
+
+/// Redacted form of [`RoomCreateWithCreatorEventContent`].
+pub type RedactedRoomCreateWithCreatorEventContent = RoomCreateWithCreatorEventContent;
+
+impl RedactedStateEventContent for RedactedRoomCreateWithCreatorEventContent {
+    type StateKey = EmptyStateKey;
+}
+
+impl RedactContent for RoomCreateWithCreatorEventContent {
+    type Redacted = RedactedRoomCreateWithCreatorEventContent;
+
+    fn redact(self, version: &RoomVersionId) -> Self::Redacted {
+        let (content, sender) = self.into_event_content();
+        // Use Ruma's redaction algorithm.
+        let content = content.redact(version);
+        Self::from_event_content(content, sender)
+    }
+}
+
+fn default_create_room_version_id() -> RoomVersionId {
+    RoomVersionId::V1
 }
 
 bitflags! {

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -117,8 +117,14 @@ impl BaseRoomInfo {
     }
 
     /// Get the room version of this room.
+    ///
+    /// For room versions earlier than room version 11, if the event is
+    /// redacted, this will return the default of [`RoomVersionId::V1`].
     pub fn room_version(&self) -> Option<&RoomVersionId> {
-        Some(&self.create.as_ref()?.as_original()?.content.room_version)
+        match self.create.as_ref()? {
+            MinimalStateEvent::Original(ev) => Some(&ev.content.room_version),
+            MinimalStateEvent::Redacted(ev) => Some(&ev.content.room_version),
+        }
     }
 
     /// Handle a state event for this room and update our info accordingly.

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -698,22 +698,19 @@ pub struct RoomInfo {
     /// The unique room id of the room.
     pub(crate) room_id: OwnedRoomId,
     /// The state of the room.
-    #[serde(rename = "room_type")] // for backwards compatibility
-    room_state: RoomState,
+    pub(crate) room_state: RoomState,
     /// The unread notifications counts.
-    notification_counts: UnreadNotificationsCount,
+    pub(crate) notification_counts: UnreadNotificationsCount,
     /// The summary of this room.
-    summary: RoomSummary,
+    pub(crate) summary: RoomSummary,
     /// Flag remembering if the room members are synced.
-    members_synced: bool,
+    pub(crate) members_synced: bool,
     /// The prev batch of this room we received during the last sync.
     pub(crate) last_prev_batch: Option<String>,
     /// How much we know about this room.
-    #[serde(default = "SyncInfo::complete")] // see fn docs for why we use this default
-    sync_info: SyncInfo,
+    pub(crate) sync_info: SyncInfo,
     /// Whether or not the encryption info was been synced.
-    #[serde(default = "encryption_state_default")] // see fn docs for why we use this default
-    encryption_state_synced: bool,
+    pub(crate) encryption_state_synced: bool,
     /// The last event send by sliding sync
     #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) latest_event: Option<SyncTimelineEvent>,
@@ -737,24 +734,6 @@ pub(crate) enum SyncInfo {
 
     /// We have all the latest state events.
     FullySynced,
-}
-
-impl SyncInfo {
-    // The sync_info field introduced a new field in the database schema, but to
-    // avoid a database migration, we let serde assume that if the room is in
-    // the database, yet the field isn't, we have synced it before this field
-    // was introduced - which was a a full sync.
-    fn complete() -> Self {
-        SyncInfo::FullySynced
-    }
-}
-
-// The encryption_state_synced field introduced a new field in the database
-// schema, but to avoid a database migration, we let serde assume that if
-// the room is in the database, yet the field isn't, we have synced it
-// before this field was introduced - which was a a full sync.
-fn encryption_state_default() -> bool {
-    true
 }
 
 impl RoomInfo {
@@ -995,7 +974,8 @@ impl RoomInfo {
         }
     }
 
-    fn creator(&self) -> Option<&UserId> {
+    /// Get the creator of this room.
+    pub fn creator(&self) -> Option<&UserId> {
         match self.base_info.create.as_ref()? {
             MinimalStateEvent::Original(ev) => Some(&ev.content.creator),
             MinimalStateEvent::Redacted(ev) => Some(&ev.content.creator),
@@ -1023,7 +1003,8 @@ impl RoomInfo {
         }
     }
 
-    fn name(&self) -> Option<&str> {
+    /// Get the name of this room.
+    pub fn name(&self) -> Option<&str> {
         let name = &self.base_info.name.as_ref()?.as_original()?.content.name;
         (!name.is_empty()).then_some(name)
     }
@@ -1190,7 +1171,7 @@ mod tests {
 
         let info_json = json!({
             "room_id": "!gda78o:server.tld",
-            "room_type": "Invited",
+            "room_state": "Invited",
             "notification_counts": {
                 "highlight_count": 1,
                 "notification_count": 2,
@@ -1234,7 +1215,7 @@ mod tests {
         // cached state
         let info_json = json!({
             "room_id": "!gda78o:server.tld",
-            "room_type": "Invited",
+            "room_state": "Invited",
             "notification_counts": {
                 "highlight_count": 1,
                 "notification_count": 2,

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -57,7 +57,7 @@ use crate::{
 /// For the migration:
 ///
 /// 1. Deserialize the stored room info using this type,
-/// 2. Get the `m.room.create` event for the room, it it is available,
+/// 2. Get the `m.room.create` event for the room, if it is available,
 /// 3. Convert this to [`RoomInfo`] with `.migrate(create_event)`,
 /// 4. Replace the room info in the store.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -1,0 +1,234 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Data migration helpers for StateStore implementations.
+
+use std::collections::HashSet;
+
+#[cfg(feature = "experimental-sliding-sync")]
+use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
+use ruma::{
+    events::{
+        room::{
+            avatar::RoomAvatarEventContent,
+            canonical_alias::RoomCanonicalAliasEventContent,
+            create::RoomCreateEventContent,
+            encryption::RoomEncryptionEventContent,
+            guest_access::RoomGuestAccessEventContent,
+            history_visibility::RoomHistoryVisibilityEventContent,
+            join_rules::RoomJoinRulesEventContent,
+            name::{RedactedRoomNameEventContent, RoomNameEventContent},
+            tombstone::RoomTombstoneEventContent,
+            topic::RoomTopicEventContent,
+        },
+        EmptyStateKey, EventContent, RedactContent, StateEventContent, StateEventType,
+    },
+    OwnedRoomId, OwnedUserId, RoomId,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    deserialized_responses::SyncOrStrippedState,
+    rooms::{
+        normal::{RoomSummary, SyncInfo},
+        BaseRoomInfo,
+    },
+    sync::UnreadNotificationsCount,
+    MinimalStateEvent, OriginalMinimalStateEvent, RoomInfo, RoomState,
+};
+
+/// [`RoomInfo`] version 1.
+///
+/// The `name` field in `RoomNameEventContent` was optional and has become
+/// required. It means that sometimes the field has been serialized with the
+/// value `null`.
+///
+/// For the migration:
+///
+/// 1. Deserialize the stored room info using this type,
+/// 2. Get the `m.room.create` event for the room, it it is available,
+/// 3. Convert this to [`RoomInfo`] with `.migrate(create_event)`,
+/// 4. Replace the room info in the store.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RoomInfoV1 {
+    room_id: OwnedRoomId,
+    room_type: RoomState,
+    notification_counts: UnreadNotificationsCount,
+    summary: RoomSummary,
+    members_synced: bool,
+    last_prev_batch: Option<String>,
+    #[serde(default = "sync_info_complete")] // see fn docs for why we use this default
+    sync_info: SyncInfo,
+    #[serde(default = "encryption_state_default")] // see fn docs for why we use this default
+    encryption_state_synced: bool,
+    #[cfg(feature = "experimental-sliding-sync")]
+    latest_event: Option<SyncTimelineEvent>,
+    base_info: BaseRoomInfoV1,
+}
+
+impl RoomInfoV1 {
+    /// Get the room ID of this room.
+    pub fn room_id(&self) -> &RoomId {
+        &self.room_id
+    }
+
+    /// Returns the state this room is in.
+    pub fn state(&self) -> RoomState {
+        self.room_type
+    }
+
+    /// Migrate this to a [`RoomInfo`], using the given `m.room.create` event
+    /// from the room state.
+    pub fn migrate(self, create: Option<&SyncOrStrippedState<RoomCreateEventContent>>) -> RoomInfo {
+        let RoomInfoV1 {
+            room_id,
+            room_type,
+            notification_counts,
+            summary,
+            members_synced,
+            last_prev_batch,
+            sync_info,
+            encryption_state_synced,
+            #[cfg(feature = "experimental-sliding-sync")]
+            latest_event,
+            base_info,
+        } = self;
+
+        RoomInfo {
+            room_id,
+            room_state: room_type,
+            notification_counts,
+            summary,
+            members_synced,
+            last_prev_batch,
+            sync_info,
+            encryption_state_synced,
+            #[cfg(feature = "experimental-sliding-sync")]
+            latest_event,
+            base_info: base_info.migrate(create),
+        }
+    }
+}
+
+// The sync_info field introduced a new field in the database schema, for
+// backwards compatibility we assume that if the room is in the database, yet
+// the field isn't, we have synced it before this field was introduced - which
+// was a a full sync.
+fn sync_info_complete() -> SyncInfo {
+    SyncInfo::FullySynced
+}
+
+// The encryption_state_synced field introduced a new field in the database
+// schema, for backwards compatibility we assume that if the room is in the
+// database, yet the field isn't, we have synced it before this field was
+// introduced - which was a a full sync.
+fn encryption_state_default() -> bool {
+    true
+}
+
+/// [`BaseRoomInfo`] version 1.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct BaseRoomInfoV1 {
+    avatar: Option<MinimalStateEvent<RoomAvatarEventContent>>,
+    canonical_alias: Option<MinimalStateEvent<RoomCanonicalAliasEventContent>>,
+    dm_targets: HashSet<OwnedUserId>,
+    encryption: Option<RoomEncryptionEventContent>,
+    guest_access: Option<MinimalStateEvent<RoomGuestAccessEventContent>>,
+    history_visibility: Option<MinimalStateEvent<RoomHistoryVisibilityEventContent>>,
+    join_rules: Option<MinimalStateEvent<RoomJoinRulesEventContent>>,
+    max_power_level: i64,
+    name: Option<MinimalStateEvent<RoomNameEventContentV1>>,
+    tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
+    topic: Option<MinimalStateEvent<RoomTopicEventContent>>,
+}
+
+impl BaseRoomInfoV1 {
+    /// Migrate this to a [`BaseRoomInfo`].
+    fn migrate(self, create: Option<&SyncOrStrippedState<RoomCreateEventContent>>) -> BaseRoomInfo {
+        let BaseRoomInfoV1 {
+            avatar,
+            canonical_alias,
+            dm_targets,
+            encryption,
+            guest_access,
+            history_visibility,
+            join_rules,
+            max_power_level,
+            name,
+            tombstone,
+            topic,
+        } = self;
+
+        let create = create.map(|ev| match ev {
+            SyncOrStrippedState::Sync(e) => e.into(),
+            SyncOrStrippedState::Stripped(e) => e.into(),
+        });
+        let name = name.map(|name| match name {
+            MinimalStateEvent::Original(ev) => {
+                MinimalStateEvent::Original(OriginalMinimalStateEvent {
+                    content: ev.content.into(),
+                    event_id: ev.event_id,
+                })
+            }
+            MinimalStateEvent::Redacted(ev) => MinimalStateEvent::Redacted(ev),
+        });
+
+        BaseRoomInfo {
+            avatar,
+            canonical_alias,
+            create,
+            dm_targets,
+            encryption,
+            guest_access,
+            history_visibility,
+            join_rules,
+            max_power_level,
+            name,
+            tombstone,
+            topic,
+        }
+    }
+}
+
+/// [`RoomNameEventContent`] version 1, with an optional `name`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct RoomNameEventContentV1 {
+    name: Option<String>,
+}
+
+impl EventContent for RoomNameEventContentV1 {
+    type EventType = StateEventType;
+
+    fn event_type(&self) -> Self::EventType {
+        StateEventType::RoomName
+    }
+}
+
+impl StateEventContent for RoomNameEventContentV1 {
+    type StateKey = EmptyStateKey;
+}
+
+impl RedactContent for RoomNameEventContentV1 {
+    type Redacted = RedactedRoomNameEventContent;
+
+    fn redact(self, _version: &ruma::RoomVersionId) -> Self::Redacted {
+        RedactedRoomNameEventContent::new()
+    }
+}
+
+impl From<RoomNameEventContentV1> for RoomNameEventContent {
+    fn from(value: RoomNameEventContentV1) -> Self {
+        RoomNameEventContent::new(value.name.unwrap_or_default())
+    }
+}

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -65,6 +65,7 @@ use crate::{
 
 pub(crate) mod ambiguity_map;
 mod memory_store;
+pub mod migration_helpers;
 
 #[cfg(any(test, feature = "testing"))]
 pub use self::integration_tests::StateStoreIntegrationTests;

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -13,8 +13,9 @@ use async_trait::async_trait;
 use deadpool_sqlite::{Object as SqliteConn, Pool as SqlitePool, Runtime};
 use itertools::Itertools;
 use matrix_sdk_base::{
-    deserialized_responses::RawAnySyncOrStrippedState,
+    deserialized_responses::{RawAnySyncOrStrippedState, SyncOrStrippedState},
     media::{MediaRequest, UniqueKey},
+    store::migration_helpers::RoomInfoV1,
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue,
 };
@@ -24,7 +25,10 @@ use ruma::{
     events::{
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
-        room::member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
+        room::{
+            create::RoomCreateEventContent,
+            member::{StrippedRoomMemberEvent, SyncRoomMemberEvent},
+        },
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnySyncStateEvent,
         GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
     },
@@ -57,7 +61,7 @@ mod keys {
     pub const MEDIA: &str = "media";
 }
 
-const DATABASE_VERSION: u8 = 2;
+const DATABASE_VERSION: u8 = 3;
 
 /// A sqlite based cryptostore.
 #[derive(Clone)]
@@ -140,7 +144,7 @@ impl SqliteStateStore {
                     .query_map((), |row| row.get::<_, Vec<u8>>(0))?
                 {
                     let data = data?;
-                    let room_info: RoomInfo = this.deserialize_json(&data)?;
+                    let room_info: RoomInfoV1 = this.deserialize_json(&data)?;
 
                     let room_id = this.encode_key(keys::ROOM_INFO, room_info.room_id());
                     let state = this
@@ -156,6 +160,56 @@ impl SqliteStateStore {
                 txn.execute_batch(include_str!(
                     "../migrations/state_store/002_b_replace_room_info.sql"
                 ))?;
+
+                Result::<_, Error>::Ok(())
+            })
+            .await?;
+        }
+
+        // Migration to v3: RoomInfo format has changed.
+        if from < 3 && to >= 3 {
+            let this = self.clone();
+            conn.with_transaction(move |txn| {
+                // Migrate data .
+                for data in txn
+                    .prepare("SELECT data FROM room_info")?
+                    .query_map((), |row| row.get::<_, Vec<u8>>(0))?
+                {
+                    let data = data?;
+                    let room_info_v1: RoomInfoV1 = this.deserialize_json(&data)?;
+
+                    // Get the `m.room.create` event from the room state.
+                    let room_id = this.encode_key(keys::STATE_EVENT, room_info_v1.room_id());
+                    let event_type =
+                        this.encode_key(keys::STATE_EVENT, StateEventType::RoomCreate.to_string());
+                    let create_res = txn
+                        .prepare(
+                            "SELECT stripped, data FROM state_event
+                             WHERE room_id = ? AND event_type = ?",
+                        )?
+                        .query_row([room_id, event_type], |row| {
+                            Ok((row.get::<_, bool>(0)?, row.get::<_, Vec<u8>>(1)?))
+                        })
+                        .optional()?;
+
+                    let create = create_res.and_then(|(stripped, data)| {
+                        let create = if stripped {
+                            SyncOrStrippedState::<RoomCreateEventContent>::Stripped(
+                                this.deserialize_json(&data).ok()?,
+                            )
+                        } else {
+                            SyncOrStrippedState::Sync(this.deserialize_json(&data).ok()?)
+                        };
+                        Some(create)
+                    });
+
+                    let migrated_room_info = room_info_v1.migrate(create.as_ref());
+
+                    let data = this.serialize_json(&migrated_room_info)?;
+                    let room_id = this.encode_key(keys::ROOM_INFO, migrated_room_info.room_id());
+                    txn.prepare_cached("UPDATE room_info SET data = ? WHERE room_id = ?")?
+                        .execute((data, room_id))?;
+                }
 
                 Result::<_, Error>::Ok(())
             })
@@ -1662,10 +1716,15 @@ mod migration_tests {
         },
     };
 
-    use matrix_sdk_base::{RoomInfo, RoomState, StateStore};
+    use matrix_sdk_base::{sync::UnreadNotificationsCount, RoomState, StateStore};
     use matrix_sdk_test::async_test;
     use once_cell::sync::Lazy;
-    use ruma::RoomId;
+    use ruma::{
+        events::{room::create::RoomCreateEventContent, StateEventType},
+        room_id, server_name, user_id, EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
+    };
+    use rusqlite::Transaction;
+    use serde_json::json;
     use tempfile::{tempdir, TempDir};
 
     use super::{create_pool, init, keys, SqliteStateStore};
@@ -1697,6 +1756,50 @@ mod migration_tests {
         Ok(this)
     }
 
+    fn room_info_v1_json(
+        room_id: &RoomId,
+        state: RoomState,
+        name: Option<&str>,
+        creator: Option<&UserId>,
+    ) -> serde_json::Value {
+        // Test with name set or not.
+        let name_content = match name {
+            Some(name) => json!({ "name": name }),
+            None => json!({ "name": null }),
+        };
+        // Test with creator set or not.
+        let create_content = match creator {
+            Some(creator) => RoomCreateEventContent::new_v1(creator.to_owned()),
+            None => RoomCreateEventContent::new_v11(),
+        };
+
+        json!({
+            "room_id": room_id,
+            "room_type": state,
+            "notification_counts": UnreadNotificationsCount::default(),
+            "summary": {
+                "heroes": [],
+                "joined_member_count": 0,
+                "invited_member_count": 0,
+            },
+            "members_synced": false,
+            "base_info": {
+                "dm_targets": [],
+                "max_power_level": 100,
+                "name": {
+                    "Original": {
+                        "content": name_content,
+                    },
+                },
+                "create": {
+                    "Original": {
+                        "content": create_content,
+                    }
+                }
+            },
+        })
+    }
+
     #[async_test]
     pub async fn test_migrating_v1_to_v2() {
         let path = new_path();
@@ -1711,13 +1814,13 @@ mod migration_tests {
                     let room_id = RoomId::parse(format!("!room_{i}:localhost")).unwrap();
                     let (state, stripped) =
                         if i < 3 { (RoomState::Joined, false) } else { (RoomState::Invited, true) };
-                    let info = RoomInfo::new(&room_id, state);
+                    let info = room_info_v1_json(&room_id, state, None, None);
 
                     let room_id = this.encode_key(keys::ROOM_INFO, room_id);
                     let data = this.serialize_json(&info)?;
 
                     txn.prepare_cached(
-                        "INSERT OR REPLACE INTO room_info (room_id, stripped, data)
+                        "INSERT INTO room_info (room_id, stripped, data)
                          VALUES (?, ?, ?)",
                     )?
                     .execute((room_id, stripped, data))?;
@@ -1737,5 +1840,136 @@ mod migration_tests {
         #[allow(deprecated)]
         let stripped_rooms = store.get_stripped_room_infos().await.unwrap();
         assert_eq!(stripped_rooms.len(), 2);
+    }
+
+    // Add a room in version 2 format of the state store.
+    fn add_room_v2(
+        this: &SqliteStateStore,
+        txn: &Transaction<'_>,
+        room_id: &RoomId,
+        name: Option<&str>,
+        create_creator: Option<&UserId>,
+        create_sender: Option<&UserId>,
+    ) -> Result<(), Error> {
+        let room_info_json = room_info_v1_json(room_id, RoomState::Joined, name, create_creator);
+
+        let encoded_room_id = this.encode_key(keys::ROOM_INFO, room_id);
+        let encoded_state =
+            this.encode_key(keys::ROOM_INFO, serde_json::to_string(&RoomState::Joined)?);
+        let data = this.serialize_json(&room_info_json)?;
+
+        txn.prepare_cached(
+            "INSERT INTO room_info (room_id, state, data)
+             VALUES (?, ?, ?)",
+        )?
+        .execute((encoded_room_id, encoded_state, data))?;
+
+        // Test with or without `m.room.create` event in the room state.
+        let Some(create_sender) = create_sender else {
+            return Ok(());
+        };
+
+        let create_content = match create_creator {
+            Some(creator) => RoomCreateEventContent::new_v1(creator.to_owned()),
+            None => RoomCreateEventContent::new_v11(),
+        };
+
+        let event_id = EventId::new(server_name!("dummy.local"));
+        let create_event = json!({
+            "content": create_content,
+            "event_id": event_id,
+            "sender": create_sender.to_owned(),
+            "origin_server_ts": MilliSecondsSinceUnixEpoch::now(),
+            "state_key": "",
+            "type": "m.room.create",
+            "unsigned": {},
+        });
+
+        let encoded_room_id = this.encode_key(keys::STATE_EVENT, room_id);
+        let encoded_event_type =
+            this.encode_key(keys::STATE_EVENT, StateEventType::RoomCreate.to_string());
+        let encoded_state_key = this.encode_key(keys::STATE_EVENT, "");
+        let stripped = false;
+        let encoded_event_id = this.encode_key(keys::STATE_EVENT, event_id);
+        let data = this.serialize_json(&create_event)?;
+
+        txn.prepare_cached(
+            "INSERT
+             INTO state_event (room_id, event_type, state_key, stripped, event_id, data)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )?
+        .execute((
+            encoded_room_id,
+            encoded_event_type,
+            encoded_state_key,
+            stripped,
+            encoded_event_id,
+            data,
+        ))?;
+
+        Ok(())
+    }
+
+    #[async_test]
+    pub async fn test_migrating_v2_to_v3() {
+        let path = new_path();
+
+        // Room A: with name, creator and sender.
+        let room_a_id = room_id!("!room_a:dummy.local");
+        let room_a_name = "Room A";
+        let room_a_creator = user_id!("@creator:dummy.local");
+        // Use a different sender to check that sender is used over creator in
+        // migration.
+        let room_a_create_sender = user_id!("@sender:dummy.local");
+
+        // Room B: without name, creator and sender.
+        let room_b_id = room_id!("!room_b:dummy.local");
+
+        // Room C: only with sender.
+        let room_c_id = room_id!("!room_c:dummy.local");
+        let room_c_create_sender = user_id!("@creator:dummy.local");
+
+        // Create and populate db.
+        {
+            let db = create_fake_db(&path, 2).await.unwrap();
+            let conn = db.pool.get().await.unwrap();
+
+            let this = db.clone();
+            conn.with_transaction(move |txn| {
+                add_room_v2(
+                    &this,
+                    txn,
+                    room_a_id,
+                    Some(room_a_name),
+                    Some(room_a_creator),
+                    Some(room_a_create_sender),
+                )?;
+                add_room_v2(&this, txn, room_b_id, None, None, None)?;
+                add_room_v2(&this, txn, room_c_id, None, None, Some(room_c_create_sender))?;
+
+                Result::<_, Error>::Ok(())
+            })
+            .await
+            .unwrap();
+        }
+
+        // This transparently migrates to the latest version.
+        let store = SqliteStateStore::open(path, Some(SECRET)).await.unwrap();
+
+        // Check all room infos are there.
+        let room_infos = store.get_room_infos().await.unwrap();
+        assert_eq!(room_infos.len(), 3);
+
+        let room_a = room_infos.iter().find(|r| r.room_id() == room_a_id).unwrap();
+        assert_eq!(room_a.name(), Some(room_a_name));
+        assert_eq!(room_a.creator(), Some(room_a_create_sender));
+
+        let room_b = room_infos.iter().find(|r| r.room_id() == room_b_id).unwrap();
+        assert_eq!(room_b.name(), None);
+        assert_eq!(room_b.creator(), None);
+
+        let room_c = room_infos.iter().find(|r| r.room_id() == room_c_id).unwrap();
+        assert_eq!(room_c.name(), None);
+        assert_eq!(room_c.creator(), Some(room_c_create_sender));
     }
 }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -23,8 +23,9 @@ pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
     deserialized_responses,
     store::{DynStateStore, MemoryStore, StateStoreExt},
-    DisplayName, Room as BaseRoom, RoomInfo, RoomMember as BaseRoomMember, RoomMemberships,
-    RoomState, SessionMeta, StateChanges, StateStore, StoreError,
+    DisplayName, Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomInfo,
+    RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
+    StateStore, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;


### PR DESCRIPTION
Due to a change in Ruma merged in #2588, the `name` field of `RoomNameEventContent` is now required. However, before, if the string was empty, Ruma would deserialize it to `None`, then re-serialize it to `null`. This fixes that.

In the process I removed the serde tweaks on `RoomInfo` to apply them during the migration.

Based on #2563 to also support the case where a client has already encountered a room using version 11.

Tested locally on Fractal.