### PR TITLE
Bugfix for invalidated private cross signing keys not being persisted

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -412,7 +412,7 @@ impl IdentityManager {
             // this means that the private part of the master key has signed
             // the identity. We can safely mark the public part of the
             // identity as verified.
-            if private_identity.has_master_key().await {
+            if private_identity.has_master_key().await && !identity.is_verified() {
                 trace!("Marked our own identity as verified");
                 identity.mark_as_verified()
             }


### PR DESCRIPTION
This PR fixes a bug where in some cases the private cross-signing keys, while being correctly invalidated, the invalidated variant of them were not persisted to storage.

The first two commits add a regression test for this, the third one is the actual fix, while the last commit ensures that we don't spam the logs with info about our identity being marked as verified if it already was verified. 