### PR TITLE
Do not signal identity update if no change

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1393,7 +1393,7 @@ pub(crate) mod tests {
 
         let (new_request_id, _) =
             manager.as_ref().unwrap().build_key_query_for_users(vec![user_id()]);
-        // Same keys/query shouldn't fire new change, identity should be unchanged
+        // There is a new signature on the msk, should trigger a change
         manager
             .as_ref()
             .unwrap()

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -50,6 +50,11 @@ enum DeviceChange {
     None,
 }
 
+enum IdentityUpdate {
+    Updated(IdentityChange),
+    Unchanged(IdentityChange),
+}
+
 struct IdentityChange {
     public: ReadOnlyUserIdentities,
     private: Option<PrivateCrossSigningIdentity>,
@@ -431,7 +436,7 @@ impl IdentityManager {
         master_key: MasterPubkey,
         self_signing: SelfSigningPubkey,
         i: ReadOnlyUserIdentities,
-    ) -> Result<IdentityChange, SignatureError> {
+    ) -> Result<IdentityUpdate, SignatureError> {
         match i {
             ReadOnlyUserIdentities::Own(mut identity) => {
                 if let Some(user_signing) = response
@@ -448,11 +453,16 @@ impl IdentityManager {
 
                         Err(SignatureError::UserIdMismatch)
                     } else {
-                        identity.update(master_key, self_signing, user_signing)?;
+                        let has_changed =
+                            identity.update(master_key, self_signing, user_signing)?;
 
                         let private = self.check_private_identity(&identity).await;
-
-                        Ok(IdentityChange { public: identity.into(), private })
+                        let id_change = IdentityChange { public: identity.into(), private };
+                        if has_changed {
+                            Ok(IdentityUpdate::Updated(id_change))
+                        } else {
+                            Ok(IdentityUpdate::Unchanged(id_change))
+                        }
                     }
                 } else {
                     warn!(
@@ -463,8 +473,13 @@ impl IdentityManager {
                 }
             }
             ReadOnlyUserIdentities::Other(mut identity) => {
-                identity.update(master_key, self_signing)?;
-                Ok(IdentityChange { public: identity.into(), private: None })
+                let has_changed = identity.update(master_key, self_signing)?;
+                let id_change = IdentityChange { public: identity.into(), private: None };
+                if has_changed {
+                    Ok(IdentityUpdate::Updated(id_change))
+                } else {
+                    Ok(IdentityUpdate::Unchanged(id_change))
+                }
             }
         }
     }
@@ -557,10 +572,14 @@ impl IdentityManager {
             warn!(?user_id, "User ID mismatch in one of the cross signing keys",);
         } else if let Some(i) = self.store.get_user_identity(user_id).await? {
             match self.handle_changed_identity(response, master_key, self_signing, i).await {
-                Ok(c) => {
+                Ok(IdentityUpdate::Updated(c)) => {
                     trace!(identity = ?c.public, "Updated a user identity");
                     changes.changed.push(c.public);
                     *changed_identity = c.private;
+                }
+                Ok(IdentityUpdate::Unchanged(c)) => {
+                    trace!(identity = ?c.public, "Unchanged user identity after key query");
+                    changes.unchanged.push(c.public);
                 }
                 Err(e) => {
                     warn!(error = ?e, "Couldn't update an existing user identity");
@@ -851,6 +870,71 @@ pub(crate) mod testing {
             .expect("Can't parse the keys upload response")
     }
 
+    // An updated version of `other_key_query` with an added signature on the msk
+    // from user_id() The new signature is not valid, not required for the
+    // current tests
+    pub fn other_key_query_cross_signed() -> KeyQueryResponse {
+        let data = response_from_file(&json!({
+            "device_keys": {
+                "@example2:localhost": {
+                    "SKISMLNIMH": {
+                        "algorithms": ["m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2"],
+                        "device_id": "SKISMLNIMH",
+                        "keys": {
+                            "curve25519:SKISMLNIMH": "qO9xFazIcW8dE0oqHGMojGgJwbBpMOhGnIfJy2pzvmI",
+                            "ed25519:SKISMLNIMH": "y3wV3AoyIGREqrJJVH8DkQtlwHBUxoZ9ApP76kFgXQ8"
+                        },
+                        "signatures": {
+                            "@example2:localhost": {
+                                "ed25519:SKISMLNIMH": "YwbT35rbjKoYFZVU1tQP8MsL06+znVNhNzUMPt6jTEYRBFoC4GDq9hQEJBiFSq37r1jvLMteggVAWw37fs1yBA",
+                                "ed25519:ZtFrSkJ1qB8Jph/ql9Eo/lKpIYCzwvKAKXfkaS4XZNc": "PWuuTE/aTkp1EJQkPHhRx2BxbF+wjMIDFxDRp7JAerlMkDsNFUTfRRusl6vqROPU36cl+yY8oeJTZGFkU6+pBQ"
+                            }
+                        },
+                        "user_id": "@example2:localhost",
+                        "unsigned": {
+                            "device_display_name": "Riot Desktop (Linux)"
+                        }
+                    }
+                }
+            },
+            "failures": {},
+            "master_keys": {
+                "@example2:localhost": {
+                    "user_id": "@example2:localhost",
+                    "usage": ["master"],
+                    "keys": {
+                        "ed25519:kC/HmRYw4HNqUp/i4BkwYENrf+hd9tvdB7A1YOf5+Do": "kC/HmRYw4HNqUp/i4BkwYENrf+hd9tvdB7A1YOf5+Do"
+                    },
+                    "signatures": {
+                        "@example2:localhost": {
+                            "ed25519:SKISMLNIMH": "KdUZqzt8VScGNtufuQ8lOf25byYLWIhmUYpPENdmM8nsldexD7vj+Sxoo7PknnTX/BL9h2N7uBq0JuykjunCAw"
+                        },
+                        "@alice:localhost": {
+                            "ed25519:DU9z4gBFKFKCk7a13sW9wjT0Iyg7Hqv5f0BPM7DEhPo": "KdUZqzt8VScGNtufuQ8lOf25byYLWIhmUYpPENdmM8nsldexD7vj+Sxoo7PknnTX/BL9h2N7uBq0JuykjunCAw"
+                        }
+                    }
+                }
+            },
+            "self_signing_keys": {
+                "@example2:localhost": {
+                    "user_id": "@example2:localhost",
+                    "usage": ["self_signing"],
+                    "keys": {
+                        "ed25519:ZtFrSkJ1qB8Jph/ql9Eo/lKpIYCzwvKAKXfkaS4XZNc": "ZtFrSkJ1qB8Jph/ql9Eo/lKpIYCzwvKAKXfkaS4XZNc"
+                    },
+                    "signatures": {
+                        "@example2:localhost": {
+                            "ed25519:kC/HmRYw4HNqUp/i4BkwYENrf+hd9tvdB7A1YOf5+Do": "W/O8BnmiUETPpH02mwYaBgvvgF/atXnusmpSTJZeUSH/vHg66xiZOhveQDG4cwaW8iMa+t9N4h1DWnRoHB4mCQ"
+                        }
+                    }
+                }
+            },
+            "user_signing_keys": {}
+        }));
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the keys upload response")
+    }
+
     pub fn own_key_query_with_user_id(user_id: &UserId) -> KeyQueryResponse {
         let data = response_from_file(&json!({
           "device_keys": {
@@ -998,7 +1082,7 @@ pub(crate) mod tests {
     use stream_assert::{assert_closed, assert_pending, assert_ready};
 
     use super::testing::{device_id, key_query, manager, other_key_query, other_user_id, user_id};
-    use crate::identities::manager::testing::own_key_query;
+    use crate::identities::manager::testing::{other_key_query_cross_signed, own_key_query};
 
     fn key_query_with_failures() -> KeysQueryResponse {
         let response = json!({
@@ -1257,12 +1341,78 @@ pub(crate) mod tests {
 
         let (identity_update, _) = assert_ready!(stream);
         assert_eq!(identity_update.new.len(), 1);
+        assert_eq!(identity_update.changed.len(), 0);
+        assert_eq!(identity_update.unchanged.len(), 0);
         assert_eq!(identity_update.new[0].user_id(), user_id());
 
         assert_pending!(stream);
 
+        let (new_request_id, _) =
+            manager.as_ref().unwrap().build_key_query_for_users(vec![user_id()]);
+        // Same keys/query shouldn't fire new change, identity should be unchanged
+        manager
+            .as_ref()
+            .unwrap()
+            .receive_keys_query_response(&new_request_id, &own_key_query())
+            .await
+            .unwrap();
+
+        let (identity_update_2, _) = assert_ready!(stream);
+        assert_eq!(identity_update_2.new.len(), 0);
+        assert_eq!(identity_update_2.changed.len(), 0);
+        assert_eq!(identity_update_2.unchanged.len(), 1);
+
         // dropping the manager (and hence dropping the store) should close the stream
         manager.take();
         assert_closed!(stream);
+    }
+
+    #[async_test]
+    async fn identities_stream_raw_signature_update() {
+        let mut manager = Some(manager().await);
+        let (request_id, _) =
+            manager.as_ref().unwrap().build_key_query_for_users(vec![other_user_id()]);
+
+        let stream = manager.as_ref().unwrap().store.identities_stream_raw();
+        pin_mut!(stream);
+
+        manager
+            .as_ref()
+            .unwrap()
+            .receive_keys_query_response(&request_id, &other_key_query())
+            .await
+            .unwrap();
+
+        let (identity_update, _) = assert_ready!(stream);
+        assert_eq!(identity_update.new.len(), 1);
+        assert_eq!(identity_update.changed.len(), 0);
+        assert_eq!(identity_update.unchanged.len(), 0);
+        assert_eq!(identity_update.new[0].user_id(), other_user_id());
+
+        let initial_msk = identity_update.new[0].master_key().clone();
+
+        let (new_request_id, _) =
+            manager.as_ref().unwrap().build_key_query_for_users(vec![user_id()]);
+        // Same keys/query shouldn't fire new change, identity should be unchanged
+        manager
+            .as_ref()
+            .unwrap()
+            .receive_keys_query_response(&new_request_id, &other_key_query_cross_signed())
+            .await
+            .unwrap();
+
+        let (identity_update_2, _) = assert_ready!(stream);
+        assert_eq!(identity_update_2.new.len(), 0);
+        assert_eq!(identity_update_2.changed.len(), 1);
+        assert_eq!(identity_update_2.unchanged.len(), 0);
+
+        let updated_msk = identity_update_2.changed[0].master_key().clone();
+
+        // Identity has a change (new signature) but it's the same msk
+        assert_eq!(initial_msk, updated_msk);
+
+        assert_pending!(stream);
+
+        manager.take();
     }
 }

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -515,7 +515,7 @@ macro_rules! cryptostore_integration_tests {
 
                 assert_eq!(loaded_user.master_key(), own_identity.master_key());
                 assert_eq!(loaded_user.self_signing_key(), own_identity.self_signing_key());
-                assert_eq!(loaded_user, own_identity.clone().into());
+                assert_eq!(loaded_user.own().unwrap().clone(), own_identity.clone());
 
                 let other_identity = get_other_identity();
 
@@ -534,7 +534,8 @@ macro_rules! cryptostore_integration_tests {
 
                 assert_eq!(loaded_user.master_key(), other_identity.master_key());
                 assert_eq!(loaded_user.self_signing_key(), other_identity.self_signing_key());
-                assert_eq!(loaded_user, other_identity.into());
+                assert_eq!(loaded_user.user_id(), other_identity.user_id());
+                assert_eq!(loaded_user.other().unwrap().clone(), other_identity);
 
                 own_identity.mark_as_verified();
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -185,6 +185,16 @@ impl Changes {
     }
 }
 
+/// This struct is used to remember whether an identity has undergone a change
+/// or remains the same as the one we already know about.
+///
+/// When the homeserver informs us of a potential change in a user's identity or
+/// device during a `/sync` response, it triggers a `/keys/query` request from
+/// our side. In response to this query, the server provides a comprehensive
+/// snapshot of all the user's devices and identities.
+///
+/// Our responsibility is to discern whether a device or identity is new,
+/// changed, or unchanged.
 #[derive(Debug, Clone, Default)]
 #[allow(missing_docs)]
 pub struct IdentityChanges {

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -847,6 +847,7 @@ pub(crate) mod tests {
             identities: IdentityChanges {
                 new: vec![alice_readonly_identity.into(), bob_public_identity.into()],
                 changed: vec![],
+                unchanged: vec![],
             },
             ..Default::default()
         };
@@ -857,6 +858,7 @@ pub(crate) mod tests {
             identities: IdentityChanges {
                 new: vec![bob_readonly_identity.into(), alice_public_identity.into()],
                 changed: vec![],
+                unchanged: vec![],
             },
             ..Default::default()
         };

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -638,7 +638,9 @@ impl IdentitiesBeingVerified {
                 .as_ref()
                 .is_some_and(|i| i.master_key() == identity.master_key())
             {
-                if verified_identities.is_some_and(|i| i.contains(&identity)) {
+                if verified_identities.is_some_and(|i| {
+                    i.iter().any(|verified| verified.user_id() == identity.user_id())
+                }) {
                     trace!(
                         user_id = self.other_user_id().as_str(),
                         "Marking the user identity of as verified."


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Improvement on the signaling of identity changes.
Currently after a keys/query we signal changes (identity stream) even if the user identity is unchanged. This can create some side effects on some clients, see https://github.com/vector-im/element-web/issues/26194.

The API for idenity change is modified from (`new`, `changed`) to (`new`, `change`, `unchanged`).

In order to do so, I implemented PartialEq for UserIdentities; This implem will check for changes on signatures on the msk.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
