### PR TITLE
Change the way we store gossip requests in indexeddb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,6 +3280,7 @@ dependencies = [
  "matrix-sdk-test",
  "ruma",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "thiserror",
  "tokio",
@@ -5277,6 +5278,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -759,10 +759,15 @@ impl GossipMachine {
                 recipient = info.request_recipient.as_str(),
                 request_type = info.request_type(),
                 request_id = info.request_id.to_string().as_str(),
-                "Marking outgoing key request as sent"
+                "Marking outgoing secret request as sent"
             );
             info.sent_out = true;
             self.save_outgoing_key_info(info).await?;
+        } else {
+            warn!(
+                request_id = id.to_string(),
+                "Unknown outgoing secret request; cannot mark as sent"
+            )
         }
 
         self.inner.outgoing_requests.remove(id);

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -31,6 +31,7 @@ matrix-sdk-store-encryption = { version = "0.2.0", path = "../matrix-sdk-store-e
 ruma = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde-wasm-bindgen = "0.5"
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -60,10 +60,10 @@ mod keys {
     pub const DEVICES: &str = "devices";
     pub const IDENTITIES: &str = "identities";
 
-    pub const OUTGOING_SECRET_REQUESTS: &str = "outgoing_secret_requests";
-    pub const UNSENT_SECRET_REQUESTS: &str = "unsent_secret_requests";
-    pub const SECRET_REQUESTS_BY_INFO: &str = "secret_requests_by_info";
-    pub const KEY_REQUEST: &str = "key_request";
+    pub const GOSSIP_REQUESTS: &str = "gossip_requests";
+    pub const GOSSIP_REQUESTS_UNSENT_INDEX: &str = "unsent";
+    pub const GOSSIP_REQUESTS_BY_INFO_INDEX: &str = "by_info";
+
     pub const ROOM_SETTINGS: &str = "room_settings";
 
     pub const SECRETS_INBOX: &str = "secrets_inbox";
@@ -161,7 +161,7 @@ impl IndexeddbCryptoStore {
         let name = format!("{prefix:0}::matrix-sdk-crypto");
 
         // Open my_db v1
-        let mut db_req: OpenDbRequest = IdbDatabase::open_u32(&name, 4)?;
+        let mut db_req: OpenDbRequest = IdbDatabase::open_u32(&name, 5)?;
         db_req.set_on_upgrade_needed(Some(|evt: &IdbVersionChangeEvent| -> Result<(), JsValue> {
             // Even if the web-sys bindings expose the version as a f64, the IndexedDB API
             // works with an unsigned integer.
@@ -182,10 +182,6 @@ impl IndexeddbCryptoStore {
                 db.create_object_store(keys::DEVICES)?;
 
                 db.create_object_store(keys::IDENTITIES)?;
-                db.create_object_store(keys::OUTGOING_SECRET_REQUESTS)?;
-                db.create_object_store(keys::UNSENT_SECRET_REQUESTS)?;
-                db.create_object_store(keys::SECRET_REQUESTS_BY_INFO)?;
-
                 db.create_object_store(keys::BACKUP_KEYS)?;
             }
 
@@ -219,6 +215,36 @@ impl IndexeddbCryptoStore {
                 let db = evt.db();
 
                 db.create_object_store(keys::SECRETS_INBOX)?;
+            }
+
+            if old_version < 5 {
+                let db = evt.db();
+
+                // Create a new store for outgoing secret requests
+                let object_store = db.create_object_store(keys::GOSSIP_REQUESTS)?;
+
+                let mut params = IdbIndexParameters::new();
+                params.unique(false);
+                object_store.create_index_with_params(
+                    keys::GOSSIP_REQUESTS_UNSENT_INDEX,
+                    &IdbKeyPath::str("unsent"),
+                    &params,
+                )?;
+
+                let mut params = IdbIndexParameters::new();
+                params.unique(true);
+                object_store.create_index_with_params(
+                    keys::GOSSIP_REQUESTS_BY_INFO_INDEX,
+                    &IdbKeyPath::str("info"),
+                    &params,
+                )?;
+
+                if old_version > 0 {
+                    // we just delete any existing requests.
+                    db.delete_object_store("outgoing_secret_requests")?;
+                    db.delete_object_store("unsent_secret_requests")?;
+                    db.delete_object_store("secret_requests_by_info")?;
+                }
             }
 
             Ok(())
@@ -427,33 +453,33 @@ impl IndexeddbCryptoStore {
         self.account_info.read().unwrap().clone()
     }
 
-    /// Fetch the outgoing secret request corresponding to the hashed request ID
-    ///
-    /// Helper for [`IndexeddbCryptoStore::get_outgoing_secret_requests`] and
-    /// [`IndexeddbCryptoStore::get_secret_request_by_info`]
-    async fn get_outgoing_secret_requests_from_encoded_key(
+    /// Transform a [`GossipRequest`] into a `JsValue` holding a
+    /// [`GossipRequestIndexedDbObject`], ready for storing
+    fn serialize_gossip_request(
         &self,
-        request_id: JsValue,
-    ) -> Result<Option<GossipRequest>> {
-        let dbs = [keys::OUTGOING_SECRET_REQUESTS, keys::UNSENT_SECRET_REQUESTS];
-        let tx = self.inner.transaction_on_multi_with_mode(&dbs, IdbTransactionMode::Readonly)?;
+        gossip_request: &GossipRequest,
+    ) -> Result<JsValue, CryptoStoreError> {
+        let obj = GossipRequestIndexedDbObject {
+            // hash the info as a key so that it can be used in index lookups.
+            info: self.encode_key_as_string(keys::GOSSIP_REQUESTS, gossip_request.info.as_key()),
 
-        let request = tx
-            .object_store(keys::OUTGOING_SECRET_REQUESTS)?
-            .get(&request_id)?
-            .await?
-            .map(|i| self.deserialize_value(i))
-            .transpose()?;
+            // serialize and encrypt the data about the request
+            request: self.serialize_value_as_bytes(gossip_request)?,
 
-        Ok(match request {
-            None => tx
-                .object_store(keys::UNSENT_SECRET_REQUESTS)?
-                .get(&request_id)?
-                .await?
-                .map(|i| self.deserialize_value(i))
-                .transpose()?,
-            Some(request) => Some(request),
-        })
+            unsent: if gossip_request.sent_out { None } else { Some(1) },
+        };
+
+        Ok(obj.try_into()?)
+    }
+
+    /// Transform a JsValue holding a [`GossipRequestIndexedDbObject`] back into
+    /// a [`GossipRequest`]
+    fn deserialize_gossip_request(
+        &self,
+        stored_request: JsValue,
+    ) -> Result<GossipRequest, CryptoStoreError> {
+        let idb_object: GossipRequestIndexedDbObject = stored_request.try_into()?;
+        self.deserialize_value_from_bytes(&idb_object.request)
     }
 }
 
@@ -515,11 +541,7 @@ impl_crypto_store! {
         .collect();
 
         if !changes.key_requests.is_empty() {
-            stores.extend([
-                keys::SECRET_REQUESTS_BY_INFO,
-                keys::UNSENT_SECRET_REQUESTS,
-                keys::OUTGOING_SECRET_REQUESTS,
-            ])
+            stores.extend([keys::GOSSIP_REQUESTS])
         }
 
         if stores.is_empty() {
@@ -667,26 +689,15 @@ impl_crypto_store! {
         }
 
         if !key_requests.is_empty() {
-            let secret_requests_by_info = tx.object_store(keys::SECRET_REQUESTS_BY_INFO)?;
-            let unsent_secret_requests = tx.object_store(keys::UNSENT_SECRET_REQUESTS)?;
-            let outgoing_secret_requests = tx.object_store(keys::OUTGOING_SECRET_REQUESTS)?;
-            for key_request in &key_requests {
-                let key_request_id =
-                    self.encode_key(keys::KEY_REQUEST, key_request.request_id.as_str());
-                secret_requests_by_info.put_key_val(
-                    &self.encode_key(keys::KEY_REQUEST, key_request.info.as_key()),
-                    &key_request_id,
-                )?;
+            let gossip_requests = tx.object_store(keys::GOSSIP_REQUESTS)?;
 
-                if key_request.sent_out {
-                    unsent_secret_requests.delete(&key_request_id)?;
-                    outgoing_secret_requests
-                        .put_key_val(&key_request_id, &self.serialize_value(&key_request)?)?;
-                } else {
-                    outgoing_secret_requests.delete(&key_request_id)?;
-                    unsent_secret_requests
-                        .put_key_val(&key_request_id, &self.serialize_value(&key_request)?)?;
-                }
+            for gossip_request in &key_requests {
+                let key_request_id = self.encode_key(keys::GOSSIP_REQUESTS, gossip_request.request_id.as_str());
+                let key_request_value = self.serialize_gossip_request(gossip_request)?;
+                gossip_requests.put_key_val_owned(
+                    key_request_id,
+                    &key_request_value,
+                )?;
             }
         }
 
@@ -785,8 +796,15 @@ impl_crypto_store! {
         &self,
         request_id: &TransactionId,
     ) -> Result<Option<GossipRequest>> {
-        let jskey = self.encode_key(keys::KEY_REQUEST, request_id.as_str());
-        self.get_outgoing_secret_requests_from_encoded_key(jskey).await
+        let jskey = self.encode_key(keys::GOSSIP_REQUESTS, request_id.as_str());
+        Ok(self
+            .inner
+            .transaction_on_one_with_mode(keys::GOSSIP_REQUESTS, IdbTransactionMode::Readonly)?
+            .object_store(keys::GOSSIP_REQUESTS)?
+            .get_owned(jskey)?
+            .await?
+            .map(|val| self.deserialize_gossip_request(val))
+            .transpose()?)
     }
 
     async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
@@ -1071,71 +1089,49 @@ impl_crypto_store! {
         &self,
         key_info: &SecretInfo,
     ) -> Result<Option<GossipRequest>> {
-        let id = self
+        let key = self.encode_key(keys::GOSSIP_REQUESTS, key_info.as_key());
+
+        let val = self
             .inner
             .transaction_on_one_with_mode(
-                keys::SECRET_REQUESTS_BY_INFO,
+                keys::GOSSIP_REQUESTS,
                 IdbTransactionMode::Readonly,
             )?
-            .object_store(keys::SECRET_REQUESTS_BY_INFO)?
-            .get(&self.encode_key(keys::KEY_REQUEST, key_info.as_key()))?
+            .object_store(keys::GOSSIP_REQUESTS)?
+            .index(keys::GOSSIP_REQUESTS_BY_INFO_INDEX)?
+            .get_owned(key)?
             .await?;
-        if let Some(id) = id {
-            self.get_outgoing_secret_requests_from_encoded_key(id).await
+
+        if let Some(val) = val {
+            let deser = self.deserialize_gossip_request(val)?;
+            Ok(Some(deser))
         } else {
             Ok(None)
         }
     }
 
     async fn get_unsent_secret_requests(&self) -> Result<Vec<GossipRequest>> {
-        Ok(self
+        let results = self
             .inner
             .transaction_on_one_with_mode(
-                keys::UNSENT_SECRET_REQUESTS,
+                keys::GOSSIP_REQUESTS,
                 IdbTransactionMode::Readonly,
             )?
-            .object_store(keys::UNSENT_SECRET_REQUESTS)?
+            .object_store(keys::GOSSIP_REQUESTS)?
+            .index(keys::GOSSIP_REQUESTS_UNSENT_INDEX)?
             .get_all()?
             .await?
             .iter()
-            .filter_map(|i| self.deserialize_value(i).ok())
-            .collect())
+            .filter_map(|val| self.deserialize_gossip_request(val).ok())
+            .collect();
+
+        Ok(results)
     }
 
     async fn delete_outgoing_secret_requests(&self, request_id: &TransactionId) -> Result<()> {
-        let jskey = self.encode_key(keys::KEY_REQUEST, request_id); //.as_str());
-        let dbs = [
-            keys::OUTGOING_SECRET_REQUESTS,
-            keys::UNSENT_SECRET_REQUESTS,
-            keys::SECRET_REQUESTS_BY_INFO,
-        ];
-        let tx = self.inner.transaction_on_multi_with_mode(&dbs, IdbTransactionMode::Readwrite)?;
-
-        let request: Option<GossipRequest> = tx
-            .object_store(keys::OUTGOING_SECRET_REQUESTS)?
-            .get(&jskey)?
-            .await?
-            .map(|i| self.deserialize_value(i))
-            .transpose()?;
-
-        let request = match request {
-            None => tx
-                .object_store(keys::UNSENT_SECRET_REQUESTS)?
-                .get(&jskey)?
-                .await?
-                .map(|i| self.deserialize_value(i))
-                .transpose()?,
-            Some(request) => Some(request),
-        };
-
-        if let Some(inner) = request {
-            tx.object_store(keys::SECRET_REQUESTS_BY_INFO)?
-                .delete(&self.encode_key(keys::KEY_REQUEST, inner.info.as_key()))?;
-        }
-
-        tx.object_store(keys::UNSENT_SECRET_REQUESTS)?.delete(&jskey)?;
-        tx.object_store(keys::OUTGOING_SECRET_REQUESTS)?.delete(&jskey)?;
-
+        let jskey = self.encode_key(keys::GOSSIP_REQUESTS, request_id);
+        let tx = self.inner.transaction_on_one_with_mode(keys::GOSSIP_REQUESTS, IdbTransactionMode::Readwrite)?;
+        tx.object_store(keys::GOSSIP_REQUESTS)?.delete_owned(jskey)?;
         tx.await.into_result().map_err(|e| e.into())
     }
 
@@ -1275,6 +1271,42 @@ impl Drop for IndexeddbCryptoStore {
         // Must release the database access manually as it's not done when
         // dropping it.
         self.inner.close();
+    }
+}
+
+/// The objects we store in the gossip_requests indexeddb object store
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct GossipRequestIndexedDbObject {
+    /// encrypted hash of the SecretInfo structure
+    info: String,
+
+    /// encrypted serialised representation of the GossipRequest as a whole
+    request: Vec<u8>,
+
+    /// whether the request has yet to be sent out
+    //
+    // Booleans don't really do what you might hope in indexeddb. Instead, we use an `Option`, and
+    // omit the value altogether if it is `None`, which means it will be excluded from the
+    // "unsent" index. If it is `Some`, the actual value is unimportant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unsent: Option<u8>,
+}
+
+impl TryInto<JsValue> for GossipRequestIndexedDbObject {
+    type Error = IndexeddbCryptoStoreError;
+
+    fn try_into(self) -> std::result::Result<JsValue, Self::Error> {
+        serde_wasm_bindgen::to_value(&self)
+            .map_err(|e| IndexeddbCryptoStoreError::Json(serde::ser::Error::custom(e.to_string())))
+    }
+}
+
+impl TryFrom<JsValue> for GossipRequestIndexedDbObject {
+    type Error = IndexeddbCryptoStoreError;
+
+    fn try_from(value: JsValue) -> std::result::Result<Self, Self::Error> {
+        serde_wasm_bindgen::from_value(value)
+            .map_err(|e| IndexeddbCryptoStoreError::Json(serde::de::Error::custom(e.to_string())))
     }
 }
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -1277,17 +1277,25 @@ impl Drop for IndexeddbCryptoStore {
 /// The objects we store in the gossip_requests indexeddb object store
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct GossipRequestIndexedDbObject {
-    /// encrypted hash of the SecretInfo structure
+    /// Encrypted hash of the [`SecretInfo`] structure.
     info: String,
 
-    /// encrypted serialised representation of the GossipRequest as a whole
+    /// Encrypted serialised representation of the [`GossipRequest`] as a whole.
     request: Vec<u8>,
 
-    /// whether the request has yet to be sent out
-    //
-    // Booleans don't really do what you might hope in indexeddb. Instead, we use an `Option`, and
-    // omit the value altogether if it is `None`, which means it will be excluded from the
-    // "unsent" index. If it is `Some`, the actual value is unimportant.
+    /// Whether the request has yet to be sent out.
+    ///
+    /// Really, this represents a boolean value, but booleans don't work as keys
+    /// in indexeddb (see [ECMA spec]). In any case, we don't need to be
+    /// able to retrieve entries where `unsent` is false, so we may as well
+    /// omit them from the index (see also [Stack Overflow]).
+    ///
+    /// To avoid too much `serde` magic, we use an `Option`, and omit the value
+    /// altogether if it is `None`, which means it will be excluded from the
+    /// "unsent" index. If it is `Some`, the actual value is unimportant.
+    ///
+    /// [ECMA spec]: https://w3c.github.io/IndexedDB/#key
+    /// [Stack overflow]: https://stackoverflow.com/a/24501949/637864
     #[serde(skip_serializing_if = "Option::is_none")]
     unsent: Option<u8>,
 }

--- a/crates/matrix-sdk-indexeddb/src/safe_encode.rs
+++ b/crates/matrix-sdk-indexeddb/src/safe_encode.rs
@@ -43,18 +43,6 @@ pub trait SafeEncode {
     /// The result will not be escaped again.
     fn as_encoded_string(&self) -> String;
 
-    /// encode self into a JsValue, internally using `as_encoded_string`
-    /// to escape the value of self.
-    fn encode(&self) -> JsValue {
-        self.as_encoded_string().into()
-    }
-
-    /// encode self into a JsValue, internally using `as_secure_string`
-    /// to escape the value of self,
-    fn encode_secure(&self, table_name: &str, store_cipher: &StoreCipher) -> JsValue {
-        self.as_secure_string(table_name, store_cipher).into()
-    }
-
     /// encode self securely for the given tablename with the given
     /// `store_cipher` hash_key, returns the value as a base64 encoded
     /// string without any padding.

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -940,7 +940,7 @@ mod tests {
             let tx =
                 db.transaction_on_one_with_mode(keys::ROOM_STATE, IdbTransactionMode::Readwrite)?;
             let state = tx.object_store(keys::ROOM_STATE)?;
-            let key = (room_id, StateEventType::RoomTopic, "").encode();
+            let key: JsValue = (room_id, StateEventType::RoomTopic, "").as_encoded_string().into();
             state.put_key_val(&key, &serialize_event(None, &wrong_redacted_state_event)?)?;
             tx.await.into_result()?;
             db.close();

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -163,9 +163,10 @@ where
     T: SafeEncode,
 {
     match store_cipher {
-        Some(cipher) => key.encode_secure(table_name, cipher),
-        None => key.encode(),
+        Some(cipher) => key.as_secure_string(table_name, cipher),
+        None => key.as_encoded_string(),
     }
+    .into()
 }
 
 fn encode_to_range<T>(


### PR DESCRIPTION
Instead of using three separate object stores, use a single one with some  structured objects and indexes.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2605 (or at least, should make whatever is going wrong much more obvious).

Consists of a series of commits which should be reviewable on their own.