### PR TITLE
ffi: Remove _blocking functions

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -161,17 +161,6 @@ impl NotificationSettings {
         Ok(RoomNotificationSettings::new(mode.into(), true))
     }
 
-    pub fn get_room_notification_settings_blocking(
-        self: Arc<Self>,
-        room_id: String,
-        is_encrypted: bool,
-        is_one_to_one: bool,
-    ) -> Result<RoomNotificationSettings, NotificationSettingsError> {
-        RUNTIME.block_on(async move {
-            self.get_room_notification_settings(room_id, is_encrypted, is_one_to_one).await
-        })
-    }
-
     /// Set the notification mode for a room.
     pub async fn set_room_notification_mode(
         &self,
@@ -183,14 +172,6 @@ impl NotificationSettings {
             .map_err(|_e| NotificationSettingsError::InvalidRoomId { room_id })?;
         notification_settings.set_room_notification_mode(&parsed_room_id, mode.into()).await?;
         Ok(())
-    }
-
-    pub fn set_room_notification_mode_blocking(
-        self: Arc<Self>,
-        room_id: String,
-        mode: RoomNotificationMode,
-    ) -> Result<(), NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.set_room_notification_mode(room_id, mode).await })
     }
 
     /// Get the user defined room notification mode
@@ -209,13 +190,6 @@ impl NotificationSettings {
         } else {
             Ok(None)
         }
-    }
-
-    pub fn get_user_defined_room_notification_mode_blocking(
-        self: Arc<Self>,
-        room_id: String,
-    ) -> Result<Option<RoomNotificationMode>, NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.get_user_defined_room_notification_mode(room_id).await })
     }
 
     /// Get the default room notification mode
@@ -238,16 +212,6 @@ impl NotificationSettings {
             .get_default_room_notification_mode(is_encrypted.into(), is_one_to_one.into())
             .await;
         mode.into()
-    }
-
-    pub fn get_default_room_notification_mode_blocking(
-        self: Arc<Self>,
-        is_encrypted: bool,
-        is_one_to_one: bool,
-    ) -> RoomNotificationMode {
-        RUNTIME.block_on(async move {
-            self.get_default_room_notification_mode(is_encrypted, is_one_to_one).await
-        })
     }
 
     /// Set the default room notification mode
@@ -275,17 +239,6 @@ impl NotificationSettings {
         Ok(())
     }
 
-    pub fn set_default_room_notification_mode_blocking(
-        self: Arc<Self>,
-        is_encrypted: bool,
-        is_one_to_one: bool,
-        mode: RoomNotificationMode,
-    ) -> Result<(), NotificationSettingsError> {
-        RUNTIME.block_on(async move {
-            self.set_default_room_notification_mode(is_encrypted, is_one_to_one, mode).await
-        })
-    }
-
     /// Restore the default notification mode for a room
     pub async fn restore_default_room_notification_mode(
         &self,
@@ -298,34 +251,16 @@ impl NotificationSettings {
         Ok(())
     }
 
-    pub fn restore_default_room_notification_mode_blocking(
-        self: Arc<Self>,
-        room_id: String,
-    ) -> Result<(), NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.restore_default_room_notification_mode(room_id).await })
-    }
-
     /// Get all room IDs for which a user-defined rule exists.
     pub async fn get_rooms_with_user_defined_rules(&self, enabled: Option<bool>) -> Vec<String> {
         let notification_settings = self.sdk_notification_settings.read().await;
         notification_settings.get_rooms_with_user_defined_rules(enabled).await
     }
 
-    pub fn get_rooms_with_user_defined_rules_blocking(
-        self: Arc<Self>,
-        enabled: Option<bool>,
-    ) -> Vec<String> {
-        RUNTIME.block_on(async move { self.get_rooms_with_user_defined_rules(enabled).await })
-    }
-
     /// Get whether some enabled keyword rules exist.
     pub async fn contains_keywords_rules(&self) -> bool {
         let notification_settings = self.sdk_notification_settings.read().await;
         notification_settings.contains_keyword_rules().await
-    }
-
-    pub fn contains_keywords_rules_blocking(self: Arc<Self>) -> bool {
-        RUNTIME.block_on(async move { self.contains_keywords_rules().await })
     }
 
     /// Get whether room mentions are enabled.
