### PR TITLE
ui: Do not add explicit receipts if implicit receipt is newer

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -874,7 +874,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         &mut item,
                         self.ctx.is_own_event,
                         self.items,
-                        &mut self.meta.users_read_receipts,
+                        &mut self.meta.read_receipts,
                     );
                 }
 
@@ -928,7 +928,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                                 &mut item,
                                 self.ctx.is_own_event,
                                 self.items,
-                                &mut self.meta.users_read_receipts,
+                                &mut self.meta.read_receipts,
                             );
                         }
 
@@ -1037,7 +1037,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         &mut item,
                         self.ctx.is_own_event,
                         self.items,
-                        &mut self.meta.users_read_receipts,
+                        &mut self.meta.read_receipts,
                     );
                 }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -301,6 +301,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         self.state
             .write()
             .await
+            .read_receipts
             .users_read_receipts
             .entry(own_user_id)
             .or_default()

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::VecDeque,
     future::Future,
     mem::{self, ManuallyDrop},
     ops::{Deref, DerefMut},
@@ -29,9 +29,7 @@ use matrix_sdk_base::{deserialized_responses::TimelineEvent, sync::JoinedRoom};
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
     events::{
-        receipt::{Receipt, ReceiptType},
-        relation::Annotation,
-        room::redaction::RoomRedactionEventContent,
+        relation::Annotation, room::redaction::RoomRedactionEventContent,
         AnyMessageLikeEventContent, AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent,
     },
     push::Action,
