### PR TITLE
feature: send voice message API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,9 +4911,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f97a398ff20e4de226a5b5b467027eec26a7988e99f98e932f413baef6e8875"
+checksum = "fa5bdb62fc6d45f0fcad39403ba2e0f7d67d187d9b992de3411e3fb7ac2cede5"
 dependencies = [
  "as_variant",
  "indexmap 2.0.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,9 +4911,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804410aee778539202b5ee62065da212ff319f9c60049e7ada1bec3acd53a689"
+checksum = "2f97a398ff20e4de226a5b5b467027eec26a7988e99f98e932f413baef6e8875"
 dependencies = [
  "as_variant",
  "indexmap 2.0.2",

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -834,8 +834,7 @@ impl Room {
             let base_audio_info: BaseAudioInfo = BaseAudioInfo::try_from(&audio_info)
                 .map_err(|_| RoomError::InvalidAttachmentData)?;
 
-            let waveform_amplitudes = waveform.iter().map(|v| (*v).into()).collect();
-            let attachment_info = AttachmentInfo::Voice(base_audio_info, Some(waveform_amplitudes));
+            let attachment_info = AttachmentInfo::Voice(base_audio_info, Some(waveform));
             let attachment_config = AttachmentConfig::new().info(attachment_info);
 
             self.send_attachment(url, mime_type, attachment_config, progress_watcher).await

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -834,7 +834,8 @@ impl Room {
             let base_audio_info: BaseAudioInfo = BaseAudioInfo::try_from(&audio_info)
                 .map_err(|_| RoomError::InvalidAttachmentData)?;
 
-            let attachment_info = AttachmentInfo::Voice(base_audio_info, Some(waveform));
+            let attachment_info =
+                AttachmentInfo::Voice { audio_info: base_audio_info, waveform: Some(waveform) };
             let attachment_config = AttachmentConfig::new().info(attachment_info);
 
             self.send_attachment(url, mime_type, attachment_config, progress_watcher).await

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -88,7 +88,7 @@ matrix-sdk-sqlite = { version = "0.1.0", path = "../matrix-sdk-sqlite", default-
 mime = "0.3.16"
 mime2ext = "0.1.52"
 rand = { version = "0.8.5", optional = true }
-ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc2965", "unstable-msc3930"] }
+ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc2965", "unstable-msc3930", "unstable-msc3245-v1-compat"] }
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -88,7 +88,12 @@ pub enum AttachmentInfo {
     /// The metadata of a file.
     File(BaseFileInfo),
     /// The metadata of a voice message
-    Voice(BaseAudioInfo, Option<Vec<u16>>),
+    Voice {
+        /// The audio info
+        audio_info: BaseAudioInfo,
+        /// The waveform of the voice message
+        waveform: Option<Vec<u16>>,
+    },
 }
 
 impl From<AttachmentInfo> for ImageInfo {
@@ -127,9 +132,9 @@ impl From<AttachmentInfo> for AudioInfo {
                 duration: info.duration,
                 size: info.size,
             }),
-            AttachmentInfo::Voice(info, _) => assign!(AudioInfo::new(), {
-                duration: info.duration,
-                size: info.size,
+            AttachmentInfo::Voice { audio_info, .. } => assign!(AudioInfo::new(), {
+                duration: audio_info.duration,
+                size: audio_info.size,
             }),
             _ => AudioInfo::new(),
         }

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -22,9 +22,12 @@ use std::time::Duration;
 use image::GenericImageView;
 use ruma::{
     assign,
-    events::room::{
-        message::{AudioInfo, FileInfo, VideoInfo},
-        ImageInfo, ThumbnailInfo,
+    events::{
+        audio::Amplitude,
+        room::{
+            message::{AudioInfo, FileInfo, VideoInfo},
+            ImageInfo, ThumbnailInfo,
+        },
     },
     OwnedTransactionId, TransactionId, UInt,
 };
@@ -77,7 +80,7 @@ pub struct BaseFileInfo {
 }
 
 /// Types of metadata for an attachment.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum AttachmentInfo {
     /// The metadata of an image.
     Image(BaseImageInfo),
@@ -87,6 +90,8 @@ pub enum AttachmentInfo {
     Audio(BaseAudioInfo),
     /// The metadata of a file.
     File(BaseFileInfo),
+    /// The metadata of a voice message
+    Voice(BaseAudioInfo, Option<Vec<Amplitude>>),
 }
 
 impl From<AttachmentInfo> for ImageInfo {

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -77,7 +77,7 @@ pub struct BaseFileInfo {
 }
 
 /// Types of metadata for an attachment.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum AttachmentInfo {
     /// The metadata of an image.
     Image(BaseImageInfo),

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -22,12 +22,9 @@ use std::time::Duration;
 use image::GenericImageView;
 use ruma::{
     assign,
-    events::{
-        audio::Amplitude,
-        room::{
-            message::{AudioInfo, FileInfo, VideoInfo},
-            ImageInfo, ThumbnailInfo,
-        },
+    events::room::{
+        message::{AudioInfo, FileInfo, VideoInfo},
+        ImageInfo, ThumbnailInfo,
     },
     OwnedTransactionId, TransactionId, UInt,
 };
@@ -91,7 +88,7 @@ pub enum AttachmentInfo {
     /// The metadata of a file.
     File(BaseFileInfo),
     /// The metadata of a voice message
-    Voice(BaseAudioInfo, Option<Vec<Amplitude>>),
+    Voice(BaseAudioInfo, Option<Vec<u16>>),
 }
 
 impl From<AttachmentInfo> for ImageInfo {

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -130,6 +130,10 @@ impl From<AttachmentInfo> for AudioInfo {
                 duration: info.duration,
                 size: info.size,
             }),
+            AttachmentInfo::Voice(info, _) => assign!(AudioInfo::new(), {
+                duration: info.duration,
+                size: info.size,
+            }),
             _ => AudioInfo::new(),
         }
     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -211,9 +211,9 @@ impl Client {
                     info: Some(Box::new(audio_info))
                 });
 
-                if let Some(AttachmentInfo::Voice(audio_info, Some(waveform))) = info {
+                if let Some(AttachmentInfo::Voice { audio_info, waveform: Some(waveform_vec) }) = info {
                     if let Some(duration) = audio_info.duration {
-                        let waveform = waveform.iter().map(|v| (*v).into()).collect();
+                        let waveform = waveform_vec.iter().map(|v| (*v).into()).collect();
                         audio_message_event_content.audio =
                             Some(UnstableAudioDetailsContentBlock::new(duration, waveform));
                     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -203,24 +203,9 @@ impl Client {
                 MessageType::Image(content)
             }
             mime::AUDIO => {
-                let mut audio_message_event_content =
+                let audio_message_event_content =
                     AudioMessageEventContent::encrypted(body.to_owned(), file);
-
-                if let Some(AttachmentInfo::Voice { audio_info, waveform: Some(waveform_vec) }) =
-                    &info
-                {
-                    if let Some(duration) = audio_info.duration {
-                        let waveform = waveform_vec.iter().map(|v| (*v).into()).collect();
-                        audio_message_event_content.audio =
-                            Some(UnstableAudioDetailsContentBlock::new(duration, waveform));
-                    }
-                    audio_message_event_content.voice = Some(UnstableVoiceContentBlock::new());
-                }
-
-                let audio_info = assign!(info.map(AudioInfo::from).unwrap_or_default(), {
-                    mimetype: Some(content_type.as_ref().to_owned()),
-                });
-                MessageType::Audio(audio_message_event_content.info(Box::new(audio_info)))
+                MessageType::Audio(crate::media::update(audio_message_event_content, content_type, info))
             }
             mime::VIDEO => {
                 let info = assign!(info.map(VideoInfo::from).unwrap_or_default(), {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -204,7 +204,11 @@ impl Client {
             mime::AUDIO => {
                 let audio_message_event_content =
                     AudioMessageEventContent::encrypted(body.to_owned(), file);
-                MessageType::Audio(crate::media::update(audio_message_event_content, content_type, info))
+                MessageType::Audio(crate::media::update(
+                    audio_message_event_content,
+                    content_type,
+                    info,
+                ))
             }
             mime::VIDEO => {
                 let info = assign!(info.map(VideoInfo::from).unwrap_or_default(), {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -45,9 +45,8 @@ use ruma::{
     assign,
     events::room::{
         message::{
-            AudioInfo, AudioMessageEventContent, FileInfo, FileMessageEventContent,
-            ImageMessageEventContent, MessageType, UnstableAudioDetailsContentBlock,
-            UnstableVoiceContentBlock, VideoInfo, VideoMessageEventContent,
+            AudioMessageEventContent, FileInfo, FileMessageEventContent, ImageMessageEventContent,
+            MessageType, VideoInfo, VideoMessageEventContent,
         },
         ImageInfo, MediaSource, ThumbnailInfo,
     },

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -215,6 +215,7 @@ impl Client {
 
                 if let Some(AttachmentInfo::Voice(audio_info, Some(waveform))) = info {
                     if let Some(duration) = audio_info.duration {
+                        let waveform = waveform.iter().map(|v| (*v).into()).collect();
                         audio_message_event_content.audio =
                             Some(UnstableAudioDetailsContentBlock::new(duration, waveform));
                     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -197,9 +197,10 @@ impl Client {
                     thumbnail_source,
                     thumbnail_info
                 });
-                let content = assign!(ImageMessageEventContent::encrypted(body.to_owned(), file), {
-                    info: Some(Box::new(info))
-                });
+                let content =
+                    assign!(ImageMessageEventContent::encrypted(body.to_owned(), file), {
+                        info: Some(Box::new(info))
+                    });
                 MessageType::Image(content)
             }
             mime::AUDIO => {
@@ -228,9 +229,10 @@ impl Client {
                     thumbnail_source,
                     thumbnail_info
                 });
-                let content = assign!(VideoMessageEventContent::encrypted(body.to_owned(), file), {
-                    info: Some(Box::new(info))
-                });
+                let content =
+                    assign!(VideoMessageEventContent::encrypted(body.to_owned(), file), {
+                        info: Some(Box::new(info))
+                    });
                 MessageType::Video(content)
             }
             _ => {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -204,7 +204,7 @@ impl Client {
             mime::AUDIO => {
                 let audio_message_event_content =
                     AudioMessageEventContent::encrypted(body.to_owned(), file);
-                MessageType::Audio(crate::media::update(
+                MessageType::Audio(crate::media::update_audio_message_event(
                     audio_message_event_content,
                     content_type,
                     info,

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -197,10 +197,9 @@ impl Client {
                     thumbnail_source,
                     thumbnail_info
                 });
-                let content =
-                    assign!(ImageMessageEventContent::encrypted(body.to_owned(), file), {
-                        info: Some(Box::new(info))
-                    });
+                let content = assign!(ImageMessageEventContent::encrypted(body.to_owned(), file), {
+                    info: Some(Box::new(info))
+                });
                 MessageType::Image(content)
             }
             mime::AUDIO => {
@@ -208,10 +207,9 @@ impl Client {
                     mimetype: Some(content_type.as_ref().to_owned()),
                 });
 
-                let mut audio_message_event_content =
-                    assign!(AudioMessageEventContent::encrypted(body.to_owned(), file), {
-                        info: Some(Box::new(audio_info))
-                    });
+                let mut audio_message_event_content = assign!(AudioMessageEventContent::encrypted(body.to_owned(), file), {
+                    info: Some(Box::new(audio_info))
+                });
 
                 if let Some(AttachmentInfo::Voice(audio_info, Some(waveform))) = info {
                     if let Some(duration) = audio_info.duration {
@@ -221,7 +219,6 @@ impl Client {
                     }
                     audio_message_event_content.voice = Some(UnstableVoiceContentBlock::new());
                 }
-
                 MessageType::Audio(audio_message_event_content)
             }
             mime::VIDEO => {
@@ -230,10 +227,9 @@ impl Client {
                     thumbnail_source,
                     thumbnail_info
                 });
-                let content =
-                    assign!(VideoMessageEventContent::encrypted(body.to_owned(), file), {
-                        info: Some(Box::new(info))
-                    });
+                let content = assign!(VideoMessageEventContent::encrypted(body.to_owned(), file), {
+                    info: Some(Box::new(info))
+                });
                 MessageType::Video(content)
             }
             _ => {

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -441,7 +441,7 @@ impl Media {
             mime::AUDIO => {
                 let audio_message_event_content =
                     message::AudioMessageEventContent::plain(body.to_owned(), url);
-                MessageType::Audio(update(audio_message_event_content, content_type, info))
+                MessageType::Audio(update_audio_message_event(audio_message_event_content, content_type, info))
             }
             mime::VIDEO => {
                 let info = assign!(info.map(VideoInfo::from).unwrap_or_default(), {
@@ -493,7 +493,7 @@ impl Media {
     }
 }
 
-pub(crate) fn update(
+pub(crate) fn update_audio_message_event(
     mut audio_message_event_content: AudioMessageEventContent,
     content_type: &Mime,
     info: Option<AttachmentInfo>,

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -441,7 +441,11 @@ impl Media {
             mime::AUDIO => {
                 let audio_message_event_content =
                     message::AudioMessageEventContent::plain(body.to_owned(), url);
-                MessageType::Audio(update_audio_message_event(audio_message_event_content, content_type, info))
+                MessageType::Audio(update_audio_message_event(
+                    audio_message_event_content,
+                    content_type,
+                    info,
+                ))
             }
             mime::VIDEO => {
                 let info = assign!(info.map(VideoInfo::from).unwrap_or_default(), {

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -455,7 +455,6 @@ impl Media {
                     }
                     audio_message_event_content.voice = Some(UnstableVoiceContentBlock::new());
                 }
-
                 MessageType::Audio(audio_message_event_content)
             }
             mime::VIDEO => {

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -449,6 +449,7 @@ impl Media {
 
                 if let Some(AttachmentInfo::Voice(audio_info, Some(waveform))) = info {
                     if let Some(duration) = audio_info.duration {
+                        let waveform = waveform.iter().map(|v| (*v).into()).collect();
                         audio_message_event_content.audio =
                             Some(UnstableAudioDetailsContentBlock::new(duration, waveform));
                     }

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -447,9 +447,9 @@ impl Media {
                     message::AudioMessageEventContent::plain(body.to_owned(), url)
                         .info(Box::new(audio_info));
 
-                if let Some(AttachmentInfo::Voice(audio_info, Some(waveform))) = info {
+                if let Some(AttachmentInfo::Voice { audio_info, waveform: Some(waveform_vec )}) = info {
                     if let Some(duration) = audio_info.duration {
-                        let waveform = waveform.iter().map(|v| (*v).into()).collect();
+                        let waveform = waveform_vec.iter().map(|v| (*v).into()).collect();
                         audio_message_event_content.audio =
                             Some(UnstableAudioDetailsContentBlock::new(duration, waveform));
                     }

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -439,15 +439,12 @@ impl Media {
                 )
             }
             mime::AUDIO => {
-                let audio_info = assign!(info.clone().map(AudioInfo::from).unwrap_or_default(), {
-                    mimetype: Some(content_type.as_ref().to_owned()),
-                });
-
                 let mut audio_message_event_content =
-                    message::AudioMessageEventContent::plain(body.to_owned(), url)
-                        .info(Box::new(audio_info));
+                    message::AudioMessageEventContent::plain(body.to_owned(), url);
 
-                if let Some(AttachmentInfo::Voice { audio_info, waveform: Some(waveform_vec )}) = info {
+                if let Some(AttachmentInfo::Voice { audio_info, waveform: Some(waveform_vec) }) =
+                    &info
+                {
                     if let Some(duration) = audio_info.duration {
                         let waveform = waveform_vec.iter().map(|v| (*v).into()).collect();
                         audio_message_event_content.audio =
@@ -455,7 +452,9 @@ impl Media {
                     }
                     audio_message_event_content.voice = Some(UnstableVoiceContentBlock::new());
                 }
-                MessageType::Audio(audio_message_event_content)
+
+                let audio_info = assign!(info.map(AudioInfo::from).unwrap_or_default(), {mimetype: Some(content_type.as_ref().to_owned()), });
+                MessageType::Audio(audio_message_event_content.info(Box::new(audio_info)))
             }
             mime::VIDEO => {
                 let info = assign!(info.map(VideoInfo::from).unwrap_or_default(), {


### PR DESCRIPTION
This PR adds a ffi binding for sending voice messages in the legacy format (before extensible events). It also makes minor changes in the `matrix-sdk` crate to accomodate this change.