### PR TITLE
ui: Update send_reply arguments

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -20,7 +20,7 @@ use matrix_sdk::{
             room::{
                 avatar::ImageInfo as RumaAvatarImageInfo,
                 message::{
-                    AddMentions, ForwardThread, LocationMessageEventContent, MessageType,
+                    ForwardThread, LocationMessageEventContent, MessageType,
                     RoomMessageEventContentWithoutRelation,
                 },
             },
@@ -518,14 +518,7 @@ impl Room {
         };
 
         RUNTIME.block_on(async move {
-            timeline
-                .send_reply(
-                    (*msg).clone().with_relation(None),
-                    &reply_item.0,
-                    ForwardThread::Yes,
-                    AddMentions::No,
-                )
-                .await?;
+            timeline.send_reply((*msg).clone(), &reply_item.0, ForwardThread::Yes).await?;
             anyhow::Ok(())
         })?;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -15,7 +15,10 @@ use ruma::{
     assign, event_id,
     events::{
         relation::InReplyTo,
-        room::message::{AddMentions, ForwardThread, Relation, RoomMessageEventContent},
+        room::message::{
+            ForwardThread, Relation, RoomMessageEventContent,
+            RoomMessageEventContentWithoutRelation,
+        },
     },
     room_id,
 };
@@ -302,10 +305,9 @@ async fn send_reply() {
 
     timeline
         .send_reply(
-            RoomMessageEventContent::text_plain("Hello, Bob!"),
+            RoomMessageEventContentWithoutRelation::text_plain("Hello, Bob!"),
             &hello_world_item,
             ForwardThread::Yes,
-            AddMentions::No,
         )
         .await
         .unwrap();


### PR DESCRIPTION
- `content` is now of type `RoomMessageEventContentWithoutRelation`, the relation was previously always overwritten if set
- `add_mentions` is now inferred from `content.mentions`

Brings the Rust API and FFI API closer together.