### PR TITLE
Remove dashmap crate usage from matrix-sdk-crypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,6 @@ dependencies = [
  "cfg-if",
  "ctor",
  "ctr",
- "dashmap",
  "eyeball",
  "futures-core",
  "futures-executor",

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -37,7 +37,6 @@ byteorder = { workspace = true }
 cbc = { version = "0.1.2", features = ["std"], optional = true }
 cfg-if = "1.0"
 ctr = "0.9.1"
-dashmap = { workspace = true }
 eyeball = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -14,11 +14,10 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
-    sync::Arc,
+    sync::{Arc, RwLock as StdRwLock},
     time::Duration,
 };
 
-use dashmap::DashMap;
 use itertools::Itertools;
 use matrix_sdk_common::deserialized_responses::{
     AlgorithmInfo, DeviceLinkProblem, EncryptionInfo, TimelineEvent, VerificationLevel,
@@ -200,7 +199,7 @@ impl OlmMachine {
         let store =
             Store::new(account.clone(), user_identity.clone(), store, verification_machine.clone());
         let device_id: OwnedDeviceId = device_id.into();
-        let users_for_key_claim = Arc::new(DashMap::new());
+        let users_for_key_claim = Arc::new(StdRwLock::new(BTreeMap::new()));
 
         let account = Account { store: store.clone(), static_data: account.static_data().clone() };
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -16,10 +16,9 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
     ops::Deref,
-    sync::Arc,
+    sync::{Arc, RwLock as StdRwLock},
 };
 
-use dashmap::DashMap;
 use futures_util::future::join_all;
 use itertools::{Either, Itertools};
 use matrix_sdk_common::executor::spawn;
@@ -42,10 +41,10 @@ use crate::{
 #[derive(Clone, Debug)]
 pub(crate) struct GroupSessionCache {
     store: Store,
-    sessions: Arc<DashMap<OwnedRoomId, OutboundGroupSession>>,
+    sessions: Arc<StdRwLock<BTreeMap<OwnedRoomId, OutboundGroupSession>>>,
     /// A map from the request id to the group session that the request belongs
     /// to. Used to mark requests belonging to the session as shared.
-    sessions_being_shared: Arc<DashMap<OwnedTransactionId, OutboundGroupSession>>,
+    sessions_being_shared: Arc<StdRwLock<BTreeMap<OwnedTransactionId, OutboundGroupSession>>>,
 }
 
 impl GroupSessionCache {
@@ -54,7 +53,7 @@ impl GroupSessionCache {
     }
 
     pub(crate) fn insert(&self, session: OutboundGroupSession) {
-        self.sessions.insert(session.room_id().to_owned(), session);
+        self.sessions.write().unwrap().insert(session.room_id().to_owned(), session);
     }
 
     /// Either get a session for the given room from the cache or load it from
@@ -66,24 +65,27 @@ impl GroupSessionCache {
     pub async fn get_or_load(&self, room_id: &RoomId) -> Option<OutboundGroupSession> {
         // Get the cached session, if there isn't one load one from the store
         // and put it in the cache.
-        if let Some(s) = self.sessions.get(room_id) {
-            Some(s.clone())
-        } else {
-            match self.store.get_outbound_group_session(room_id).await {
-                Ok(Some(s)) => {
+        if let Some(s) = self.sessions.read().unwrap().get(room_id) {
+            return Some(s.clone());
+        }
+
+        match self.store.get_outbound_group_session(room_id).await {
+            Ok(Some(s)) => {
+                {
+                    let mut sessions_being_shared = self.sessions_being_shared.write().unwrap();
                     for request_id in s.pending_request_ids() {
-                        self.sessions_being_shared.insert(request_id, s.clone());
+                        sessions_being_shared.insert(request_id, s.clone());
                     }
-
-                    self.sessions.insert(room_id.to_owned(), s.clone());
-
-                    Some(s)
                 }
-                Ok(None) => None,
-                Err(e) => {
-                    error!("Couldn't restore an outbound group session: {e:?}");
-                    None
-                }
+
+                self.sessions.write().unwrap().insert(room_id.to_owned(), s.clone());
+
+                Some(s)
+            }
+            Ok(None) => None,
+            Err(e) => {
+                error!("Couldn't restore an outbound group session: {e:?}");
+                None
             }
         }
     }
@@ -95,7 +97,7 @@ impl GroupSessionCache {
     /// * `room_id` - The id of the room for which we should get the outbound
     /// group session.
     fn get(&self, room_id: &RoomId) -> Option<OutboundGroupSession> {
-        self.sessions.get(room_id).map(|s| s.clone())
+        self.sessions.read().unwrap().get(room_id).cloned()
     }
 
     /// Get or load the session for the given room with the given session id.
@@ -162,7 +164,9 @@ impl GroupSessionManager {
     }
 
     pub async fn mark_request_as_sent(&self, request_id: &TransactionId) -> StoreResult<()> {
-        if let Some((_, session)) = self.sessions.sessions_being_shared.remove(request_id) {
+        let removed_session =
+            self.sessions.sessions_being_shared.write().unwrap().remove(request_id);
+        if let Some(session) = removed_session {
             let no_olm = session.mark_request_as_sent(request_id);
 
             let mut changes = Changes::default();
@@ -353,7 +357,7 @@ impl GroupSessionManager {
         );
 
         let users_shared_with: BTreeSet<OwnedUserId> =
-            outbound.shared_with_set.iter().map(|k| k.key().clone()).collect();
+            outbound.shared_with_set.read().unwrap().keys().cloned().collect();
 
         let users_shared_with: BTreeSet<&UserId> =
             users_shared_with.iter().map(Deref::deref).collect();
@@ -403,10 +407,9 @@ impl GroupSessionManager {
                 let recipient_device_ids: BTreeSet<&DeviceId> =
                     recipients.iter().map(|d| d.device_id()).collect();
 
-                if let Some(shared) = outbound.shared_with_set.get(user_id) {
+                if let Some(shared) = outbound.shared_with_set.read().unwrap().get(user_id) {
                     // Devices that received this session
-                    let shared: BTreeSet<OwnedDeviceId> =
-                        shared.iter().map(|d| d.key().clone()).collect();
+                    let shared: BTreeSet<OwnedDeviceId> = shared.keys().cloned().collect();
                     let shared: BTreeSet<&DeviceId> = shared.iter().map(|d| d.as_ref()).collect();
 
                     // The set difference between
@@ -440,7 +443,7 @@ impl GroupSessionManager {
     pub async fn encrypt_request(
         chunk: Vec<Device>,
         outbound: OutboundGroupSession,
-        being_shared: Arc<DashMap<OwnedTransactionId, OutboundGroupSession>>,
+        being_shared: Arc<StdRwLock<BTreeMap<OwnedTransactionId, OutboundGroupSession>>>,
     ) -> OlmResult<(Vec<Session>, Vec<(Device, WithheldCode)>)> {
         let (id, request, share_infos, used_sessions, no_olm) =
             Self::encrypt_session_for(outbound.clone(), chunk).await?;
@@ -453,7 +456,7 @@ impl GroupSessionManager {
             );
 
             outbound.add_request(id.clone(), request.into(), share_infos);
-            being_shared.insert(id, outbound.clone());
+            being_shared.write().unwrap().insert(id, outbound.clone());
         }
 
         Ok((used_sessions, no_olm))
@@ -579,7 +582,13 @@ impl GroupSessionManager {
         // leave it be.
         if code == &WithheldCode::NoOlm {
             device.was_withheld_code_sent()
-                || self.sessions.sessions.iter().any(|s| s.is_withheld_to(device, code))
+                || self
+                    .sessions
+                    .sessions
+                    .read()
+                    .unwrap()
+                    .values()
+                    .any(|s| s.is_withheld_to(device, code))
         } else {
             group_session.is_withheld_to(device, code)
         }
@@ -642,11 +651,13 @@ impl GroupSessionManager {
             .map(chunk_to_request)
             .collect();
 
+        let mut sessions_being_shared = self.sessions.sessions_being_shared.write().unwrap();
         for (request, share_info) in result {
             if !request.messages.is_empty() {
                 let txn_id = request.txn_id.to_owned();
                 group_session.add_request(txn_id.to_owned(), request.into(), share_info);
-                self.sessions.sessions_being_shared.insert(txn_id, group_session.clone());
+
+                sessions_being_shared.insert(txn_id, group_session.clone());
             }
         }
 

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -15,10 +15,9 @@
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
-    sync::Arc,
+    sync::{Arc, RwLock as StdRwLock},
 };
 
-use dashmap::DashMap;
 use ruma::{
     events::{
         key::verification::VerificationMethod, AnyToDeviceEvent, AnyToDeviceEventContent,
@@ -50,7 +49,7 @@ use crate::{
 pub struct VerificationMachine {
     pub(crate) store: VerificationStore,
     verifications: VerificationCache,
-    requests: Arc<DashMap<OwnedUserId, HashMap<String, VerificationRequest>>>,
+    requests: Arc<StdRwLock<HashMap<OwnedUserId, HashMap<String, VerificationRequest>>>>,
 }
 
 impl VerificationMachine {
@@ -154,11 +153,13 @@ impl VerificationMachine {
         user_id: &UserId,
         flow_id: impl AsRef<str>,
     ) -> Option<VerificationRequest> {
-        self.requests.get(user_id)?.get(flow_id.as_ref()).cloned()
+        self.requests.read().unwrap().get(user_id)?.get(flow_id.as_ref()).cloned()
     }
 
     pub fn get_requests(&self, user_id: &UserId) -> Vec<VerificationRequest> {
         self.requests
+            .read()
+            .unwrap()
             .get(user_id)
             .map(|v| v.iter().map(|(_, value)| value.clone()).collect())
             .unwrap_or_default()
@@ -173,8 +174,8 @@ impl VerificationMachine {
             return;
         }
 
-        let mut entry = self.requests.entry(request.other_user().to_owned()).or_default();
-        let user_requests = entry.value_mut();
+        let mut requests = self.requests.write().unwrap();
+        let user_requests = requests.entry(request.other_user().to_owned()).or_default();
 
         // Cancel all the old verifications requests as well as the new one we
         // have for this user if someone tries to have two verifications going
@@ -245,20 +246,16 @@ impl VerificationMachine {
     pub fn garbage_collect(&self) -> Vec<Raw<AnyToDeviceEvent>> {
         let mut events = vec![];
 
-        for mut user_verification in self.requests.iter_mut() {
-            user_verification.retain(|_, v| !(v.is_done() || v.is_cancelled()));
-        }
-        self.requests.retain(|_, v| !v.is_empty());
+        let mut requests: Vec<OutgoingVerificationRequest> = {
+            let mut requests = self.requests.write().unwrap();
 
-        let mut requests: Vec<OutgoingVerificationRequest> = self
-            .requests
-            .iter()
-            .flat_map(|v| {
-                let requests: Vec<OutgoingVerificationRequest> =
-                    v.value().iter().filter_map(|(_, v)| v.cancel_if_timed_out()).collect();
-                requests
-            })
-            .collect();
+            for user_verification in requests.values_mut() {
+                user_verification.retain(|_, v| !(v.is_done() || v.is_cancelled()));
+            }
+            requests.retain(|_, v| !v.is_empty());
+
+            requests.values().flatten().filter_map(|(_, v)| v.cancel_if_timed_out()).collect()
+        };
 
         requests.extend(self.verifications.garbage_collect());
 


### PR DESCRIPTION
There are a lot of small changes to how long the maps are locked, but I was conservative with changes, plus in some places where it seemed reasonable / useful to extend lock durations, it wasn't easily possible because there was a `.await` in the middle, so an async-aware lock would have been required.

Closes https://github.com/vector-im/element-web/issues/26301.