### PR TITLE
widget chores: move the common parsing part out of the to-widget specific structures

### DIFF
--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -15,6 +15,5 @@
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-pub(super) enum FromWidgetRequest {
-    // TODO
-}
+#[serde(rename_all = "camelCase")]
+pub(super) enum FromWidgetRequest {}

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -100,6 +100,8 @@ impl WidgetMachine {
         let message = match serde_json::from_str::<IncomingWidgetMessage>(raw) {
             Ok(msg) => msg,
             Err(e) => {
+                // TODO: There is a special error handling required for the invalid
+                // messages. Refer to the `widget-api-poc` for implementation notes.
                 error!("Failed to parse incoming message: {e}");
                 return;
             }

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -120,7 +120,7 @@ impl WidgetMachine {
         }
     }
 
-    #[instrument(skip_all, fields(request_id = ?request_id))]
+    #[instrument(skip_all, fields(?request_id))]
     fn process_to_widget_response(&mut self, request_id: String, response: ToWidgetResponse) {
         let Ok(request_id) = Uuid::parse_str(&request_id) else {
             error!("Response's request_id is not a valid UUID");

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -17,7 +17,6 @@ use std::marker::PhantomData;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
-use uuid::Uuid;
 
 use super::{ToWidgetRequestMeta, WidgetMachine};
 use crate::widget::Permissions;
@@ -58,12 +57,6 @@ where
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct ToWidgetResponse {
-    /// The ID of the widget that sent this.
-    pub(super) widget_id: String,
-
-    /// The request ID that this response corresponds to.
-    pub(super) request_id: Uuid,
-
     /// The action from the original request.
     pub(super) action: String,
 


### PR DESCRIPTION
Per-commit review is recommended as I moved some parts around for [arguable] readability (that produces a bigger diff than this PR probably requires 😃).