### PR TITLE
ui: Require PaginationOptions strategy to be Sync

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -208,7 +208,7 @@ impl<'a> PaginationOptions<'a> {
     /// `ControlFlow::Break(())`).
     pub fn custom(
         initial_event_limit: u16,
-        pagination_strategy: impl Fn(PaginationOutcome) -> ControlFlow<(), u16> + Send + 'a,
+        pagination_strategy: impl Fn(PaginationOutcome) -> ControlFlow<(), u16> + Send + Sync + 'a,
     ) -> Self {
         Self::new(PaginationOptionsInner::Custom {
             event_limit_if_first: Some(initial_event_limit),
@@ -265,7 +265,7 @@ pub enum PaginationOptionsInner<'a> {
     },
     Custom {
         event_limit_if_first: Option<u16>,
-        strategy: Arc<dyn Fn(PaginationOutcome) -> ControlFlow<(), u16> + Send + 'a>,
+        strategy: Arc<dyn Fn(PaginationOutcome) -> ControlFlow<(), u16> + Send + Sync + 'a>,
     },
 }
 


### PR DESCRIPTION
Otherwise `PaginationOptions` is not `Send`.

Gave a compilation error when trying to update the SDK in Fractal:

```
error[E0277]: `dyn Fn(PaginationOutcome) -> std::ops::ControlFlow<(), u16> + std::marker::Send` cannot be shared between threads safely
   ::: src/session/model/room/timeline/mod.rs:405:22
    |
405 |           let handle = spawn_tokio!(async move {
    |  ______________________-
406 | |             matrix_timeline
407 | |                 .paginate_backwards(PaginationOptions::until_num_items(
408 | |                     MAX_BATCH_SIZE,
...   |
411 | |                 .await
412 | |         });
    | |__________- in this macro invocation
    |
    = help: the trait `std::marker::Sync` is not implemented for `dyn Fn(PaginationOutcome) -> std::ops::ControlFlow<(), u16> + std::marker::Send`
    = note: required for `std::sync::Arc<dyn Fn(PaginationOutcome) -> std::ops::ControlFlow<(), u16> + std::marker::Send>` to implement `std::marker::Send`
note: required because it appears within the type `PaginationOptionsInner<'_>`
   --> /var/home/cakeh/.cargo/git/checkouts/matrix-rust-sdk-c2bbb6e340a69c23/3a08a62/crates/matrix-sdk-ui/src/timeline/pagination.rs:258:10
    |
258 | pub enum PaginationOptionsInner<'a> {
    |          ^^^^^^^^^^^^^^^^^^^^^^
note: required because it appears within the type `PaginationOptions<'_>`
   --> /var/home/cakeh/.cargo/git/checkouts/matrix-rust-sdk-c2bbb6e340a69c23/3a08a62/crates/matrix-sdk-ui/src/timeline/pagination.rs:173:12
    |
173 | pub struct PaginationOptions<'a> {
    |            ^^^^^^^^^^^^^^^^^
note: required because it's used within this `async fn` body
   --> /var/home/cakeh/.cargo/git/checkouts/matrix-rust-sdk-c2bbb6e340a69c23/3a08a62/crates/matrix-sdk-ui/src/timeline/mod.rs:158:5
    |
158 |     #[instrument(skip_all, fields(room_id = ?self.room().room_id(), ?options))]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: required because it captures the following types: `impl futures_util::Future<Output = Result<(), matrix_sdk::Error>>`
note: required because it's used within this `async` block
   --> src/session/model/room/timeline/mod.rs:405:35
    |
405 |           let handle = spawn_tokio!(async move {
    |  ___________________________________^
406 | |             matrix_timeline
407 | |                 .paginate_backwards(PaginationOptions::until_num_items(
408 | |                     MAX_BATCH_SIZE,
...   |
411 | |                 .await
412 | |         });
    | |_________^
note: required by a bound in `Runtime::spawn`
   --> /var/home/cakeh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.30.0/src/runtime/runtime.rs:241:21
    |
239 |     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
    |            ----- required by a bound in this associated function
240 |     where
241 |         F: Future + Send + 'static,
    |                     ^^^^ required by this bound in `Runtime::spawn`
    = note: this error originates in the macro `spawn_tokio` which comes from the expansion of the attribute macro `instrument` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
```