### PR TITLE
Add a backup specific method to import room keys

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1464,6 +1464,7 @@ impl OlmMachine {
             progress_listener.on_progress(progress as i32, total as i32)
         };
 
+        #[allow(deprecated)]
         let result =
             self.runtime.block_on(self.inner.import_room_keys(keys, from_backup, listener))?;
 

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,10 @@
 # unreleased
 
+- Add two new methods to import room keys,
+  `OlmMachine::store()::import_exported_room_keys()` for file exports and
+  `OlmMachine::backup_machine()::import_backed_up_room_keys()` for backups. The
+  `OlmMachine::import_room_keys()` method is now deprecated.
+
 - Add support for secret storage.
 
 - Add initial support for MSC3814 - dehydrated devices.

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -305,7 +305,7 @@ mod tests {
         }
 
         assert_eq!(
-            machine.import_room_keys(decrypted, false, |_, _| {}).await.unwrap(),
+            machine.store().import_exported_room_keys(decrypted, |_, _| {}).await.unwrap(),
             RoomKeyImportResult::new(0, 1, BTreeMap::new())
         );
     }
@@ -332,17 +332,20 @@ mod tests {
             )]),
         );
 
-        assert_eq!(machine.import_room_keys(export, false, |_, _| {}).await?, keys);
+        assert_eq!(machine.store().import_exported_room_keys(export, |_, _| {}).await?, keys);
 
         let export = vec![session.export_at_index(10).await];
         assert_eq!(
-            machine.import_room_keys(export, false, |_, _| {}).await?,
+            machine.store().import_exported_room_keys(export, |_, _| {}).await?,
             RoomKeyImportResult::new(0, 1, BTreeMap::new())
         );
 
         let better_export = vec![session.export().await];
 
-        assert_eq!(machine.import_room_keys(better_export, false, |_, _| {}).await?, keys);
+        assert_eq!(
+            machine.store().import_exported_room_keys(better_export, |_, _| {}).await?,
+            keys
+        );
 
         let another_session = machine.create_inbound_session(room_id).await?;
         let export = vec![another_session.export_at_index(10).await];
@@ -359,7 +362,7 @@ mod tests {
             )]),
         );
 
-        assert_eq!(machine.import_room_keys(export, false, |_, _| {}).await?, keys);
+        assert_eq!(machine.store().import_exported_room_keys(export, |_, _| {}).await?, keys);
 
         Ok(())
     }

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -96,7 +96,7 @@ async fn retry_message_decryption() {
     let exported_keys = decrypt_room_key_export(Cursor::new(SESSION_KEY), "1234").unwrap();
 
     let olm_machine = OlmMachine::new(own_user_id, "SomeDeviceId".into()).await;
-    olm_machine.import_room_keys(exported_keys, false, |_, _| {}).await.unwrap();
+    olm_machine.store().import_exported_room_keys(exported_keys, |_, _| {}).await.unwrap();
 
     timeline
         .inner
@@ -201,7 +201,7 @@ async fn retry_edit_decryption() {
 
     let own_user_id = user_id!("@example:morheus.localhost");
     let olm_machine = OlmMachine::new(own_user_id, "SomeDeviceId".into()).await;
-    olm_machine.import_room_keys(keys, false, |_, _| {}).await.unwrap();
+    olm_machine.store().import_exported_room_keys(keys, |_, _| {}).await.unwrap();
 
     timeline
         .inner
@@ -304,7 +304,7 @@ async fn retry_edit_and_more() {
 
     let olm_machine = OlmMachine::new(user_id!("@jptest:matrix.org"), DEVICE_ID.into()).await;
     let keys = decrypt_room_key_export(Cursor::new(SESSION_KEY), "testing").unwrap();
-    olm_machine.import_room_keys(keys, false, |_, _| {}).await.unwrap();
+    olm_machine.store().import_exported_room_keys(keys, |_, _| {}).await.unwrap();
 
     timeline
         .inner
@@ -389,7 +389,7 @@ async fn retry_message_decryption_highlighted() {
     let exported_keys = decrypt_room_key_export(Cursor::new(SESSION_KEY), "1234").unwrap();
 
     let olm_machine = OlmMachine::new(own_user_id, "SomeDeviceId".into()).await;
-    olm_machine.import_room_keys(exported_keys, false, |_, _| {}).await.unwrap();
+    olm_machine.store().import_exported_room_keys(exported_keys, |_, _| {}).await.unwrap();
 
     timeline
         .inner

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -438,7 +438,7 @@ async fn read_receipts_updates_on_message_decryption() {
     let exported_keys = decrypt_room_key_export(Cursor::new(SESSION_KEY), "1234").unwrap();
 
     let olm_machine = OlmMachine::new(own_user_id, "SomeDeviceId".into()).await;
-    olm_machine.import_room_keys(exported_keys, false, |_, _| {}).await.unwrap();
+    olm_machine.store().import_exported_room_keys(exported_keys, |_, _| {}).await.unwrap();
 
     timeline
         .inner

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1052,7 +1052,7 @@ impl Encryption {
         let task = tokio::task::spawn_blocking(decrypt);
         let import = task.await.expect("Task join error")?;
 
-        Ok(olm.import_room_keys(import, false, |_, _| {}).await?)
+        Ok(olm.store().import_exported_room_keys(import, |_, _| {}).await?)
     }
 
     /// Enables the crypto-store cross-process lock.


### PR DESCRIPTION
This PR adds source specific methods to import room keys instead of using a
boolean. The booelan could be easily forgotten and the structure of the room key
collection differs in a file export compared to when we download them from a
backup.

This makes it much easier to import room keys from a backup.

- [x] Public API changes documented in changelogs (optional)
