### PR TITLE
Prevent debug builds from crashing on iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ debug = 2
 # Custom profile for use in (debug) builds of the binding crates, use
 # `--profile reldbg` to select
 [profile.reldbg]
-inherits = "dev"
+inherits = "dbg"
 opt-level = 3
 
 [patch.crates-io]


### PR DESCRIPTION
We thought we fixed all the dbg crashers but they're back now. While the reldbg profile helps us build the sdk faster, we cannot use it for debugging which is tremendously useful. 
This change takes the `opt-level = 3` "fix" from `reldbg` and applies it to `dbg` as well which, together with `debug = 2` seems to give us the best of both worlds. 

Not entirely sure what the downsides are, debug symbols seem to work just fine.. (-ish, they weren't great to being with)

L.E. Went with having `reldbg` inherit from `dev` instead
