### PR TITLE
ui: Keep track of the order of all received events in the Timeline

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -197,7 +197,7 @@ impl TimelineEventKind {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub(super) enum TimelineItemPosition {
     Start,
     End {

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -59,7 +59,7 @@ use super::{
     pagination::PaginationTokens,
     reactions::ReactionToggleResult,
     traits::RoomDataProvider,
-    util::{compare_events_positions, rfind_event_by_id, rfind_event_item, RelativePosition},
+    util::{rfind_event_by_id, rfind_event_item, RelativePosition},
     AnnotationKey, EventSendState, EventTimelineItem, InReplyToDetails, Message, Profile,
     RepliedToEvent, TimelineDetails, TimelineItem, TimelineItemContent, TimelineItemKind,
 };
@@ -947,7 +947,7 @@ impl TimelineInner {
                     state.user_receipt(own_user_id, ReceiptType::Read, room).await
                 {
                     if let Some(relative_pos) =
-                        compare_events_positions(&old_pub_read, event_id, &state.items)
+                        state.meta.compare_events_positions(&old_pub_read, event_id)
                     {
                         return relative_pos == RelativePosition::After;
                     }
@@ -960,7 +960,7 @@ impl TimelineInner {
                     state.latest_user_read_receipt(own_user_id, room).await
                 {
                     if let Some(relative_pos) =
-                        compare_events_positions(&old_priv_read, event_id, &state.items)
+                        state.meta.compare_events_positions(&old_priv_read, event_id)
                     {
                         return relative_pos == RelativePosition::After;
                     }
@@ -968,11 +968,10 @@ impl TimelineInner {
             }
             SendReceiptType::FullyRead => {
                 if let Some(old_fully_read) = self.fully_read_event().await {
-                    if let Some(relative_pos) = compare_events_positions(
-                        &old_fully_read.content.event_id,
-                        event_id,
-                        &state.items,
-                    ) {
+                    if let Some(relative_pos) = state
+                        .meta
+                        .compare_events_positions(&old_fully_read.content.event_id, event_id)
+                    {
                         return relative_pos == RelativePosition::After;
                     }
                 }

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     future::Future,
     mem::{self, ManuallyDrop},
     ops::{Deref, DerefMut},
@@ -35,8 +35,8 @@ use ruma::{
         AnyMessageLikeEventContent, AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent,
     },
     push::Action,
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
-    UserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
+    RoomVersionId, UserId,
 };
 use tracing::{debug, error, instrument, trace, warn};
 
@@ -551,12 +551,20 @@ impl TimelineInnerStateTransaction<'_> {
                     let event_type = event.event_type();
                     let event_id = event.event_id();
                     warn!(%event_type, %event_id, "Failed to deserialize timeline event: {e}");
+
+                    self.add_event(event_id.to_owned(), false, position);
+
                     return HandleEventResult::default();
                 }
                 Err(e) => {
                     let event_type: Option<String> = raw.get_field("type").ok().flatten();
                     let event_id: Option<String> = raw.get_field("event_id").ok().flatten();
                     warn!(event_type, event_id, "Failed to deserialize timeline event: {e}");
+
+                    if let Some(Ok(event_id)) = event_id.map(EventId::parse) {
+                        self.add_event(event_id.to_owned(), false, position);
+                    }
+
                     return HandleEventResult::default();
                 }
             },
@@ -565,6 +573,8 @@ impl TimelineInnerStateTransaction<'_> {
         if let Some(token) = back_pagination_token {
             self.meta.back_pagination_tokens.push((event_id.clone(), token));
         }
+
+        self.add_event(event_id.clone(), should_add, position);
 
         let is_own_event = sender == room_data_provider.own_user_id();
         let sender_profile = room_data_provider.profile(&sender).await;
@@ -618,6 +628,7 @@ impl TimelineInnerStateTransaction<'_> {
             self.items.clear();
         }
 
+        self.all_events.clear();
         self.reactions.clear();
         self.fully_read_event = None;
         self.event_should_update_fully_read_marker = false;
@@ -677,6 +688,9 @@ impl DerefMut for TimelineInnerStateTransaction<'_> {
 
 #[derive(Debug)]
 pub(in crate::timeline) struct TimelineInnerMetadata {
+    /// List of all the events as received in the timeline, even the ones that
+    /// are discarded in the timeline items.
+    all_events: VecDeque<EventMeta>,
     next_internal_id: u64,
     pub reactions: Reactions,
     pub poll_pending_events: PollPendingEvents,
@@ -706,6 +720,7 @@ pub(in crate::timeline) struct TimelineInnerMetadata {
 impl TimelineInnerMetadata {
     fn new(room_version: RoomVersionId) -> TimelineInnerMetadata {
         Self {
+            all_events: Default::default(),
             next_internal_id: Default::default(),
             reactions: Default::default(),
             poll_pending_events: Default::default(),
@@ -716,6 +731,32 @@ impl TimelineInnerMetadata {
             in_flight_reaction: Default::default(),
             room_version,
             back_pagination_tokens: Vec::new(),
+        }
+    }
+
+    fn add_event(&mut self, event_id: OwnedEventId, visible: bool, position: TimelineItemPosition) {
+        let meta = EventMeta { event_id, visible };
+
+        match position {
+            TimelineItemPosition::Start => self.all_events.push_front(meta),
+            TimelineItemPosition::End { .. } => {
+                // Handle duplicated event.
+                if let Some(pos) =
+                    self.all_events.iter().position(|ev| ev.event_id == meta.event_id)
+                {
+                    self.all_events.remove(pos);
+                }
+
+                self.all_events.push_back(meta);
+            }
+            #[cfg(feature = "e2e-encryption")]
+            TimelineItemPosition::Update(_) => {
+                if let Some(event) =
+                    self.all_events.iter_mut().find(|e| e.event_id == meta.event_id)
+                {
+                    event.visible = visible;
+                }
+            }
         }
     }
 
@@ -789,4 +830,13 @@ impl TimelineInnerMetadata {
             }
         }
     }
+}
+
+/// Metadata about an event.
+#[derive(Debug, Clone)]
+struct EventMeta {
+    /// The ID of the event.
+    event_id: OwnedEventId,
+    /// Whether the event is among the timeline items.
+    visible: bool,
 }

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -28,7 +28,7 @@ use super::{
     inner::{TimelineInnerMetadata, TimelineInnerState, TimelineInnerStateTransaction},
     item::timeline_item,
     traits::RoomDataProvider,
-    util::{compare_events_positions, rfind_event_by_id, RelativePosition},
+    util::{rfind_event_by_id, RelativePosition},
     EventTimelineItem, TimelineItem,
 };
 
@@ -148,8 +148,7 @@ impl TimelineInnerState {
         };
 
         // Compare by position in the timeline.
-        if let Some(relative_pos) =
-            compare_events_positions(pub_event_id, priv_event_id, &self.items)
+        if let Some(relative_pos) = self.meta.compare_events_positions(pub_event_id, priv_event_id)
         {
             if relative_pos == RelativePosition::After {
                 return private_read_receipt;

--- a/crates/matrix-sdk-ui/src/timeline/util.rs
+++ b/crates/matrix-sdk-ui/src/timeline/util.rs
@@ -82,25 +82,6 @@ pub(super) enum RelativePosition {
     Before,
 }
 
-pub(super) fn compare_events_positions(
-    event_a: &EventId,
-    event_b: &EventId,
-    timeline_items: &Vector<Arc<TimelineItem>>,
-) -> Option<RelativePosition> {
-    if event_a == event_b {
-        return Some(RelativePosition::Same);
-    }
-
-    let (pos_event_a, _) = rfind_event_by_id(timeline_items, event_a)?;
-    let (pos_event_b, _) = rfind_event_by_id(timeline_items, event_b)?;
-
-    if pos_event_a > pos_event_b {
-        Some(RelativePosition::Before)
-    } else {
-        Some(RelativePosition::After)
-    }
-}
-
 #[derive(PartialEq)]
 pub(super) struct Date {
     year: i32,


### PR DESCRIPTION
`TimelineInnerState::latest_user_read_receipt()` should be more accurate. This is also a preliminary step to have more accurate tracking of read receipts.

First split of #2646.