### PR TITLE
`DeduplicatedRequestHandler` :sparkles: 

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -978,7 +978,7 @@ impl BaseClient {
                 // TODO: All the actions in this loop used to be done only when the membership
                 // event was not in the store before. This was changed with the new room API,
                 // because e.g. leaving a room makes members events outdated and they need to be
-                // fetched by `get_members`. Therefore, they need to be overwritten here, even
+                // fetched by `members`. Therefore, they need to be overwritten here, even
                 // if they exist.
                 // However, this makes a new problem occur where setting the member events here
                 // potentially races with the sync.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -146,6 +146,8 @@ async fn retry_failed() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
+    mock_encryption_state(&server, false).await;
+
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await);
     let (_, mut timeline_stream) =

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -23,6 +23,9 @@ Breaking changes:
 - Event handler closures now need to implement `FnOnce` + `Clone` instead of `Fn`
   - As a consequence, you no longer need to explicitly need to `clone` variables they capture
     before constructing an `async move {}` block inside
+- `Room::sync_members` doesn't return the underlying Ruma response anymore. If you need to get the
+  room members, you can use `Room::members` or `Room::get_member` which will make sure that the
+  members are up to date.
 
 Bug fixes:
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -167,7 +167,8 @@ pub(crate) struct ClientInner {
     /// room.
     pub(crate) members_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<Result<(), ()>>>>>,
     /// Locks for requests on the encryption state of rooms.
-    pub(crate) encryption_state_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
+    pub(crate) encryption_state_request_locks:
+        Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<Result<(), ()>>>>>,
     pub(crate) typing_notice_times: DashMap<OwnedRoomId, Instant>,
     /// Event handlers. See `add_event_handler`.
     pub(crate) event_handlers: EventHandlerStore,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -165,7 +165,7 @@ pub(crate) struct ClientInner {
     pub(crate) key_claim_lock: Mutex<()>,
     /// Lock to ensure that only one members request is running at a time, per
     /// room.
-    pub(crate) members_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
+    pub(crate) members_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<Result<(), ()>>>>>,
     /// Locks for requests on the encryption state of rooms.
     pub(crate) encryption_state_request_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
     pub(crate) typing_notice_times: DashMap<OwnedRoomId, Instant>,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -159,7 +159,7 @@ pub(crate) struct ClientInner {
     /// Locks making sure we only have one group session sharing request in
     /// flight per room.
     #[cfg(feature = "e2e-encryption")]
-    pub(crate) group_session_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<()>>>>,
+    pub(crate) group_session_locks: Mutex<BTreeMap<OwnedRoomId, Arc<Mutex<Result<(), ()>>>>>,
     /// Lock making sure we're only doing one key claim request at a time.
     #[cfg(feature = "e2e-encryption")]
     pub(crate) key_claim_lock: Mutex<()>,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -76,6 +76,7 @@ use crate::oidc::Oidc;
 use crate::{
     authentication::{AuthCtx, AuthData, ReloadSessionCallback, SaveSessionCallback},
     config::RequestConfig,
+    deduplicating_handler::DeduplicatingHandler,
     error::{HttpError, HttpResult},
     event_handler::{
         EventHandler, EventHandlerDropGuard, EventHandlerHandle, EventHandlerStore, SyncEvent,
@@ -83,7 +84,6 @@ use crate::{
     http_client::HttpClient,
     matrix_auth::MatrixAuth,
     notification_settings::NotificationSettings,
-    room::DeduplicatedRequestHandler,
     sync::{RoomUpdate, SyncResponse},
     Account, AuthApi, AuthSession, Error, Media, RefreshTokenError, Result, Room,
     TransmissionProgress,
@@ -162,16 +162,16 @@ pub(crate) struct ClientInner {
     /// Handler making sure we only have one group session sharing request in
     /// flight per room.
     #[cfg(feature = "e2e-encryption")]
-    pub(crate) group_session_deduplicated_handler: DeduplicatedRequestHandler<OwnedRoomId>,
+    pub(crate) group_session_deduplicated_handler: DeduplicatingHandler<OwnedRoomId>,
     /// Lock making sure we're only doing one key claim request at a time.
     #[cfg(feature = "e2e-encryption")]
     pub(crate) key_claim_lock: Mutex<()>,
     /// Handler to ensure that only one members request is running at a time,
     /// given a room.
-    pub(crate) members_request_deduplicated_handler: DeduplicatedRequestHandler<OwnedRoomId>,
+    pub(crate) members_request_deduplicated_handler: DeduplicatingHandler<OwnedRoomId>,
     /// Handler to ensure that only one encryption state request is running at a
     /// time, given a room.
-    pub(crate) encryption_state_deduplicated_handler: DeduplicatedRequestHandler<OwnedRoomId>,
+    pub(crate) encryption_state_deduplicated_handler: DeduplicatingHandler<OwnedRoomId>,
     pub(crate) typing_notice_times: DashMap<OwnedRoomId, Instant>,
     /// Event handlers. See `add_event_handler`.
     pub(crate) event_handlers: EventHandlerStore,

--- a/crates/matrix-sdk/src/deduplicating_handler.rs
+++ b/crates/matrix-sdk/src/deduplicating_handler.rs
@@ -1,0 +1,83 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use futures_core::Future;
+use matrix_sdk_common::SendOutsideWasm;
+use tokio::sync::Mutex;
+
+use crate::{Error, Result};
+
+type DeduplicatedRequestMap<Key> = Mutex<BTreeMap<Key, Arc<Mutex<Result<(), ()>>>>>;
+
+/// Handler that properly deduplicates function calls given a key uniquely
+/// identifying the call kind, and will properly report error upwards in case
+/// the concurrent call failed.
+///
+/// This is handy for deduplicating per-room requests, but can also be used in
+/// other contexts.
+pub(crate) struct DeduplicatingHandler<Key> {
+    inflight: DeduplicatedRequestMap<Key>,
+}
+
+impl<Key> Default for DeduplicatingHandler<Key> {
+    fn default() -> Self {
+        Self { inflight: Default::default() }
+    }
+}
+
+impl<Key: Clone + Ord + std::hash::Hash> DeduplicatingHandler<Key> {
+    pub async fn run<'a, F: Future<Output = Result<()>> + SendOutsideWasm + 'a>(
+        &self,
+        key: Key,
+        code: F,
+    ) -> Result<()> {
+        let mut map = self.inflight.lock().await;
+
+        if let Some(mutex) = map.get(&key).cloned() {
+            // If a request is already going on, await the release of the lock.
+            drop(map);
+
+            return mutex.lock().await.map_err(|()| Error::ConcurrentRequestFailed);
+        }
+
+        // Assume a successful request; we'll modify the result in case of failures
+        // later.
+        let request_mutex = Arc::new(Mutex::new(Ok(())));
+
+        map.insert(key.clone(), request_mutex.clone());
+
+        let mut request_guard = request_mutex.lock().await;
+        drop(map);
+
+        match code.await {
+            Ok(()) => {
+                self.inflight.lock().await.remove(&key);
+                Ok(())
+            }
+
+            Err(err) => {
+                // Propagate the error state to other callers.
+                *request_guard = Err(());
+
+                // Remove the request from the in-flights set.
+                self.inflight.lock().await.remove(&key);
+
+                // Bubble up the error.
+                Err(err)
+            }
+        }
+    }
+}

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -266,6 +266,10 @@ pub enum Error {
     #[error(transparent)]
     Oidc(#[from] crate::oidc::OidcError),
 
+    /// A concurrent request to a deduplicated request has failed.
+    #[error("a concurrent request failed; see logs for details")]
+    ConcurrentRequestFailed,
+
     /// An other error was raised
     /// this might happen because encryption was enabled on the base-crate
     /// but not here and that raised.

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -34,6 +34,7 @@ pub mod attachment;
 mod authentication;
 mod client;
 pub mod config;
+mod deduplicating_handler;
 #[cfg(feature = "e2e-encryption")]
 pub mod encryption;
 mod error;

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1147,7 +1147,7 @@ mod tests {
                 .mount_as_scoped(&server)
                 .await;
 
-            assert_matches!(room0.request_members().await, Ok(Some(_)));
+            assert_matches!(room0.request_members().await, Ok(()));
         }
 
         // Members are now synced! We can start subscribing and see how it goes.

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -558,12 +558,10 @@ async fn fetch_members_deduplication() {
     }
 
     // Wait on all of them at once.
-    let results = join_all(tasks).await;
+    join_all(tasks).await;
 
-    // See how many of them sent a request and thus have a response.
-    let response_count =
-        results.iter().filter(|r| r.as_ref().unwrap().as_ref().unwrap().is_some()).count();
-    assert_eq!(response_count, 1);
+    // Ensure we called the endpoint exactly once.
+    server.verify().await;
 }
 
 #[async_test]

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -129,3 +129,65 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_failed_members_response() -> Result<()> {
+    let time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
+    let alice = get_sync_aware_client_for_user(format!("alice{time}")).await?;
+    let bob = get_sync_aware_client_for_user(format!("bob{time}")).await?;
+
+    let invite = vec![bob.user_id().unwrap().to_owned()];
+    let request = assign!(CreateRoomRequest::new(), {
+        invite,
+        is_direct: true,
+    });
+
+    let alice_room = alice.create_room(request).await?;
+    alice_room.enable_encryption().await?;
+    alice.sync_once().await?;
+
+    warn!("alice has created and enabled encryption in the room");
+
+    bob.sync_once().await?;
+
+    // Cause a failure of a sync_members request by asking for members before
+    // joining. Since this is a private DM room, it will fail with a 401, as
+    // we're not authorized to look at state history.
+    let result = bob.get_room(alice_room.room_id()).unwrap().sync_members().await;
+    assert!(result.is_err());
+
+    bob.get_room(alice_room.room_id()).unwrap().join().await?;
+
+    warn!("bob has joined");
+
+    // Bob sends message WITHOUT syncing.
+    warn!("bob sends message...");
+    let bob_room = bob.get_room(alice_room.room_id()).unwrap();
+    let message = "Hello world!";
+    let bob_message_content = Arc::new(Mutex::new(message));
+    bob_room.send(RoomMessageEventContent::text_plain(message), None).await?;
+    warn!("bob is done sending the message");
+
+    // Alice sees the message.
+    let alice_found_event = Arc::new(Mutex::new(false));
+    warn!("alice is looking for decrypted message");
+
+    let found_event_handler = alice_found_event.clone();
+    let bob_message_content = bob_message_content.clone();
+    alice.add_event_handler(move |event: SyncRoomMessageEvent| async move {
+        warn!("Found a message \\o/ {event:?}");
+        let MessageType::Text(text_content) = &event.as_original().unwrap().content.msgtype else {
+            return;
+        };
+        if text_content.body == *bob_message_content.lock().unwrap() {
+            *found_event_handler.lock().unwrap() = true;
+        }
+    });
+
+    alice.sync_once().await?;
+
+    let found = *alice_found_event.lock().unwrap();
+    assert!(found, "event has not been found for alice");
+
+    Ok(())
+}


### PR DESCRIPTION
This introduces a reusable way to run at most one request, given a key identifying what's the request for. It's used in place of our manual (and unfortunately buggy, as [this issue showed](https://github.com/vector-im/element-x-ios-rageshakes/issues/934)) implementation of similar de-duplication in the code base. This one is heavily commented and scrutinized, and it could be also tested in isolation. This will cause a few extra allocations, but nothing that should kill performance overall, since these requests are relatively infrequent.

This PR can be reviewed commit by commit; you can observe how I got to the final form :grin: 

Fixes https://github.com/vector-im/element-x-ios-rageshakes/issues/934.