### PR TITLE
`matrix-sdk-common`: add js console tracing layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,7 @@ dependencies = [
  "tracing-subscriber",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -33,6 +33,8 @@ tokio = { workspace = true, features = ["rt", "time", "sync"] }
 futures-util = { workspace = true, features = ["channel"] }
 wasm-bindgen-futures = { version = "0.4.33", optional = true }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
+web-sys = {version = "0.3.60", features = ["console"] }
+tracing-subscriber = { version = "0.3.14", default-features = false }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Utilities for `tracing` in JS environments
+
 use std::{fmt, fmt::Write};
 
 use tracing::{
@@ -19,8 +21,6 @@ use tracing::{
     Event, Level, Subscriber,
 };
 use tracing_subscriber::layer::Context;
-
-//! Utilities for `tracing` in JS environments
 
 /// An implementation of `tracing_subscriber::layer::Layer` which directs all
 /// events to the JS console

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -20,7 +20,7 @@ use tracing::{
 };
 use tracing_subscriber::layer::Context;
 
-///! Utilities for `tracing` in wasm environments
+///! Utilities for `tracing` in JS environments
 
 /// An implementation of `tracing_subscriber::layer::Layer` which directs all
 /// events to the JS console

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -20,7 +20,7 @@ use tracing::{
 };
 use tracing_subscriber::layer::Context;
 
-///! Utilities for `tracing` in JS environments
+//! Utilities for `tracing` in JS environments
 
 /// An implementation of `tracing_subscriber::layer::Layer` which directs all
 /// events to the JS console
@@ -32,6 +32,12 @@ impl Layer {
         Self {}
     }
 }
+
+impl Default for Layer {
+     fn default() -> Self {
+         Self::new()
+     }
+ }
 
 impl<S> tracing_subscriber::layer::Layer<S> for Layer
 where

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -24,7 +24,7 @@ use tracing_subscriber::layer::Context;
 
 /// An implementation of `tracing_subscriber::layer::Layer` which directs all
 /// events to the JS console
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Layer {}
 
 impl Layer {
@@ -32,12 +32,6 @@ impl Layer {
         Self {}
     }
 }
-
-impl Default for Layer {
-     fn default() -> Self {
-         Self::new()
-     }
- }
 
 impl<S> tracing_subscriber::layer::Layer<S> for Layer
 where

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -29,7 +29,7 @@ pub mod timeout;
 pub mod tracing_timer;
 
 #[cfg(target_arch = "wasm32")]
-pub mod wasm_tracing;
+pub mod js_tracing;
 
 pub use store_locks::LEASE_DURATION_MS;
 

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -28,6 +28,9 @@ pub mod store_locks;
 pub mod timeout;
 pub mod tracing_timer;
 
+#[cfg(target_arch = "wasm32")]
+pub mod wasm_tracing;
+
 pub use store_locks::LEASE_DURATION_MS;
 
 /// Alias for `Send` on non-wasm, empty trait (implemented by everything) on

--- a/crates/matrix-sdk-common/src/wasm_tracing.rs
+++ b/crates/matrix-sdk-common/src/wasm_tracing.rs
@@ -1,0 +1,129 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{fmt, fmt::Write};
+
+use tracing::{
+    field::{Field, Visit},
+    metadata::LevelFilter,
+    Event, Level, Metadata, Subscriber,
+};
+use tracing_subscriber::layer::Context;
+
+///! Utilities for `tracing` in wasm environments
+
+/// An implementation of `tracing_subscriber::layer::Layer` which directs all
+/// events to the JS console
+#[derive(Debug)]
+pub struct Layer {
+    min_level: Level,
+    enabled: bool,
+}
+
+impl Layer {
+    pub fn new<L>(min_level: L) -> Self
+    where
+        L: Into<Level>,
+    {
+        Self { min_level: min_level.into(), enabled: true }
+    }
+
+    pub fn turn_on(&mut self) {
+        self.enabled = true;
+    }
+
+    pub fn turn_off(&mut self) {
+        self.enabled = false;
+    }
+
+    pub fn set_min_level(&mut self, min_level: Level) {
+        self.min_level = min_level;
+    }
+}
+
+impl<S> tracing_subscriber::layer::Layer<S> for Layer
+where
+    S: Subscriber,
+{
+    fn enabled(&self, metadata: &Metadata<'_>, _: Context<'_, S>) -> bool {
+        self.enabled && metadata.level() <= &self.min_level
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        if !self.enabled {
+            Some(LevelFilter::OFF)
+        } else {
+            Some(LevelFilter::from_level(self.min_level))
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
+        let mut recorder = StringVisitor::new();
+        event.record(&mut recorder);
+        let metadata = event.metadata();
+        let level = metadata.level();
+
+        let origin = metadata
+            .file()
+            .and_then(|file| metadata.line().map(|ln| format!("{file}:{ln}")))
+            .unwrap_or_default();
+
+        let message = format!("{level} {origin}{recorder}");
+
+        match *level {
+            Level::TRACE | Level::DEBUG => web_sys::console::debug_1(&message.into()),
+            Level::INFO => web_sys::console::info_1(&message.into()),
+            Level::WARN => web_sys::console::warn_1(&message.into()),
+            Level::ERROR => web_sys::console::error_1(&message.into()),
+        }
+    }
+}
+
+struct StringVisitor {
+    string: String,
+}
+
+impl StringVisitor {
+    fn new() -> Self {
+        Self { string: String::new() }
+    }
+}
+
+impl Visit for StringVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        match field.name() {
+            "message" => {
+                if !self.string.is_empty() {
+                    self.string.push('\n');
+                }
+
+                let _ = write!(self.string, "{value:?}");
+            }
+
+            field_name => {
+                let _ = write!(self.string, "\n{field_name} = {value:?}");
+            }
+        }
+    }
+}
+
+impl fmt::Display for StringVisitor {
+    fn fmt(&self, mut f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.string.is_empty() {
+            write!(&mut f, " {}", self.string)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/crates/matrix-sdk-common/src/wasm_tracing.rs
+++ b/crates/matrix-sdk-common/src/wasm_tracing.rs
@@ -16,8 +16,7 @@ use std::{fmt, fmt::Write};
 
 use tracing::{
     field::{Field, Visit},
-    metadata::LevelFilter,
-    Event, Level, Metadata, Subscriber,
+    Event, Level, Subscriber,
 };
 use tracing_subscriber::layer::Context;
 
@@ -26,29 +25,11 @@ use tracing_subscriber::layer::Context;
 /// An implementation of `tracing_subscriber::layer::Layer` which directs all
 /// events to the JS console
 #[derive(Debug)]
-pub struct Layer {
-    min_level: Level,
-    enabled: bool,
-}
+pub struct Layer {}
 
 impl Layer {
-    pub fn new<L>(min_level: L) -> Self
-    where
-        L: Into<Level>,
-    {
-        Self { min_level: min_level.into(), enabled: true }
-    }
-
-    pub fn turn_on(&mut self) {
-        self.enabled = true;
-    }
-
-    pub fn turn_off(&mut self) {
-        self.enabled = false;
-    }
-
-    pub fn set_min_level(&mut self, min_level: Level) {
-        self.min_level = min_level;
+    pub fn new() -> Self {
+        Self {}
     }
 }
 
@@ -56,18 +37,6 @@ impl<S> tracing_subscriber::layer::Layer<S> for Layer
 where
     S: Subscriber,
 {
-    fn enabled(&self, metadata: &Metadata<'_>, _: Context<'_, S>) -> bool {
-        self.enabled && metadata.level() <= &self.min_level
-    }
-
-    fn max_level_hint(&self) -> Option<LevelFilter> {
-        if !self.enabled {
-            Some(LevelFilter::OFF)
-        } else {
-            Some(LevelFilter::from_level(self.min_level))
-        }
-    }
-
     fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
         let mut recorder = StringVisitor::new();
         event.record(&mut recorder);


### PR DESCRIPTION
Implement a `tracing_subsciber` `Layer` which sends output to the javascript console.

Obviously, this only works on the wasm32 target.

This is lifted from `matrix-rust-sdk-crypto-wasm`, so that we can use it in tests etc for other crates.

PR to follow to remove it from `matrix-rust-sdk-crypto-wasm`