### PR TITLE
ffi: use the `Timeline::send_single_receipt` method instead of that of `Room`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -399,26 +399,6 @@ impl Room {
         })
     }
 
-    pub fn send_read_marker(
-        &self,
-        fully_read_event_id: String,
-        read_receipt_event_id: Option<String>,
-    ) -> Result<(), ClientError> {
-        let fully_read =
-            EventId::parse(fully_read_event_id).context("parsing fully read event ID")?;
-        let read_receipt = read_receipt_event_id
-            .map(EventId::parse)
-            .transpose()
-            .context("parsing read receipt event ID")?;
-        let receipts =
-            Receipts::new().fully_read_marker(fully_read).public_read_receipt(read_receipt);
-
-        RUNTIME.block_on(async move {
-            self.inner.send_multiple_receipts(receipts).await?;
-            Ok(())
-        })
-    }
-
     pub fn send(&self, msg: Arc<RoomMessageEventContentWithoutRelation>) {
         let timeline = match &*RUNTIME.block_on(self.timeline.read()) {
             Some(t) => Arc::clone(t),

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -7,7 +7,7 @@ use matrix_sdk::{
         AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
         BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
     },
-    room::{Receipts, Room as SdkRoom},
+    room::Room as SdkRoom,
     ruma::{
         api::client::{receipt::create_receipt::v3::ReceiptType, room::report_content},
         events::{
@@ -392,7 +392,11 @@ impl Room {
         let event_id = EventId::parse(event_id)?;
 
         RUNTIME.block_on(async move {
-            self.inner
+            self.timeline
+                .read()
+                .await
+                .clone()
+                .context("Timeline not set up, can't send read receipt")?
                 .send_single_receipt(ReceiptType::Read, ReceiptThread::Unthreaded, event_id)
                 .await?;
             Ok(())


### PR DESCRIPTION
While looking at rageshakes recently, I noticed that we would send lots of read receipts for the same event. That's because the FFI method invokes `Room::send_single_receipt`, which unconditionally sends a receipt; there's an equivalent method on the `Timeline` struct that sends it only if needed, so let's use that in the FFI layer.