### PR TITLE
widget: Separate reading of message and state events

### DIFF
--- a/crates/matrix-sdk/src/widget/client/actions.rs
+++ b/crates/matrix-sdk/src/widget/client/actions.rs
@@ -14,11 +14,11 @@
 
 use std::{borrow::Cow, error::Error, ops::Deref};
 
-use ruma::events::TimelineEventType;
+use ruma::events::{MessageLikeEventType, StateEventType, TimelineEventType};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::widget::Permissions;
+use crate::widget::{Permissions, StateKeySelector};
 
 /// Action (a command) that client (driver) must perform.
 #[allow(dead_code)] // TODO: Remove once all actions are implemented.
@@ -30,9 +30,11 @@ pub(crate) enum Action {
     AcquirePermissions(Command<Permissions>),
     /// Get OpenId token for a given request ID.
     GetOpenId(Command<()>),
-    /// Read matrix event(s) that corresponds to the given description.
-    ReadMatrixEvent(Command<ReadEventCommand>),
-    // Send matrix event that corresponds to the given description.
+    /// Read message event(s).
+    ReadMessageLikeEvent(Command<ReadMessageLikeEventCommand>),
+    /// Read state event(s).
+    ReadStateEvent(Command<ReadStateEventCommand>),
+    /// Send matrix event that corresponds to the given description.
     SendMatrixEvent(Command<SendEventCommand>),
     /// Subscribe to the events in the *current* room, i.e. a room which this
     /// widget is instantiated with. The client is aware of the room.
@@ -42,12 +44,23 @@ pub(crate) enum Action {
     Unsubscribe,
 }
 
-/// Command to read matrix event(s).
-pub(crate) struct ReadEventCommand {
-    /// Read event(s) of a given type.
-    pub(crate) event_type: TimelineEventType,
-    /// Limits for the Matrix request.
+/// Command to read matrix message event(s).
+pub(crate) struct ReadMessageLikeEventCommand {
+    /// The event type to read.
+    pub(crate) event_type: MessageLikeEventType,
+
+    /// The maximum number of events to return.
     pub(crate) limit: u32,
+}
+
+/// Command to read matrix state event(s).
+pub(crate) struct ReadStateEventCommand {
+    /// The event type to read.
+    pub(crate) event_type: StateEventType,
+
+    /// The `state_key` to read, or `Any` to receive any/all events of the given
+    /// type, regardless of their `state_key`.
+    pub(crate) state_key: StateKeySelector,
 }
 
 /// Command to send matrix event.

--- a/crates/matrix-sdk/src/widget/client/outgoing.rs
+++ b/crates/matrix-sdk/src/widget/client/outgoing.rs
@@ -31,17 +31,12 @@ pub(crate) trait Request {
     type Response;
 }
 
+// `toWidget` requests
+
 /// Send a request to a widget asking it to respond with the list of
 /// permissinos (capabilities) that the widget wants to have.
 pub(crate) struct RequestPermissions;
 impl Request for RequestPermissions {
-    type Response = Permissions;
-}
-
-/// Ask the client (permission provider) to acquire given permissions
-/// from the user. The client must eventually respond with granted permissions.
-pub(crate) struct AcquirePermissions(pub(crate) Permissions);
-impl Request for AcquirePermissions {
     type Response = Permissions;
 }
 
@@ -51,16 +46,25 @@ impl Request for UpdatePermissions {
     type Response = ();
 }
 
-/// Request open ID from the Matrix client.
-pub(crate) struct RequestOpenId;
-impl Request for RequestOpenId {
-    type Response = RumaOpenIdResponse;
-}
-
 /// Send a request to the widget asking it to update its open ID state.
 pub(crate) struct UpdateOpenId(pub(crate) OpenIdResponse);
 impl Request for UpdateOpenId {
     type Response = ();
+}
+
+// requests to the `MatrixDriver`
+
+/// Ask the client (permission provider) to acquire given permissions
+/// from the user. The client must eventually respond with granted permissions.
+pub(crate) struct AcquirePermissions(pub(crate) Permissions);
+impl Request for AcquirePermissions {
+    type Response = Permissions;
+}
+
+/// Request open ID from the Matrix client.
+pub(crate) struct RequestOpenId;
+impl Request for RequestOpenId {
+    type Response = RumaOpenIdResponse;
 }
 
 /// Ask the client to read matrix event(s) that corresponds to the given

--- a/crates/matrix-sdk/src/widget/client/outgoing.rs
+++ b/crates/matrix-sdk/src/widget/client/outgoing.rs
@@ -21,7 +21,7 @@ use ruma::{
 };
 
 use super::{
-    actions::{ReadEventCommand, SendEventCommand},
+    actions::{ReadMessageLikeEventCommand, SendEventCommand},
     openid::OpenIdResponse,
 };
 use crate::widget::Permissions;
@@ -69,7 +69,7 @@ impl Request for RequestOpenId {
 
 /// Ask the client to read matrix event(s) that corresponds to the given
 /// description and return a list of events as a response.
-pub(crate) struct ReadMatrixEvent(pub(crate) ReadEventCommand);
+pub(crate) struct ReadMatrixEvent(pub(crate) ReadMessageLikeEventCommand);
 impl Request for ReadMatrixEvent {
     type Response = Vec<Raw<AnyTimelineEvent>>;
 }

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -34,24 +34,24 @@ use crate::{
 
 /// Thin wrapper around the Matrix API that provides convenient high level
 /// functions.
-pub struct MatrixDriver {
+pub(crate) struct MatrixDriver {
     room: Room,
 }
 
 impl MatrixDriver {
     /// Creates a new `MatrixDriver` for a given `room`.
-    pub fn new(room: Room) -> Self {
+    pub(crate) fn new(room: Room) -> Self {
         Self { room }
     }
 
     /// Requests an OpenID token for the current user.
-    pub async fn get_open_id(&self) -> HttpResult<OpenIdResponse> {
+    pub(crate) async fn get_open_id(&self) -> HttpResult<OpenIdResponse> {
         let user_id = self.room.own_user_id().to_owned();
         self.room.client.send(OpenIdRequest::new(user_id), None).await
     }
 
     /// Reads the latest `limit` events of a given `event_type` from the room.
-    pub async fn read(
+    pub(crate) async fn read(
         &self,
         event_type: TimelineEventType,
         limit: u32,
@@ -68,7 +68,7 @@ impl MatrixDriver {
     }
 
     /// Sends a given `event` to the room.
-    pub async fn send(
+    pub(crate) async fn send(
         &self,
         event_type: TimelineEventType,
         state_key: Option<String>,
@@ -83,7 +83,7 @@ impl MatrixDriver {
 
     /// Starts forwarding new room events. Once the returned `EventReceiver`
     /// is dropped, forwarding will be stopped.
-    pub fn events(&self) -> EventReceiver {
+    pub(crate) fn events(&self) -> EventReceiver {
         let (tx, rx) = unbounded_channel();
         let handle = self.room.add_event_handler(move |raw: Raw<AnySyncTimelineEvent>| {
             let _ = tx.send(raw.cast());
@@ -97,13 +97,13 @@ impl MatrixDriver {
 
 /// A simple entity that wraps an `UnboundedReceiver`
 /// along with the drop guard for the room event handler.
-pub struct EventReceiver {
+pub(crate) struct EventReceiver {
     rx: UnboundedReceiver<Raw<AnyTimelineEvent>>,
     _drop_guard: EventHandlerDropGuard,
 }
 
 impl EventReceiver {
-    pub async fn recv(&mut self) -> Option<Raw<AnyTimelineEvent>> {
+    pub(crate) async fn recv(&mut self) -> Option<Raw<AnyTimelineEvent>> {
         self.rx.recv().await
     }
 }

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -141,7 +141,7 @@ impl WidgetDriver {
 
         // Process events that we receive **from** the client api implementation,
         // i.e. the commands (actions) that the client sends to us.
-        let matrix = MatrixDriver::new(room);
+        let matrix_driver = MatrixDriver::new(room);
         let mut event_forwarding_guard: Option<DropGuard> = None;
         while let Some(action) = actions.recv().await {
             match action {
@@ -152,17 +152,24 @@ impl WidgetDriver {
                     events_tx.send(event).map_err(|_| ())?;
                 }
                 Action::GetOpenId(cmd) => {
-                    let result = cmd.result(matrix.get_open_id().await);
+                    let result = cmd.result(matrix_driver.get_open_id().await);
                     events_tx.send(Event::OpenIdReceived(result)).map_err(|_| ())?;
                 }
-                Action::ReadMatrixEvent(cmd) => {
-                    let matrix_events = matrix.read(cmd.event_type.clone(), cmd.limit).await;
-                    let event = Event::MatrixEventRead(cmd.result(matrix_events));
-                    events_tx.send(event).map_err(|_| ())?;
+                Action::ReadMessageLikeEvent(cmd) => {
+                    let events = matrix_driver
+                        .read_message_like_events(cmd.event_type.clone(), cmd.limit)
+                        .await;
+                    events_tx.send(Event::MatrixEventRead(cmd.result(events))).map_err(|_| ())?;
+                }
+                Action::ReadStateEvent(cmd) => {
+                    let events = matrix_driver
+                        .read_state_events(cmd.event_type.clone(), &cmd.state_key)
+                        .await;
+                    events_tx.send(Event::MatrixEventRead(cmd.result(events))).map_err(|_| ())?;
                 }
                 Action::SendMatrixEvent(cmd) => {
                     let SendEventCommand { event_type, state_key, content } = cmd.clone();
-                    let matrix_event_id = matrix.send(event_type, state_key, content).await;
+                    let matrix_event_id = matrix_driver.send(event_type, state_key, content).await;
                     let event = Event::MatrixEventSent(cmd.result(matrix_event_id));
                     events_tx.send(event).map_err(|_| ())?;
                 }
@@ -175,7 +182,7 @@ impl WidgetDriver {
                         };
 
                         event_forwarding_guard = Some(guard);
-                        let (mut matrix, events_tx) = (matrix.events(), events_tx.clone());
+                        let (mut matrix, events_tx) = (matrix_driver.events(), events_tx.clone());
                         tokio::spawn(async move {
                             loop {
                                 tokio::select! {
@@ -196,4 +203,12 @@ impl WidgetDriver {
 
         Ok(())
     }
+}
+
+// TODO: Decide which module this type should live in
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub(crate) enum StateKeySelector {
+    Key(String),
+    Any,
 }

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -136,7 +136,7 @@ impl WidgetSettings {
             user_id: url_params::USER_ID.to_owned(),
             room_id: url_params::ROOM_ID.to_owned(),
             widget_id: url_params::WIDGET_ID.to_owned(),
-            display_name: url_params::DISPLAY_NAME.to_string(),
+            display_name: url_params::DISPLAY_NAME.to_owned(),
             lang: url_params::LANGUAGE.to_owned(),
             theme: url_params::CLIENT_THEME.to_owned(),
             client_id: url_params::CLIENT_ID.to_owned(),

--- a/crates/matrix-sdk/src/widget/settings/mod.rs
+++ b/crates/matrix-sdk/src/widget/settings/mod.rs
@@ -32,6 +32,15 @@ pub struct WidgetSettings {
 }
 
 impl WidgetSettings {
+    /// Create a new WidgetSettings instance
+    pub fn new(
+        id: String,
+        init_on_content_load: bool,
+        raw_url: &str,
+    ) -> Result<Self, url::ParseError> {
+        Ok(Self { id, init_on_content_load, raw_url: Url::parse(raw_url)? })
+    }
+
     /// Widget's unique identifier.
     pub fn id(&self) -> &String {
         &self.id
@@ -119,15 +128,6 @@ impl WidgetSettings {
         url_params::replace_properties(&mut generated_url, query_props);
 
         Ok(generated_url)
-    }
-
-    /// Create a new WidgetSettings instance
-    pub fn new(
-        id: String,
-        init_on_content_load: bool,
-        raw_url: &str,
-    ) -> Result<Self, url::ParseError> {
-        Ok(Self { id, init_on_content_load, raw_url: Url::parse(raw_url)? })
     }
 }
 

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -19,6 +19,8 @@ mod client;
 mod matrix_auth;
 mod refresh_token;
 mod room;
+#[cfg(feature = "experimental-widgets")]
+mod widget;
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 #[ctor::ctor]

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -1,0 +1,228 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use matrix_sdk::{
+    config::SyncSettings,
+    widget::{Permissions, PermissionsProvider, WidgetDriver, WidgetDriverHandle, WidgetSettings},
+};
+use matrix_sdk_common::executor::spawn;
+use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder};
+use once_cell::sync::Lazy;
+use ruma::{owned_room_id, serde::JsonObject, OwnedRoomId};
+use serde::Serialize;
+use serde_json::json;
+use tracing::error;
+use wiremock::{
+    matchers::{header, method, path_regex, query_param},
+    Mock, MockServer, ResponseTemplate,
+};
+
+use crate::{logged_in_client, mock_sync};
+
+/// Create a JSON string from a [`json!`][serde_json::json] "literal".
+#[macro_export]
+macro_rules! json_string {
+    ($( $tt:tt )*) => { ::serde_json::json!( $($tt)* ).to_string() };
+}
+
+const WIDGET_ID: &str = "test-widget";
+static ROOM_ID: Lazy<OwnedRoomId> = Lazy::new(|| owned_room_id!("!a98sd12bjh:example.org"));
+
+async fn run_test_driver() -> (MockServer, WidgetDriverHandle) {
+    struct DummyPermissionsProvider;
+
+    #[async_trait]
+    impl PermissionsProvider for DummyPermissionsProvider {
+        async fn acquire_permissions(&self, permissions: Permissions) -> Permissions {
+            // Grant all permissions that the widget asks for
+            permissions
+        }
+    }
+
+    let (client, mock_server) = logged_in_client().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let mut ev_builder = SyncResponseBuilder::new();
+    ev_builder.add_joined_room(JoinedRoomBuilder::new(ROOM_ID.clone()));
+
+    mock_sync(&mock_server, ev_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    mock_server.reset().await;
+
+    let room = client.get_room(&ROOM_ID).unwrap();
+
+    let (driver, handle) = WidgetDriver::new(
+        WidgetSettings::new(WIDGET_ID.to_owned(), true, "https://foo.bar/widget").unwrap(),
+    );
+
+    spawn(async move {
+        if let Err(()) = driver.run(room, DummyPermissionsProvider).await {
+            error!("An error encountered in running the WidgetDriver (no details available yet)");
+        }
+    });
+
+    (mock_server, handle)
+}
+
+async fn recv_message(driver_handle: &WidgetDriverHandle) -> JsonObject {
+    serde_json::from_str(&driver_handle.recv().await.unwrap()).unwrap()
+}
+
+async fn send_request(
+    driver_handle: &WidgetDriverHandle,
+    request_id: &str,
+    action: &str,
+    data: impl Serialize,
+) {
+    let sent = driver_handle
+        .send(json_string!({
+            "api": "fromWidget",
+            "widgetId": WIDGET_ID,
+            "requestId": request_id,
+            "action": action,
+            "data": data,
+        }))
+        .await;
+    assert!(sent);
+}
+
+async fn send_response(
+    driver_handle: &WidgetDriverHandle,
+    request_id: &str,
+    action: &str,
+    request_data: impl Serialize,
+    response_data: impl Serialize,
+) {
+    let sent = driver_handle
+        .send(json_string!({
+            "api": "toWidget",
+            "widgetId": WIDGET_ID,
+            "requestId": request_id,
+            "action": action,
+            "data": request_data,
+            "response": response_data,
+        }))
+        .await;
+    assert!(sent);
+}
+
+#[async_test]
+#[ignore = "widget API is not yet fully implemented"]
+async fn read_messages() {
+    let (mock_server, driver_handle) = run_test_driver().await;
+
+    {
+        // Tell the driver that we're ready for communication
+        send_request(&driver_handle, "1-content-loaded", "content_loaded", json!({})).await;
+
+        // Receive the response
+        let msg = recv_message(&driver_handle).await;
+        assert_eq!(msg["api"], "fromWidget");
+        assert_eq!(msg["action"], "content_loaded");
+        assert!(msg["data"].as_object().unwrap().is_empty());
+    }
+
+    let caps = json!(["m.receive.event:m.room.message"]);
+
+    {
+        // Receive toWidget capabilities request
+        let msg = recv_message(&driver_handle).await;
+        assert_eq!(msg["api"], "toWidget");
+        assert_eq!(msg["action"], "capabilities");
+        let data = &msg["data"];
+        let request_id = msg["requestId"].as_str().unwrap();
+
+        // Answer with caps we want
+        send_response(&driver_handle, request_id, "capabilities", data, &caps).await;
+    }
+
+    {
+        // Receive a "request" with the permissions we were actually granted (wtf?)
+        let msg = recv_message(&driver_handle).await;
+        assert_eq!(msg["api"], "toWidget");
+        assert_eq!(msg["action"], "notify_capabilities");
+        assert_eq!(msg["data"], caps);
+        let request_id = msg["requestId"].as_str().unwrap();
+
+        // ACK the request
+        send_response(&driver_handle, request_id, "notify_capabilities", caps, json!({})).await;
+    }
+
+    {
+        let response_json = json!({
+            "chunk": [
+              {
+                "content": {
+                    "body": "hello",
+                    "msgtype": "m.text",
+                },
+                "event_id": "$msda7m0df9E9op3",
+                "origin_server_ts": 152037280,
+                "sender": "@example:localhost",
+                "type": "m.room.message",
+                "room_id": &*ROOM_ID,
+              },
+              {
+                "content": {
+                    "body": "This room has been replaced",
+                    "replacement_room": "!newroom:localhost",
+                },
+                "event_id": "$foun39djjod0f",
+                "origin_server_ts": 152039280,
+                "sender": "@bob:localhost",
+                "state_key": "",
+                "type": "m.room.tombstone",
+                "room_id": &*ROOM_ID,
+              },
+            ],
+            "end": "t47409-4357353_219380_26003_2269",
+            "start": "t392-516_47314_0_7_1_1_1_11444_1"
+        });
+        Mock::given(method("GET"))
+            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
+            .and(header("authorization", "Bearer 1234"))
+            .and(query_param("limit", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response_json))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        // Ask the driver to read messages
+        send_request(
+            &driver_handle,
+            "2-read-messages",
+            "org.matrix.msc2876.read_events",
+            json!({
+                "type": "m.room.message",
+                "limit": 2,
+            }),
+        )
+        .await;
+
+        // Receive the response
+        let msg = recv_message(&driver_handle).await;
+        assert_eq!(msg["api"], "fromWidget");
+        assert_eq!(msg["action"], "org.matrix.msc2876.read_events");
+        let events = msg["data"]["events"].as_array().unwrap();
+
+        assert_eq!(events.len(), 2);
+        let first_event = &events[0];
+        assert_eq!(first_event["content"]["body"], "hello");
+    }
+
+    mock_server.verify().await;
+}


### PR DESCRIPTION
For state events, widgets should only ever receive the latest state of any `event_type` / `state_key` combination. The previous implementation could return outdated ones as well.

This is a rewrite of <del>some of the changes from</del> #2717, should be a bit cleaner both in terms of code as well as commits.