### PR TITLE
Maintain an in-memory cache of the backup keys

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -63,3 +63,5 @@
   `OutgoingRequest` to `(OwnedTransactionId, KeysBackupRequest)`.
 
 - Expose new `OlmMachine::get_room_event_encryption_info` method.
+
+- Maintain an in-memory cache of the `BackupKeys`.

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -415,7 +415,7 @@ impl BackupMachine {
 
     /// Get the backup keys we have saved in our crypto store.
     pub async fn get_backup_keys(&self) -> Result<BackupKeys, CryptoStoreError> {
-        self.store.load_backup_keys().await
+        self.store.get_backup_keys().await
     }
 
     /// Encrypt a batch of room keys and return a request that needs to be sent

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -756,7 +756,7 @@ impl Store {
             }
             SecretName::RecoveryKey => {
                 #[cfg(feature = "backups_v1")]
-                if let Some(key) = self.load_backup_keys().await?.decryption_key {
+                if let Some(key) = self.get_backup_keys().await?.decryption_key {
                     let exported = key.to_base64();
                     Some(exported)
                 } else {
@@ -1260,6 +1260,11 @@ impl Store {
     /// ```
     pub fn secrets_stream(&self) -> impl Stream<Item = GossippedSecret> {
         self.inner.store.secrets_stream()
+    }
+
+    /// Get the backup keys we have stored.
+    pub async fn get_backup_keys(&self) -> Result<BackupKeys> {
+        self.inner.store.get_backup_keys().await
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -613,7 +613,7 @@ impl IdentitiesBeingVerified {
         let mut secrets = self.private_identity.get_missing_secrets().await;
 
         #[cfg(feature = "backups_v1")]
-        if self.store.inner.load_backup_keys().await?.decryption_key.is_none() {
+        if self.store.inner.get_backup_keys().await?.decryption_key.is_none() {
             secrets.push(ruma::events::secret::request::SecretName::RecoveryKey);
         }
 


### PR DESCRIPTION
In Element Web R, we end up calling `BackupMachine::get_backup_keys` quite often (every time we get a UISI) so it's not ideal to have to do an indexeddb each time.