### PR TITLE
ui: Remove transaction ID parameter on Timeline::{send, send_reply}

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     future::{Future, IntoFuture},
+    marker,
     path::Path,
     pin::Pin,
 };
@@ -8,8 +9,190 @@ use std::{
 use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk::{attachment::AttachmentConfig, TransmissionProgress};
 use mime::Mime;
+use ruma::{
+    events::{
+        room::message::{
+            AddMentions, ForwardThread, OriginalRoomMessageEvent, RoomMessageEventContent,
+        },
+        AnyMessageLikeEventContent,
+    },
+    OwnedTransactionId, TransactionId,
+};
+use tracing::{error, info_span, Instrument};
 
-use super::{Error, Timeline};
+use super::{
+    Error, EventTimelineItem, LocalMessage, Timeline, TimelineItemContent, UnsupportedReplyItem,
+};
+
+pub struct Send<'a> {
+    timeline: &'a Timeline,
+    content: AnyMessageLikeEventContent,
+    txn_id: Option<OwnedTransactionId>,
+}
+
+impl<'a> Send<'a> {
+    pub(crate) fn new(timeline: &'a Timeline, content: AnyMessageLikeEventContent) -> Self {
+        Self { timeline, content, txn_id: None }
+    }
+
+    /// Set a custom transaction ID.
+    ///
+    /// The transaction ID is a locally-unique ID describing a message
+    /// transaction with the homeserver. Unless you're doing something special,
+    /// you can pass in `None` which will create a suitable one for you
+    /// automatically.
+    ///
+    /// * On the sending side, this field is used for re-trying earlier failed
+    ///   transactions. Subsequent messages *must never* re-use an earlier
+    ///   transaction ID.
+    /// * On the receiving side, the field is used for recognizing our own
+    ///   messages when they arrive down the sync: the server includes the ID in
+    ///   the [`MessageLikeUnsigned`][ruma::events::MessageLikeUnsigned] field
+    ///   `transaction_id` of the corresponding
+    ///   [`SyncMessageLikeEvent`][ruma::events::SyncMessageLikeEvent], but only
+    ///   for the *sending* device. Other devices will not see it.
+    pub fn with_transaction_id(mut self, txn_id: &TransactionId) -> Self {
+        self.txn_id = Some(txn_id.to_owned());
+        self
+    }
+}
+
+impl<'a> IntoFuture for Send<'a> {
+    type Output = ();
+    #[cfg(target_arch = "wasm32")]
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+    #[cfg(not(target_arch = "wasm32"))]
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + marker::Send + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self { timeline, content, txn_id } = self;
+        let span = info_span!(
+            "send",
+            room_id = ?timeline.room().room_id(),
+            txn_id = txn_id.as_ref().map(debug),
+        );
+
+        let txn_id = txn_id.unwrap_or_else(TransactionId::new);
+        let fut = async move {
+            timeline.inner.handle_local_event(txn_id.clone(), content.clone()).await;
+            if timeline.msg_sender.send(LocalMessage { content, txn_id }).await.is_err() {
+                error!("Internal error: timeline message receiver is closed");
+            }
+        };
+
+        Box::pin(fut.instrument(span))
+    }
+}
+
+pub struct SendReply<'a> {
+    timeline: &'a Timeline,
+    content: RoomMessageEventContent,
+    reply_item: &'a EventTimelineItem,
+    forward_thread: ForwardThread,
+    add_mentions: AddMentions,
+    txn_id: Option<OwnedTransactionId>,
+}
+
+impl<'a> SendReply<'a> {
+    pub(crate) fn new(
+        timeline: &'a Timeline,
+        content: RoomMessageEventContent,
+        reply_item: &'a EventTimelineItem,
+        forward_thread: ForwardThread,
+        add_mentions: AddMentions,
+    ) -> Self {
+        Self { timeline, content, reply_item, forward_thread, add_mentions, txn_id: None }
+    }
+
+    /// Set a custom transaction ID.
+    ///
+    /// The transaction ID is a locally-unique ID describing a message
+    /// transaction with the homeserver. Unless you're doing something special,
+    /// you can pass in `None` which will create a suitable one for you
+    /// automatically.
+    ///
+    /// * On the sending side, this field is used for re-trying earlier failed
+    ///   transactions. Subsequent messages *must never* re-use an earlier
+    ///   transaction ID.
+    /// * On the receiving side, the field is used for recognizing our own
+    ///   messages when they arrive down the sync: the server includes the ID in
+    ///   the [`MessageLikeUnsigned`][ruma::events::MessageLikeUnsigned] field
+    ///   `transaction_id` of the corresponding
+    ///   [`SyncMessageLikeEvent`][ruma::events::SyncMessageLikeEvent], but only
+    ///   for the *sending* device. Other devices will not see it.
+    pub fn with_transaction_id(mut self, txn_id: &TransactionId) -> Self {
+        self.txn_id = Some(txn_id.to_owned());
+        self
+    }
+}
+
+impl<'a> IntoFuture for SendReply<'a> {
+    type Output = Result<(), UnsupportedReplyItem>;
+    #[cfg(target_arch = "wasm32")]
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
+    #[cfg(not(target_arch = "wasm32"))]
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + marker::Send + 'a>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self { timeline, content, reply_item, forward_thread, add_mentions, txn_id } = self;
+        let span = info_span!("send_reply", ?forward_thread, ?add_mentions).entered();
+
+        let fut = 'make_fut: {
+            // Error returns here must be in sync with
+            // `EventTimelineItem::can_be_replied_to`
+            let Some(event_id) = reply_item.event_id() else {
+                break 'make_fut Err(UnsupportedReplyItem::MISSING_EVENT_ID);
+            };
+
+            let content = match reply_item.content() {
+                TimelineItemContent::Message(msg) => {
+                    let event = OriginalRoomMessageEvent {
+                        event_id: event_id.to_owned(),
+                        sender: reply_item.sender().to_owned(),
+                        origin_server_ts: reply_item.timestamp(),
+                        room_id: timeline.room().room_id().to_owned(),
+                        content: msg.to_content(),
+                        unsigned: Default::default(),
+                    };
+                    content.make_reply_to(&event, forward_thread, add_mentions)
+                }
+                _ => {
+                    let Some(raw_event) = reply_item.latest_json() else {
+                        break 'make_fut Err(UnsupportedReplyItem::MISSING_JSON);
+                    };
+
+                    content.make_reply_to_raw(
+                        raw_event,
+                        event_id.to_owned(),
+                        timeline.room().room_id(),
+                        forward_thread,
+                        add_mentions,
+                    )
+                }
+            };
+
+            let mut send_fut = timeline.send(content.into());
+            if let Some(txn_id) = txn_id {
+                send_fut = send_fut.with_transaction_id(&txn_id);
+            }
+
+            Ok(send_fut)
+        };
+
+        Box::pin(
+            async move {
+                match fut {
+                    Ok(fut) => {
+                        fut.await;
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+            .instrument(span.exit()),
+        )
+    }
+}
 
 pub struct SendAttachment<'a> {
     timeline: &'a Timeline,
@@ -42,7 +225,7 @@ impl<'a> IntoFuture for SendAttachment<'a> {
     #[cfg(target_arch = "wasm32")]
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
     #[cfg(not(target_arch = "wasm32"))]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + marker::Send + 'a>>;
 
     fn into_future(self) -> Self::IntoFuture {
         let Self { timeline, url, mime_type, config, send_progress } = self;

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2519,7 +2519,10 @@ async fn test_room_latest_event() -> Result<(), Error> {
     // Insert a local event in the `Timeline`.
     let txn_id: &TransactionId = "foobar-txn-id".into();
 
-    timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into(), Some(txn_id)).await;
+    timeline
+        .send(RoomMessageEventContent::text_plain("Hello, World!").into())
+        .with_transaction_id(txn_id)
+        .await;
 
     // The latest event of the `Timeline` is a local event.
     assert_matches!(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -70,7 +70,8 @@ async fn echo() {
     #[allow(unknown_lints, clippy::redundant_async_block)] // false positive
     let send_hdl = spawn(async move {
         timeline
-            .send(RoomMessageEventContent::text_plain("Hello, World!").into(), Some(txn_id))
+            .send(RoomMessageEventContent::text_plain("Hello, World!").into())
+            .with_transaction_id(txn_id)
             .await
     });
 
@@ -154,7 +155,10 @@ async fn retry_failed() {
     let event_id = event_id!("$wWgymRfo7ri1uQx0NXO40vLJ");
     let txn_id: &TransactionId = "my-txn-id".into();
 
-    timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into(), Some(txn_id)).await;
+    timeline
+        .send(RoomMessageEventContent::text_plain("Hello, World!").into())
+        .with_transaction_id(txn_id)
+        .await;
 
     // First, local echo is added
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
@@ -223,7 +227,10 @@ async fn dedup_by_event_id_late() {
         .mount(&server)
         .await;
 
-    timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into(), Some(txn_id)).await;
+    timeline
+        .send(RoomMessageEventContent::text_plain("Hello, World!").into())
+        .with_transaction_id(txn_id)
+        .await;
 
     assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { .. })); // day divider
     let local_echo = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
@@ -278,7 +285,10 @@ async fn cancel_failed() {
 
     let txn_id: &TransactionId = "my-txn-id".into();
 
-    timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into(), Some(txn_id)).await;
+    timeline
+        .send(RoomMessageEventContent::text_plain("Hello, World!").into())
+        .with_transaction_id(txn_id)
+        .await;
 
     // Local echo is added (immediately)
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -76,8 +76,8 @@ async fn message_order() {
         .mount(&server)
         .await;
 
-    timeline.send(RoomMessageEventContent::text_plain("First!").into(), None).await;
-    timeline.send(RoomMessageEventContent::text_plain("Second.").into(), None).await;
+    timeline.send(RoomMessageEventContent::text_plain("First!").into()).await;
+    timeline.send(RoomMessageEventContent::text_plain("Second.").into()).await;
 
     // Local echoes are available as soon as `timeline.send` returns
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
@@ -125,8 +125,14 @@ async fn retry_order() {
 
     // Send two messages without mocking the server response.
     // It will respond with a 404, resulting in a failed-to-send state.
-    timeline.send(RoomMessageEventContent::text_plain("First!").into(), Some("1".into())).await;
-    timeline.send(RoomMessageEventContent::text_plain("Second.").into(), Some("2".into())).await;
+    timeline
+        .send(RoomMessageEventContent::text_plain("First!").into())
+        .with_transaction_id("1".into())
+        .await;
+    timeline
+        .send(RoomMessageEventContent::text_plain("Second.").into())
+        .with_transaction_id("2".into())
+        .await;
 
     // Local echoes are available as soon as `timeline.send` returns
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
@@ -229,7 +235,7 @@ async fn clear_with_echoes() {
     {
         let (_, mut timeline_stream) = timeline.subscribe().await;
 
-        timeline.send(RoomMessageEventContent::text_plain("Send failure").into(), None).await;
+        timeline.send(RoomMessageEventContent::text_plain("Send failure").into()).await;
 
         // Wait for the first message to fail. Don't use time, but listen for the first
         // timeline item diff to get back signalling the error.
@@ -250,7 +256,7 @@ async fn clear_with_echoes() {
         .await;
 
     // (this one)
-    timeline.send(RoomMessageEventContent::text_plain("Pending").into(), None).await;
+    timeline.send(RoomMessageEventContent::text_plain("Pending").into()).await;
 
     // Another message comes in.
     sync_builder.add_joined_room(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -306,7 +306,6 @@ async fn send_reply() {
             &hello_world_item,
             ForwardThread::Yes,
             AddMentions::No,
-            None,
         )
         .await
         .unwrap();

--- a/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
@@ -49,7 +49,7 @@ async fn test_toggling_reaction() -> Result<()> {
     let (_items, mut stream) = timeline.subscribe().await;
 
     // Send message
-    timeline.send(RoomMessageEventContent::text_plain("hi!").into(), None).await;
+    timeline.send(RoomMessageEventContent::text_plain("hi!").into()).await;
 
     // Sync until the remote echo arrives
     let event_id = loop {


### PR DESCRIPTION
They now return named futures with a setter for the transaction ID instead.

It's a little bit annoying for FFI. I can extend this PR to include a trait `OptionalTransactionId` or whatever that's implemented for all the relevant types one might want to pass? Also I think it would make sense to do the same thing for the send methods outside the timeline, where a txn ID is more commonly used, but also a bit ugly to set oftentimes. Wdyt?