### PR TITLE
sdk(widget): add matrix i/o part

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -5903,9 +5904,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -135,6 +135,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 # support *sending* streams, which makes it useless for us.
 reqwest = { version = "0.11.10", default_features = false, features = ["stream"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
+tokio-util = "0.7.9"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -1,0 +1,95 @@
+//! Matrix driver implementation that exposes Matrix functionality
+//! that is relevant for the widget API.
+
+use ruma::{
+    api::client::{
+        account::request_openid_token::v3::{Request as OpenIdRequest, Response as OpenIdResponse},
+        filter::RoomEventFilter,
+    },
+    assign,
+    events::{AnySyncTimelineEvent, AnyTimelineEvent, TimelineEventType},
+    serde::Raw,
+    OwnedEventId,
+};
+use serde_json::Value as JsonValue;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+
+use crate::{
+    event_handler::EventHandlerDropGuard, room::MessagesOptions, HttpResult, Result, Room,
+};
+
+/// Thin wrapper around the Matrix API that provides convenient high level
+/// functions.
+pub struct MatrixDriver {
+    room: Room,
+}
+
+impl MatrixDriver {
+    /// Creates a new `MatrixDriver` for a given `room`.
+    pub fn new(room: Room) -> Self {
+        Self { room }
+    }
+
+    /// Requests an OpenID token for the current user.
+    pub async fn get_open_id(&self) -> HttpResult<OpenIdResponse> {
+        let user_id = self.room.own_user_id().to_owned();
+        self.room.client.send(OpenIdRequest::new(user_id), None).await
+    }
+
+    /// Reads the latest `limit` events of a given `event_type` from the room.
+    pub async fn read(
+        &self,
+        event_type: TimelineEventType,
+        limit: u32,
+    ) -> Result<Vec<Raw<AnyTimelineEvent>>> {
+        let options = assign!(MessagesOptions::backward(), {
+            limit: limit.into(),
+            filter: assign!(RoomEventFilter::default(), {
+                types: Some(vec![event_type.to_string()])
+            }),
+        });
+
+        let messages = self.room.messages(options).await?;
+        Ok(messages.chunk.into_iter().map(|ev| ev.event.cast()).collect())
+    }
+
+    /// Sends a given `event` to the room.
+    pub async fn send(
+        &self,
+        event_type: TimelineEventType,
+        state_key: Option<String>,
+        content: JsonValue,
+    ) -> Result<OwnedEventId> {
+        let type_str = event_type.to_string();
+        Ok(match state_key {
+            Some(key) => self.room.send_state_event_raw(content, &type_str, &key).await?.event_id,
+            None => self.room.send_raw(content, &type_str, None).await?.event_id,
+        })
+    }
+
+    /// Starts forwarding new room events. Once the returned `EventReceiver`
+    /// is dropped, forwarding will be stopped.
+    pub fn events(&self) -> EventReceiver {
+        let (tx, rx) = unbounded_channel();
+        let handle = self.room.add_event_handler(move |raw: Raw<AnySyncTimelineEvent>| {
+            let _ = tx.send(raw.cast());
+            async {}
+        });
+
+        let drop_guard = self.room.client().event_handler_drop_guard(handle);
+        EventReceiver { rx, _drop_guard: drop_guard }
+    }
+}
+
+/// A simple entity that wraps an `UnboundedReceiver`
+/// along with the drop guard for the room event handler.
+pub struct EventReceiver {
+    rx: UnboundedReceiver<Raw<AnyTimelineEvent>>,
+    _drop_guard: EventHandlerDropGuard,
+}
+
+impl EventReceiver {
+    pub async fn recv(&mut self) -> Option<Raw<AnyTimelineEvent>> {
+        self.rx.recv().await
+    }
+}

--- a/crates/matrix-sdk/src/widget/permissions.rs
+++ b/crates/matrix-sdk/src/widget/permissions.rs
@@ -17,7 +17,7 @@ pub trait PermissionsProvider: Send + Sync + 'static {
 }
 
 /// Permissions that a widget can request from a client.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Permissions {
     /// Types of the messages that a widget wants to be able to fetch.
     pub read: Vec<EventFilter>,


### PR DESCRIPTION
Another small PR following the previous one rel. to the sans-io implementation 🙂 This one adds the I/O part to the widget API. Now, when the state machine is structurally decoupled from the i/o, the Matrix part looks tiny and elegant (as it should be).