### PR TITLE
widget: Subscribe and unsubscribe to matrix events

### DIFF
--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(dead_code)]
-
 //! A high-level API for requests that we send to the matrix driver.
 
 use std::marker::PhantomData;
@@ -32,7 +30,6 @@ use super::{incoming::MatrixDriverResponse, MatrixDriverRequestMeta, WidgetMachi
 use crate::widget::{Capabilities, StateKeySelector};
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) enum MatrixDriverRequestData {
     /// Acquire capabilities from the user given the set of desired
     /// capabilities.

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -507,7 +507,6 @@ impl WidgetMachine {
 type ToWidgetResponseFn = Box<dyn FnOnce(Box<RawJsonValue>, &mut WidgetMachine) + Send>;
 
 pub(crate) struct ToWidgetRequestMeta {
-    #[allow(dead_code)]
     action: &'static str,
     response_fn: Option<ToWidgetResponseFn>,
 }

--- a/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
@@ -116,6 +116,12 @@ pub(super) fn assert_capabilities_dance(
             .process(IncomingMessage::MatrixDriverResponse { request_id, response: Ok(response) });
     }
 
+    // We get the `Subscribe` command since we requested some reading capabilities.
+    {
+        let action = actions_recv.try_recv().unwrap();
+        assert_matches!(action, Action::Subscribe);
+    }
+
     // Inform the widget about the acquired capabilities.
     {
         let action = actions_recv.try_recv().unwrap();

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -112,3 +112,13 @@ impl ToWidgetRequest for NotifyOpenIdChanged {
     const ACTION: &'static str = "openid_credentials";
     type ResponseData = OpenIdResponse;
 }
+
+/// Notify the widget that we received a new matrix event.
+/// This is a "response" to the widget subscribing to the events in the room.
+#[derive(Serialize)]
+pub(crate) struct NotifyNewMatrixEvent(pub(crate) serde_json::Value);
+
+impl ToWidgetRequest for NotifyNewMatrixEvent {
+    const ACTION: &'static str = "send_event";
+    type ResponseData = ();
+}

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -101,7 +101,7 @@ pub(super) struct NotifyPermissionsChanged {
 
 impl ToWidgetRequest for NotifyPermissionsChanged {
     const ACTION: &'static str = "notify_capabilities";
-    type ResponseData = ();
+    type ResponseData = Empty;
 }
 
 /// Notify the widget that the OpenID credentials changed.
@@ -120,5 +120,8 @@ pub(crate) struct NotifyNewMatrixEvent(pub(crate) serde_json::Value);
 
 impl ToWidgetRequest for NotifyNewMatrixEvent {
     const ACTION: &'static str = "send_event";
-    type ResponseData = ();
+    type ResponseData = Empty;
 }
+
+#[derive(Deserialize)]
+pub(crate) struct Empty {}

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -14,6 +14,7 @@
 
 use std::marker::PhantomData;
 
+use ruma::{events::AnyTimelineEvent, serde::Raw};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::error;
@@ -116,7 +117,8 @@ impl ToWidgetRequest for NotifyOpenIdChanged {
 /// Notify the widget that we received a new matrix event.
 /// This is a "response" to the widget subscribing to the events in the room.
 #[derive(Serialize)]
-pub(crate) struct NotifyNewMatrixEvent(pub(crate) serde_json::Value);
+#[serde(transparent)]
+pub(crate) struct NotifyNewMatrixEvent(pub(crate) Raw<AnyTimelineEvent>);
 
 impl ToWidgetRequest for NotifyNewMatrixEvent {
     const ACTION: &'static str = "send_event";

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -124,8 +124,9 @@ impl MatrixDriver {
     /// is dropped, forwarding will be stopped.
     pub(crate) fn events(&self) -> EventReceiver {
         let (tx, rx) = unbounded_channel();
+        let room_id = self.room.room_id().to_owned();
         let handle = self.room.add_event_handler(move |raw: Raw<AnySyncTimelineEvent>| {
-            let _ = tx.send(raw.cast());
+            let _ = tx.send(attach_room_id(&raw, &room_id));
             async {}
         });
 


### PR DESCRIPTION
- ~~OpenID request handling + tests.~~ 
- ~~Error handling when an outgoing matrix request fails.~~

edit(jplatte): First parts merged in #2752.

- Basic `Subscribe` / `Unsubscribe` when the capabilities are negotiated.