### PR TITLE
support creating emotes

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -56,30 +56,35 @@ pub fn message_event_content_new(
 #[uniffi::export]
 pub fn message_event_content_from_markdown(
     md: String,
-    emote: bool,
 ) -> Arc<RoomMessageEventContentWithoutRelation> {
-    if emote {
-        Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::emote_markdown(md)))
-    } else {
-        Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_markdown(md)))
-    }
+    Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_markdown(md)))
+}
+
+#[uniffi::export]
+pub fn message_event_content_from_markdown_as_emote(
+    md: String,
+) -> Arc<RoomMessageEventContentWithoutRelation> {
+    Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::emote_markdown(md)))
 }
 
 #[uniffi::export]
 pub fn message_event_content_from_html(
     body: String,
     html_body: String,
-    emote: bool,
 ) -> Arc<RoomMessageEventContentWithoutRelation> {
-    if emote {
-        Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::emote_html(
-            body, html_body,
-        )))
-    } else {
-        Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_html(
-            body, html_body,
-        )))
-    }
+    Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_html(
+        body, html_body,
+    )))
+}
+
+#[uniffi::export]
+pub fn message_event_content_from_html_as_emote(
+    body: String,
+    html_body: String,
+) -> Arc<RoomMessageEventContentWithoutRelation> {
+    Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::emote_html(
+        body, html_body,
+    )))
 }
 
 #[uniffi::export(callback_interface)]

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -56,18 +56,32 @@ pub fn message_event_content_new(
 #[uniffi::export]
 pub fn message_event_content_from_markdown(
     md: String,
+    emote: bool,
 ) -> Arc<RoomMessageEventContentWithoutRelation> {
-    Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_markdown(md)))
+    if emote {
+        Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::emote_markdown(md)))
+    }
+    else {
+        Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_markdown(md)))
+    }
 }
 
 #[uniffi::export]
 pub fn message_event_content_from_html(
     body: String,
     html_body: String,
+    emote: bool,
 ) -> Arc<RoomMessageEventContentWithoutRelation> {
-    Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_html(
-        body, html_body,
-    )))
+    if emote {
+        Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::emote_html(
+            body, html_body,
+        )))
+    }
+    else {
+        Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_html(
+            body, html_body,
+        )))
+    }
 }
 
 #[uniffi::export(callback_interface)]

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -60,8 +60,7 @@ pub fn message_event_content_from_markdown(
 ) -> Arc<RoomMessageEventContentWithoutRelation> {
     if emote {
         Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::emote_markdown(md)))
-    }
-    else {
+    } else {
         Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_markdown(md)))
     }
 }
@@ -76,8 +75,7 @@ pub fn message_event_content_from_html(
         Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::emote_html(
             body, html_body,
         )))
-    }
-    else {
+    } else {
         Arc::new(RoomMessageEventContentWithoutRelation::new(RumaMessageType::text_html(
             body, html_body,
         )))


### PR DESCRIPTION
adds an emote param to `message_event_content_from_markdown` and `message_event_content_from_html` on the timeline API, so that clients can create `m.room.message` events with `msgtype` `m.emote`.

I've done it this way on the assumption that the `msgtype` returned in the `RoomMessageEventContentWithoutRelation` is immutable, and so can't be overridden by the client - thus needing this new param to specify it at creation time.

I've probably done this all wrong :D

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)