### PR TITLE
widget: Rename remaining "permissions" to capabilities

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -41,7 +41,7 @@ impl WidgetDriver {
             return;
         };
 
-        let capabilities_provider = PermissionsProviderWrap(capabilities_provider.into());
+        let capabilities_provider = CapabilitiesProviderWrap(capabilities_provider.into());
         if let Err(()) = driver.run(room.inner.clone(), capabilities_provider).await {
             // TODO
         }
@@ -258,9 +258,9 @@ impl WidgetDriverHandle {
     }
 }
 
-/// Permissions that a widget can request from a client.
+/// Capabilities that a widget can request from a client.
 #[derive(uniffi::Record)]
-pub struct WidgetPermissions {
+pub struct WidgetCapabilities {
     /// Types of the messages that a widget wants to be able to fetch.
     pub read: Vec<WidgetEventFilter>,
     /// Types of the messages that a widget wants to be able to send.
@@ -273,8 +273,8 @@ pub struct WidgetPermissions {
     pub requires_client: bool,
 }
 
-impl From<WidgetPermissions> for matrix_sdk::widget::Capabilities {
-    fn from(value: WidgetPermissions) -> Self {
+impl From<WidgetCapabilities> for matrix_sdk::widget::Capabilities {
+    fn from(value: WidgetCapabilities) -> Self {
         Self {
             read: value.read.into_iter().map(Into::into).collect(),
             send: value.send.into_iter().map(Into::into).collect(),
@@ -283,7 +283,7 @@ impl From<WidgetPermissions> for matrix_sdk::widget::Capabilities {
     }
 }
 
-impl From<matrix_sdk::widget::Capabilities> for WidgetPermissions {
+impl From<matrix_sdk::widget::Capabilities> for WidgetCapabilities {
     fn from(value: matrix_sdk::widget::Capabilities) -> Self {
         Self {
             read: value.read.into_iter().map(Into::into).collect(),
@@ -348,13 +348,13 @@ impl From<matrix_sdk::widget::EventFilter> for WidgetEventFilter {
 
 #[uniffi::export(callback_interface)]
 pub trait WidgetCapabilitiesProvider: Send + Sync {
-    fn acquire_capabilities(&self, capabilities: WidgetPermissions) -> WidgetPermissions;
+    fn acquire_capabilities(&self, capabilities: WidgetCapabilities) -> WidgetCapabilities;
 }
 
-struct PermissionsProviderWrap(Arc<dyn WidgetCapabilitiesProvider>);
+struct CapabilitiesProviderWrap(Arc<dyn WidgetCapabilitiesProvider>);
 
 #[async_trait]
-impl matrix_sdk::widget::CapabilitiesProvider for PermissionsProviderWrap {
+impl matrix_sdk::widget::CapabilitiesProvider for CapabilitiesProviderWrap {
     async fn acquire_capabilities(
         &self,
         capabilities: matrix_sdk::widget::Capabilities,

--- a/crates/matrix-sdk/src/widget/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/capabilities.rs
@@ -34,7 +34,7 @@ pub trait CapabilitiesProvider: Send + Sync + 'static {
     async fn acquire_capabilities(&self, capabilities: Capabilities) -> Capabilities;
 }
 
-/// Permissions that a widget can request from a client.
+/// Capabilities that a widget can request from a client.
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Capabilities {

--- a/crates/matrix-sdk/src/widget/machine/incoming.rs
+++ b/crates/matrix-sdk/src/widget/machine/incoming.rs
@@ -46,7 +46,7 @@ pub(crate) enum IncomingMessage {
 pub(crate) enum MatrixDriverResponse {
     /// Client acquired capabilities from the user.
     ///
-    /// A response to an `Action::AcquirePermissions` command.
+    /// A response to an `Action::AcquireCapabilities` command.
     CapabilitiesAcquired(Capabilities),
     /// Client got OpenId token for a given request ID.
     /// A response to an `Action::GetOpenId` command.

--- a/crates/matrix-sdk/src/widget/machine/mod.rs
+++ b/crates/matrix-sdk/src/widget/machine/mod.rs
@@ -40,7 +40,7 @@ use self::{
     incoming::{IncomingWidgetMessage, IncomingWidgetMessageKind},
     openid::{OpenIdResponse, OpenIdState},
     to_widget::{
-        NotifyNewMatrixEvent, NotifyOpenIdChanged, NotifyPermissionsChanged, RequestCapabilities,
+        NotifyCapabilitiesChanged, NotifyNewMatrixEvent, NotifyOpenIdChanged, RequestCapabilities,
         ToWidgetRequest, ToWidgetRequestHandle, ToWidgetResponse,
     },
 };
@@ -524,7 +524,7 @@ impl WidgetMachine {
                         }
 
                         machine.capabilities = CapabilitiesState::Negotiated(approved.clone());
-                        machine.send_to_widget_request(NotifyPermissionsChanged {
+                        machine.send_to_widget_request(NotifyCapabilitiesChanged {
                             approved,
                             requested,
                         });

--- a/crates/matrix-sdk/src/widget/machine/to_widget.rs
+++ b/crates/matrix-sdk/src/widget/machine/to_widget.rs
@@ -95,12 +95,12 @@ pub(super) struct RequestCapabilitiesResponse {
 
 /// Notify the widget that the list of the granted capabilities has changed.
 #[derive(Serialize)]
-pub(super) struct NotifyPermissionsChanged {
+pub(super) struct NotifyCapabilitiesChanged {
     pub(super) requested: Capabilities,
     pub(super) approved: Capabilities,
 }
 
-impl ToWidgetRequest for NotifyPermissionsChanged {
+impl ToWidgetRequest for NotifyCapabilitiesChanged {
     const ACTION: &'static str = "notify_capabilities";
     type ResponseData = Empty;
 }

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -47,10 +47,10 @@ const WIDGET_ID: &str = "test-widget";
 static ROOM_ID: Lazy<OwnedRoomId> = Lazy::new(|| owned_room_id!("!a98sd12bjh:example.org"));
 
 async fn run_test_driver(init_on_content_load: bool) -> (MockServer, WidgetDriverHandle) {
-    struct DummyPermissionsProvider;
+    struct DummyCapabilitiesProvider;
 
     #[async_trait]
-    impl CapabilitiesProvider for DummyPermissionsProvider {
+    impl CapabilitiesProvider for DummyCapabilitiesProvider {
         async fn acquire_capabilities(&self, capabilities: Capabilities) -> Capabilities {
             // Grant all capabilities that the widget asks for
             capabilities
@@ -77,7 +77,7 @@ async fn run_test_driver(init_on_content_load: bool) -> (MockServer, WidgetDrive
     );
 
     spawn(async move {
-        if let Err(()) = driver.run(room, DummyPermissionsProvider).await {
+        if let Err(()) = driver.run(room, DummyCapabilitiesProvider).await {
             error!("An error encountered in running the WidgetDriver (no details available yet)");
         }
     });


### PR DESCRIPTION
… a few uppercase Permissions were missed last time.
