### PR TITLE
oidc: add more simple tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,6 +3060,7 @@ dependencies = [
  "serde_html_form",
  "serde_json",
  "serde_urlencoded",
+ "stream_assert",
  "tempfile",
  "thiserror",
  "tokio",

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -148,6 +148,7 @@ matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base", default_feat
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
 once_cell = { workspace = true }
 serde_urlencoded = "0.7.1"
+stream_assert = { workspace = true }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -50,11 +50,6 @@ impl CrossProcessRefreshManager {
         Self { store, store_lock: lock, known_session_hash: Arc::new(Mutex::new(None)) }
     }
 
-    /// Returns the value in the database representing the lock holder.
-    pub fn lock_holder(&self) -> &str {
-        self.store_lock.lock_holder()
-    }
-
     /// Wait for up to 60 seconds to get a cross-process store lock, then either
     /// timeout (as an error) or return a lock guard.
     ///

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -257,6 +257,7 @@ pub(crate) struct OidcAuthData {
     pub(crate) authorization_data: Mutex<HashMap<String, AuthorizationValidationData>>,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for OidcAuthData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OidcAuthData")
@@ -308,6 +309,10 @@ impl Oidc {
     /// Must be called after `set_session_meta`.
     async fn deferred_enable_cross_process_refresh_lock(&self) -> Result<()> {
         let deferred_init_lock = self.ctx().deferred_cross_process_lock_init.lock().await;
+
+        // Don't `take()` the value, so that subsequent calls to
+        // `enable_cross_process_refresh_lock` will keep on failing if we've enabled the
+        // lock at least once.
         let Some(lock_value) = deferred_init_lock.as_ref() else {
             return Ok(());
         };
@@ -335,10 +340,9 @@ impl Oidc {
 
         let manager = CrossProcessRefreshManager::new(store.clone(), lock);
 
-        self.ctx()
-            .cross_process_token_refresh_manager
-            .set(manager)
-            .map_err(|_| crate::Error::Oidc(CrossProcessRefreshLockError::DuplicatedLock.into()))?;
+        // This method is guarded with the `deferred_cross_process_lock_init` lock held,
+        // so this `set` can't be an error.
+        let _ = self.ctx().cross_process_token_refresh_manager.set(manager);
 
         Ok(())
     }
@@ -1310,6 +1314,7 @@ pub struct OidcSessionTokens {
     pub latest_id_token: Option<IdToken<'static>>,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl fmt::Debug for OidcSessionTokens {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SessionTokens").finish_non_exhaustive()

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -317,19 +317,6 @@ impl Oidc {
             return Ok(());
         };
 
-        // If the lock has already been created, don't recreate it from scratch.
-        if let Some(prev_lock) = self.ctx().cross_process_token_refresh_manager.get() {
-            let prev_holder = prev_lock.lock_holder();
-            if prev_holder == lock_value {
-                return Ok(());
-            }
-            warn!(
-                prev_holder,
-                new_holder = lock_value,
-                "recreating cross-process store refresh token lock with a different holder value"
-            );
-        }
-
         // FIXME We shouldn't be using the crypto store for that! see also https://github.com/matrix-org/matrix-rust-sdk/issues/2472
         let olm_machine_lock = self.client.olm_machine().await;
         let olm_machine =

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -1344,14 +1344,6 @@ impl AuthorizationResponse {
 
         Err(RedirectUriQueryParseError::UnknownFormat)
     }
-
-    /// Access the state field, on either variant.
-    pub fn state(&self) -> &str {
-        match self {
-            Self::Success(code) => &code.state,
-            Self::Error(error) => &error.state,
-        }
-    }
 }
 
 /// The data returned by the provider in the redirect URI after a successful


### PR DESCRIPTION
This adds simple tests for OIDC, and removes some dead code (see code comments). Can be reviewed commit by commit.

Part of #2602.