### PR TITLE
Backup support in the main crate

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -21,6 +21,7 @@ WeeChat = "WeeChat"
 sing = "sign"
 singed = "signed"
 singing = "signing"
+Nd = "Nd"
 
 [files]
 # Our json files contain a bunch of base64 encoded ed25519 keys which aren't

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-backups"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures-util",
+ "matrix-sdk",
+ "tokio",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "example-command-bot"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tower",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ sha2 = "0.10.8"
 stream_assert = "0.1.1"
 thiserror = "1.0.38"
 tokio = { version = "1.30.0", default-features = false, features = ["sync"] }
+tokio-stream = "0.1.14"
 tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-core = "0.1.32"
 uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "0a03b713306d6ce3de033157fc2ce92a238c2e24" }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -46,7 +46,7 @@ tracing-opentelemetry = "0.22.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = { version = "0.2.2" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tokio-stream = { version = "0.1.14", features = ["time"] }
+tokio-stream = { workspace = true, features = ["time"] }
 uniffi = { workspace = true, features = ["tokio"] }
 url = "2.2.2"
 zeroize = { workspace = true }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -51,7 +51,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 subtle = "2.5.0"
-tokio-stream = { version = "0.1.12", features = ["sync"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -773,6 +773,7 @@ struct TimelineDropHandle {
     event_handler_handles: Vec<EventHandlerHandle>,
     room_update_join_handle: JoinHandle<()>,
     ignore_user_list_update_join_handle: JoinHandle<()>,
+    room_key_from_backups_join_handle: JoinHandle<()>,
 }
 
 impl Drop for TimelineDropHandle {
@@ -782,6 +783,7 @@ impl Drop for TimelineDropHandle {
         }
         self.room_update_join_handle.abort();
         self.ignore_user_list_update_join_handle.abort();
+        self.room_key_from_backups_join_handle.abort();
     }
 }
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -97,6 +97,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true, optional = true }
 tempfile = "3.3.0"
 thiserror = { workspace = true }
+tokio-stream = { workspace = true, features = ["sync"] }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 url = "2.2.2"

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -464,7 +464,7 @@ impl ClientBuilder {
             oidc: OidcCtx::new(authentication_server_info, allow_insecure_oidc),
         });
 
