### PR TITLE
ui: Improve read receipts

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -20,7 +20,7 @@ use imbl::Vector;
 use matrix_sdk::{
     deserialized_responses::SyncTimelineEvent, executor::spawn, sync::RoomUpdate, Room,
 };
-use ruma::events::{receipt::ReceiptType, AnySyncTimelineEvent};
+use ruma::events::AnySyncTimelineEvent;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{info, info_span, trace, warn, Instrument};
 
@@ -119,18 +119,6 @@ impl TimelineBuilder {
         let track_read_marker_and_receipts = settings.track_read_receipts;
 
         let mut inner = TimelineInner::new(room).with_settings(settings);
-
-        if track_read_marker_and_receipts {
-            if let Some(read_receipt) = inner.own_user_stored_read_receipt(ReceiptType::Read).await
-            {
-                inner.set_initial_user_receipt(ReceiptType::Read, read_receipt).await;
-            }
-            if let Some(read_receipt) =
-                inner.own_user_stored_read_receipt(ReceiptType::ReadPrivate).await
-            {
-                inner.set_initial_user_receipt(ReceiptType::ReadPrivate, read_receipt).await;
-            }
-        }
 
         if has_events {
             inner.add_initial_events(events).await;

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -197,7 +197,7 @@ impl TimelineEventKind {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub(super) enum TimelineItemPosition {
     Start,
     End {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -57,7 +57,6 @@ use super::{
     inner::{TimelineInnerMetadata, TimelineInnerStateTransaction},
     item::timeline_item,
     polls::PollState,
-    read_receipts::maybe_add_implicit_read_receipt,
     util::{rfind_event_by_id, rfind_event_item, timestamp_to_date},
     EventTimelineItem, InReplyToDetails, Message, OtherState, ReactionGroup, ReactionSenderData,
     Sticker, TimelineDetails, TimelineItem, TimelineItemContent, VirtualTimelineItem,
@@ -224,7 +223,6 @@ pub(super) struct TimelineEventHandler<'a, 'o> {
     items: &'a mut ObservableVectorTransaction<'o, Arc<TimelineItem>>,
     meta: &'a mut TimelineInnerMetadata,
     ctx: TimelineEventContext,
-    track_read_receipts: bool,
     result: HandleEventResult,
 }
 
@@ -252,10 +250,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     pub(super) fn new(
         state: &'a mut TimelineInnerStateTransaction<'o>,
         ctx: TimelineEventContext,
-        track_read_receipts: bool,
     ) -> Self {
         let TimelineInnerStateTransaction { items, meta } = state;
-        Self { items, meta, ctx, track_read_receipts, result: HandleEventResult::default() }
+        Self { items, meta, ctx, result: HandleEventResult::default() }
     }
 
     /// Handle an event.
@@ -868,16 +865,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     self.items.push_front(day_divider);
                 }
 
-                if self.track_read_receipts {
-                    maybe_add_implicit_read_receipt(
-                        0,
-                        &mut item,
-                        self.ctx.is_own_event,
-                        self.items,
-                        &mut self.meta.users_read_receipts,
-                    );
-                }
-
                 let item = self.meta.new_timeline_item(item);
                 self.items.insert(1, item);
             }
@@ -921,17 +908,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     {
                         // If the old item is the last one and no day divider
                         // changes need to happen, replace and return early.
-
-                        if self.track_read_receipts {
-                            maybe_add_implicit_read_receipt(
-                                idx,
-                                &mut item,
-                                self.ctx.is_own_event,
-                                self.items,
-                                &mut self.meta.users_read_receipts,
-                            );
-                        }
-
                         trace!(idx, "Replacing existing event");
                         self.items.set(idx, timeline_item(item, old_item_id));
                         return;
@@ -1029,16 +1005,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         self.items.insert(insert_idx, new_day_divider);
                         insert_idx += 1;
                     }
-                }
-
-                if self.track_read_receipts {
-                    maybe_add_implicit_read_receipt(
-                        insert_idx,
-                        &mut item,
-                        self.ctx.is_own_event,
-                        self.items,
-                        &mut self.meta.users_read_receipts,
-                    );
                 }
 
                 let id = match removed_event_item_id {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
@@ -19,7 +19,7 @@ use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
     events::{receipt::Receipt, AnySyncTimelineEvent},
     serde::Raw,
-    OwnedEventId, OwnedUserId, UserId,
+    OwnedEventId, OwnedUserId,
 };
 
 use super::BundledReactions;
@@ -62,17 +62,6 @@ pub(in crate::timeline) struct RemoteEventTimelineItem {
 }
 
 impl RemoteEventTimelineItem {
-    pub fn add_read_receipt(&mut self, user_id: OwnedUserId, receipt: Receipt) {
-        self.read_receipts.insert(user_id, receipt);
-    }
-
-    /// Remove the read receipt for the given user.
-    ///
-    /// Returns `true` if there was one, `false` if not.
-    pub fn remove_read_receipt(&mut self, user_id: &UserId) -> bool {
-        self.read_receipts.remove(user_id).is_some()
-    }
-
     /// Clone the current event item, and update its `reactions`.
     pub fn with_reactions(&self, reactions: BundledReactions) -> Self {
         Self { reactions, ..self.clone() }

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -953,6 +953,55 @@ impl TimelineInner {
         // Let the server handle unknown receipts.
         true
     }
+
+    /// Get the latest read receipt of the given type for our own user in the
+    /// room of this timeline.
+    ///
+    /// Any error encountered is logged.
+    async fn own_user_stored_read_receipt_for_type_and_thread(
+        &self,
+        receipt_type: ReceiptType,
+        receipt_thread: ReceiptThread,
+    ) -> Option<(OwnedEventId, Receipt)> {
+        match self
+            .room()
+            .user_receipt(receipt_type.clone(), receipt_thread.clone(), self.room().own_user_id())
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                error!(
+                    ?receipt_type,
+                    ?receipt_thread,
+                    "Failed to get read receipt of own user from the store: {e}"
+                );
+                None
+            }
+        }
+    }
+
+    /// Get the latest read receipt of the given type for our own user in the
+    /// room of this timeline.
+    pub(super) async fn own_user_stored_read_receipt(
+        &self,
+        receipt_type: ReceiptType,
+    ) -> Option<(OwnedEventId, Receipt)> {
+        // If we cant find the unthreaded receipt, load the one from the main thread.
+        // Ideally we would get both and use the most recent one, but it is not possible
+        // to no which is the most recent at this stage since we don't have any events.
+        if let Some(receipt) = self
+            .own_user_stored_read_receipt_for_type_and_thread(
+                receipt_type.clone(),
+                ReceiptThread::Unthreaded,
+            )
+            .await
+        {
+            Some(receipt)
+        } else {
+            self.own_user_stored_read_receipt_for_type_and_thread(receipt_type, ReceiptThread::Main)
+                .await
+        }
+    }
 }
 
 #[derive(Default)]

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -885,6 +885,15 @@ impl TimelineInner {
         self.state.read().await.latest_user_read_receipt(user_id, room).await
     }
 
+    /// Get the ID of the timeline event with the latest read receipt for the
+    /// given user.
+    pub(super) async fn latest_user_read_receipt_timeline_event_id(
+        &self,
+        user_id: &UserId,
+    ) -> Option<OwnedEventId> {
+        self.state.read().await.latest_user_read_receipt_timeline_event_id(user_id)
+    }
+
     /// Check whether the given receipt should be sent.
     ///
     /// Returns `false` if the given receipt is older than the current one.

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -58,7 +58,7 @@ use super::{
     item::timeline_item,
     reactions::ReactionToggleResult,
     traits::RoomDataProvider,
-    util::{compare_events_positions, rfind_event_by_id, rfind_event_item, RelativePosition},
+    util::{rfind_event_by_id, rfind_event_item, RelativePosition},
     AnnotationKey, EventSendState, EventTimelineItem, InReplyToDetails, Message, Profile,
     RepliedToEvent, TimelineDetails, TimelineItem, TimelineItemContent, TimelineItemKind,
 };
@@ -904,7 +904,7 @@ impl TimelineInner {
                     state.user_receipt(own_user_id, ReceiptType::Read, room).await
                 {
                     if let Some(relative_pos) =
-                        compare_events_positions(&old_pub_read, event_id, &state.items)
+                        state.meta.compare_events_positions(&old_pub_read, event_id)
                     {
                         return relative_pos == RelativePosition::After;
                     }
@@ -917,7 +917,7 @@ impl TimelineInner {
                     state.latest_user_read_receipt(own_user_id, room).await
                 {
                     if let Some(relative_pos) =
-                        compare_events_positions(&old_priv_read, event_id, &state.items)
+                        state.meta.compare_events_positions(&old_priv_read, event_id)
                     {
                         return relative_pos == RelativePosition::After;
                     }
@@ -925,11 +925,10 @@ impl TimelineInner {
             }
             SendReceiptType::FullyRead => {
                 if let Some(old_fully_read) = self.fully_read_event().await {
-                    if let Some(relative_pos) = compare_events_positions(
-                        &old_fully_read.content.event_id,
-                        event_id,
-                        &state.items,
-                    ) {
+                    if let Some(relative_pos) = state
+                        .meta
+                        .compare_events_positions(&old_fully_read.content.event_id, event_id)
+                    {
                         return relative_pos == RelativePosition::After;
                     }
                 }

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -53,7 +53,10 @@ use crate::{
         polls::PollPendingEvents,
         reactions::{ReactionToggleResult, Reactions},
         traits::RoomDataProvider,
-        util::{find_read_marker, rfind_event_by_id, rfind_event_item, timestamp_to_date},
+        util::{
+            find_read_marker, rfind_event_by_id, rfind_event_item, timestamp_to_date,
+            RelativePosition,
+        },
         AnnotationKey, Error as TimelineError, Profile, ReactionSenderData, TimelineItem,
         TimelineItemKind, VirtualTimelineItem,
     },
@@ -727,6 +730,33 @@ impl TimelineInnerMetadata {
                 }
             }
         }
+    }
+
+    /// Get the relative positions of two events in the timeline.
+    ///
+    /// This method assumes that all events since the end of the timeline are
+    /// known.
+    pub fn compare_events_positions(
+        &self,
+        event_a: &EventId,
+        event_b: &EventId,
+    ) -> Option<RelativePosition> {
+        if event_a == event_b {
+            return Some(RelativePosition::Same);
+        }
+
+        // We can make early returns here because we know all events since the end of
+        // the timeline, so the first event encountered is the oldest one.
+        for meta in self.all_events.iter().rev() {
+            if meta.event_id == event_a {
+                return Some(RelativePosition::Before);
+            }
+            if meta.event_id == event_b {
+                return Some(RelativePosition::After);
+            }
+        }
+
+        None
     }
 
     pub fn next_internal_id(&mut self) -> u64 {

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -572,7 +572,8 @@ impl TimelineInnerStateTransaction<'_> {
             },
         };
 
-        let is_own_event = sender == room_data_provider.own_user_id();
+        let own_user_id = room_data_provider.own_user_id();
+        let is_own_event = sender == own_user_id;
 
         let event_metadata = FullEventMeta {
             event_id: &event_id,
@@ -601,7 +602,7 @@ impl TimelineInnerStateTransaction<'_> {
                     self.read_receipts.set_user_receipt_timeline_item(user_id, event_id.clone());
                 }
 
-                read_receipts
+                read_receipts.into_iter().filter(|(user_id, _)| user_id != own_user_id).collect()
             } else {
                 Default::default()
             },

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -693,6 +693,21 @@ impl Timeline {
         self.inner.latest_user_read_receipt(user_id).await
     }
 
+    /// Get the ID of the timeline event with the latest read receipt for the
+    /// given user.
+    ///
+    /// Contrary to [`Self::latest_user_read_receipt()`], this allows to know
+    /// the position of the read receipt in the timeline even if the event it
+    /// applies to is not visible in the timeline, unless the event is unknown
+    /// by this timeline.
+    #[instrument(skip(self))]
+    pub async fn latest_user_read_receipt_timeline_event_id(
+        &self,
+        user_id: &UserId,
+    ) -> Option<OwnedEventId> {
+        self.inner.latest_user_read_receipt_timeline_event_id(user_id).await
+    }
+
     /// Send the given receipt.
     ///
     /// This uses [`Room::send_single_receipt`] internally, but checks

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -28,7 +28,7 @@ use super::{
     inner::{TimelineInnerMetadata, TimelineInnerState, TimelineInnerStateTransaction},
     item::timeline_item,
     traits::RoomDataProvider,
-    util::{compare_events_positions, rfind_event_by_id, RelativePosition},
+    util::{rfind_event_by_id, RelativePosition},
     EventTimelineItem, TimelineItem,
 };
 
@@ -148,8 +148,7 @@ impl TimelineInnerState {
         };
 
         // Compare by position in the timeline.
-        if let Some(relative_pos) =
-            compare_events_positions(pub_event_id, priv_event_id, &self.items)
+        if let Some(relative_pos) = self.meta.compare_events_positions(pub_event_id, priv_event_id)
         {
             if relative_pos == RelativePosition::After {
                 return private_read_receipt;

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -137,28 +137,26 @@ impl ReadReceipts {
         // - If old_receipt_pos is None and new_receipt_pos is Some, the new receipt is
         //   more recent because it has a place in the timeline.
 
-        if !is_own_user {
-            // Remove the old receipt from the old event.
-            if let Some(old_event_id) = old_event_id {
-                let is_empty =
-                    if let Some(event_receipts) = self.events_read_receipts.get_mut(old_event_id) {
-                        event_receipts.remove(new_receipt.user_id);
-                        event_receipts.is_empty()
-                    } else {
-                        false
-                    };
-                // Remove the entry if the map is empty.
-                if is_empty {
-                    self.events_read_receipts.remove(old_event_id);
-                }
+        // Remove the old receipt from the old event.
+        if let Some(old_event_id) = old_event_id {
+            let is_empty =
+                if let Some(event_receipts) = self.events_read_receipts.get_mut(old_event_id) {
+                    event_receipts.remove(new_receipt.user_id);
+                    event_receipts.is_empty()
+                } else {
+                    false
+                };
+            // Remove the entry if the map is empty.
+            if is_empty {
+                self.events_read_receipts.remove(old_event_id);
             }
-
-            // Add the new receipt to the new event.
-            self.events_read_receipts
-                .entry(new_receipt.event_id.to_owned())
-                .or_default()
-                .insert(new_receipt.user_id.to_owned(), new_receipt.receipt.clone());
         }
+
+        // Add the new receipt to the new event.
+        self.events_read_receipts
+            .entry(new_receipt.event_id.to_owned())
+            .or_default()
+            .insert(new_receipt.user_id.to_owned(), new_receipt.receipt.clone());
 
         // Update the receipt of the user.
         self.users_read_receipts.entry(new_receipt.user_id.to_owned()).or_default().insert(
@@ -203,7 +201,6 @@ impl ReadReceipts {
         let events_iter = all_events.iter().skip_while(|meta| meta.event_id != event_id).skip(1);
 
         for hidden_event_meta in events_iter.take_while(|meta| !meta.visible) {
-            tracing::debug!("hidden event: {hidden_event_meta:?}");
             let Some(event_receipts) = self.events_read_receipts.get(&hidden_event_meta.event_id)
             else {
                 continue;

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -371,7 +371,8 @@ impl TimelineInnerStateTransaction<'_> {
                 }
 
                 for (user_id, receipt) in receipts {
-                    if receipt.thread != ReceiptThread::Unthreaded {
+                    // For now we only care about receipts in the main thread.
+                    if !matches!(receipt.thread, ReceiptThread::Unthreaded | ReceiptThread::Main) {
                         continue;
                     }
 

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
 
 use eyeball_im::ObservableVectorTransaction;
 use indexmap::IndexMap;
@@ -24,13 +27,241 @@ use ruma::{
 use tracing::{error, warn};
 
 use super::{
-    event_item::EventTimelineItemKind,
-    inner::{TimelineInnerMetadata, TimelineInnerState, TimelineInnerStateTransaction},
+    inner::{EventMeta, FullEventMeta, TimelineInnerState, TimelineInnerStateTransaction},
     item::timeline_item,
     traits::RoomDataProvider,
     util::{rfind_event_by_id, RelativePosition},
-    EventTimelineItem, TimelineItem,
+    TimelineItem,
 };
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct ReadReceipts {
+    /// Map of public read receipts on events.
+    ///
+    /// Event ID => User ID => Read receipt of the user.
+    pub events_read_receipts: HashMap<OwnedEventId, IndexMap<OwnedUserId, Receipt>>,
+    /// Map of all user read receipts.
+    ///
+    /// User ID => Receipt type => Read receipt of the user of the given
+    /// type.
+    pub users_read_receipts: HashMap<OwnedUserId, HashMap<ReceiptType, UserTimelineReceipt>>,
+}
+
+impl ReadReceipts {
+    /// Remove all data.
+    pub(super) fn clear(&mut self) {
+        self.events_read_receipts.clear();
+        self.users_read_receipts.clear();
+    }
+
+    /// Update the timeline items with the given read receipt if it is more
+    /// recent than the current one.
+    ///
+    /// In the process,if applicable, this method updates the
+    /// `users_read_receipts` map to use the new receipt. If
+    /// `update_old_item` is `true`, it also removes the corresponding
+    /// receipt from its old item.
+    ///
+    /// Returns the event ID of the timeline item on which the receipt should
+    /// appear, if the receipt was updated.
+    ///
+    /// Currently this method only works reliably if the timeline was started
+    /// from the end of the timeline.
+    fn maybe_update_read_receipt(
+        &mut self,
+        new_receipt: FullReceipt<'_>,
+        is_own_user: bool,
+        all_events: &VecDeque<EventMeta>,
+    ) -> ReadReceiptTimelineUpdate {
+        // Get old receipt.
+        let old_receipt = self
+            .users_read_receipts
+            .get(new_receipt.user_id)
+            .and_then(|receipts| receipts.get(&new_receipt.receipt_type));
+        if old_receipt.is_some_and(|old_receipt| old_receipt.event_id == new_receipt.event_id) {
+            // The receipt has not changed so there is nothing to do.
+            return ReadReceiptTimelineUpdate::default();
+        }
+        let old_event_id = old_receipt.map(|r| &r.event_id);
+        let old_item_event_id = old_receipt.and_then(|r| r.timeline_event_id.clone());
+
+        // Find receipts positions.
+        let mut old_receipt_pos = None;
+        let mut new_receipt_pos = None;
+        let mut new_item_event_id = None;
+        for (pos, event) in all_events.iter().rev().enumerate() {
+            if old_event_id == Some(&event.event_id) {
+                old_receipt_pos = Some(pos);
+            }
+
+            if new_receipt.event_id == event.event_id {
+                new_receipt_pos = Some(pos);
+            }
+            // The receipt should appear on the first event that is visible.
+            if new_receipt_pos.is_some() && new_item_event_id.is_none() && event.visible {
+                new_item_event_id = Some(event.event_id.clone());
+            }
+
+            if new_receipt_pos.is_some()
+                && new_item_event_id.is_some()
+                && (old_receipt.is_none() || old_receipt_pos.is_some())
+            {
+                // We have everything we need, stop.
+                break;
+            }
+        }
+
+        // Check if the old receipt is more recent than the new receipt.
+        if let Some(old_receipt_pos) = old_receipt_pos {
+            let Some(new_receipt_pos) = new_receipt_pos else {
+                // The old receipt is more recent since we can't find the new receipt in the
+                // timeline and we supposedly have all events since the end of the timeline.
+                return ReadReceiptTimelineUpdate::default();
+            };
+
+            if old_receipt_pos < new_receipt_pos {
+                // The old receipt is more recent than the new one.
+                return ReadReceiptTimelineUpdate::default();
+            }
+        }
+
+        // The new receipt is deemed more recent from now on because:
+        // - If old_receipt_pos is Some, we already checked all the cases where it
+        //   wouldn't be more recent.
+        // - If both old_receipt_pos and new_receipt_pos are None, they are both
+        //   explicit read receipts so the server should only send us a more recent
+        //   receipt.
+        // - If old_receipt_pos is None and new_receipt_pos is Some, the new receipt is
+        //   more recent because it has a place in the timeline.
+
+        if !is_own_user {
+            // Remove the old receipt from the old event.
+            if let Some(old_event_id) = old_event_id {
+                let is_empty =
+                    if let Some(event_receipts) = self.events_read_receipts.get_mut(old_event_id) {
+                        event_receipts.remove(new_receipt.user_id);
+                        event_receipts.is_empty()
+                    } else {
+                        false
+                    };
+                // Remove the entry if the map is empty.
+                if is_empty {
+                    self.events_read_receipts.remove(old_event_id);
+                }
+            }
+
+            // Add the new receipt to the new event.
+            self.events_read_receipts
+                .entry(new_receipt.event_id.to_owned())
+                .or_default()
+                .insert(new_receipt.user_id.to_owned(), new_receipt.receipt.clone());
+        }
+
+        // Update the receipt of the user.
+        self.users_read_receipts.entry(new_receipt.user_id.to_owned()).or_default().insert(
+            new_receipt.receipt_type,
+            UserTimelineReceipt {
+                event_id: new_receipt.event_id.to_owned(),
+                receipt: new_receipt.receipt.clone(),
+                timeline_event_id: new_item_event_id.clone(),
+            },
+        );
+
+        if is_own_user || (new_item_event_id.is_some() && new_item_event_id == old_item_event_id) {
+            // The receipt did not change in the timeline.
+            return ReadReceiptTimelineUpdate::default();
+        }
+
+        ReadReceiptTimelineUpdate {
+            old_event_id: old_item_event_id,
+            new_event_id: new_item_event_id,
+        }
+    }
+
+    /// Get the user read receipts for the given event.
+    ///
+    /// This loads all the receipts on the event and the receipts on the
+    /// following events that were discarded.
+    #[tracing::instrument(ret)]
+    pub(super) fn read_receipts_for_event(
+        &self,
+        event_id: &EventId,
+        all_events: &VecDeque<EventMeta>,
+        at_end: bool,
+    ) -> IndexMap<OwnedUserId, Receipt> {
+        let mut all_receipts = self.events_read_receipts.get(event_id).cloned().unwrap_or_default();
+
+        if at_end {
+            // No need to search for extra receipts, there are no events after.
+            return all_receipts;
+        }
+
+        // Iterate past the event.
+        let events_iter = all_events.iter().skip_while(|meta| meta.event_id != event_id).skip(1);
+
+        for hidden_event_meta in events_iter.take_while(|meta| !meta.visible) {
+            tracing::debug!("hidden event: {hidden_event_meta:?}");
+            let Some(event_receipts) = self.events_read_receipts.get(&hidden_event_meta.event_id)
+            else {
+                continue;
+            };
+
+            all_receipts.extend(event_receipts.iter().map(|(k, v)| (k.clone(), v.clone())));
+        }
+
+        all_receipts
+    }
+
+    /// Get the unthreaded receipt of the given type for the given user in the
+    /// timeline.
+    pub(super) async fn user_receipt(
+        &self,
+        user_id: &UserId,
+        receipt_type: ReceiptType,
+        room: &Room,
+    ) -> Option<(OwnedEventId, Receipt)> {
+        if let Some(user_receipt) =
+            self.users_read_receipts.get(user_id).and_then(|user_map| user_map.get(&receipt_type))
+        {
+            return Some((user_receipt.event_id.clone(), user_receipt.receipt.clone()));
+        }
+
+        room.user_receipt(receipt_type.clone(), ReceiptThread::Unthreaded, user_id)
+            .await
+            .unwrap_or_else(|e| {
+                error!("Could not get user read receipt of type {receipt_type:?}: {e}");
+                None
+            })
+    }
+
+    /// Set the timeline item on which a user receipt appears.
+    pub(super) fn set_user_receipt_timeline_item(
+        &mut self,
+        user_id: &UserId,
+        timeline_event_id: OwnedEventId,
+    ) {
+        if let Some(user_receipt) = self
+            .users_read_receipts
+            .get_mut(user_id)
+            .and_then(|user_map| user_map.get_mut(&ReceiptType::Read))
+        {
+            user_receipt.timeline_event_id = Some(timeline_event_id);
+        } else {
+            error!(%user_id, "inconsistent state: user receipt for timeline item not found");
+        }
+    }
+}
+
+/// The read receipt of a user in the timeline.
+#[derive(Clone, Debug)]
+pub(super) struct UserTimelineReceipt {
+    /// The real event ID of the receipt.
+    pub event_id: OwnedEventId,
+    /// The content of the receipt.
+    pub receipt: Receipt,
+    /// The ID of the event on which the receipt appears in the timeline.
+    pub timeline_event_id: Option<OwnedEventId>,
+}
 
 struct FullReceipt<'a> {
     event_id: &'a EventId,
@@ -39,22 +270,91 @@ struct FullReceipt<'a> {
     receipt: &'a Receipt,
 }
 
-impl TimelineInnerStateTransaction<'_> {
-    /// Update the new item pointed to by the user's read receipt.
-    fn add_read_receipt(
-        &mut self,
-        receipt_item_pos: Option<usize>,
+/// A read receipt update in the timeline.
+#[derive(Clone, Debug, Default)]
+pub(super) struct ReadReceiptTimelineUpdate {
+    /// The old event that had the receipt of the user, if any.
+    old_event_id: Option<OwnedEventId>,
+    /// The new event that has the receipt of the user, if any.
+    new_event_id: Option<OwnedEventId>,
+}
+
+impl ReadReceiptTimelineUpdate {
+    /// Remove the old receipt from the corresponding timeline item.
+    fn remove_old_receipt(
+        &self,
+        items: &mut ObservableVectorTransaction<Arc<TimelineItem>>,
+        user_id: &UserId,
+    ) {
+        let Some(event_id) = &self.old_event_id else {
+            // Nothing to do.
+            return;
+        };
+
+        let Some((receipt_pos, event_item)) = rfind_event_by_id(items, event_id) else {
+            error!(%event_id, %user_id, "inconsistent state: old event item for read receipt was not found");
+            return;
+        };
+
+        let event_item_id = event_item.internal_id;
+        let mut event_item = event_item.clone();
+
+        if let Some(remote_event_item) = event_item.as_remote_mut() {
+            if remote_event_item.read_receipts.remove(user_id).is_none() {
+                error!(
+                    %event_id, %user_id,
+                    "inconsistent state: old event item for user's read \
+                     receipt doesn't have a receipt for the user"
+                );
+            }
+            items.set(receipt_pos, timeline_item(event_item, event_item_id));
+        } else {
+            warn!("received a read receipt for a local item, this should not be possible");
+        }
+    }
+
+    /// Add the new receipt to the corresponding timeline item.
+    fn add_new_receipt(
+        self,
+        items: &mut ObservableVectorTransaction<Arc<TimelineItem>>,
         user_id: OwnedUserId,
         receipt: Receipt,
     ) {
-        let Some(pos) = receipt_item_pos else { return };
-        let timeline_item = self.items[pos].clone();
-        let Some(mut event_item) = timeline_item.as_event().cloned() else { return };
+        let Some(event_id) = self.new_event_id else {
+            // Nothing to do.
+            return;
+        };
 
-        event_item.as_remote_mut().unwrap().add_read_receipt(user_id, receipt);
-        self.items.set(pos, timeline_item.with_kind(event_item));
+        let Some((receipt_pos, event_item)) = rfind_event_by_id(items, &event_id) else {
+            // This can happen for new timeline items, the receipts will be loaded directly
+            // during construction of the item.
+            return;
+        };
+
+        let event_item_id = event_item.internal_id;
+        let mut event_item = event_item.clone();
+
+        if let Some(remote_event_item) = event_item.as_remote_mut() {
+            remote_event_item.read_receipts.insert(user_id, receipt);
+            items.set(receipt_pos, timeline_item(event_item, event_item_id));
+        } else {
+            warn!("received a read receipt for a local item, this should not be possible");
+        }
     }
 
+    /// Apply this update to the timeline.
+    fn apply(
+        self,
+        items: &mut ObservableVectorTransaction<Arc<TimelineItem>>,
+        user_id: OwnedUserId,
+        receipt: Receipt,
+    ) {
+        self.remove_old_receipt(items, &user_id);
+        self.add_new_receipt(items, user_id, receipt);
+    }
+}
+
+impl TimelineInnerStateTransaction<'_> {
     pub(super) fn handle_explicit_read_receipts(
         &mut self,
         receipt_event_content: ReceiptEventContent,
@@ -72,8 +372,6 @@ impl TimelineInnerStateTransaction<'_> {
                         continue;
                     }
 
-                    let receipt_item_pos =
-                        rfind_event_by_id(&self.items, &event_id).map(|(pos, _)| pos);
                     let is_own_user_id = user_id == own_user_id;
                     let full_receipt = FullReceipt {
                         event_id: &event_id,
@@ -82,48 +380,118 @@ impl TimelineInnerStateTransaction<'_> {
                         receipt: &receipt,
                     };
 
-                    let read_receipt_updated = maybe_update_read_receipt(
-                        full_receipt,
-                        receipt_item_pos,
-                        is_own_user_id,
-                        &mut self.items,
-                        &mut self.meta.users_read_receipts,
-                    );
-
-                    if read_receipt_updated && !is_own_user_id {
-                        self.add_read_receipt(receipt_item_pos, user_id, receipt);
-                    }
+                    self.meta
+                        .read_receipts
+                        .maybe_update_read_receipt(
+                            full_receipt,
+                            is_own_user_id,
+                            &self.meta.all_events,
+                        )
+                        .apply(&mut self.items, user_id, receipt);
                 }
             }
         }
     }
 
-    /// Load the read receipts from the store for the given event ID.
+    /// Load the read receipts from the room data provider for the given event
+    /// ID.
+    ///
+    /// Populates the read receipts maps.
     pub(super) async fn load_read_receipts_for_event<P: RoomDataProvider>(
         &mut self,
-        event_id: &EventId,
+        event_id: OwnedEventId,
         room_data_provider: &P,
-    ) -> IndexMap<OwnedUserId, Receipt> {
-        let read_receipts = room_data_provider.read_receipts_for_event(event_id).await;
+    ) {
+        let read_receipts = room_data_provider.read_receipts_for_event(&event_id).await;
 
-        // Filter out receipts for our own user.
+        // Since they are explicit read receipts, we need to check if they are
+        // superseded by implicit read receipts.
         let own_user_id = room_data_provider.own_user_id();
-        let read_receipts: IndexMap<OwnedUserId, Receipt> =
-            read_receipts.into_iter().filter(|(user_id, _)| user_id != own_user_id).collect();
-
-        // Keep track of the user's read receipt.
-        for (user_id, receipt) in read_receipts.clone() {
-            // Only insert the read receipt if the user is not known to avoid conflicts with
-            // `TimelineInner::handle_read_receipts`.
-            if !self.users_read_receipts.contains_key(&user_id) {
-                self.users_read_receipts
-                    .entry(user_id)
-                    .or_default()
-                    .insert(ReceiptType::Read, (event_id.to_owned(), receipt));
-            }
+        for (user_id, receipt) in read_receipts {
+            let full_receipt = FullReceipt {
+                event_id: &event_id,
+                user_id: &user_id,
+                receipt_type: ReceiptType::Read,
+                receipt: &receipt,
+            };
+            self.meta
+                .read_receipts
+                .maybe_update_read_receipt(
+                    full_receipt,
+                    user_id == own_user_id,
+                    &self.meta.all_events,
+                )
+                .apply(&mut self.items, user_id, receipt);
         }
+    }
 
-        read_receipts
+    /// Add an implicit read receipt to the given event item, if it is more
+    /// recent than the current read receipt for the sender of the event.
+    ///
+    /// According to the spec, read receipts should not point to events sent by
+    /// our own user, but these events are used to reset the notification
+    /// count, so we need to handle them locally too. For that we create an
+    /// "implicit" read receipt, compared to the "explicit" ones sent by the
+    /// client.
+    pub(super) fn maybe_add_implicit_read_receipt(&mut self, event_metadata: FullEventMeta<'_>) {
+        let FullEventMeta { event_id, sender, is_own_event, timestamp, .. } = event_metadata;
+
+        let (Some(user_id), Some(timestamp)) = (sender, timestamp) else {
+            // We cannot add a read receipt if we do not know the user or the timestamp.
+            return;
+        };
+
+        let receipt = Receipt::new(timestamp);
+        let new_receipt =
+            FullReceipt { event_id, user_id, receipt_type: ReceiptType::Read, receipt: &receipt };
+
+        self.meta
+            .read_receipts
+            .maybe_update_read_receipt(new_receipt, is_own_event, &self.meta.all_events)
+            .apply(&mut self.items, user_id.to_owned(), receipt);
+    }
+
+    /// Update the read receipts on the event with the given event ID and the
+    /// previous visible event because of a visibility change.
+    pub(super) fn maybe_update_read_receipts_of_prev_event(&mut self, event_id: &EventId) {
+        // Find the previous visible event, if there is one.
+        let Some((prev_item_pos, prev_event_item)) = self
+            .all_events
+            .iter()
+            .rev()
+            .skip_while(|meta| meta.event_id != event_id)
+            .skip(1)
+            .find(|meta| meta.visible)
+            .and_then(|meta| rfind_event_by_id(&self.items, &meta.event_id))
+        else {
+            return;
+        };
+
+        let prev_event_item_id = prev_event_item.internal_id;
+        let mut prev_event_item = prev_event_item.clone();
+
+        if let Some(remote_prev_event_item) = prev_event_item.as_remote_mut() {
+            let read_receipts = self.read_receipts.read_receipts_for_event(
+                &remote_prev_event_item.event_id,
+                &self.all_events,
+                false,
+            );
+
+            // If the count did not change, the receipts did not change either.
+            if read_receipts.len() != remote_prev_event_item.read_receipts.len() {
+                for user_id in read_receipts.keys() {
+                    self.read_receipts.set_user_receipt_timeline_item(
+                        user_id,
+                        remote_prev_event_item.event_id.clone(),
+                    );
+                }
+
+                remote_prev_event_item.read_receipts = read_receipts;
+                self.items.set(prev_item_pos, timeline_item(prev_event_item, prev_event_item_id));
+            }
+        } else {
+            warn!("loading read receipts for a local item, this should not be possible");
+        }
     }
 }
 
@@ -136,8 +504,10 @@ impl TimelineInnerState {
         user_id: &UserId,
         room: &Room,
     ) -> Option<(OwnedEventId, Receipt)> {
-        let public_read_receipt = self.user_receipt(user_id, ReceiptType::Read, room).await;
-        let private_read_receipt = self.user_receipt(user_id, ReceiptType::ReadPrivate, room).await;
+        let public_read_receipt =
+            self.read_receipts.user_receipt(user_id, ReceiptType::Read, room).await;
+        let private_read_receipt =
+            self.read_receipts.user_receipt(user_id, ReceiptType::ReadPrivate, room).await;
 
         // If we only have one, return it.
         let Some((pub_event_id, pub_receipt)) = &public_read_receipt else {
@@ -171,145 +541,4 @@ impl TimelineInnerState {
         // receipt.
         private_read_receipt
     }
-}
-
-impl TimelineInnerMetadata {
-    /// Get the unthreaded receipt of the given type for the given user in the
-    /// timeline.
-    pub(super) async fn user_receipt(
-        &self,
-        user_id: &UserId,
-        receipt_type: ReceiptType,
-        room: &Room,
-    ) -> Option<(OwnedEventId, Receipt)> {
-        if let Some(receipt) = self
-            .users_read_receipts
-            .get(user_id)
-            .and_then(|user_map| user_map.get(&receipt_type))
-            .cloned()
-        {
-            return Some(receipt);
-        }
-
-        room.user_receipt(receipt_type.clone(), ReceiptThread::Unthreaded, user_id)
-            .await
-            .unwrap_or_else(|e| {
-                error!("Could not get user read receipt of type {receipt_type:?}: {e}");
-                None
-            })
-    }
-}
-
-/// Add an implicit read receipt to the given event item, if it is more recent
-/// than the current read receipt for the sender of the event.
-///
-/// According to the spec, read receipts should not point to events sent by our
-/// own user, but these events are used to reset the notification count, so we
-/// need to handle them locally too. For that we create an "implicit" read
-/// receipt, compared to the "explicit" ones sent by the client.
-pub(super) fn maybe_add_implicit_read_receipt(
-    item_pos: usize,
-    event_item: &mut EventTimelineItem,
-    is_own_event: bool,
-    timeline_items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
-    users_read_receipts: &mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
-) {
-    let EventTimelineItemKind::Remote(remote_event_item) = &mut event_item.kind else {
-        return;
-    };
-
-    let receipt = Receipt::new(event_item.timestamp);
-    let new_receipt = FullReceipt {
-        event_id: &remote_event_item.event_id,
-        user_id: &event_item.sender,
-        receipt_type: ReceiptType::Read,
-        receipt: &receipt,
-    };
-
-    let read_receipt_updated = maybe_update_read_receipt(
-        new_receipt,
-        Some(item_pos),
-        is_own_event,
-        timeline_items,
-        users_read_receipts,
-    );
-    if read_receipt_updated && !is_own_event {
-        remote_event_item.add_read_receipt(event_item.sender.clone(), receipt);
-    }
-}
-
-/// Update the timeline items with the given read receipt if it is more recent
-/// than the current one.
-///
-/// In the process, this method removes the corresponding receipt from its old
-/// item, if applicable, and updates the `users_read_receipts` map to use the
-/// new receipt.
-///
-/// Returns true if the read receipt was saved.
-///
-/// Currently this method only works reliably if the timeline was started from
-/// the end of the timeline.
-fn maybe_update_read_receipt(
-    receipt: FullReceipt<'_>,
-    new_item_pos: Option<usize>,
-    is_own_user_id: bool,
-    timeline_items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
-    users_read_receipts: &mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
-) -> bool {
-    let old_event_id = users_read_receipts
-        .get(receipt.user_id)
-        .and_then(|receipts| receipts.get(&receipt.receipt_type))
-        .map(|(event_id, _)| event_id);
-    if old_event_id.is_some_and(|id| id == receipt.event_id) {
-        // Nothing to do.
-        return false;
-    }
-
-    let old_item_and_pos = old_event_id.and_then(|e| rfind_event_by_id(timeline_items, e));
-    if let Some((old_receipt_pos, old_event_item)) = old_item_and_pos {
-        let Some(new_receipt_pos) = new_item_pos else {
-            // The old receipt is likely more recent since we can't find the
-            // event of the new receipt in the timeline. Even if it isn't, we
-            // wouldn't know where to put it.
-            return false;
-        };
-
-        if old_receipt_pos > new_receipt_pos {
-            // The old receipt is more recent than the new one.
-            return false;
-        }
-
-        if !is_own_user_id {
-            // Remove the read receipt for this user from the old event.
-            let old_event_item_id = old_event_item.internal_id;
-            let mut old_event_item = old_event_item.clone();
-            if let Some(old_remote_event_item) = old_event_item.as_remote_mut() {
-                if !old_remote_event_item.remove_read_receipt(receipt.user_id) {
-                    error!(
-                        "inconsistent state: old event item for user's read \
-                         receipt doesn't have a receipt for the user"
-                    );
-                }
-                timeline_items
-                    .set(old_receipt_pos, timeline_item(old_event_item, old_event_item_id));
-            } else {
-                warn!("received a read receipt for a local item, this should not be possible");
-            }
-        }
-    }
-
-    // The new receipt is deemed more recent from now on because:
-    // - If old_receipt_item is Some, we already checked all the cases where it
-    //   wouldn't be more recent.
-    // - If both old_receipt_item and new_receipt_item are None, they are both
-    //   explicit read receipts so the server should only send us a more recent
-    //   receipt.
-    // - If old_receipt_item is None and new_receipt_item is Some, the new receipt
-    //   is likely more recent because it has a place in the timeline.
-    users_read_receipts
-        .entry(receipt.user_id.to_owned())
-        .or_default()
-        .insert(receipt.receipt_type, (receipt.event_id.to_owned(), receipt.receipt.clone()));
-
-    true
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -12,19 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use eyeball_im::VectorDiff;
-use matrix_sdk_test::{async_test, ALICE, BOB};
-use ruma::events::{
-    receipt::{ReceiptThread, ReceiptType},
-    room::message::RoomMessageEventContent,
+use matrix_sdk_test::{async_test, ALICE, BOB, CAROL};
+use ruma::{
+    event_id,
+    events::{
+        receipt::{ReceiptThread, ReceiptType},
+        room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+    },
+    room_id, server_name, EventId,
 };
 use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::inner::TimelineInnerSettings;
 
+fn filter_notice(ev: &AnySyncTimelineEvent) -> bool {
+    match ev {
+        AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
+            SyncRoomMessageEvent::Original(msg),
+        )) => !matches!(msg.content.msgtype, MessageType::Notice(_)),
+        _ => true,
+    }
+}
+
 #[async_test]
-async fn read_receipts_updates() {
+async fn read_receipts_updates_on_visible_events() {
     let timeline = TestTimeline::new()
         .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
     let mut stream = timeline.subscribe().await;
@@ -48,9 +64,9 @@ async fn read_receipts_updates() {
     // Implicit read receipt of Bob is updated.
     timeline.handle_live_message_event(*BOB, RoomMessageEventContent::text_plain("C")).await;
 
-    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 2, value } => value);
-    let event_a = item_a.as_event().unwrap();
-    assert!(event_a.read_receipts().is_empty());
+    let item_b = assert_next_matches!(stream, VectorDiff::Set { index: 2, value } => value);
+    let event_b = item_b.as_event().unwrap();
+    assert!(event_b.read_receipts().is_empty());
 
     let item_c = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
     let event_c = item_c.as_event().unwrap();
@@ -81,4 +97,191 @@ async fn read_receipts_updates() {
     let event_d = item_d.as_event().unwrap();
     assert_eq!(event_d.read_receipts().len(), 1);
     assert!(event_d.read_receipts().get(*BOB).is_some());
+}
+
+#[async_test]
+async fn read_receipts_updates_on_filtered_events() {
+    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+        track_read_receipts: true,
+        event_filter: Arc::new(filter_notice),
+        ..Default::default()
+    });
+    let mut stream = timeline.subscribe().await;
+
+    timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("A")).await;
+    timeline.handle_live_message_event(*BOB, RoomMessageEventContent::notice_plain("B")).await;
+
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+
+    // No read receipt for our own user.
+    let item_a = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    // Implicit read receipt of Bob.
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+
+    // Implicit read receipt of Bob is updated.
+    timeline.handle_live_message_event(*BOB, RoomMessageEventContent::text_plain("C")).await;
+
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    let item_c = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_c = item_c.as_event().unwrap();
+    assert_eq!(event_c.read_receipts().len(), 1);
+    assert!(event_c.read_receipts().get(*BOB).is_some());
+
+    // Populate more events.
+    let event_d_id = EventId::new(server_name!("dummy.local"));
+    timeline
+        .handle_live_message_event_with_id(
+            *ALICE,
+            &event_d_id,
+            RoomMessageEventContent::notice_plain("D"),
+        )
+        .await;
+
+    timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("E")).await;
+
+    let item_e = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_e = item_e.as_event().unwrap();
+    assert!(event_e.read_receipts().is_empty());
+
+    // Explicit read receipt is updated but its visible event doesn't change.
+    timeline
+        .handle_read_receipts([(
+            event_d_id,
+            ReceiptType::Read,
+            BOB.to_owned(),
+            ReceiptThread::Unthreaded,
+        )])
+        .await;
+
+    // Explicit read receipt is updated and its visible event changes.
+    timeline
+        .handle_read_receipts([(
+            event_e.event_id().unwrap().to_owned(),
+            ReceiptType::Read,
+            BOB.to_owned(),
+            ReceiptThread::Unthreaded,
+        )])
+        .await;
+
+    let item_c = assert_next_matches!(stream, VectorDiff::Set { index: 2, value } => value);
+    let event_c = item_c.as_event().unwrap();
+    assert!(event_c.read_receipts().is_empty());
+
+    let item_e = assert_next_matches!(stream, VectorDiff::Set { index: 3, value } => value);
+    let event_e = item_e.as_event().unwrap();
+    assert_eq!(event_e.read_receipts().len(), 1);
+    assert!(event_e.read_receipts().get(*BOB).is_some());
+}
+
+#[async_test]
+async fn read_receipts_updates_on_filtered_events_with_stored() {
+    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+        track_read_receipts: true,
+        event_filter: Arc::new(filter_notice),
+        ..Default::default()
+    });
+    let mut stream = timeline.subscribe().await;
+
+    timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("A")).await;
+    timeline
+        .handle_live_message_event_with_id(
+            *CAROL,
+            event_id!("$event_with_bob_receipt"),
+            RoomMessageEventContent::notice_plain("B"),
+        )
+        .await;
+
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+
+    // No read receipt for our own user.
+    let item_a = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    // Stored read receipt of Bob.
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+
+    // Implicit read receipt of Carol.
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 2);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+    assert!(event_a.read_receipts().get(*CAROL).is_some());
+
+    // Implicit read receipt of Bob is updated.
+    timeline.handle_live_message_event(*BOB, RoomMessageEventContent::text_plain("C")).await;
+
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+
+    let item_c = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_c = item_c.as_event().unwrap();
+    assert_eq!(event_c.read_receipts().len(), 1);
+    assert!(event_c.read_receipts().get(*BOB).is_some());
+}
+
+#[async_test]
+async fn read_receipts_updates_on_back_paginated_filtered_events() {
+    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+        track_read_receipts: true,
+        event_filter: Arc::new(filter_notice),
+        ..Default::default()
+    });
+    let mut stream = timeline.subscribe().await;
+    let room_id = room_id!("!room:localhost");
+
+    timeline
+        .handle_back_paginated_message_event_with_id(
+            *ALICE,
+            room_id,
+            event_id!("$event_a"),
+            RoomMessageEventContent::text_plain("A"),
+        )
+        .await;
+    timeline
+        .handle_back_paginated_message_event_with_id(
+            *CAROL,
+            room_id,
+            event_id!("$event_with_bob_receipt"),
+            RoomMessageEventContent::notice_plain("B"),
+        )
+        .await;
+
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
+
+    // No read receipt for our own user.
+    let item_a = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    // Add non-filtered event to show read receipts.
+    timeline
+        .handle_back_paginated_message_event_with_id(
+            *CAROL,
+            room_id,
+            event_id!("$event_c"),
+            RoomMessageEventContent::text_plain("C"),
+        )
+        .await;
+
+    // Implicit read receipt of Carol.
+    let item_c = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
+    let event_c = item_c.as_event().unwrap();
+    println!("event C id: {:?}", event_c.event_id());
+    assert_eq!(event_c.read_receipts().len(), 2);
+    assert!(event_c.read_receipts().get(*BOB).is_some());
+    assert!(event_c.read_receipts().get(*CAROL).is_some());
 }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -105,13 +105,27 @@ impl RoomDataProvider for Room {
     }
 
     async fn read_receipts_for_event(&self, event_id: &EventId) -> IndexMap<OwnedUserId, Receipt> {
-        match self.event_receipts(ReceiptType::Read, ReceiptThread::Unthreaded, event_id).await {
-            Ok(receipts) => receipts.into_iter().collect(),
-            Err(e) => {
-                error!(?event_id, "Failed to get read receipts for event: {e}");
-                IndexMap::new()
-            }
-        }
+        let mut unthreaded_receipts =
+            match self.event_receipts(ReceiptType::Read, ReceiptThread::Unthreaded, event_id).await
+            {
+                Ok(receipts) => receipts.into_iter().collect(),
+                Err(e) => {
+                    error!(?event_id, "Failed to get unthreaded read receipts for event: {e}");
+                    IndexMap::new()
+                }
+            };
+
+        let main_thread_receipts =
+            match self.event_receipts(ReceiptType::Read, ReceiptThread::Main, event_id).await {
+                Ok(receipts) => receipts,
+                Err(e) => {
+                    error!(?event_id, "Failed to get main thread read receipts for event: {e}");
+                    Vec::new()
+                }
+            };
+
+        unthreaded_receipts.extend(main_thread_receipts);
+        unthreaded_receipts
     }
 
     async fn push_rules_and_context(&self) -> Option<(Ruleset, PushConditionRoomCtx)> {

--- a/crates/matrix-sdk-ui/src/timeline/util.rs
+++ b/crates/matrix-sdk-ui/src/timeline/util.rs
@@ -82,25 +82,6 @@ pub(super) enum RelativePosition {
     Before,
 }
 
-pub(super) fn compare_events_positions(
-    event_a: &EventId,
-    event_b: &EventId,
-    timeline_items: &Vector<Arc<TimelineItem>>,
-) -> Option<RelativePosition> {
-    if event_a == event_b {
-        return Some(RelativePosition::Same);
-    }
-
-    let (pos_event_a, _) = rfind_event_by_id(timeline_items, event_a)?;
-    let (pos_event_b, _) = rfind_event_by_id(timeline_items, event_b)?;
-
-    if pos_event_a > pos_event_b {
-        Some(RelativePosition::Before)
-    } else {
-        Some(RelativePosition::After)
-    }
-}
-
 #[derive(PartialEq)]
 pub(super) struct Date {
     year: i32,

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -119,6 +119,9 @@ async fn edit() {
     assert_matches!(msg.in_reply_to(), None);
     assert!(!msg.is_edited());
 
+    // Implicit read receipt of Alice changed.
+    assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 1, .. }));
+
     let edit = assert_matches!(
         timeline_stream.next().await,
         Some(VectorDiff::Set { index: 1, value }) => value

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -212,14 +212,22 @@ async fn read_receipts_updates_for_visible_events() {
     let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(*ALICE).await.unwrap();
     assert_eq!(alice_receipt_event_id, third_event_id);
 
-    // New user with explicit read receipt.
+    // New user with 2 explicit read receipts.
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
+                second_event_id: {
+                    "m.read": {
+                        *BOB: {
+                            "ts": 1436451350,
+                        },
+                    },
+                },
                 third_event_id: {
                     "m.read": {
                         *BOB: {
                             "ts": 1436451550,
+                            "thread_id": "main",
                         },
                     },
                 },

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -20,12 +20,18 @@ use futures_util::StreamExt;
 use matrix_sdk::{config::SyncSettings, room::Receipts};
 use matrix_sdk_test::{
     async_test, sync_timeline_event, EphemeralTestEvent, JoinedRoomBuilder,
-    RoomAccountDataTestEvent, SyncResponseBuilder,
+    RoomAccountDataTestEvent, SyncResponseBuilder, ALICE, BOB,
 };
 use matrix_sdk_ui::timeline::RoomExt;
 use ruma::{
-    api::client::receipt::create_receipt::v3::ReceiptType, event_id,
-    events::receipt::ReceiptThread, room_id, user_id,
+    api::client::receipt::create_receipt::v3::ReceiptType,
+    event_id,
+    events::{
+        receipt::ReceiptThread,
+        room::message::{MessageType, SyncRoomMessageEvent},
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+    },
+    room_id,
 };
 use serde_json::json;
 use wiremock::{
@@ -35,15 +41,22 @@ use wiremock::{
 
 use crate::{logged_in_client, mock_sync};
 
+fn filter_notice(ev: &AnySyncTimelineEvent) -> bool {
+    match ev {
+        AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
+            SyncRoomMessageEvent::Original(msg),
+        )) => !matches!(msg.content.msgtype, MessageType::Notice(_)),
+        _ => true,
+    }
+}
+
 #[async_test]
-async fn read_receipts_updates() {
+async fn read_receipts_updates_for_visible_events() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let own_user_id = client.user_id().unwrap();
-    let alice = user_id!("@alice:localhost");
-    let bob = user_id!("@bob:localhost");
 
     let second_event_id = event_id!("$e32037280er453l:localhost");
     let third_event_id = event_id!("$Sg2037280074GZr34:localhost");
@@ -63,9 +76,9 @@ async fn read_receipts_updates() {
 
     let own_receipt = timeline.latest_user_read_receipt(own_user_id).await;
     assert_matches!(own_receipt, None);
-    let alice_receipt = timeline.latest_user_read_receipt(alice).await;
+    let alice_receipt = timeline.latest_user_read_receipt(*ALICE).await;
     assert_matches!(alice_receipt, None);
-    let bob_receipt = timeline.latest_user_read_receipt(bob).await;
+    let bob_receipt = timeline.latest_user_read_receipt(*BOB).await;
     assert_matches!(bob_receipt, None);
 
     ev_builder.add_joined_room(
@@ -79,7 +92,7 @@ async fn read_receipts_updates() {
                 },
                 "event_id": "$152037280074GZeOm:localhost",
                 "origin_server_ts": 152037280,
-                "sender": "@example:localhost",
+                "sender": own_user_id,
                 "type": "m.room.message",
                 "unsigned": {
                     "age": 598971
@@ -92,7 +105,7 @@ async fn read_receipts_updates() {
                 },
                 "event_id": second_event_id,
                 "origin_server_ts": 152039280,
-                "sender": alice,
+                "sender": *ALICE,
                 "type": "m.room.message",
             }))
             .add_timeline_event(sync_timeline_event!({
@@ -102,7 +115,7 @@ async fn read_receipts_updates() {
                 },
                 "event_id": third_event_id,
                 "origin_server_ts": 152045280,
-                "sender": alice,
+                "sender": *ALICE,
                 "type": "m.room.message",
             })),
     );
@@ -135,7 +148,7 @@ async fn read_receipts_updates() {
     let third_event = third_item.as_event().unwrap();
     assert_eq!(third_event.read_receipts().len(), 1);
 
-    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(*ALICE).await.unwrap();
     assert_eq!(alice_receipt_event_id, third_event_id);
 
     // Read receipt on unknown event is ignored.
@@ -144,7 +157,7 @@ async fn read_receipts_updates() {
             "content": {
                 "$unknowneventid": {
                     "m.read": {
-                        alice: {
+                        *ALICE: {
                             "ts": 1436453550,
                         },
                     },
@@ -158,7 +171,7 @@ async fn read_receipts_updates() {
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
-    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(*ALICE).await.unwrap();
     assert_eq!(alice_receipt_event_id, third_event.event_id().unwrap());
 
     // Read receipt on older event is ignored.
@@ -167,7 +180,7 @@ async fn read_receipts_updates() {
             "content": {
                 second_event_id: {
                     "m.read": {
-                        alice: {
+                        *ALICE: {
                             "ts": 1436451550,
                         },
                     },
@@ -177,7 +190,7 @@ async fn read_receipts_updates() {
         })),
     ));
 
-    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(*ALICE).await.unwrap();
     assert_eq!(alice_receipt_event_id, third_event_id);
 
     // Read receipt on same event is ignored.
@@ -186,7 +199,7 @@ async fn read_receipts_updates() {
             "content": {
                 third_event_id: {
                     "m.read": {
-                        alice: {
+                        *ALICE: {
                             "ts": 1436451550,
                         },
                     },
@@ -196,7 +209,7 @@ async fn read_receipts_updates() {
         })),
     ));
 
-    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(*ALICE).await.unwrap();
     assert_eq!(alice_receipt_event_id, third_event_id);
 
     // New user with explicit read receipt.
@@ -205,7 +218,7 @@ async fn read_receipts_updates() {
             "content": {
                 third_event_id: {
                     "m.read": {
-                        bob: {
+                        *BOB: {
                             "ts": 1436451550,
                         },
                     },
@@ -223,7 +236,7 @@ async fn read_receipts_updates() {
     let third_event = third_item.as_event().unwrap();
     assert_eq!(third_event.read_receipts().len(), 2);
 
-    let (bob_receipt_event_id, _) = timeline.latest_user_read_receipt(bob).await.unwrap();
+    let (bob_receipt_event_id, _) = timeline.latest_user_read_receipt(*BOB).await.unwrap();
     assert_eq!(bob_receipt_event_id, third_event_id);
 
     // Private read receipt is updated.
@@ -249,6 +262,184 @@ async fn read_receipts_updates() {
     let (own_user_receipt_event_id, _) =
         timeline.latest_user_read_receipt(own_user_id).await.unwrap();
     assert_eq!(own_user_receipt_event_id, second_event_id);
+}
+
+#[async_test]
+async fn read_receipts_updates_for_filtered_events() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let own_user_id = client.user_id().unwrap();
+
+    let event_a_id = event_id!("$152037280074GZeOm:localhost");
+    let event_b_id = event_id!("$e32037280er453l:localhost");
+    let event_c_id = event_id!("$Sg2037280074GZr34:localhost");
+
+    let mut ev_builder = SyncResponseBuilder::new();
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline_builder().event_filter(filter_notice).build().await;
+    let (items, mut timeline_stream) = timeline.subscribe().await;
+
+    assert!(items.is_empty());
+
+    let own_receipt = timeline.latest_user_read_receipt(own_user_id).await;
+    assert_matches!(own_receipt, None);
+    let alice_receipt = timeline.latest_user_read_receipt(*ALICE).await;
+    assert_matches!(alice_receipt, None);
+    let bob_receipt = timeline.latest_user_read_receipt(*BOB).await;
+    assert_matches!(bob_receipt, None);
+
+    ev_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            // Event A
+            .add_timeline_event(sync_timeline_event!({
+                "content": {
+                    "body": "is dancing",
+                    "msgtype": "m.text"
+                },
+                "event_id": event_a_id,
+                "origin_server_ts": 152037280,
+                "sender": own_user_id,
+                "type": "m.room.message",
+            }))
+            // Event B
+            .add_timeline_event(sync_timeline_event!({
+                "content": {
+                    "body": "I'm dancing too",
+                    "msgtype": "m.notice"
+                },
+                "event_id": event_b_id,
+                "origin_server_ts": 152039280,
+                "sender": *BOB,
+                "type": "m.room.message",
+            }))
+            // Event C
+            .add_timeline_event(sync_timeline_event!({
+                "content": {
+                    "body": "Viva la macarena!",
+                    "msgtype": "m.text"
+                },
+                "event_id": event_c_id,
+                "origin_server_ts": 152045280,
+                "sender": *ALICE,
+                "type": "m.room.message",
+            })),
+    );
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let _day_divider = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+
+    // We don't list the read receipt of our own user on events.
+    let item_a = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    let (own_receipt_event_id, _) = timeline.latest_user_read_receipt(own_user_id).await.unwrap();
+    assert_eq!(own_receipt_event_id, event_a_id);
+
+    // Implicit read receipt of @bob:localhost.
+    let item_a = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+
+    let (bob_receipt_event_id, _) = timeline.latest_user_read_receipt(*BOB).await.unwrap();
+    assert_eq!(bob_receipt_event_id, event_b_id);
+
+    // Implicit read receipt of @alice:localhost.
+    let item_c = assert_matches!(timeline_stream.next().await, Some(VectorDiff::PushBack { value }) => value);
+    let event_c = item_c.as_event().unwrap();
+    assert_eq!(event_c.read_receipts().len(), 1);
+
+    let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(*ALICE).await.unwrap();
+    assert_eq!(alice_receipt_event_id, event_c_id);
+
+    // Read receipt on filtered event.
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+        EphemeralTestEvent::Custom(json!({
+            "content": {
+                event_b_id: {
+                    "m.read": {
+                        own_user_id: {
+                            "ts": 1436451550,
+                        },
+                    },
+                },
+            },
+            "type": "m.receipt",
+        })),
+    ));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let (own_receipt_event_id, _) = timeline.latest_user_read_receipt(own_user_id).await.unwrap();
+    assert_eq!(own_receipt_event_id, event_b_id);
+
+    // Update with explicit read receipt.
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+        EphemeralTestEvent::Custom(json!({
+            "content": {
+                event_c_id: {
+                    "m.read": {
+                        *BOB: {
+                            "ts": 1436451550,
+                        },
+                    },
+                },
+            },
+            "type": "m.receipt",
+        })),
+    ));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let item_a = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 1, value }) => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    let item_c = assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 2, value }) => value);
+    let event_c = item_c.as_event().unwrap();
+    assert_eq!(event_c.read_receipts().len(), 2);
+
+    let (bob_receipt_event_id, _) = timeline.latest_user_read_receipt(*BOB).await.unwrap();
+    assert_eq!(bob_receipt_event_id, event_c_id);
+
+    // Private read receipt is updated.
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+        EphemeralTestEvent::Custom(json!({
+            "content": {
+                event_c_id: {
+                    "m.read.private": {
+                        own_user_id: {
+                            "ts": 1436453550,
+                        },
+                    },
+                },
+            },
+            "type": "m.receipt",
+        })),
+    ));
+
+    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let (own_user_receipt_event_id, _) =
+        timeline.latest_user_read_receipt(own_user_id).await.unwrap();
+    assert_eq!(own_user_receipt_event_id, event_c_id);
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -378,8 +378,9 @@ async fn test_timeline_duplicated_events() -> Result<()> {
 
         assert_timeline_stream! {
             [timeline_stream]
+            update[3] "$x3:bar.org";
+            update[1] "$x1:bar.org";
             remove[1];
-            update[2] "$x3:bar.org";
             append    "$x1:bar.org";
             update[3] "$x1:bar.org";
             append    "$x4:bar.org";

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -181,13 +181,16 @@ async fn event_filter() {
     let second_event = second.as_event().unwrap();
     assert_eq!(second_event.event_id(), Some(second_event_id));
 
+    // The implicit read receipt of Alice is updated.
+    assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 1, .. }));
+
     // The edit is applied to the first event.
     let first = assert_matches!(
         timeline_stream.next().await,
         Some(VectorDiff::Set { index: 1, value }) => value
     );
     let first_event = first.as_event().unwrap();
-    assert!(!first_event.read_receipts().is_empty());
+    assert!(first_event.read_receipts().is_empty());
     let msg = assert_matches!(
         first_event.content(),
         TimelineItemContent::Message(msg) => msg


### PR DESCRIPTION
This PR includes several improvements:

- Make sure we can handle read receipts on events we are not showing in the Timeline by keeping track of all event IDs we receive. The read receipts should be more accurate.
- Fix the issue where the user might have two read receipts show up in the timeline when back paginating.
- Use thread receipts on the main thread as well as unthreaded read receipts. This brings the read receipts count on par with Element Web.

There is this code path that is triggered somehow according to the logs but I am not sure how that is possible:

https://github.com/zecakeh/matrix-rust-sdk/blob/4e8eaedd9d68f6c4ee6a4dd0f9027158cb48a4da/crates/matrix-sdk-ui/src/timeline/read_receipts.rs#L301-L302

Looking at the spans, the corresponding timeline item should have already been added so I am not sure why it is not found. It seems to only happen on events received via sync. The issue is that it probably means that the old receipt still shows up on the old item.

Should fix most of #2031.