### PR TITLE
oidc: tweak logging of tokens hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,6 +3087,7 @@ dependencies = [
  "serde_html_form",
  "serde_json",
  "serde_urlencoded",
+ "sha2",
  "stream_assert",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ once_cell = "1.16.0"
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"
+sha2 = "0.10.8"
 stream_assert = "0.1.1"
 thiserror = "1.0.38"
 tokio = { version = "1.30.0", default-features = false, features = ["sync"] }

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.8.5"
 ruma = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10.8"
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -51,7 +51,7 @@ rmp-serde = "1.1.1"
 ruma = { workspace = true, features = ["rand", "canonical-json", "unstable-msc3814"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
-sha2 = "0.10.2"
+sha2 = { workspace = true }
 subtle = "2.5.0"
 tokio-stream = { version = "0.1.12", features = ["sync"] }
 tokio = { workspace = true, default-features = false, features = ["sync"] }

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.8.5"
 rmp-serde = "1.1.2"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sha2 = "0.10.8"
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -47,6 +47,7 @@ experimental-oidc = [
     "dep:language-tags",
     "dep:mas-oidc-client",
     "dep:rand",
+    "dep:sha2",
     "dep:tower",
 ]
 experimental-sliding-sync = [
@@ -92,6 +93,7 @@ ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true, optional = true }
 tempfile = "3.3.0"
 thiserror = { workspace = true }
 tower = { version = "0.4.13", features = ["make"], optional = true }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -15,10 +15,9 @@
 // limitations under the License.
 
 use std::{
-    collections::{btree_map, hash_map::DefaultHasher, BTreeMap},
+    collections::{btree_map, BTreeMap},
     fmt::{self, Debug},
     future::Future,
-    hash::{Hash, Hasher},
     pin::Pin,
     sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock},
 };
@@ -1259,15 +1258,6 @@ impl Client {
         };
 
         let access_token = self.access_token();
-        let access_token = access_token.as_deref();
-        {
-            let hash = access_token.as_ref().map(|t| {
-                let mut hasher = DefaultHasher::new();
-                t.hash(&mut hasher);
-                hasher.finish()
-            });
-            tracing::trace!("Attempting request with access_token {hash:?}");
-        }
 
         self.inner
             .http_client
@@ -1275,7 +1265,7 @@ impl Client {
                 request,
                 config,
                 homeserver,
-                access_token,
+                access_token.as_deref(),
                 self.server_versions().await?,
                 send_progress,
             )

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -162,7 +162,7 @@ async fn no_refresh_token() {
 }
 
 #[async_test]
-async fn refresh_token() {
+async fn test_refresh_token() {
     let (builder, server) = test_client_builder().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())


### PR DESCRIPTION
See commit messages.

A note: the first time it will run on an iOS device, since the hash algorithm has changed, and we store the tokens hash in the crypto database, this will result in a false-positive "some other process changed the tokens under my feet", but that's no biggie: in `Oidc::restore_session`, the app will retrieve the latest session tokens from the keychain and update them everywhere (in the app's memory and store), so that's all good.