### PR TITLE
chore(ui): Add `homepage` and `license` to `Cargo.toml`

### DIFF
--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -2,6 +2,8 @@
 name = "matrix-sdk-ui"
 version = "0.6.0"
 edition = "2021"
+repository = "https://github.com/matrix-org/matrix-rust-sdk"
+license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [features]


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2647.