### PR TITLE
Fix: wait for disk operations to finish before returning the media file in `get_media_file`.

### DIFF
--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -208,7 +208,9 @@ impl Media {
             _ => (TempFileBuilder::new().tempfile()?, None),
         };
 
-        TokioFile::from_std(temp_file.reopen()?).write_all(&data).await?;
+        let mut file = TokioFile::from_std(temp_file.reopen()?);
+        file.write_all(&data).await?;
+        file.sync_all().await?;
 
         Ok(MediaFileHandle { file: temp_file, _directory: temp_dir })
     }

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -210,6 +210,7 @@ impl Media {
 
         let mut file = TokioFile::from_std(temp_file.reopen()?);
         file.write_all(&data).await?;
+        // Make sure the file metadata is flushed to disk.
         file.sync_all().await?;
 
         Ok(MediaFileHandle { file: temp_file, _directory: temp_dir })


### PR DESCRIPTION
This PR fixes a problem where the disk size of the media file is 0 just after calling `get_media_file`.