@@ -338,12 +273,6 @@ impl NotificationSettings {
             )
             .await?;
         Ok(enabled)
-    }
-
-    pub fn is_room_mention_enabled_blocking(
-        self: Arc<Self>,
-    ) -> Result<bool, NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.is_room_mention_enabled().await })
     }
 
     /// Set whether room mentions are enabled.
@@ -362,13 +291,6 @@ impl NotificationSettings {
         Ok(())
     }
 
-    pub fn set_room_mention_enabled_blocking(
-        self: Arc<Self>,
-        enabled: bool,
-    ) -> Result<(), NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.set_room_mention_enabled(enabled).await })
-    }
-
     /// Get whether user mentions are enabled.
     pub async fn is_user_mention_enabled(&self) -> Result<bool, NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
@@ -379,12 +301,6 @@ impl NotificationSettings {
             )
             .await?;
         Ok(enabled)
-    }
-
-    pub fn is_user_mention_enabled_blocking(
-        self: Arc<Self>,
-    ) -> Result<bool, NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.is_user_mention_enabled().await })
     }
 
     /// Set whether user mentions are enabled.
@@ -403,13 +319,6 @@ impl NotificationSettings {
         Ok(())
     }
 
-    pub fn set_user_mention_enabled_blocking(
-        self: Arc<Self>,
-        enabled: bool,
-    ) -> Result<(), NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.set_user_mention_enabled(enabled).await })
-    }
-
     /// Get whether the `.m.rule.call` push rule is enabled
     pub async fn is_call_enabled(&self) -> Result<bool, NotificationSettingsError> {
         let notification_settings = self.sdk_notification_settings.read().await;
@@ -417,10 +326,6 @@ impl NotificationSettings {
             .is_push_rule_enabled(RuleKind::Underride, PredefinedUnderrideRuleId::Call.as_str())
             .await?;
         Ok(enabled)
-    }
-
-    pub fn is_call_enabled_blocking(self: Arc<Self>) -> Result<bool, NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.is_call_enabled().await })
     }
 
     /// Set whether the `.m.rule.call` push rule is enabled
@@ -434,13 +339,6 @@ impl NotificationSettings {
             )
             .await?;
         Ok(())
-    }
-
-    pub fn set_call_enabled_blocking(
-        self: Arc<Self>,
-        enabled: bool,
-    ) -> Result<(), NotificationSettingsError> {
-        RUNTIME.block_on(async move { self.set_call_enabled(enabled).await })
     }
 
     /// Unmute a room.
