### PR TITLE
feat: enable automatic cross-signing boostrapping

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -26,6 +26,8 @@ use tracing::{debug, field::debug, instrument, Span};
 use url::Url;
 
 use super::{Client, ClientInner};
+#[cfg(feature = "e2e-encryption")]
+use crate::encryption::EncryptionSettings;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::http_client::HttpSettings;
 #[cfg(feature = "experimental-oidc")]
@@ -86,6 +88,8 @@ pub struct ClientBuilder {
     server_versions: Option<Box<[MatrixVersion]>>,
     handle_refresh_tokens: bool,
     base_client: Option<BaseClient>,
+    #[cfg(feature = "e2e-encryption")]
+    encryption_settings: EncryptionSettings,
 }
 
 impl ClientBuilder {
@@ -101,6 +105,7 @@ impl ClientBuilder {
             server_versions: None,
             handle_refresh_tokens: false,
             base_client: None,
+            encryption_settings: Default::default(),
         }
     }
 
@@ -322,6 +327,14 @@ impl ClientBuilder {
         self
     }
 
+    /// Enables specific encryption settings that will persist throughout the
+    /// entire lifetime of the `Client`.
+    #[cfg(feature = "e2e-encryption")]
+    pub fn with_encryption_settings(mut self, settings: EncryptionSettings) -> Self {
+        self.encryption_settings = settings;
+        self
+    }
+
     /// Create a [`Client`] with the options set on this builder.
     ///
     /// # Errors
@@ -459,6 +472,8 @@ impl ClientBuilder {
             base_client,
             self.server_versions,
             self.respect_login_well_known,
+            #[cfg(feature = "e2e-encryption")]
+            self.encryption_settings,
         ));
 
         debug!("Done building the Client");

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -105,6 +105,7 @@ impl ClientBuilder {
             server_versions: None,
             handle_refresh_tokens: false,
             base_client: None,
+            #[cfg(feature = "e2e-encryption")]
             encryption_settings: Default::default(),
         }
     }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -72,7 +72,6 @@ use crate::{
     authentication::{AuthCtx, AuthData, ReloadSessionCallback, SaveSessionCallback},
     config::RequestConfig,
     deduplicating_handler::DeduplicatingHandler,
-    encryption::EncryptionSettings,
     error::{HttpError, HttpResult},
     event_handler::{
         EventHandler, EventHandlerDropGuard, EventHandlerHandle, EventHandlerStore, SyncEvent,
@@ -85,7 +84,10 @@ use crate::{
     TransmissionProgress,
 };
 #[cfg(feature = "e2e-encryption")]
-use crate::{encryption::Encryption, store_locks::CrossProcessStoreLock};
+use crate::{
+    encryption::{Encryption, EncryptionSettings},
+    store_locks::CrossProcessStoreLock,
+};
 
 mod builder;
 mod futures;
@@ -1921,7 +1923,7 @@ impl Client {
                 self.inner.server_versions.get().cloned(),
                 self.inner.respect_login_well_known,
                 #[cfg(feature = "e2e-encryption")]
-                self.inner.encryption_settings.clone(),
+                self.inner.encryption_settings,
             )),
         };
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -84,6 +84,14 @@ pub use self::futures::PrepareEncryptedFile;
 use self::identities::{DeviceUpdates, IdentityUpdates};
 pub use crate::error::RoomKeyImportError;
 
