### PR TITLE
Add a dummy crypto store cache

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -187,9 +187,6 @@ impl BaseClient {
     ///
     /// * `session_meta` - The meta of a session that the user already has from
     ///   a previous login call.
-    /// * `regenerate_olm`: whether the `OlmMachine` should be regenerated or
-    ///   not. True for
-    /// restored sessions, false for inherited sessions.
     ///
     /// This method panics if it is called twice.
     pub async fn set_session_meta(&self, session_meta: SessionMeta) -> Result<()> {

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -115,7 +115,7 @@ struct StoreCache {
 
 struct StoreCacheGuard<'a> {
     cache: &'a StoreCache,
-    // TODO(bnjbvr, #2624) add cross-process lock guard here.
+    // TODO: (bnjbvr, #2624) add cross-process lock guard here.
 }
 
 impl<'a> Deref for StoreCacheGuard<'a> {
@@ -542,7 +542,7 @@ impl Store {
     }
 
     async fn cache(&self) -> Result<StoreCacheGuard<'_>> {
-        // TODO(bnjbvr, #2624) If configured with a cross-process lock:
+        // TODO: (bnjbvr, #2624) If configured with a cross-process lock:
         // - try to take the lock,
         // - if acquired, look if another process touched the underlying storage,
         // - if yes, reload everything; if no, return current cache

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -857,7 +857,7 @@ impl Store {
         &self,
         users: impl Iterator<Item = &UserId>,
     ) -> Result<()> {
-        self.load_tracked_users().await?;
+        self.ensure_sync_tracked_users().await?;
 
         let mut store_updates = Vec::new();
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
@@ -883,7 +883,7 @@ impl Store {
         &self,
         users: impl Iterator<Item = &UserId>,
     ) -> Result<()> {
-        self.load_tracked_users().await?;
+        self.ensure_sync_tracked_users().await?;
 
         let mut store_updates: Vec<(&UserId, bool)> = Vec::new();
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
@@ -930,7 +930,7 @@ impl Store {
     /// This method ensures that we're only going to load the users from the
     /// actual [`CryptoStore`] once, it will also make sure that any
     /// concurrent calls to this method get deduplicated.
-    async fn load_tracked_users(&self) -> Result<()> {
+    async fn ensure_sync_tracked_users(&self) -> Result<()> {
         // Check if the users are loaded, and in that case do nothing.
         let loaded = self.inner.cache.tracked_user_loading_lock.read().await;
         if *loaded {
@@ -978,7 +978,7 @@ impl Store {
     pub(crate) async fn users_for_key_query(
         &self,
     ) -> Result<(HashSet<OwnedUserId>, SequenceNumber)> {
-        self.load_tracked_users().await?;
+        self.ensure_sync_tracked_users().await?;
 
         Ok(self.inner.users_for_key_query.lock().await.users_for_key_query())
     }
@@ -1021,7 +1021,7 @@ impl Store {
 
     /// See the docs for [`crate::OlmMachine::tracked_users()`].
     pub(crate) async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>> {
-        self.load_tracked_users().await?;
+        self.ensure_sync_tracked_users().await?;
 
         Ok(self.inner.cache.tracked_users.iter().map(|u| u.clone()).collect())
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -546,7 +546,13 @@ impl Store {
         // - try to take the lock,
         // - if acquired, look if another process touched the underlying storage,
         // - if yes, reload everything; if no, return current cache
-        Ok(StoreCacheGuard { cache: &self.inner.cache })
+
+        let cache = StoreCacheGuard { cache: &self.inner.cache };
+
+        // Make sure tracked users are always up to date.
+        self.ensure_sync_tracked_users(&cache).await?;
+
+        Ok(cache)
     }
 
     #[cfg(test)]
@@ -883,7 +889,6 @@ impl Store {
         users: impl Iterator<Item = &UserId>,
     ) -> Result<()> {
         let cache = self.cache().await?;
-        self.ensure_sync_tracked_users(&cache).await?;
 
         let mut store_updates = Vec::new();
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
@@ -910,7 +915,6 @@ impl Store {
         users: impl Iterator<Item = &UserId>,
     ) -> Result<()> {
         let cache = self.cache().await?;
-        self.ensure_sync_tracked_users(&cache).await?;
 
         let mut store_updates: Vec<(&UserId, bool)> = Vec::new();
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
@@ -1008,8 +1012,8 @@ impl Store {
     pub(crate) async fn users_for_key_query(
         &self,
     ) -> Result<(HashSet<OwnedUserId>, SequenceNumber)> {
-        let cache = self.cache().await?;
-        self.ensure_sync_tracked_users(&cache).await?;
+        // Make sure the tracked users set is up to date.
+        let _cache = self.cache().await?;
 
         Ok(self.inner.users_for_key_query.lock().await.users_for_key_query())
     }
@@ -1053,7 +1057,6 @@ impl Store {
     /// See the docs for [`crate::OlmMachine::tracked_users()`].
     pub(crate) async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>> {
         let cache = self.cache().await?;
-        self.ensure_sync_tracked_users(&cache).await?;
 
         Ok(cache.tracked_users.iter().map(|u| u.clone()).collect())
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -113,11 +113,28 @@ struct StoreCache {
     tracked_user_loading_lock: RwLock<bool>,
 }
 
+struct StoreCacheGuard<'a> {
+    cache: &'a StoreCache,
+    // TODO(bnjbvr, #2624) add cross-process lock guard here.
+}
+
+impl<'a> Deref for StoreCacheGuard<'a> {
+    type Target = StoreCache;
+
+    fn deref(&self) -> &Self::Target {
+        self.cache
+    }
+}
+
 #[derive(Debug)]
 struct StoreInner {
     user_id: OwnedUserId,
     identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
     store: Arc<CryptoStoreWrapper>,
+
+    /// In-memory cache for the current crypto store.
+    ///
+    /// ⚠ Must remain private.
     cache: StoreCache,
 
     verification_machine: VerificationMachine,
@@ -524,6 +541,14 @@ impl Store {
         &self.inner.verification_machine.store.account
     }
 
+    async fn cache(&self) -> Result<StoreCacheGuard<'_>> {
+        // TODO(bnjbvr, #2624) If configured with a cross-process lock:
+        // - try to take the lock,
+        // - if acquired, look if another process touched the underlying storage,
+        // - if yes, reload everything; if no, return current cache
+        Ok(StoreCacheGuard { cache: &self.inner.cache })
+    }
+
     #[cfg(test)]
     /// test helper to reset the cross signing identity
     pub(crate) async fn reset_cross_signing_identity(&self) {
@@ -844,7 +869,7 @@ impl Store {
     /// next time [`Store::users_for_key_query()`] is called.
     pub(crate) async fn mark_user_as_changed(&self, user: &UserId) -> Result<()> {
         self.inner.users_for_key_query.lock().await.insert_user(user);
-        self.inner.cache.tracked_users.insert(user.to_owned());
+        self.cache().await?.tracked_users.insert(user.to_owned());
 
         self.inner.store.save_tracked_users(&[(user, true)]).await
     }
@@ -857,14 +882,15 @@ impl Store {
         &self,
         users: impl Iterator<Item = &UserId>,
     ) -> Result<()> {
-        self.ensure_sync_tracked_users().await?;
+        let cache = self.cache().await?;
+        self.ensure_sync_tracked_users(&cache).await?;
 
         let mut store_updates = Vec::new();
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
 
         for user_id in users {
-            if !self.inner.cache.tracked_users.contains(user_id) {
-                self.inner.cache.tracked_users.insert(user_id.to_owned());
+            if !cache.tracked_users.contains(user_id) {
+                cache.tracked_users.insert(user_id.to_owned());
                 key_query_lock.insert_user(user_id);
                 store_updates.push((user_id, true))
             }
@@ -883,13 +909,14 @@ impl Store {
         &self,
         users: impl Iterator<Item = &UserId>,
     ) -> Result<()> {
-        self.ensure_sync_tracked_users().await?;
+        let cache = self.cache().await?;
+        self.ensure_sync_tracked_users(&cache).await?;
 
         let mut store_updates: Vec<(&UserId, bool)> = Vec::new();
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
 
         for user_id in users {
-            if self.inner.cache.tracked_users.contains(user_id) {
+            if cache.tracked_users.contains(user_id) {
                 key_query_lock.insert_user(user_id);
                 store_updates.push((user_id, true));
             }
@@ -911,10 +938,13 @@ impl Store {
         let mut store_updates: Vec<(&UserId, bool)> = Vec::new();
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
 
-        for user_id in users {
-            if self.inner.cache.tracked_users.contains(user_id) {
-                let clean = key_query_lock.maybe_remove_user(user_id, sequence_number);
-                store_updates.push((user_id, !clean));
+        {
+            let cache = self.cache().await?;
+            for user_id in users {
+                if cache.tracked_users.contains(user_id) {
+                    let clean = key_query_lock.maybe_remove_user(user_id, sequence_number);
+                    store_updates.push((user_id, !clean));
+                }
             }
         }
         self.inner.store.save_tracked_users(&store_updates).await?;
@@ -930,16 +960,16 @@ impl Store {
     /// This method ensures that we're only going to load the users from the
     /// actual [`CryptoStore`] once, it will also make sure that any
     /// concurrent calls to this method get deduplicated.
-    async fn ensure_sync_tracked_users(&self) -> Result<()> {
+    async fn ensure_sync_tracked_users(&self, cache: &StoreCacheGuard<'_>) -> Result<()> {
         // Check if the users are loaded, and in that case do nothing.
-        let loaded = self.inner.cache.tracked_user_loading_lock.read().await;
+        let loaded = cache.tracked_user_loading_lock.read().await;
         if *loaded {
             return Ok(());
         }
 
         // Otherwise, we may load the users.
         drop(loaded);
-        let mut loaded = self.inner.cache.tracked_user_loading_lock.write().await;
+        let mut loaded = cache.tracked_user_loading_lock.write().await;
 
         // Check again if the users have been loaded, in case another call to this
         // method loaded the tracked users between the time we tried to
@@ -952,7 +982,7 @@ impl Store {
 
         let mut query_users_lock = self.inner.users_for_key_query.lock().await;
         for user in tracked_users {
-            self.inner.cache.tracked_users.insert(user.user_id.to_owned());
+            cache.tracked_users.insert(user.user_id.to_owned());
 
             if user.dirty {
                 query_users_lock.insert_user(&user.user_id);
@@ -978,7 +1008,8 @@ impl Store {
     pub(crate) async fn users_for_key_query(
         &self,
     ) -> Result<(HashSet<OwnedUserId>, SequenceNumber)> {
-        self.ensure_sync_tracked_users().await?;
+        let cache = self.cache().await?;
+        self.ensure_sync_tracked_users(&cache).await?;
 
         Ok(self.inner.users_for_key_query.lock().await.users_for_key_query())
     }
@@ -1021,9 +1052,10 @@ impl Store {
 
     /// See the docs for [`crate::OlmMachine::tracked_users()`].
     pub(crate) async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>> {
-        self.ensure_sync_tracked_users().await?;
+        let cache = self.cache().await?;
+        self.ensure_sync_tracked_users(&cache).await?;
 
-        Ok(self.inner.cache.tracked_users.iter().map(|u| u.clone()).collect())
+        Ok(cache.tracked_users.iter().map(|u| u.clone()).collect())
     }
 
     /// Check whether there is a global flag to only encrypt messages for

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -107,13 +107,20 @@ pub struct Store {
     inner: Arc<StoreInner>,
 }
 
+#[derive(Debug, Default)]
+struct StoreCache {
+    tracked_users: DashSet<OwnedUserId>,
+    tracked_user_loading_lock: RwLock<bool>,
+}
+
 #[derive(Debug)]
 struct StoreInner {
     user_id: OwnedUserId,
     identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
     store: Arc<CryptoStoreWrapper>,
+    cache: StoreCache,
+
     verification_machine: VerificationMachine,
-    tracked_users_cache: DashSet<OwnedUserId>,
 
     /// Record of the users that are waiting for a /keys/query.
     //
@@ -124,8 +131,6 @@ struct StoreInner {
 
     // condition variable that is notified each time an update is received for a user.
     users_for_key_query_condvar: Condvar,
-
-    tracked_user_loading_lock: RwLock<bool>,
 }
 
 /// Aggregated changes to be saved in the database.
@@ -496,10 +501,9 @@ impl Store {
             identity,
             store,
             verification_machine,
-            tracked_users_cache: DashSet::new(),
             users_for_key_query: AsyncStdMutex::new(UsersForKeyQuery::new()),
             users_for_key_query_condvar: Condvar::new(),
-            tracked_user_loading_lock: RwLock::new(false),
+            cache: Default::default(),
         });
 
         Self { inner }
@@ -840,7 +844,7 @@ impl Store {
     /// next time [`Store::users_for_key_query()`] is called.
     pub(crate) async fn mark_user_as_changed(&self, user: &UserId) -> Result<()> {
         self.inner.users_for_key_query.lock().await.insert_user(user);
-        self.inner.tracked_users_cache.insert(user.to_owned());
+        self.inner.cache.tracked_users.insert(user.to_owned());
 
         self.inner.store.save_tracked_users(&[(user, true)]).await
     }
@@ -859,8 +863,8 @@ impl Store {
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
 
         for user_id in users {
-            if !self.inner.tracked_users_cache.contains(user_id) {
-                self.inner.tracked_users_cache.insert(user_id.to_owned());
+            if !self.inner.cache.tracked_users.contains(user_id) {
+                self.inner.cache.tracked_users.insert(user_id.to_owned());
                 key_query_lock.insert_user(user_id);
                 store_updates.push((user_id, true))
             }
@@ -885,7 +889,7 @@ impl Store {
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
 
         for user_id in users {
-            if self.inner.tracked_users_cache.contains(user_id) {
+            if self.inner.cache.tracked_users.contains(user_id) {
                 key_query_lock.insert_user(user_id);
                 store_updates.push((user_id, true));
             }
@@ -908,7 +912,7 @@ impl Store {
         let mut key_query_lock = self.inner.users_for_key_query.lock().await;
 
         for user_id in users {
-            if self.inner.tracked_users_cache.contains(user_id) {
+            if self.inner.cache.tracked_users.contains(user_id) {
                 let clean = key_query_lock.maybe_remove_user(user_id, sequence_number);
                 store_updates.push((user_id, !clean));
             }
@@ -928,14 +932,14 @@ impl Store {
     /// concurrent calls to this method get deduplicated.
     async fn load_tracked_users(&self) -> Result<()> {
         // Check if the users are loaded, and in that case do nothing.
-        let loaded = self.inner.tracked_user_loading_lock.read().await;
+        let loaded = self.inner.cache.tracked_user_loading_lock.read().await;
         if *loaded {
             return Ok(());
         }
 
         // Otherwise, we may load the users.
         drop(loaded);
-        let mut loaded = self.inner.tracked_user_loading_lock.write().await;
+        let mut loaded = self.inner.cache.tracked_user_loading_lock.write().await;
 
         // Check again if the users have been loaded, in case another call to this
         // method loaded the tracked users between the time we tried to
@@ -948,7 +952,7 @@ impl Store {
 
         let mut query_users_lock = self.inner.users_for_key_query.lock().await;
         for user in tracked_users {
-            self.inner.tracked_users_cache.insert(user.user_id.to_owned());
+            self.inner.cache.tracked_users.insert(user.user_id.to_owned());
 
             if user.dirty {
                 query_users_lock.insert_user(&user.user_id);
@@ -1019,7 +1023,7 @@ impl Store {
     pub(crate) async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>> {
         self.load_tracked_users().await?;
 
-        Ok(self.inner.tracked_users_cache.iter().map(|u| u.clone()).collect())
+        Ok(self.inner.cache.tracked_users.iter().map(|u| u.clone()).collect())
     }
 
     /// Check whether there is a global flag to only encrypt messages for

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -42,7 +42,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
     ops::Deref,
-    sync::{atomic::AtomicBool, Arc},
+    sync::Arc,
     time::Duration,
 };
 
@@ -57,7 +57,7 @@ use ruma::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use thiserror::Error;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tracing::{info, warn};
 use vodozemac::{base64_encode, megolm::SessionOrdering, Curve25519PublicKey};
 use zeroize::Zeroize;
@@ -125,8 +125,7 @@ struct StoreInner {
     // condition variable that is notified each time an update is received for a user.
     users_for_key_query_condvar: Condvar,
 
-    tracked_user_loading_lock: Mutex<()>,
-    tracked_users_loaded: AtomicBool,
+    tracked_user_loading_lock: RwLock<bool>,
 }
 
 /// Aggregated changes to be saved in the database.
@@ -500,8 +499,7 @@ impl Store {
             tracked_users_cache: DashSet::new(),
             users_for_key_query: AsyncStdMutex::new(UsersForKeyQuery::new()),
             users_for_key_query_condvar: Condvar::new(),
-            tracked_users_loaded: AtomicBool::new(false),
-            tracked_user_loading_lock: Mutex::new(()),
+            tracked_user_loading_lock: RwLock::new(false),
         });
 
         Self { inner }
@@ -929,28 +927,35 @@ impl Store {
     /// actual [`CryptoStore`] once, it will also make sure that any
     /// concurrent calls to this method get deduplicated.
     async fn load_tracked_users(&self) -> Result<()> {
-        // If the users are loaded do nothing, otherwise acquire a lock.
-        if !self.inner.tracked_users_loaded.load(Ordering::SeqCst) {
-            let _lock = self.inner.tracked_user_loading_lock.lock().await;
+        // Check if the users are loaded, and in that case do nothing.
+        let loaded = self.inner.tracked_user_loading_lock.read().await;
+        if *loaded {
+            return Ok(());
+        }
 
-            // Check again if the users have been loaded, in case another call to this
-            // method loaded the tracked users between the time we tried to
-            // acquire the lock and the time we actually acquired the lock.
-            if !self.inner.tracked_users_loaded.load(Ordering::SeqCst) {
-                let tracked_users = self.inner.store.load_tracked_users().await?;
+        // Otherwise, we may load the users.
+        drop(loaded);
+        let mut loaded = self.inner.tracked_user_loading_lock.write().await;
 
-                let mut query_users_lock = self.inner.users_for_key_query.lock().await;
-                for user in tracked_users {
-                    self.inner.tracked_users_cache.insert(user.user_id.to_owned());
+        // Check again if the users have been loaded, in case another call to this
+        // method loaded the tracked users between the time we tried to
+        // acquire the lock and the time we actually acquired the lock.
+        if *loaded {
+            return Ok(());
+        }
 
-                    if user.dirty {
-                        query_users_lock.insert_user(&user.user_id);
-                    }
-                }
+        let tracked_users = self.inner.store.load_tracked_users().await?;
 
-                self.inner.tracked_users_loaded.store(true, Ordering::SeqCst);
+        let mut query_users_lock = self.inner.users_for_key_query.lock().await;
+        for user in tracked_users {
+            self.inner.tracked_users_cache.insert(user.user_id.to_owned());
+
+            if user.dirty {
+                query_users_lock.insert_user(&user.user_id);
             }
         }
+
+        *loaded = true;
 
         Ok(())
     }


### PR DESCRIPTION
This sets up the code so we have a dummy `StoreCache`, and I've moved what was previously cached in the `StoreInner` within that. It gives a pretty good idea of what the changes will look like:

- add field to the cache struct
- retrieve the cache using a new `async` fallible `cache()` function in the store (might be exposed to the whole crate later)

Considering the APIs that are making use of the cache, they can either 1. try to acquire the cache on their own, or 2. expect a cache to be provided as a function parameter. This PR shows both cases. It won't always be as simple to port things to the cache in the first place, because we might take some functions that are sync and make them `async`, or take infallible functions and make them fallible now.

Part of #2624.