### PR TITLE
ffi: Allow MessageType to contain arbitrary msgtype values, plus body

### DIFF
--- a/bindings/matrix-sdk-ffi/src/event.rs
+++ b/bindings/matrix-sdk-ffi/src/event.rs
@@ -185,7 +185,7 @@ impl TryFrom<AnySyncMessageLikeEvent> for MessageLikeEventContent {
                         _ => None,
                     });
                 MessageLikeEventContent::RoomMessage {
-                    message_type: original_content.msgtype.try_into()?,
+                    message_type: original_content.msgtype.into(),
                     in_reply_to_event_id,
                 }
             }


### PR DESCRIPTION
… allows the FFI type MessageLikeEventContent to hold custom msgtypes, which is useful for notification.
Also allows sending custom msgtypes, as long as no fields other than the msgtype itself and body are needed.

Fixes #2703.
