### PR TITLE
ui: Keep track of read receipts on all events 

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
@@ -19,7 +19,7 @@ use matrix_sdk::deserialized_responses::EncryptionInfo;
 use ruma::{
     events::{receipt::Receipt, AnySyncTimelineEvent},
     serde::Raw,
-    OwnedEventId, OwnedUserId, UserId,
+    OwnedEventId, OwnedUserId,
 };
 
 use super::BundledReactions;
@@ -62,17 +62,6 @@ pub(in crate::timeline) struct RemoteEventTimelineItem {
 }
 
 impl RemoteEventTimelineItem {
-    pub fn add_read_receipt(&mut self, user_id: OwnedUserId, receipt: Receipt) {
-        self.read_receipts.insert(user_id, receipt);
-    }
-
-    /// Remove the read receipt for the given user.
-    ///
-    /// Returns `true` if there was one, `false` if not.
-    pub fn remove_read_receipt(&mut self, user_id: &UserId) -> bool {
-        self.read_receipts.remove(user_id).is_some()
-    }
-
     /// Clone the current event item, and update its `reactions`.
     pub fn with_reactions(&self, reactions: BundledReactions) -> Self {
         Self { reactions, ..self.clone() }

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -67,7 +67,7 @@ use super::{
 mod state;
 
 pub(super) use self::state::{
-    TimelineInnerMetadata, TimelineInnerState, TimelineInnerStateTransaction,
+    FullEventMeta, TimelineInnerMetadata, TimelineInnerState, TimelineInnerStateTransaction,
 };
 
 #[derive(Clone, Debug)]
@@ -228,7 +228,6 @@ impl<P: RoomDataProvider> TimelineInner<P> {
                     sender_profile,
                     txn_id.clone(),
                     event_content.clone(),
-                    &self.settings,
                 );
                 ReactionState::Sending(txn_id)
             }
@@ -249,7 +248,6 @@ impl<P: RoomDataProvider> TimelineInner<P> {
                     TransactionId::new(),
                     to_redact,
                     no_reason.clone(),
-                    &self.settings,
                 );
 
                 // Remember the remote echo to redact on the homeserver
@@ -359,7 +357,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let profile = self.room_data_provider.profile_from_user_id(&sender).await;
 
         let mut state = self.state.write().await;
-        state.handle_local_event(sender, profile, txn_id, content, &self.settings);
+        state.handle_local_event(sender, profile, txn_id, content);
     }
 
     /// Handle the creation of a new local event.
@@ -374,7 +372,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let profile = self.room_data_provider.profile_from_user_id(&sender).await;
 
         let mut state = self.state.write().await;
-        state.handle_local_redaction(sender, profile, txn_id, to_redact, content, &self.settings);
+        state.handle_local_redaction(sender, profile, txn_id, to_redact, content);
     }
 
     /// Update the send state of a local event represented by a transaction ID.

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -67,7 +67,8 @@ use super::{
 mod state;
 
 pub(super) use self::state::{
-    FullEventMeta, TimelineInnerMetadata, TimelineInnerState, TimelineInnerStateTransaction,
+    EventMeta, FullEventMeta, TimelineInnerMetadata, TimelineInnerState,
+    TimelineInnerStateTransaction,
 };
 
 #[derive(Clone, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -718,12 +718,14 @@ impl TimelineInnerStateTransaction<'_> {
                 if let Some(event) =
                     self.all_events.iter_mut().find(|e| e.event_id == event_meta.event_id)
                 {
-                    event.visible = event_meta.visible;
+                    if event.visible != event_meta.visible {
+                        event.visible = event_meta.visible;
 
-                    if settings.track_read_receipts {
-                        // Since the event's visibility changed, we need to update the read
-                        // receipts of the previous visible event.
-                        self.maybe_update_read_receipts_of_prev_event(event_meta.event_id);
+                        if settings.track_read_receipts {
+                            // Since the event's visibility changed, we need to update the read
+                            // receipts of the previous visible event.
+                            self.maybe_update_read_receipts_of_prev_event(event_meta.event_id);
+                        }
                     }
                 }
             }

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -915,7 +915,7 @@ impl TimelineInnerMetadata {
 
 /// Full metadata about an event.
 #[derive(Debug, Clone, Copy)]
-pub struct FullEventMeta<'a> {
+pub(crate) struct FullEventMeta<'a> {
     /// The ID of the event.
     pub event_id: &'a EventId,
     /// Whether the event is among the timeline items.
@@ -936,7 +936,7 @@ impl<'a> FullEventMeta<'a> {
 
 /// Metadata about an event that needs to be kept in memory.
 #[derive(Debug, Clone)]
-pub struct EventMeta {
+pub(crate) struct EventMeta {
     /// The ID of the event.
     pub event_id: OwnedEventId,
     /// Whether the event is among the timeline items.

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -50,7 +50,7 @@ use crate::{
         item::timeline_item,
         polls::PollPendingEvents,
         reactions::{ReactionToggleResult, Reactions},
-        read_receipts::{maybe_add_implicit_read_receipt, ReadReceipts},
+        read_receipts::ReadReceipts,
         traits::RoomDataProvider,
         util::{
             find_read_marker, rfind_event_by_id, rfind_event_item, timestamp_to_date,
@@ -724,11 +724,7 @@ impl TimelineInnerStateTransaction<'_> {
         {
             self.load_read_receipts_for_event(event_meta.event_id, room_data_provider).await;
 
-            maybe_add_implicit_read_receipt(
-                event_meta,
-                &mut self.items,
-                &mut self.meta.read_receipts,
-            );
+            self.maybe_add_implicit_read_receipt(event_meta);
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -406,7 +406,7 @@ impl TimelineInnerStateTransaction<'_> {
     /// previous visible event because of a visibility change.
     pub(super) fn maybe_update_read_receipts_of_prev_event(&mut self, event_id: &EventId) {
         // Find the previous visible event, if there is one.
-        let Some((prev_item_pos, prev_event_item)) = self
+        let Some(prev_event_meta) = self
             .all_events
             .iter()
             .rev()
@@ -416,8 +416,14 @@ impl TimelineInnerStateTransaction<'_> {
             .skip(1)
             // Find the first visible item.
             .find(|meta| meta.visible)
-            .and_then(|meta| rfind_event_by_id(&self.items, &meta.event_id))
         else {
+            return;
+        };
+
+        let Some((prev_item_pos, prev_event_item)) =
+            rfind_event_by_id(&self.items, &prev_event_meta.event_id)
+        else {
+            error!("inconsistent state: timeline item of visible event was not found");
             return;
         };
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -106,6 +106,18 @@ impl TestTimeline {
         self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
     }
 
+    async fn handle_live_message_event_with_id<C>(
+        &self,
+        sender: &UserId,
+        event_id: &EventId,
+        content: C,
+    ) where
+        C: MessageLikeEventContent,
+    {
+        let ev = self.event_builder.make_sync_message_event_with_id(sender, event_id, content);
+        self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
+    }
+
     async fn handle_live_redacted_message_event<C>(&self, sender: &UserId, content: C)
     where
         C: RedactedMessageLikeEventContent,

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -12,20 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use eyeball_im::VectorDiff;
 use matrix_sdk_test::{async_test, ALICE, BOB, CAROL};
 use ruma::{
     event_id,
     events::{
         receipt::{ReceiptThread, ReceiptType},
-        room::message::RoomMessageEventContent,
+        room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
     },
-    room_id,
+    owned_event_id, room_id,
 };
-use stream_assert::assert_next_matches;
+use stream_assert::{assert_next_matches, assert_pending};
 
 use super::TestTimeline;
 use crate::timeline::inner::TimelineInnerSettings;
+
+fn filter_notice(ev: &AnySyncTimelineEvent) -> bool {
+    match ev {
+        AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
+            SyncRoomMessageEvent::Original(msg),
+        )) => !matches!(msg.content.msgtype, MessageType::Notice(_)),
+        _ => true,
+    }
+}
 
 #[async_test]
 async fn read_receipts_updates_on_live_events() {
@@ -123,4 +135,196 @@ async fn read_receipts_updates_on_back_paginated_events() {
     let event_b = items[1].as_event().unwrap();
     assert_eq!(event_b.read_receipts().len(), 1);
     assert!(event_b.read_receipts().get(*CAROL).is_some());
+}
+
+#[async_test]
+async fn read_receipts_updates_on_filtered_events() {
+    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+        track_read_receipts: true,
+        event_filter: Arc::new(filter_notice),
+        ..Default::default()
+    });
+    let mut stream = timeline.subscribe().await;
+
+    timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("A")).await;
+    timeline.handle_live_message_event(*BOB, RoomMessageEventContent::notice_plain("B")).await;
+
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+
+    // No read receipt for our own user.
+    let item_a = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    // Implicit read receipt of Bob.
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+
+    // Implicit read receipt of Bob is updated.
+    timeline.handle_live_message_event(*BOB, RoomMessageEventContent::text_plain("C")).await;
+
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    let item_c = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_c = item_c.as_event().unwrap();
+    assert_eq!(event_c.read_receipts().len(), 1);
+    assert!(event_c.read_receipts().get(*BOB).is_some());
+
+    // Populate more events.
+    let event_d_id = owned_event_id!("$event_d");
+    timeline
+        .handle_live_message_event_with_id(
+            *ALICE,
+            &event_d_id,
+            RoomMessageEventContent::notice_plain("D"),
+        )
+        .await;
+
+    timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("E")).await;
+
+    let item_e = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_e = item_e.as_event().unwrap();
+    assert!(event_e.read_receipts().is_empty());
+
+    // Explicit read receipt is updated but its visible event doesn't change.
+    timeline
+        .handle_read_receipts([(
+            event_d_id,
+            ReceiptType::Read,
+            BOB.to_owned(),
+            ReceiptThread::Unthreaded,
+        )])
+        .await;
+
+    // Explicit read receipt is updated and its visible event changes.
+    timeline
+        .handle_read_receipts([(
+            event_e.event_id().unwrap().to_owned(),
+            ReceiptType::Read,
+            BOB.to_owned(),
+            ReceiptThread::Unthreaded,
+        )])
+        .await;
+
+    let item_c = assert_next_matches!(stream, VectorDiff::Set { index: 2, value } => value);
+    let event_c = item_c.as_event().unwrap();
+    assert!(event_c.read_receipts().is_empty());
+
+    let item_e = assert_next_matches!(stream, VectorDiff::Set { index: 3, value } => value);
+    let event_e = item_e.as_event().unwrap();
+    assert_eq!(event_e.read_receipts().len(), 1);
+    assert!(event_e.read_receipts().get(*BOB).is_some());
+
+    assert_pending!(stream);
+}
+
+#[async_test]
+async fn read_receipts_updates_on_filtered_events_with_stored() {
+    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+        track_read_receipts: true,
+        event_filter: Arc::new(filter_notice),
+        ..Default::default()
+    });
+    let mut stream = timeline.subscribe().await;
+
+    timeline.handle_live_message_event(*ALICE, RoomMessageEventContent::text_plain("A")).await;
+    timeline
+        .handle_live_message_event_with_id(
+            *CAROL,
+            event_id!("$event_with_bob_receipt"),
+            RoomMessageEventContent::notice_plain("B"),
+        )
+        .await;
+
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+
+    // No read receipt for our own user.
+    let item_a = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    // Stored read receipt of Bob.
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+
+    // Implicit read receipt of Carol.
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 2);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+    assert!(event_a.read_receipts().get(*CAROL).is_some());
+
+    // Implicit read receipt of Bob is updated.
+    timeline.handle_live_message_event(*BOB, RoomMessageEventContent::text_plain("C")).await;
+
+    let item_a = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+
+    let item_c = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let event_c = item_c.as_event().unwrap();
+    assert_eq!(event_c.read_receipts().len(), 1);
+    assert!(event_c.read_receipts().get(*BOB).is_some());
+
+    assert_pending!(stream);
+}
+
+#[async_test]
+async fn read_receipts_updates_on_back_paginated_filtered_events() {
+    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+        track_read_receipts: true,
+        event_filter: Arc::new(filter_notice),
+        ..Default::default()
+    });
+    let mut stream = timeline.subscribe().await;
+    let room_id = room_id!("!room:localhost");
+
+    timeline
+        .handle_back_paginated_message_event_with_id(
+            *ALICE,
+            room_id,
+            event_id!("$event_a"),
+            RoomMessageEventContent::text_plain("A"),
+        )
+        .await;
+    timeline
+        .handle_back_paginated_message_event_with_id(
+            *CAROL,
+            room_id,
+            event_id!("$event_with_bob_receipt"),
+            RoomMessageEventContent::notice_plain("B"),
+        )
+        .await;
+
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushFront { value } => value);
+
+    // No read receipt for our own user.
+    let item_a = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
+    let event_a = item_a.as_event().unwrap();
+    assert!(event_a.read_receipts().is_empty());
+
+    // Add non-filtered event to show read receipts.
+    timeline
+        .handle_back_paginated_message_event_with_id(
+            *CAROL,
+            room_id,
+            event_id!("$event_c"),
+            RoomMessageEventContent::text_plain("C"),
+        )
+        .await;
+
+    // Implicit read receipt of Carol.
+    let item_c = assert_next_matches!(stream, VectorDiff::Insert { index: 1, value } => value);
+    let event_c = item_c.as_event().unwrap();
+    assert_eq!(event_c.read_receipts().len(), 2);
+    assert!(event_c.read_receipts().get(*BOB).is_some());
+    assert!(event_c.read_receipts().get(*CAROL).is_some());
+
+    assert_pending!(stream);
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -328,3 +328,138 @@ async fn read_receipts_updates_on_back_paginated_filtered_events() {
 
     assert_pending!(stream);
 }
