### PR TITLE
Remove redundant field Store::user_id

### DIFF
--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -95,7 +95,7 @@ impl DehydratedDevices {
 
         let verification_machine =
             VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
-        let store = Store::new(user_id.into(), user_identity, store, verification_machine);
+        let store = Store::new(user_identity, store, verification_machine);
 
         let account = Account { inner: account, store };
 

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1123,7 +1123,7 @@ mod tests {
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
-        let store = Store::new(user_id.to_owned(), identity, store, verification);
+        let store = Store::new(identity, store, verification);
         let session_cache = GroupSessionCache::new(store.clone());
 
         GossipMachine::new(user_id, device_id, store, session_cache, Arc::new(DashMap::new()))
@@ -1143,7 +1143,7 @@ mod tests {
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
 
-        let store = Store::new(user_id.clone(), identity, store, verification);
+        let store = Store::new(identity, store, verification);
         store.save_devices(&[device, another_device]).await.unwrap();
         let session_cache = GroupSessionCache::new(store.clone());
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -812,7 +812,7 @@ pub(crate) mod testing {
         let account = ReadOnlyAccount::with_device_id(&user_id, device_id());
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let verification = VerificationMachine::new(account, identity.clone(), store.clone());
-        let store = Store::new(user_id.clone(), identity, store, verification);
+        let store = Store::new(identity, store, verification);
         IdentityManager::new(user_id, device_id().into(), store)
     }
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -193,8 +193,7 @@ impl OlmMachine {
 
         let verification_machine =
             VerificationMachine::new(account.clone(), user_identity.clone(), store.clone());
-        let store =
-            Store::new(user_id.clone(), user_identity.clone(), store, verification_machine.clone());
+        let store = Store::new(user_identity.clone(), store, verification_machine.clone());
         let device_id: OwnedDeviceId = device_id.into();
         let users_for_key_claim = Arc::new(DashMap::new());
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -523,7 +523,7 @@ mod tests {
         let user_id = user_id.to_owned();
         let device_id = device_id.into();
 
-        let store = Store::new(user_id.clone(), identity, store, verification);
+        let store = Store::new(identity, store, verification);
 
         let account = Account { inner: account, store: store.clone() };
 

--- a/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
+++ b/crates/matrix-sdk-crypto/src/store/crypto_store_wrapper.rs
@@ -55,6 +55,11 @@ impl CryptoStoreWrapper {
         }
     }
 
+    /// UserId associated with this store
+    pub(crate) fn user_id(&self) -> &UserId {
+        &self.user_id
+    }
+
     /// Save the set of changes to the store.
     ///
     /// Also responsible for sending updates to the broadcast streams such as

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -109,7 +109,6 @@ pub struct Store {
 
 #[derive(Debug)]
 struct StoreInner {
-    user_id: OwnedUserId,
     identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
     store: Arc<CryptoStoreWrapper>,
     verification_machine: VerificationMachine,
@@ -508,13 +507,11 @@ impl From<&InboundGroupSession> for RoomKeyInfo {
 impl Store {
     /// Create a new Store
     pub(crate) fn new(
-        user_id: OwnedUserId,
         identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
         store: Arc<CryptoStoreWrapper>,
         verification_machine: VerificationMachine,
     ) -> Self {
         let inner = Arc::new(StoreInner {
-            user_id,
             identity,
             store,
             verification_machine,
@@ -530,7 +527,7 @@ impl Store {
 
     /// UserId associated with this store
     pub(crate) fn user_id(&self) -> &UserId {
-        &self.inner.user_id
+        self.inner.store.user_id()
     }
 
     /// DeviceId associated with this store


### PR DESCRIPTION
7419b2c86b8f0f20c2b64737a8cd5462582cba8b added a `user_id` to `CryptoStoreWrapper` so the field in the higher-level store is redundant and means that there is not a single point of truth.