+/// Settings for end-to-end encryption features.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EncryptionSettings {
+    /// Automatically bootstrap cross-signing for a user once they're logged, in
+    /// case it's not already done yet.
+    pub auto_enable_cross_signing: bool,
+}
+
 impl Client {
     pub(crate) async fn olm_machine(&self) -> RwLockReadGuard<'_, Option<OlmMachine>> {
         self.base_client().olm_machine().await
@@ -472,6 +480,11 @@ pub struct Encryption {
 impl Encryption {
     pub(crate) fn new(client: Client) -> Self {
         Self { client }
+    }
+
+    /// Returns the current encryption settings for this client.
+    pub(crate) fn settings(&self) -> EncryptionSettings {
+        self.client.inner.encryption_settings
     }
 
     /// Get the public ed25519 key of our own device. This is usually what is

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -89,6 +89,9 @@ pub use crate::error::RoomKeyImportError;
 pub struct EncryptionSettings {
     /// Automatically bootstrap cross-signing for a user once they're logged, in
     /// case it's not already done yet.
+    ///
+    /// This requires to login with a username and password, or that MSC3967 is
+    /// enabled on the server, as of 2023-10-20.
     pub auto_enable_cross_signing: bool,
 }
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1206,7 +1206,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn get_dm_room_returns_the_room_we_have_with_this_user() {
+    async fn test_get_dm_room_returns_the_room_we_have_with_this_user() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
         // This is the user ID that is inside MemberAdditional.
@@ -1229,7 +1229,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn get_dm_room_still_finds_room_where_participant_is_only_invited() {
+    async fn test_get_dm_room_still_finds_room_where_participant_is_only_invited() {
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
         // This is the user ID that is inside MemberInvite
@@ -1250,7 +1250,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn get_dm_room_still_finds_left_room() {
+    async fn test_get_dm_room_still_finds_left_room() {
         // See the discussion in https://github.com/matrix-org/matrix-rust-sdk/issues/2017
         // and the high-level issue at https://github.com/vector-im/element-x-ios/issues/1077
 

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -199,7 +199,11 @@ impl LoginBuilder {
                 _ => None,
             };
 
-            self.auth.client.encryption().bootstrap_cross_signing_if_needed(auth_data).await?;
+            if let Err(err) =
+                self.auth.client.encryption().bootstrap_cross_signing_if_needed(auth_data).await
+            {
+                tracing::warn!("cross-signing bootstrapping failed: {err}");
+            }
         }
 
         Ok(response)

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -192,7 +192,6 @@ impl LoginBuilder {
         // TODO: (#2763) put this into a background task.
         #[cfg(feature = "e2e-encryption")]
         if self.auth.client.encryption().settings().auto_enable_cross_signing {
-            // TODO: We need to test each of those.
             let auth_data = match login_info {
                 login::v3::LoginInfo::Password(p) => {
                     Some(AuthData::Password(Password::new(p.identifier, p.password)))

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -20,10 +20,7 @@ use std::{
 };
 
 use ruma::{
-    api::client::{
-        session::login,
-        uiaa::{AuthData, Password, RegistrationToken, UserIdentifier},
-    },
+    api::client::{session::login, uiaa::UserIdentifier},
     assign,
     serde::JsonObject,
 };
@@ -192,6 +189,8 @@ impl LoginBuilder {
         // TODO: (#2763) put this into a background task.
         #[cfg(feature = "e2e-encryption")]
         if self.auth.client.encryption().settings().auto_enable_cross_signing {
+            use ruma::api::client::uiaa::{AuthData, Password};
+
             let auth_data = match login_info {
                 login::v3::LoginInfo::Password(p) => {
                     Some(AuthData::Password(Password::new(p.identifier, p.password)))

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -912,7 +912,18 @@ impl Oidc {
         };
 
         self.client.base_client().set_session_meta(session).await.map_err(crate::Error::from)?;
+        // At this point the Olm machine has been set up.
+
+        // Enable the cross-process lock for refreshes, if needs be.
         self.deferred_enable_cross_process_refresh_lock().await?;
+
+        // Bootstrap cross signing, if needs be.
+        // TODO: (#2763) put this into a background task.
+        if self.client.encryption().settings().auto_enable_cross_signing {
+            // According to MSC3967, OIDC doesn't require User-Interactive Authentication to
+            // call this API. Let's find out!
+            self.client.encryption().bootstrap_cross_signing_if_needed(None).await?;
+        }
 
         if let Some(cross_process_manager) = self.ctx().cross_process_token_refresh_manager.get() {
             if let Some(tokens) = self.session_tokens() {

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -922,7 +922,10 @@ impl Oidc {
         if self.client.encryption().settings().auto_enable_cross_signing {
             // According to MSC3967, OIDC doesn't require User-Interactive Authentication to
             // call this API. Let's find out!
-            self.client.encryption().bootstrap_cross_signing_if_needed(None).await?;
+            if let Err(err) = self.client.encryption().bootstrap_cross_signing_if_needed(None).await
+            {
+                warn!("cross-signing bootstrapping failed: {err}");
+            }
         }
 
         if let Some(cross_process_manager) = self.ctx().cross_process_token_refresh_manager.get() {

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -324,6 +324,7 @@ fn test_serialize_session() {
     );
 }
 
+#[cfg(feature = "e2e-encryption")]
 #[async_test]
 async fn test_login_with_cross_signing_bootstrapping() {
     let server = MockServer::start().await;
@@ -500,6 +501,7 @@ async fn test_login_with_cross_signing_bootstrapping() {
     }
 }
 
+#[cfg(feature = "e2e-encryption")]
 #[async_test]
 async fn test_login_with_cross_signing_bootstrapping_already_bootstrapped() {
     // Even if we enabled cross-signing bootstrap for another device, it won't

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -44,7 +44,7 @@ fn session() -> MatrixSession {
 }
 
 #[async_test]
-async fn login_username_refresh_token() {
+async fn test_login_username_refresh_token() {
     let (client, server) = no_retry_test_client().await;
 
     Mock::given(method("POST"))


### PR DESCRIPTION
This adds support for automatically enabling the cross-signing bootstrapping, if the user so desires. This enables it for OIDC too, where [MSC3967](https://github.com/matrix-org/matrix-spec-proposals/pull/3967) ensures we don't need any UIAI for that.

Extracted from #2666.