### PR TITLE
crypto: Implemented sharing room keys for past messages (MSC3061) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4882,9 +4882,9 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c63fe7f06396db1480c40cf44a57ad4359847cf6c6b3cdaa67507a00a79bb9"
+checksum = "f067a50962653d837e5ead753c3c33129aaeaaa25a2e9b4868cdc8e5af3edd4a"
 dependencies = [
  "assign",
  "js_int",
@@ -4949,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.27.4"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1784ded2966b990151d7d30a4533b737e1100ca9856178a999f3763a615a1efe"
+checksum = "e44bf8dca3bd734c175784faddeb14b1780a504f34683ac899331a141b8dfa55"
 dependencies = [
  "as_variant",
  "indexmap 2.0.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.11.0"
-ruma = { version = "0.9.0", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids"] }
+ruma = { version = "0.9.1", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3061"] }
 ruma-common = "0.12.0"
 once_cell = "1.16.0"
 serde = "1.0.151"

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -749,6 +749,39 @@ impl OlmMachine {
         Ok(requests.into_iter().map(|r| r.as_ref().into()).collect())
     }
 
+    /// Shares historical room keys used in previous sessions with the list of
+    /// users for the given room.
+    ///
+    /// After the request was sent out and a successful response was received
+    /// the response body should be passed back to the state machine using the
+    /// [mark_request_as_sent()](Self::mark_request_as_sent) method.
+    ///
+    /// This method should be called after users have been invited to the room.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The unique id of the room of which previous room keys
+    /// will be sent out.
+    ///
+    /// * `users` - The list of users which are considered to be members of the
+    /// room and should receive previous room keys.
+    #[cfg(feature = "automatic-room-key-forwarding")]
+    pub fn share_room_history_keys(
+        &self,
+        room_id: String,
+        users: Vec<String>,
+    ) -> Result<Vec<Request>, CryptoStoreError> {
+        let users: Vec<OwnedUserId> =
+            users.into_iter().filter_map(|u| UserId::parse(u).ok()).collect();
+
+        let room_id = RoomId::parse(room_id)?;
+        let requests = self.runtime.block_on(
+            self.inner.share_room_history_keys(&room_id, users.iter().map(Deref::deref)),
+        )?;
+
+        Ok(requests.into_iter().map(|r| r.as_ref().into()).collect())
+    }
+
     /// Encrypt the given event with the given type and content for the given
     /// room.
     ///

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -765,7 +765,6 @@ impl OlmMachine {
     ///
     /// * `users` - The list of users which are considered to be members of the
     /// room and should receive previous room keys.
-    #[cfg(feature = "automatic-room-key-forwarding")]
     pub fn share_room_history_keys(
         &self,
         room_id: String,

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -926,7 +926,7 @@ impl OlmMachine {
                             for device in &devices {
                                 let info = MegolmV1AesSha2Content {
                                     room_id: room_id.to_owned(),
-                                    sender_key: device.curve25519_key().unwrap(),
+                                    sender_key: session.sender_key(),
                                     session_id: session.session_id().to_string(),
                                 };
                                 let content = RoomKeyRequestContent::new_request(
@@ -945,6 +945,7 @@ impl OlmMachine {
                                         device.to_owned(),
                                         session,
                                         None,
+                                        true,
                                     )
                                     .await
                                 {

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1325,11 +1325,14 @@ impl Account {
             )
             .into())
         } else {
-            // If this event is an `m.room_key` event, defer the check for the
-            // Ed25519 key of the sender until we decrypt room events. This
-            // ensures that we receive the room key even if we don't have access
-            // to the device.
-            if !matches!(*event, AnyDecryptedOlmEvent::RoomKey(_)) {
+            // If this event is an `m.room_key` or `m.forwarded_room_key` event,
+            // defer the check for the Ed25519 key of the sender until we decrypt
+            // room events. This ensures that we receive the room key even if we
+            // don't have access to the device.
+            if !matches!(
+                *event,
+                AnyDecryptedOlmEvent::RoomKey(_) | AnyDecryptedOlmEvent::ForwardedRoomKey(_)
+            ) {
                 let Some(device) =
                     store.get_device_from_curve_key(event.sender(), sender_key).await?
                 else {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -95,6 +95,10 @@ pub struct ExportedRoomKey {
         serialize_with = "serialize_curve_key_vec"
     )]
     pub forwarding_curve25519_key_chain: Vec<Curve25519PublicKey>,
+
+    /// Used to mark as having been used for shared history
+    #[serde(default)]
+    pub shared_history: bool,
 }
 
 /// A backed up version of an `InboundGroupSession`
@@ -119,6 +123,10 @@ pub struct BackedUpRoomKey {
     /// Chain of Curve25519 keys through which this session was forwarded, via
     /// m.forwarded_room_key events.
     pub forwarding_curve25519_key_chain: Vec<Curve25519PublicKey>,
+
+    /// Used to mark as having been used for shared history
+    #[serde(default)]
+    pub shared_history: bool,
 }
 
 impl TryFrom<ExportedRoomKey> for ForwardedRoomKeyContent {
@@ -151,6 +159,7 @@ impl TryFrom<ExportedRoomKey> for ForwardedRoomKeyContent {
                             forwarding_curve25519_key_chain: room_key
                                 .forwarding_curve25519_key_chain
                                 .clone(),
+                            shared_history: room_key.shared_history,
                             other: Default::default(),
                         }
                         .into(),
@@ -168,6 +177,7 @@ impl TryFrom<ExportedRoomKey> for ForwardedRoomKeyContent {
                         session_key: room_key.session_key,
                         claimed_sender_key: room_key.sender_key,
                         claimed_signing_keys: room_key.sender_claimed_keys,
+                        shared_history: room_key.shared_history,
                         other: Default::default(),
                     }
                     .into(),
@@ -186,6 +196,7 @@ impl From<ExportedRoomKey> for BackedUpRoomKey {
             session_key: k.session_key,
             sender_claimed_keys: k.sender_claimed_keys,
             forwarding_curve25519_key_chain: k.forwarding_curve25519_key_chain,
+            shared_history: k.shared_history,
         }
     }
 }
@@ -211,6 +222,7 @@ impl TryFrom<ForwardedRoomKeyContent> for ExportedRoomKey {
                     sender_claimed_keys,
                     sender_key: content.claimed_sender_key,
                     session_key: content.session_key,
+                    shared_history: content.shared_history,
                 })
             }
             #[cfg(feature = "experimental-algorithms")]
@@ -222,6 +234,7 @@ impl TryFrom<ForwardedRoomKeyContent> for ExportedRoomKey {
                 sender_claimed_keys: content.claimed_signing_keys,
                 sender_key: content.claimed_sender_key,
                 session_key: content.session_key,
+                shared_history: content.shared_history,
             }),
             ForwardedRoomKeyContent::Unknown(c) => Err(SessionExportError::Algorithm(c.algorithm)),
         }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -483,12 +483,17 @@ impl OutboundGroupSession {
 
     pub(crate) async fn as_content(&self) -> RoomKeyContent {
         let session_key = self.session_key().await;
+        let shared_history = matches!(
+            self.settings.history_visibility,
+            HistoryVisibility::Shared | HistoryVisibility::WorldReadable
+        );
 
         RoomKeyContent::MegolmV1AesSha2(
             MegolmV1AesSha2RoomKeyContent::new(
                 self.room_id().to_owned(),
                 self.session_id().to_owned(),
                 session_key,
+                shared_history,
             )
             .into(),
         )

--- a/crates/matrix-sdk-crypto/src/types/events/forwarded_room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/forwarded_room_key.rs
@@ -127,6 +127,10 @@ pub struct ForwardedMegolmV1AesSha2Content {
     )]
     pub claimed_ed25519_key: Ed25519PublicKey,
 
+    /// Used to mark as having been used for shared history
+    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    pub shared_history: bool,
+
     #[serde(flatten)]
     pub(crate) other: BTreeMap<String, Value>,
 }
@@ -162,6 +166,10 @@ pub struct ForwardedMegolmV2AesSha2Content {
     #[serde(default)]
     pub claimed_signing_keys: SigningKeys<DeviceKeyAlgorithm>,
 
+    /// Used to mark as having been used for shared history
+    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    pub shared_history: bool,
+
     #[serde(flatten)]
     pub(crate) other: BTreeMap<String, Value>,
 }
@@ -184,6 +192,7 @@ impl std::fmt::Debug for ForwardedMegolmV1AesSha2Content {
             .field("forwarding_curve25519_key_chain", &self.forwarding_curve25519_key_chain)
             .field("claimed_sender_key", &self.claimed_sender_key)
             .field("claimed_ed25519_key", &self.claimed_ed25519_key)
+            .field("shared_history", &self.shared_history)
             .finish_non_exhaustive()
     }
 }
@@ -195,6 +204,7 @@ impl std::fmt::Debug for ForwardedMegolmV2AesSha2Content {
             .field("session_id", &self.session_id)
             .field("claimed_sender_key", &self.claimed_sender_key)
             .field("sender_claimed_keys", &self.claimed_signing_keys)
+            .field("shared_history", &self.shared_history)
             .finish_non_exhaustive()
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/events/room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key.rs
@@ -74,6 +74,7 @@ impl RoomKeyContent {
             pub room_id: &'a RoomId,
             pub session_id: &'a str,
             pub session_key: &'a str,
+            pub shared_history: bool,
             #[serde(flatten)]
             other: &'a BTreeMap<String, Value>,
         }
@@ -83,6 +84,7 @@ impl RoomKeyContent {
                 room_id: &content.room_id,
                 session_id: &content.session_id,
                 session_key: "",
+                shared_history: content.shared_history,
                 other: &content.other,
             };
 
@@ -113,6 +115,9 @@ pub struct MegolmV1AesSha2Content {
     ///
     /// [`InboundGroupSession`]: vodozemac::megolm::InboundGroupSession
     pub session_key: SessionKey,
+    /// Used to mark as having been used for shared history
+    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    pub shared_history: bool,
     /// Any other, custom and non-specced fields of the content.
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
@@ -120,8 +125,13 @@ pub struct MegolmV1AesSha2Content {
 
 impl MegolmV1AesSha2Content {
     /// Create a new `m.megolm.v1.aes-sha2` `m.room_key` content.
-    pub fn new(room_id: OwnedRoomId, session_id: String, session_key: SessionKey) -> Self {
-        Self { room_id, session_id, session_key, other: Default::default() }
+    pub fn new(
+        room_id: OwnedRoomId,
+        session_id: String,
+        session_key: SessionKey,
+        shared_history: bool,
+    ) -> Self {
+        Self { room_id, session_id, session_key, shared_history, other: Default::default() }
     }
 }
 
@@ -223,7 +233,8 @@ pub(super) mod tests {
                                 tino//CDQENtcKuEt0I9s0+Kk4YSH310Szse2RQ+vjple31\
                                 QrCexmqfFJzkR/BJ5ogJHrPBQL0LgsPyglIbMTLg7qygIaY\
                                 U5Fe2QdKMH7nTZPNIRHh1RaMfHVETAUJBax88EWZBoifk80\
-                                gdHUwHSgMk77vCc2a5KHKLDA"
+                                gdHUwHSgMk77vCc2a5KHKLDA",
+                "org.matrix.msc3061.shared_history": true
             },
             "type": "m.room_key",
             "m.custom.top": "something custom in the top",

--- a/crates/matrix-sdk-crypto/src/types/events/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/to_device.rs
@@ -474,7 +474,8 @@ mod tests {
                                 3LqBjD21sULYEO5YTKdpMVhi9i6ZSZhdvZvp//tzRpDT7wpWVWI\
                                 00Y3EPEjmpm/HfZ4MMAKpk+tzJVuuvfAcHBZgpnxBGzYOc/DAqa\
                                 pK7Tk3t3QJ1UMSD94HfAqlb1JF5QBPwoh0fOvD8pJdanB8zxz05\
-                                tKFdR73/vo2Q/zE3"
+                                tKFdR73/vo2Q/zE3",
+                "org.matrix.msc3061.shared_history": true
             },
             "type": "m.forwarded_room_key"
         })

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -986,6 +986,27 @@ impl Room {
         let request = invite_user::v3::Request::new(self.room_id().to_owned(), recipient);
         self.client.send(request, None).await?;
 
+        // MSC3061: Forward past room keys to invitee
+        #[cfg(feature = "e2e-encryption")]
+        if self.is_encrypted().await?
+            && matches!(
+                self.history_visibility(),
+                HistoryVisibility::Shared | HistoryVisibility::WorldReadable
+            )
+        {
+            match self.client.olm_machine().await.as_ref() {
+                Some(olm) => {
+                    // Get the most up-to-date device list before forwarding room keys
+                    let (req_id, request) = olm.query_keys_for_users(std::iter::once(user_id));
+                    self.client.keys_query(&req_id, request.device_keys).await?;
+
+                    olm.share_room_history_keys(self.room_id(), std::iter::once(user_id)).await?;
+                    self.client.send_outgoing_requests().await?;
+                }
+                None => panic!("Olm machine wasn't started"),
+            }
+        }
+
         Ok(())
     }
 
@@ -999,6 +1020,9 @@ impl Room {
         let recipient = InvitationRecipient::ThirdPartyId(invite_id);
         let request = invite_user::v3::Request::new(self.room_id().to_owned(), recipient);
         self.client.send(request, None).await?;
+
+        // MSC3061: 3PID invites cannot forward past room keys since UserId
+        // lookup and invite is handled by the homeserver, not the client.
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -987,7 +987,7 @@ impl Room {
         self.client.send(request, None).await?;
 
         // MSC3061: Forward past room keys to invitee
-        #[cfg(feature = "e2e-encryption")]
+        #[cfg(all(feature = "e2e-encryption", feature = "automatic-room-key-forwarding"))]
         if self.is_encrypted().await?
             && matches!(
                 self.history_visibility(),

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -37,6 +37,7 @@ async fn invite_user_by_id() {
         .await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
+    mock_encryption_state(&server, false).await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 


### PR DESCRIPTION
Fixes #580 

## Overview

I have created an implementation for MSC 3061 and wanted to share the changes should the team want to merge into the SDK. 

Note this follows the implementation suggested in the MSC where keys are forwarded upon invitation of a new user. Based on past discussion in https://github.com/matrix-org/matrix-rust-sdk/issues/580 however, this approach was was not preferred due to some flaws. I thought I would still share this implementation however for the following reasons:
1.  MSC 3061 has officially been merged into the spec per my understanding: https://github.com/matrix-org/matrix-spec-proposals/pull/3061
2. The proposed changes discussed in https://github.com/matrix-org/matrix-rust-sdk/issues/580 sounded to me that it requires a new MSC proposal for adding a new event type and improving the key sharing process.
3. This implementation provides a working solution that is equivalent to what is offered currently in the other Matrix SDKs, which can be used until the preferred solution is developed.

Any feedback welcome.

## PR Dependencies:
* ~vodozemac: https://github.com/matrix-org/vodozemac/pull/114~
* ruma: https://github.com/ruma/ruma/pull/1669

## Testing:

Tested key sharing with verified and unverified devices with multiple clients including:
- FUTO Circles iOS / Android
- iamb
-  Element / Cinny (interoperability testing since these don't use the crypto FFI)

## Todo:
- [x] Update Cargo.toml to point to upstream SDK instead of fork with the ruma/~vodozemac~ changes
- [ ] Docs: Update room key sharing  diagram indicating how `HistoryVisibility` is taken into account when sharing keys (https://raw.githubusercontent.com/matrix-org/matrix-rust-sdk/main/contrib/key-sharing-algorithm/model.png)
- [ ] Build and deploy a new crypto FFI release?
- [ ] Public API changes documented in changelogs (optional)

<!-- description of the changes in this PR -->

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Michael Hollister <michael@futo.org>