+
+#[cfg(feature = "e2e-encryption")]
+#[async_test]
+async fn read_receipts_updates_on_message_decryption() {
+    use std::{io::Cursor, iter};
+
+    use assert_matches::assert_matches;
+    use matrix_sdk_base::crypto::{decrypt_room_key_export, OlmMachine};
+    use ruma::{
+        events::room::encrypted::{
+            EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
+        },
+        user_id,
+    };
+
+    use crate::timeline::{EncryptedMessage, TimelineItemContent};
+
+    fn filter_text_msg(ev: &AnySyncTimelineEvent) -> bool {
+        match ev {
+            AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
+                SyncRoomMessageEvent::Original(msg),
+            )) => !matches!(msg.content.msgtype, MessageType::Text(_)),
+            _ => true,
+        }
+    }
+
+    const SESSION_ID: &str = "gM8i47Xhu0q52xLfgUXzanCMpLinoyVyH7R58cBuVBU";
+    const SESSION_KEY: &[u8] = b"\
+        -----BEGIN MEGOLM SESSION DATA-----\n\
+        ASKcWoiAVUM97482UAi83Avce62hSLce7i5JhsqoF6xeAAAACqt2Cg3nyJPRWTTMXxXH7TXnkfdlmBXbQtq5\
+        bpHo3LRijcq2Gc6TXilESCmJN14pIsfKRJrWjZ0squ/XsoTFytuVLWwkNaW3QF6obeg2IoVtJXLMPdw3b2vO\
+        vgwGY3OMP0XafH13j1vcb6YLzvgLkZQLnYvd47hv3yK/9GmKS9tokuaQ7dCVYckYcIOS09EDTs70YdxUd5WG\
+        rQynATCLFP1p/NAGv70r9MK7Cy/mNpjD0r4qC7UEDIoi1kOWzHgnLo19wtvwsb8Fg8ATxcs3Wmtj8hIUYpDx\
+        ia4sM10zbytUuaPUAfCDf42IyxdmOnGe1CueXhgI71y+RW0s0argNqUt7jB70JT0o9CyX6UBGRaqLk2MPY9T\
+        hUu5J8X3UgIa6rcbWigzohzWm9rdbEHFrSWqjpfQYMaAKQQgETrjSy4XTrp2RhC2oNqG/hylI4ab+F4X6fpH\
+        DYP1NqNMP5g36xNu7LhDnrUB5qsPjYOmWORxGLfudpF3oLYCSlr3DgHqEIB6HjQblLZ3KQuPBse3zxyROTnS\
+        AhdPH4a/z1wioFtKNVph3hecsiKEdqnz4Y2coSIdhz58mJ9JWNQoFAENE5CSsoEZAGvafYZVpW4C75YY2zq1\
+        wIeiFi1dT43/jLAUGkslsi1VvnyfUu8qO404RxYO3XHoGLMFoFLOO+lZ+VGci2Vz10AhxJhEBHxRKxw4k2uB\
+        HztoSJUr/2Y\n\
+        -----END MEGOLM SESSION DATA-----";
+
+    let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
+        track_read_receipts: true,
+        event_filter: Arc::new(filter_text_msg),
+        ..Default::default()
+    });
+    let mut stream = timeline.subscribe().await;
+
+    timeline
+        .handle_live_message_event(
+            &CAROL,
+            RoomMessageEventContent::notice_plain("I am not encrypted"),
+        )
+        .await;
+
+    timeline
+        .handle_live_message_event(
+            &BOB,
+            RoomEncryptedEventContent::new(
+                EncryptedEventScheme::MegolmV1AesSha2(
+                    MegolmV1AesSha2ContentInit {
+                        ciphertext: "\
+                            AwgAEtABPRMavuZMDJrPo6pGQP4qVmpcuapuXtzKXJyi3YpEsjSWdzuRKIgJzD4P\
+                            cSqJM1A8kzxecTQNJsC5q22+KSFEPxPnI4ltpm7GFowSoPSW9+bFdnlfUzEP1jPq\
+                            YevHAsMJp2fRKkzQQbPordrUk1gNqEpGl4BYFeRqKl9GPdKFwy45huvQCLNNueql\
+                            CFZVoYMuhxrfyMiJJAVNTofkr2um2mKjDTlajHtr39pTG8k0eOjSXkLOSdZvNOMz\
+                            hGhSaFNeERSA2G2YbeknOvU7MvjiO0AKuxaAe1CaVhAI14FCgzrJ8g0y5nly+n7x\
+                            QzL2G2Dn8EoXM5Iqj8W99iokQoVsSrUEnaQ1WnSIfewvDDt4LCaD/w7PGETMCQ"
+                            .to_owned(),
+                        sender_key: "DeHIg4gwhClxzFYcmNntPNF9YtsdZbmMy8+3kzCMXHA".to_owned(),
+                        device_id: "NLAZCWIOCO".into(),
+                        session_id: SESSION_ID.into(),
+                    }
+                    .into(),
+                ),
+                None,
+            ),
+        )
+        .await;
+
+    assert_eq!(timeline.inner.items().await.len(), 3);
+
+    let _day_divider = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+
+    // The first event only has Carol's receipt.
+    let clear_item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let clear_event = clear_item.as_event().unwrap();
+    assert_matches!(clear_event.content(), TimelineItemContent::Message(_));
+    assert_eq!(clear_event.read_receipts().len(), 1);
+    assert!(clear_event.read_receipts().get(*CAROL).is_some());
+
+    // The second event is encrypted and only has Bob's receipt.
+    let encrypted_item = assert_next_matches!(stream, VectorDiff::PushBack { value } => value);
+    let encrypted_event = encrypted_item.as_event().unwrap();
+    let session_id = assert_matches!(
+        encrypted_event.content(),
+        TimelineItemContent::UnableToDecrypt(
+            EncryptedMessage::MegolmV1AesSha2 { session_id, .. },
+        ) => session_id
+    );
+    assert_eq!(session_id, SESSION_ID);
+    assert_eq!(encrypted_event.read_receipts().len(), 1);
+    assert!(encrypted_event.read_receipts().get(*BOB).is_some());
+
+    // Decrypt encrypted message.
+    let own_user_id = user_id!("@example:morheus.localhost");
+    let exported_keys = decrypt_room_key_export(Cursor::new(SESSION_KEY), "1234").unwrap();
+
+    let olm_machine = OlmMachine::new(own_user_id, "SomeDeviceId".into()).await;
+    olm_machine.import_room_keys(exported_keys, false, |_, _| {}).await.unwrap();
+
+    timeline
+        .inner
+        .retry_event_decryption_test(
+            room_id!("!DovneieKSTkdHKpIXy:morpheus.localhost"),
+            olm_machine,
+            Some(iter::once(SESSION_ID.to_owned()).collect()),
+        )
+        .await;
+
+    assert_eq!(timeline.inner.items().await.len(), 2);
+
+    // The first event now has both receipts.
+    let clear_item = assert_next_matches!(stream, VectorDiff::Set { index: 1, value } => value);
+    let clear_event = clear_item.as_event().unwrap();
+    assert_matches!(clear_event.content(), TimelineItemContent::Message(_));
+    assert_eq!(clear_event.read_receipts().len(), 2);
+    assert!(clear_event.read_receipts().get(*CAROL).is_some());
+    assert!(clear_event.read_receipts().get(*BOB).is_some());
+
+    // The second event is removed.
+    assert_next_matches!(stream, VectorDiff::Remove { index: 2 });
+
+    assert_pending!(stream);
+}

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -119,6 +119,9 @@ async fn edit() {
     assert_matches!(msg.in_reply_to(), None);
     assert!(!msg.is_edited());
 
+    // Implicit read receipt of Alice changed.
+    assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 1, .. }));
+
     let edit = assert_matches!(
         timeline_stream.next().await,
         Some(VectorDiff::Set { index: 1, value }) => value

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -378,8 +378,9 @@ async fn test_timeline_duplicated_events() -> Result<()> {
 
         assert_timeline_stream! {
             [timeline_stream]
+            update[3] "$x3:bar.org";
+            update[1] "$x1:bar.org";
             remove[1];
-            update[2] "$x3:bar.org";
             append    "$x1:bar.org";
             update[3] "$x1:bar.org";
             append    "$x4:bar.org";

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -181,13 +181,16 @@ async fn event_filter() {
     let second_event = second.as_event().unwrap();
     assert_eq!(second_event.event_id(), Some(second_event_id));
 
+    // The implicit read receipt of Alice is updated.
+    assert_matches!(timeline_stream.next().await, Some(VectorDiff::Set { index: 1, .. }));
+
     // The edit is applied to the first event.
     let first = assert_matches!(
         timeline_stream.next().await,
         Some(VectorDiff::Set { index: 1, value }) => value
     );
     let first_event = first.as_event().unwrap();
-    assert!(!first_event.read_receipts().is_empty());
+    assert!(first_event.read_receipts().is_empty());
     let msg = assert_matches!(
         first_event.content(),
         TimelineItemContent::Message(msg) => msg


### PR DESCRIPTION
Not only the events in the Timeline. This increases the accuracy of read receipts.

The read receipts of discarded events are displayed on timeline event items.

3rd split of #2646.