### PR TITLE
crypto: Remove inner mutable shared state from `Account`

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/dehydrated_devices.rs
@@ -54,12 +54,13 @@ impl Drop for DehydratedDevices {
 
 #[uniffi::export]
 impl DehydratedDevices {
-    pub fn create(&self) -> Arc<DehydratedDevice> {
-        DehydratedDevice {
-            inner: ManuallyDrop::new(self.inner.create()),
+    pub fn create(&self) -> Result<Arc<DehydratedDevice>, DehydrationError> {
+        let inner = self.runtime.block_on(self.inner.create())?;
+
+        Ok(Arc::new(DehydratedDevice {
+            inner: ManuallyDrop::new(inner),
             runtime: self.runtime.to_owned(),
-        }
-        .into()
+        }))
     }
 
     pub fn rehydrate(

--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -291,7 +291,7 @@ impl DehydratedDevice {
     /// let pickle_key = [0u8; 32];
     ///
     /// // Create the dehydrated device.
-    /// let device = machine.dehydrated_devices().create();
+    /// let device = machine.dehydrated_devices().create().await?;
     ///
     /// // Create the request that should upload the device.
     /// let request = device
@@ -318,9 +318,9 @@ impl DehydratedDevice {
         let mut transaction = self.store.transaction().await?;
 
         let account = transaction.account().await?;
-        account.generate_fallback_key_helper().await;
+        account.generate_fallback_key_helper();
 
-        let (device_keys, one_time_keys, fallback_keys) = account.keys_for_upload().await;
+        let (device_keys, one_time_keys, fallback_keys) = account.keys_for_upload();
 
         let mut device_keys = device_keys
             .expect("We should always try to upload device keys for a dehydrated device.");
@@ -331,7 +331,7 @@ impl DehydratedDevice {
 
         let pickle_key = expand_pickle_key(pickle_key, &self.store.static_account().device_id);
         let device_id = self.store.static_account().device_id.clone();
-        let device_data = account.dehydrate(&pickle_key).await;
+        let device_data = account.dehydrate(&pickle_key);
         let initial_device_display_name = Some(initial_device_display_name);
 
         transaction.commit().await?;

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1156,15 +1156,16 @@ mod tests {
     ) -> (GossipMachine, OutboundGroupSession, GossipMachine) {
         let alice_machine = get_machine().await;
         let alice_device = ReadOnlyDevice::from_account(
-            alice_machine.inner.store.cache().await.unwrap().account(),
+            alice_machine.inner.store.cache().await.unwrap().account().await.unwrap(),
         )
         .await;
 
         let bob_machine = test_gossip_machine(other_machine_owner);
 
-        let bob_device =
-            ReadOnlyDevice::from_account(bob_machine.inner.store.cache().await.unwrap().account())
-                .await;
+        let bob_device = ReadOnlyDevice::from_account(
+            bob_machine.inner.store.cache().await.unwrap().account().await.unwrap(),
+        )
+        .await;
 
         // We need a trusted device, otherwise we won't request keys
         let second_device = ReadOnlyDevice::from_account(&alice_2_account()).await;

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1155,14 +1155,15 @@ mod tests {
         algorithm: EventEncryptionAlgorithm,
     ) -> (GossipMachine, OutboundGroupSession, GossipMachine) {
         let alice_machine = get_machine().await;
-        let alice_device =
-            ReadOnlyDevice::from_account(&alice_machine.inner.store.cache().await.unwrap().account)
-                .await;
+        let alice_device = ReadOnlyDevice::from_account(
+            alice_machine.inner.store.cache().await.unwrap().account(),
+        )
+        .await;
 
         let bob_machine = test_gossip_machine(other_machine_owner);
 
         let bob_device =
-            ReadOnlyDevice::from_account(&bob_machine.inner.store.cache().await.unwrap().account)
+            ReadOnlyDevice::from_account(bob_machine.inner.store.cache().await.unwrap().account())
                 .await;
 
         // We need a trusted device, otherwise we won't request keys

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -869,7 +869,7 @@ impl ReadOnlyDevice {
     pub async fn from_machine_test_helper(
         machine: &OlmMachine,
     ) -> Result<ReadOnlyDevice, crate::CryptoStoreError> {
-        Ok(ReadOnlyDevice::from_account(&machine.store().cache().await?.account).await)
+        Ok(ReadOnlyDevice::from_account(machine.store().cache().await?.account()).await)
     }
 
     /// Create a `ReadOnlyDevice` from an `Account`

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -869,7 +869,7 @@ impl ReadOnlyDevice {
     pub async fn from_machine_test_helper(
         machine: &OlmMachine,
     ) -> Result<ReadOnlyDevice, crate::CryptoStoreError> {
-        Ok(ReadOnlyDevice::from_account(machine.store().cache().await?.account()).await)
+        Ok(ReadOnlyDevice::from_account(machine.store().cache().await?.account().await?).await)
     }
 
     /// Create a `ReadOnlyDevice` from an `Account`

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -869,7 +869,7 @@ impl ReadOnlyDevice {
     pub async fn from_machine_test_helper(
         machine: &OlmMachine,
     ) -> Result<ReadOnlyDevice, crate::CryptoStoreError> {
-        Ok(ReadOnlyDevice::from_account(&*machine.store().cache().await?.account().await?).await)
+        Ok(ReadOnlyDevice::from_account(&*machine.store().cache().await?.account().await?))
     }
 
     /// Create a `ReadOnlyDevice` from an `Account`
@@ -884,8 +884,8 @@ impl ReadOnlyDevice {
     /// *Don't* use this after we received a keys/query response, other
     /// users/devices might add signatures to our own device, which can't be
     /// replicated locally.
-    pub async fn from_account(account: &Account) -> ReadOnlyDevice {
-        let device_keys = account.device_keys().await;
+    pub fn from_account(account: &Account) -> ReadOnlyDevice {
+        let device_keys = account.device_keys();
         let mut device = ReadOnlyDevice::try_from(&device_keys)
             .expect("Creating a device from our own account should always succeed");
         device.first_time_seen_ts = account.creation_local_time();

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -869,7 +869,7 @@ impl ReadOnlyDevice {
     pub async fn from_machine_test_helper(
         machine: &OlmMachine,
     ) -> Result<ReadOnlyDevice, crate::CryptoStoreError> {
-        Ok(ReadOnlyDevice::from_account(machine.store().cache().await?.account().await?).await)
+        Ok(ReadOnlyDevice::from_account(&*machine.store().cache().await?.account().await?).await)
     }
 
     /// Create a `ReadOnlyDevice` from an `Account`

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -167,7 +167,10 @@ impl IdentityManager {
 
         if let Some(sequence_number) = sequence_number {
             self.store
+                .cache()
+                .await?
                 .mark_tracked_users_as_up_to_date(
+                    &self.store,
                     response.device_keys.keys().map(Deref::deref),
                     sequence_number,
                 )

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -755,11 +755,10 @@ impl IdentityManager {
     /// key query.
     pub async fn receive_device_changes(
         &self,
-        store: &Store, // TODO: (bnjbvr) remove
         cache: &StoreCache,
         users: impl Iterator<Item = &UserId>,
     ) -> StoreResult<()> {
-        cache.mark_tracked_users_as_changed(store, users).await
+        cache.mark_tracked_users_as_changed(&self.store, users).await
     }
 
     /// See the docs for [`OlmMachine::update_tracked_users()`].
@@ -1131,10 +1130,7 @@ pub(crate) mod tests {
 
         {
             let cache = manager.store.cache().await.unwrap();
-            manager
-                .receive_device_changes(&manager.store, &cache, [alice].iter().map(Deref::deref))
-                .await
-                .unwrap();
+            manager.receive_device_changes(&cache, [alice].iter().map(Deref::deref)).await.unwrap();
         }
 
         assert!(
@@ -1337,10 +1333,7 @@ pub(crate) mod tests {
         // another invalidation turns up
         {
             let cache = manager.store.cache().await.unwrap();
-            manager
-                .receive_device_changes(&manager.store, &cache, [alice].into_iter())
-                .await
-                .unwrap();
+            manager.receive_device_changes(&cache, [alice].into_iter()).await.unwrap();
         }
 
         // the response from the query arrives

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1174,7 +1174,7 @@ pub(crate) mod tests {
         let identity_request = private_identity.as_upload_request().await;
         drop(private_identity);
 
-        let device_keys = manager.store.cache().await.unwrap().account.device_keys().await;
+        let device_keys = manager.store.cache().await.unwrap().account().device_keys().await;
         manager
             .receive_keys_query_response(
                 &TransactionId::new(),

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -697,13 +697,15 @@ impl IdentityManager {
         // tracking ourselves.
         //
         // The check for emptiness is done first for performance.
-        let (users, sequence_number) =
-            if users.is_empty() && !self.store.tracked_users().await?.contains(self.user_id()) {
-                self.store.cache().await?.mark_user_as_changed(&self.store, self.user_id()).await?;
+        let (users, sequence_number) = {
+            let cache = self.store.cache().await?;
+            if users.is_empty() && !cache.tracked_users().contains(self.user_id()) {
+                cache.mark_user_as_changed(&self.store, self.user_id()).await?;
                 self.store.users_for_key_query().await?
             } else {
                 (users, sequence_number)
-            };
+            }
+        };
 
         if users.is_empty() {
             Ok(BTreeMap::new())
@@ -1123,20 +1125,19 @@ pub(crate) mod tests {
         let manager = manager_test_helper(user_id(), device_id()).await;
         let alice = user_id!("@alice:example.org");
 
-        assert!(
-            manager.store.tracked_users().await.unwrap().is_empty(),
-            "No users are initially tracked"
-        );
-
         {
             let cache = manager.store.cache().await.unwrap();
+
+            assert!(cache.tracked_users().is_empty(), "No users are initially tracked");
+
             manager.receive_device_changes(&cache, [alice].iter().map(Deref::deref)).await.unwrap();
+
+            assert!(
+                !cache.tracked_users().contains(alice),
+                "Receiving a device changes update for a user we don't track does nothing"
+            );
         }
 
-        assert!(
-            !manager.store.tracked_users().await.unwrap().contains(alice),
-            "Receiving a device changes update for a user we don't track does nothing"
-        );
         assert!(
             !manager.store.users_for_key_query().await.unwrap().0.contains(alice),
             "The user we don't track doesn't end up in the `/keys/query` request"
@@ -1146,7 +1147,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_manager_creation() {
         let manager = manager_test_helper(user_id(), device_id()).await;
-        assert!(manager.store.tracked_users().await.unwrap().is_empty())
+        assert!(manager.store.cache().await.unwrap().tracked_users().is_empty())
     }
 
     #[async_test]
@@ -1304,7 +1305,7 @@ pub(crate) mod tests {
         let manager = manager_test_helper(user_id(), device_id()).await;
 
         assert!(
-            manager.store.tracked_users().await.unwrap().is_empty(),
+            manager.store.cache().await.unwrap().tracked_users().is_empty(),
             "No users are initially tracked"
         );
 
@@ -1312,7 +1313,7 @@ pub(crate) mod tests {
 
         assert!(!requests.is_empty(), "We query the keys for our own user");
         assert!(
-            manager.store.tracked_users().await.unwrap().contains(manager.user_id()),
+            manager.store.cache().await.unwrap().tracked_users().contains(manager.user_id()),
             "Our own user is now tracked"
         );
     }
@@ -1356,20 +1357,18 @@ pub(crate) mod tests {
         let manager = manager_test_helper(user_id(), device_id()).await;
         let alice = user_id!("@alice:example.org");
 
-        assert!(
-            manager.store.tracked_users().await.unwrap().is_empty(),
-            "No users are initially tracked"
-        );
-
         {
             let cache = manager.store.cache().await.unwrap();
+            assert!(cache.tracked_users().is_empty(), "No users are initially tracked");
+
             cache.mark_user_as_changed(&manager.store, alice).await.unwrap();
+
+            assert!(
+                cache.tracked_users().contains(alice),
+                "Alice is tracked after being marked as tracked"
+            );
         }
 
-        assert!(
-            manager.store.tracked_users().await.unwrap().contains(alice),
-            "Alice is tracked after being marked as tracked"
-        );
         let (reqid, req) = manager.users_for_key_query().await.unwrap().pop_first().unwrap();
         assert!(req.device_keys.contains_key(alice));
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -785,7 +785,7 @@ pub(crate) mod testing {
         identities::IdentityManager,
         machine::testing::response_from_file,
         olm::{Account, PrivateCrossSigningIdentity},
-        store::{CryptoStoreWrapper, MemoryStore, Store},
+        store::{CryptoStoreWrapper, MemoryStore, PendingChanges, Store},
         types::DeviceKeys,
         verification::VerificationMachine,
         UploadSigningKeysRequest,
@@ -803,15 +803,20 @@ pub(crate) mod testing {
         device_id!("WSKKLTJZCL")
     }
 
-    pub(crate) async fn manager(user_id: &UserId, device_id: &DeviceId) -> IdentityManager {
+    pub(crate) async fn manager_test_helper(
+        user_id: &UserId,
+        device_id: &DeviceId,
+    ) -> IdentityManager {
         let identity = PrivateCrossSigningIdentity::new(user_id.into()).await;
         let identity = Arc::new(Mutex::new(identity));
         let user_id = user_id.to_owned();
         let account = Account::with_device_id(&user_id, device_id);
+        let static_account = account.static_data().clone();
         let store = Arc::new(CryptoStoreWrapper::new(&user_id, MemoryStore::new()));
         let verification =
-            VerificationMachine::new(account.static_data.clone(), identity.clone(), store.clone());
-        let store = Store::new(account, identity, store, verification);
+            VerificationMachine::new(static_account.clone(), identity.clone(), store.clone());
+        let store = Store::new(static_account, identity, store, verification);
+        store.save_pending_changes(PendingChanges { account: Some(account) }).await.unwrap();
         IdentityManager::new(store)
     }
 
@@ -1087,7 +1092,9 @@ pub(crate) mod tests {
     use serde_json::json;
     use stream_assert::{assert_closed, assert_pending, assert_ready};
 
-    use super::testing::{device_id, key_query, manager, other_key_query, other_user_id, user_id};
+    use super::testing::{
+        device_id, key_query, manager_test_helper, other_key_query, other_user_id, user_id,
+    };
     use crate::{
         identities::manager::testing::{other_key_query_cross_signed, own_key_query},
         olm::PrivateCrossSigningIdentity,
@@ -1112,7 +1119,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_tracked_users() {
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
         let alice = user_id!("@alice:example.org");
 
         assert!(
@@ -1132,13 +1139,13 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_manager_creation() {
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
         assert!(manager.store.tracked_users().await.unwrap().is_empty())
     }
 
     #[async_test]
     async fn test_manager_key_query_response() {
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
         let other_user = other_user_id();
         let devices = manager.store.get_user_devices(other_user).await.unwrap();
         assert_eq!(devices.devices().count(), 0);
@@ -1165,7 +1172,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn test_manager_own_key_query_response() -> anyhow::Result<()> {
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
         let our_user = user_id();
         let devices = manager.store.get_user_devices(our_user).await?;
         assert_eq!(devices.devices().count(), 0);
@@ -1200,7 +1207,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn private_identity_invalidation_after_public_keys_change() {
         let user_id = user_id!("@example1:localhost");
-        let manager = manager(user_id, "DEVICEID".into()).await;
+        let manager = manager_test_helper(user_id, "DEVICEID".into()).await;
 
         let identity_request = {
             let private_identity = manager.store.private_identity();
@@ -1288,7 +1295,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn no_tracked_users_key_query_request() {
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
 
         assert!(
             manager.store.tracked_users().await.unwrap().is_empty(),
@@ -1308,8 +1315,8 @@ pub(crate) mod tests {
     /// user is not removed from the list of outdated users when the
     /// response is received
     #[async_test]
-    async fn invalidation_race_handling() {
-        let manager = manager(user_id(), device_id()).await;
+    async fn test_invalidation_race_handling() {
+        let manager = manager_test_helper(user_id(), device_id()).await;
         let alice = other_user_id();
         manager.update_tracked_users([alice]).await.unwrap();
 
@@ -1337,7 +1344,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn failure_handling() {
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
         let alice = user_id!("@alice:example.org");
 
         assert!(
@@ -1377,7 +1384,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_out_of_band_key_query() {
         // build the request
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
         let (reqid, req) = manager.build_key_query_for_users(vec![user_id()]);
         assert!(req.device_keys.contains_key(user_id()));
 
@@ -1396,7 +1403,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn devices_stream() {
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
         let (request_id, _) = manager.build_key_query_for_users(vec![user_id()]);
 
         let stream = manager.store.devices_stream();
@@ -1410,7 +1417,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn identities_stream() {
-        let manager = manager(user_id(), device_id()).await;
+        let manager = manager_test_helper(user_id(), device_id()).await;
         let (request_id, _) = manager.build_key_query_for_users(vec![user_id()]);
 
         let stream = manager.store.user_identities_stream();
@@ -1424,7 +1431,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn identities_stream_raw() {
-        let mut manager = Some(manager(user_id(), device_id()).await);
+        let mut manager = Some(manager_test_helper(user_id(), device_id()).await);
         let (request_id, _) = manager.as_ref().unwrap().build_key_query_for_users(vec![user_id()]);
 
         let stream = manager.as_ref().unwrap().store.identities_stream_raw();
@@ -1469,7 +1476,7 @@ pub(crate) mod tests {
 
     #[async_test]
     async fn identities_stream_raw_signature_update() {
-        let mut manager = Some(manager(user_id(), device_id()).await);
+        let mut manager = Some(manager_test_helper(user_id(), device_id()).await);
         let (request_id, _) =
             manager.as_ref().unwrap().build_key_query_for_users(vec![other_user_id()]);
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -755,7 +755,7 @@ impl IdentityManager {
     /// key query.
     pub async fn receive_device_changes(
         &self,
-        store: &Store,
+        store: &Store, // TODO: (bnjbvr) remove
         cache: &StoreCache,
         users: impl Iterator<Item = &UserId>,
     ) -> StoreResult<()> {
@@ -767,7 +767,7 @@ impl IdentityManager {
         &self,
         users: impl IntoIterator<Item = &UserId>,
     ) -> StoreResult<()> {
-        self.store.update_tracked_users(users.into_iter()).await
+        self.store.cache().await?.update_tracked_users(&self.store, users.into_iter()).await
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1077,6 +1077,7 @@ pub(crate) mod testing {
 pub(crate) mod tests {
     use std::ops::Deref;
 
+    use anyhow::Context;
     use futures_util::pin_mut;
     use matrix_sdk_test::{async_test, response_from_file};
     use ruma::{
@@ -1163,10 +1164,10 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn test_manager_own_key_query_response() {
+    async fn test_manager_own_key_query_response() -> anyhow::Result<()> {
         let manager = manager(user_id(), device_id()).await;
         let our_user = user_id();
-        let devices = manager.store.get_user_devices(our_user).await.unwrap();
+        let devices = manager.store.get_user_devices(our_user).await?;
         assert_eq!(devices.devices().count(), 0);
 
         let private_identity = manager.store.private_identity();
@@ -1174,26 +1175,26 @@ pub(crate) mod tests {
         let identity_request = private_identity.as_upload_request().await;
         drop(private_identity);
 
-        let device_keys = manager.store.cache().await.unwrap().account().device_keys().await;
+        let device_keys = manager.store.cache().await?.account().await?.device_keys().await;
         manager
             .receive_keys_query_response(
                 &TransactionId::new(),
                 &key_query(identity_request, device_keys),
             )
-            .await
-            .unwrap();
+            .await?;
 
-        let identity = manager.store.get_user_identity(our_user).await.unwrap().unwrap();
-        let identity = identity.own().unwrap();
+        let identity =
+            manager.store.get_user_identity(our_user).await?.context("missing user identity")?;
+        let identity = identity.own().context("missing own identity")?;
         assert!(identity.is_verified());
 
-        let devices = manager.store.get_user_devices(our_user).await.unwrap();
+        let devices = manager.store.get_user_devices(our_user).await?;
         assert_eq!(devices.devices().count(), 1);
 
-        let device =
-            manager.store.get_readonly_device(our_user, device_id!(device_id())).await.unwrap();
+        let device = manager.store.get_readonly_device(our_user, device_id!(device_id())).await?;
 
         assert!(device.is_some());
+        Ok(())
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1088,7 +1088,6 @@ pub(crate) mod testing {
 pub(crate) mod tests {
     use std::ops::Deref;
 
-    use anyhow::Context;
     use futures_util::pin_mut;
     use matrix_sdk_test::{async_test, response_from_file};
     use ruma::{
@@ -1181,10 +1180,10 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn test_manager_own_key_query_response() -> anyhow::Result<()> {
+    async fn test_manager_own_key_query_response() {
         let manager = manager_test_helper(user_id(), device_id()).await;
         let our_user = user_id();
-        let devices = manager.store.get_user_devices(our_user).await?;
+        let devices = manager.store.get_user_devices(our_user).await.unwrap();
         assert_eq!(devices.devices().count(), 0);
 
         let private_identity = manager.store.private_identity();
@@ -1192,26 +1191,32 @@ pub(crate) mod tests {
         let identity_request = private_identity.as_upload_request().await;
         drop(private_identity);
 
-        let device_keys = manager.store.cache().await?.account().await?.device_keys();
+        let device_keys =
+            manager.store.cache().await.unwrap().account().await.unwrap().device_keys();
         manager
             .receive_keys_query_response(
                 &TransactionId::new(),
                 &key_query(identity_request, device_keys),
             )
-            .await?;
+            .await
+            .unwrap();
 
-        let identity =
-            manager.store.get_user_identity(our_user).await?.context("missing user identity")?;
-        let identity = identity.own().context("missing own identity")?;
+        let identity = manager
+            .store
+            .get_user_identity(our_user)
+            .await
+            .unwrap()
+            .expect("missing user identity");
+        let identity = identity.own().expect("missing own identity");
         assert!(identity.is_verified());
 
-        let devices = manager.store.get_user_devices(our_user).await?;
+        let devices = manager.store.get_user_devices(our_user).await.unwrap();
         assert_eq!(devices.devices().count(), 1);
 
-        let device = manager.store.get_readonly_device(our_user, device_id!(device_id())).await?;
+        let device =
+            manager.store.get_readonly_device(our_user, device_id!(device_id())).await.unwrap();
 
         assert!(device.is_some());
-        Ok(())
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -37,7 +37,7 @@ use crate::{
     requests::KeysQueryRequest,
     store::{
         caches::SequenceNumber, Changes, DeviceChanges, IdentityChanges, Result as StoreResult,
-        Store,
+        Store, StoreCache,
     },
     types::{CrossSigningKey, DeviceKeys, MasterPubkey, SelfSigningPubkey, UserSigningPubkey},
     utilities::FailuresCache,
@@ -755,9 +755,11 @@ impl IdentityManager {
     /// key query.
     pub async fn receive_device_changes(
         &self,
+        store: &Store,
+        cache: &StoreCache,
         users: impl Iterator<Item = &UserId>,
     ) -> StoreResult<()> {
-        self.store.mark_tracked_users_as_changed(users).await
+        cache.mark_tracked_users_as_changed(store, users).await
     }
 
     /// See the docs for [`OlmMachine::update_tracked_users()`].
@@ -1126,7 +1128,15 @@ pub(crate) mod tests {
             manager.store.tracked_users().await.unwrap().is_empty(),
             "No users are initially tracked"
         );
-        manager.receive_device_changes([alice].iter().map(Deref::deref)).await.unwrap();
+
+        {
+            let cache = manager.store.cache().await.unwrap();
+            manager
+                .receive_device_changes(&manager.store, &cache, [alice].iter().map(Deref::deref))
+                .await
+                .unwrap();
+        }
+
         assert!(
             !manager.store.tracked_users().await.unwrap().contains(alice),
             "Receiving a device changes update for a user we don't track does nothing"
@@ -1325,7 +1335,13 @@ pub(crate) mod tests {
         assert!(req.device_keys.contains_key(alice));
 
         // another invalidation turns up
-        manager.receive_device_changes([alice].into_iter()).await.unwrap();
+        {
+            let cache = manager.store.cache().await.unwrap();
+            manager
+                .receive_device_changes(&manager.store, &cache, [alice].into_iter())
+                .await
+                .unwrap();
+        }
 
         // the response from the query arrives
         manager.receive_keys_query_response(&reqid, &other_key_query()).await.unwrap();

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1182,7 +1182,7 @@ pub(crate) mod tests {
         let identity_request = private_identity.as_upload_request().await;
         drop(private_identity);
 
-        let device_keys = manager.store.cache().await?.account().await?.device_keys().await;
+        let device_keys = manager.store.cache().await?.account().await?.device_keys();
         manager
             .receive_keys_query_response(
                 &TransactionId::new(),

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -147,7 +147,7 @@ impl OwnUserIdentity {
         }
 
         let cache = self.store.cache().await?;
-        cache.account().sign_master_key(self.master_key.clone()).await
+        cache.account().await?.sign_master_key(self.master_key.clone()).await
     }
 
     /// Send a verification request to our other devices.
@@ -174,7 +174,7 @@ impl OwnUserIdentity {
     /// own device keys with our self-signing key.
     pub async fn trusts_our_own_device(&self) -> Result<bool, CryptoStoreError> {
         Ok(if let Some(signatures) = self.verification_machine.store.device_signatures().await? {
-            let mut device_keys = self.store.cache().await?.account().device_keys().await;
+            let mut device_keys = self.store.cache().await?.account().await?.device_keys().await;
             device_keys.signatures = signatures;
 
             self.inner.self_signing_key().verify_device_keys(&device_keys).is_ok()

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -146,8 +146,8 @@ impl OwnUserIdentity {
             error!(error = ?e, "Couldn't store our own user identity after marking it as verified");
         }
 
-        let account = &self.store.cache().await?.account;
-        account.sign_master_key(self.master_key.clone()).await
+        let cache = self.store.cache().await?;
+        cache.account().sign_master_key(self.master_key.clone()).await
     }
 
     /// Send a verification request to our other devices.
@@ -174,7 +174,7 @@ impl OwnUserIdentity {
     /// own device keys with our self-signing key.
     pub async fn trusts_our_own_device(&self) -> Result<bool, CryptoStoreError> {
         Ok(if let Some(signatures) = self.verification_machine.store.device_signatures().await? {
-            let mut device_keys = self.store.cache().await?.account.device_keys().await;
+            let mut device_keys = self.store.cache().await?.account().device_keys().await;
             device_keys.signatures = signatures;
 
             self.inner.self_signing_key().verify_device_keys(&device_keys).is_ok()

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -147,7 +147,8 @@ impl OwnUserIdentity {
         }
 
         let cache = self.store.cache().await?;
-        cache.account().await?.sign_master_key(self.master_key.clone()).await
+        let account = cache.account().await?;
+        account.sign_master_key(self.master_key.clone()).await
     }
 
     /// Send a verification request to our other devices.

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -148,7 +148,7 @@ impl OwnUserIdentity {
 
         let cache = self.store.cache().await?;
         let account = cache.account().await?;
-        account.sign_master_key(self.master_key.clone()).await
+        account.sign_master_key(self.master_key.clone())
     }
 
     /// Send a verification request to our other devices.
@@ -175,7 +175,7 @@ impl OwnUserIdentity {
     /// own device keys with our self-signing key.
     pub async fn trusts_our_own_device(&self) -> Result<bool, CryptoStoreError> {
         Ok(if let Some(signatures) = self.verification_machine.store.device_signatures().await? {
-            let mut device_keys = self.store.cache().await?.account().await?.device_keys().await;
+            let mut device_keys = self.store.cache().await?.account().await?.device_keys();
             device_keys.signatures = signatures;
 
             self.inner.self_signing_key().verify_device_keys(&device_keys).is_ok()

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1171,7 +1171,6 @@ impl OlmMachine {
             .inner
             .identity_manager
             .receive_device_changes(
-                transaction.store(),
                 transaction.cache(),
                 sync_changes.changed_devices.changed.iter().map(|u| u.as_ref()),
             )

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2439,6 +2439,7 @@ pub(crate) mod tests {
     #[async_test]
     async fn test_keys_for_upload() {
         let machine = OlmMachine::new(user_id(), alice_device_id()).await;
+
         let key_counts = BTreeMap::from([(DeviceKeyAlgorithm::SignedCurve25519, 49u8.into())]);
         machine
             .receive_sync_changes(EncryptionSyncChanges {
@@ -2451,13 +2452,15 @@ pub(crate) mod tests {
             .await
             .expect("We should be able to update our one-time key counts");
 
-        let cache = machine.store().cache().await.unwrap();
-        let account = cache.account().await.unwrap();
-        let ed25519_key = account.identity_keys().ed25519;
+        let (ed25519_key, mut request) = {
+            let cache = machine.store().cache().await.unwrap();
+            let account = cache.account().await.unwrap();
+            let ed25519_key = account.identity_keys().ed25519;
 
-        let mut request =
-            machine.keys_for_upload(&account).await.expect("Can't prepare initial key upload");
-        drop(account); // Release the account lock.
+            let request =
+                machine.keys_for_upload(&account).await.expect("Can't prepare initial key upload");
+            (ed25519_key, request)
+        };
 
         let one_time_key: SignedKey = request
             .one_time_keys

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1169,7 +1169,11 @@ impl OlmMachine {
         if let Err(e) = self
             .inner
             .identity_manager
-            .receive_device_changes(sync_changes.changed_devices.changed.iter().map(|u| u.as_ref()))
+            .receive_device_changes(
+                transaction.store(),
+                transaction.cache(),
+                sync_changes.changed_devices.changed.iter().map(|u| u.as_ref()),
+            )
             .await
         {
             error!(error = ?e, "Error marking a tracked user as changed");

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -505,7 +505,7 @@ impl OlmMachine {
         if reset || identity.is_empty().await {
             info!("Creating new cross signing identity");
             let cache = self.inner.store.cache().await?;
-            let account = cache.account();
+            let account = cache.account().await?;
             let (id, request, signature_request) = account.bootstrap_cross_signing().await;
 
             *identity = id;
@@ -1876,7 +1876,7 @@ impl OlmMachine {
         let mut signatures = Signatures::new();
 
         let cache = self.inner.store.cache().await?;
-        let account = cache.account();
+        let account = cache.account().await?;
         let key_id = account.signing_key_id();
         let signature = account.sign(message).await;
         signatures.add_signature(self.user_id().to_owned(), key_id, signature);
@@ -2028,7 +2028,7 @@ impl OlmMachine {
     #[cfg(any(feature = "testing", test))]
     pub async fn uploaded_key_count(&self) -> Result<u64, CryptoStoreError> {
         let cache = self.inner.store.cache().await?;
-        Ok(cache.account().uploaded_key_count())
+        Ok(cache.account().await?.uploaded_key_count())
     }
 }
 
@@ -2294,7 +2294,7 @@ pub(crate) mod tests {
         let machine = OlmMachine::new(user_id(), alice_device_id()).await;
 
         let cache = machine.store().cache().await.unwrap();
-        let account = cache.account();
+        let account = cache.account().await.unwrap();
         assert!(!account.shared());
 
         let own_device = machine
@@ -2340,7 +2340,7 @@ pub(crate) mod tests {
 
         let (device_keys, identity_keys) = {
             let cache = machine.store().cache().await.unwrap();
-            let account = cache.account();
+            let account = cache.account().await.unwrap();
             let device_keys = account.device_keys().await;
             let identity_keys = account.identity_keys();
             (device_keys, identity_keys)
@@ -2431,7 +2431,7 @@ pub(crate) mod tests {
             .expect("We should be able to update our one-time key counts");
 
         let cache = machine.store().cache().await.unwrap();
-        let account = cache.account();
+        let account = cache.account().await.unwrap();
         let ed25519_key = account.identity_keys().ed25519;
 
         let mut request =

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -344,7 +344,7 @@ impl OlmMachine {
     /// See [`update_tracked_users`](#method.update_tracked_users) for more
     /// information.
     pub async fn tracked_users(&self) -> StoreResult<HashSet<OwnedUserId>> {
-        self.store().tracked_users().await
+        Ok(self.store().cache().await?.tracked_users())
     }
 
     /// Enable or disable room key forwarding.

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -504,7 +504,8 @@ impl OlmMachine {
 
         if reset || identity.is_empty().await {
             info!("Creating new cross signing identity");
-            let account = &self.inner.store.cache().await?.account;
+            let cache = self.inner.store.cache().await?;
+            let account = cache.account();
             let (id, request, signature_request) = account.bootstrap_cross_signing().await;
 
             *identity = id;
@@ -534,10 +535,11 @@ impl OlmMachine {
     }
 
     /// Get the underlying Olm account of the machine.
+    // TODO(BENJI) replace with direct access to the cache.
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
     pub(crate) async fn account(&self) -> Result<Account, CryptoStoreError> {
-        Ok(self.inner.store.cache().await?.account.clone())
+        Ok(self.inner.store.cache().await?.account().clone())
     }
 
     /// Receive a successful keys upload response.
@@ -1881,7 +1883,8 @@ impl OlmMachine {
     pub async fn sign(&self, message: &str) -> Result<Signatures, CryptoStoreError> {
         let mut signatures = Signatures::new();
 
-        let account = &self.inner.store.cache().await?.account;
+        let cache = self.inner.store.cache().await?;
+        let account = cache.account();
         let key_id = account.signing_key_id();
         let signature = account.sign(message).await;
         signatures.add_signature(self.user_id().to_owned(), key_id, signature);
@@ -2032,7 +2035,8 @@ impl OlmMachine {
     /// Testing purposes only.
     #[cfg(any(feature = "testing", test))]
     pub async fn uploaded_key_count(&self) -> Result<u64, CryptoStoreError> {
-        Ok(self.inner.store.cache().await?.account.uploaded_key_count())
+        let cache = self.inner.store.cache().await?;
+        Ok(cache.account().uploaded_key_count())
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -15,7 +15,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     fmt,
-    ops::Deref,
+    ops::{Deref, Not as _},
     sync::Arc,
 };
 
@@ -560,7 +560,7 @@ impl Account {
     /// If no keys need to be uploaded the `DeviceKeys` will be `None` and the
     /// one-time and fallback keys maps will be empty.
     pub fn keys_for_upload(&self) -> (Option<DeviceKeys>, OneTimeKeys, FallbackKeys) {
-        let device_keys = if !self.shared() { Some(self.device_keys()) } else { None };
+        let device_keys = self.shared().not().then(|| self.device_keys());
 
         let one_time_keys = self.signed_one_time_keys();
         let fallback_keys = self.signed_fallback_keys();

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -314,7 +314,6 @@ impl StaticAccountData {
 ///
 /// An account is the central identity for encrypted communication between two
 /// devices.
-#[derive(Clone)]
 pub struct Account {
     pub(crate) static_data: StaticAccountData,
     /// `vodozemac` account.
@@ -1354,6 +1353,18 @@ impl Account {
                 raw_event: Raw::from_json(RawJsonValue::from_string(plaintext)?),
                 sender_key,
             })
+        }
+    }
+
+    /// Test-only.
+    #[cfg(any(test, feature = "testing"))]
+    #[doc(hidden)]
+    pub fn clone_for_testing(&self) -> Self {
+        Self {
+            static_data: self.static_data.clone(),
+            inner: self.inner.clone(),
+            shared: self.shared.clone(),
+            uploaded_signed_key_count: self.uploaded_signed_key_count.clone(),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1345,7 +1345,7 @@ impl Account {
     /// Cloning should only be done for testing purposes or when we are certain
     /// that we don't want the inner state to be shared.
     #[doc(hidden)]
-    pub fn clone_internal(&self) -> Self {
+    pub fn deep_clone(&self) -> Self {
         // `vodozemac::Account` isn't really clonable, but... Don't tell anyone.
         Self::from_pickle(self.pickle()).unwrap()
     }

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -16,10 +16,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     fmt,
     ops::Deref,
-    sync::{
-        atomic::{AtomicBool, AtomicU64, Ordering},
-        Arc,
-    },
+    sync::Arc,
 };
 
 use ruma::{
@@ -317,15 +314,15 @@ impl StaticAccountData {
 pub struct Account {
     pub(crate) static_data: StaticAccountData,
     /// `vodozemac` account.
-    inner: Arc<Mutex<InnerAccount>>,
+    inner: InnerAccount,
     /// Is this account ready to encrypt messages? (i.e. has it shared keys with
     /// a homeserver)
-    shared: Arc<AtomicBool>,
+    shared: bool,
     /// The number of signed one-time keys we have uploaded to the server. If
     /// this is None, no action will be taken. After a sync request the client
     /// needs to set this for us, depending on the count we will suggest the
     /// client to upload new keys.
-    uploaded_signed_key_count: Arc<AtomicU64>,
+    uploaded_signed_key_count: u64,
 }
 
 impl Deref for Account {
@@ -373,6 +370,9 @@ impl fmt::Debug for Account {
     }
 }
 
+pub type OneTimeKeys = BTreeMap<OwnedDeviceKeyId, Raw<ruma::encryption::OneTimeKey>>;
+pub type FallbackKeys = OneTimeKeys;
+
 impl Account {
     fn new_helper(mut account: InnerAccount, user_id: &UserId, device_id: &DeviceId) -> Self {
         let identity_keys = account.identity_keys();
@@ -397,9 +397,9 @@ impl Account {
                 identity_keys: Arc::new(identity_keys),
                 creation_local_time: MilliSecondsSinceUnixEpoch::now(),
             },
-            inner: Arc::new(Mutex::new(account)),
-            shared: Arc::new(AtomicBool::new(false)),
-            uploaded_signed_key_count: Arc::new(AtomicU64::new(0)),
+            inner: account,
+            shared: false,
+            uploaded_signed_key_count: 0,
         }
     }
 
@@ -430,47 +430,47 @@ impl Account {
     /// # Arguments
     ///
     /// * `new_count` - The new count that was reported by the server.
-    pub fn update_uploaded_key_count(&self, new_count: u64) {
-        self.uploaded_signed_key_count.store(new_count, Ordering::SeqCst);
+    pub fn update_uploaded_key_count(&mut self, new_count: u64) {
+        self.uploaded_signed_key_count = new_count;
     }
 
     /// Get the currently known uploaded key count.
     pub fn uploaded_key_count(&self) -> u64 {
-        self.uploaded_signed_key_count.load(Ordering::SeqCst)
+        self.uploaded_signed_key_count
     }
 
     /// Has the account been shared with the server.
     pub fn shared(&self) -> bool {
-        self.shared.load(Ordering::SeqCst)
+        self.shared
     }
 
     /// Mark the account as shared.
     ///
     /// Messages shouldn't be encrypted with the session before it has been
     /// shared.
-    pub fn mark_as_shared(&self) {
-        self.shared.store(true, Ordering::SeqCst);
+    pub fn mark_as_shared(&mut self) {
+        self.shared = true;
     }
 
     /// Get the one-time keys of the account.
     ///
     /// This can be empty, keys need to be generated first.
-    pub async fn one_time_keys(&self) -> HashMap<KeyId, Curve25519PublicKey> {
-        self.inner.lock().await.one_time_keys()
+    pub fn one_time_keys(&self) -> HashMap<KeyId, Curve25519PublicKey> {
+        self.inner.one_time_keys()
     }
 
     /// Generate count number of one-time keys.
-    pub async fn generate_one_time_keys_helper(&self, count: usize) -> OneTimeKeyGenerationResult {
-        self.inner.lock().await.generate_one_time_keys(count)
+    pub fn generate_one_time_keys_helper(&mut self, count: usize) -> OneTimeKeyGenerationResult {
+        self.inner.generate_one_time_keys(count)
     }
 
     /// Get the maximum number of one-time keys the account can hold.
-    pub async fn max_one_time_keys(&self) -> usize {
-        self.inner.lock().await.max_number_of_one_time_keys()
+    pub fn max_one_time_keys(&self) -> usize {
+        self.inner.max_number_of_one_time_keys()
     }
 
-    pub(crate) async fn update_key_counts(
-        &self,
+    pub(crate) fn update_key_counts(
+        &mut self,
         one_time_key_counts: &BTreeMap<DeviceKeyAlgorithm, UInt>,
         unused_fallback_keys: Option<&[DeviceKeyAlgorithm]>,
     ) {
@@ -489,13 +489,13 @@ impl Account {
             }
 
             self.update_uploaded_key_count(count);
-            self.generate_one_time_keys().await;
+            self.generate_one_time_keys();
         }
 
         if let Some(unused) = unused_fallback_keys {
             if !unused.contains(&DeviceKeyAlgorithm::SignedCurve25519) {
                 // Generate a new fallback key if we don't have one.
-                self.generate_fallback_key_helper().await;
+                self.generate_fallback_key_helper();
             }
         }
     }
@@ -509,13 +509,13 @@ impl Account {
     /// Generally `Some` means that keys should be uploaded, while `None` means
     /// that keys should not be uploaded.
     #[instrument(skip_all)]
-    pub async fn generate_one_time_keys(&self) -> Option<u64> {
+    pub fn generate_one_time_keys(&mut self) -> Option<u64> {
         // Only generate one-time keys if there aren't any, otherwise the caller
         // might have failed to upload them the last time this method was
         // called.
-        if self.one_time_keys().await.is_empty() {
+        if self.one_time_keys().is_empty() {
             let count = self.uploaded_key_count();
-            let max_keys = self.max_one_time_keys().await;
+            let max_keys = self.max_one_time_keys();
 
             if count >= max_keys as u64 {
                 return None;
@@ -524,7 +524,7 @@ impl Account {
             let key_count = (max_keys as u64) - count;
             let key_count: usize = key_count.try_into().unwrap_or(max_keys);
 
-            let result = self.generate_one_time_keys_helper(key_count).await;
+            let result = self.generate_one_time_keys_helper(key_count);
 
             debug!(
                 count = key_count,
@@ -539,11 +539,9 @@ impl Account {
         }
     }
 
-    pub(crate) async fn generate_fallback_key_helper(&self) {
-        let mut account = self.inner.lock().await;
-
-        if account.fallback_key().is_empty() {
-            let removed_fallback_key = account.generate_fallback_key();
+    pub(crate) fn generate_fallback_key_helper(&mut self) {
+        if self.inner.fallback_key().is_empty() {
+            let removed_fallback_key = self.inner.generate_fallback_key();
 
             debug!(
                 ?removed_fallback_key,
@@ -552,8 +550,8 @@ impl Account {
         }
     }
 
-    async fn fallback_key(&self) -> HashMap<KeyId, Curve25519PublicKey> {
-        self.inner.lock().await.fallback_key()
+    fn fallback_key(&self) -> HashMap<KeyId, Curve25519PublicKey> {
+        self.inner.fallback_key()
     }
 
     /// Get a tuple of device, one-time, and fallback keys that need to be
@@ -561,36 +559,30 @@ impl Account {
     ///
     /// If no keys need to be uploaded the `DeviceKeys` will be `None` and the
     /// one-time and fallback keys maps will be empty.
-    pub async fn keys_for_upload(
-        &self,
-    ) -> (
-        Option<DeviceKeys>,
-        BTreeMap<OwnedDeviceKeyId, Raw<ruma::encryption::OneTimeKey>>,
-        BTreeMap<OwnedDeviceKeyId, Raw<ruma::encryption::OneTimeKey>>,
-    ) {
-        let device_keys = if !self.shared() { Some(self.device_keys().await) } else { None };
+    pub fn keys_for_upload(&self) -> (Option<DeviceKeys>, OneTimeKeys, FallbackKeys) {
+        let device_keys = if !self.shared() { Some(self.device_keys()) } else { None };
 
-        let one_time_keys = self.signed_one_time_keys().await;
-        let fallback_keys = self.signed_fallback_keys().await;
+        let one_time_keys = self.signed_one_time_keys();
+        let fallback_keys = self.signed_fallback_keys();
 
         (device_keys, one_time_keys, fallback_keys)
     }
 
     /// Mark the current set of one-time keys as being published.
-    pub async fn mark_keys_as_published(&self) {
-        self.inner.lock().await.mark_keys_as_published();
+    pub fn mark_keys_as_published(&mut self) {
+        self.inner.mark_keys_as_published();
     }
 
     /// Sign the given string using the accounts signing key.
     ///
     /// Returns the signature as a base64 encoded string.
-    pub async fn sign(&self, string: &str) -> Ed25519Signature {
-        self.inner.lock().await.sign(string)
+    pub fn sign(&self, string: &str) -> Ed25519Signature {
+        self.inner.sign(string)
     }
 
     /// Get a serializeable version of the `Account` so it can be persisted.
-    pub async fn pickle(&self) -> PickledAccount {
-        let pickle = self.inner.lock().await.pickle();
+    pub fn pickle(&self) -> PickledAccount {
+        let pickle = self.inner.pickle();
 
         PickledAccount {
             user_id: self.user_id().to_owned(),
@@ -602,11 +594,11 @@ impl Account {
         }
     }
 
-    pub(crate) async fn dehydrate(&self, pickle_key: &[u8; 32]) -> Raw<DehydratedDeviceData> {
-        let device_pickle =
-            self.inner.lock().await.to_libolm_pickle(pickle_key).expect(
-                "We should be able to convert a freshly created Account into a libolm pickle",
-            );
+    pub(crate) fn dehydrate(&self, pickle_key: &[u8; 32]) -> Raw<DehydratedDeviceData> {
+        let device_pickle = self
+            .inner
+            .to_libolm_pickle(pickle_key)
+            .expect("We should be able to convert a freshly created Account into a libolm pickle");
 
         let data = DehydratedDeviceData::V1(DehydratedDeviceV1::new(device_pickle));
         Raw::from_json(to_raw_value(&data).expect("Coulnd't our dehydrated device data"))
@@ -652,15 +644,15 @@ impl Account {
                 identity_keys: Arc::new(identity_keys),
                 creation_local_time: pickle.creation_local_time,
             },
-            inner: Arc::new(Mutex::new(account)),
-            shared: Arc::new(AtomicBool::from(pickle.shared)),
-            uploaded_signed_key_count: Arc::new(AtomicU64::new(pickle.uploaded_signed_key_count)),
+            inner: account,
+            shared: pickle.shared,
+            uploaded_signed_key_count: pickle.uploaded_signed_key_count,
         })
     }
 
     /// Sign the device keys of the account and return them so they can be
     /// uploaded.
-    pub async fn device_keys(&self) -> DeviceKeys {
+    pub fn device_keys(&self) -> DeviceKeys {
         let mut device_keys = self.unsigned_device_keys();
 
         // Create a copy of the device keys containing only fields that will
@@ -669,7 +661,6 @@ impl Account {
             serde_json::to_value(&device_keys).expect("device key is always safe to serialize");
         let signature = self
             .sign_json(json_device_keys)
-            .await
             .expect("Newly created device keys can always be signed");
 
         device_keys.signatures.add_signature(
@@ -689,11 +680,11 @@ impl Account {
     }
 
     /// Sign the given CrossSigning Key in place
-    pub async fn sign_cross_signing_key(
+    pub fn sign_cross_signing_key(
         &self,
         cross_signing_key: &mut CrossSigningKey,
     ) -> Result<(), SignatureError> {
-        let signature = self.sign_json(serde_json::to_value(&cross_signing_key)?).await?;
+        let signature = self.sign_json(serde_json::to_value(&cross_signing_key)?)?;
 
         cross_signing_key.signatures.add_signature(
             self.user_id().to_owned(),
@@ -705,7 +696,7 @@ impl Account {
     }
 
     /// Sign the given Master Key
-    pub async fn sign_master_key(
+    pub fn sign_master_key(
         &self,
         master_key: MasterPubkey,
     ) -> Result<SignatureUploadRequest, SignatureError> {
@@ -714,7 +705,7 @@ impl Account {
 
         let mut cross_signing_key: CrossSigningKey = master_key.as_ref().clone();
         cross_signing_key.signatures.clear();
-        self.sign_cross_signing_key(&mut cross_signing_key).await?;
+        self.sign_cross_signing_key(&mut cross_signing_key)?;
 
         let mut user_signed_keys = SignedKeys::new();
         user_signed_keys.add_cross_signing_keys(public_key, cross_signing_key.to_raw());
@@ -730,41 +721,41 @@ impl Account {
     ///
     /// * `json` - The value that should be converted into a canonical JSON
     /// string.
-    pub async fn sign_json(&self, json: Value) -> Result<Ed25519Signature, SignatureError> {
-        self.inner.lock().await.sign_json(json)
+    pub fn sign_json(&self, json: Value) -> Result<Ed25519Signature, SignatureError> {
+        self.inner.sign_json(json)
     }
 
     /// Generate, sign and prepare one-time keys to be uploaded.
     ///
     /// If no one-time keys need to be uploaded returns an empty BTreeMap.
-    pub async fn signed_one_time_keys(
+    pub fn signed_one_time_keys(
         &self,
     ) -> BTreeMap<OwnedDeviceKeyId, Raw<ruma::encryption::OneTimeKey>> {
-        let one_time_keys = self.one_time_keys().await;
+        let one_time_keys = self.one_time_keys();
 
         if one_time_keys.is_empty() {
             BTreeMap::new()
         } else {
-            self.signed_keys(one_time_keys, false).await
+            self.signed_keys(one_time_keys, false)
         }
     }
 
     /// Sign and prepare fallback keys to be uploaded.
     ///
     /// If no fallback keys need to be uploaded returns an empty BTreeMap.
-    pub async fn signed_fallback_keys(
+    pub fn signed_fallback_keys(
         &self,
     ) -> BTreeMap<OwnedDeviceKeyId, Raw<ruma::encryption::OneTimeKey>> {
-        let fallback_key = self.fallback_key().await;
+        let fallback_key = self.fallback_key();
 
         if fallback_key.is_empty() {
             BTreeMap::new()
         } else {
-            self.signed_keys(fallback_key, true).await
+            self.signed_keys(fallback_key, true)
         }
     }
 
-    async fn signed_keys(
+    fn signed_keys(
         &self,
         keys: HashMap<KeyId, Curve25519PublicKey>,
         fallback: bool,
@@ -772,7 +763,7 @@ impl Account {
         let mut keys_map = BTreeMap::new();
 
         for (key_id, key) in keys {
-            let signed_key = self.sign_key(key, fallback).await;
+            let signed_key = self.sign_key(key, fallback);
 
             keys_map.insert(
                 DeviceKeyId::from_parts(
@@ -786,7 +777,7 @@ impl Account {
         keys_map
     }
 
-    async fn sign_key(&self, key: Curve25519PublicKey, fallback: bool) -> SignedKey {
+    fn sign_key(&self, key: Curve25519PublicKey, fallback: bool) -> SignedKey {
         let mut key = if fallback {
             SignedKey::new_fallback(key.to_owned())
         } else {
@@ -795,7 +786,6 @@ impl Account {
 
         let signature = self
             .sign_json(serde_json::to_value(&key).expect("Can't serialize a signed key"))
-            .await
             .expect("Newly created one-time keys can always be signed");
 
         key.signatures_mut().add_signature(
@@ -821,15 +811,14 @@ impl Account {
     /// created and shared with us.
     ///
     /// * `fallback_used` - Was the one-time key a fallback key.
-    pub async fn create_outbound_session_helper(
+    pub fn create_outbound_session_helper(
         &self,
         config: SessionConfig,
         identity_key: Curve25519PublicKey,
         one_time_key: Curve25519PublicKey,
         fallback_used: bool,
     ) -> Session {
-        let session =
-            self.inner.lock().await.create_outbound_session(config, identity_key, one_time_key);
+        let session = self.inner.create_outbound_session(config, identity_key, one_time_key);
 
         let now = SecondsSinceUnixEpoch::now();
         let session_id = session.session_id();
@@ -858,7 +847,8 @@ impl Account {
     ///
     /// * `key_map` - A map from the algorithm and device ID to the one-time key
     ///   that the other account created and shared with us.
-    pub async fn create_outbound_session(
+    #[allow(clippy::result_large_err)]
+    pub fn create_outbound_session(
         &self,
         device: &ReadOnlyDevice,
         key_map: &BTreeMap<OwnedDeviceKeyId, Raw<ruma::encryption::OneTimeKey>>,
@@ -906,9 +896,7 @@ impl Account {
         let one_time_key = one_time_key.key();
         let config = device.olm_session_config();
 
-        Ok(self
-            .create_outbound_session_helper(config, identity_key, one_time_key, is_fallback)
-            .await)
+        Ok(self.create_outbound_session_helper(config, identity_key, one_time_key, is_fallback))
     }
 
     /// Create a new session with another account given a pre-key Olm message.
@@ -929,20 +917,18 @@ impl Account {
             session,
         )
     )]
-    pub async fn create_inbound_session(
-        &self,
+    pub fn create_inbound_session(
+        &mut self,
         their_identity_key: Curve25519PublicKey,
         message: &PreKeyMessage,
     ) -> Result<InboundCreationResult, SessionCreationError> {
         debug!("Creating a new Olm session from a pre-key message");
 
         let result =
-            self.inner.lock().await.create_inbound_session(their_identity_key, message).map_err(
-                |e| {
-                    warn!("Failed to create a new Olm session from a pre-key message: {e:?}");
-                    e
-                },
-            )?;
+            self.inner.create_inbound_session(their_identity_key, message).map_err(|e| {
+                warn!("Failed to create a new Olm session from a pre-key message: {e:?}");
+                e
+            })?;
 
         let now = SecondsSinceUnixEpoch::now();
         let session_id = result.session.session_id();
@@ -971,17 +957,17 @@ impl Account {
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
     /// Testing only helper to create a session for the given Account
-    pub async fn create_session_for(&self, other: &Account) -> (Session, Session) {
+    pub async fn create_session_for(&mut self, other: &mut Account) -> (Session, Session) {
         use ruma::events::dummy::ToDeviceDummyEventContent;
 
-        other.generate_one_time_keys_helper(1).await;
-        let one_time = other.signed_one_time_keys().await;
+        other.generate_one_time_keys_helper(1);
+        let one_time = other.signed_one_time_keys();
 
-        let device = ReadOnlyDevice::from_account(other).await;
+        let device = ReadOnlyDevice::from_account(other);
 
-        let mut our_session = self.create_outbound_session(&device, &one_time).await.unwrap();
+        let mut our_session = self.create_outbound_session(&device, &one_time).unwrap();
 
-        other.mark_keys_as_published().await;
+        other.mark_keys_as_published();
 
         let message = our_session
             .encrypt(
@@ -1015,17 +1001,15 @@ impl Account {
             panic!("Wrong Olm message type");
         };
 
-        let our_device = ReadOnlyDevice::from_account(self).await;
-        let other_session = other
-            .create_inbound_session(our_device.curve25519_key().unwrap(), &prekey)
-            .await
-            .unwrap();
+        let our_device = ReadOnlyDevice::from_account(self);
+        let other_session =
+            other.create_inbound_session(our_device.curve25519_key().unwrap(), &prekey).unwrap();
 
         (our_session, other_session.session)
     }
 
     async fn decrypt_olm_helper(
-        &self,
+        &mut self,
         store: &Store,
         sender: &UserId,
         sender_key: Curve25519PublicKey,
@@ -1051,7 +1035,7 @@ impl Account {
 
     #[cfg(feature = "experimental-algorithms")]
     async fn decrypt_olm_v2(
-        &self,
+        &mut self,
         store: &Store,
         sender: &UserId,
         content: &OlmV2Curve25519AesSha2Content,
@@ -1061,7 +1045,7 @@ impl Account {
 
     #[instrument(skip_all, fields(sender, sender_key = %content.sender_key))]
     async fn decrypt_olm_v1(
-        &self,
+        &mut self,
         store: &Store,
         sender: &UserId,
         content: &OlmV1Curve25519AesSha2Content,
@@ -1083,7 +1067,7 @@ impl Account {
 
     #[instrument(skip_all, fields(algorithm = ?event.content.algorithm()))]
     pub(crate) async fn decrypt_to_device_event(
-        &self,
+        &mut self,
         store: &Store,
         event: &EncryptedToDeviceEvent,
     ) -> OlmResult<OlmDecryptionInfo> {
@@ -1109,8 +1093,8 @@ impl Account {
     }
 
     /// Handles a response to a /keys/upload request.
-    pub async fn receive_keys_upload_response(
-        &self,
+    pub fn receive_keys_upload_response(
+        &mut self,
         response: &upload_keys::v3::Response,
     ) -> OlmResult<()> {
         if !self.shared() {
@@ -1121,8 +1105,8 @@ impl Account {
         debug!("Marking one-time keys as published");
         // First mark the current keys as published, as updating the key counts might
         // generate some new keys if we're still below the limit.
-        self.mark_keys_as_published().await;
-        self.update_key_counts(&response.one_time_key_counts, None).await;
+        self.mark_keys_as_published();
+        self.update_key_counts(&response.one_time_key_counts, None);
 
         Ok(())
     }
@@ -1182,7 +1166,7 @@ impl Account {
     /// Decrypt an Olm message, creating a new Olm session if possible.
     #[instrument(skip(self, message))]
     async fn decrypt_olm_message(
-        &self,
+        &mut self,
         store: &Store,
         sender: &UserId,
         sender_key: Curve25519PublicKey,
@@ -1220,7 +1204,7 @@ impl Account {
 
                 OlmMessage::PreKey(m) => {
                     // Create the new session.
-                    let result = match self.create_inbound_session(sender_key, m).await {
+                    let result = match self.create_inbound_session(sender_key, m) {
                         Ok(r) => r,
                         Err(_) => {
                             return Err(OlmError::SessionWedged(sender.to_owned(), sender_key));
@@ -1356,16 +1340,14 @@ impl Account {
         }
     }
 
-    /// Test-only.
-    #[cfg(any(test, feature = "testing"))]
+    /// Internal use only.
+    ///
+    /// Cloning should only be done for testing purposes or when we are certain
+    /// that we don't want the inner state to be shared.
     #[doc(hidden)]
-    pub fn clone_for_testing(&self) -> Self {
-        Self {
-            static_data: self.static_data.clone(),
-            inner: self.inner.clone(),
-            shared: self.shared.clone(),
-            uploaded_signed_key_count: self.uploaded_signed_key_count.clone(),
-        }
+    pub fn clone_internal(&self) -> Self {
+        // `vodozemac::Account` isn't really clonable, but... Don't tell anyone.
+        Self::from_pickle(self.pickle()).unwrap()
     }
 }
 
@@ -1405,14 +1387,14 @@ mod tests {
         device_id!("DEVICEID")
     }
 
-    #[async_test]
-    async fn one_time_key_creation() -> Result<()> {
-        let account = Account::with_device_id(user_id(), device_id());
+    #[test]
+    fn test_one_time_key_creation() -> Result<()> {
+        let mut account = Account::with_device_id(user_id(), device_id());
 
-        let (_, one_time_keys, _) = account.keys_for_upload().await;
+        let (_, one_time_keys, _) = account.keys_for_upload();
         assert!(!one_time_keys.is_empty());
 
-        let (_, second_one_time_keys, _) = account.keys_for_upload().await;
+        let (_, second_one_time_keys, _) = account.keys_for_upload();
         assert!(!second_one_time_keys.is_empty());
 
         let device_key_ids: BTreeSet<&DeviceKeyId> =
@@ -1422,17 +1404,17 @@ mod tests {
 
         assert_eq!(device_key_ids, second_device_key_ids);
 
-        account.mark_keys_as_published().await;
+        account.mark_keys_as_published();
         account.update_uploaded_key_count(50);
-        account.generate_one_time_keys().await;
+        account.generate_one_time_keys();
 
-        let (_, third_one_time_keys, _) = account.keys_for_upload().await;
+        let (_, third_one_time_keys, _) = account.keys_for_upload();
         assert!(third_one_time_keys.is_empty());
 
         account.update_uploaded_key_count(0);
-        account.generate_one_time_keys().await;
+        account.generate_one_time_keys();
 
-        let (_, fourth_one_time_keys, _) = account.keys_for_upload().await;
+        let (_, fourth_one_time_keys, _) = account.keys_for_upload();
         assert!(!fourth_one_time_keys.is_empty());
 
         let fourth_device_key_ids: BTreeSet<&DeviceKeyId> =
@@ -1442,11 +1424,11 @@ mod tests {
         Ok(())
     }
 
-    #[async_test]
-    async fn fallback_key_creation() -> Result<()> {
-        let account = Account::with_device_id(user_id(), device_id());
+    #[test]
+    fn test_fallback_key_creation() -> Result<()> {
+        let mut account = Account::with_device_id(user_id(), device_id());
 
-        let (_, _, fallback_keys) = account.keys_for_upload().await;
+        let (_, _, fallback_keys) = account.keys_for_upload();
 
         // We don't create fallback keys since we don't know if the server
         // supports them, we need to receive a sync response to decide if we're
@@ -1457,36 +1439,36 @@ mod tests {
 
         // A `None` here means that the server doesn't support fallback keys, no
         // fallback key gets uploaded.
-        account.update_key_counts(&one_time_keys, None).await;
-        let (_, _, fallback_keys) = account.keys_for_upload().await;
+        account.update_key_counts(&one_time_keys, None);
+        let (_, _, fallback_keys) = account.keys_for_upload();
         assert!(fallback_keys.is_empty());
 
         // The empty array means that the server supports fallback keys but
         // there isn't a unused fallback key on the server. This time we upload
         // a fallback key.
         let unused_fallback_keys = &[];
-        account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref())).await;
-        let (_, _, fallback_keys) = account.keys_for_upload().await;
+        account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref()));
+        let (_, _, fallback_keys) = account.keys_for_upload();
         assert!(!fallback_keys.is_empty());
-        account.mark_keys_as_published().await;
+        account.mark_keys_as_published();
 
         // There's an unused fallback key on the server, nothing to do here.
         let unused_fallback_keys = &[DeviceKeyAlgorithm::SignedCurve25519];
-        account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref())).await;
-        let (_, _, fallback_keys) = account.keys_for_upload().await;
+        account.update_key_counts(&one_time_keys, Some(unused_fallback_keys.as_ref()));
+        let (_, _, fallback_keys) = account.keys_for_upload();
         assert!(fallback_keys.is_empty());
 
         Ok(())
     }
 
-    #[async_test]
-    async fn fallback_key_signing() -> Result<()> {
+    #[test]
+    fn test_fallback_key_signing() -> Result<()> {
         let key = vodozemac::Curve25519PublicKey::from_base64(
             "7PUPP6Ijt5R8qLwK2c8uK5hqCNF9tOzWYgGaAay5JBs",
         )?;
         let account = Account::with_device_id(user_id(), device_id());
 
-        let key = account.sign_key(key, true).await;
+        let key = account.sign_key(key, true);
 
         let canonical_key = key.to_canonical_json()?;
 
@@ -1499,14 +1481,14 @@ mod tests {
             .has_signed_raw(key.signatures(), &canonical_key)
             .expect("Couldn't verify signature");
 
-        let device = ReadOnlyDevice::from_account(&account).await;
+        let device = ReadOnlyDevice::from_account(&account);
         device.verify_one_time_key(&key).expect("The device can verify its own signature");
 
         Ok(())
     }
 
-    #[async_test]
-    async fn test_account_and_device_creation_timestamp() -> Result<()> {
+    #[test]
+    fn test_account_and_device_creation_timestamp() -> Result<()> {
         let now = MilliSecondsSinceUnixEpoch::now();
         let account = Account::with_device_id(user_id(), device_id());
         let then = MilliSecondsSinceUnixEpoch::now();
@@ -1514,7 +1496,7 @@ mod tests {
         assert!(account.creation_local_time() >= now);
         assert!(account.creation_local_time() <= then);
 
-        let device = ReadOnlyDevice::from_account(&account).await;
+        let device = ReadOnlyDevice::from_account(&account);
         assert_eq!(account.creation_local_time(), device.first_time_seen_ts());
 
         Ok(())

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -513,7 +513,6 @@ impl PrivateCrossSigningIdentity {
 
         account
             .sign_cross_signing_key(&mut public_key)
-            .await
             .expect("Can't sign our freshly created master key with our account");
 
         master.public_key = public_key
@@ -672,7 +671,7 @@ mod tests {
     }
 
     #[test]
-    fn signature_verification() {
+    fn test_signature_verification() {
         let signing = Signing::new();
         let user_id = user_id();
         let key_id = DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, "DEVICEID".into());
@@ -696,7 +695,7 @@ mod tests {
     }
 
     #[test]
-    fn pickling_signing() {
+    fn test_pickling_signing() {
         let signing = Signing::new();
         let pickled = signing.pickle();
 
@@ -706,7 +705,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn private_identity_creation() {
+    async fn test_private_identity_creation() {
         let identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
 
         let master_key = identity.master_key.lock().await;
@@ -724,7 +723,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn identity_pickling() {
+    async fn test_identity_pickling() {
         let identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
 
         let pickled = identity.pickle().await;
@@ -744,7 +743,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn private_identity_signed_by_account() {
+    async fn test_private_identity_signed_by_account() {
         let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
         let master = identity.master_key.lock().await;
@@ -767,11 +766,11 @@ mod tests {
     }
 
     #[async_test]
-    async fn sign_device() {
+    async fn test_sign_device() {
         let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
 
-        let mut device = ReadOnlyDevice::from_account(&account).await;
+        let mut device = ReadOnlyDevice::from_account(&account);
         let self_signing = identity.self_signing_key.lock().await;
         let self_signing = self_signing.as_ref().unwrap();
 
@@ -784,7 +783,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn sign_user_identity() {
+    async fn test_sign_user_identity() {
         let account = Account::with_device_id(user_id(), device_id!("DEVICEID"));
         let (identity, _, _) = PrivateCrossSigningIdentity::with_account(&account).await;
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -969,7 +969,7 @@ mod tests {
             .expect("Can't parse the keys claim response")
     }
 
-    async fn machine_with_user(user_id: &UserId, device_id: &DeviceId) -> OlmMachine {
+    async fn machine_with_user_test_helper(user_id: &UserId, device_id: &DeviceId) -> OlmMachine {
         let keys_query = keys_query_response();
         let keys_claim = keys_claim_response();
         let txn_id = TransactionId::new();
@@ -985,10 +985,10 @@ mod tests {
     }
 
     async fn machine() -> OlmMachine {
-        machine_with_user(alice_id(), alice_device_id()).await
+        machine_with_user_test_helper(alice_id(), alice_device_id()).await
     }
 
-    async fn machine_with_shared_room_key() -> OlmMachine {
+    async fn machine_with_shared_room_key_test_helper() -> OlmMachine {
         let machine = machine().await;
         let room_id = room_id!("!test:localhost");
         let keys_claim = keys_claim_response();
@@ -1119,7 +1119,7 @@ mod tests {
 
     #[async_test]
     async fn ratcheted_sharing() {
-        let machine = machine_with_shared_room_key().await;
+        let machine = machine_with_shared_room_key_test_helper().await;
 
         let room_id = room_id!("!test:localhost");
         let late_joiner = user_id!("@bob:localhost");
@@ -1147,7 +1147,7 @@ mod tests {
 
     #[async_test]
     async fn changing_encryption_settings() {
-        let machine = machine_with_shared_room_key().await;
+        let machine = machine_with_shared_room_key_test_helper().await;
         let room_id = room_id!("!test:localhost");
         let keys_claim = keys_claim_response();
 
@@ -1201,7 +1201,7 @@ mod tests {
         let device_id = device_id!("TESTDEVICE");
         let room_id = room_id!("!test:localhost");
 
-        let machine = machine_with_user(user_id, device_id).await;
+        let machine = machine_with_user_test_helper(user_id, device_id).await;
 
         let (outbound, _) = machine
             .inner
@@ -1343,7 +1343,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn no_olm_withheld_only_sent_once() {
+    async fn test_no_olm_withheld_only_sent_once() {
         let keys_query = keys_query_response();
         let txn_id = TransactionId::new();
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -438,7 +438,8 @@ impl SessionManager {
             }
         }
 
-        match self.key_request_machine.collect_incoming_key_requests().await {
+        let store_cache = self.store.cache().await?;
+        match self.key_request_machine.collect_incoming_key_requests(&store_cache).await {
             Ok(sessions) => {
                 let changes = Changes { sessions, ..Default::default() };
                 self.store.save_changes(changes).await?

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -599,7 +599,10 @@ mod tests {
         // now bob turns up, and we start tracking his devices...
         let bob = bob_account();
         let bob_device = ReadOnlyDevice::from_account(&bob);
-        manager.store.update_tracked_users(iter::once(bob.user_id())).await.unwrap();
+        {
+            let cache = manager.store.cache().await.unwrap();
+            cache.update_tracked_users(&manager.store, iter::once(bob.user_id())).await.unwrap();
+        }
 
         // ... and start off an attempt to get the missing sessions. This should block
         // for now.

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -654,8 +654,11 @@ mod tests {
         let manager = session_manager_test_helper().await;
         let bob = bob_account();
 
-        let manager_account = &manager.store.cache().await.unwrap().account;
-        let (_, mut session) = bob.create_session_for(manager_account).await;
+        let (_, mut session) = {
+            let cache = manager.store.cache().await.unwrap();
+            let manager_account = cache.account();
+            bob.create_session_for(manager_account).await
+        };
 
         let bob_device = ReadOnlyDevice::from_account(&bob).await;
         let time = SystemTime::now() - Duration::from_secs(3601);

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -656,7 +656,7 @@ mod tests {
 
         let (_, mut session) = {
             let cache = manager.store.cache().await.unwrap();
-            let manager_account = cache.account();
+            let manager_account = cache.account().await.unwrap();
             bob.create_session_for(manager_account).await
         };
 

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -397,12 +397,12 @@ mod tests {
     use super::{DeviceStore, GroupSessionStore, SequenceNumber, SessionStore};
     use crate::{
         identities::device::testing::get_device,
-        olm::{tests::get_account_and_session, InboundGroupSession},
+        olm::{tests::get_account_and_session_test_helper, InboundGroupSession},
     };
 
     #[async_test]
     async fn test_session_store() {
-        let (_, session) = get_account_and_session().await;
+        let (_, session) = get_account_and_session_test_helper();
 
         let store = SessionStore::new();
 
@@ -419,7 +419,7 @@ mod tests {
 
     #[async_test]
     async fn test_session_store_bulk_storing() {
-        let (_, session) = get_account_and_session().await;
+        let (_, session) = get_account_and_session_test_helper();
 
         let store = SessionStore::new();
         store.set_for_sender(&session.sender_key.to_base64(), vec![session.clone()]);
@@ -434,7 +434,7 @@ mod tests {
 
     #[async_test]
     async fn test_group_session_store() {
-        let (account, _) = get_account_and_session().await;
+        let (account, _) = get_account_and_session_test_helper();
         let room_id = room_id!("!test:localhost");
         let curve_key = "Nn0L2hkcCMFKqynTjyGsJbth7QrVmX3lbrksMkrGOAw";
 

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -66,7 +66,7 @@ macro_rules! cryptostore_integration_tests {
                 let store = get_store(name, None).await;
                 let account = get_account();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.clone_for_testing()), }).await.expect("Can't save account");
 
                 (account, store)
             }
@@ -124,7 +124,7 @@ macro_rules! cryptostore_integration_tests {
                 let store = get_store("load_account", None).await;
                 let account = get_account();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.clone_for_testing()), }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -138,7 +138,7 @@ macro_rules! cryptostore_integration_tests {
                     get_store("load_account_with_passphrase", Some("secret_passphrase")).await;
                 let account = get_account();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.clone_for_testing()), }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -151,12 +151,12 @@ macro_rules! cryptostore_integration_tests {
                 let store = get_store("save_and_share_account", None).await;
                 let account = get_account();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.clone_for_testing()), }).await.expect("Can't save account");
 
                 account.mark_as_shared();
                 account.update_uploaded_key_count(50);
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.clone_for_testing()), }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -169,7 +169,7 @@ macro_rules! cryptostore_integration_tests {
             async fn load_sessions() {
                 let store = get_store("load_sessions", None).await;
                 let (account, session) = get_account_and_session().await;
-                store.save_pending_changes(PendingChanges { account: Some(account.clone()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.clone_for_testing()), }).await.expect("Can't save account");
 
                 let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
 
@@ -193,7 +193,7 @@ macro_rules! cryptostore_integration_tests {
                 let sender_key = session.sender_key.to_base64();
                 let session_id = session.session_id().to_owned();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.clone_for_testing()), }).await.expect("Can't save account");
 
                 let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
                 store.save_changes(changes).await.unwrap();
@@ -491,7 +491,7 @@ macro_rules! cryptostore_integration_tests {
 
                 let account = Account::with_device_id(&user_id, device_id);
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone()), })
+                store.save_pending_changes(PendingChanges { account: Some(account), })
                     .await
                     .expect("Can't save account");
 

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -66,7 +66,7 @@ macro_rules! cryptostore_integration_tests {
                 let store = get_store(name, None).await;
                 let account = get_account();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone_internal()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.deep_clone()), }).await.expect("Can't save account");
 
                 (account, store)
             }
@@ -123,7 +123,7 @@ macro_rules! cryptostore_integration_tests {
                 let store = get_store("load_account", None).await;
                 let account = get_account();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone_internal()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.deep_clone()), }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -137,7 +137,7 @@ macro_rules! cryptostore_integration_tests {
                     get_store("load_account_with_passphrase", Some("secret_passphrase")).await;
                 let account = get_account();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone_internal()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.deep_clone()), }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -150,12 +150,12 @@ macro_rules! cryptostore_integration_tests {
                 let store = get_store("save_and_share_account", None).await;
                 let mut account = get_account();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone_internal()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.deep_clone()), }).await.expect("Can't save account");
 
                 account.mark_as_shared();
                 account.update_uploaded_key_count(50);
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone_internal()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.deep_clone()), }).await.expect("Can't save account");
 
                 let loaded_account = store.load_account().await.expect("Can't load account");
                 let loaded_account = loaded_account.unwrap();
@@ -168,7 +168,7 @@ macro_rules! cryptostore_integration_tests {
             async fn load_sessions() {
                 let store = get_store("load_sessions", None).await;
                 let (account, session) = get_account_and_session().await;
-                store.save_pending_changes(PendingChanges { account: Some(account.clone_internal()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.deep_clone()), }).await.expect("Can't save account");
 
                 let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
 
@@ -192,7 +192,7 @@ macro_rules! cryptostore_integration_tests {
                 let sender_key = session.sender_key.to_base64();
                 let session_id = session.session_id().to_owned();
 
-                store.save_pending_changes(PendingChanges { account: Some(account.clone_internal()), }).await.expect("Can't save account");
+                store.save_pending_changes(PendingChanges { account: Some(account.deep_clone()), }).await.expect("Can't save account");
 
                 let changes = Changes { sessions: vec![session.clone()], ..Default::default() };
                 store.save_changes(changes).await.unwrap();

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -52,6 +52,7 @@ fn encode_key_info(info: &SecretInfo) -> String {
 /// An in-memory only store that will forget all the E2EE key once it's dropped.
 #[derive(Debug)]
 pub struct MemoryStore {
+    account: StdRwLock<Option<Account>>,
     sessions: SessionStore,
     inbound_group_sessions: GroupSessionStore,
     olm_hashes: StdRwLock<HashMap<String, HashSet<String>>>,
@@ -70,6 +71,7 @@ pub struct MemoryStore {
 impl Default for MemoryStore {
     fn default() -> Self {
         MemoryStore {
+            account: Default::default(),
             sessions: SessionStore::new(),
             inbound_group_sessions: GroupSessionStore::new(),
             olm_hashes: Default::default(),
@@ -126,7 +128,7 @@ impl CryptoStore for MemoryStore {
     type Error = Infallible;
 
     async fn load_account(&self) -> Result<Option<Account>> {
-        Ok(None)
+        Ok(self.account.read().unwrap().as_ref().map(|acc| acc.clone_for_testing()))
     }
 
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
@@ -137,8 +139,11 @@ impl CryptoStore for MemoryStore {
         Ok(self.next_batch_token.read().await.clone())
     }
 
-    async fn save_pending_changes(&self, _changes: PendingChanges) -> Result<()> {
-        // TODO(bnjbvr) why didn't save_changes save the account?
+    async fn save_pending_changes(&self, changes: PendingChanges) -> Result<()> {
+        if let Some(account) = changes.account {
+            *self.account.write().unwrap() = Some(account);
+        }
+
         Ok(())
     }
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -128,7 +128,7 @@ impl CryptoStore for MemoryStore {
     type Error = Infallible;
 
     async fn load_account(&self) -> Result<Option<Account>> {
-        Ok(self.account.read().unwrap().as_ref().map(|acc| acc.clone_for_testing()))
+        Ok(self.account.read().unwrap().as_ref().map(|acc| acc.clone_internal()))
     }
 
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {
@@ -445,13 +445,13 @@ mod tests {
 
     use crate::{
         identities::device::testing::get_device,
-        olm::{tests::get_account_and_session, InboundGroupSession, OlmMessageHash},
+        olm::{tests::get_account_and_session_test_helper, InboundGroupSession, OlmMessageHash},
         store::{memorystore::MemoryStore, Changes, CryptoStore, PendingChanges},
     };
 
     #[async_test]
     async fn test_session_store() {
-        let (account, session) = get_account_and_session().await;
+        let (account, session) = get_account_and_session_test_helper();
         let store = MemoryStore::new();
 
         assert!(store.load_account().await.unwrap().is_none());
@@ -469,7 +469,7 @@ mod tests {
 
     #[async_test]
     async fn test_group_session_store() {
-        let (account, _) = get_account_and_session().await;
+        let (account, _) = get_account_and_session_test_helper();
         let room_id = room_id!("!test:localhost");
         let curve_key = "Nn0L2hkcCMFKqynTjyGsJbth7QrVmX3lbrksMkrGOAw";
 

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -128,7 +128,7 @@ impl CryptoStore for MemoryStore {
     type Error = Infallible;
 
     async fn load_account(&self) -> Result<Option<Account>> {
-        Ok(self.account.read().unwrap().as_ref().map(|acc| acc.clone_internal()))
+        Ok(self.account.read().unwrap().as_ref().map(|acc| acc.deep_clone()))
     }
 
     async fn load_identity(&self) -> Result<Option<PrivateCrossSigningIdentity>> {

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -117,10 +117,11 @@ pub(crate) struct StoreCache {
 impl StoreCache {
     /// Returns a reference to the `Account.`
     ///
-    /// Either load the account from the cache, or the store, if missing from the cache.
+    /// Either load the account from the cache, or the store, if missing from
+    /// the cache.
     ///
-    /// Note there should always be an account stored at least in the store, so this doesn't return
-    /// an `Option`.
+    /// Note there should always be an account stored at least in the store, so
+    /// this doesn't return an `Option`.
     pub async fn account(&self) -> Result<impl Deref<Target = Account> + '_> {
         let mut guard = self.account.lock().await;
         if guard.is_some() {

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -241,6 +241,11 @@ impl StoreCache {
 
         store.inner.store.save_tracked_users(&store_updates).await
     }
+
+    /// See the docs for [`crate::OlmMachine::tracked_users()`].
+    pub(crate) fn tracked_users(&self) -> HashSet<OwnedUserId> {
+        self.tracked_users.read().unwrap().iter().cloned().collect()
+    }
 }
 
 pub(crate) struct StoreCacheGuard {
@@ -1203,11 +1208,6 @@ impl Store {
             }
             _ => UserKeyQueryResult::WasPending,
         }
-    }
-
-    /// See the docs for [`crate::OlmMachine::tracked_users()`].
-    pub(crate) async fn tracked_users(&self) -> Result<HashSet<OwnedUserId>> {
-        Ok(self.cache().await?.tracked_users.read().unwrap().iter().cloned().collect())
     }
 
     /// Check whether there is a global flag to only encrypt messages for

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1168,9 +1168,6 @@ impl Store {
     pub(crate) async fn users_for_key_query(
         &self,
     ) -> Result<(HashSet<OwnedUserId>, SequenceNumber)> {
-        // Make sure the tracked users set is up to date.
-        let _cache = self.cache().await?;
-
         Ok(self.inner.users_for_key_query.lock().await.users_for_key_query())
     }
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -119,8 +119,8 @@ impl StoreCache {
     ///
     /// Note there should always be an account stored at least in the store, so this doesn't return
     /// an `Option`.
-    pub fn account(&self) -> &Account {
-        &self.account
+    pub async fn account(&self) -> Result<&Account> {
+        Ok(&self.account)
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -109,7 +109,19 @@ pub struct Store {
 pub(crate) struct StoreCache {
     tracked_users: StdRwLock<BTreeSet<OwnedUserId>>,
     tracked_user_loading_lock: RwLock<bool>,
-    pub account: Account,
+    account: Account,
+}
+
+impl StoreCache {
+    /// Returns a reference to the `Account.`
+    ///
+    /// Either load the account from the cache, or the store, if missing from the cache.
+    ///
+    /// Note there should always be an account stored at least in the store, so this doesn't return
+    /// an `Option`.
+    pub fn account(&self) -> &Account {
+        &self.account
+    }
 }
 
 pub(crate) struct StoreCacheGuard {

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -340,7 +340,7 @@ impl StoreTransaction {
         }
 
         // Save changes in the database.
-        let account = self.changes.account.as_ref().map(|acc| acc.clone_internal());
+        let account = self.changes.account.as_ref().map(|acc| acc.deep_clone());
 
         self.store.save_pending_changes(self.changes).await?;
 

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -842,8 +842,8 @@ pub(crate) mod tests {
         let bob_readonly_identity =
             ReadOnlyOwnUserIdentity::from_private(&*bob_private_identity.lock().await).await;
 
-        let alice_device = ReadOnlyDevice::from_account(&alice).await;
-        let bob_device = ReadOnlyDevice::from_account(&bob).await;
+        let alice_device = ReadOnlyDevice::from_account(&alice);
+        let bob_device = ReadOnlyDevice::from_account(&bob);
 
         let alice_changes = Changes {
             identities: IdentityChanges {

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -929,7 +929,7 @@ mod tests {
         let flow_id = FlowId::ToDevice("test_transaction".into());
 
         let device_key = account.static_data.identity_keys.ed25519;
-        let alice_device = ReadOnlyDevice::from_account(&account).await;
+        let alice_device = ReadOnlyDevice::from_account(&account);
 
         let identities = store.get_identities(alice_device).await.unwrap();
 
@@ -998,8 +998,8 @@ mod tests {
             let master_key = private_identity.master_public_key().await.unwrap();
             let master_key = master_key.get_first_key().unwrap().to_owned();
 
-            let alice_device = ReadOnlyDevice::from_account(&alice_account).await;
-            let bob_device = ReadOnlyDevice::from_account(&bob_account).await;
+            let alice_device = ReadOnlyDevice::from_account(&alice_account);
+            let bob_device = ReadOnlyDevice::from_account(&bob_account);
 
             let mut changes = Changes::default();
             changes.identities.new.push(identity.clone().into());

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -1705,7 +1705,7 @@ mod tests {
         // test what happens when we cancel() a request that we have just received over
         // to-device messages.
         let (_alice, alice_store, bob, bob_store) = setup_stores().await;
-        let bob_device = ReadOnlyDevice::from_account(&bob).await;
+        let bob_device = ReadOnlyDevice::from_account(&bob);
 
         // Set up the pair of verification requests
         let bob_request = build_test_request(&bob_store, alice_id(), None);
@@ -1742,7 +1742,7 @@ mod tests {
         let room_id = room_id!("!test:localhost");
 
         let (_alice, alice_store, bob, bob_store) = setup_stores().await;
-        let bob_device = ReadOnlyDevice::from_account(&bob).await;
+        let bob_device = ReadOnlyDevice::from_account(&bob);
 
         let content = VerificationRequest::request(
             &bob_store.account.user_id,
@@ -1797,7 +1797,7 @@ mod tests {
     #[async_test]
     async fn test_requesting_until_sas_to_device() {
         let (_alice, alice_store, bob, bob_store) = setup_stores().await;
-        let bob_device = ReadOnlyDevice::from_account(&bob).await;
+        let bob_device = ReadOnlyDevice::from_account(&bob);
 
         // Set up the pair of verification requests
         let bob_request = build_test_request(&bob_store, alice_id(), None);

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -888,13 +888,13 @@ mod tests {
         device_id!("BOBDEVCIE")
     }
 
-    async fn machine_pair() -> (VerificationStore, ReadOnlyDevice, VerificationStore, ReadOnlyDevice)
-    {
+    fn machine_pair_test_helper(
+    ) -> (VerificationStore, ReadOnlyDevice, VerificationStore, ReadOnlyDevice) {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
-        let alice_device = ReadOnlyDevice::from_account(&alice).await;
+        let alice_device = ReadOnlyDevice::from_account(&alice);
 
         let bob = Account::with_device_id(bob_id(), bob_device_id());
-        let bob_device = ReadOnlyDevice::from_account(&bob).await;
+        let bob_device = ReadOnlyDevice::from_account(&bob);
 
         let alice_store = VerificationStore {
             account: alice.static_data.clone(),
@@ -916,7 +916,7 @@ mod tests {
 
     #[async_test]
     async fn sas_wrapper_full() {
-        let (alice_store, alice_device, bob_store, bob_device) = machine_pair().await;
+        let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper();
 
         let identities = alice_store.get_identities(bob_device).await.unwrap();
 
@@ -990,7 +990,7 @@ mod tests {
 
     #[async_test]
     async fn sas_with_restricted_methods() {
-        let (alice_store, alice_device, bob_store, bob_device) = machine_pair().await;
+        let (alice_store, alice_device, bob_store, bob_device) = machine_pair_test_helper();
         let identities = alice_store.get_identities(bob_device).await.unwrap();
 
         let short_auth_strings = vec![ShortAuthenticationString::Decimal];

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -1553,10 +1553,10 @@ mod tests {
         mac_method: Option<SupportedMacMethod>,
     ) -> (SasState<Created>, SasState<WeAccepted>) {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
-        let alice_device = ReadOnlyDevice::from_account(&alice).await;
+        let alice_device = ReadOnlyDevice::from_account(&alice);
 
         let bob = Account::with_device_id(bob_id(), bob_device_id());
-        let bob_device = ReadOnlyDevice::from_account(&bob).await;
+        let bob_device = ReadOnlyDevice::from_account(&bob);
 
         let flow_id = TransactionId::new().into();
         let alice_sas = SasState::<Created>::new(
@@ -1805,7 +1805,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn sas_unknown_method() {
+    async fn test_sas_unknown_method() {
         let (alice, bob) = get_sas_pair(None).await;
 
         let content = json!({
@@ -1824,12 +1824,12 @@ mod tests {
     }
 
     #[async_test]
-    async fn sas_from_start_unknown_method() {
+    async fn test_sas_from_start_unknown_method() {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
-        let alice_device = ReadOnlyDevice::from_account(&alice).await;
+        let alice_device = ReadOnlyDevice::from_account(&alice);
 
         let bob = Account::with_device_id(bob_id(), bob_device_id());
-        let bob_device = ReadOnlyDevice::from_account(&bob).await;
+        let bob_device = ReadOnlyDevice::from_account(&bob);
 
         let flow_id = TransactionId::new().into();
         let alice_sas = SasState::<Created>::new(

--- a/crates/matrix-sdk-indexeddb/src/crypto_store.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store.rs
@@ -532,7 +532,7 @@ impl_crypto_store! {
 
         let account_pickle = if let Some(account) = changes.account {
             *self.static_account.write().unwrap() = Some(account.static_data().clone());
-            Some(account.pickle().await)
+            Some(account.pickle())
         } else {
             None
         };

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -693,7 +693,7 @@ impl CryptoStore for SqliteCryptoStore {
 
         let pickled_account = if let Some(account) = changes.account {
             *self.static_account.write().unwrap() = Some(account.static_data().clone());
-            Some(account.pickle().await)
+            Some(account.pickle())
         } else {
             None
         };


### PR DESCRIPTION
The `Account` is lazily loaded in the cache, and transferred from the cache to `PendingChanges` in case of `StoreTransaction`. Later, `Account` is made not cloneable anymore, and inner mutable shared state is removed from there, so we can identify which interactions with the cache must be transactions (i.e. which Account function calls require write access), and which can just be reads from the cache (i.e. which Account function calls requires read-only access). Eventually, the cache is put behind a RwLock, so we can't read and write to the cache at the same time; this lock is taken in write access during transactions, and in read-only access during cache reads.

This can be reviewed commit by commit. 

Multiple parts of https://github.com/matrix-org/matrix-rust-sdk/issues/2624.