### PR TITLE
widget: Add support for read-state-event fromWidget requests

### DIFF
--- a/crates/matrix-sdk/src/widget/filter.rs
+++ b/crates/matrix-sdk/src/widget/filter.rs
@@ -234,7 +234,7 @@ mod tests {
         assert!(!self_member_event_filter().matches(&message_event(TimelineEventType::Reaction)));
     }
 
-    // Tests against an `m.room.member` filter with `state_key = @self:example.me`
+    // Tests against an `m.room.member` filter with any `state_key`.
     fn member_event_filter() -> EventFilter {
         EventFilter::State(StateEventFilter::WithType(StateEventType::RoomMember))
     }

--- a/crates/matrix-sdk/src/widget/machine/driver_req.rs
+++ b/crates/matrix-sdk/src/widget/machine/driver_req.rs
@@ -24,7 +24,7 @@ use ruma::{
 use tracing::error;
 
 use super::{
-    actions::{MatrixDriverRequestData, ReadMessageLikeEventCommand},
+    actions::{MatrixDriverRequestData, ReadMessageLikeEventCommand, ReadStateEventCommand},
     incoming::MatrixDriverResponse,
     MatrixDriverRequestMeta, SendEventCommand, WidgetMachine,
 };
@@ -129,15 +129,15 @@ impl FromMatrixDriverResponse for request_openid_token::v3::Response {
 /// Ask the client to read matrix event(s) that corresponds to the given
 /// description and return a list of events as a response.
 #[derive(Debug)]
-pub(crate) struct ReadMatrixEvent(pub(crate) ReadMessageLikeEventCommand);
+pub(crate) struct ReadMatrixMessageLikeEvent(pub(crate) ReadMessageLikeEventCommand);
 
-impl From<ReadMatrixEvent> for MatrixDriverRequestData {
-    fn from(value: ReadMatrixEvent) -> Self {
+impl From<ReadMatrixMessageLikeEvent> for MatrixDriverRequestData {
+    fn from(value: ReadMatrixMessageLikeEvent) -> Self {
         MatrixDriverRequestData::ReadMessageLikeEvent(value.0)
     }
 }
 
-impl MatrixDriverRequest for ReadMatrixEvent {
+impl MatrixDriverRequest for ReadMatrixMessageLikeEvent {
     type Response = Vec<Raw<AnyTimelineEvent>>;
 }
 
@@ -151,6 +151,21 @@ impl FromMatrixDriverResponse for Vec<Raw<AnyTimelineEvent>> {
             }
         }
     }
+}
+
+/// Ask the client to read matrix event(s) that corresponds to the given
+/// description and return a list of events as a response.
+#[derive(Debug)]
+pub(crate) struct ReadMatrixStateEvent(pub(crate) ReadStateEventCommand);
+
+impl From<ReadMatrixStateEvent> for MatrixDriverRequestData {
+    fn from(value: ReadMatrixStateEvent) -> Self {
+        MatrixDriverRequestData::ReadStateEvent(value.0)
+    }
+}
+
+impl MatrixDriverRequest for ReadMatrixStateEvent {
+    type Response = Vec<Raw<AnyTimelineEvent>>;
 }
 
 /// Ask the client to send matrix event that corresponds to the given

--- a/crates/matrix-sdk/src/widget/machine/from_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/from_widget.rs
@@ -14,13 +14,21 @@
 
 use std::fmt;
 
+use ruma::{
+    events::{AnyTimelineEvent, MessageLikeEventType, StateEventType},
+    serde::Raw,
+};
 use serde::{Deserialize, Serialize};
+
+use crate::widget::StateKeySelector;
 
 #[derive(Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case", content = "data")]
 pub(super) enum FromWidgetRequest {
     SupportedApiVersions {},
     ContentLoaded {},
+    #[serde(rename = "org.matrix.msc2876.read_events")]
+    ReadEvent(ReadEventRequest),
 }
 
 #[derive(Serialize)]
@@ -96,4 +104,25 @@ pub(super) enum ApiVersion {
     /// Supports access to the TURN servers.
     #[serde(rename = "town.robin.msc3846")]
     MSC3846,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub(super) enum ReadEventRequest {
+    ReadStateEvent {
+        #[serde(rename = "type")]
+        event_type: StateEventType,
+        state_key: StateKeySelector,
+    },
+    #[allow(dead_code)]
+    ReadMessageLikeEvent {
+        #[serde(rename = "type")]
+        event_type: MessageLikeEventType,
+        limit: Option<u32>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct ReadEventResponse {
+    pub(super) events: Vec<Raw<AnyTimelineEvent>>,
 }

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -21,7 +21,7 @@ use ruma::serde::{JsonObject, Raw};
 use serde::Serialize;
 use serde_json::value::RawValue as RawJsonValue;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tracing::{error, instrument, trace, warn};
+use tracing::{error, info_span, instrument, trace, warn};
 use uuid::Uuid;
 
 use self::{
@@ -119,6 +119,9 @@ impl WidgetMachine {
 
         match message.kind {
             IncomingWidgetMessageKind::Request(request) => {
+                let _guard =
+                    info_span!("process_from_widget_request", request_id = ?message.request_id)
+                        .entered();
                 self.process_from_widget_request(request);
             }
             IncomingWidgetMessageKind::Response(response) => {
@@ -127,7 +130,6 @@ impl WidgetMachine {
         }
     }
 
-    #[instrument(skip_all, fields(request_id))]
     fn process_from_widget_request(&mut self, raw_request: Raw<FromWidgetRequest>) {
         let request = match raw_request.deserialize() {
             Ok(r) => r,

--- a/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
@@ -62,7 +62,7 @@ fn machine_can_request_capabilities_on_content_load() {
     assert_capabilities_dance(&mut machine, &mut actions_recv);
 }
 
-fn assert_capabilities_dance(
+pub(super) fn assert_capabilities_dance(
     machine: &mut WidgetMachine,
     actions_recv: &mut UnboundedReceiver<Action>,
 ) {


### PR DESCRIPTION
Subset of #2743. Still needs tests, but it should not allow widgets to read more than what is negotiated through capabilities.