### PR TITLE
widget: Rename "permissions" to "capabilities"

### DIFF
--- a/crates/matrix-sdk/src/widget/machine/actions.rs
+++ b/crates/matrix-sdk/src/widget/machine/actions.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
-use super::driver_req::AcquirePermissions;
+use super::driver_req::AcquireCapabilities;
+#[cfg(doc)]
+use super::incoming::MatrixDriverResponse;
 use crate::widget::StateKeySelector;
 
 /// Action (a command) that client (driver) must perform.
@@ -88,9 +90,12 @@ pub(crate) struct SendEventCommand {
 #[derive(Debug)]
 #[allow(dead_code)]
 pub(crate) enum MatrixDriverRequestData {
-    /// Acquire permissions from the user given the set of desired permissions.
-    /// Must eventually be answered with `Event::PermissionsAcquired`.
-    AcquirePermissions(AcquirePermissions),
+    /// Acquire capabilities from the user given the set of desired
+    /// capabilities.
+    ///
+    /// Must eventually be answered with
+    /// [`MatrixDriverResponse::CapabilitiesAcquired`].
+    AcquireCapabilities(AcquireCapabilities),
 
     /// Get OpenId token for a given request ID.
     GetOpenId,

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -28,7 +28,7 @@ use super::{
     incoming::MatrixDriverResponse,
     MatrixDriverRequestMeta, SendEventCommand, WidgetMachine,
 };
-use crate::widget::Permissions;
+use crate::widget::Capabilities;
 
 /// A handle to a pending `toWidget` request.
 pub(crate) struct MatrixDriverRequestHandle<'m, T> {
@@ -71,27 +71,27 @@ pub(crate) trait FromMatrixDriverResponse: Sized {
     fn from_response(_: MatrixDriverResponse) -> Option<Self>;
 }
 
-/// Ask the client (permission provider) to acquire given permissions
-/// from the user. The client must eventually respond with granted permissions.
+/// Ask the client (capability provider) to acquire given capabilities
+/// from the user. The client must eventually respond with granted capabilities.
 #[derive(Debug)]
-pub(crate) struct AcquirePermissions {
-    pub(crate) desired_permissions: Permissions,
+pub(crate) struct AcquireCapabilities {
+    pub(crate) desired_capabilities: Capabilities,
 }
 
-impl From<AcquirePermissions> for MatrixDriverRequestData {
-    fn from(value: AcquirePermissions) -> Self {
-        MatrixDriverRequestData::AcquirePermissions(value)
+impl From<AcquireCapabilities> for MatrixDriverRequestData {
+    fn from(value: AcquireCapabilities) -> Self {
+        MatrixDriverRequestData::AcquireCapabilities(value)
     }
 }
 
-impl MatrixDriverRequest for AcquirePermissions {
-    type Response = Permissions;
+impl MatrixDriverRequest for AcquireCapabilities {
+    type Response = Capabilities;
 }
 
-impl FromMatrixDriverResponse for Permissions {
+impl FromMatrixDriverResponse for Capabilities {
     fn from_response(ev: MatrixDriverResponse) -> Option<Self> {
         match ev {
-            MatrixDriverResponse::PermissionsAcquired(response) => Some(response),
+            MatrixDriverResponse::CapabilitiesAcquired(response) => Some(response),
             _ => {
                 error!("bug in MatrixDriver, received wrong event response");
                 None

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -20,7 +20,7 @@ use serde_json::value::RawValue as RawJsonValue;
 use uuid::Uuid;
 
 use super::{from_widget::FromWidgetRequest, to_widget::ToWidgetResponse};
-use crate::widget::Permissions;
+use crate::widget::Capabilities;
 
 /// Incoming event that the client API must process.
 pub(crate) enum IncomingMessage {
@@ -44,9 +44,10 @@ pub(crate) enum IncomingMessage {
 }
 
 pub(crate) enum MatrixDriverResponse {
-    /// Client acquired permissions from the user.
+    /// Client acquired capabilities from the user.
+    ///
     /// A response to an `Action::AcquirePermissions` command.
-    PermissionsAcquired(Permissions),
+    CapabilitiesAcquired(Capabilities),
     /// Client got OpenId token for a given request ID.
     /// A response to an `Action::GetOpenId` command.
     OpenIdReceived(request_openid_token::v3::Response),

--- a/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
@@ -91,27 +91,27 @@ fn assert_capabilities_dance(
         })));
     }
 
-    // Try to acquire permissions by sending a request to a matrix driver.
+    // Try to acquire capabilities by sending a request to a matrix driver.
     {
         let action = actions_recv.try_recv().unwrap();
-        let (request_id, permissions) = assert_matches!(
+        let (request_id, capabilities) = assert_matches!(
             action,
             Action::MatrixDriverRequest {
                 request_id,
-                data: MatrixDriverRequestData::AcquirePermissions(data)
-            } => (request_id, data.desired_permissions)
+                data: MatrixDriverRequestData::AcquireCapabilities(data)
+            } => (request_id, data.desired_capabilities)
         );
         assert_eq!(
-            permissions,
+            capabilities,
             from_value(json!(["org.matrix.msc2762.receive.state_event:m.room.member"])).unwrap()
         );
 
-        let response = MatrixDriverResponse::PermissionsAcquired(permissions);
+        let response = MatrixDriverResponse::CapabilitiesAcquired(capabilities);
         machine
             .process(IncomingMessage::MatrixDriverResponse { request_id, response: Ok(response) });
     }
 
-    // Inform the widget about the acquired permissions.
+    // Inform the widget about the acquired capabilities.
     {
         let action = actions_recv.try_recv().unwrap();
         let msg = assert_matches!(action, Action::SendToWidget(msg) => msg);

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -19,7 +19,7 @@ use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
 
 use super::{ToWidgetRequestMeta, WidgetMachine};
-use crate::widget::Permissions;
+use crate::widget::Capabilities;
 
 /// A handle to a pending `toWidget` request.
 pub(crate) struct ToWidgetRequestHandle<'m, T> {
@@ -84,14 +84,14 @@ pub(crate) struct RequestPermissions {}
 
 impl ToWidgetRequest for RequestPermissions {
     const ACTION: &'static str = "capabilities";
-    type ResponseData = Permissions;
+    type ResponseData = Capabilities;
 }
 
 /// Notify the widget that the list of the granted capabilities has changed.
 #[derive(Serialize)]
 pub(crate) struct NotifyPermissionsChanged {
-    pub(crate) requested: Permissions,
-    pub(crate) approved: Permissions,
+    pub(crate) requested: Capabilities,
+    pub(crate) approved: Capabilities,
 }
 
 impl ToWidgetRequest for NotifyPermissionsChanged {

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -19,7 +19,9 @@ use async_trait::async_trait;
 use futures_util::FutureExt;
 use matrix_sdk::{
     config::SyncSettings,
-    widget::{Permissions, PermissionsProvider, WidgetDriver, WidgetDriverHandle, WidgetSettings},
+    widget::{
+        Capabilities, CapabilitiesProvider, WidgetDriver, WidgetDriverHandle, WidgetSettings,
+    },
 };
 use matrix_sdk_common::executor::spawn;
 use matrix_sdk_test::{async_test, JoinedRoomBuilder, SyncResponseBuilder};
@@ -48,10 +50,10 @@ async fn run_test_driver(init_on_content_load: bool) -> (MockServer, WidgetDrive
     struct DummyPermissionsProvider;
 
     #[async_trait]
-    impl PermissionsProvider for DummyPermissionsProvider {
-        async fn acquire_permissions(&self, permissions: Permissions) -> Permissions {
-            // Grant all permissions that the widget asks for
-            permissions
+    impl CapabilitiesProvider for DummyPermissionsProvider {
+        async fn acquire_capabilities(&self, capabilities: Capabilities) -> Capabilities {
+            // Grant all capabilities that the widget asks for
+            capabilities
         }
     }
 
@@ -142,7 +144,7 @@ async fn negotiate_capabilities_immediately() {
     }
 
     {
-        // Receive a "request" with the permissions we were actually granted (wtf?)
+        // Receive a "request" with the capabilities we were actually granted (wtf?)
         let msg = recv_message(&driver_handle).await;
         assert_eq!(msg["api"], "toWidget");
         assert_eq!(msg["action"], "notify_capabilities");
@@ -187,7 +189,7 @@ async fn read_messages() {
     }
 
     {
-        // Receive a "request" with the permissions we were actually granted (wtf?)
+        // Receive a "request" with the capabilities we were actually granted (wtf?)
         let msg = recv_message(&driver_handle).await;
         assert_eq!(msg["api"], "toWidget");
         assert_eq!(msg["action"], "notify_capabilities");


### PR DESCRIPTION
… to match the postMessage JSON API.