### PR TITLE
Simplify construction of `Option`s

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -46,6 +46,7 @@ use std::{
     time::Duration,
 };
 
+use as_variant::as_variant;
 use async_std::sync::{Condvar, Mutex as AsyncStdMutex};
 use atomic::Ordering;
 use dashmap::DashSet;
@@ -702,14 +703,12 @@ impl Store {
 
     ///  Get the Identity of `user_id`
     pub(crate) async fn get_identity(&self, user_id: &UserId) -> Result<Option<UserIdentities>> {
-        let own_identity =
-            self.inner.store.get_user_identity(self.user_id()).await?.and_then(|i| {
-                if let ReadOnlyUserIdentities::Own(i) = i {
-                    Some(i)
-                } else {
-                    None
-                }
-            });
+        let own_identity = self
+            .inner
+            .store
+            .get_user_identity(self.user_id())
+            .await?
+            .and_then(as_variant!(ReadOnlyUserIdentities::Own));
 
         Ok(self.inner.store.get_user_identity(user_id).await?.map(|i| {
             UserIdentities::new(i, self.inner.verification_machine.to_owned(), own_identity)

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/common.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/common.rs
@@ -21,6 +21,7 @@
 
 use std::collections::BTreeMap;
 
+use as_variant::as_variant;
 use ruma::{
     encryption::KeyUsage, serde::Raw, DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId,
     OwnedUserId, UserId,
@@ -110,11 +111,7 @@ impl SigningKey {
     /// Get the Ed25519 key, if the cross-signing key is actually an Ed25519
     /// key.
     pub fn ed25519(&self) -> Option<Ed25519PublicKey> {
-        if let SigningKey::Ed25519(k) = self {
-            Some(*k)
-        } else {
-            None
-        }
+        as_variant!(self, SigningKey::Ed25519).copied()
     }
 
     /// Try to create a `SigningKey` from an `DeviceKeyAlgorithm` and a string

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -23,12 +23,6 @@
 //!    way, meaning the white-space and field order won't be preserved but the
 //!    data will.
 
-mod backup;
-mod cross_signing;
-mod device_keys;
-pub mod events;
-mod one_time_keys;
-
 use std::{
     borrow::Borrow,
     collections::{
@@ -37,15 +31,19 @@ use std::{
     },
 };
 
-pub use backup::*;
-pub use cross_signing::*;
-pub use device_keys::*;
-pub use one_time_keys::*;
 use ruma::{
     serde::StringEnum, DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, UserId,
 };
 use serde::{Deserialize, Serialize, Serializer};
 use vodozemac::{Curve25519PublicKey, Ed25519PublicKey, Ed25519Signature, KeyError};
+
+mod backup;
+mod cross_signing;
+mod device_keys;
+pub mod events;
+mod one_time_keys;
+
+pub use self::{backup::*, cross_signing::*, device_keys::*, one_time_keys::*};
 
 /// Represents a potentially decoded signature (but *not* a validated one).
 ///

--- a/crates/matrix-sdk-crypto/src/types/mod.rs
+++ b/crates/matrix-sdk-crypto/src/types/mod.rs
@@ -31,6 +31,7 @@ use std::{
     },
 };
 
+use as_variant::as_variant;
 use ruma::{
     serde::StringEnum, DeviceKeyAlgorithm, DeviceKeyId, OwnedDeviceKeyId, OwnedUserId, UserId,
 };
@@ -77,11 +78,7 @@ pub struct InvalidSignature {
 impl Signature {
     /// Get the Ed25519 signature, if this is one.
     pub fn ed25519(&self) -> Option<Ed25519Signature> {
-        if let Self::Ed25519(signature) = &self {
-            Some(*signature)
-        } else {
-            None
-        }
+        as_variant!(self, Self::Ed25519).copied()
     }
 
     /// Convert the signature to a base64 encoded string.

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -87,11 +87,8 @@ impl AnyEvent<'_> {
         match self {
             AnyEvent::Room(e) => match e {
                 AnyMessageLikeEvent::RoomMessage(MessageLikeEvent::Original(m)) => {
-                    if let MessageType::VerificationRequest(v) = &m.content.msgtype {
-                        Some(RequestContent::from(v).into())
-                    } else {
-                        None
-                    }
+                    as_variant!(&m.content.msgtype, MessageType::VerificationRequest)
+                        .map(|v| RequestContent::from(v).into())
                 }
                 AnyMessageLikeEvent::KeyVerificationReady(MessageLikeEvent::Original(e)) => {
                     Some(ReadyContent::from(&e.content).into())

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -22,6 +22,7 @@ mod sas;
 
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
+use as_variant::as_variant;
 use event_enums::OutgoingContent;
 pub use machine::VerificationMachine;
 #[cfg(feature = "qrcode")]
@@ -200,22 +201,13 @@ pub enum Verification {
 impl Verification {
     /// Try to deconstruct this verification enum into a SAS verification.
     pub fn sas_v1(self) -> Option<Sas> {
-        #[allow(irrefutable_let_patterns)]
-        if let Verification::SasV1(sas) = self {
-            Some(sas)
-        } else {
-            None
-        }
+        as_variant!(self, Verification::SasV1)
     }
 
     /// Try to deconstruct this verification enum into a QR code verification.
     #[cfg(feature = "qrcode")]
     pub fn qr_v1(self) -> Option<QrVerification> {
-        if let Verification::QrV1(qr) = self {
-            Some(qr)
-        } else {
-            None
-        }
+        as_variant!(self, Verification::QrV1)
     }
 
     /// Has this verification finished.
@@ -429,11 +421,7 @@ pub enum FlowId {
 impl FlowId {
     /// Get the room ID if the flow ID comes from a room event.
     pub fn room_id(&self) -> Option<&RoomId> {
-        if let Self::InRoom(room_id, _) = &self {
-            Some(room_id)
-        } else {
-            None
-        }
+        as_variant!(self, Self::InRoom(room_id, _) => room_id)
     }
 
     /// Get the ID a string.

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use as_variant::as_variant;
 use eyeball::{ObservableWriteGuard, SharedObservable};
 use futures_core::Stream;
 use futures_util::StreamExt;
@@ -202,11 +203,9 @@ impl QrVerification {
     /// Get info about the cancellation if the verification flow has been
     /// cancelled.
     pub fn cancel_info(&self) -> Option<CancelInfo> {
-        if let InnerState::Cancelled(c) = &*self.state.read() {
-            Some(c.state.clone().into())
-        } else {
-            None
-        }
+        as_variant!(&*self.state.read(), InnerState::Cancelled(c) => {
+            c.state.clone().into()
+        })
     }
 
     /// Has the verification flow completed.

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -14,6 +14,7 @@
 
 use std::{ops::Add, sync::Arc, time::Duration};
 
+use as_variant::as_variant;
 use eyeball::{ObservableWriteGuard, SharedObservable, WeakObservable};
 use futures_core::Stream;
 use futures_util::StreamExt;
@@ -301,11 +302,9 @@ impl VerificationRequest {
     /// Get info about the cancellation if the verification request has been
     /// cancelled.
     pub fn cancel_info(&self) -> Option<CancelInfo> {
-        if let InnerRequest::Cancelled(c) = &*self.inner.read() {
-            Some(c.state.clone().into())
-        } else {
-            None
-        }
+        as_variant!(&*self.inner.read(), InnerRequest::Cancelled(c) => {
+            c.state.clone().into()
+        })
     }
 
     /// Has the verification request been answered by another device.
@@ -559,11 +558,9 @@ impl VerificationRequest {
             ObservableWriteGuard::set(&mut guard, updated);
         }
 
-        let content = if let InnerRequest::Cancelled(c) = &*guard {
-            Some(c.state.as_content(self.flow_id()))
-        } else {
-            None
-        };
+        let content = as_variant!(&*guard, InnerRequest::Cancelled(c) => {
+            c.state.as_content(self.flow_id())
+        });
 
         let request = content.map(|c| match c {
             OutgoingContent::ToDevice(content) => {

--- a/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use as_variant::as_variant;
 #[cfg(test)]
 use matrix_sdk_common::instant::Instant;
 use ruma::{
@@ -443,18 +444,10 @@ impl InnerSas {
     }
 
     pub fn verified_devices(&self) -> Option<Arc<[ReadOnlyDevice]>> {
-        if let InnerSas::Done(s) = self {
-            Some(s.verified_devices())
-        } else {
-            None
-        }
+        as_variant!(self, InnerSas::Done).map(|s| s.verified_devices())
     }
 
     pub fn verified_identities(&self) -> Option<Arc<[ReadOnlyUserIdentities]>> {
-        if let InnerSas::Done(s) = self {
-            Some(s.verified_identities())
-        } else {
-            None
-        }
+        as_variant!(self, InnerSas::Done).map(|s| s.verified_identities())
     }
 }

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -255,11 +255,7 @@ impl Sas {
 
     /// Get the room id if the verification is happening inside a room.
     pub fn room_id(&self) -> Option<&RoomId> {
-        if let FlowId::InRoom(r, _) = self.flow_id() {
-            Some(r)
-        } else {
-            None
-        }
+        as_variant!(self.flow_id(), FlowId::InRoom(r, _) => r)
     }
 
     /// Does this verification flow support displaying emoji for the short
@@ -291,11 +287,9 @@ impl Sas {
     /// Get info about the cancellation if the verification flow has been
     /// cancelled.
     pub fn cancel_info(&self) -> Option<CancelInfo> {
-        if let InnerSas::Cancelled(c) = &*self.inner.read() {
-            Some(c.state.as_ref().clone().into())
-        } else {
-            None
-        }
+        as_variant!(&*self.inner.read(), InnerSas::Cancelled(c) => {
+            c.state.as_ref().clone().into()
+        })
     }
 
     /// Did we initiate the verification flow.

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -188,28 +188,24 @@ impl From<&InnerSas> for SasState {
                 Self::Accepted { accepted_protocols: s.state.accepted_protocols.to_owned() }
             }
             InnerSas::KeysExchanged(s) => {
-                let emojis = if value.supports_emoji() {
+                let emojis = value.supports_emoji().then(|| {
                     let emojis = s.get_emoji();
                     let indices = s.get_emoji_index();
 
-                    Some(EmojiShortAuthString { emojis, indices })
-                } else {
-                    None
-                };
+                    EmojiShortAuthString { emojis, indices }
+                });
 
                 let decimals = s.get_decimal();
 
                 Self::KeysExchanged { emojis, decimals }
             }
             InnerSas::MacReceived(s) => {
-                let emojis = if value.supports_emoji() {
+                let emojis = value.supports_emoji().then(|| {
                     let emojis = s.get_emoji();
                     let indices = s.get_emoji_index();
 
-                    Some(EmojiShortAuthString { emojis, indices })
-                } else {
-                    None
-                };
+                    EmojiShortAuthString { emojis, indices }
+                });
 
                 let decimals = s.get_decimal();
 

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -978,25 +978,21 @@ impl SasState<Accepted> {
     }
 
     pub fn into_key_sent(self, request_id: &TransactionId) -> Option<SasState<KeySent>> {
-        if self.state.request_id == request_id {
-            Some(SasState {
-                inner: self.inner,
-                our_public_key: self.our_public_key,
-                ids: self.ids,
-                verification_flow_id: self.verification_flow_id,
-                creation_time: self.creation_time,
-                last_event_time: Instant::now().into(),
-                started_from_request: self.started_from_request,
-                state: Arc::new(KeySent {
-                    we_started: true,
-                    start_content: self.state.start_content.clone(),
-                    commitment: self.state.commitment.clone(),
-                    accepted_protocols: self.state.accepted_protocols.clone(),
-                }),
-            })
-        } else {
-            None
-        }
+        (self.state.request_id == request_id).then(|| SasState {
+            inner: self.inner,
+            our_public_key: self.our_public_key,
+            ids: self.ids,
+            verification_flow_id: self.verification_flow_id,
+            creation_time: self.creation_time,
+            last_event_time: Instant::now().into(),
+            started_from_request: self.started_from_request,
+            state: Arc::new(KeySent {
+                we_started: true,
+                start_content: self.state.start_content.clone(),
+                commitment: self.state.commitment.clone(),
+                accepted_protocols: self.state.accepted_protocols.clone(),
+            }),
+        })
     }
 
     /// Get the content for the key event.
@@ -1106,25 +1102,21 @@ impl SasState<KeyReceived> {
         self,
         request_id: &TransactionId,
     ) -> Option<SasState<KeysExchanged>> {
-        if self.state.request_id == request_id {
-            Some(SasState {
-                inner: self.inner,
-                our_public_key: self.our_public_key,
-                ids: self.ids,
-                verification_flow_id: self.verification_flow_id,
-                creation_time: self.creation_time,
-                last_event_time: Instant::now().into(),
-                started_from_request: self.started_from_request,
-                state: KeysExchanged {
-                    sas: self.state.sas.clone(),
-                    we_started: self.state.we_started,
-                    accepted_protocols: self.state.accepted_protocols.clone(),
-                }
-                .into(),
-            })
-        } else {
-            None
-        }
+        (self.state.request_id == request_id).then(|| SasState {
+            inner: self.inner,
+            our_public_key: self.our_public_key,
+            ids: self.ids,
+            verification_flow_id: self.verification_flow_id,
+            creation_time: self.creation_time,
+            last_event_time: Instant::now().into(),
+            started_from_request: self.started_from_request,
+            state: KeysExchanged {
+                sas: self.state.sas.clone(),
+                we_started: self.state.we_started,
+                accepted_protocols: self.state.accepted_protocols.clone(),
+            }
+            .into(),
+        })
     }
 }
 

--- a/crates/matrix-sdk/src/encryption/verification/mod.rs
+++ b/crates/matrix-sdk/src/encryption/verification/mod.rs
@@ -35,6 +35,7 @@ mod qrcode;
 mod requests;
 mod sas;
 
+use as_variant::as_variant;
 pub use matrix_sdk_base::crypto::{
     format_emojis, AcceptSettings, AcceptedProtocols, CancelInfo, Emoji, EmojiShortAuthString,
     SasState,
@@ -62,22 +63,13 @@ pub enum Verification {
 impl Verification {
     /// Try to deconstruct this verification enum into a SAS verification.
     pub fn sas(self) -> Option<SasVerification> {
-        #[allow(irrefutable_let_patterns)]
-        if let Verification::SasV1(sas) = self {
-            Some(sas)
-        } else {
-            None
-        }
+        as_variant!(self, Verification::SasV1)
     }
 
-    #[cfg(feature = "qrcode")]
     /// Try to deconstruct this verification enum into a QR code verification.
+    #[cfg(feature = "qrcode")]
     pub fn qr(self) -> Option<QrVerification> {
-        if let Verification::QrV1(qr) = self {
-            Some(qr)
-        } else {
-            None
-        }
+        as_variant!(self, Verification::QrV1)
     }
 
     /// Has this verification finished.

--- a/testing/sliding-sync-integration-test/src/notification_client.rs
+++ b/testing/sliding-sync-integration-test/src/notification_client.rs
@@ -154,11 +154,8 @@ async fn test_notification() -> Result<()> {
         .iter()
         .find_map(|event| {
             let event = event.event.deserialize().ok()?;
-            if event.event_type() == TimelineEventType::RoomMessage {
-                Some(event.event_id().to_owned())
-            } else {
-                None
-            }
+            (event.event_type() == TimelineEventType::RoomMessage)
+                .then(|| event.event_id().to_owned())
         })
         .expect("missing message from alice in bob's client");
 


### PR DESCRIPTION
Recently noticed a place where we could still benefit from `as_variant` and decided to go on another search for explicit construction of `None` that could be replaced by helpers like it (and `bool::then`).