@@ -52,6 +50,7 @@ use crate::{
         item::timeline_item,
         polls::PollPendingEvents,
         reactions::{ReactionToggleResult, Reactions},
+        read_receipts::ReadReceipts,
         traits::RoomDataProvider,
         util::{
             find_read_marker, rfind_event_by_id, rfind_event_item, timestamp_to_date,
@@ -632,6 +631,7 @@ impl TimelineInnerStateTransaction<'_> {
         }
 
         self.all_events.clear();
+        self.read_receipts.clear();
         self.reactions.clear();
         self.fully_read_event = None;
         self.event_should_update_fully_read_marker = false;
@@ -704,9 +704,7 @@ pub(in crate::timeline) struct TimelineInnerMetadata {
     /// - The fully-read marker points to an event that is not in the timeline,
     /// - The fully-read marker item would be the last item in the timeline.
     pub event_should_update_fully_read_marker: bool,
-    /// User ID => Receipt type => Read receipt of the user of the given
-    /// type.
-    pub users_read_receipts: HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
+    pub read_receipts: ReadReceipts,
     /// the local reaction request state that is queued next
     pub reaction_state: IndexMap<AnnotationKey, ReactionState>,
     /// the in flight reaction request state that is ongoing
@@ -729,7 +727,7 @@ impl TimelineInnerMetadata {
             poll_pending_events: Default::default(),
             fully_read_event: Default::default(),
             event_should_update_fully_read_marker: Default::default(),
-            users_read_receipts: Default::default(),
+            read_receipts: Default::default(),
             reaction_state: Default::default(),
             in_flight_reaction: Default::default(),
             room_version,

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -587,7 +587,8 @@ impl TimelineInnerStateTransaction<'_> {
             is_own_event,
             encryption_info: event.encryption_info,
             read_receipts: if settings.track_read_receipts {
-                self.load_read_receipts_for_event(&event_id, room_data_provider).await
+                self.load_read_receipts_for_event(&event_id, room_data_provider).await;
+                self.meta.read_receipts.read_receipts_for_event(&event_id)
             } else {
                 Default::default()
             },

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -123,17 +123,14 @@ impl ReadReceipts {
 
         // Remove the old receipt from the old event.
         if let Some(old_event_id) = old_event_id {
-            let is_empty =
-                if let Some(event_receipts) = self.events_read_receipts.get_mut(old_event_id) {
-                    event_receipts.remove(receipt.user_id);
-                    event_receipts.is_empty()
-                } else {
-                    false
-                };
-            // Remove the entry if the map is empty.
-            if is_empty {
-                self.events_read_receipts.remove(old_event_id);
-            }
+            if let Some(event_receipts) = self.events_read_receipts.get_mut(old_event_id) {
+                event_receipts.remove(receipt.user_id);
+
+                // Remove the entry if the map is empty.
+                if event_receipts.is_empty() {
+                    self.events_read_receipts.remove(old_event_id);
+                }
+            };
         }
 
         // Add the new receipt to the new event.

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -32,6 +32,99 @@ use super::{
     EventTimelineItem, TimelineItem,
 };
 
+#[derive(Clone, Debug, Default)]
+pub(super) struct ReadReceipts {
+    /// Map of all user read receipts.
+    ///
+    /// User ID => Receipt type => Read receipt of the user of the given
+    /// type.
+    pub users_read_receipts: HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
+}
+
+impl ReadReceipts {
+    /// Remove all data.
+    pub(super) fn clear(&mut self) {
+        self.users_read_receipts.clear();
+    }
+
+    /// Update the timeline items with the given read receipt if it is more
+    /// recent than the current one.
+    ///
+    /// In the process, this method removes the corresponding receipt from its
+    /// old item, if applicable, and updates the `users_read_receipts` map
+    /// to use the new receipt.
+    ///
+    /// Returns true if the read receipt was saved.
+    ///
+    /// Currently this method only works reliably if the timeline was started
+    /// from the end of the timeline.
+    fn maybe_update_read_receipt(
+        &mut self,
+        receipt: FullReceipt<'_>,
+        new_item_pos: Option<usize>,
+        is_own_user_id: bool,
+        timeline_items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
+    ) -> bool {
+        let old_event_id = self
+            .users_read_receipts
+            .get(receipt.user_id)
+            .and_then(|receipts| receipts.get(&receipt.receipt_type))
+            .map(|(event_id, _)| event_id);
+        if old_event_id.is_some_and(|id| id == receipt.event_id) {
+            // Nothing to do.
+            return false;
+        }
+
+        let old_item_and_pos = old_event_id.and_then(|e| rfind_event_by_id(timeline_items, e));
+        if let Some((old_receipt_pos, old_event_item)) = old_item_and_pos {
+            let Some(new_receipt_pos) = new_item_pos else {
+                // The old receipt is likely more recent since we can't find the
+                // event of the new receipt in the timeline. Even if it isn't, we
+                // wouldn't know where to put it.
+                return false;
+            };
+
+            if old_receipt_pos > new_receipt_pos {
+                // The old receipt is more recent than the new one.
+                return false;
+            }
+
+            if !is_own_user_id {
+                // Remove the read receipt for this user from the old event.
+                let old_event_item_id = old_event_item.internal_id;
+                let mut old_event_item = old_event_item.clone();
+                if let Some(old_remote_event_item) = old_event_item.as_remote_mut() {
+                    if !old_remote_event_item.remove_read_receipt(receipt.user_id) {
+                        error!(
+                            "inconsistent state: old event item for user's read \
+                         receipt doesn't have a receipt for the user"
+                        );
+                    }
+                    timeline_items
+                        .set(old_receipt_pos, timeline_item(old_event_item, old_event_item_id));
+                } else {
+                    warn!("received a read receipt for a local item, this should not be possible");
+                }
+            }
+        }
+
+        // The new receipt is deemed more recent from now on because:
+        // - If old_receipt_item is Some, we already checked all the cases where it
+        //   wouldn't be more recent.
+        // - If both old_receipt_item and new_receipt_item are None, they are both
+        //   explicit read receipts so the server should only send us a more recent
+        //   receipt.
+        // - If old_receipt_item is None and new_receipt_item is Some, the new receipt
+        //   is likely more recent because it has a place in the timeline.
+        self.users_read_receipts
+            .entry(receipt.user_id.to_owned())
+            .or_default()
+            .insert(receipt.receipt_type, (receipt.event_id.to_owned(), receipt.receipt.clone()));
+
+        true
+    }
+}
+
 struct FullReceipt<'a> {
     event_id: &'a EventId,
     user_id: &'a UserId,
@@ -82,12 +175,11 @@ impl TimelineInnerStateTransaction<'_> {
                         receipt: &receipt,
                     };
 
-                    let read_receipt_updated = maybe_update_read_receipt(
+                    let read_receipt_updated = self.meta.read_receipts.maybe_update_read_receipt(
                         full_receipt,
                         receipt_item_pos,
                         is_own_user_id,
                         &mut self.items,
-                        &mut self.meta.users_read_receipts,
                     );
 
                     if read_receipt_updated && !is_own_user_id {
@@ -115,8 +207,10 @@ impl TimelineInnerStateTransaction<'_> {
         for (user_id, receipt) in read_receipts.clone() {
             // Only insert the read receipt if the user is not known to avoid conflicts with
             // `TimelineInner::handle_read_receipts`.
-            if !self.users_read_receipts.contains_key(&user_id) {
-                self.users_read_receipts
+            if !self.meta.read_receipts.users_read_receipts.contains_key(&user_id) {
+                self.meta
+                    .read_receipts
+                    .users_read_receipts
                     .entry(user_id)
                     .or_default()
                     .insert(ReceiptType::Read, (event_id.to_owned(), receipt));
@@ -183,6 +277,7 @@ impl TimelineInnerMetadata {
         room: &Room,
     ) -> Option<(OwnedEventId, Receipt)> {
         if let Some(receipt) = self
+            .read_receipts
             .users_read_receipts
             .get(user_id)
             .and_then(|user_map| user_map.get(&receipt_type))
@@ -212,7 +307,7 @@ pub(super) fn maybe_add_implicit_read_receipt(
     event_item: &mut EventTimelineItem,
     is_own_event: bool,
     timeline_items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
-    users_read_receipts: &mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
+    read_receipts: &mut ReadReceipts,
 ) {
     let EventTimelineItemKind::Remote(remote_event_item) = &mut event_item.kind else {
         return;
@@ -226,90 +321,13 @@ pub(super) fn maybe_add_implicit_read_receipt(
         receipt: &receipt,
     };
 
-    let read_receipt_updated = maybe_update_read_receipt(
+    let read_receipt_updated = read_receipts.maybe_update_read_receipt(
         new_receipt,
         Some(item_pos),
         is_own_event,
         timeline_items,
-        users_read_receipts,
     );
     if read_receipt_updated && !is_own_event {
         remote_event_item.add_read_receipt(event_item.sender.clone(), receipt);
     }
-}
-
-/// Update the timeline items with the given read receipt if it is more recent
-/// than the current one.
-///
-/// In the process, this method removes the corresponding receipt from its old
-/// item, if applicable, and updates the `users_read_receipts` map to use the
-/// new receipt.
-///
-/// Returns true if the read receipt was saved.
-///
-/// Currently this method only works reliably if the timeline was started from
-/// the end of the timeline.
-fn maybe_update_read_receipt(
-    receipt: FullReceipt<'_>,
-    new_item_pos: Option<usize>,
-    is_own_user_id: bool,
-    timeline_items: &mut ObservableVectorTransaction<'_, Arc<TimelineItem>>,
-    users_read_receipts: &mut HashMap<OwnedUserId, HashMap<ReceiptType, (OwnedEventId, Receipt)>>,
-) -> bool {
-    let old_event_id = users_read_receipts
-        .get(receipt.user_id)
-        .and_then(|receipts| receipts.get(&receipt.receipt_type))
-        .map(|(event_id, _)| event_id);
-    if old_event_id.is_some_and(|id| id == receipt.event_id) {
-        // Nothing to do.
-        return false;
-    }
-
-    let old_item_and_pos = old_event_id.and_then(|e| rfind_event_by_id(timeline_items, e));
-    if let Some((old_receipt_pos, old_event_item)) = old_item_and_pos {
-        let Some(new_receipt_pos) = new_item_pos else {
-            // The old receipt is likely more recent since we can't find the
-            // event of the new receipt in the timeline. Even if it isn't, we
-            // wouldn't know where to put it.
-            return false;
-        };
-
-        if old_receipt_pos > new_receipt_pos {
-            // The old receipt is more recent than the new one.
-            return false;
-        }
-
-        if !is_own_user_id {
-            // Remove the read receipt for this user from the old event.
-            let old_event_item_id = old_event_item.internal_id;
-            let mut old_event_item = old_event_item.clone();
-            if let Some(old_remote_event_item) = old_event_item.as_remote_mut() {
-                if !old_remote_event_item.remove_read_receipt(receipt.user_id) {
-                    error!(
-                        "inconsistent state: old event item for user's read \
-                         receipt doesn't have a receipt for the user"
-                    );
-                }
-                timeline_items
-                    .set(old_receipt_pos, timeline_item(old_event_item, old_event_item_id));
-            } else {
-                warn!("received a read receipt for a local item, this should not be possible");
-            }
-        }
-    }
-
-    // The new receipt is deemed more recent from now on because:
-    // - If old_receipt_item is Some, we already checked all the cases where it
-    //   wouldn't be more recent.
-    // - If both old_receipt_item and new_receipt_item are None, they are both
-    //   explicit read receipts so the server should only send us a more recent
-    //   receipt.
-    // - If old_receipt_item is None and new_receipt_item is Some, the new receipt
-    //   is likely more recent because it has a place in the timeline.
-    users_read_receipts
-        .entry(receipt.user_id.to_owned())
-        .or_default()
-        .insert(receipt.receipt_type, (receipt.event_id.to_owned(), receipt.receipt.clone()));
-
-    true
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -24,8 +24,9 @@ use futures_util::{FutureExt, StreamExt};
 use indexmap::IndexMap;
 use matrix_sdk::deserialized_responses::{SyncTimelineEvent, TimelineEvent};
 use matrix_sdk_base::latest_event::LatestEvent;
-use matrix_sdk_test::{EventBuilder, ALICE};
+use matrix_sdk_test::{EventBuilder, ALICE, BOB};
 use ruma::{
+    event_id,
     events::{
         receipt::{Receipt, ReceiptThread, ReceiptType},
         relation::Annotation,
@@ -39,8 +40,8 @@ use ruma::{
     push::{PushConditionRoomCtx, Ruleset},
     room_id,
     serde::Raw,
-    server_name, uint, EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomVersionId,
-    TransactionId, UserId,
+    server_name, uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId,
+    OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
 };
 
 use super::{
@@ -197,6 +198,19 @@ impl TestTimeline {
         txn_id
     }
 
+    async fn handle_back_paginated_message_event_with_id<C>(
+        &self,
+        sender: &UserId,
+        room_id: &RoomId,
+        event_id: &EventId,
+        content: C,
+    ) where
+        C: MessageLikeEventContent,
+    {
+        let ev = self.event_builder.make_message_event_with_id(sender, room_id, event_id, content);
+        self.handle_back_paginated_custom_event(ev).await;
+    }
+
     async fn handle_back_paginated_custom_event(&self, event: Raw<AnyTimelineEvent>) {
         let timeline_event = TimelineEvent::new(event.cast());
         self.inner
@@ -250,8 +264,12 @@ impl RoomDataProvider for TestRoomDataProvider {
         None
     }
 
-    async fn read_receipts_for_event(&self, _event_id: &EventId) -> IndexMap<OwnedUserId, Receipt> {
-        IndexMap::new()
+    async fn read_receipts_for_event(&self, event_id: &EventId) -> IndexMap<OwnedUserId, Receipt> {
+        if event_id == event_id!("$event_with_bob_receipt") {
+            [(BOB.to_owned(), Receipt::new(MilliSecondsSinceUnixEpoch(uint!(10))))].into()
+        } else {
+            IndexMap::new()
+        }
     }
 
     async fn push_rules_and_context(&self) -> Option<(Ruleset, PushConditionRoomCtx)> {


### PR DESCRIPTION
Should avoid the same user appearing on two different events receipts in the timeline

2nd split of #2646.