@@ -464,15 +362,5 @@ impl NotificationSettings {
             .unmute_room(&parsed_room_id, is_encrypted.into(), is_one_to_one.into())
             .await?;
         Ok(())
-    }
-
-    pub fn unmute_room_blocking(
-        self: Arc<Self>,
-        room_id: String,
-        is_encrypted: bool,
-        is_one_to_one: bool,
-    ) -> Result<(), NotificationSettingsError> {
-        RUNTIME
-            .block_on(async move { self.unmute_room(room_id, is_encrypted, is_one_to_one).await })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -197,10 +197,6 @@ impl Room {
         Ok(())
     }
 
-    pub fn fetch_members_blocking(self: Arc<Self>) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move { self.fetch_members().await })
-    }
-
     pub fn display_name(&self) -> Result<String, ClientError> {
         let r = self.inner.clone();
         RUNTIME.block_on(async move { Ok(r.display_name().await?.to_string()) })
@@ -218,21 +214,10 @@ impl Room {
         Ok(Arc::new(RoomMembersIterator::new(self.inner.members(RoomMemberships::empty()).await?)))
     }
 
-    pub fn members_blocking(self: Arc<Self>) -> Result<Arc<RoomMembersIterator>, ClientError> {
-        RUNTIME.block_on(async move { self.members().await })
-    }
-
     pub async fn member(&self, user_id: String) -> Result<Arc<RoomMember>, ClientError> {
         let user_id = UserId::parse(&*user_id).context("Invalid user id.")?;
         let member = self.inner.get_member(&user_id).await?.context("No user found")?;
         Ok(Arc::new(RoomMember::new(member)))
-    }
-
-    pub fn member_blocking(
-        self: Arc<Self>,
-        user_id: String,
-    ) -> Result<Arc<RoomMember>, ClientError> {
-        RUNTIME.block_on(async move { self.member(user_id).await })
     }
 
     pub fn member_avatar_url(&self, user_id: String) -> Result<Option<String>, ClientError> {
@@ -285,13 +270,6 @@ impl Room {
         }
     }
 
-    pub async fn add_timeline_listener_blocking(
-        self: Arc<Self>,
-        listener: Box<dyn TimelineListener>,
-    ) -> RoomTimelineListenerResult {
-        RUNTIME.block_on(async move { self.add_timeline_listener(listener).await })
-    }
-
     pub async fn room_info(&self) -> Result<RoomInfo, ClientError> {
         let avatar_url = self.inner.avatar_url();
 
@@ -326,10 +304,6 @@ impl Room {
             None => None,
         };
         Ok(RoomInfo::new(&self.inner, avatar_url, latest_event).await?)
-    }
-
-    pub fn room_info_blocking(self: Arc<Self>) -> Result<RoomInfo, ClientError> {
-        RUNTIME.block_on(async move { self.room_info().await })
     }
 
     pub fn subscribe_to_room_info_updates(
@@ -981,17 +955,9 @@ impl Room {
         Ok(self.inner.can_user_redact(&user_id).await?)
     }
 
-    pub fn can_user_redact_blocking(self: Arc<Self>, user_id: String) -> Result<bool, ClientError> {
-        RUNTIME.block_on(async move { self.can_user_redact(user_id).await })
-    }
-
     pub async fn can_user_ban(&self, user_id: String) -> Result<bool, ClientError> {
         let user_id = UserId::parse(&user_id)?;
         Ok(self.inner.can_user_ban(&user_id).await?)
-    }
-
-    pub fn can_user_ban_blocking(self: Arc<Self>, user_id: String) -> Result<bool, ClientError> {
-        RUNTIME.block_on(async move { self.can_user_ban(user_id).await })
     }
 
     pub async fn can_user_invite(&self, user_id: String) -> Result<bool, ClientError> {
@@ -999,17 +965,9 @@ impl Room {
         Ok(self.inner.can_user_invite(&user_id).await?)
     }
 
-    pub fn can_user_invite_blocking(self: Arc<Self>, user_id: String) -> Result<bool, ClientError> {
-        RUNTIME.block_on(async move { self.can_user_invite(user_id).await })
-    }
-
     pub async fn can_user_kick(&self, user_id: String) -> Result<bool, ClientError> {
         let user_id = UserId::parse(&user_id)?;
         Ok(self.inner.can_user_kick(&user_id).await?)
-    }
-
-    pub fn can_user_kick_blocking(self: Arc<Self>, user_id: String) -> Result<bool, ClientError> {
-        RUNTIME.block_on(async move { self.can_user_kick(user_id).await })
     }
 
     pub async fn can_user_send_state(
@@ -1021,14 +979,6 @@ impl Room {
         Ok(self.inner.can_user_send_state(&user_id, state_event.into()).await?)
     }
 
-    pub fn can_user_send_state_blocking(
-        self: Arc<Self>,
-        user_id: String,
-        state_event: StateEventType,
-    ) -> Result<bool, ClientError> {
-        RUNTIME.block_on(async move { self.can_user_send_state(user_id, state_event).await })
-    }
-
     pub async fn can_user_send_message(
         &self,
         user_id: String,
@@ -1038,27 +988,12 @@ impl Room {
         Ok(self.inner.can_user_send_message(&user_id, message.into()).await?)
     }
 
-    pub fn can_user_send_message_blocking(
-        self: Arc<Self>,
-        user_id: String,
-        message: MessageLikeEventType,
-    ) -> Result<bool, ClientError> {
-        RUNTIME.block_on(async move { self.can_user_send_message(user_id, message).await })
-    }
-
     pub async fn can_user_trigger_room_notification(
         &self,
         user_id: String,
     ) -> Result<bool, ClientError> {
         let user_id = UserId::parse(&user_id)?;
         Ok(self.inner.can_user_trigger_room_notification(&user_id).await?)
-    }
-
-    pub fn can_user_trigger_room_notification_blocking(
-        self: Arc<Self>,
-        user_id: String,
-    ) -> Result<bool, ClientError> {
-        RUNTIME.block_on(async move { self.can_user_trigger_room_notification(user_id).await })
     }
 
     pub fn own_user_id(&self) -> String {
@@ -1133,10 +1068,6 @@ impl SendAttachmentJoinHandle {
     pub async fn join(&self) -> Result<(), RoomError> {
         let join_hdl = self.join_hdl.clone();
         RUNTIME.spawn(async move { (&mut *join_hdl.lock().await).await.unwrap() }).await.unwrap()
-    }
-
-    pub fn join_blocking(self: Arc<Self>) -> Result<(), RoomError> {
-        RUNTIME.block_on(async move { self.join().await })
     }
 
     pub fn cancel(&self) {

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -436,11 +436,6 @@ impl RoomListItem {
         Ok(RoomInfo::new(self.inner.inner_room(), avatar_url, latest_event).await?)
     }
 
-    // Temporary workaround for coroutine leaks on Kotlin
-    pub fn room_info_blocking(self: Arc<Self>) -> Result<RoomInfo, ClientError> {
-        RUNTIME.block_on(async move { self.room_info().await })
-    }
-
     /// Building a `Room`.
     ///
     /// Be careful that building a `Room` builds its entire `Timeline` at the

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -73,10 +73,6 @@ impl SessionVerificationController {
         Ok(())
     }
 
-    pub fn request_verification_blocking(self: Arc<Self>) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move { self.request_verification().await })
-    }
-
     pub async fn start_sas_verification(&self) -> Result<(), ClientError> {
         let verification_request = self.verification_request.read().unwrap().clone();
 
@@ -103,10 +99,6 @@ impl SessionVerificationController {
         Ok(())
     }
 
-    pub fn start_sas_verification_blocking(self: Arc<Self>) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move { self.start_sas_verification().await })
-    }
-
     pub async fn approve_verification(&self) -> Result<(), ClientError> {
         let sas_verification = self.sas_verification.read().unwrap().clone();
         if let Some(sas_verification) = sas_verification {
@@ -114,10 +106,6 @@ impl SessionVerificationController {
         }
 
         Ok(())
-    }
-
-    pub fn approve_verification_blocking(self: Arc<Self>) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move { self.approve_verification().await })
     }
 
     pub async fn decline_verification(&self) -> Result<(), ClientError> {
@@ -129,10 +117,6 @@ impl SessionVerificationController {
         Ok(())
     }
 
-    pub fn decline_verification_blocking(self: Arc<Self>) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move { self.decline_verification().await })
-    }
-
     pub async fn cancel_verification(&self) -> Result<(), ClientError> {
         let verification_request = self.verification_request.read().unwrap().clone();
         if let Some(verification) = verification_request {
@@ -140,10 +124,6 @@ impl SessionVerificationController {
         }
 
         Ok(())
-    }
-
-    pub fn cancel_verification_blocking(self: Arc<Self>) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move { self.cancel_verification().await })
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -65,16 +65,8 @@ impl SyncService {
         self.inner.start().await;
     }
 
-    pub fn start_blocking(self: Arc<Self>) {
-        RUNTIME.block_on(async move { self.start().await });
-    }
-
     pub async fn stop(&self) -> Result<(), ClientError> {
         Ok(self.inner.stop().await?)
-    }
-
-    pub fn stop_blocking(self: Arc<Self>) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move { self.stop().await })
     }
 
     pub fn state(&self, listener: Box<dyn SyncServiceStateObserver>) -> Arc<TaskHandle> {
@@ -112,9 +104,5 @@ impl SyncServiceBuilder {
     pub async fn finish(self: Arc<Self>) -> Result<Arc<SyncService>, ClientError> {
         let this = unwrap_or_clone_arc(self);
         Ok(Arc::new(SyncService { inner: Arc::new(this.builder.build().await?) }))
-    }
-
-    pub fn finish_blocking(self: Arc<Self>) -> Result<Arc<SyncService>, ClientError> {
-        RUNTIME.block_on(self.finish())
     }
 }


### PR DESCRIPTION
Except for full_room_blocking, which is apparently noticably faster. They were only added as a workaround for a UniFFI bug that has now been fixed.
