### PR TITLE
chore: make `Client::homeserver` not async by changing the underlying mutex kind

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -3,7 +3,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use futures_util::future::join;
 use matrix_sdk::{
     oidc::{
         types::{
@@ -388,11 +387,9 @@ impl AuthenticationService {
         &self,
         client: &Arc<Client>,
     ) -> Result<HomeserverLoginDetails, AuthenticationError> {
-        let login_details = join(client.async_homeserver(), client.supports_password_login()).await;
-
-        let url = login_details.0;
         let supports_oidc_login = client.discovered_authentication_server().is_some();
-        let supports_password_login = login_details.1.ok().unwrap_or(false);
+        let supports_password_login = client.supports_password_login().await.ok().unwrap_or(false);
+        let url = client.homeserver();
 
         Ok(HomeserverLoginDetails { url, supports_oidc_login, supports_password_login })
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -310,10 +310,6 @@ impl Client {
         })
     }
 
-    pub(crate) async fn async_homeserver(&self) -> String {
-        self.inner.homeserver().await.to_string()
-    }
-
     /// The homeserver's trusted OIDC Provider that was discovered in the
     /// well-known.
     ///
@@ -612,7 +608,7 @@ impl Client {
 
     /// The homeserver this client is configured to use.
     pub fn homeserver(&self) -> String {
-        RUNTIME.block_on(self.async_homeserver())
+        self.inner.homeserver().to_string()
     }
 
     pub fn rooms(&self) -> Vec<Arc<Room>> {
@@ -770,7 +766,7 @@ impl Client {
     async fn session_inner(client: matrix_sdk::Client) -> Result<Session, ClientError> {
         let auth_api = client.auth_api().context("Missing authentication API")?;
 
-        let homeserver_url = client.homeserver().await.into();
+        let homeserver_url = client.homeserver().into();
         let sliding_sync_proxy = client.sliding_sync_proxy().map(|url| url.to_string());
 
         Session::new(auth_api, homeserver_url, sliding_sync_proxy)

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -171,7 +171,7 @@ impl LoginBuilder {
     )]
     pub async fn send(self) -> Result<login::v3::Response> {
         let client = &self.auth.client;
-        let homeserver = client.homeserver().await;
+        let homeserver = client.homeserver();
         info!(homeserver = homeserver.as_str(), identifier = ?self.login_method.id(), "Logging in");
 
         let request = assign!(login::v3::Request::new(self.login_method.into_login_info()), {
@@ -334,7 +334,7 @@ where
         const SSO_SERVER_BIND_TRIES: u8 = 10;
 
         let client = &self.auth.client;
-        let homeserver = client.homeserver().await;
+        let homeserver = client.homeserver();
         info!(%homeserver, "Logging in");
 
         let (signal_tx, signal_rx) = oneshot::channel();

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -111,7 +111,7 @@ impl MatrixAuth {
         redirect_url: &str,
         idp_id: Option<&str>,
     ) -> Result<String> {
-        let homeserver = self.client.homeserver().await;
+        let homeserver = self.client.homeserver();
         let server_versions = self.client.server_versions().await?;
 
         let request = if let Some(id) = idp_id {
@@ -540,7 +540,7 @@ impl MatrixAuth {
         &self,
         request: register::v3::Request,
     ) -> HttpResult<register::v3::Response> {
-        let homeserver = self.client.homeserver().await;
+        let homeserver = self.client.homeserver();
         info!("Registering to {homeserver}");
         self.client.send(request, None).await
     }
@@ -816,7 +816,7 @@ impl MatrixAuth {
         &self,
         response: &login::v3::Response,
     ) -> Result<()> {
-        self.client.maybe_update_login_well_known(response.well_known.as_ref()).await;
+        self.client.maybe_update_login_well_known(response.well_known.as_ref());
 
         self.set_session(response.into()).await?;
 

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -24,7 +24,7 @@ use wiremock::{
 use crate::{logged_in_client, no_retry_test_client};
 
 #[async_test]
-async fn restore_session() {
+async fn test_restore_session() {
     let (client, _) = logged_in_client().await;
     let auth = client.matrix_auth();
 
@@ -35,7 +35,7 @@ async fn restore_session() {
 }
 
 #[async_test]
-async fn login() {
+async fn test_login() {
     let (client, server) = no_retry_test_client().await;
     let homeserver = Url::parse(&server.uri()).unwrap();
 
@@ -70,11 +70,11 @@ async fn login() {
     assert_matches!(client.auth_api(), Some(AuthApi::Matrix(_)));
     assert_matches!(client.session(), Some(AuthSession::Matrix(_)));
 
-    assert_eq!(client.homeserver().await, homeserver);
+    assert_eq!(client.homeserver(), homeserver);
 }
 
 #[async_test]
-async fn login_with_discovery() {
+async fn test_login_with_discovery() {
     let (client, server) = no_retry_test_client().await;
 
     Mock::given(method("POST"))
@@ -88,11 +88,11 @@ async fn login_with_discovery() {
     let logged_in = client.logged_in();
     assert!(logged_in, "Client should be logged in");
 
-    assert_eq!(client.homeserver().await.as_str(), "https://example.org/");
+    assert_eq!(client.homeserver().as_str(), "https://example.org/");
 }
 
 #[async_test]
-async fn login_no_discovery() {
+async fn test_login_no_discovery() {
     let (client, server) = no_retry_test_client().await;
 
     Mock::given(method("POST"))
@@ -106,12 +106,12 @@ async fn login_no_discovery() {
     let logged_in = client.logged_in();
     assert!(logged_in, "Client should be logged in");
 
-    assert_eq!(client.homeserver().await, Url::parse(&server.uri()).unwrap());
+    assert_eq!(client.homeserver(), Url::parse(&server.uri()).unwrap());
 }
 
 #[async_test]
 #[cfg(feature = "sso-login")]
-async fn login_with_sso() {
+async fn test_login_with_sso() {
     let (client, server) = no_retry_test_client().await;
 
     Mock::given(method("POST"))
@@ -148,7 +148,7 @@ async fn login_with_sso() {
 }
 
 #[async_test]
-async fn login_with_sso_token() {
+async fn test_login_with_sso_token() {
     let (client, server) = no_retry_test_client().await;
 
     Mock::given(method("GET"))
@@ -183,7 +183,7 @@ async fn login_with_sso_token() {
 }
 
 #[async_test]
-async fn login_error() {
+async fn test_login_error() {
     let (client, server) = no_retry_test_client().await;
 
     Mock::given(method("POST"))
@@ -214,7 +214,7 @@ async fn login_error() {
 }
 
 #[async_test]
-async fn register_error() {
+async fn test_register_error() {
     let (client, server) = no_retry_test_client().await;
 
     Mock::given(method("POST"))
@@ -255,7 +255,7 @@ async fn register_error() {
 }
 
 #[test]
-fn deserialize_session() {
+fn test_deserialize_session() {
     // First version, or second version without refresh token.
     let json = json!({
         "access_token": "abcd",
@@ -283,7 +283,7 @@ fn deserialize_session() {
 }
 
 #[test]
-fn serialize_session() {
+fn test_serialize_session() {
     // Without refresh token.
     let mut session = MatrixSession {
         meta: SessionMeta {

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -348,7 +348,7 @@ impl OidcCli {
 
             match cmd {
                 Some("whoami") => {
-                    self.whoami().await;
+                    self.whoami();
                 }
                 Some("account") => {
                     self.account(None);
@@ -405,13 +405,13 @@ impl OidcCli {
     }
 
     /// Get information about this session.
-    async fn whoami(&self) {
+    fn whoami(&self) {
         let client = &self.client;
         let oidc = client.oidc();
 
         let user_id = client.user_id().expect("A logged in client has a user ID");
         let device_id = client.device_id().expect("A logged in client has a device ID");
-        let homeserver = client.homeserver().await;
+        let homeserver = client.homeserver();
         let issuer = oidc.issuer().expect("A logged in OIDC client has an issuer");
 
         println!("\nUser ID: {user_id}");
@@ -724,7 +724,7 @@ async fn build_client(
                 if let Some(issuer_info) = client.oidc().authentication_server_info().cloned() {
                     println!("Found issuer: {}", issuer_info.issuer);
 
-                    let homeserver = client.homeserver().await.to_string();
+                    let homeserver = client.homeserver().to_string();
                     return Ok((
                         client,
                         ClientSession { homeserver, db_path, passphrase },


### PR DESCRIPTION
The mutex used for the `homeserver` field is very short-lived, so use a std mutex instead, which makes a few methods sync instead of async.