### PR TITLE
ui: Handle read receipts in the main thread

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -19,12 +19,9 @@ use imbl::Vector;
 use matrix_sdk::{
     deserialized_responses::SyncTimelineEvent, executor::spawn, sync::RoomUpdate, Room,
 };
-use ruma::events::{
-    receipt::{ReceiptThread, ReceiptType},
-    AnySyncTimelineEvent,
-};
+use ruma::events::{receipt::ReceiptType, AnySyncTimelineEvent};
 use tokio::sync::{broadcast, mpsc, Notify};
-use tracing::{error, info, info_span, trace, warn, Instrument, Span};
+use tracing::{info, info_span, trace, warn, Instrument, Span};
 
 #[cfg(feature = "e2e-encryption")]
 use super::to_device::{handle_forwarded_room_key_event, handle_room_key_event};
@@ -123,42 +120,8 @@ impl TimelineBuilder {
         let mut inner = TimelineInner::new(room).with_settings(settings);
 
         if track_read_marker_and_receipts {
-            match inner
-                .room()
-                .user_receipt(
-                    ReceiptType::Read,
-                    ReceiptThread::Unthreaded,
-                    inner.room().own_user_id(),
-                )
-                .await
-            {
-                Ok(Some(read_receipt)) => {
-                    inner.set_initial_user_receipt(ReceiptType::Read, read_receipt).await;
-                }
-                Err(e) => {
-                    error!("Failed to get public read receipt of own user from the store: {e}");
-                }
-                _ => {}
-            }
-            match inner
-                .room()
-                .user_receipt(
-                    ReceiptType::ReadPrivate,
-                    ReceiptThread::Unthreaded,
-                    inner.room().own_user_id(),
-                )
-                .await
-            {
-                Ok(Some(private_read_receipt)) => {
-                    inner
-                        .set_initial_user_receipt(ReceiptType::ReadPrivate, private_read_receipt)
-                        .await;
-                }
-                Err(e) => {
-                    error!("Failed to get private read receipt of own user from the store: {e}");
-                }
-                _ => {}
-            }
+            inner.populate_initial_user_receipt(ReceiptType::Read).await;
+            inner.populate_initial_user_receipt(ReceiptType::ReadPrivate).await;
         }
 
         if has_events {

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -825,6 +825,16 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let own_user_id = self.room_data_provider.own_user_id();
         self.state.write().await.handle_read_receipts(receipt_event_content, own_user_id);
     }
+
+    /// Get the latest read receipt for the given user.
+    ///
+    /// Useful to get the latest read receipt, whether it's private or public.
+    pub(super) async fn latest_user_read_receipt(
+        &self,
+        user_id: &UserId,
+    ) -> Option<(OwnedEventId, Receipt)> {
+        self.state.read().await.latest_user_read_receipt(user_id, &self.room_data_provider).await
+    }
 }
 
 impl TimelineInner {
@@ -924,17 +934,6 @@ impl TimelineInner {
         state.items.set(index, timeline_item(item, internal_id));
 
         Ok(())
-    }
-
-    /// Get the latest read receipt for the given user.
-    ///
-    /// Useful to get the latest read receipt, whether it's private or public.
-    pub(super) async fn latest_user_read_receipt(
-        &self,
-        user_id: &UserId,
-    ) -> Option<(OwnedEventId, Receipt)> {
-        let room = self.room();
-        self.state.read().await.latest_user_read_receipt(user_id, room).await
     }
 
     /// Check whether the given receipt should be sent.

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -276,6 +276,15 @@ impl RoomDataProvider for TestRoomDataProvider {
         None
     }
 
+    async fn user_receipt(
+        &self,
+        _receipt_type: ReceiptType,
+        _thread: ReceiptThread,
+        _user_id: &UserId,
+    ) -> Option<(OwnedEventId, Receipt)> {
+        None
+    }
+
     async fn read_receipts_for_event(&self, event_id: &EventId) -> IndexMap<OwnedUserId, Receipt> {
         if event_id == event_id!("$event_with_bob_receipt") {
             [(BOB.to_owned(), Receipt::new(MilliSecondsSinceUnixEpoch(uint!(10))))].into()

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -493,7 +493,7 @@ async fn initial_public_unthreaded_receipt() {
 async fn initial_public_main_thread_receipt() {
     let event_id = owned_event_id!("$event_with_receipt");
 
-    // Add initial unthreaded public receipt.
+    // Add initial public receipt on the main thread.
     let mut initial_user_receipts = ReadReceiptMap::new();
     initial_user_receipts
         .entry(ReceiptType::Read)
@@ -518,7 +518,7 @@ async fn initial_public_main_thread_receipt() {
 async fn initial_private_unthreaded_receipt() {
     let event_id = owned_event_id!("$event_with_receipt");
 
-    // Add initial unthreaded public receipt.
+    // Add initial unthreaded private receipt.
     let mut initial_user_receipts = ReadReceiptMap::new();
     initial_user_receipts
         .entry(ReceiptType::ReadPrivate)
@@ -543,7 +543,7 @@ async fn initial_private_unthreaded_receipt() {
 async fn initial_private_main_thread_receipt() {
     let event_id = owned_event_id!("$event_with_receipt");
 
-    // Add initial unthreaded public receipt.
+    // Add initial private receipt on the main thread.
     let mut initial_user_receipts = ReadReceiptMap::new();
     initial_user_receipts
         .entry(ReceiptType::ReadPrivate)

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -214,14 +214,22 @@ async fn read_receipts_updates() {
     let (alice_receipt_event_id, _) = timeline.latest_user_read_receipt(alice).await.unwrap();
     assert_eq!(alice_receipt_event_id, third_event_id);
 
-    // New user with explicit read receipt.
+    // New user with explicit threaded and unthreaded read receipts.
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
+                second_event_id: {
+                    "m.read": {
+                        bob: {
+                            "ts": 1436451350,
+                        },
+                    },
+                },
                 third_event_id: {
                     "m.read": {
                         bob: {
                             "ts": 1436451550,
+                            "thread_id": "main",
                         },
                     },
                 },


### PR DESCRIPTION
Improves the compatibility with clients using threads. This should give us the same receipts as Element Web.

4th split of #2646.
