### PR TITLE
Introduce `StaticAccountData` for `ReadOnlyAccount` immutable fields

### DIFF
--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -93,9 +93,13 @@ impl DehydratedDevices {
         let account = ReadOnlyAccount::new(user_id);
         let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
 
-        let verification_machine =
-            VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
-        let store = Store::new(user_id.into(), user_identity, store, verification_machine);
+        let verification_machine = VerificationMachine::new(
+            account.static_data().clone(),
+            user_identity.clone(),
+            store.clone(),
+        );
+        let store =
+            Store::new(user_id.into(), account.clone(), user_identity, store, verification_machine);
 
         let account = Account { inner: account, store };
 

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -291,7 +291,7 @@ impl DehydratedDevice {
         skip_all, fields(
             user_id = ?self.account.user_id(),
             device_id = ?self.account.device_id(),
-            identity_keys = ?self.account.identity_keys,
+            identity_keys = ?self.account.identity_keys(),
         )
     )]
     pub async fn keys_for_upload(

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1122,8 +1122,9 @@ mod tests {
         let account = ReadOnlyAccount::with_device_id(&user_id, &device_id);
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
-        let verification = VerificationMachine::new(account, identity.clone(), store.clone());
-        let store = Store::new(user_id.to_owned(), identity, store, verification);
+        let verification =
+            VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());
+        let store = Store::new(user_id.to_owned(), account, identity, store, verification);
         let session_cache = GroupSessionCache::new(store.clone());
 
         GossipMachine::new(user_id, device_id, store, session_cache, Arc::new(DashMap::new()))
@@ -1141,9 +1142,10 @@ mod tests {
 
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
-        let verification = VerificationMachine::new(account, identity.clone(), store.clone());
+        let verification =
+            VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());
 
-        let store = Store::new(user_id.clone(), identity, store, verification);
+        let store = Store::new(user_id.clone(), account, identity, store, verification);
         store.save_devices(&[device, another_device]).await.unwrap();
         let session_cache = GroupSessionCache::new(store.clone());
 

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1057,7 +1057,7 @@ mod tests {
     #[cfg(feature = "automatic-room-key-forwarding")]
     use crate::{
         gossiping::KeyForwardDecision,
-        olm::OutboundGroupSession,
+        olm::{Account, OutboundGroupSession},
         types::{
             events::{
                 forwarded_room_key::ForwardedRoomKeyContent, olm_v1::AnyDecryptedOlmEvent,
@@ -1069,7 +1069,7 @@ mod tests {
     };
     use crate::{
         identities::{LocalTrust, ReadOnlyDevice},
-        olm::{Account, PrivateCrossSigningIdentity, ReadOnlyAccount},
+        olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
         session_manager::GroupSessionCache,
         store::{CryptoStoreWrapper, MemoryStore, Store},
         types::events::room::encrypted::{EncryptedEvent, RoomEncryptedEventContent},
@@ -1166,7 +1166,7 @@ mod tests {
     ) -> (GossipMachine, Account, OutboundGroupSession, GossipMachine) {
         let alice_machine = get_machine().await;
         let alice_account = Account {
-            inner: alice_machine.inner.store.account().clone(),
+            static_data: alice_machine.inner.store.account().static_data().clone(),
             store: alice_machine.inner.store.clone(),
         };
         let alice_device = ReadOnlyDevice::from_account(alice_machine.inner.store.account()).await;
@@ -1696,7 +1696,6 @@ mod tests {
     #[async_test]
     async fn secret_share_cycle() {
         let alice_machine = get_machine().await;
-        let alice_account = Account { inner: account(), store: alice_machine.inner.store.clone() };
 
         let second_account = alice_2_account();
         let alice_device = ReadOnlyDevice::from_account(&second_account).await;
@@ -1707,7 +1706,8 @@ mod tests {
         alice_machine.inner.store.save_devices(&[alice_device.clone()]).await.unwrap();
 
         // Create Olm sessions for our two accounts.
-        let (alice_session, _) = alice_account.create_session_for(&second_account).await;
+        let (alice_session, _) =
+            alice_machine.inner.store.account().create_session_for(&second_account).await;
 
         alice_machine.inner.store.save_sessions(&[alice_session]).await.unwrap();
 

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -177,8 +177,8 @@ impl Device {
 
     /// Is this our own device?
     pub fn is_our_own_device(&self) -> bool {
-        let own_ed25519_key = self.verification_machine.store.account.identity_keys().ed25519;
-        let own_curve25519_key = self.verification_machine.store.account.identity_keys().curve25519;
+        let own_ed25519_key = self.verification_machine.store.account.identity_keys.ed25519;
+        let own_curve25519_key = self.verification_machine.store.account.identity_keys.curve25519;
 
         self.user_id() == self.verification_machine.own_user_id()
             && self.device_id() == self.verification_machine.own_device_id()

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -811,8 +811,9 @@ pub(crate) mod testing {
         let user_id = user_id().to_owned();
         let account = ReadOnlyAccount::with_device_id(&user_id, device_id());
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
-        let verification = VerificationMachine::new(account, identity.clone(), store.clone());
-        let store = Store::new(user_id.clone(), identity, store, verification);
+        let verification =
+            VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());
+        let store = Store::new(user_id.clone(), account, identity, store, verification);
         IdentityManager::new(user_id, device_id().into(), store)
     }
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -191,10 +191,18 @@ impl OlmMachine {
     ) -> Self {
         let user_id: OwnedUserId = user_id.into();
 
-        let verification_machine =
-            VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
-        let store =
-            Store::new(user_id.clone(), user_identity.clone(), store, verification_machine.clone());
+        let verification_machine = VerificationMachine::new(
+            account.static_data().clone(),
+            user_identity.clone(),
+            store.clone(),
+        );
+        let store = Store::new(
+            user_id.clone(),
+            account.clone(),
+            user_identity.clone(),
+            store,
+            verification_machine.clone(),
+        );
         let device_id: OwnedDeviceId = device_id.into();
         let users_for_key_claim = Arc::new(DashMap::new());
 

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -24,7 +24,7 @@ mod signing;
 mod utility;
 
 pub(crate) use account::{Account, OlmDecryptionInfo, SessionType};
-pub use account::{OlmMessageHash, PickledAccount, ReadOnlyAccount};
+pub use account::{OlmMessageHash, PickledAccount, ReadOnlyAccount, StaticAccountData};
 pub(crate) use group_sessions::ShareState;
 pub use group_sessions::{
     BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession,

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -460,7 +460,7 @@ impl PrivateCrossSigningIdentity {
     /// Sign an Olm account with this private identity.
     pub(crate) async fn sign_account(
         &self,
-        account: &ReadOnlyAccount,
+        account: &ReadOnlyAccount, // TODO(BNJ) think this could be StaticAccountData
     ) -> Result<SignatureUploadRequest, SignatureError> {
         let mut device_keys = account.unsigned_device_keys();
         self.sign_device_keys(&mut device_keys).await

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -227,6 +227,8 @@ impl GroupSessionManager {
     ) -> OlmResult<(OutboundGroupSession, InboundGroupSession)> {
         let (outbound, inbound) = self
             .account
+            .store
+            .account()
             .create_group_session_pair(room_id, settings)
             .await
             .map_err(|_| EventError::UnsupportedAlgorithm)?;

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -576,8 +576,8 @@ mod tests {
     async fn session_creation_waits_for_keys_query() {
         let manager = session_manager().await;
         let identity_manager = IdentityManager::new(
-            manager.account.user_id.clone(),
-            manager.account.device_id.clone(),
+            manager.account.user_id().to_owned(),
+            manager.account.device_id().to_owned(),
             manager.store.clone(),
         );
 
@@ -596,7 +596,7 @@ mod tests {
         // for now.
         let missing_sessions_task = {
             let manager = manager.clone();
-            let bob_user_id = bob.user_id.clone();
+            let bob_user_id = bob.user_id().to_owned();
 
             #[allow(unknown_lints, clippy::redundant_async_block)] // false positive
             tokio::spawn(async move {

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -517,13 +517,16 @@ mod tests {
         let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
         store.save_account(account.clone()).await.unwrap();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id)));
-        let verification =
-            VerificationMachine::new(account.clone(), identity.clone(), store.clone());
+        let verification = VerificationMachine::new(
+            account.static_data().clone(),
+            identity.clone(),
+            store.clone(),
+        );
 
         let user_id = user_id.to_owned();
         let device_id = device_id.into();
 
-        let store = Store::new(user_id.clone(), identity, store, verification);
+        let store = Store::new(user_id.clone(), account.clone(), identity, store, verification);
 
         let account = Account { inner: account, store: store.clone() };
 

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -96,7 +96,7 @@ macro_rules! cryptostore_integration_tests {
             #[async_test]
             async fn save_account_via_generic_save() {
                 let store = get_store("save_account_via_generic", None).await;
-                assert!(store.get_account_info().is_none());
+                assert!(store.get_static_account().is_none());
                 assert!(store.load_account().await.unwrap().is_none());
                 let account = get_account();
 
@@ -104,18 +104,18 @@ macro_rules! cryptostore_integration_tests {
                     .save_changes(Changes { account: Some(account), ..Default::default() })
                     .await
                     .expect("Can't save account");
-                assert!(store.get_account_info().is_some());
+                assert!(store.get_static_account().is_some());
             }
 
             #[async_test]
             async fn save_account() {
                 let store = get_store("save_account", None).await;
-                assert!(store.get_account_info().is_none());
+                assert!(store.get_static_account().is_none());
                 assert!(store.load_account().await.unwrap().is_none());
                 let account = get_account();
 
                 store.save_account(account).await.expect("Can't save account");
-                assert!(store.get_account_info().is_some());
+                assert!(store.get_static_account().is_some());
             }
 
             #[async_test]

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -61,7 +61,7 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub(crate) struct VerificationStore {
-    pub account: ReadOnlyAccount,
+    pub account: ReadOnlyAccount, // TODO(BNJ) could this be a StaticAccountData?
     pub private_identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
     inner: Arc<CryptoStoreWrapper>,
 }

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -927,7 +927,7 @@ mod tests {
 
         let flow_id = FlowId::ToDevice("test_transaction".into());
 
-        let device_key = account.identity_keys.ed25519;
+        let device_key = account.static_data.identity_keys.ed25519;
         let alice_device = ReadOnlyDevice::from_account(&account).await;
 
         let identities = store.get_identities(alice_device).await.unwrap();

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -527,7 +527,7 @@ impl QrVerification {
 
         let inner: QrVerificationData = SelfVerificationNoMasterKey::new(
             flow_id.as_str().to_owned(),
-            store.account.identity_keys().ed25519,
+            store.account.identity_keys.ed25519,
             own_master_key,
             secret,
         )
@@ -580,9 +580,10 @@ impl QrVerification {
 
         let identities = store.get_identities(other_device).await?;
 
-        let own_identity = identities.own_identity.as_ref().ok_or_else(|| {
-            ScanError::MissingCrossSigningIdentity(store.account.user_id().to_owned())
-        })?;
+        let own_identity = identities
+            .own_identity
+            .as_ref()
+            .ok_or_else(|| ScanError::MissingCrossSigningIdentity(store.account.user_id.clone()))?;
 
         let other_identity = identities
             .identity_being_verified
@@ -611,9 +612,9 @@ impl QrVerification {
             }
             QrVerificationData::SelfVerification(_) => {
                 check_master_key(qr_code.first_key(), other_identity)?;
-                if qr_code.second_key() != store.account.identity_keys().ed25519 {
+                if qr_code.second_key() != store.account.identity_keys.ed25519 {
                     return Err(ScanError::KeyMismatch {
-                        expected: store.account.identity_keys().ed25519.to_base64(),
+                        expected: store.account.identity_keys.ed25519.to_base64(),
                         found: qr_code.second_key().to_base64(),
                     });
                 }
@@ -635,7 +636,7 @@ impl QrVerification {
         };
 
         let secret = qr_code.secret().to_owned();
-        let own_device_id = store.account.device_id().to_owned();
+        let own_device_id = store.account.device_id.clone();
 
         Ok(Self {
             flow_id,
@@ -920,7 +921,7 @@ mod tests {
         let master_key = master_key.get_first_key().unwrap().to_owned();
 
         let store = VerificationStore {
-            account: account.clone(),
+            account: account.static_data.clone(),
             inner: store,
             private_identity: Mutex::new(private_identity).into(),
         };
@@ -983,7 +984,7 @@ mod tests {
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
 
             let store = VerificationStore {
-                account: alice_account.clone(),
+                account: alice_account.static_data.clone(),
                 inner: store,
                 private_identity: Mutex::new(private_identity).into(),
             };
@@ -1021,7 +1022,7 @@ mod tests {
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
             let bob_store = VerificationStore {
-                account: bob_account.clone(),
+                account: bob_account.static_data.clone(),
                 inner: bob_store,
                 private_identity: Mutex::new(private_identity).into(),
             };

--- a/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
@@ -33,13 +33,14 @@ use vodozemac::{sas::EstablishedSas, Curve25519PublicKey};
 use super::{sas_state::SupportedMacMethod, FlowId, OutgoingContent};
 use crate::{
     identities::{ReadOnlyDevice, ReadOnlyUserIdentities},
+    olm::StaticAccountData,
     verification::event_enums::{MacContent, StartContent},
-    Emoji, ReadOnlyAccount, ReadOnlyOwnUserIdentity,
+    Emoji, ReadOnlyOwnUserIdentity,
 };
 
 #[derive(Clone, Debug)]
 pub struct SasIds {
-    pub account: ReadOnlyAccount,
+    pub account: StaticAccountData,
     pub own_identity: Option<ReadOnlyOwnUserIdentity>,
     pub other_device: ReadOnlyDevice,
     pub other_identity: Option<ReadOnlyUserIdentities>,
@@ -170,8 +171,8 @@ fn extra_mac_info_receive(ids: &SasIds, flow_id: &str) -> String {
         {second_user}{second_device}{transaction_id}",
         first_user = ids.other_device.user_id(),
         first_device = ids.other_device.device_id(),
-        second_user = ids.account.user_id(),
-        second_device = ids.account.device_id(),
+        second_user = ids.account.user_id,
+        second_device = ids.account.device_id,
         transaction_id = flow_id,
     )
 }
@@ -268,8 +269,8 @@ fn extra_mac_info_send(ids: &SasIds, flow_id: &str) -> String {
     format!(
         "MATRIX_KEY_VERIFICATION_MAC{first_user}{first_device}\
         {second_user}{second_device}{transaction_id}",
-        first_user = ids.account.user_id(),
-        first_device = ids.account.device_id(),
+        first_user = ids.account.user_id,
+        first_device = ids.account.device_id,
         second_user = ids.other_device.user_id(),
         second_device = ids.other_device.device_id(),
         transaction_id = flow_id,
@@ -293,8 +294,8 @@ pub fn get_mac_content(
 ) -> OutgoingContent {
     let mut mac: BTreeMap<String, Base64> = BTreeMap::new();
 
-    let key_id = DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, ids.account.device_id());
-    let key = ids.account.identity_keys().ed25519.to_base64();
+    let key_id = DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, &ids.account.device_id);
+    let key = ids.account.identity_keys.ed25519.to_base64();
     let info = extra_mac_info_send(ids, flow_id.as_str());
 
     mac.insert(key_id.to_string(), mac_method.calculate_mac(sas, &key, &format!("{info}{key_id}")));
@@ -352,7 +353,7 @@ fn extra_info_sas(
     we_started: bool,
 ) -> String {
     let our_info =
-        format!("{}|{}|{}", ids.account.user_id(), ids.account.device_id(), own_pubkey.to_base64());
+        format!("{}|{}|{}", ids.account.user_id, ids.account.device_id, own_pubkey.to_base64());
     let their_info = format!(
         "{}|{}|{}",
         ids.other_device.user_id(),

--- a/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/inner_sas.rs
@@ -32,12 +32,13 @@ use super::{
 };
 use crate::{
     identities::{ReadOnlyDevice, ReadOnlyUserIdentities},
+    olm::StaticAccountData,
     verification::{
         cache::RequestInfo,
         event_enums::{AnyVerificationContent, OutgoingContent, OwnedAcceptContent, StartContent},
         Cancelled, Emoji,
     },
-    ReadOnlyAccount, ReadOnlyOwnUserIdentity,
+    ReadOnlyOwnUserIdentity,
 };
 
 #[derive(Clone, Debug)]
@@ -58,7 +59,7 @@ pub enum InnerSas {
 
 impl InnerSas {
     pub fn start(
-        account: ReadOnlyAccount,
+        account: StaticAccountData,
         other_device: ReadOnlyDevice,
         own_identity: Option<ReadOnlyOwnUserIdentity>,
         other_identity: Option<ReadOnlyUserIdentities>,
@@ -157,7 +158,7 @@ impl InnerSas {
     }
 
     pub fn from_start_event(
-        account: ReadOnlyAccount,
+        account: StaticAccountData,
         other_device: ReadOnlyDevice,
         flow_id: FlowId,
         content: &StartContent<'_>,

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -313,7 +313,7 @@ impl Sas {
         short_auth_strings: Option<Vec<ShortAuthenticationString>>,
     ) -> (Sas, OutgoingContent) {
         let (inner, content) = InnerSas::start(
-            identities.store.account.clone(),
+            identities.store.account.static_data().clone(), // TODO(bnjbvr, #2624) store could dup static data
             identities.device_being_verified.clone(),
             identities.own_identity.clone(),
             identities.identity_being_verified.clone(),
@@ -399,7 +399,7 @@ impl Sas {
         we_started: bool,
     ) -> Result<Sas, OutgoingContent> {
         let inner = InnerSas::from_start_event(
-            identities.store.account.clone(),
+            identities.store.account.static_data().clone(), // TODO(bnjbvr, #2624) store could dup StaticAccountData
             identities.device_being_verified.clone(),
             flow_id.clone(),
             content,

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -58,6 +58,7 @@ use super::{
 };
 use crate::{
     identities::{ReadOnlyDevice, ReadOnlyUserIdentities},
+    olm::StaticAccountData,
     verification::{
         cache::RequestInfo,
         event_enums::{
@@ -66,7 +67,7 @@ use crate::{
         },
         Cancelled, Emoji, FlowId,
     },
-    ReadOnlyAccount, ReadOnlyOwnUserIdentity,
+    ReadOnlyOwnUserIdentity,
 };
 
 const KEY_AGREEMENT_PROTOCOLS: &[KeyAgreementProtocol] =
@@ -484,12 +485,12 @@ impl<S: Clone> SasState<S> {
     /// Get our own user id.
     #[cfg(test)]
     pub fn user_id(&self) -> &UserId {
-        self.ids.account.user_id()
+        &self.ids.account.user_id
     }
 
     /// Get our own device ID.
     pub fn device_id(&self) -> &DeviceId {
-        self.ids.account.device_id()
+        &self.ids.account.device_id
     }
 
     #[cfg(test)]
@@ -551,7 +552,7 @@ impl SasState<Created> {
     ///
     /// * `other_identity` - The identity of the other user if one exists.
     pub fn new(
-        account: ReadOnlyAccount,
+        account: StaticAccountData,
         other_device: ReadOnlyDevice,
         own_identity: Option<ReadOnlyOwnUserIdentity>,
         other_identity: Option<ReadOnlyUserIdentities>,
@@ -572,7 +573,7 @@ impl SasState<Created> {
 
     fn new_helper(
         flow_id: FlowId,
-        account: ReadOnlyAccount,
+        account: StaticAccountData,
         other_device: ReadOnlyDevice,
         own_identity: Option<ReadOnlyOwnUserIdentity>,
         other_identity: Option<ReadOnlyUserIdentities>,
@@ -674,7 +675,7 @@ impl SasState<Started> {
     /// * `event` - The m.key.verification.start event that was sent to us by
     /// the other side.
     pub fn from_start_event(
-        account: ReadOnlyAccount,
+        account: StaticAccountData,
         other_device: ReadOnlyDevice,
         own_identity: Option<ReadOnlyOwnUserIdentity>,
         other_identity: Option<ReadOnlyUserIdentities>,
@@ -1545,7 +1546,7 @@ mod tests {
     }
 
     fn bob_device_id() -> &'static DeviceId {
-        device_id!("BOBDEVCIE")
+        device_id!("BOBDEVICE")
     }
 
     async fn get_sas_pair(
@@ -1558,14 +1559,21 @@ mod tests {
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
         let flow_id = TransactionId::new().into();
-        let alice_sas =
-            SasState::<Created>::new(alice.clone(), bob_device, None, None, flow_id, false, None);
+        let alice_sas = SasState::<Created>::new(
+            alice.static_data().clone(),
+            bob_device,
+            None,
+            None,
+            flow_id,
+            false,
+            None,
+        );
 
         let start_content = alice_sas.as_content();
         let flow_id = start_content.flow_id();
 
         let bob_sas = SasState::<Started>::from_start_event(
-            bob.clone(),
+            bob.static_data().clone(),
             alice_device,
             None,
             None,
@@ -1824,8 +1832,15 @@ mod tests {
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
         let flow_id = TransactionId::new().into();
-        let alice_sas =
-            SasState::<Created>::new(alice.clone(), bob_device, None, None, flow_id, false, None);
+        let alice_sas = SasState::<Created>::new(
+            alice.static_data().clone(),
+            bob_device,
+            None,
+            None,
+            flow_id,
+            false,
+            None,
+        );
 
         let mut start_content = alice_sas.as_content();
         let method = start_content.method_mut();
@@ -1841,7 +1856,7 @@ mod tests {
         let content = StartContent::from(&start_content);
 
         SasState::<Started>::from_start_event(
-            bob.clone(),
+            bob.static_data().clone(),
             alice_device.clone(),
             None,
             None,
@@ -1864,7 +1879,7 @@ mod tests {
         let flow_id = content.flow_id().to_owned();
 
         SasState::<Started>::from_start_event(
-            bob.clone(),
+            bob.static_data().clone(),
             alice_device,
             None,
             None,

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -22,8 +22,8 @@ use gloo_utils::format::JsValueSerdeExt;
 use indexed_db_futures::prelude::*;
 use matrix_sdk_crypto::{
     olm::{
-        IdentityKeys, InboundGroupSession, OlmMessageHash, OutboundGroupSession,
-        PrivateCrossSigningIdentity, Session, StaticAccountData,
+        InboundGroupSession, OlmMessageHash, OutboundGroupSession, PrivateCrossSigningIdentity,
+        Session, StaticAccountData,
     },
     store::{
         caches::SessionStore, BackupKeys, Changes, CryptoStore, CryptoStoreError, RoomKeyCounts,
@@ -36,7 +36,7 @@ use matrix_sdk_crypto::{
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
     events::secret::request::SecretName, DeviceId, MilliSecondsSinceUnixEpoch, OwnedDeviceId,
-    OwnedUserId, RoomId, TransactionId, UserId,
+    RoomId, TransactionId, UserId,
 };
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::sync::Mutex;
@@ -92,7 +92,7 @@ mod keys {
 ///
 /// [IndexedDB]: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
 pub struct IndexeddbCryptoStore {
-    static_account: Arc<RwLock<Option<StaticAccountData>>>,
+    static_account: RwLock<Option<StaticAccountData>>,
     name: String,
     pub(crate) inner: IdbDatabase,
 
@@ -246,13 +246,7 @@ impl IndexeddbCryptoStore {
         let db: IdbDatabase = db_req.into_future().await?;
         let session_cache = SessionStore::new();
 
-        Ok(Self {
-            name,
-            session_cache,
-            inner: db,
-            store_cipher,
-            static_account: RwLock::new(None).into(),
-        })
+        Ok(Self { name, session_cache, inner: db, store_cipher, static_account: RwLock::new(None) })
     }
 
     /// Open a new `IndexeddbCryptoStore` with default name and no passphrase


### PR DESCRIPTION
This introduces a new data structure, `StaticAccountData` (we could just call it `StaticAccount`) that contains all the immutable fields from the `ReadOnlyAccount`. The `ReadOnlyAccount` is "cached" in one place, the `Store`; after #2625 lands, we can put the `ReadOnlyAccount` in the actual cache.

Then, all the structs storing `ReadOnlyAccount` are changed according to the following rules:
- if all uses were only of static data, store a `StaticAccountData`
- if there are uses of the actual inner-mutable `ReadOnlyAccount` fields, refer to the `Store`'s `ReadOnlyAccount`

The first step was supposed to be carried in small, incremental commits, but I've pulled a thread at some point, and it unraveled lots of uses that could be simplified at once.

This can be reviewed commit by commit. I've left some future work items as `TODO(BNJ)`; can be ideas to try as followups, not guaranteed they'll work fine.

Part of #2624.