### PR TITLE
matrix-sdk-common: a tracing `MakeWriter` writing to a JS Logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3143,6 +3143,7 @@ dependencies = [
  "futures-util",
  "gloo-timers 0.3.0",
  "instant",
+ "js-sys",
  "matrix-sdk-test",
  "ruma",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,6 +3151,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -34,7 +34,7 @@ futures-util = { workspace = true, features = ["channel"] }
 wasm-bindgen-futures = { version = "0.4.33", optional = true }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 web-sys = {version = "0.3.60", features = ["console"] }
-tracing-subscriber = { version = "0.3.14", default-features = false, features= ["fmt"] }
+tracing-subscriber = { version = "0.3.14", default-features = false, features = ["fmt", "ansi"] }
 wasm-bindgen = "0.2.84"
 
 [dev-dependencies]

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -42,3 +42,6 @@ assert_matches = { workspace = true }
 matrix-sdk-test = { path = "../../testing/matrix-sdk-test/", version= "0.6.0"}
 wasm-bindgen-test = "0.3.33"
 tracing-subscriber = "0.3.15"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+js-sys = "0.3.64"

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -34,7 +34,7 @@ futures-util = { workspace = true, features = ["channel"] }
 wasm-bindgen-futures = { version = "0.4.33", optional = true }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 web-sys = {version = "0.3.60", features = ["console"] }
-tracing-subscriber = { version = "0.3.14", default-features = false }
+tracing-subscriber = { version = "0.3.14", default-features = false, features= ["fmt"] }
 wasm-bindgen = "0.2.84"
 
 [dev-dependencies]

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -35,6 +35,7 @@ wasm-bindgen-futures = { version = "0.4.33", optional = true }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 web-sys = {version = "0.3.60", features = ["console"] }
 tracing-subscriber = { version = "0.3.14", default-features = false }
+wasm-bindgen = "0.2.84"
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -13,86 +13,207 @@
 // limitations under the License.
 
 //! Utilities for `tracing` in JS environments
-
-use std::{fmt, fmt::Write};
-
-use tracing::{
-    field::{Field, Visit},
-    Event, Level, Subscriber,
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    fmt,
+    fmt::Debug,
+    io,
+    rc::Rc,
+    sync::atomic::{AtomicU32, Ordering},
 };
-use tracing_subscriber::layer::Context;
 
-/// An implementation of `tracing_subscriber::layer::Layer` which directs all
-/// events to the JS console
-#[derive(Debug, Default)]
-pub struct Layer {}
+use tracing::{level_filters::LevelFilter, Level, Metadata};
+use tracing_subscriber::fmt::{
+    format::{DefaultFields, Format, Pretty},
+    MakeWriter, Subscriber,
+};
+use wasm_bindgen::prelude::*;
 
-impl Layer {
+#[wasm_bindgen]
+extern "C" {
+    /// The type of a javascript-side `Logger` object which we can use to log
+    /// from the rust side.
+    pub type JsLogger;
+
+    #[wasm_bindgen(method)]
+    pub fn debug(this: &JsLogger, data: &JsValue);
+
+    #[wasm_bindgen(method)]
+    pub fn info(this: &JsLogger, data: &JsValue);
+
+    #[wasm_bindgen(method)]
+    pub fn warn(this: &JsLogger, data: &JsValue);
+
+    #[wasm_bindgen(method)]
+    pub fn error(this: &JsLogger, data: &JsValue);
+}
+
+/// A [`MakeWriter`] which will construct an [`io::Write`] instance that will
+/// write to either a [`JsLogger`] or the JavaScript console.
+///
+/// You can either construct this as part of an entire [`Subscriber`], via
+/// [`make_tracing_subscriber`], but it's also possible to
+/// call [`MakeJsLogWriter::new`] or [`MakeJsLogWriter::new_with_logger`] and
+/// then feed the result into
+/// [`tracing_subscriber::fmt::SubscriberBuilder::with_writer`], for example:
+///
+/// ```
+/// # use matrix_sdk_common::js_tracing::MakeJsLogWriter;
+/// # use tracing_subscriber::util::SubscriberInitExt;
+/// let subscriber =
+///     tracing_subscriber::fmt().with_writer(MakeJsLogWriter::new()).finish();
+/// subscriber.init();
+/// ```
+#[derive(Debug)]
+pub struct MakeJsLogWriter {
+    /// The logger to send messages to, or `None` for the console.
+    ///
+    /// Since [`MakeWriter`]s need to be [`Send`], and references to JS-side
+    /// objects are not `Send`, we cannot refer directly to the logger here. In
+    /// practice, the lack of `Send` shouldn't be a problem, because there
+    /// will only ever be one thread in the WASM environment, but the types
+    /// don't know that.
+    ///
+    /// So, we indirect through a thread-local hashmap instance. Each time we
+    /// construct a new `MakeJsLogWriter` backed by a `JsLogger`, we assign
+    /// it a unique ID; we then store that ID in the thread-local hashmap.
+    /// Then, when we come to use the logger, provided we are really
+    /// in the same thread, we can look up the logger in the map.
+    logger_id: Option<u32>,
+}
+
+thread_local!(static LOGGER_MAP: RefCell<HashMap<u32, Rc<JsLogger>>> = RefCell::new(HashMap::new()));
+static NEXT_LOGGER_ID: AtomicU32 = AtomicU32::new(0);
+
+impl MakeJsLogWriter {
+    /// Construct a new [`MakeJsLogWriter`] which will make [`io::Write`]
+    /// instances that will write to the JavaScript console.
     pub fn new() -> Self {
-        Self {}
+        Self { logger_id: None }
+    }
+
+    /// Construct a new [`MakeJsLogWriter`] which will make [`io::Write`]
+    /// instances that will write to the given [`JsLogger`].
+    pub fn new_with_logger(logger: JsLogger) -> Self {
+        let logger_id = NEXT_LOGGER_ID.fetch_add(1, Ordering::Relaxed);
+        let maker = Self { logger_id: Some(logger_id) };
+        LOGGER_MAP.with_borrow_mut(|m| m.insert(logger_id, Rc::new(logger)));
+        maker
+    }
+
+    /// Helper function containing the common parts of
+    /// [`MakeJsLogWriter::make_writer`] and
+    /// [`MakeJsLogWriter::make_writer_for`].
+    ///
+    /// Constructs the actual [`JsLogWriter`] once we have figured out what log
+    /// level we want.
+    fn make_writer_for_level(&self, level: Level) -> JsLogWriter {
+        let logger = self.logger_id.map(|logger_id| {
+            LOGGER_MAP.with_borrow(|m| m.get(&logger_id).expect("logger id not found").clone())
+        });
+        JsLogWriter { logger, level }
     }
 }
 
-impl<S> tracing_subscriber::layer::Layer<S> for Layer
-where
-    S: Subscriber,
-{
-    fn on_event(&self, event: &Event<'_>, _: Context<'_, S>) {
-        let mut recorder = StringVisitor::new();
-        event.record(&mut recorder);
-        let metadata = event.metadata();
-        let level = metadata.level();
-
-        let origin = metadata
-            .file()
-            .and_then(|file| metadata.line().map(|ln| format!("{file}:{ln}")))
-            .unwrap_or_default();
-
-        let message = format!("{level} {origin}{recorder}");
-
-        match *level {
-            Level::TRACE | Level::DEBUG => web_sys::console::debug_1(&message.into()),
-            Level::INFO => web_sys::console::info_1(&message.into()),
-            Level::WARN => web_sys::console::warn_1(&message.into()),
-            Level::ERROR => web_sys::console::error_1(&message.into()),
+impl Drop for MakeJsLogWriter {
+    fn drop(&mut self) {
+        if let Some(logger_id) = self.logger_id {
+            LOGGER_MAP.with_borrow_mut(|m| m.remove(&logger_id));
         }
     }
 }
 
-struct StringVisitor {
-    string: String,
-}
+impl<'a> MakeWriter<'a> for MakeJsLogWriter {
+    type Writer = JsLogWriter;
 
-impl StringVisitor {
-    fn new() -> Self {
-        Self { string: String::new() }
+    fn make_writer(&'a self) -> JsLogWriter {
+        self.make_writer_for_level(Level::INFO)
+    }
+
+    fn make_writer_for(&'a self, meta: &Metadata<'_>) -> JsLogWriter {
+        self.make_writer_for_level(meta.level().clone())
     }
 }
 
-impl Visit for StringVisitor {
-    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        match field.name() {
-            "message" => {
-                if !self.string.is_empty() {
-                    self.string.push('\n');
-                }
+/// An [`io::Write`] instance that will write to either a [`JsLogger`] or the
+/// JavaScript console.
+pub struct JsLogWriter {
+    /// The logger to send messages to, or `None` for the console.
+    logger: Option<Rc<JsLogger>>,
 
-                let _ = write!(self.string, "{value:?}");
-            }
+    /// The log level to log messages at.
+    level: Level,
+}
 
-            field_name => {
-                let _ = write!(self.string, "\n{field_name} = {value:?}");
-            }
+impl Debug for JsLogWriter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JsLogWriter").field("level", &self.level).finish_non_exhaustive()
+    }
+}
+
+impl io::Write for JsLogWriter {
+    fn write(&mut self, data: &[u8]) -> Result<usize, io::Error> {
+        use std::str;
+        let message = str::from_utf8(data)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?
+            .trim_end();
+        let message = JsValue::from_str(message);
+
+        match &self.logger {
+            Some(logger) => write_message_to_logger(self.level, &message, logger.as_ref()),
+            None => write_message_to_console(self.level, &message),
         }
+
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> Result<(), io::Error> {
+        Ok(())
     }
 }
 
-impl fmt::Display for StringVisitor {
-    fn fmt(&self, mut f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if !self.string.is_empty() {
-            write!(&mut f, " {}", self.string)
-        } else {
-            Ok(())
-        }
-    }
+fn write_message_to_logger(level: Level, message: &JsValue, logger: &JsLogger) {
+    match level {
+        Level::TRACE | Level::DEBUG => logger.debug(message),
+        Level::INFO => logger.info(message),
+        Level::WARN => logger.warn(message),
+        Level::ERROR => logger.error(message),
+    };
+}
+
+fn write_message_to_console(level: Level, message: &JsValue) {
+    match level {
+        Level::TRACE | Level::DEBUG => web_sys::console::debug_1(&message),
+        Level::INFO => web_sys::console::info_1(&message),
+        Level::WARN => web_sys::console::warn_1(&message),
+        Level::ERROR => web_sys::console::error_1(&message),
+    };
+}
+
+/// The type of [`Subscriber`] returned by [`make_tracing_subscriber`]
+pub type JsLoggingSubscriber =
+    Subscriber<DefaultFields, Format<Pretty, ()>, LevelFilter, MakeJsLogWriter>;
+
+/// Construct a [`tracing::Subscriber`] which will format logs and send them to
+/// the Javascript console or the given logging object.
+///
+/// # Arguments
+///
+/// * `logger` - if `None`, logs will be sent to the JS console. Otherwise, must
+///   be a reference to a javascript object implementing `debug`, `info`, `warn`
+///   and `error` methods each taking a single `String` parameter.
+pub fn make_tracing_subscriber(logger: Option<JsLogger>) -> JsLoggingSubscriber {
+    let make_writer = match logger {
+        Some(logger) => MakeJsLogWriter::new_with_logger(logger),
+        None => MakeJsLogWriter::new(),
+    };
+
+    let format = tracing_subscriber::fmt::format().without_time().pretty();
+
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .with_writer(make_writer)
+        .with_ansi(false)
+        .event_format(format)
+        .finish()
 }

--- a/crates/matrix-sdk-common/src/js_tracing.rs
+++ b/crates/matrix-sdk-common/src/js_tracing.rs
@@ -126,6 +126,12 @@ impl Drop for MakeJsLogWriter {
     }
 }
 
+impl Default for MakeJsLogWriter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> MakeWriter<'a> for MakeJsLogWriter {
     type Writer = JsLogWriter;
 
@@ -134,7 +140,7 @@ impl<'a> MakeWriter<'a> for MakeJsLogWriter {
     }
 
     fn make_writer_for(&'a self, meta: &Metadata<'_>) -> JsLogWriter {
-        self.make_writer_for_level(meta.level().clone())
+        self.make_writer_for_level(*meta.level())
     }
 }
 
@@ -186,10 +192,10 @@ fn write_message_to_logger(level: Level, message: &JsValue, logger: &JsLogger) {
 
 fn write_message_to_console(level: Level, message: &JsValue) {
     match level {
-        Level::TRACE | Level::DEBUG => web_sys::console::debug_1(&message),
-        Level::INFO => web_sys::console::info_1(&message),
-        Level::WARN => web_sys::console::warn_1(&message),
-        Level::ERROR => web_sys::console::error_1(&message),
+        Level::TRACE | Level::DEBUG => web_sys::console::debug_1(message),
+        Level::INFO => web_sys::console::info_1(message),
+        Level::WARN => web_sys::console::warn_1(message),
+        Level::ERROR => web_sys::console::error_1(message),
     };
 }
 


### PR DESCRIPTION
Replace the old `tracing_subscriber::layer::Layer` (which I don't think anyone had gotten around to using) with a `MakeWriter` which can then be plugged into a `fmt::Subscriber`.