-        let inner = Arc::new(ClientInner::new(
+        let inner = ClientInner::new(
             auth_ctx,
             homeserver,
             #[cfg(feature = "experimental-sliding-sync")]
@@ -475,7 +475,7 @@ impl ClientBuilder {
             self.respect_login_well_known,
             #[cfg(feature = "e2e-encryption")]
             self.encryption_settings,
-        ));
+        );
 
         debug!("Done building the Client");
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -557,7 +557,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use url::Url;
     /// # let homeserver = Url::parse("http://localhost:8080").unwrap();
     /// use matrix_sdk::{
@@ -708,7 +708,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use url::Url;
     /// # use tokio::sync::mpsc;
     /// #
@@ -760,7 +760,7 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use matrix_sdk::{
     ///     event_handler::Ctx, ruma::events::room::message::SyncRoomMessageEvent,
     ///     Room,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -85,6 +85,7 @@ use crate::{
 };
 #[cfg(feature = "e2e-encryption")]
 use crate::{
+    encryption::backups::types::BackupClientState,
     encryption::{Encryption, EncryptionSettings},
     store_locks::CrossProcessStoreLock,
 };
@@ -160,6 +161,13 @@ pub(crate) struct ClientLocks {
     /// [`SecretStore::put_secret`]: crate::encryption::secret_storage::SecretStore::put_secret
     #[cfg(feature = "e2e-encryption")]
     pub(crate) store_secret_lock: Mutex<()>,
+    /// Lock ensuring that only one method at a time might modify our backup.
+    #[cfg(feature = "e2e-encryption")]
+    pub(crate) backup_modify_lock: Mutex<()>,
+    /// Lock ensuring that we're going to attempt to upload backups for a single
+    /// requester.
+    #[cfg(feature = "e2e-encryption")]
+    pub(crate) backup_upload_lock: Mutex<()>,
     /// Handler making sure we only have one group session sharing request in
     /// flight per room.
     #[cfg(feature = "e2e-encryption")]
@@ -235,6 +243,8 @@ pub(crate) struct ClientInner {
     /// End-to-end encryption settings.
     #[cfg(feature = "e2e-encryption")]
     pub(crate) encryption_settings: EncryptionSettings,
+    #[cfg(feature = "e2e-encryption")]
+    pub(crate) backup_state: BackupClientState,
 }
 
 impl ClientInner {
@@ -271,6 +281,7 @@ impl ClientInner {
             sync_beat: event_listener::Event::new(),
             #[cfg(feature = "e2e-encryption")]
             encryption_settings,
+            backup_state: Default::default(),
         }
     }
 }

--- a/crates/matrix-sdk/src/client/tasks.rs
+++ b/crates/matrix-sdk/src/client/tasks.rs
@@ -34,12 +34,14 @@ pub(crate) struct ClientTasks {
 #[cfg(feature = "e2e-encryption")]
 pub(crate) struct BackupUploadingTask {
     sender: mpsc::UnboundedSender<()>,
+    #[allow(dead_code)]
     join_handle: JoinHandle<()>,
 }
 
 #[cfg(feature = "e2e-encryption")]
 impl Drop for BackupUploadingTask {
     fn drop(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
         self.join_handle.abort();
     }
 }

--- a/crates/matrix-sdk/src/client/tasks.rs
+++ b/crates/matrix-sdk/src/client/tasks.rs
@@ -24,18 +24,11 @@ use crate::{
     Client,
 };
 
+#[derive(Default)]
 pub(crate) struct ClientTasks {
     #[cfg(feature = "e2e-encryption")]
-    pub(crate) upload_room_keys: BackupUploadingTask,
-}
-
-impl ClientTasks {
-    pub(crate) fn new(client: Weak<ClientInner>) -> Self {
-        Self {
-            #[cfg(feature = "e2e-encryption")]
-            upload_room_keys: BackupUploadingTask::new(client),
-        }
-    }
+    pub(crate) upload_room_keys: Option<BackupUploadingTask>,
+    pub(crate) setup_e2ee: Option<JoinHandle<()>>,
 }
 
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/client/tasks.rs
+++ b/crates/matrix-sdk/src/client/tasks.rs
@@ -1,0 +1,87 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Weak;
+
+use tokio::sync::mpsc::{self, UnboundedReceiver};
+use tracing::{trace, warn};
+
+use super::ClientInner;
+use crate::{
+    encryption::backups::UploadState,
+    executor::{spawn, JoinHandle},
+    Client,
+};
+
+pub(crate) struct ClientTasks {
+    #[cfg(feature = "e2e-encryption")]
+    pub(crate) upload_room_keys: BackupUploadingTask,
+}
+
+impl ClientTasks {
+    pub(crate) fn new(client: Weak<ClientInner>) -> Self {
+        Self {
+            #[cfg(feature = "e2e-encryption")]
+            upload_room_keys: BackupUploadingTask::new(client),
+        }
+    }
+}
+
+#[cfg(feature = "e2e-encryption")]
+pub(crate) struct BackupUploadingTask {
+    sender: mpsc::UnboundedSender<()>,
+    join_handle: JoinHandle<()>,
+}
+
+#[cfg(feature = "e2e-encryption")]
+impl Drop for BackupUploadingTask {
+    fn drop(&mut self) {
+        self.join_handle.abort();
+    }
+}
+
+#[cfg(feature = "e2e-encryption")]
+impl BackupUploadingTask {
+    pub(crate) fn new(client: Weak<ClientInner>) -> Self {
+        let (sender, receiver) = mpsc::unbounded_channel();
+
+        let join_handle = spawn(async move {
+            Self::listen(client, receiver).await;
+        });
+
+        Self { sender, join_handle }
+    }
+
+    pub(crate) fn trigger_upload(&self) {
+        let _ = self.sender.send(());
+    }
+
+    pub(crate) async fn listen(client: Weak<ClientInner>, mut receiver: UnboundedReceiver<()>) {
+        while receiver.recv().await.is_some() {
+            if let Some(client) = client.upgrade() {
+                let client = Client { inner: client };
+
+                if let Err(e) = client.encryption().backups().backup_room_keys().await {
+                    client.inner.backup_state.upload_progress.set(UploadState::Error);
+                    warn!("Error backing up room keys {e:?}");
+                }
+
+                client.inner.backup_state.upload_progress.set(UploadState::Idle);
+            } else {
+                trace!("Client got dropped, shutting down the task");
+                break;
+            }
+        }
+    }
+}

--- a/crates/matrix-sdk/src/encryption/backups/futures.rs
+++ b/crates/matrix-sdk/src/encryption/backups/futures.rs
@@ -1,0 +1,158 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Named futures for the backup support.
+
+use std::{future::IntoFuture, time::Duration};
+
+use futures_core::Stream;
+use futures_util::StreamExt;
+use matrix_sdk_common::boxed_into_future;
+use thiserror::Error;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use tracing::trace;
+
+use super::{Backups, UploadState};
+use crate::utils::ChannelObservable;
+
+/// Error describin how waiting for the backup upload to settle down can fail.
+#[derive(Clone, Copy, Debug, Error)]
+pub enum SteadyStateError {
+    /// The currently active backup got either deleted or a new one was created.
+    ///
+    /// No further room keys will be uploaded to the currently active
+    /// backup.
+    #[error("The backup got disabled while waiting for the room keys to be uploaded.")]
+    BackupDisabled,
+    /// Uploading the room keys to the homeserver failed.
+    ///
+    /// Uploading will be retried again at a later point in time, or
+    /// immediately if you wait for the steady state again.
+    #[error("There was a connection error.")]
+    Connection,
+    /// We missed some updates to the [`UploadState`] from the upload task.
+    ///
+    /// This error doesn't imply that there was an error with the uploading of
+    /// room keys, it just means that we didn't receive all the transitions
+    /// in the [`UploadState`]. You might want to retry waiting for the
+    /// steady state.
+    #[error("We couldn't read status updates from the upload task quickly enough.")]
+    Lagged,
+}
+
+/// Named future for the [`Backups::wait_for_steady_state()`] method.
+#[derive(Debug)]
+pub struct WaitForSteadyState<'a> {
+    pub(super) backups: &'a Backups,
+    pub(super) progress: ChannelObservable<UploadState>,
+    pub(super) timeout: Option<Duration>,
+}
+
+impl<'a> WaitForSteadyState<'a> {
+    /// Subscribe to the progress of the backup upload step while waiting for it
+    /// to settle down.
+    pub fn subscribe_to_progress(
+        &self,
+    ) -> impl Stream<Item = Result<UploadState, BroadcastStreamRecvError>> {
+        self.progress.subscribe()
+    }
+
+    /// Set the delay between each upload request.
+    ///
+    /// Uploading room keys might require multiple requests to be sent out. The
+    /// [`Client`] waits for a while before it sends the next request out.
+    ///
+    /// This method allows you to override how long the [`Client`] will wait.
+    /// The default value is 100 ms.
+    ///
+    /// [`Client`]: crate::Client
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.timeout = Some(delay);
+
+        self
+    }
+}
+
+impl<'a> IntoFuture for WaitForSteadyState<'a> {
+    type Output = Result<(), SteadyStateError>;
+    boxed_into_future!(extra_bounds: 'a);
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let Self { backups, timeout, progress } = self;
+
+            trace!("Creating a stream to wait for the steady state");
+
+            let mut stream = progress.subscribe();
+
+            let old_delay = if let Some(delay) = timeout {
+                let mut lock = backups.client.inner.backup_state.upload_delay.write().unwrap();
+                let old_delay = Some(lock.to_owned());
+
+                *lock = delay;
+
+                old_delay
+            } else {
+                None
+            };
+
+            trace!("Waiting for the upload steady state");
+
+            let ret = if backups.are_enabled().await {
+                backups.maybe_trigger_backup();
+
+                let mut ret = Ok(());
+
+                // TODO: Do we want to be smart here and remember the count when we started
+                // waiting and prevent the total from increasing, in case new room
+                // keys arrive after we started waiting.
+                while let Some(state) = stream.next().await {
+                    trace!(?state, "Update state while waiting for the backup steady state");
+
+                    match state {
+                        Ok(UploadState::Done) => {
+                            ret = Ok(());
+                            break;
+                        }
+                        Ok(UploadState::Error) => {
+                            if backups.are_enabled().await {
+                                ret = Err(SteadyStateError::Connection);
+                            } else {
+                                ret = Err(SteadyStateError::BackupDisabled);
+                            }
+
+                            break;
+                        }
+                        Err(_) => {
+                            ret = Err(SteadyStateError::Lagged);
+                            break;
+                        }
+                        _ => (),
+                    }
+                }
+
+                ret
+            } else {
+                Err(SteadyStateError::BackupDisabled)
+            };
+
+            if let Some(old_delay) = old_delay {
+                let mut lock = backups.client.inner.backup_state.upload_delay.write().unwrap();
+                *lock = old_delay;
+            }
+
+            ret
+        })
+    }
+}

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -1,0 +1,1153 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Room key backup support
+//!
+//! This module implements support for server-side key backups[[1]]. The module
+//! allows you to connect to an existing backup, create or delete backups from
+//! the homeserver, and download room keys from a backup.
+//!
+//! [1]: https://spec.matrix.org/unstable/client-server-api/#server-side-key-backups
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use futures_core::Stream;
+use futures_util::StreamExt;
+use matrix_sdk_base::crypto::{
+    backups::MegolmV1BackupKey, store::BackupDecryptionKey, types::RoomKeyBackupInfo,
+    GossippedSecret, KeysBackupRequest, OlmMachine, RoomKeyImportResult,
+};
+use ruma::{
+    api::client::{
+        backup::{
+            add_backup_keys, create_backup_version, get_backup_keys, get_backup_keys_for_room,
+            get_backup_keys_for_session, get_latest_backup_info, RoomKeyBackup,
+        },
+        error::ErrorKind,
+    },
+    events::secret::{request::SecretName, send::ToDeviceSecretSendEvent},
+    serde::Raw,
+    RoomId, TransactionId,
+};
+use tokio_stream::wrappers::{errors::BroadcastStreamRecvError, BroadcastStream};
+use tracing::{error, info, instrument, trace, warn, Span};
+
+pub mod futures;
+pub(crate) mod types;
+
+pub use types::{BackupState, UploadState};
+
+use self::futures::WaitForSteadyState;
+use crate::{Client, Error};
+
+/// The backups manager for the [`Client`].
+#[derive(Debug, Clone)]
+pub struct Backups {
+    pub(super) client: Client,
+}
+
+impl Backups {
+    /// Create a new backup recovery key and backup version.
+    ///
+    /// The backup recovery key will be persisted locally and shared with
+    /// trusted devices as `m.secret.send` events.
+    ///
+    /// After the backup has been created, all room keys will be uploaded to the
+    /// homeserver.
+    ///
+    /// *Warning*: This will overwrite any existing backup.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use matrix_sdk::{Client, encryption::backups::BackupState};
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://example.com")?;
+    /// # let client = Client::new(homeserver).await?;
+    /// let backups = client.encryption().backups();
+    /// backups.create().await?;
+    ///
+    /// assert_eq!(backups.state(), BackupState::Enabled);
+    /// # anyhow::Ok(()) };
+    /// ```
+    pub async fn create(&self) -> Result<(), Error> {
+        let _guard = self.client.locks().backup_modify_lock.lock().await;
+
+        self.set_state(BackupState::Creating);
+
+        // Create a future so we can catch errors and go back to the `Unknown` state.
+        let future = async {
+            let olm_machine = self.client.olm_machine().await;
+            let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+
+            // Create a new backup recovery key.
+            let decryption_key = BackupDecryptionKey::new().expect(
+                "We should be able to generate enough randomness to create a new backup recovery \
+                 key",
+            );
+
+            // Get the info about the new backup key, this needs to be uploaded to the
+            // homeserver[1].
+            //
+            // We need to sign the `RoomKeyBackupInfo` so other clients which might want
+            // to start using the backup without having access to the
+            // `BackupDecryptionKey` can do so, as per [spec]:
+            //
+            // Clients must only store keys in backups after they have ensured that the
+            // auth_data  is trusted. This can be done either by:
+            //
+            //  * checking that it is signed by the user’s master cross-signing key or by a
+            //    verified device belonging to the same user, or
+            //  * by deriving the public key from a private key that it obtained from a
+            //    trusted source. Trusted sources for the private key include the user
+            //    entering the key, retrieving the key stored in secret storage, or
+            //    obtaining the key via secret sharing from a verified device belonging to
+            //    the same user.
+            //
+            // Do note, I do think that the signature checking should be completely removed,
+            // and once we have proper authentication for backups from MSC4048, activating a
+            // backup without access to the backup recovery key won't be possible.
+            //
+            // [1]: https://spec.matrix.org/v1.8/client-server-api/#post_matrixclientv3room_keysversion
+            // [spec]: https://spec.matrix.org/v1.8/client-server-api/#server-side-key-backups
+            let mut backup_info = decryption_key.to_backup_info();
+
+            if let Err(e) = olm_machine.backup_machine().sign_backup(&mut backup_info).await {
+                warn!("Unable to sign the newly created backup version: {e:?}");
+            }
+
+            let algorithm = Raw::new(&backup_info)?.cast();
+            let request = create_backup_version::v3::Request::new(algorithm);
+            let response = self.client.send(request, Default::default()).await?;
+            let version = response.version;
+
+            // Reset any state we might have had before the new backup was created.
+            // TODO: This should remove the old stored key and version.
+            olm_machine.backup_machine().disable_backup().await?;
+
+            let backup_key = decryption_key.megolm_v1_public_key();
+
+            // Save the newly created keys and the version we received from the server.
+            olm_machine
+                .backup_machine()
+                .save_decryption_key(Some(decryption_key), Some(version.to_owned()))
+                .await?;
+
+            // Enable the backup and start the upload of room keys.
+            self.enable(olm_machine, backup_key, version).await?;
+
+            Ok(())
+        };
+
+        let result = future.await;
+
+        if result.is_err() {
+            self.set_state(BackupState::Unknown)
+        }
+
+        result
+    }
+
+    /// Disable and delete the currently active backup.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use matrix_sdk::{Client, encryption::backups::BackupState};
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://example.com")?;
+    /// # let client = Client::new(homeserver).await?;
+    /// let backups = client.encryption().backups();
+    /// backups.disable().await?;
+    ///
+    /// assert_eq!(backups.state(), BackupState::Unknown);
+    /// # anyhow::Ok(()) };
+    /// ```
+    #[instrument(skip_all, fields(version))]
+    pub async fn disable(&self) -> Result<(), Error> {
+        let _guard = self.client.locks().backup_modify_lock.lock().await;
+
+        self.set_state(BackupState::Disabling);
+
+        // Create a future so we can catch errors and go back to the `Unknown` state.
+        let future = async {
+            let olm_machine = self.client.olm_machine().await;
+            let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+
+            let backup_keys = olm_machine.backup_machine().get_backup_keys().await?;
+
+            if let Some(version) = backup_keys.backup_version {
+                Span::current().record("version", &version);
+
+                info!("Disabling and deleting backup");
+
+                olm_machine.backup_machine().disable_backup().await?;
+
+                info!("Backup successfully disabled");
+
+                let request =
+                    ruma::api::client::backup::delete_backup_version::v3::Request::new(version);
+
+                self.client.send(request, Default::default()).await?;
+                self.set_state(BackupState::Unknown);
+
+                info!("Backup successfully disabled and deleted");
+            } else {
+                info!("Backup is not enabled, can't disable it");
+            }
+
+            Ok(())
+        };
+
+        let result = future.await;
+
+        if result.is_err() {
+            self.set_state(BackupState::Unknown);
+        }
+
+        result
+    }
+
+    /// Wait for room keys to be uploaded.
+    ///
+    /// This method will wake up a task to upload room keys which have not yet
+    /// been uploaded to the homeserver. It will then wait for the task to
+    /// finish uploading.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use matrix_sdk::{Client, encryption::backups::UploadState};
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://example.com")?;
+    /// # let client = Client::new(homeserver).await?;
+    /// use futures_util::StreamExt;
+    ///
+    /// let backups = client.encryption().backups();
+    /// let wait_for_steady_state = backups.wait_for_steady_state();
+    ///
+    /// let mut progress_stream = wait_for_steady_state.subscribe_to_progress();
+    ///
+    /// tokio::spawn(async move {
+    ///     while let Some(update) = progress_stream.next().await {
+    ///         let Ok(update) = update else { break };
+    ///
+    ///         match update {
+    ///             UploadState::Uploading(counts) => {
+    ///                 println!(
+    ///                     "Uploaded {} out of {} room keys.",
+    ///                     counts.backed_up, counts.total
+    ///                 );
+    ///             }
+    ///             UploadState::Error => break,
+    ///             UploadState::Done => break,
+    ///             _ => (),
+    ///         }
+    ///     }
+    /// });
+    ///
+    /// wait_for_steady_state.await?;
+    ///
+    /// # anyhow::Ok(()) };
+    /// ```
+    pub fn wait_for_steady_state(&self) -> WaitForSteadyState<'_> {
+        WaitForSteadyState {
+            backups: self,
+            progress: self.client.inner.backup_state.upload_progress.clone(),
+            timeout: None,
+        }
+    }
+
+    /// Get a stream of updates to the [`BackupState`].
+    ///
+    /// This method will send out the current state as the first update.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use matrix_sdk::{Client, encryption::backups::BackupState};
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://example.com")?;
+    /// # let client = Client::new(homeserver).await?;
+    /// use futures_util::StreamExt;
+    ///
+    /// let backups = client.encryption().backups();
+    ///
+    /// let mut state_stream = backups.state_stream();
+    ///
+    /// while let Some(update) = state_stream.next().await {
+    ///     let Ok(update) = update else { break };
+    ///
+    ///     match update {
+    ///         BackupState::Enabled => {
+    ///             println!("Backups have been enabled");
+    ///         }
+    ///         _ => (),
+    ///     }
+    /// }
+    /// # anyhow::Ok(()) };
+    /// ```
+    pub fn state_stream(
+        &self,
+    ) -> impl Stream<Item = Result<BackupState, BroadcastStreamRecvError>> {
+        self.client.inner.backup_state.global_state.subscribe()
+    }
+
+    /// Get the current [`BackupState`] for this [`Client`].
+    pub fn state(&self) -> BackupState {
+        self.client.inner.backup_state.global_state.get()
+    }
+
+    /// Are backups enabled for the current [`Client`]?
+    ///
+    /// This method will check if we locally have an active backup key and
+    /// backup version and are ready to upload room keys to a backup.
+    pub async fn are_enabled(&self) -> bool {
+        let olm_machine = self.client.olm_machine().await;
+
+        if let Some(machine) = olm_machine.as_ref() {
+            machine.backup_machine().enabled().await
+        } else {
+            false
+        }
+    }
+
+    /// Does a backup exist on the server?
+    ///
+    /// This method will request info about the current backup from the
+    /// homeserver and if a backup exits return `true`, otherwise `false`.
+    pub async fn exists_on_server(&self) -> Result<bool, Error> {
+        Ok(self.get_current_version().await?.is_some())
+    }
+
+    /// Subscribe to a stream of room keys we download and import from backups.
+    pub fn room_keys_for_room_stream(
+        &self,
+        room_id: &RoomId,
+    ) -> impl Stream<Item = Result<BTreeMap<String, BTreeSet<String>>, BroadcastStreamRecvError>>
+    {
+        let room_id = room_id.to_owned();
+
+        // TODO: This is a bit crap to say the least, the type is non descriptive and
+        // doesn't even contain all the important data, it should be a stream of
+        // `RoomKeyInfo` like the OlmMachine has... But on the other hand we
+        // should just used the OlmMachine stream and remove this.
+        self.room_keys_stream().filter_map(move |import_result| {
+            let room_id = room_id.to_owned();
+
+            async move {
+                match import_result {
+                    Ok(mut import_result) => import_result.keys.remove(&room_id).map(Ok),
+                    Err(e) => Some(Err(e)),
+                }
+            }
+        })
+    }
+
+    /// Download all room keys for a certain room from the backup on the
+    /// homeserver.
+    pub async fn download_room_keys_for_room(&self, room_id: &RoomId) -> Result<(), Error> {
+        let olm_machine = self.client.olm_machine().await;
+        let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+
+        let backup_keys = olm_machine.store().load_backup_keys().await?;
+
+        if let Some(decryption_key) = backup_keys.decryption_key {
+            if let Some(version) = backup_keys.backup_version {
+                let request =
+                    get_backup_keys_for_room::v3::Request::new(version, room_id.to_owned());
+                let response = self.client.send(request, Default::default()).await?;
+                let response = get_backup_keys::v3::Response::new(BTreeMap::from([(
+                    room_id.to_owned(),
+                    RoomKeyBackup::new(response.sessions),
+                )]));
+
+                self.handle_downloaded_room_keys(response, decryption_key, olm_machine).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Download a single room key from the backup on the homeserver.
+    pub async fn download_room_key(&self, room_id: &RoomId, session_id: &str) -> Result<(), Error> {
+        let olm_machine = self.client.olm_machine().await;
+        let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+
+        let backup_keys = olm_machine.store().load_backup_keys().await?;
+
+        if let Some(decryption_key) = backup_keys.decryption_key {
+            if let Some(version) = backup_keys.backup_version {
+                let request = get_backup_keys_for_session::v3::Request::new(
+                    version,
+                    room_id.to_owned(),
+                    session_id.to_owned(),
+                );
+                let response = self.client.send(request, Default::default()).await?;
+                let response = get_backup_keys::v3::Response::new(BTreeMap::from([(
+                    room_id.to_owned(),
+                    RoomKeyBackup::new(BTreeMap::from([(
+                        session_id.to_owned(),
+                        response.key_data,
+                    )])),
+                )]));
+
+                self.handle_downloaded_room_keys(response, decryption_key, olm_machine).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Set the state of the backup.
+    fn set_state(&self, state: BackupState) {
+        self.client.inner.backup_state.global_state.set(state);
+    }
+
+    /// Set the backup state to the `Enabled` variant and insert the backup key
+    /// and version into the [`OlmMachine`].
+    async fn enable(
+        &self,
+        olm_machine: &OlmMachine,
+        backup_key: MegolmV1BackupKey,
+        version: String,
+    ) -> Result<(), Error> {
+        backup_key.set_version(version);
+        olm_machine.backup_machine().enable_backup_v1(backup_key).await?;
+
+        self.set_state(BackupState::Enabled);
+
+        Ok(())
+    }
+
+    /// Decrypt and forward a response containing backed up room keys to the
+    /// [`OlmMachine`].
+    async fn handle_downloaded_room_keys(
+        &self,
+        backed_up_keys: get_backup_keys::v3::Response,
+        backup_decryption_key: BackupDecryptionKey,
+        olm_machine: &OlmMachine,
+    ) -> Result<(), Error> {
+        let mut decrypted_room_keys: BTreeMap<_, BTreeMap<_, _>> = BTreeMap::new();
+
+        for (room_id, room_keys) in backed_up_keys.rooms {
+            for (session_id, room_key) in room_keys.sessions {
+                // TODO: Log that we're skipping some keys here.
+                let Ok(room_key) = room_key.deserialize() else {
+                    warn!("Couldn't deseriazlie a room key we downloaded from backups, session ID: {session_id}");
+                    continue;
+                };
+
+                let Ok(room_key) =
+                    backup_decryption_key.decrypt_session_data(room_key.session_data)
+                else {
+                    continue;
+                };
+
+                decrypted_room_keys
+                    .entry(room_id.to_owned())
+                    .or_default()
+                    .insert(session_id, room_key);
+            }
+        }
+
+        let result = olm_machine
+            .backup_machine()
+            .import_backed_up_room_keys(decrypted_room_keys, |_, _| {})
+            .await?;
+
+        // Since we can't use the usual room keys stream from the `OlmMachine`
+        // we're going to send things out in our own custom broadcaster.
+        let _ = self.client.inner.backup_state.room_keys_broadcaster.send(result);
+
+        Ok(())
+    }
+
+    /// Download all room keys from the backup on the homeserver.
+    async fn download_all_room_keys(
+        &self,
+        decryption_key: BackupDecryptionKey,
+        version: String,
+    ) -> Result<(), Error> {
+        let request = get_backup_keys::v3::Request::new(version);
+        let response = self.client.send(request, Default::default()).await?;
+
+        let olm_machine = self.client.olm_machine().await;
+        let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+
+        self.handle_downloaded_room_keys(response, decryption_key, olm_machine).await?;
+
+        Ok(())
+    }
+
+    fn room_keys_stream(
+        &self,
+    ) -> impl Stream<Item = Result<RoomKeyImportResult, BroadcastStreamRecvError>> {
+        BroadcastStream::new(self.client.inner.backup_state.room_keys_broadcaster.subscribe())
+    }
+
+    /// Get info about the currently active backup from the server.
+    async fn get_current_version(
+        &self,
+    ) -> Result<Option<get_latest_backup_info::v3::Response>, Error> {
+        let request = get_latest_backup_info::v3::Request::new();
+
+        match self.client.send(request, None).await {
+            Ok(r) => Ok(Some(r)),
+            Err(e) => {
+                if let Some(kind) = e.client_api_error_kind() {
+                    if kind == &ErrorKind::NotFound {
+                        Ok(None)
+                    } else {
+                        Err(e.into())
+                    }
+                } else {
+                    Err(e.into())
+                }
+            }
+        }
+    }
+
+    #[instrument(skip(self, olm_machine, request))]
+    async fn send_backup_request(
+        &self,
+        olm_machine: &OlmMachine,
+        request_id: &TransactionId,
+        request: KeysBackupRequest,
+    ) -> Result<(), Error> {
+        trace!("Uploading some room keys");
+
+        let request = add_backup_keys::v3::Request::new(request.version, request.rooms);
+
+        match self.client.send(request, Default::default()).await {
+            Ok(response) => {
+                olm_machine.mark_request_as_sent(request_id, &response).await?;
+
+                let new_counts = olm_machine.backup_machine().room_key_counts().await?;
+
+                self.client
+                    .inner
+                    .backup_state
+                    .upload_progress
+                    .set(UploadState::Uploading(new_counts));
+
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let delay =
+                        self.client.inner.backup_state.upload_delay.read().unwrap().to_owned();
+                    tokio::time::sleep(delay).await;
+                }
+
+                Ok(())
+            }
+            Err(error) => {
+                if let Some(kind) = error.client_api_error_kind() {
+                    match kind {
+                        ErrorKind::NotFound => {
+                            warn!("No backup found on the server, the backup got likely deleted, disabling backups.");
+
+                            self.handle_deleted_backup_version(olm_machine).await?;
+                        }
+                        ErrorKind::WrongRoomKeysVersion { current_version } => {
+                            warn!(
+                                new_version = current_version,
+                                "A new backup version was found on the server, disabling backups"
+                            );
+
+                            // TODO: If we're verified and there are other devices besides us,
+                            // request the new backup key over `m.secret.send`.
+
+                            self.handle_deleted_backup_version(olm_machine).await?;
+                        }
+
+                        _ => (),
+                    }
+                }
+
+                Err(error.into())
+            }
+        }
+    }
+
+    /// Poll the [`OlmMachine`] for room keys which need to be backed up and
+    /// send out the request to the homeserver.
+    ///
+    /// This should only be called by the [`BackupUploadingTask`].
+    ///
+    /// [`BackupUploadingTask`]: crate::client::tasks::BackupUploadingTask
+    pub(crate) async fn backup_room_keys(&self) -> Result<(), Error> {
+        let _guard = self.client.locks().backup_upload_lock.lock().await;
+
+        let olm_machine = self.client.olm_machine().await;
+        let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+
+        let old_counts = olm_machine.backup_machine().room_key_counts().await?;
+
+        self.client
+            .inner
+            .backup_state
+            .upload_progress
+            .set(UploadState::CheckingIfUploadNeeded(old_counts));
+
+        while let Some((request_id, request)) = olm_machine.backup_machine().backup().await? {
+            self.send_backup_request(olm_machine, &request_id, request).await?;
+        }
+
+        self.client.inner.backup_state.upload_progress.set(UploadState::Done);
+
+        Ok(())
+    }
+
+    /// Set up a `m.secret.send` listener and re-enable backups if we have a
+    /// backup recovery key stored.
+    pub(crate) async fn setup_and_resume(&self) -> Result<(), Error> {
+        info!("Setting up secret listeners and trying to resume backups");
+
+        self.client.add_event_handler(Self::secret_send_event_handler);
+        self.maybe_resume_backups().await?;
+
+        Ok(())
+    }
+
+    /// Try to enable backups with the given backup recovery key.
+    ///
+    /// This should be called if we receive a backup recovery, either:
+    ///
+    /// * As a `m.secret.send` to-device event from a trusted device
+    /// * From the `m.megolm_backup.v1` global account data event.
+    ///
+    /// In both cases the method will compare the currently active backup
+    /// version to the backup recovery key and if we have received a
+    /// machting key activate backups on this device and start uploading
+    /// room keys to the backup.
+    ///
+    /// Returns true if backups are already or have been enabled, otherwise
+    /// false.
+    #[instrument(skip_all)]
+    pub(crate) async fn maybe_enable_backups(
+        &self,
+        maybe_recovery_key: &str,
+    ) -> Result<bool, Error> {
+        let _guard = self.client.locks().backup_modify_lock.lock().await;
+
+        // Create a future here which allows us to catch any failure that might happen
+        // so we can later on fall back to the correct `BackupState`.
+        let future = async {
+            self.set_state(BackupState::Enabling);
+
+            let olm_machine = self.client.olm_machine().await;
+            let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+            let backup_machine = olm_machine.backup_machine();
+
+            let decryption_key =
+                BackupDecryptionKey::from_base64(maybe_recovery_key).map_err(|e| {
+                    <serde_json::Error as serde::de::Error>::custom(format!(
+                        "Couldn't deserialize the backup recovery key: {e:?}"
+                    ))
+                })?;
+
+            // Let's try to see if there's a backup on the homeserver.
+            let current_version = self.get_current_version().await?;
+
+            let Some(current_version) = current_version else {
+                warn!("Tried to enable backups, but no backup version was found on the server.");
+                return Ok(false);
+            };
+
+            Span::current().record("backup_version", &current_version.version);
+
+            let backup_info: RoomKeyBackupInfo = current_version.algorithm.deserialize_as()?;
+            let stored_keys = backup_machine.get_backup_keys().await?;
+
+            if stored_keys.backup_version.as_ref() == Some(&current_version.version)
+                && self.are_enabled().await
+            {
+                // If we already have a backup enabled which is using the currently active
+                // backup version, do nothing but tell the caller using the return value that
+                // backups are enabled.
+                Ok(true)
+            } else if decryption_key.backup_key_matches(&backup_info) {
+                info!(
+                    "We have found the correct backup recovery key, storing the backup recovery \
+                     key and enabling backups"
+                );
+
+                // We're enabling a new backup, reset the `backed_up` flags on the room keys and
+                // remove any key/version we might have.
+                backup_machine.disable_backup().await?;
+
+                let backup_key = decryption_key.megolm_v1_public_key();
+                backup_key.set_version(current_version.version.to_owned());
+
+                // Persist the new keys and enable the backup.
+                backup_machine
+                    .save_decryption_key(
+                        Some(decryption_key.to_owned()),
+                        Some(current_version.version.to_owned()),
+                    )
+                    .await?;
+                backup_machine.enable_backup_v1(backup_key).await?;
+
+                // If the user has set up the client to download any room keys, do so now. This
+                // is not really useful in a real scenario since the API to
+                // download room keys is not paginated.
+                //
+                // You need to download all room keys at once, parse a potentially huge JSON
+                // response and decrypt all the room keys found in the backup.
+                //
+                // This doesn't work for any sizeable account.
+                if self.client.inner.encryption_settings.auto_download_from_backup {
+                    self.set_state(BackupState::Downloading);
+
+                    if let Err(e) =
+                        self.download_all_room_keys(decryption_key, current_version.version).await
+                    {
+                        warn!("Couldn't automatically download all room keys from backup: {e:?}");
+                    }
+                }
+
+                // Trigger the upload of any room keys we might need to upload.
+                self.maybe_trigger_backup();
+
+                Ok(true)
+            } else {
+                let derived_key = decryption_key.megolm_v1_public_key();
+                let downloaded_key = current_version.algorithm;
+
+                warn!(
+                    ?derived_key,
+                    ?downloaded_key,
+                    "Found an active backup but the recovery key we received isn't the one used in \
+                     this backup version"
+                );
+
+                Ok(false)
+            }
+        };
+
+        match future.await {
+            Ok(enabled) => {
+                if enabled {
+                    self.set_state(BackupState::Enabled);
+                } else {
+                    self.set_state(BackupState::Unknown);
+                }
+
+                Ok(enabled)
+            }
+            Err(e) => {
+                self.set_state(BackupState::Unknown);
+
+                Err(e)
+            }
+        }
+    }
+
+    /// Try to resume backups from a backup recovery key we have found in the
+    /// crypto store.
+    ///
+    /// Returns true if backups have been resumed, false otherwise.
+    async fn resume_backup_from_stored_backup_key(
+        &self,
+        olm_machine: &OlmMachine,
+    ) -> Result<bool, Error> {
+        let backup_keys = olm_machine.store().load_backup_keys().await?;
+
+        if let Some(decryption_key) = backup_keys.decryption_key {
+            if let Some(version) = backup_keys.backup_version {
+                let backup_key = decryption_key.megolm_v1_public_key();
+
+                self.enable(olm_machine, backup_key, version).await?;
+
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Try to resume backups by iterating through the `m.secret.send` events
+    /// the [`OlmMachine`] has received and stored in the secret inbox.
+    async fn maybe_resume_from_secret_inbox(&self, olm_machine: &OlmMachine) -> Result<(), Error> {
+        let secrets = olm_machine.store().get_secrets_from_inbox(&SecretName::RecoveryKey).await?;
+
+        for secret in secrets {
+            if self.handle_received_secret(secret).await? {
+                break;
+            }
+        }
+
+        olm_machine.store().delete_secrets_from_inbox(&SecretName::RecoveryKey).await?;
+
+        Ok(())
+    }
+
+    /// Check and re-enable a backup if we have a backup recovery key locally.
+    async fn maybe_resume_backups(&self) -> Result<(), Error> {
+        let olm_machine = self.client.olm_machine().await;
+        let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+
+        // Let us first check if we have a stored backup recovery key and a backup
+        // version.
+        if !self.resume_backup_from_stored_backup_key(olm_machine).await? {
+            // We didn't manage to enable backups from a stored backup recovery key, let us
+            // check our secret inbox. Perhaps we can find a valid key there.
+            self.maybe_resume_from_secret_inbox(olm_machine).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Listen for `m.secret.send` to-device events and check the secret inbox
+    /// if we do receive one.
+    pub(crate) async fn secret_send_event_handler(_: ToDeviceSecretSendEvent, client: Client) {
+        let olm_machine = client.olm_machine().await;
+
+        // TODO: Because of our crude multi-process support, which reloads the whole
+        // [`OlmMachine`] the `secrets_stream` might stop giving you updates. Once
+        // that's fixed, stop listening to individual secret send events and
+        // listen to the secrets stream.
+        if let Some(olm_machine) = olm_machine.as_ref() {
+            if let Err(e) =
+                client.encryption().backups().maybe_resume_from_secret_inbox(olm_machine).await
+            {
+                error!("Could not handle `m.secret.send` event: {e:?}");
+            }
+        } else {
+            error!("Tried to handle a `m.secret.send` event but no OlmMachine was initialized");
+        }
+    }
+
+    /// Try to enable backups using the secret found in the [`GossippedSecret`].
+    ///
+    /// The [`GossippedSecret`] represents a `m.secret.send` event we received
+    /// from a trusted device and have pulled out of the secret inbox.
+    ///
+    /// Returns true if we enabled backups, false otherwise.
+    pub(crate) async fn handle_received_secret(
+        &self,
+        secret: GossippedSecret,
+    ) -> Result<bool, Error> {
+        if secret.secret_name == SecretName::RecoveryKey {
+            if self.maybe_enable_backups(&secret.event.content.secret).await? {
+                let olm_machine = self.client.olm_machine().await;
+                let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
+                olm_machine.store().delete_secrets_from_inbox(&secret.secret_name).await?;
+
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Send a notification to the task which is responsible to upload room keys
+    /// to the backup that it might have new room keys to back up.
+    pub(crate) fn maybe_trigger_backup(&self) {
+        // TODO: Wake a background task up to upload room keys
+    }
+
+    /// Disable our backups locally if we notice that the backup has been
+    /// removed on the homeserver.
+    async fn handle_deleted_backup_version(&self, olm_machine: &OlmMachine) -> Result<(), Error> {
+        olm_machine.backup_machine().disable_backup().await?;
+        self.set_state(BackupState::Unknown);
+
+        Ok(())
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod test {
+    use std::time::Duration;
+
+    use matrix_sdk_base::crypto::olm::ExportedRoomKey;
+    use matrix_sdk_test::async_test;
+    use serde_json::json;
+    use wiremock::{
+        matchers::{header, method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    use super::*;
+    use crate::test_utils::logged_in_client;
+
+    fn room_key() -> ExportedRoomKey {
+        let json = json!({
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "room_id": "!DovneieKSTkdHKpIXy:morpheus.localhost",
+            "sender_key": "DeHIg4gwhClxzFYcmNntPNF9YtsdZbmMy8+3kzCMXHA",
+            "session_id": "gM8i47Xhu0q52xLfgUXzanCMpLinoyVyH7R58cBuVBU",
+            "session_key": "AQAAAABvWMNZjKFtebYIePKieQguozuoLgzeY6wKcyJjLJcJtQgy1dPqTBD12U+XrYLrRHn\
+                            lKmxoozlhFqJl456+9hlHCL+yq+6ScFuBHtJepnY1l2bdLb4T0JMDkNsNErkiLiLnD6yp3J\
+                            DSjIhkdHxmup/huygrmroq6/L5TaThEoqvW4DPIuO14btKudsS34FF82pwjKS4p6Mlch+0e\
+                            fHAblQV",
+            "sender_claimed_keys":{},
+            "forwarding_curve25519_key_chain":[]
+        });
+
+        serde_json::from_value(json)
+            .expect("We should be able to deserialize our exported room key")
+    }
+
+    async fn backup_disabling_test_body(
+        client: &Client,
+        server: &MockServer,
+        put_response: ResponseTemplate,
+    ) {
+        let _post_scope = Mock::given(method("POST"))
+            .and(path("_matrix/client/unstable/room_keys/version"))
+            .and(header("authorization", "Bearer 1234"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+              "version": "1"
+            })))
+            .expect(1)
+            .named("POST for the backup creation")
+            .mount_as_scoped(server)
+            .await;
+
+        let _put_scope = Mock::given(method("PUT"))
+            .and(path("_matrix/client/unstable/room_keys/keys"))
+            .and(header("authorization", "Bearer 1234"))
+            .respond_with(put_response)
+            .expect(1)
+            .named("POST for the backup creation")
+            .mount_as_scoped(server)
+            .await;
+
+        client
+            .encryption()
+            .backups()
+            .create()
+            .await
+            .expect("We should be able to create a new backup");
+
+        assert_eq!(client.encryption().backups().state(), BackupState::Enabled);
+
+        client
+            .encryption()
+            .backups()
+            .backup_room_keys()
+            .await
+            .expect_err("Backups should be disabled");
+
+        assert_eq!(client.encryption().backups().state(), BackupState::Unknown);
+    }
+
+    #[async_test]
+    async fn backup_disabling_after_remote_deletion() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        {
+            let machine = client.olm_machine().await;
+            machine
+                .as_ref()
+                .unwrap()
+                .store()
+                .import_exported_room_keys(vec![room_key()], |_, _| {})
+                .await
+                .expect("We should be able to import a room key");
+        }
+
+        backup_disabling_test_body(
+            &client,
+            &server,
+            ResponseTemplate::new(404).set_body_json(json!({
+                "errcode": "M_NOT_FOUND",
+                "error": "Unknown backup version"
+            })),
+        )
+        .await;
+
+        backup_disabling_test_body(
+            &client,
+            &server,
+            ResponseTemplate::new(403).set_body_json(json!({
+                "current_version": "42",
+                "errcode": "M_WRONG_ROOM_KEYS_VERSION",
+                "error": "Wrong backup version."
+            })),
+        )
+        .await;
+
+        server.verify().await;
+    }
+
+    #[async_test]
+    async fn exists_on_server() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        {
+            let _scope = Mock::given(method("GET"))
+                .and(path("_matrix/client/r0/room_keys/version"))
+                .and(header("authorization", "Bearer 1234"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                    "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
+                    "auth_data": {
+                        "public_key": "abcdefg",
+                        "signatures": {},
+                    },
+                    "count": 42,
+                    "etag": "anopaquestring",
+                    "version": "1",
+                })))
+                .expect(1)
+                .mount_as_scoped(&server)
+                .await;
+
+            let exists = client
+                .encryption()
+                .backups()
+                .exists_on_server()
+                .await
+                .expect("We should be able to check if backups exist on the server");
+
+            assert!(exists, "We should deduce that a backup exist on the server");
+        }
+
+        {
+            let _scope = Mock::given(method("GET"))
+                .and(path("_matrix/client/r0/room_keys/version"))
+                .and(header("authorization", "Bearer 1234"))
+                .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+                    "errcode": "M_NOT_FOUND",
+                    "error": "No current backup version"
+                })))
+                .expect(1)
+                .mount_as_scoped(&server)
+                .await;
+
+            let exists = client
+                .encryption()
+                .backups()
+                .exists_on_server()
+                .await
+                .expect("We should be able to check if backups exist on the server");
+
+            assert!(!exists, "We should deduce that no backup exist on the server");
+        }
+
+        {
+            let _scope = Mock::given(method("GET"))
+                .and(path("_matrix/client/r0/room_keys/version"))
+                .and(header("authorization", "Bearer 1234"))
+                .respond_with(ResponseTemplate::new(429).set_body_json(json!({
+                    "errcode": "M_LIMIT_EXCEEDED",
+                    "error": "Too many requests",
+                    "retry_after_ms": 2000
+                })))
+                .expect(1)
+                .mount_as_scoped(&server)
+                .await;
+
+            client.encryption().backups().exists_on_server().await.expect_err(
+                "If the /version endpoint returns a non 404 error we should throw an error",
+            );
+        }
+
+        {
+            let _scope = Mock::given(method("GET"))
+                .and(path("_matrix/client/r0/room_keys/version"))
+                .and(header("authorization", "Bearer 1234"))
+                .respond_with(ResponseTemplate::new(404))
+                .expect(1)
+                .mount_as_scoped(&server)
+                .await;
+
+            client.encryption().backups().exists_on_server().await.expect_err(
+                "If the /version endpoint returns a non-Matrix 404 error we should throw an error",
+            );
+        }
+
+        server.verify().await;
+    }
+
+    #[async_test]
+    async fn waiting_for_steady_state_resets_the_delay() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("POST"))
+            .and(path("_matrix/client/unstable/room_keys/version"))
+            .and(header("authorization", "Bearer 1234"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+              "version": "1"
+            })))
+            .expect(1)
+            .named("POST for the backup creation")
+            .mount(&server)
+            .await;
+
+        client
+            .encryption()
+            .backups()
+            .create()
+            .await
+            .expect("We should be able to create a new backup");
+
+        let backups = client.encryption().backups();
+
+        let old_duration = { client.inner.backup_state.upload_delay.read().unwrap().to_owned() };
+
+        let wait_for_steady_state =
+            backups.wait_for_steady_state().with_delay(Duration::from_nanos(100));
+
+        let mut progress_stream = wait_for_steady_state.subscribe_to_progress();
+
+        let task = matrix_sdk_common::executor::spawn({
+            let client = client.to_owned();
+            async move {
+                while let Some(state) = progress_stream.next().await {
+                    let Ok(state) = state else {
+                        panic!("Error while waiting for the upload state")
+                    };
+
+                    match state {
+                        UploadState::Idle => (),
+                        UploadState::CheckingIfUploadNeeded(_) => (),
+                        UploadState::Done => {
+                            let current_delay = {
+                                client.inner.backup_state.upload_delay.read().unwrap().to_owned()
+                            };
+
+                            assert_ne!(current_delay, old_duration);
+                            break;
+                        }
+                        _ => panic!("We should not have entered any other state"),
+                    }
+                }
+            }
+        });
+
+        wait_for_steady_state.await.expect("We should be able to wait for the steady state");
+        task.await.unwrap();
+
+        let current_duration =
+            { client.inner.backup_state.upload_delay.read().unwrap().to_owned() };
+
+        assert_eq!(old_duration, current_duration);
+
+        server.verify().await;
+    }
+}

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -154,7 +154,7 @@ impl Backups {
         let result = future.await;
 
         if result.is_err() {
-            self.set_state(BackupState::Unknown)
+            self.set_state(BackupState::Unknown);
         }
 
         result
@@ -865,8 +865,8 @@ impl Backups {
     pub(crate) fn maybe_trigger_backup(&self) {
         let tasks = self.client.inner.tasks.lock().unwrap();
 
-        if let Some(tasks) = tasks.as_ref() {
-            tasks.upload_room_keys.trigger_upload();
+        if let Some(tasks) = tasks.upload_room_keys.as_ref() {
+            tasks.trigger_upload();
         }
     }
 

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -602,14 +602,6 @@ impl Backups {
         let olm_machine = self.client.olm_machine().await;
         let olm_machine = olm_machine.as_ref().ok_or(Error::NoOlmMachine)?;
 
-        let old_counts = olm_machine.backup_machine().room_key_counts().await?;
-
-        self.client
-            .inner
-            .backup_state
-            .upload_progress
-            .set(UploadState::CheckingIfUploadNeeded(old_counts));
-
         while let Some((request_id, request)) = olm_machine.backup_machine().backup().await? {
             self.send_backup_request(olm_machine, &request_id, request).await?;
         }
@@ -1136,7 +1128,6 @@ mod test {
 
                     match state {
                         UploadState::Idle => (),
-                        UploadState::CheckingIfUploadNeeded(_) => (),
                         UploadState::Done => {
                             let current_delay = {
                                 client.inner.backup_state.upload_delay.read().unwrap().to_owned()

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -863,7 +863,11 @@ impl Backups {
     /// Send a notification to the task which is responsible to upload room keys
     /// to the backup that it might have new room keys to back up.
     pub(crate) fn maybe_trigger_backup(&self) {
-        // TODO: Wake a background task up to upload room keys
+        let tasks = self.client.inner.tasks.lock().unwrap();
+
+        if let Some(tasks) = tasks.as_ref() {
+            tasks.upload_room_keys.trigger_upload();
+        }
     }
 
     /// Disable our backups locally if we notice that the backup has been

--- a/crates/matrix-sdk/src/encryption/backups/types.rs
+++ b/crates/matrix-sdk/src/encryption/backups/types.rs
@@ -1,0 +1,127 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use matrix_sdk_base::crypto::{store::RoomKeyCounts, RoomKeyImportResult};
+use tokio::sync::broadcast;
+
+use crate::utils::ChannelObservable;
+#[cfg(doc)]
+use crate::{
+    encryption::{backups::Backups, secret_storage::SecretStore},
+    Client,
+};
+
+/// The states the upload task can be in.
+///
+/// You can listen on the state of the upload task using the
+/// [`Backups::wait_for_steady_state()`] method.
+///
+/// [`Backups::wait_for_steady_state()`]: crate::encryption::backups::Backups::wait_for_steady_state
+#[derive(Clone, Debug)]
+pub enum UploadState {
+    /// The task is iddle, waiting for new room keys to arrive to try to upload
+    /// them.
+    Idle,
+    /// The task has awoken and is checking if new room keys need to be
+    /// uploaded.
+    CheckingIfUploadNeeded(RoomKeyCounts),
+    /// The task is currently uploading room keys to the homeserver.
+    Uploading(RoomKeyCounts),
+    /// There was an error while trying to upload room keys, the task will go
+    /// back to the `Idle` state and try again later.
+    Error,
+    /// All room keys have been successfully uploaded, the task will now go back
+    /// to the `Idle` state.
+    Done,
+}
+
+pub(crate) struct BackupClientState {
+    pub(super) upload_delay: Arc<RwLock<Duration>>,
+    pub(crate) upload_progress: ChannelObservable<UploadState>,
+    pub(super) global_state: ChannelObservable<BackupState>,
+    pub(super) room_keys_broadcaster: broadcast::Sender<RoomKeyImportResult>,
+}
+
+const DEFAULT_BACKUP_UPLOAD_DELAY: Duration = Duration::from_millis(100);
+
+impl Default for BackupClientState {
+    fn default() -> Self {
+        Self {
+            upload_delay: RwLock::new(DEFAULT_BACKUP_UPLOAD_DELAY).into(),
+            upload_progress: ChannelObservable::new(UploadState::Idle),
+            global_state: Default::default(),
+            room_keys_broadcaster: broadcast::Sender::new(100),
+        }
+    }
+}
+
+/// The states the backup support for the current [`Client`] can be in.
+///
+/// Backups can be either enabled automatically if we receive a valid backup
+/// recovery key[[1]] or the [`Client`] can create a new backup themselves.
+///
+/// The [`Client`] can also delete and disable a currently active backup.
+///
+/// Backups will be enabled automatically if we receive the backup recovery key
+/// either from:
+///
+/// * Another device using `m.secret.send`[[2]], this usually happens after
+///   interactive
+/// verification has been done.
+/// * Secret storage[[3]], this can be done with the
+///   [`SecretStore::import_secrets()`] method.
+///
+/// [1]: https://spec.matrix.org/v1.8/client-server-api/#recovery-key
+/// [2]: https://spec.matrix.org/v1.8/client-server-api/#sharing
+/// [3]: https://spec.matrix.org/v1.8/client-server-api/#secret-storage
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BackupState {
+    /// Backups are not active locally and we don't know if they exist on the
+    /// server.
+    ///
+    /// The reason why we don't know if a backup might exist is that we don't
+    /// get notified by the server about the creation or deletion of
+    /// backups. If we want to know the current state of things we need to poll
+    /// the server, this can be done with the
+    /// [`Backups::exists_on_server()`] method.
+    #[default]
+    Unknown,
+    /// A new backup is being created by this [`Client`], this state will be
+    /// entered if you call the [`Backups::create()`] method.
+    Creating,
+    /// An existing backup is being enabled to be used by this [`Client`]. We
+    /// will enter this state if we have received a backup recovery key.
+    Enabling,
+    /// An existing backup will be enabled to be used by this [`Client`] after
+    /// the client has been restored. This state happens every time a
+    /// [`Client`] is restored and we previously have enabled a backup.
+    Resuming,
+    /// Backups are enabled and room keys are actively being backed up.
+    Enabled,
+    /// Room keys are currently being downloaded. This state will only happen
+    /// after a `Enabling` state. The [`Client`] will attempt to download
+    /// all room keys from the backup before transitioning into the
+    /// `Enabled` state.
+    Downloading,
+    /// The backups are being disabled and deleted from the server. This state
+    /// will happen when you call the [`Backups::disable()`] method, after
+    /// backups have been disabled we're going to transition into the
+    /// `Unknown` state.
+    Disabling,
+}

--- a/crates/matrix-sdk/src/encryption/backups/types.rs
+++ b/crates/matrix-sdk/src/encryption/backups/types.rs
@@ -35,7 +35,7 @@ use crate::{
 /// [`Backups::wait_for_steady_state()`]: crate::encryption::backups::Backups::wait_for_steady_state
 #[derive(Clone, Debug)]
 pub enum UploadState {
-    /// The task is iddle, waiting for new room keys to arrive to try to upload
+    /// The task is idle, waiting for new room keys to arrive to try to upload
     /// them.
     Idle,
     /// The task has awoken and is checking if new room keys need to be
@@ -71,20 +71,19 @@ impl Default for BackupClientState {
     }
 }
 
-/// The states the backup support for the current [`Client`] can be in.
+/// The possible states of the [`Client`]'s room key backup mechanism.
 ///
-/// Backups can be either enabled automatically if we receive a valid backup
-/// recovery key[[1]] or the [`Client`] can create a new backup themselves.
+/// A local backup instance can be created either by receiving a valid backup
+/// recovery key [[1]] or by having the [`Client`] create a new backup itself.
 ///
 /// The [`Client`] can also delete and disable a currently active backup.
 ///
 /// Backups will be enabled automatically if we receive the backup recovery key
 /// either from:
 ///
-/// * Another device using `m.secret.send`[[2]], this usually happens after
-///   interactive
-/// verification has been done.
-/// * Secret storage[[3]], this can be done with the
+/// * Another device using `m.secret.send`[[2]], which usually happens after
+///   completing interactive verification.
+/// * Secret storage[[3]], which is done by calling the
 ///   [`SecretStore::import_secrets()`] method.
 ///
 /// [1]: https://spec.matrix.org/v1.8/client-server-api/#recovery-key
@@ -92,36 +91,34 @@ impl Default for BackupClientState {
 /// [3]: https://spec.matrix.org/v1.8/client-server-api/#secret-storage
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum BackupState {
-    /// Backups are not active locally and we don't know if they exist on the
-    /// server.
+    /// There is no locally active backup and we don't know whether there backup
+    /// exists on the server.
     ///
-    /// The reason why we don't know if a backup might exist is that we don't
-    /// get notified by the server about the creation or deletion of
-    /// backups. If we want to know the current state of things we need to poll
-    /// the server, this can be done with the
-    /// [`Backups::exists_on_server()`] method.
+    /// The reason we don't know whether a server-side backup exists is that we
+    /// don't get notified by the server about the creation and deletion of
+    /// backups. If we want to know the current state, we need to poll the
+    /// server, which is done using the [`Backups::exists_on_server()`] method.
     #[default]
     Unknown,
-    /// A new backup is being created by this [`Client`], this state will be
+    /// A new backup is being created by this [`Client`]. This state will be
     /// entered if you call the [`Backups::create()`] method.
     Creating,
-    /// An existing backup is being enabled to be used by this [`Client`]. We
+    /// An existing backup is being enabled for use by this [`Client`]. We
     /// will enter this state if we have received a backup recovery key.
     Enabling,
     /// An existing backup will be enabled to be used by this [`Client`] after
     /// the client has been restored. This state happens every time a
-    /// [`Client`] is restored and we previously have enabled a backup.
+    /// [`Client`] is restored after we'd previously enabled a backup.
     Resuming,
-    /// Backups are enabled and room keys are actively being backed up.
+    /// The backup is enabled and room keys are actively being backed up.
     Enabled,
     /// Room keys are currently being downloaded. This state will only happen
-    /// after a `Enabling` state. The [`Client`] will attempt to download
+    /// after an `Enabling` state. The [`Client`] will attempt to download
     /// all room keys from the backup before transitioning into the
     /// `Enabled` state.
     Downloading,
-    /// The backups are being disabled and deleted from the server. This state
-    /// will happen when you call the [`Backups::disable()`] method, after
-    /// backups have been disabled we're going to transition into the
-    /// `Unknown` state.
+    /// The backup is being disabled and deleted from the server. This state
+    /// will happen when you call the [`Backups::disable()`] method. After it
+    /// has been disabled, we're going to transition into the `Unknown` state.
     Disabling,
 }

--- a/crates/matrix-sdk/src/encryption/backups/types.rs
+++ b/crates/matrix-sdk/src/encryption/backups/types.rs
@@ -38,9 +38,6 @@ pub enum UploadState {
     /// The task is idle, waiting for new room keys to arrive to try to upload
     /// them.
     Idle,
-    /// The task has awoken and is checking if new room keys need to be
-    /// uploaded.
-    CheckingIfUploadNeeded(RoomKeyCounts),
     /// The task is currently uploading room keys to the homeserver.
     Uploading(RoomKeyCounts),
     /// There was an error while trying to upload room keys, the task will go

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -58,8 +58,10 @@ use tokio::sync::RwLockReadGuard;
 use tracing::{debug, instrument, trace, warn};
 
 use self::{
+    backups::Backups,
     futures::PrepareEncryptedFile,
     identities::{DeviceUpdates, IdentityUpdates},
+    secret_storage::SecretStorage,
 };
 use crate::{
     attachment::{AttachmentInfo, Thumbnail},
@@ -72,6 +74,7 @@ use crate::{
     Client, Error, Result, Room, TransmissionProgress,
 };
 
+pub mod backups;
 pub mod futures;
 pub mod identities;
 pub mod secret_storage;
@@ -87,7 +90,6 @@ pub use matrix_sdk_base::crypto::{
     SessionCreationError, SignatureError, VERSION,
 };
 
-use self::secret_storage::SecretStorage;
 pub use crate::error::RoomKeyImportError;
 
 /// Settings for end-to-end encryption features.
@@ -99,6 +101,18 @@ pub struct EncryptionSettings {
     /// This requires to login with a username and password, or that MSC3967 is
     /// enabled on the server, as of 2023-10-20.
     pub auto_enable_cross_signing: bool,
+
+    /// Automatically download all room keys from the backup when the backup
+    /// recovery key has been received. The backup recovery key can be received
+    /// in two ways:
+    ///
+    /// 1. Received as a `m.secret.send` to-device event, after a successful
+    ///    interactive verification.
+    /// 2. Imported from secret storage using the
+    ///    [`SecretStore::import_secrets()`] method.
+    ///
+    /// [`SecretStore::import_secrets()`]: crate::encryption::secret_storage::SecretStore::import_secrets
+    pub auto_download_from_backup: bool,
 }
 
 impl Client {
@@ -1054,12 +1068,21 @@ impl Encryption {
         let task = tokio::task::spawn_blocking(decrypt);
         let import = task.await.expect("Task join error")?;
 
-        Ok(olm.store().import_exported_room_keys(import, |_, _| {}).await?)
+        let ret = olm.store().import_exported_room_keys(import, |_, _| {}).await?;
+
+        self.backups().maybe_trigger_backup();
+
+        Ok(ret)
     }
 
     /// Get the secret storage manager of the client.
     pub fn secret_storage(&self) -> SecretStorage {
         SecretStorage { client: self.client.to_owned() }
+    }
+
+    /// Get the backups manager of the client.
+    pub fn backups(&self) -> Backups {
+        Backups { client: self.client.to_owned() }
     }
 
     /// Enables the crypto-store cross-process lock.

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -109,7 +109,7 @@ pub struct EncryptionSettings {
     ///
     /// 1. Received as a `m.secret.send` to-device event, after a successful
     ///    interactive verification.
-    /// 2. Imported from secret storage using the
+    /// 2. Imported from secret storage (4S) using the
     ///    [`SecretStore::import_secrets()`] method.
     ///
     /// [`SecretStore::import_secrets()`]: crate::encryption::secret_storage::SecretStore::import_secrets

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -826,7 +826,10 @@ impl MatrixAuth {
 
     async fn set_session(&self, session: MatrixSession) -> Result<()> {
         self.set_session_tokens(session.tokens);
-        self.client.base_client().set_session_meta(session.meta).await?;
+        self.client.set_session_meta(session.meta).await?;
+
+        #[cfg(feature = "e2e-encryption")]
+        self.client.encryption().run_initialization_tasks().await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -712,7 +712,7 @@ impl Oidc {
             authorization_data: Default::default(),
         };
 
-        self.client.base_client().set_session_meta(meta).await?;
+        self.client.set_session_meta(meta).await?;
         self.deferred_enable_cross_process_refresh_lock().await?;
 
         self.client
@@ -754,6 +754,9 @@ impl Oidc {
                 // sync with what we had.
             }
         }
+
+        #[cfg(feature = "e2e-encryption")]
+        self.client.encryption().run_initialization_tasks().await?;
 
         Ok(())
     }
@@ -911,7 +914,7 @@ impl Oidc {
             device_id: whoami_res.device_id.ok_or(OidcError::MissingDeviceId)?,
         };
 
-        self.client.base_client().set_session_meta(session).await.map_err(crate::Error::from)?;
+        self.client.set_session_meta(session).await.map_err(crate::Error::from)?;
         // At this point the Olm machine has been set up.
 
         // Enable the cross-process lock for refreshes, if needs be.
@@ -951,6 +954,9 @@ impl Oidc {
                     .map_err(|err| crate::Error::Oidc(err.into()))?;
             }
         }
+
+        #[cfg(feature = "e2e-encryption")]
+        self.client.encryption().run_initialization_tasks().await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/utils.rs
+++ b/crates/matrix-sdk/src/utils.rs
@@ -36,9 +36,9 @@ use crate::Room;
 
 /// An observable with channel semantics.
 ///
-/// This type allows you to have a shared mutable value where updates to the
-/// value will be send out to subscribers. Each update will be send to all the
-/// subscribers and intermediate updates to the value will not be skipped.
+/// Channel semantics means that each update to the shared mutable value will be
+/// sent out to subscribers. That is, intermediate updates to the value will not
+/// be skipped like they would be in an observable without channel semantics.
 #[cfg(feature = "e2e-encryption")]
 #[derive(Clone, Debug)]
 pub(crate) struct ChannelObservable<T: Clone + Send> {
@@ -63,8 +63,7 @@ impl<T: 'static + Send + Clone> ChannelObservable<T> {
         Self { value: RwLock::new(value).into(), channel }
     }
 
-    /// Subscribe to updates to the underlying data of the
-    /// [`ChannelObservable`].
+    /// Subscribe to updates to the observable value.
     ///
     /// The current value will always be emitted as the first item in the
     /// stream.

--- a/crates/matrix-sdk/tests/integration/encryption.rs
+++ b/crates/matrix-sdk/tests/integration/encryption.rs
@@ -1,2 +1,3 @@
+mod backups;
 mod secret_storage;
 mod verification;

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -1,0 +1,1149 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{fs::File, io::Write};
+
+use assert_matches::assert_matches;
+use futures_util::{pin_mut, StreamExt};
+use matrix_sdk::{
+    config::RequestConfig,
+    encryption::{
+        backups::{futures::SteadyStateError, BackupState, UploadState},
+        EncryptionSettings,
+    },
+    matrix_auth::{MatrixSession, MatrixSessionTokens},
+    Client,
+};
+use matrix_sdk_base::SessionMeta;
+use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder};
+use ruma::{
+    device_id, event_id, events::room::message::RoomMessageEvent, room_id, user_id, UserId,
+};
+use serde_json::json;
+use tempfile::tempdir;
+use tokio::spawn;
+use wiremock::{
+    matchers::{header, method, path},
+    Mock, ResponseTemplate,
+};
+
+use crate::{mock_sync, no_retry_test_client, test_client_builder};
+
+const ROOM_KEY: &[u8] = b"\
+        -----BEGIN MEGOLM SESSION DATA-----\n\
+        ASKcWoiAVUM97482UAi83Avce62hSLce7i5JhsqoF6xeAAAACqt2Cg3nyJPRWTTMXxXH7TXnkfdlmBXbQtq5\
+        bpHo3LRijcq2Gc6TXilESCmJN14pIsfKRJrWjZ0squ/XsoTFytuVLWwkNaW3QF6obeg2IoVtJXLMPdw3b2vO\
+        vgwGY3OMP0XafH13j1vcb6YLzvgLkZQLnYvd47hv3yK/9GmKS9tokuaQ7dCVYckYcIOS09EDTs70YdxUd5WG\
+        rQynATCLFP1p/NAGv70r9MK7Cy/mNpjD0r4qC7UEDIoi1kOWzHgnLo19wtvwsb8Fg8ATxcs3Wmtj8hIUYpDx\
+        ia4sM10zbytUuaPUAfCDf42IyxdmOnGe1CueXhgI71y+RW0s0argNqUt7jB70JT0o9CyX6UBGRaqLk2MPY9T\
+        hUu5J8X3UgIa6rcbWigzohzWm9rdbEHFrSWqjpfQYMaAKQQgETrjSy4XTrp2RhC2oNqG/hylI4ab+F4X6fpH\
+        DYP1NqNMP5g36xNu7LhDnrUB5qsPjYOmWORxGLfudpF3oLYCSlr3DgHqEIB6HjQblLZ3KQuPBse3zxyROTnS\
+        AhdPH4a/z1wioFtKNVph3hecsiKEdqnz4Y2coSIdhz58mJ9JWNQoFAENE5CSsoEZAGvafYZVpW4C75YY2zq1\
+        wIeiFi1dT43/jLAUGkslsi1VvnyfUu8qO404RxYO3XHoGLMFoFLOO+lZ+VGci2Vz10AhxJhEBHxRKxw4k2uB\
+        HztoSJUr/2Y\n\
+        -----END MEGOLM SESSION DATA-----";
+
+async fn mount_once(
+    server: &wiremock::MockServer,
+    method_argument: &str,
+    path_argument: &str,
+    response: ResponseTemplate,
+) {
+    Mock::given(method(method_argument))
+        .and(path(path_argument))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(response)
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+#[async_test]
+async fn create() {
+    let user_id = user_id!("@example:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+
+    let (client, server) = no_retry_test_client().await;
+
+    assert!(
+        !client.encryption().backups().are_enabled().await,
+        "Backups can't be enabled before we logged in"
+    );
+
+    client.restore_session(session).await.unwrap();
+
+    mount_once(
+        &server,
+        "POST",
+        "_matrix/client/unstable/room_keys/version",
+        ResponseTemplate::new(200).set_body_json(json!({ "version": "1"})),
+    )
+    .await;
+
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Unknown,
+        "We should initially be in the unknown state"
+    );
+
+    let mut states = client.encryption().backups().state_stream();
+
+    let task = spawn(async move {
+        let mut counter = 0;
+
+        while let Some(state) = states.next().await {
+            let Ok(state) = state else { panic!("Error while receiving backup state updates") };
+
+            match state {
+                BackupState::Unknown => {
+                    assert_eq!(counter, 0, "The initial state should be unknown");
+                    counter += 1;
+                }
+                BackupState::Creating => {
+                    assert_eq!(counter, 1, "The second state should be the creation state");
+                    counter += 1;
+                }
+                BackupState::Enabled => {
+                    assert_eq!(counter, 2, "The third and final state should be the enabled state");
+                    counter += 1;
+                    break;
+                }
+                state => {
+                    panic!("Received an invalid state for the creation of the backp {state:?}")
+                }
+            }
+        }
+
+        assert_eq!(counter, 3, "We should have gone through 3 states");
+    });
+
+    client.encryption().backups().create().await.expect("We should be able to create a new backup");
+
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Enabled,
+        "Backups should be enabled after the create call"
+    );
+
+    task.await.unwrap();
+
+    server.verify().await;
+}
+
+#[async_test]
+async fn creation_failure() {
+    let user_id = user_id!("@example:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (client, server) = no_retry_test_client().await;
+    client.restore_session(session).await.unwrap();
+
+    mount_once(
+        &server,
+        "POST",
+        "_matrix/client/unstable/room_keys/version",
+        ResponseTemplate::new(200).set_body_json(json!({
+            "errcode": "M_LIMIT_EXCEEDED",
+            "error": "Too many requests",
+            "retry_after_ms": 2000
+        })),
+    )
+    .await;
+
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Unknown,
+        "We should initially be in the unknown state"
+    );
+
+    let states = client.encryption().backups().state_stream();
+
+    let task = spawn(async move {
+        pin_mut!(states);
+
+        let mut counter = 0;
+        let mut unknown_counter = 0;
+
+        while let Some(state) = states.next().await {
+            let Ok(state) = state else { panic!("Error while receiving backup state updates") };
+
+            match state {
+                BackupState::Creating => {
+                    assert_eq!(counter, 1, "The second state should be the creation state");
+                    counter += 1;
+                }
+                BackupState::Unknown => {
+                    counter += 1;
+                    unknown_counter += 1;
+
+                    if counter == 3 {
+                        break;
+                    };
+                }
+                state => {
+                    panic!("Received an invalid state for the creation of the backp {state:?}")
+                }
+            }
+        }
+
+        assert_eq!(unknown_counter, 2, "We should have gone through 2 Unknown states");
+        assert_eq!(counter, 3, "We should have gone through 3 states");
+    });
+
+    client
+        .encryption()
+        .backups()
+        .create()
+        .await
+        .expect_err("Creating a new backup should have failed");
+
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Unknown,
+        "Backups should not be enabled since the creation step failed"
+    );
+
+    task.await.unwrap();
+
+    server.verify().await;
+}
+
+#[async_test]
+async fn disabling() {
+    let user_id = user_id!("@example:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (client, server) = no_retry_test_client().await;
+    client.restore_session(session).await.unwrap();
+
+    mount_once(
+        &server,
+        "POST",
+        "_matrix/client/unstable/room_keys/version",
+        ResponseTemplate::new(200).set_body_json(json!({ "version": "1"})),
+    )
+    .await;
+
+    mount_once(
+        &server,
+        "DELETE",
+        "_matrix/client/r0/room_keys/version/1",
+        ResponseTemplate::new(200).set_body_json(json!({})),
+    )
+    .await;
+
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Unknown,
+        "We should initially be in the unknown state"
+    );
+
+    client.encryption().backups().create().await.expect("We should be able to create a new backup");
+
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Enabled,
+        "Backups should be enabled after they were created"
+    );
+
+    let states = client.encryption().backups().state_stream();
+
+    client.encryption().backups().disable().await.expect("We should be able to disable our backup");
+
+    let task = spawn(async move {
+        pin_mut!(states);
+
+        let mut counter = 0;
+
+        while let Some(state) = states.next().await {
+            let Ok(state) = state else { panic!("Error while receiving backup state updates") };
+
+            match state {
+                BackupState::Enabled => {
+                    assert_eq!(counter, 0, "The initial state should be the enabled state");
+                    counter += 1;
+                }
+                BackupState::Disabling => {
+                    assert_eq!(counter, 1, "The second state should be the disabling state");
+                    counter += 1;
+                }
+                BackupState::Unknown => {
+                    assert_eq!(counter, 2, "The final state should be the disabled state");
+                    counter += 1;
+                    break;
+                }
+                state => {
+                    panic!("Received an invalid state for the creation of the backp {state:?}")
+                }
+            }
+        }
+
+        assert_eq!(counter, 3, "We should have gone through 3 states");
+    });
+
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Unknown,
+        "Backups should be in the unknown state."
+    );
+
+    task.await.unwrap();
+
+    server.verify().await;
+}
+
+#[async_test]
+#[cfg(feature = "sqlite")]
+async fn backup_resumption() {
+    use tempfile::tempdir;
+
+    let dir = tempdir().unwrap();
+
+    let user_id = user_id!("@example:morpheus.localhost");
+
+    let (builder, server) = test_client_builder().await;
+    let client = builder
+        .request_config(RequestConfig::new().disable_retry())
+        .sqlite_store(dir.path(), None)
+        .build()
+        .await
+        .unwrap();
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+
+    Mock::given(method("POST"))
+        .and(path("_matrix/client/unstable/room_keys/version"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "version": "1" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client.restore_session(session.to_owned()).await.unwrap();
+
+    client.encryption().backups().create().await.expect("We should be able to create a new backup");
+
+    assert_eq!(client.encryption().backups().state(), BackupState::Enabled);
+    assert!(client.encryption().backups().are_enabled().await);
+
+    drop(client);
+
+    let builder = matrix_sdk::Client::builder()
+        .homeserver_url(server.uri())
+        .server_versions([ruma::api::MatrixVersion::V1_0]);
+
+    let client = builder
+        .request_config(RequestConfig::new().disable_retry())
+        .sqlite_store(dir.path(), None)
+        .build()
+        .await
+        .unwrap();
+
+    client.restore_session(session).await.unwrap();
+    client.encryption().wait_for_e2ee_initialization_tasks().await;
+
+    assert_eq!(client.encryption().backups().state(), BackupState::Enabled);
+    assert!(client.encryption().backups().are_enabled().await);
+}
+
+async fn setup_backups(client: &Client, server: &wiremock::MockServer) {
+    let dir = tempdir().unwrap();
+    let mut room_key_path = dir.path().to_owned();
+    room_key_path.push("room_key.txt");
+
+    {
+        let mut file =
+            File::create(&room_key_path).expect("We should be able to create a temporary file");
+        file.write_all(ROOM_KEY).unwrap();
+    }
+
+    client.encryption().import_room_keys(room_key_path, "1234").await.unwrap();
+
+    mount_once(
+        server,
+        "POST",
+        "_matrix/client/unstable/room_keys/version",
+        ResponseTemplate::new(200).set_body_json(json!({ "version": "1"})),
+    )
+    .await;
+
+    let backups = client.encryption().backups();
+
+    assert_eq!(
+        backups.state(),
+        BackupState::Unknown,
+        "We should initially be in the unknown state"
+    );
+
+    backups.create().await.expect("We should be able to create a new backup");
+
+    assert_eq!(
+        backups.state(),
+        BackupState::Enabled,
+        "Backups should be enabled after the create call"
+    );
+}
+
+#[async_test]
+async fn steady_state_waiting() {
+    let user_id = user_id!("@example:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (client, server) = no_retry_test_client().await;
+    client.restore_session(session).await.unwrap();
+
+    setup_backups(&client, &server).await;
+
+    mount_once(
+        &server,
+        "PUT",
+        "_matrix/client/unstable/room_keys/keys",
+        ResponseTemplate::new(200).set_body_json(json!({
+            "count": 1,
+            "etag": "abcdefg",
+        }
+        )),
+    )
+    .await;
+
+    let backups = client.encryption().backups();
+
+    let wait_for_steady_state = backups.wait_for_steady_state();
+
+    let mut progress_stream = wait_for_steady_state.subscribe_to_progress();
+
+    wait_for_steady_state
+        .await
+        .expect("The waiting for the steady state should return successfully");
+
+    let task = spawn(async move {
+        let mut counter = 0;
+
+        while let Some(state) = progress_stream.next().await {
+            let Ok(state) = state else { panic!("Error while waiting for the upload state") };
+
+            match state {
+                UploadState::Idle => {
+                    assert_eq!(counter, 0, "The initial state should be the idle state");
+                    counter += 1;
+                }
+                UploadState::CheckingIfUploadNeeded(counts) => {
+                    assert_eq!(counter, 1, "The second state should be the checking if state");
+                    assert_eq!(counts.total, 1, "We should have one room key in total");
+                    assert_eq!(counts.backed_up, 0, "No room key should be yet backed up.");
+                    counter += 1;
+                }
+                UploadState::Uploading(counts) => {
+                    assert_eq!(counter, 2, "The third state should be the upload state");
+                    assert_eq!(counts.total, 1, "We should have one room key in total");
+                    assert_eq!(counts.backed_up, 1, "All room keys should be uploaded");
+                    counter += 1;
+                }
+                UploadState::Done => {
+                    assert_eq!(counter, 3, "The final state should be the Done state");
+                    break;
+                }
+                UploadState::Error => panic!("We should not have entered the error state"),
+            }
+        }
+
+        assert_eq!(counter, 3, "We should have gone through 4 states, counter: {counter}");
+    });
+
+    task.await.unwrap();
+
+    server.verify().await;
+}
+
+#[async_test]
+async fn steady_state_waiting_errors() {
+    let user_id = user_id!("@example:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (client, server) = no_retry_test_client().await;
+    client.restore_session(session).await.unwrap();
+
+    let result = client.encryption().backups().wait_for_steady_state().await;
+
+    assert_matches!(
+        result,
+        Err(SteadyStateError::BackupDisabled),
+        "The steady state method should tell us that the backup is not yet enabled"
+    );
+
+    setup_backups(&client, &server).await;
+    let backups = client.encryption().backups();
+
+    let result = backups.wait_for_steady_state().await;
+
+    assert_matches!(
+        result,
+        Err(SteadyStateError::Connection),
+        "The steady state method should tell us that it couldn't reach the homeserver"
+    );
+
+    mount_once(
+        &server,
+        "PUT",
+        "_matrix/client/unstable/room_keys/keys",
+        ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "No current backup version"
+        })),
+    )
+    .await;
+
+    let wait_for_steady_state = backups.wait_for_steady_state();
+    let mut progress_stream = wait_for_steady_state.subscribe_to_progress();
+
+    let task = spawn(async move {
+        let mut counter = 0;
+
+        while let Some(state) = progress_stream.next().await {
+            let Ok(state) = state else { panic!("Error while waiting for the upload state") };
+
+            match state {
+                UploadState::Idle => {
+                    assert_eq!(counter, 0, "The initial state should be the idle state");
+                    counter += 1;
+                }
+                UploadState::CheckingIfUploadNeeded(counts) => {
+                    assert_eq!(counter, 1, "The second state should be the checking if state");
+                    assert_eq!(counts.total, 1, "We should have one room key in total");
+                    assert_eq!(counts.backed_up, 0, "No room key should be yet backed up.");
+                    counter += 1;
+                }
+                UploadState::Error => {
+                    assert_eq!(counter, 2, "The third state should be the error state");
+                    counter += 1;
+                    break;
+                }
+                _ => panic!("We should not have entered any other state"),
+            }
+        }
+
+        assert_eq!(counter, 3, "We should have gone through 3 states, counter: {counter}");
+    });
+
+    let result = wait_for_steady_state.await;
+
+    assert_matches!(
+        result,
+        Err(SteadyStateError::BackupDisabled),
+        "The steady state method should tell us that the backup is deleted"
+    );
+
+    task.await.unwrap();
+}
+
+async fn mock_secret_store_with_backup_key(
+    user_id: &UserId,
+    key_id: &str,
+    server: &wiremock::MockServer,
+) {
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "_matrix/client/r0/user/{user_id}/account_data/m.secret_storage.default_key"
+        )))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "key": key_id,
+        })))
+        .expect(1..)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "_matrix/client/r0/user/{user_id}/account_data/m.secret_storage.key.{key_id}"
+        )))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
+            "iv": "1Sl4os6UhNRkVQcT6ArQ0g",
+            "mac": "UCZlTzqVT7mNvLkwlcCJmuq9nA27oxqpXGdLr9SxD/Y",
+            "name": null,
+            "passphrase": {
+                "algorithm": "m.pbkdf2",
+                "iterations": 1,
+                "salt": "ooLiz7Kz0TeWH2eYcyjP2fCegEB7PH5B"
+            }
+        })))
+        .expect(1..)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("_matrix/client/r0/user/{user_id}/account_data/m.cross_signing.master")))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "Account data not found"
+        })))
+        .expect(1..)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "_matrix/client/r0/user/{user_id}/account_data/m.cross_signing.user_signing"
+        )))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "Account data not found"
+        })))
+        .expect(1..)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "_matrix/client/r0/user/{user_id}/account_data/m.cross_signing.self_signing"
+        )))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "Account data not found"
+        })))
+        .expect(1..)
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("_matrix/client/r0/keys/query"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "device_keys": {}
+        })))
+        .expect(1..)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("_matrix/client/r0/user/{user_id}/account_data/m.megolm_backup.v1")))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "encrypted": {
+                "yJWwBm2Ts8jHygTBslKpABFyykavhhfA": {
+                    "ciphertext": "c39B25f6GSvW7gCUZI1OC0V821Ht2WUfxPWB43rvFSsubouHf16ImqLrwQ",
+                    "iv": "hpyoGAElX8YRuigbqa7tfA",
+                    "mac": "nE/RCVmFQxu+KuqxmYDDzIxf2JUlxz2oTpoJTj5pUxM"
+                }
+            }
+        })))
+        .expect(1..)
+        .mount(server)
+        .await;
+}
+
+#[async_test]
+async fn enable_from_secret_storage() {
+    const SECRET_STORE_KEY: &str = "mypassphrase";
+    const KEY_ID: &str = "yJWwBm2Ts8jHygTBslKpABFyykavhhfA";
+
+    let user_id = user_id!("@example2:morpheus.localhost");
+    let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
+    let event_id = event_id!("$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (builder, server) = test_client_builder().await;
+    let encryption_settings =
+        EncryptionSettings { auto_download_from_backup: true, ..Default::default() };
+    let client = builder
+        .request_config(RequestConfig::new().disable_retry())
+        .with_encryption_settings(encryption_settings)
+        .build()
+        .await
+        .unwrap();
+
+    client.restore_session(session).await.unwrap();
+
+    mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
+
+    let sync = SyncResponseBuilder::new()
+        .add_joined_room(JoinedRoomBuilder::new(room_id))
+        .build_json_sync_response();
+    mock_sync(&server, sync, None).await;
+
+    client.sync_once(Default::default()).await.expect("We should be able to sync with the server");
+
+    Mock::given(method("GET"))
+        .and(path("_matrix/client/r0/rooms/!DovneieKSTkdHKpIXy:morpheus.localhost/event/$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content": {
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "ciphertext": "AwgAEpABhetEzzZzyYrxtEVUtlJnZtJcURBlQUQJ9irVeklCTs06LwgTMQj61PMUS4Vy\
+                               YOX+PD67+hhU40/8olOww+Ud0m2afjMjC3wFX+4fFfSkoWPVHEmRVucfcdSF1RSB4EmK\
+                               PIP4eo1X6x8kCIMewBvxl2sI9j4VNvDvAN7M3zkLJfFLOFHbBviI4FN7hSFHFeM739Zg\
+                               iwxEs3hIkUXEiAfrobzaMEM/zY7SDrTdyffZndgJo7CZOVhoV6vuaOhmAy4X2t4UnbuV\
+                               JGJjKfV57NAhp8W+9oT7ugwO",
+                "device_id": "KIUVQQSDTM",
+                "sender_key": "LvryVyoCjdONdBCi2vvoSbI34yTOx7YrCFACUEKoXnc",
+                "session_id": "64H7XKokIx0ASkYDHZKlT5zd/Zccz/cQspPNdvnNULA"
+            },
+            "event_id": "$JbFHtZpEJiH8uaajZjPLz0QUZc1xtBR9rPGBOjF6WFM",
+            "origin_server_ts": 1698579035927u64,
+            "sender": "@example2:morpheus.localhost",
+            "type": "m.room.encrypted",
+            "unsigned": {
+                "age": 14393491
+            }
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let room = client.get_room(room_id).expect("We should have access to the room after the sync");
+    let event = room.event(event_id).await.expect("We should be able to fetch our encrypted event");
+
+    assert_matches!(
+        event.encryption_info,
+        None,
+        "We should not be able to decrypt our encrypted event before we import the room keys from \
+         the backup"
+    );
+
+    let secret_storage = client.encryption().secret_storage();
+
+    let store = secret_storage
+        .open_secret_store(SECRET_STORE_KEY)
+        .await
+        .expect("We should be able to open our secret store");
+
+    Mock::given(method("GET"))
+        .and(path("_matrix/client/r0/room_keys/version"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
+            "auth_data": {
+                "public_key": "hdx5rSn94rBuvJI5cwnhKAVmFyZgfJjk7vwEBD6mIHc",
+                "signatures": {}
+            },
+            "count": 1,
+            "etag": "1",
+            "version": "6"
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("_matrix/client/r0/room_keys/keys"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "rooms": {
+                room_id: {
+                    "sessions": {
+                        "64H7XKokIx0ASkYDHZKlT5zd/Zccz/cQspPNdvnNULA": {
+                            "first_message_index": 0,
+                            "forwarded_count": 0,
+                            "is_verified": true,
+                            "session_data": {
+                                "ciphertext": "UaxxJxPZN5jqhSoFw59s83KlK0k77KJRxowPUC3P2/bS+TIBXw2y\
+                                               qMHCpv01s+8mE95XU6RZO2/elktHiW1/mzx/2vqb4pFuARtj3rxF\
+                                               zCBO7cpVhmrSU6uKW9KH2HirZMZzyXLqr3v6xoOTe5roIF5scPR0\
+                                               cWxPcS/4+BZz4xGhGCVuTPFjWDszY1/iz4JAVosAF7XZLGh7aVhF\
+                                               +ciDDoaaqwkD2nnMUlGEl2uchWuZv7v2q9Pmmd+qzRCdLx5c+GK3\
+                                               OyT8qCSxubOvuSruwTliBl++drlMnh4vRO8UKPTuMNvEN89YKiSC\
+                                               MVzXVDCS6tnjligxUENYkyUqYCKdASLDFs1cCXJDED16oQGonkU8\
+                                               Lf7ccGg6XboJCmJfobrmDc3s/9IymtKaxquA2Vw2pW8Otoy4x9PK\
+                                               17xHLo2nT2nf3Amp6xaCYx+tblGkLIqw8H3YZZVPVuKAVpPdAhgC\
+                                               +aJA9n8qow3BLcCJSdGRMSV9MquidGgbEA/DCd6Eq3jokshcXR4v\
+                                               Ma5nT4CokeZ6OdAtMWgZSaGltyNNoc+b6hk6AqcYaoMslG58DC32\
+                                               EVSiFFwtSpKx7I6+J+hlV813Vx6IK0DoqTcYyVm4kFMvKnIoyAKJ\
+                                               yoCSik4NQpL7DcokDhs56UJ1LcDgQTnGLqhH2Q",
+                                "ephemeral": "+KmnQw7ECkCD+s2Hc0hhntT8n9zTLJvFHgX7g3XKBjs",
+                                "mac": "xdzih3IkRv4"
+                            }
+                        }
+                    }
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let room_key_stream = client.encryption().backups().room_keys_for_room_stream(room_id);
+
+    let task = spawn(async move {
+        pin_mut!(room_key_stream);
+
+        if let Some(Ok(room_keys)) = room_key_stream.next().await {
+            let (_, room_key_set) = room_keys.first_key_value().unwrap();
+            assert!(room_key_set.contains("64H7XKokIx0ASkYDHZKlT5zd/Zccz/cQspPNdvnNULA"));
+        } else {
+            panic!("Failed to get an update about room keys being imported from the backup")
+        }
+    });
+
+    store
+        .import_secrets()
+        .await
+        .expect("We should be able to import our secrets from the secret store");
+
+    task.await.unwrap();
+
+    let event = room.event(event_id).await.expect("We should be able to fetch our encrypted event");
+
+    assert_matches!(event.encryption_info, Some(..), "The event should now be decrypted");
+    let event: RoomMessageEvent =
+        event.event.deserialize_as().expect("We should be able to deserialize the event");
+    let event = event.as_original().unwrap();
+    assert_eq!(event.content.body(), "tt");
+
+    assert_eq!(client.encryption().backups().state(), BackupState::Enabled);
+
+    store
+        .import_secrets()
+        .await
+        .expect("We should be able to import our secrets from the secret store");
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Enabled,
+        "Importing the secrets again should leave the backups in the enabled state."
+    );
+}
+
+#[async_test]
+async fn enable_from_secret_storage_no_existing_backup() {
+    const SECRET_STORE_KEY: &str = "mypassphrase";
+    const KEY_ID: &str = "yJWwBm2Ts8jHygTBslKpABFyykavhhfA";
+    let user_id = user_id!("@example2:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (builder, server) = test_client_builder().await;
+    let encryption_settings =
+        EncryptionSettings { auto_download_from_backup: true, ..Default::default() };
+    let client = builder
+        .request_config(RequestConfig::new().disable_retry())
+        .with_encryption_settings(encryption_settings)
+        .build()
+        .await
+        .unwrap();
+
+    client.restore_session(session).await.unwrap();
+
+    mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
+
+    let secret_storage = client.encryption().secret_storage();
+
+    let store = secret_storage
+        .open_secret_store(SECRET_STORE_KEY)
+        .await
+        .expect("We should be able to open our secret store");
+
+    store.import_secrets().await.expect_err(
+        "We should return an error if we couldn't fetch the backup version from the server",
+    );
+    assert_eq!(client.encryption().backups().state(), BackupState::Unknown);
+
+    Mock::given(method("GET"))
+        .and(path("_matrix/client/r0/room_keys/version"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "No current backup version"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    store.import_secrets().await.unwrap();
+    assert_eq!(client.encryption().backups().state(), BackupState::Unknown);
+}
+
+#[async_test]
+async fn enable_from_secret_storage_mismatched_key() {
+    const SECRET_STORE_KEY: &str = "mypassphrase";
+    const KEY_ID: &str = "yJWwBm2Ts8jHygTBslKpABFyykavhhfA";
+    let user_id = user_id!("@example2:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (builder, server) = test_client_builder().await;
+    let encryption_settings =
+        EncryptionSettings { auto_download_from_backup: true, ..Default::default() };
+    let client = builder
+        .request_config(RequestConfig::new().disable_retry())
+        .with_encryption_settings(encryption_settings)
+        .build()
+        .await
+        .unwrap();
+
+    client.restore_session(session).await.unwrap();
+
+    mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
+
+    let secret_storage = client.encryption().secret_storage();
+
+    let store = secret_storage
+        .open_secret_store(SECRET_STORE_KEY)
+        .await
+        .expect("We should be able to open our secret store");
+
+    Mock::given(method("GET"))
+        .and(path("_matrix/client/r0/room_keys/version"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
+            "auth_data": {
+                "public_key": "SISFU86lzyzyS0RpkVZRDot/TScaShnbILRYfw1uVSk",
+                "signatures": {}
+            },
+            "count": 1,
+            "etag": "1",
+            "version": "6"
+
+
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    store.import_secrets().await.unwrap();
+    assert_eq!(
+        client.encryption().backups().state(),
+        BackupState::Unknown,
+        "The backup should go into the disabled state if we the current backup isn't using the \
+         backup recovery key we received from secret storage"
+    );
+}
+
+#[async_test]
+async fn enable_from_secret_storage_manual_download() {
+    const SECRET_STORE_KEY: &str = "mypassphrase";
+    const KEY_ID: &str = "yJWwBm2Ts8jHygTBslKpABFyykavhhfA";
+    let user_id = user_id!("@example2:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (builder, server) = test_client_builder().await;
+    let client =
+        builder.request_config(RequestConfig::new().disable_retry()).build().await.unwrap();
+
+    client.restore_session(session).await.unwrap();
+
+    mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
+
+    let secret_storage = client.encryption().secret_storage();
+
+    let store = secret_storage
+        .open_secret_store(SECRET_STORE_KEY)
+        .await
+        .expect("We should be able to open our secret store");
+
+    Mock::given(method("GET"))
+        .and(path("_matrix/client/r0/room_keys/version"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "No current backup version"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    store.import_secrets().await.unwrap();
+    assert_eq!(client.encryption().backups().state(), BackupState::Unknown);
+}
+
+#[async_test]
+async fn enable_from_secret_storage_and_manual_download() {
+    const SECRET_STORE_KEY: &str = "mypassphrase";
+    const KEY_ID: &str = "yJWwBm2Ts8jHygTBslKpABFyykavhhfA";
+
+    let user_id = user_id!("@example2:morpheus.localhost");
+    let room_id = room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+    let (builder, server) = test_client_builder().await;
+    let encryption_settings =
+        EncryptionSettings { auto_download_from_backup: true, ..Default::default() };
+    let client = builder
+        .request_config(RequestConfig::new().disable_retry())
+        .with_encryption_settings(encryption_settings)
+        .build()
+        .await
+        .unwrap();
+
+    client.restore_session(session).await.unwrap();
+
+    mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
+
+    let secret_storage = client.encryption().secret_storage();
+
+    let store = secret_storage
+        .open_secret_store(SECRET_STORE_KEY)
+        .await
+        .expect("We should be able to open our secret store");
+
+    Mock::given(method("GET"))
+        .and(path("_matrix/client/r0/room_keys/version"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "algorithm": "m.megolm_backup.v1.curve25519-aes-sha2",
+            "auth_data": {
+                "public_key": "hdx5rSn94rBuvJI5cwnhKAVmFyZgfJjk7vwEBD6mIHc",
+                "signatures": {}
+            },
+            "count": 1,
+            "etag": "1",
+            "version": "6"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    store.import_secrets().await.unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/r0/room_keys/keys/!DovneieKSTkdHKpIXy:morpheus.localhost"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sessions": {
+                "64H7XKokIx0ASkYDHZKlT5zd/Zccz/cQspPNdvnNULA": {
+                    "first_message_index": 0,
+                    "forwarded_count": 0,
+                    "is_verified": true,
+                    "session_data": {
+                        "ciphertext": "UaxxJxPZN5jqhSoFw59s83KlK0k77KJRxowPUC3P2/bS+TIBXw2y\
+                                       qMHCpv01s+8mE95XU6RZO2/elktHiW1/mzx/2vqb4pFuARtj3rxF\
+                                       zCBO7cpVhmrSU6uKW9KH2HirZMZzyXLqr3v6xoOTe5roIF5scPR0\
+                                       cWxPcS/4+BZz4xGhGCVuTPFjWDszY1/iz4JAVosAF7XZLGh7aVhF\
+                                       +ciDDoaaqwkD2nnMUlGEl2uchWuZv7v2q9Pmmd+qzRCdLx5c+GK3\
+                                       OyT8qCSxubOvuSruwTliBl++drlMnh4vRO8UKPTuMNvEN89YKiSC\
+                                       MVzXVDCS6tnjligxUENYkyUqYCKdASLDFs1cCXJDED16oQGonkU8\
+                                       Lf7ccGg6XboJCmJfobrmDc3s/9IymtKaxquA2Vw2pW8Otoy4x9PK\
+                                       17xHLo2nT2nf3Amp6xaCYx+tblGkLIqw8H3YZZVPVuKAVpPdAhgC\
+                                       +aJA9n8qow3BLcCJSdGRMSV9MquidGgbEA/DCd6Eq3jokshcXR4v\
+                                       Ma5nT4CokeZ6OdAtMWgZSaGltyNNoc+b6hk6AqcYaoMslG58DC32\
+                                       EVSiFFwtSpKx7I6+J+hlV813Vx6IK0DoqTcYyVm4kFMvKnIoyAKJ\
+                                       yoCSik4NQpL7DcokDhs56UJ1LcDgQTnGLqhH2Q",
+                        "ephemeral": "+KmnQw7ECkCD+s2Hc0hhntT8n9zTLJvFHgX7g3XKBjs",
+                        "mac": "xdzih3IkRv4"
+                    }
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let room_key_stream = client.encryption().backups().room_keys_for_room_stream(room_id);
+
+    let task = spawn(async move {
+        pin_mut!(room_key_stream);
+
+        if let Some(Ok(room_keys)) = room_key_stream.next().await {
+            let (_, room_key_set) = room_keys.first_key_value().unwrap();
+            assert!(room_key_set.contains("64H7XKokIx0ASkYDHZKlT5zd/Zccz/cQspPNdvnNULA"));
+        } else {
+            panic!("Failed to get an update about room keys being imported from the backup")
+        }
+    });
+
+    client
+        .encryption()
+        .backups()
+        .download_room_keys_for_room(room_id)
+        .await
+        .expect("We should be able to download room keys for a certain room");
+
+    task.await.unwrap();
+
+    let room_key_stream = client.encryption().backups().room_keys_for_room_stream(room_id);
+
+    let task = spawn(async move {
+        pin_mut!(room_key_stream);
+
+        if let Some(Ok(room_keys)) = room_key_stream.next().await {
+            let (_, room_key_set) = room_keys.first_key_value().unwrap();
+            assert!(room_key_set.contains("D5SdVi/nyxdkl97K6EZrpb5N6GcF3YzmvE9EegkVDns"));
+        } else {
+            panic!("Failed to get an update about room keys being imported from the backup")
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/r0/room_keys/keys/!DovneieKSTkdHKpIXy:morpheus.localhost/D5SdVi%2Fnyxdkl97K6EZrpb5N6GcF3YzmvE9EegkVDns"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "first_message_index": 0,
+            "forwarded_count": 0,
+            "is_verified": true,
+            "session_data": {
+                "ciphertext": "JSPY1qaa8QwuurezB8l2QsK+wcwXJ6Rm3gA5AHQYrJCK1wnbIexJMx6vKFklpobTFiV6\
+                               9fh7VtcpYlZoiWTjiqwPU8ceUsmI7+Q1ZXjwS6Z6PbKszvWbUdaTKY7gcJKQWz93NAmV\
+                               PkAh/xjRqkKeJBlKZWzWctZ2k6QkwH5c9gHbPgQBe1usQefln7RHsEjM0+6nSV6+6qBm\
+                               20uK+xfpElMBZ8d3IZvbapoT11UktzUikSQ0E6DXMj+cAfX9CftXbA5BsStXvThNldad\
+                               49ZByrntoJ0yMLMk6G0uom4NaPTt75u8tX+AEHrgxFV8C7hICUPFsOFPU2ykb5qvK0JU\
+                               JdJ0qkZ2GJybhCZiQdLOC5Ciwm12k4eYBKktJAGYlPhh9oWTlITGoaDpHorDFwZpSZqY\
+                               rXaHyuCpAtd8Gc8L5HuZXDt9uN29ZTCGr3R8zpMqUG4DbpV1aV2QBrLfIZGt9OURU502\
+                               OSonHf+USrfR3ap+Yunde8gYnkyMuydRZ/0dvWqBKST0CtRQrQ+uWbPP1ATcjdhs3XnI\
+                               +N5FRIOrcrJtxbqDk1Lz+sRbFBnMZzuYTJZpPazu94AZx/t1CZyk9NZ5qbnE3wNxp2mj\
+                               YvMjwbEEQ98zvwdF7PzeDoMa/9M+tXzEOuM/A+LjMpczxKFAqQ",
+                "ephemeral": "Kv+mvdiIk4gvrocQWM5kdr5FzyFLgwJ4o6WL/r1EC0s",
+                "mac": "5MTP4/BAzXc"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    client
+        .encryption()
+        .backups()
+        .download_room_key(room_id, "D5SdVi/nyxdkl97K6EZrpb5N6GcF3YzmvE9EegkVDns")
+        .await
+        .expect("We should be able to download a single room key");
+
+    task.await.unwrap();
+
+    server.verify().await;
+}

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -454,27 +454,22 @@ async fn steady_state_waiting() {
                     assert_eq!(counter, 0, "The initial state should be the idle state");
                     counter += 1;
                 }
-                UploadState::CheckingIfUploadNeeded(counts) => {
-                    assert_eq!(counter, 1, "The second state should be the checking if state");
-                    assert_eq!(counts.total, 1, "We should have one room key in total");
-                    assert_eq!(counts.backed_up, 0, "No room key should be yet backed up.");
-                    counter += 1;
-                }
                 UploadState::Uploading(counts) => {
-                    assert_eq!(counter, 2, "The third state should be the upload state");
+                    assert_eq!(counter, 1, "The third state should be the upload state");
                     assert_eq!(counts.total, 1, "We should have one room key in total");
                     assert_eq!(counts.backed_up, 1, "All room keys should be uploaded");
                     counter += 1;
                 }
                 UploadState::Done => {
-                    assert_eq!(counter, 3, "The final state should be the Done state");
+                    assert_eq!(counter, 2, "The final state should be the Done state");
+                    counter += 1;
                     break;
                 }
                 UploadState::Error => panic!("We should not have entered the error state"),
             }
         }
 
-        assert_eq!(counter, 3, "We should have gone through 4 states, counter: {counter}");
+        assert_eq!(counter, 3, "We should have gone through 3 states, counter: {counter}");
     });
 
     task.await.unwrap();
@@ -537,14 +532,8 @@ async fn steady_state_waiting_errors() {
                     assert_eq!(counter, 0, "The initial state should be the idle state");
                     counter += 1;
                 }
-                UploadState::CheckingIfUploadNeeded(counts) => {
-                    assert_eq!(counter, 1, "The second state should be the checking if state");
-                    assert_eq!(counts.total, 1, "We should have one room key in total");
-                    assert_eq!(counts.backed_up, 0, "No room key should be yet backed up.");
-                    counter += 1;
-                }
                 UploadState::Error => {
-                    assert_eq!(counter, 2, "The third state should be the error state");
+                    assert_eq!(counter, 1, "The second state should be the error state");
                     counter += 1;
                     break;
                 }
@@ -552,7 +541,7 @@ async fn steady_state_waiting_errors() {
             }
         }
 
-        assert_eq!(counter, 3, "We should have gone through 3 states, counter: {counter}");
+        assert_eq!(counter, 2, "We should have gone through 2 states, counter: {counter}");
     });
 
     let result = wait_for_steady_state.await;

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -500,6 +500,20 @@ async fn restore_cross_signing_from_secret_store() {
         .mount(&server)
         .await;
 
+    Mock::given(method("GET"))
+        .and(path(
+            "_matrix/client/r0/user/@example:morpheus.localhost/account_data/m.megolm_backup.v1",
+        ))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "Account data not found"
+        })))
+        .expect(1)
+        .named("m.megolm_backup.v1 account data GET")
+        .mount(&server)
+        .await;
+
     Mock::given(method("POST"))
         .and(path("_matrix/client/unstable/keys/signatures/upload"))
         .and(header("authorization", "Bearer 1234"))

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -439,6 +439,7 @@ async fn test_login_with_cross_signing_bootstrapping() {
             .server_versions([MatrixVersion::V1_0])
             .with_encryption_settings(matrix_sdk::encryption::EncryptionSettings {
                 auto_enable_cross_signing: true,
+                ..Default::default()
             })
             .request_config(RequestConfig::new().disable_retry())
             .build()
@@ -489,6 +490,7 @@ async fn test_login_with_cross_signing_bootstrapping() {
             .server_versions([MatrixVersion::V1_0])
             .with_encryption_settings(matrix_sdk::encryption::EncryptionSettings {
                 auto_enable_cross_signing: true,
+                ..Default::default()
             })
             .request_config(RequestConfig::new().disable_retry())
             .build()
@@ -562,6 +564,7 @@ async fn test_login_doesnt_fail_if_cross_signing_bootstrapping_failed() {
         .server_versions([MatrixVersion::V1_0])
         .with_encryption_settings(matrix_sdk::encryption::EncryptionSettings {
             auto_enable_cross_signing: true,
+            ..Default::default()
         })
         .request_config(RequestConfig::new().disable_retry())
         .build()
@@ -680,6 +683,7 @@ async fn test_login_with_cross_signing_bootstrapping_already_bootstrapped() {
     let client = builder
         .with_encryption_settings(matrix_sdk::encryption::EncryptionSettings {
             auto_enable_cross_signing: true,
+            ..Default::default()
         })
         .request_config(RequestConfig::new().disable_retry())
         .build()

--- a/examples/backups/Cargo.toml
+++ b/examples/backups/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "example-backups"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "example-backups"
+test = false
+
+[dependencies]
+anyhow = "1"
+tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+clap = { version = "4.0.15", features = ["derive"] }
+futures-util = "0.3.24"
+tracing-subscriber = "0.3.16"
+url = "2.3.1"
+# when copy-pasting this, please use a git dependency or make sure that you
+# have copied the example as it was at the time of the release you use.
+matrix-sdk = { path = "../../crates/matrix-sdk" }

--- a/examples/backups/src/main.rs
+++ b/examples/backups/src/main.rs
@@ -1,0 +1,120 @@
+use anyhow::Result;
+use clap::Parser;
+use futures_util::{pin_mut, StreamExt};
+use matrix_sdk::{
+    config::SyncSettings,
+    encryption::{backups::BackupState, secret_storage::SecretStore},
+    Client,
+};
+use url::Url;
+
+/// A command line example showcasing how to resume backups by importing the
+/// backup key from secret storage.
+#[derive(Parser, Debug)]
+struct Cli {
+    /// The homeserver to connect to.
+    #[clap(value_parser)]
+    homeserver: Url,
+
+    /// The user ID that should be used to restore the session.
+    #[clap(value_parser)]
+    user_name: String,
+
+    /// The password that should be used for the login.
+    #[clap(value_parser)]
+    password: String,
+
+    /// Set the proxy that should be used for the connection.
+    #[clap(short, long)]
+    proxy: Option<Url>,
+
+    /// Enable verbose logging output.
+    #[clap(short, long, action)]
+    verbose: bool,
+
+    /// The secret storage key, this key will be used to open the secret-store.
+    #[clap(long, action)]
+    secret_store_key: String,
+}
+
+async fn import_known_secrets(client: &Client, secret_store: SecretStore) -> Result<()> {
+    secret_store.import_secrets().await?;
+
+    let status = client
+        .encryption()
+        .cross_signing_status()
+        .await
+        .expect("We should be able to get our cross-signing status");
+
+    if status.is_complete() {
+        println!("Successfully imported all the cross-signing keys");
+    } else {
+        eprintln!("Couldn't import all the cross-signing keys: {status:?}");
+    }
+
+    Ok(())
+}
+
+async fn login(cli: &Cli) -> Result<Client> {
+    let builder = Client::builder().homeserver_url(&cli.homeserver);
+
+    let builder = if let Some(proxy) = &cli.proxy { builder.proxy(proxy) } else { builder };
+
+    let client = builder.build().await?;
+
+    client
+        .matrix_auth()
+        .login_username(&cli.user_name, &cli.password)
+        .initial_device_display_name("rust-sdk")
+        .await?;
+
+    Ok(client)
+}
+
+async fn listen_for_backup_state_changes(client: Client) {
+    let stream = client.encryption().backups().state_stream();
+    pin_mut!(stream);
+
+    while let Some(state) = stream.next().await {
+        let Ok(state) = state else { panic!("Error while receiving backup state updates") };
+
+        match state {
+            BackupState::Unknown => (),
+            BackupState::Enabling => println!("Trying to enable backups"),
+            BackupState::Resuming => println!("Trying to resume backups"),
+            BackupState::Enabled => println!("Backups have been successfully enabled"),
+            BackupState::Downloading => println!("Downloading the room keys from the backup"),
+            BackupState::Disabling => println!("Disabling the backup"),
+            BackupState::Creating => println!("Trying to create a new backup"),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    if cli.verbose {
+        tracing_subscriber::fmt::init();
+    }
+
+    let client = login(&cli).await?;
+
+    client.sync_once(Default::default()).await?;
+
+    let secret_store =
+        client.encryption().secret_storage().open_secret_store(&cli.secret_store_key).await?;
+
+    let _task = tokio::spawn({
+        let client = client.to_owned();
+        async move { listen_for_backup_state_changes(client.to_owned()).await }
+    });
+
+    import_known_secrets(&client, secret_store).await?;
+
+    loop {
+        if let Err(e) = client.sync(SyncSettings::new()).await {
+            eprintln!("Error syncing: {e:?}")
+        }
+    }
+}

--- a/examples/backups/src/main.rs
+++ b/examples/backups/src/main.rs
@@ -106,8 +106,8 @@ async fn main() -> Result<()> {
         client.encryption().secret_storage().open_secret_store(&cli.secret_store_key).await?;
 
     let _task = tokio::spawn({
-        let client = client.to_owned();
-        async move { listen_for_backup_state_changes(client.to_owned()).await }
+        let client = client.clone();
+        async move { listen_for_backup_state_changes(client).await }
     });
 
     import_known_secrets(&client, secret_store).await?;

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -68,7 +68,10 @@ impl TestClientBuilder {
 
         if self.bootstrap_cross_signing {
             client_builder = client_builder.with_encryption_settings(
-                matrix_sdk::encryption::EncryptionSettings { auto_enable_cross_signing: true },
+                matrix_sdk::encryption::EncryptionSettings {
+                    auto_enable_cross_signing: true,
+                    ..Default::default()
+                },
             );
         }
 


### PR DESCRIPTION
This PR adds support to download backups and start backing room keys up when:

1. The user imports secrets from secrets storage
2. The user performs an interactive verification and receives the backup key as a `m.secret.send` event.

Due to no 1, this PR depends on #2621.

The PR has also ballooned up to include a full API to:

1. Create a new backup.
2. Delete and disable an existing backup.
3. Expose the various methods to download room keys from the backup.
4. An example to play with the backup support
5. Comprehensive integration tests

- [ ] Public API changes documented in changelogs (optional)