### PR TITLE
crypto: Fuse `ReadOnlyAccount` and `Account` :sparkles: 

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -248,7 +248,7 @@ async fn migrate_data(
         uploaded_signed_key_count: data.account.uploaded_signed_key_count as u64,
         creation_local_time: MilliSecondsSinceUnixEpoch(UInt::default()),
     };
-    let account = matrix_sdk_crypto::olm::ReadOnlyAccount::from_pickle(pickled_account)?;
+    let account = matrix_sdk_crypto::olm::Account::from_pickle(pickled_account)?;
 
     processed_steps += 1;
     listener(processed_steps, total_steps);

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -466,7 +466,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn dehydrated_device_rehydration() {
+    async fn test_dehydrated_device_rehydration() {
         let room_id = room_id!("!test:example.org");
         let alice = get_olm_machine().await;
 
@@ -510,6 +510,9 @@ mod tests {
             .rehydrate(PICKLE_KEY, &request.device_id, request.device_data)
             .await
             .expect("We should be able to rehydrate the device");
+
+        assert_eq!(rehydrated.rehydrated.device_id(), request.device_id);
+        assert_eq!(rehydrated.original.device_id(), alice.device_id());
 
         // Push the to-device event containing the room key into the rehydrated device.
         let ret = rehydrated

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -59,7 +59,7 @@ use vodozemac::LibolmPickleError;
 use crate::{
     store::{CryptoStoreWrapper, MemoryStore, RoomKeyInfo, Store},
     verification::VerificationMachine,
-    EncryptionSyncChanges, OlmError, OlmMachine, ReadOnlyAccount, SignatureError,
+    Account, EncryptionSyncChanges, OlmError, OlmMachine, SignatureError,
 };
 
 /// Error type for device dehydration issues.
@@ -89,7 +89,7 @@ impl DehydratedDevices {
         let user_id = self.inner.user_id();
         let user_identity = self.inner.store().private_identity();
 
-        let account = ReadOnlyAccount::new(user_id);
+        let account = Account::new(user_id);
         let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
 
         let verification_machine = VerificationMachine::new(

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1065,7 +1065,7 @@ mod tests {
     };
     use crate::{
         identities::{LocalTrust, ReadOnlyDevice},
-        olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
+        olm::{Account, PrivateCrossSigningIdentity},
         session_manager::GroupSessionCache,
         store::{CryptoStoreWrapper, MemoryStore, Store},
         types::events::room::encrypted::{EncryptedEvent, RoomEncryptedEventContent},
@@ -1098,16 +1098,16 @@ mod tests {
         room_id!("!test:example.org")
     }
 
-    fn account() -> ReadOnlyAccount {
-        ReadOnlyAccount::with_device_id(alice_id(), alice_device_id())
+    fn account() -> Account {
+        Account::with_device_id(alice_id(), alice_device_id())
     }
 
-    fn bob_account() -> ReadOnlyAccount {
-        ReadOnlyAccount::with_device_id(bob_id(), bob_device_id())
+    fn bob_account() -> Account {
+        Account::with_device_id(bob_id(), bob_device_id())
     }
 
-    fn alice_2_account() -> ReadOnlyAccount {
-        ReadOnlyAccount::with_device_id(alice_id(), alice2_device_id())
+    fn alice_2_account() -> Account {
+        Account::with_device_id(alice_id(), alice2_device_id())
     }
 
     #[cfg(feature = "automatic-room-key-forwarding")]
@@ -1115,7 +1115,7 @@ mod tests {
         let user_id = user_id.to_owned();
         let device_id = DeviceId::new();
 
-        let account = ReadOnlyAccount::with_device_id(&user_id, &device_id);
+        let account = Account::with_device_id(&user_id, &device_id);
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let verification =
@@ -1128,13 +1128,11 @@ mod tests {
 
     async fn get_machine() -> GossipMachine {
         let user_id = alice_id().to_owned();
-        let account = ReadOnlyAccount::with_device_id(&user_id, alice_device_id());
+        let account = Account::with_device_id(&user_id, alice_device_id());
         let device = ReadOnlyDevice::from_account(&account).await;
-        let another_device = ReadOnlyDevice::from_account(&ReadOnlyAccount::with_device_id(
-            &user_id,
-            alice2_device_id(),
-        ))
-        .await;
+        let another_device =
+            ReadOnlyDevice::from_account(&Account::with_device_id(&user_id, alice2_device_id()))
+                .await;
 
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
@@ -1153,7 +1151,7 @@ mod tests {
         other_machine_owner: &UserId,
         create_sessions: bool,
         algorithm: EventEncryptionAlgorithm,
-    ) -> (GossipMachine, ReadOnlyAccount, OutboundGroupSession, GossipMachine) {
+    ) -> (GossipMachine, Account, OutboundGroupSession, GossipMachine) {
         let alice_machine = get_machine().await;
         let alice_device = ReadOnlyDevice::from_account(alice_machine.inner.store.account()).await;
 

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -55,8 +55,7 @@ use crate::{
         DeviceKey, DeviceKeys, EventEncryptionAlgorithm, Signatures, SignedKey,
     },
     verification::VerificationMachine,
-    MegolmError, OutgoingVerificationRequest, ReadOnlyAccount, Sas, ToDeviceRequest,
-    VerificationRequest,
+    Account, MegolmError, OutgoingVerificationRequest, Sas, ToDeviceRequest, VerificationRequest,
 };
 
 pub enum MaybeEncryptedRoomKey {
@@ -906,7 +905,7 @@ impl ReadOnlyDevice {
     /// *Don't* use this after we received a keys/query response, other
     /// users/devices might add signatures to our own device, which can't be
     /// replicated locally.
-    pub async fn from_account(account: &ReadOnlyAccount) -> ReadOnlyDevice {
+    pub async fn from_account(account: &Account) -> ReadOnlyDevice {
         let device_keys = account.device_keys().await;
         let mut device = ReadOnlyDevice::try_from(&device_keys)
             .expect("Creating a device from our own account should always succeed");

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -778,7 +778,7 @@ pub(crate) mod testing {
     use crate::{
         identities::IdentityManager,
         machine::testing::response_from_file,
-        olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
+        olm::{Account, PrivateCrossSigningIdentity},
         store::{CryptoStoreWrapper, MemoryStore, Store},
         types::DeviceKeys,
         verification::VerificationMachine,
@@ -801,7 +801,7 @@ pub(crate) mod testing {
         let identity = PrivateCrossSigningIdentity::new(user_id().into()).await;
         let identity = Arc::new(Mutex::new(identity));
         let user_id = user_id().to_owned();
-        let account = ReadOnlyAccount::with_device_id(&user_id, device_id());
+        let account = Account::with_device_id(&user_id, device_id());
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let verification =
             VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -786,7 +786,7 @@ pub(crate) mod tests {
     };
     use crate::{
         identities::{manager::testing::own_key_query, Device},
-        olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
+        olm::{Account, PrivateCrossSigningIdentity},
         store::{CryptoStoreWrapper, MemoryStore},
         types::{CrossSigningKey, MasterPubkey, SelfSigningPubkey, Signatures, UserSigningPubkey},
         verification::VerificationMachine,
@@ -862,7 +862,7 @@ pub(crate) mod tests {
         let private_identity =
             Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(second.user_id())));
         let verification_machine = VerificationMachine::new(
-            ReadOnlyAccount::with_device_id(second.user_id(), second.device_id()).static_data,
+            Account::with_device_id(second.user_id(), second.device_id()).static_data,
             private_identity,
             Arc::new(CryptoStoreWrapper::new(second.user_id(), MemoryStore::new())),
         );
@@ -897,13 +897,13 @@ pub(crate) mod tests {
         let response = own_key_query();
         let (_, device) = device(&response);
 
-        let account = ReadOnlyAccount::with_device_id(device.user_id(), device.device_id());
+        let account = Account::with_device_id(device.user_id(), device.device_id());
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
 
         let id = Arc::new(Mutex::new(identity.clone()));
 
         let verification_machine = VerificationMachine::new(
-            ReadOnlyAccount::with_device_id(device.user_id(), device.device_id()).static_data,
+            Account::with_device_id(device.user_id(), device.device_id()).static_data,
             id.clone(),
             Arc::new(CryptoStoreWrapper::new(device.user_id(), MemoryStore::new())),
         );

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -83,7 +83,7 @@ pub use identities::{
 pub use machine::{EncryptionSyncChanges, OlmMachine};
 #[cfg(feature = "qrcode")]
 pub use matrix_sdk_qrcode;
-pub use olm::{CrossSigningStatus, EncryptionSettings, ReadOnlyAccount, Session};
+pub use olm::{Account, CrossSigningStatus, EncryptionSettings, Session};
 pub use requests::{
     IncomingResponse, KeysBackupRequest, KeysQueryRequest, OutgoingRequest, OutgoingRequests,
     OutgoingVerificationRequest, RoomMessageRequest, ToDeviceRequest, UploadSigningKeysRequest,

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -175,7 +175,7 @@ impl OlmMachine {
 
         Ok(Self::new_helper(
             self.user_id(),
-            self.device_id(),
+            device_id,
             store,
             account,
             self.store().private_identity(),

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -62,8 +62,8 @@ use crate::{
     gossiping::GossipMachine,
     identities::{user::UserIdentities, Device, IdentityManager, UserDevices},
     olm::{
-        CrossSigningStatus, EncryptionSettings, ExportedRoomKey, IdentityKeys, InboundGroupSession,
-        OlmDecryptionInfo, PrivateCrossSigningIdentity, ReadOnlyAccount, SessionType,
+        Account, CrossSigningStatus, EncryptionSettings, ExportedRoomKey, IdentityKeys,
+        InboundGroupSession, OlmDecryptionInfo, PrivateCrossSigningIdentity, SessionType,
     },
     requests::{IncomingResponse, OutgoingRequest, UploadSigningKeysRequest},
     session_manager::{GroupSessionManager, SessionManager},
@@ -166,7 +166,7 @@ impl OlmMachine {
         device_data: Raw<DehydratedDeviceData>,
     ) -> Result<OlmMachine, DehydrationError> {
         let account =
-            ReadOnlyAccount::rehydrate(pickle_key, self.user_id(), device_id, device_data).await?;
+            Account::rehydrate(pickle_key, self.user_id(), device_id, device_data).await?;
 
         let store = Arc::new(CryptoStoreWrapper::new(self.user_id(), MemoryStore::new()));
 
@@ -176,7 +176,7 @@ impl OlmMachine {
     fn new_helper(
         device_id: &DeviceId,
         store: Arc<CryptoStoreWrapper>,
-        account: ReadOnlyAccount,
+        account: Account,
         user_identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
     ) -> Self {
         let verification_machine = VerificationMachine::new(
@@ -264,7 +264,7 @@ impl OlmMachine {
                 account
             }
             None => {
-                let account = ReadOnlyAccount::with_device_id(user_id, device_id);
+                let account = Account::with_device_id(user_id, device_id);
 
                 Span::current()
                     .record("ed25519_key", display(account.identity_keys().ed25519))
@@ -529,7 +529,7 @@ impl OlmMachine {
     /// Get the underlying Olm account of the machine.
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
-    pub(crate) fn account(&self) -> &ReadOnlyAccount {
+    pub(crate) fn account(&self) -> &Account {
         self.inner.store.account()
     }
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -211,8 +211,7 @@ impl OlmMachine {
             group_session_manager.session_cache(),
             users_for_key_claim.clone(),
         );
-        let identity_manager =
-            IdentityManager::new(user_id.clone(), device_id.clone(), store.clone());
+        let identity_manager = IdentityManager::new(store.clone());
 
         let session_manager = SessionManager::new(
             account.clone(),

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -496,11 +496,11 @@ impl Account {
 #[derive(Clone)]
 #[cfg_attr(not(tarpaulin_include), derive(Debug))]
 pub struct StaticAccountData {
-    /// The user_id this account belongs to
+    /// The user_id this account belongs to.
     pub user_id: OwnedUserId,
-    /// The device_id of this entry
+    /// The device_id of this entry.
     pub device_id: OwnedDeviceId,
-    /// The associated identity keys
+    /// The associated identity keys.
     pub identity_keys: Arc<IdentityKeys>,
     // The creation time of the account in milliseconds since epoch.
     creation_local_time: MilliSecondsSinceUnixEpoch,
@@ -567,7 +567,7 @@ impl StaticAccountData {
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
     /// Testing only facility to create a group session pair with default
-    /// settings
+    /// settings.
     pub async fn create_group_session_pair_with_defaults(
         &self,
         room_id: &RoomId,
@@ -609,7 +609,7 @@ impl StaticAccountData {
         )
     }
 
-    /// Generate the unsigned `DeviceKeys` from this ReadOnlyAccount
+    /// Generate the unsigned `DeviceKeys` from this `StaticAccountData`.
     pub fn unsigned_device_keys(&self) -> DeviceKeys {
         let identity_keys = self.identity_keys();
         let keys = BTreeMap::from([
@@ -647,7 +647,7 @@ impl StaticAccountData {
         *self.identity_keys
     }
 
-    /// Get the local timestamp creation of the account in secs since epoch
+    /// Get the local timestamp creation of the account in secs since epoch.
     pub fn creation_local_time(&self) -> MilliSecondsSinceUnixEpoch {
         self.creation_local_time
     }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -78,12 +78,6 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub(crate) struct Account {
-    pub store: Store,
-    pub static_data: StaticAccountData,
-}
-
-#[derive(Debug, Clone)]
 pub(crate) enum SessionType {
     New(Session),
     Existing(Session),

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -146,7 +146,7 @@ impl OlmMessageHash {
     }
 }
 
-impl ReadOnlyAccount {
+impl Account {
     async fn decrypt_olm_helper(
         &self,
         store: &Store,
@@ -660,7 +660,7 @@ impl StaticAccountData {
 /// An account is the central identity for encrypted communication between two
 /// devices.
 #[derive(Clone)]
-pub struct ReadOnlyAccount {
+pub struct Account {
     pub(crate) static_data: StaticAccountData,
     /// `vodozemac` account.
     inner: Arc<Mutex<InnerAccount>>,
@@ -674,7 +674,7 @@ pub struct ReadOnlyAccount {
     uploaded_signed_key_count: Arc<AtomicU64>,
 }
 
-impl Deref for ReadOnlyAccount {
+impl Deref for Account {
     type Target = StaticAccountData;
 
     fn deref(&self) -> &Self::Target {
@@ -710,7 +710,7 @@ fn default_account_creation_time() -> MilliSecondsSinceUnixEpoch {
 }
 
 #[cfg(not(tarpaulin_include))]
-impl fmt::Debug for ReadOnlyAccount {
+impl fmt::Debug for Account {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Account")
             .field("identity_keys", &self.identity_keys())
@@ -719,7 +719,7 @@ impl fmt::Debug for ReadOnlyAccount {
     }
 }
 
-impl ReadOnlyAccount {
+impl Account {
     fn new_helper(mut account: InnerAccount, user_id: &UserId, device_id: &DeviceId) -> Self {
         let identity_keys = account.identity_keys();
 
@@ -1317,7 +1317,7 @@ impl ReadOnlyAccount {
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
     /// Testing only helper to create a session for the given Account
-    pub async fn create_session_for(&self, other: &ReadOnlyAccount) -> (Session, Session) {
+    pub async fn create_session_for(&self, other: &Account) -> (Session, Session) {
         use ruma::events::dummy::ToDeviceDummyEventContent;
 
         other.generate_one_time_keys_helper(1).await;
@@ -1371,7 +1371,7 @@ impl ReadOnlyAccount {
     }
 }
 
-impl PartialEq for ReadOnlyAccount {
+impl PartialEq for Account {
     fn eq(&self, other: &Self) -> bool {
         self.identity_keys() == other.identity_keys() && self.shared() == other.shared()
     }
@@ -1392,7 +1392,7 @@ mod tests {
     };
     use serde_json::json;
 
-    use super::ReadOnlyAccount;
+    use super::Account;
     use crate::{
         olm::SignedJsonObject,
         types::{DeviceKeys, SignedKey},
@@ -1409,7 +1409,7 @@ mod tests {
 
     #[async_test]
     async fn one_time_key_creation() -> Result<()> {
-        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
+        let account = Account::with_device_id(user_id(), device_id());
 
         let (_, one_time_keys, _) = account.keys_for_upload().await;
         assert!(!one_time_keys.is_empty());
@@ -1446,7 +1446,7 @@ mod tests {
 
     #[async_test]
     async fn fallback_key_creation() -> Result<()> {
-        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
+        let account = Account::with_device_id(user_id(), device_id());
 
         let (_, _, fallback_keys) = account.keys_for_upload().await;
 
@@ -1486,7 +1486,7 @@ mod tests {
         let key = vodozemac::Curve25519PublicKey::from_base64(
             "7PUPP6Ijt5R8qLwK2c8uK5hqCNF9tOzWYgGaAay5JBs",
         )?;
-        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
+        let account = Account::with_device_id(user_id(), device_id());
 
         let key = account.sign_key(key, true).await;
 
@@ -1510,7 +1510,7 @@ mod tests {
     #[async_test]
     async fn test_account_and_device_creation_timestamp() -> Result<()> {
         let now = MilliSecondsSinceUnixEpoch::now();
-        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
+        let account = Account::with_device_id(user_id(), device_id());
         let then = MilliSecondsSinceUnixEpoch::now();
 
         assert!(account.creation_local_time() >= now);

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -610,7 +610,7 @@ mod tests {
     use ruma::{device_id, room_id, user_id, DeviceId, UserId};
     use vodozemac::{megolm::SessionOrdering, Curve25519PublicKey};
 
-    use crate::{olm::InboundGroupSession, ReadOnlyAccount};
+    use crate::{olm::InboundGroupSession, Account};
 
     fn alice_id() -> &'static UserId {
         user_id!("@alice:example.org")
@@ -667,7 +667,7 @@ mod tests {
 
     #[async_test]
     async fn session_comparison() {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
 
         let (_, inbound) = alice.create_group_session_pair_with_defaults(room_id).await;

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -740,7 +740,7 @@ mod tests {
     };
 
     use super::{EncryptionSettings, ROTATION_MESSAGES, ROTATION_PERIOD};
-    use crate::{MegolmError, ReadOnlyAccount};
+    use crate::{Account, MegolmError};
 
     #[test]
     fn test_encryption_settings_conversion() {
@@ -768,7 +768,7 @@ mod tests {
         let settings = EncryptionSettings { rotation_period_msgs: 1, ..Default::default() };
 
         let account =
-            ReadOnlyAccount::with_device_id(user_id!("@alice:example.org"), device_id!("DEVICEID"))
+            Account::with_device_id(user_id!("@alice:example.org"), device_id!("DEVICEID"))
                 .static_data;
         let (session, _) = account
             .create_group_session_pair(room_id!("!test_room:example.org"), settings)

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -23,7 +23,7 @@ mod session;
 mod signing;
 mod utility;
 
-pub(crate) use account::{Account, OlmDecryptionInfo, SessionType};
+pub(crate) use account::{OlmDecryptionInfo, SessionType};
 pub use account::{OlmMessageHash, PickledAccount, ReadOnlyAccount, StaticAccountData};
 pub(crate) use group_sessions::ShareState;
 pub use group_sessions::{

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -23,8 +23,8 @@ mod session;
 mod signing;
 mod utility;
 
+pub use account::{Account, OlmMessageHash, PickledAccount, StaticAccountData};
 pub(crate) use account::{OlmDecryptionInfo, SessionType};
-pub use account::{OlmMessageHash, PickledAccount, ReadOnlyAccount, StaticAccountData};
 pub(crate) use group_sessions::ShareState;
 pub use group_sessions::{
     BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession,
@@ -56,7 +56,7 @@ pub(crate) mod tests {
     };
 
     use crate::{
-        olm::{ExportedRoomKey, InboundGroupSession, ReadOnlyAccount, Session},
+        olm::{Account, ExportedRoomKey, InboundGroupSession, Session},
         types::events::{
             forwarded_room_key::ForwardedRoomKeyContent, room::encrypted::EncryptedEvent,
         },
@@ -79,9 +79,9 @@ pub(crate) mod tests {
         device_id!("BOBDEVICE")
     }
 
-    pub(crate) async fn get_account_and_session() -> (ReadOnlyAccount, Session) {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
-        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
+    pub(crate) async fn get_account_and_session() -> (Account, Session) {
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
+        let bob = Account::with_device_id(bob_id(), bob_device_id());
 
         bob.generate_one_time_keys_helper(1).await;
         let one_time_key = *bob.one_time_keys().await.values().next().unwrap();
@@ -100,7 +100,7 @@ pub(crate) mod tests {
 
     #[test]
     fn account_creation() {
-        let account = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let account = Account::with_device_id(alice_id(), alice_device_id());
 
         assert!(!account.shared());
 
@@ -110,7 +110,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn one_time_keys_creation() {
-        let account = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let account = Account::with_device_id(alice_id(), alice_device_id());
         let one_time_keys = account.one_time_keys().await;
 
         assert!(!one_time_keys.is_empty());
@@ -130,8 +130,8 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn session_creation() {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
-        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
+        let bob = Account::with_device_id(bob_id(), bob_device_id());
         let alice_keys = alice.identity_keys();
         alice.generate_one_time_keys_helper(1).await;
         let one_time_keys = alice.one_time_keys().await;
@@ -168,7 +168,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn group_session_creation() {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
 
         let (outbound, _) = alice.create_group_session_pair_with_defaults(room_id).await;
@@ -204,7 +204,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn edit_decryption() {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
         let event_id = event_id!("$1234adfad:asdf");
 
@@ -263,7 +263,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn relates_to_decryption() {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
         let event_id = event_id!("$1234adfad:asdf");
 
@@ -335,7 +335,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn group_session_export() {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let room_id = room_id!("!test:localhost");
 
         let (_, inbound) = alice.create_group_session_pair_with_defaults(room_id).await;

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -36,8 +36,7 @@ use crate::{
     requests::UploadSigningKeysRequest,
     store::SecretImportError,
     types::{DeviceKeys, MasterPubkey, SelfSigningPubkey, UserSigningPubkey},
-    OwnUserIdentity, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyOwnUserIdentity,
-    ReadOnlyUserIdentity,
+    Account, OwnUserIdentity, ReadOnlyDevice, ReadOnlyOwnUserIdentity, ReadOnlyUserIdentity,
 };
 
 /// Private cross signing identity.
@@ -507,7 +506,7 @@ impl PrivateCrossSigningIdentity {
     /// account will sign the master key and the self signing key will sign the
     /// account.
     pub(crate) async fn with_account(
-        account: &ReadOnlyAccount,
+        account: &Account,
     ) -> (Self, UploadSigningKeysRequest, SignatureUploadRequest) {
         let mut master = MasterSigning::new(account.user_id().into());
         let mut public_key = master.public_key.as_ref().to_owned();
@@ -664,7 +663,7 @@ mod tests {
     use super::{PrivateCrossSigningIdentity, Signing};
     use crate::{
         identities::{ReadOnlyDevice, ReadOnlyUserIdentity},
-        olm::{ReadOnlyAccount, SignedJsonObject, VerifyJson},
+        olm::{Account, SignedJsonObject, VerifyJson},
         types::Signatures,
     };
 
@@ -746,7 +745,7 @@ mod tests {
 
     #[async_test]
     async fn private_identity_signed_by_account() {
-        let account = ReadOnlyAccount::with_device_id(user_id(), device_id!("DEVICEID"));
+        let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
         let master = identity.master_key.lock().await;
         let master = master.as_ref().unwrap();
@@ -769,7 +768,7 @@ mod tests {
 
     #[async_test]
     async fn sign_device() {
-        let account = ReadOnlyAccount::with_device_id(user_id(), device_id!("DEVICEID"));
+        let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
 
         let mut device = ReadOnlyDevice::from_account(&account).await;
@@ -786,11 +785,11 @@ mod tests {
 
     #[async_test]
     async fn sign_user_identity() {
-        let account = ReadOnlyAccount::with_device_id(user_id(), device_id!("DEVICEID"));
+        let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
 
         let bob_account =
-            ReadOnlyAccount::with_device_id(user_id!("@bob:localhost"), device_id!("DEVICEID"));
+            Account::with_device_id(user_id!("@bob:localhost"), device_id!("DEVICEID"));
         let (bob_private, _, _) = PrivateCrossSigningIdentity::with_account(&bob_account).await;
         let mut bob_public = ReadOnlyUserIdentity::from_private(&bob_private).await;
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -32,7 +32,7 @@ use tracing::{debug, error, info, instrument, trace};
 use crate::{
     error::{EventError, MegolmResult, OlmResult},
     identities::device::MaybeEncryptedRoomKey,
-    olm::{Account, InboundGroupSession, OutboundGroupSession, Session, ShareInfo, ShareState},
+    olm::{InboundGroupSession, OutboundGroupSession, Session, ShareInfo, ShareState},
     store::{Changes, Result as StoreResult, Store},
     types::events::{room::encrypted::RoomEncryptedEventContent, room_key_withheld::WithheldCode},
     Device, EncryptionSettings, OlmError, ToDeviceRequest,
@@ -133,7 +133,6 @@ pub struct CollectRecipientsResult {
 
 #[derive(Debug, Clone)]
 pub struct GroupSessionManager {
-    account: Account,
     /// Store for the encryption keys.
     /// Persists all the encryption keys so a client can resume the session
     /// without the need to create new keys.
@@ -145,8 +144,8 @@ pub struct GroupSessionManager {
 impl GroupSessionManager {
     const MAX_TO_DEVICE_MESSAGES: usize = 250;
 
-    pub(crate) fn new(account: Account, store: Store) -> Self {
-        Self { account, store: store.clone(), sessions: GroupSessionCache::new(store) }
+    pub(crate) fn new(store: Store) -> Self {
+        Self { store: store.clone(), sessions: GroupSessionCache::new(store) }
     }
 
     pub async fn invalidate_group_session(&self, room_id: &RoomId) -> StoreResult<bool> {
@@ -230,8 +229,8 @@ impl GroupSessionManager {
         settings: EncryptionSettings,
     ) -> OlmResult<(OutboundGroupSession, InboundGroupSession)> {
         let (outbound, inbound) = self
-            .account
-            .static_data
+            .store
+            .static_account()
             .create_group_session_pair(room_id, settings)
             .await
             .map_err(|_| EventError::UnsupportedAlgorithm)?;

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -480,7 +480,7 @@ mod tests {
     use crate::{
         gossiping::GossipMachine,
         identities::{IdentityManager, ReadOnlyDevice},
-        olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
+        olm::{Account, PrivateCrossSigningIdentity},
         session_manager::GroupSessionCache,
         store::{CryptoStoreWrapper, MemoryStore, Store},
         verification::VerificationMachine,
@@ -494,8 +494,8 @@ mod tests {
         device_id!("DEVICEID")
     }
 
-    fn bob_account() -> ReadOnlyAccount {
-        ReadOnlyAccount::with_device_id(user_id!("@bob:localhost"), device_id!("BOBDEVICE"))
+    fn bob_account() -> Account {
+        Account::with_device_id(user_id!("@bob:localhost"), device_id!("BOBDEVICE"))
     }
 
     fn keys_claim_with_failure() -> KeyClaimResponse {
@@ -530,7 +530,7 @@ mod tests {
         let device_id = device_id();
 
         let users_for_key_claim = Arc::new(StdRwLock::new(BTreeMap::new()));
-        let account = ReadOnlyAccount::with_device_id(user_id, device_id);
+        let account = Account::with_device_id(user_id, device_id);
         let store = Arc::new(CryptoStoreWrapper::new(user_id, MemoryStore::new()));
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(user_id)));
         let verification = VerificationMachine::new(
@@ -696,7 +696,7 @@ mod tests {
     #[async_test]
     async fn failure_handling() {
         let alice = user_id!("@alice:example.org");
-        let alice_account = ReadOnlyAccount::with_device_id(alice, "DEVICEID".into());
+        let alice_account = Account::with_device_id(alice, "DEVICEID".into());
         let alice_device = ReadOnlyDevice::from_account(&alice_account).await;
 
         let manager = session_manager().await;
@@ -739,7 +739,7 @@ mod tests {
         let response = KeyClaimResponse::try_from_http_response(response).unwrap();
 
         let alice = user_id!("@alice:example.org");
-        let alice_account = ReadOnlyAccount::with_device_id(alice, "DEVICEID".into());
+        let alice_account = Account::with_device_id(alice, "DEVICEID".into());
         let alice_device = ReadOnlyDevice::from_account(&alice_account).await;
 
         let manager = session_manager().await;

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -593,13 +593,9 @@ mod tests {
     }
 
     #[async_test]
-    async fn session_creation_waits_for_keys_query() {
+    async fn test_session_creation_waits_for_keys_query() {
         let manager = session_manager().await;
-        let identity_manager = IdentityManager::new(
-            manager.account.static_data.user_id.clone(),
-            manager.account.static_data.device_id.clone(),
-            manager.store.clone(),
-        );
+        let identity_manager = IdentityManager::new(manager.store.clone());
 
         // start a keys query request. At this point, we are only interested in our own
         // devices.

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -20,7 +20,7 @@ macro_rules! cryptostore_integration_tests {
             use $crate::{
                 olm::{
                     Curve25519PublicKey, InboundGroupSession, OlmMessageHash,
-                    PrivateCrossSigningIdentity, ReadOnlyAccount, Session,
+                    PrivateCrossSigningIdentity, Account, Session,
                 },
                 store::{
                     BackupKeys, Changes, CryptoStore, DeviceChanges,
@@ -62,7 +62,7 @@ macro_rules! cryptostore_integration_tests {
                 device_id!("BOBDEVICE")
             }
 
-            pub async fn get_loaded_store(name: &str) -> (ReadOnlyAccount, impl CryptoStore) {
+            pub async fn get_loaded_store(name: &str) -> (Account, impl CryptoStore) {
                 let store = get_store(name, None).await;
                 let account = get_account();
 
@@ -71,13 +71,13 @@ macro_rules! cryptostore_integration_tests {
                 (account, store)
             }
 
-            fn get_account() -> ReadOnlyAccount {
-                ReadOnlyAccount::with_device_id(alice_id(), alice_device_id())
+            fn get_account() -> Account {
+                Account::with_device_id(alice_id(), alice_device_id())
             }
 
-            async fn get_account_and_session() -> (ReadOnlyAccount, Session) {
-                let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
-                let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
+            async fn get_account_and_session() -> (Account, Session) {
+                let alice = Account::with_device_id(alice_id(), alice_device_id());
+                let bob = Account::with_device_id(bob_id(), bob_device_id());
 
                 bob.generate_one_time_keys_helper(1).await;
                 let one_time_key = *bob.one_time_keys().await.values().next().unwrap();
@@ -403,13 +403,13 @@ macro_rules! cryptostore_integration_tests {
                 let dir = "device_saving";
                 let (_account, store) = get_loaded_store(dir.clone()).await;
 
-                let alice_device_1 = ReadOnlyDevice::from_account(&ReadOnlyAccount::with_device_id(
+                let alice_device_1 = ReadOnlyDevice::from_account(&Account::with_device_id(
                     "@alice:localhost".try_into().unwrap(),
                     "FIRSTDEVICE".into(),
                 ))
                 .await;
 
-                let alice_device_2 = ReadOnlyDevice::from_account(&ReadOnlyAccount::with_device_id(
+                let alice_device_2 = ReadOnlyDevice::from_account(&Account::with_device_id(
                     "@alice:localhost".try_into().unwrap(),
                     "SECONDDEVICE".into(),
                 ))
@@ -489,7 +489,7 @@ macro_rules! cryptostore_integration_tests {
 
                 let store = get_store(dir, None).await;
 
-                let account = ReadOnlyAccount::with_device_id(&user_id, device_id);
+                let account = Account::with_device_id(&user_id, device_id);
 
                 store.save_changes(Changes { account: Some(account.clone()), ..Default::default() })
                     .await

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -29,8 +29,8 @@ use tracing::warn;
 
 use super::{
     caches::{DeviceStore, GroupSessionStore, SessionStore},
-    BackupKeys, Changes, CryptoStore, InboundGroupSession, ReadOnlyAccount, RoomKeyCounts,
-    RoomSettings, Session,
+    Account, BackupKeys, Changes, CryptoStore, InboundGroupSession, RoomKeyCounts, RoomSettings,
+    Session,
 };
 use crate::{
     gossiping::{GossipRequest, GossippedSecret, SecretInfo},
@@ -125,7 +125,7 @@ type Result<T> = std::result::Result<T, Infallible>;
 impl CryptoStore for MemoryStore {
     type Error = Infallible;
 
-    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
+    async fn load_account(&self) -> Result<Option<Account>> {
         Ok(None)
     }
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -67,8 +67,8 @@ use crate::{
         user::UserIdentities, Device, ReadOnlyDevice, ReadOnlyUserIdentities, UserDevices,
     },
     olm::{
-        InboundGroupSession, OlmMessageHash, OutboundGroupSession, PrivateCrossSigningIdentity,
-        ReadOnlyAccount, Session, StaticAccountData,
+        Account, InboundGroupSession, OlmMessageHash, OutboundGroupSession,
+        PrivateCrossSigningIdentity, Session, StaticAccountData,
     },
     types::{events::room_key_withheld::RoomKeyWithheldEvent, EventEncryptionAlgorithm},
     verification::VerificationMachine,
@@ -137,7 +137,7 @@ struct StoreInner {
 
     verification_machine: VerificationMachine,
 
-    account: ReadOnlyAccount, // TODO(bnjbvr, #2624) move this into the store cache
+    account: Account, // TODO(bnjbvr, #2624) move this into the store cache
 
     /// Record of the users that are waiting for a /keys/query.
     //
@@ -159,7 +159,7 @@ struct StoreInner {
 #[derive(Default, Debug)]
 #[allow(missing_docs)]
 pub struct Changes {
-    pub account: Option<ReadOnlyAccount>,
+    pub account: Option<Account>,
     pub private_identity: Option<PrivateCrossSigningIdentity>,
     pub backup_version: Option<String>,
     pub backup_decryption_key: Option<BackupDecryptionKey>,
@@ -533,7 +533,7 @@ impl From<&InboundGroupSession> for RoomKeyInfo {
 impl Store {
     /// Create a new Store
     pub(crate) fn new(
-        account: ReadOnlyAccount,
+        account: Account,
         identity: Arc<Mutex<PrivateCrossSigningIdentity>>,
         store: Arc<CryptoStoreWrapper>,
         verification_machine: VerificationMachine,
@@ -563,7 +563,7 @@ impl Store {
     }
 
     /// The Account associated with this store
-    pub(crate) fn account(&self) -> &ReadOnlyAccount {
+    pub(crate) fn account(&self) -> &Account {
         &self.inner.account
     }
 
@@ -608,7 +608,7 @@ impl Store {
         self.inner.store.save_changes(changes).await
     }
 
-    pub(crate) async fn save_account(&self, account: ReadOnlyAccount) -> Result<()> {
+    pub(crate) async fn save_account(&self, account: Account) -> Result<()> {
         self.inner
             .store
             .save_changes(Changes { account: Some(account), ..Default::default() })

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -28,8 +28,8 @@ use crate::{
         Session,
     },
     types::events::room_key_withheld::RoomKeyWithheldEvent,
-    GossipRequest, GossippedSecret, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyUserIdentities,
-    SecretInfo, TrackedUser,
+    Account, GossipRequest, GossippedSecret, ReadOnlyDevice, ReadOnlyUserIdentities, SecretInfo,
+    TrackedUser,
 };
 
 /// Represents a store that the `OlmMachine` uses to store E2EE data (such as
@@ -41,7 +41,7 @@ pub trait CryptoStore: AsyncTraitDeps {
     type Error: fmt::Debug + Into<CryptoStoreError>;
 
     /// Load an account that was previously stored.
-    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>, Self::Error>;
+    async fn load_account(&self) -> Result<Option<Account>, Self::Error>;
 
     /// Try to load a private cross signing identity, if one is stored.
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>, Self::Error>;
@@ -276,7 +276,7 @@ impl<T: fmt::Debug> fmt::Debug for EraseCryptoStoreError<T> {
 impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
     type Error = CryptoStoreError;
 
-    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
+    async fn load_account(&self) -> Result<Option<Account>> {
         self.0.load_account().await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -539,7 +539,7 @@ mod tests {
             tests::{alice_device_id, alice_id, setup_stores, wrap_any_to_device_content},
             FlowId, VerificationStore,
         },
-        ReadOnlyAccount, VerificationRequest,
+        Account, VerificationRequest,
     };
 
     async fn verification_machine() -> (VerificationMachine, VerificationStore) {
@@ -574,7 +574,7 @@ mod tests {
 
     #[async_test]
     async fn create() {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let identity = Arc::new(Mutex::new(PrivateCrossSigningIdentity::empty(alice_id())));
         let _ = VerificationMachine::new(
             alice.static_data,

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -748,7 +748,7 @@ pub(crate) mod tests {
         requests::{OutgoingRequest, OutgoingRequests},
         store::{Changes, CryptoStore, CryptoStoreWrapper, IdentityChanges, MemoryStore},
         types::events::ToDeviceEvents,
-        OutgoingVerificationRequest, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyOwnUserIdentity,
+        Account, OutgoingVerificationRequest, ReadOnlyDevice, ReadOnlyOwnUserIdentity,
         ReadOnlyUserIdentity,
     };
 
@@ -821,15 +821,14 @@ pub(crate) mod tests {
         device_id!("BOBDEVCIE")
     }
 
-    pub(crate) async fn setup_stores(
-    ) -> (ReadOnlyAccount, VerificationStore, ReadOnlyAccount, VerificationStore) {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+    pub(crate) async fn setup_stores() -> (Account, VerificationStore, Account, VerificationStore) {
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let alice_store = MemoryStore::new();
         let (alice_private_identity, _, _) =
             PrivateCrossSigningIdentity::with_account(&alice).await;
         let alice_private_identity = Mutex::new(alice_private_identity);
 
-        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
+        let bob = Account::with_device_id(bob_id(), bob_device_id());
         let bob_store = MemoryStore::new();
         let (bob_private_identity, _, _) = PrivateCrossSigningIdentity::with_account(&bob).await;
         let bob_private_identity = Mutex::new(bob_private_identity);

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -890,7 +890,7 @@ mod tests {
     use tokio::sync::Mutex;
 
     use crate::{
-        olm::{PrivateCrossSigningIdentity, ReadOnlyAccount},
+        olm::{Account, PrivateCrossSigningIdentity},
         store::{Changes, CryptoStoreWrapper, MemoryStore},
         verification::{
             event_enums::{DoneContent, OutgoingContent, StartContent},
@@ -913,7 +913,7 @@ mod tests {
 
     #[async_test]
     async fn test_verification_creation() {
-        let account = ReadOnlyAccount::with_device_id(user_id(), device_id());
+        let account = Account::with_device_id(user_id(), device_id());
         let store = memory_store(account.user_id());
 
         let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
@@ -978,7 +978,7 @@ mod tests {
     #[async_test]
     async fn test_reciprocate_receival() {
         let test = |flow_id: FlowId| async move {
-            let alice_account = ReadOnlyAccount::with_device_id(user_id(), device_id());
+            let alice_account = Account::with_device_id(user_id(), device_id());
             let store = memory_store(alice_account.user_id());
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
@@ -990,7 +990,7 @@ mod tests {
             };
 
             let bob_account =
-                ReadOnlyAccount::with_device_id(alice_account.user_id(), device_id!("BOBDEVICE"));
+                Account::with_device_id(alice_account.user_id(), device_id!("BOBDEVICE"));
 
             let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
             let identity = private_identity.to_public_identity().await.unwrap();

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -869,7 +869,7 @@ mod tests {
             event_enums::{AcceptContent, KeyContent, MacContent, OutgoingContent, StartContent},
             VerificationStore,
         },
-        ReadOnlyAccount, ReadOnlyDevice, SasState,
+        Account, ReadOnlyDevice, SasState,
     };
 
     fn alice_id() -> &'static UserId {
@@ -890,10 +890,10 @@ mod tests {
 
     async fn machine_pair() -> (VerificationStore, ReadOnlyDevice, VerificationStore, ReadOnlyDevice)
     {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let alice_device = ReadOnlyDevice::from_account(&alice).await;
 
-        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
+        let bob = Account::with_device_id(bob_id(), bob_device_id());
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
         let alice_store = VerificationStore {

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -1530,7 +1530,7 @@ mod tests {
             event_enums::{AcceptContent, KeyContent, MacContent, StartContent},
             FlowId,
         },
-        AcceptedProtocols, ReadOnlyAccount, ReadOnlyDevice,
+        AcceptedProtocols, Account, ReadOnlyDevice,
     };
 
     fn alice_id() -> &'static UserId {
@@ -1552,10 +1552,10 @@ mod tests {
     async fn get_sas_pair(
         mac_method: Option<SupportedMacMethod>,
     ) -> (SasState<Created>, SasState<WeAccepted>) {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let alice_device = ReadOnlyDevice::from_account(&alice).await;
 
-        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
+        let bob = Account::with_device_id(bob_id(), bob_device_id());
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
         let flow_id = TransactionId::new().into();
@@ -1825,10 +1825,10 @@ mod tests {
 
     #[async_test]
     async fn sas_from_start_unknown_method() {
-        let alice = ReadOnlyAccount::with_device_id(alice_id(), alice_device_id());
+        let alice = Account::with_device_id(alice_id(), alice_device_id());
         let alice_device = ReadOnlyDevice::from_account(&alice).await;
 
-        let bob = ReadOnlyAccount::with_device_id(bob_id(), bob_device_id());
+        let bob = Account::with_device_id(bob_id(), bob_device_id());
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
 
         let flow_id = TransactionId::new().into();

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -30,8 +30,8 @@ use matrix_sdk_crypto::{
         RoomSettings,
     },
     types::events::room_key_withheld::RoomKeyWithheldEvent,
-    GossipRequest, GossippedSecret, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyUserIdentities,
-    SecretInfo, TrackedUser,
+    Account, GossipRequest, GossippedSecret, ReadOnlyDevice, ReadOnlyUserIdentities, SecretInfo,
+    TrackedUser,
 };
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
@@ -802,7 +802,7 @@ impl_crypto_store! {
             .transpose()?)
     }
 
-    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
+    async fn load_account(&self) -> Result<Option<Account>> {
         if let Some(pickle) = self
             .inner
             .transaction_on_one_with_mode(keys::CORE, IdbTransactionMode::Readonly)?
@@ -812,7 +812,7 @@ impl_crypto_store! {
         {
             let pickle = self.deserialize_value(pickle)?;
 
-            let account = ReadOnlyAccount::from_pickle(pickle).map_err(CryptoStoreError::from)?;
+            let account = Account::from_pickle(pickle).map_err(CryptoStoreError::from)?;
 
             *self.static_account.write().unwrap() = Some(account.static_data().clone());
 

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -29,8 +29,8 @@ use matrix_sdk_crypto::{
     },
     store::{caches::SessionStore, BackupKeys, Changes, CryptoStore, RoomKeyCounts, RoomSettings},
     types::events::room_key_withheld::RoomKeyWithheldEvent,
-    GossipRequest, GossippedSecret, ReadOnlyAccount, ReadOnlyDevice, ReadOnlyUserIdentities,
-    SecretInfo, TrackedUser,
+    Account, GossipRequest, GossippedSecret, ReadOnlyDevice, ReadOnlyUserIdentities, SecretInfo,
+    TrackedUser,
 };
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{
@@ -652,12 +652,12 @@ impl SqliteObjectCryptoStoreExt for deadpool_sqlite::Object {}
 impl CryptoStore for SqliteCryptoStore {
     type Error = Error;
 
-    async fn load_account(&self) -> Result<Option<ReadOnlyAccount>> {
+    async fn load_account(&self) -> Result<Option<Account>> {
         let conn = self.acquire().await?;
         if let Some(pickle) = conn.get_kv("account").await? {
             let pickle = self.deserialize_value(&pickle)?;
 
-            let account = ReadOnlyAccount::from_pickle(pickle).map_err(|_| Error::Unpickle)?;
+            let account = Account::from_pickle(pickle).map_err(|_| Error::Unpickle)?;
 
             *self.static_account.write().unwrap() = Some(account.static_data().clone());
 


### PR DESCRIPTION
This started as "oh it looks like I can avoid using `Account` here and there" until there was only a single meaningful use in `OlmMachine`. But what is an `Account`, other than a `ReadOnlyAccount` with extra capabilities and access to a store? By passing the store as a parameter to most `Account` methods, those methods could be moved to the `ReadOnlyAccount`, resulting in their merging \o/

Then I could rename `ReadOnlyAccount` to `Account`. The universe is a bit more in order.

This can be reviewed commit by commit.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/2624.