### PR TITLE
Make the crypto stores more robust when writing

### DIFF
--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -516,7 +516,6 @@ mod tests {
         let users_for_key_claim = Arc::new(DashMap::new());
         let account = ReadOnlyAccount::with_device_id(user_id, device_id);
         let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
-        store.save_account(account.clone()).await.unwrap();
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id)));
         let verification = VerificationMachine::new(
             account.static_data().clone(),
@@ -525,6 +524,7 @@ mod tests {
         );
 
         let store = Store::new(account.clone(), identity, store, verification);
+        store.save_account(account.clone()).await.unwrap();
 
         let account = Account { static_data: account.static_data.clone(), store: store.clone() };
 

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -65,7 +65,8 @@ macro_rules! cryptostore_integration_tests {
             pub async fn get_loaded_store(name: &str) -> (ReadOnlyAccount, impl CryptoStore) {
                 let store = get_store(name, None).await;
                 let account = get_account();
-                store.save_account(account.clone()).await.expect("Can't save account");
+
+                store.save_changes(Changes { account: Some(account.clone()), ..Default::default() }).await.expect("Can't save account");
 
                 (account, store)
             }
@@ -114,7 +115,7 @@ macro_rules! cryptostore_integration_tests {
                 assert!(store.load_account().await.unwrap().is_none());
                 let account = get_account();
 
-                store.save_account(account).await.expect("Can't save account");
+                store.save_changes(Changes { account: Some(account), ..Default::default() }).await.expect("Can't save account");
                 assert!(store.get_static_account().is_some());
             }
 
@@ -123,7 +124,7 @@ macro_rules! cryptostore_integration_tests {
                 let store = get_store("load_account", None).await;
                 let account = get_account();
 
-                store.save_account(account.clone()).await.expect("Can't save account");
+                store.save_changes(Changes { account: Some(account.clone()), ..Default::default() }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -137,7 +138,7 @@ macro_rules! cryptostore_integration_tests {
                     get_store("load_account_with_passphrase", Some("secret_passphrase")).await;
                 let account = get_account();
 
-                store.save_account(account.clone()).await.expect("Can't save account");
+                store.save_changes(Changes { account: Some(account.clone()), ..Default::default() }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -150,12 +151,12 @@ macro_rules! cryptostore_integration_tests {
                 let store = get_store("save_and_share_account", None).await;
                 let account = get_account();
 
-                store.save_account(account.clone()).await.expect("Can't save account");
+                store.save_changes(Changes { account: Some(account.clone()), ..Default::default() }).await.expect("Can't save account");
 
                 account.mark_as_shared();
                 account.update_uploaded_key_count(50);
 
-                store.save_account(account.clone()).await.expect("Can't save account");
+                store.save_changes(Changes { account: Some(account.clone()), ..Default::default() }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -168,7 +169,7 @@ macro_rules! cryptostore_integration_tests {
             async fn load_sessions() {
                 let store = get_store("load_sessions", None).await;
                 let (account, session) = get_account_and_session().await;
-                store.save_account(account.clone()).await.expect("Can't save account");
+                store.save_changes(Changes { account: Some(account.clone()), ..Default::default() }).await.expect("Can't save account");
 
                 let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
 
@@ -192,7 +193,7 @@ macro_rules! cryptostore_integration_tests {
                 let sender_key = session.sender_key.to_base64();
                 let session_id = session.session_id().to_owned();
 
-                store.save_account(account.clone()).await.expect("Can't save account");
+                store.save_changes(Changes { account: Some(account.clone()), ..Default::default() }).await.expect("Can't save account");
 
                 let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
                 store.save_changes(changes).await.unwrap();
@@ -490,7 +491,9 @@ macro_rules! cryptostore_integration_tests {
 
                 let account = ReadOnlyAccount::with_device_id(&user_id, device_id);
 
-                store.save_account(account.clone()).await.expect("Can't save account");
+                store.save_changes(Changes { account: Some(account.clone()), ..Default::default() })
+                    .await
+                    .expect("Can't save account");
 
                 let own_identity = get_own_identity();
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -94,13 +94,13 @@ impl MemoryStore {
         Self::default()
     }
 
-    pub(crate) async fn save_devices(&self, devices: Vec<ReadOnlyDevice>) {
+    pub(crate) fn save_devices(&self, devices: Vec<ReadOnlyDevice>) {
         for device in devices {
             let _ = self.devices.add(device);
         }
     }
 
-    async fn delete_devices(&self, devices: Vec<ReadOnlyDevice>) {
+    fn delete_devices(&self, devices: Vec<ReadOnlyDevice>) {
         for device in devices {
             let _ = self.devices.remove(device.user_id(), device.device_id());
         }
@@ -112,7 +112,7 @@ impl MemoryStore {
         }
     }
 
-    async fn save_inbound_group_sessions(&self, sessions: Vec<InboundGroupSession>) {
+    fn save_inbound_group_sessions(&self, sessions: Vec<InboundGroupSession>) {
         for session in sessions {
             self.inbound_group_sessions.add(session);
         }
@@ -140,11 +140,11 @@ impl CryptoStore for MemoryStore {
 
     async fn save_changes(&self, changes: Changes) -> Result<()> {
         self.save_sessions(changes.sessions).await;
-        self.save_inbound_group_sessions(changes.inbound_group_sessions).await;
+        self.save_inbound_group_sessions(changes.inbound_group_sessions);
 
-        self.save_devices(changes.devices.new).await;
-        self.save_devices(changes.devices.changed).await;
-        self.delete_devices(changes.devices.deleted).await;
+        self.save_devices(changes.devices.new);
+        self.save_devices(changes.devices.changed);
+        self.delete_devices(changes.devices.deleted);
 
         for identity in changes.identities.new.into_iter().chain(changes.identities.changed) {
             let _ = self.identities.insert(identity.user_id().to_owned(), identity.clone());
@@ -445,7 +445,7 @@ mod tests {
         .unwrap();
 
         let store = MemoryStore::new();
-        store.save_inbound_group_sessions(vec![inbound.clone()]).await;
+        store.save_inbound_group_sessions(vec![inbound.clone()]);
 
         let loaded_session =
             store.get_inbound_group_session(room_id, outbound.session_id()).await.unwrap().unwrap();
@@ -457,7 +457,7 @@ mod tests {
         let device = get_device();
         let store = MemoryStore::new();
 
-        store.save_devices(vec![device.clone()]).await;
+        store.save_devices(vec![device.clone()]);
 
         let loaded_device =
             store.get_device(device.user_id(), device.device_id()).await.unwrap().unwrap();
@@ -473,7 +473,7 @@ mod tests {
 
         assert_eq!(&device, loaded_device);
 
-        store.delete_devices(vec![device.clone()]).await;
+        store.delete_devices(vec![device.clone()]);
         assert!(store.get_device(device.user_id(), device.device_id()).await.unwrap().is_none());
     }
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -130,10 +130,6 @@ impl CryptoStore for MemoryStore {
         Ok(None)
     }
 
-    async fn save_account(&self, _: ReadOnlyAccount) -> Result<()> {
-        Ok(())
-    }
-
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
         Ok(None)
     }
@@ -419,7 +415,7 @@ mod tests {
         let store = MemoryStore::new();
 
         assert!(store.load_account().await.unwrap().is_none());
-        store.save_account(account).await.unwrap();
+        store.save_changes(Changes { account: Some(account), ..Default::default() }).await.unwrap();
 
         store.save_sessions(vec![session.clone()]).await;
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -186,8 +186,9 @@ impl CryptoStore for MemoryStore {
             }
         }
 
-        // Note: this will save an empty next_batch token, if provided an empty one.
-        *self.next_batch_token.write().await = changes.next_batch_token;
+        if let Some(next_batch_token) = changes.next_batch_token {
+            *self.next_batch_token.write().await = Some(next_batch_token);
+        }
 
         Ok(())
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -609,6 +609,13 @@ impl Store {
         self.inner.store.save_changes(changes).await
     }
 
+    pub(crate) async fn save_account(&self, account: ReadOnlyAccount) -> Result<()> {
+        self.inner
+            .store
+            .save_changes(Changes { account: Some(account), ..Default::default() })
+            .await
+    }
+
     /// Compare the given `InboundGroupSession` with an existing session we have
     /// in the store.
     ///

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -43,13 +43,6 @@ pub trait CryptoStore: AsyncTraitDeps {
     /// Load an account that was previously stored.
     async fn load_account(&self) -> Result<Option<ReadOnlyAccount>, Self::Error>;
 
-    /// Save the given account in the store.
-    ///
-    /// # Arguments
-    ///
-    /// * `account` - The account that should be stored.
-    async fn save_account(&self, account: ReadOnlyAccount) -> Result<(), Self::Error>;
-
     /// Try to load a private cross signing identity, if one is stored.
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>, Self::Error>;
 
@@ -285,10 +278,6 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
 
     async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
         self.0.load_account().await.map_err(Into::into)
-    }
-
-    async fn save_account(&self, account: ReadOnlyAccount) -> Result<()> {
-        self.0.save_account(account).await.map_err(Into::into)
     }
 
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -855,7 +855,7 @@ pub(crate) mod tests {
             ..Default::default()
         };
         alice_store.save_changes(alice_changes).await.unwrap();
-        alice_store.save_devices(vec![bob_device]).await;
+        alice_store.save_devices(vec![bob_device]);
 
         let bob_changes = Changes {
             identities: IdentityChanges {
@@ -866,7 +866,7 @@ pub(crate) mod tests {
             ..Default::default()
         };
         bob_store.save_changes(bob_changes).await.unwrap();
-        bob_store.save_devices(vec![alice_device]).await;
+        bob_store.save_devices(vec![alice_device]);
 
         let alice_store = VerificationStore {
             inner: Arc::new(CryptoStoreWrapper::new(alice.user_id(), alice_store)),

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -903,7 +903,7 @@ mod tests {
         };
 
         let bob_store = MemoryStore::new();
-        bob_store.save_devices(vec![alice_device.clone()]).await;
+        bob_store.save_devices(vec![alice_device.clone()]);
 
         let bob_store = VerificationStore {
             account: bob.static_data.clone(),

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -823,11 +823,6 @@ impl_crypto_store! {
         }
     }
 
-    async fn save_account(&self, account: ReadOnlyAccount) -> Result<()> {
-        self.save_changes(Changes { account: Some(account), ..Default::default() })
-            .await
-    }
-
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
         if let Some(pickle) = self
             .inner

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -665,15 +665,6 @@ impl CryptoStore for SqliteCryptoStore {
         }
     }
 
-    async fn save_account(&self, account: ReadOnlyAccount) -> Result<()> {
-        *self.static_account.write().unwrap() = Some(account.static_data().clone());
-
-        let pickled_account = account.pickle().await;
-        let serialized_account = self.serialize_value(&pickled_account)?;
-        self.acquire().await?.set_kv("account", serialized_account).await?;
-        Ok(())
-    }
-
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
         let conn = self.acquire().await?;
         if let Some(i) = conn.get_kv("identity").await? {


### PR DESCRIPTION
See individual commit messages. This implements a few enhancements we've talked about with @poljar, notably one possible source of race conditions when writing changes to the crypto stores.