### PR TITLE
ui: Add method to know the position in the timeline of a user read receipt

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -835,6 +835,15 @@ impl<P: RoomDataProvider> TimelineInner<P> {
     ) -> Option<(OwnedEventId, Receipt)> {
         self.state.read().await.latest_user_read_receipt(user_id, &self.room_data_provider).await
     }
+
+    /// Get the ID of the timeline event with the latest read receipt for the
+    /// given user.
+    pub(super) async fn latest_user_read_receipt_timeline_event_id(
+        &self,
+        user_id: &UserId,
+    ) -> Option<OwnedEventId> {
+        self.state.read().await.latest_user_read_receipt_timeline_event_id(user_id)
+    }
 }
 
 impl TimelineInner {

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -642,7 +642,7 @@ impl Timeline {
     /// Get the ID of the timeline event with the latest read receipt for the
     /// given user.
     ///
-    /// Contrary to [`Self::latest_user_read_receipt()`], this allows to know
+    /// In contrary to [`Self::latest_user_read_receipt()`], this allows to know
     /// the position of the read receipt in the timeline even if the event it
     /// applies to is not visible in the timeline, unless the event is unknown
     /// by this timeline.

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -639,6 +639,21 @@ impl Timeline {
         self.inner.latest_user_read_receipt(user_id).await
     }
 
+    /// Get the ID of the timeline event with the latest read receipt for the
+    /// given user.
+    ///
+    /// Contrary to [`Self::latest_user_read_receipt()`], this allows to know
+    /// the position of the read receipt in the timeline even if the event it
+    /// applies to is not visible in the timeline, unless the event is unknown
+    /// by this timeline.
+    #[instrument(skip(self))]
+    pub async fn latest_user_read_receipt_timeline_event_id(
+        &self,
+        user_id: &UserId,
+    ) -> Option<OwnedEventId> {
+        self.inner.latest_user_read_receipt_timeline_event_id(user_id).await
+    }
+
     /// Send the given receipt.
     ///
     /// This uses [`Room::send_single_receipt`] internally, but checks

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -53,6 +53,7 @@ pub(super) struct ReadReceipts {
 impl ReadReceipts {
     /// Remove all data.
     pub(super) fn clear(&mut self) {
+        self.events_read_receipts.clear();
         self.users_read_receipts.clear();
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -466,7 +466,11 @@ impl TimelineInnerState {
         let private_read_receipt =
             self.user_receipt(user_id, ReceiptType::ReadPrivate, room_data_provider).await;
 
-        match self.pub_or_priv_receipt(public_read_receipt.as_ref(), private_read_receipt.as_ref())
+        // Let's assume that a private read receipt should be more recent than a public
+        // read receipt, otherwise there's no point in the private read receipt,
+        // and use it as default.
+        match self
+            .compare_optional_receipts(public_read_receipt.as_ref(), private_read_receipt.as_ref())
         {
             Ordering::Greater => public_read_receipt,
             Ordering::Less => private_read_receipt,
@@ -493,8 +497,11 @@ impl TimelineInnerState {
             .get(user_id)
             .and_then(|user_map| user_map.get(&ReceiptType::ReadPrivate));
 
+        // Let's assume that a private read receipt should be more recent than a public
+        // read receipt, otherwise there's no point in the private read receipt,
+        // and use it as default.
         let (latest_receipt_id, _) =
-            match self.pub_or_priv_receipt(public_read_receipt, private_read_receipt) {
+            match self.compare_optional_receipts(public_read_receipt, private_read_receipt) {
                 Ordering::Greater => public_read_receipt?,
                 Ordering::Less => private_read_receipt?,
                 _ => unreachable!(),
@@ -538,84 +545,55 @@ impl TimelineInnerMetadata {
             .user_receipt(receipt_type.clone(), ReceiptThread::Main, user_id)
             .await;
 
-        // If we only have one, return it.
-        let Some(unthreaded_receipt) = &unthreaded_read_receipt else {
-            return main_thread_read_receipt;
-        };
-        let Some(main_thread_receipt) = &main_thread_read_receipt else {
-            return unthreaded_read_receipt;
-        };
-
-        match self.compare_receipts(unthreaded_receipt, main_thread_receipt) {
-            Some(Ordering::Greater) => unthreaded_read_receipt,
-            Some(Ordering::Less) => main_thread_read_receipt,
-            _ => {
-                // As a fallback, let's use the unthreaded read receipt, since it's the one
-                // we should be using.
-                unthreaded_read_receipt
-            }
+        // Let's use the unthreaded read receipt as default, since it's the one we
+        // should be using.
+        match self.compare_optional_receipts(
+            main_thread_read_receipt.as_ref(),
+            unthreaded_read_receipt.as_ref(),
+        ) {
+            Ordering::Greater => main_thread_read_receipt,
+            Ordering::Less => unthreaded_read_receipt,
+            _ => unreachable!(),
         }
     }
 
-    /// Compares two receipts to know which one is more recent.
+    /// Compares two optional receipts to know which one is more recent.
     ///
-    /// Returns `Ordering::Greater` if the first one is more recent than the
-    /// second one, `Ordering::Less` if it is older, and `None` if it's not
-    /// possible to know which one is the more recent.
-    fn compare_receipts(
+    /// Returns `Ordering::Greater` if the left-hand side is more recent than
+    /// the right-hand side, and `Ordering::Less` if it is older. If it's
+    /// not possible to know which one is the more recent, defaults to
+    /// `Ordering::Less`, making the right-hand side the default.
+    fn compare_optional_receipts(
         &self,
-        first: &(OwnedEventId, Receipt),
-        second: &(OwnedEventId, Receipt),
-    ) -> Option<Ordering> {
-        let (first_event_id, first_receipt) = first;
-        let (second_event_id, second_receipt) = second;
-
-        // Compare by position in the timeline.
-        if let Some(relative_pos) = self.compare_events_positions(first_event_id, second_event_id) {
-            if relative_pos == RelativePosition::After {
-                return Some(Ordering::Less);
-            }
-
-            return Some(Ordering::Greater);
-        }
-
-        // Compare by timestamp.
-        if let Some((first_ts, second_ts)) = first_receipt.ts.zip(second_receipt.ts) {
-            if second_ts > first_ts {
-                return Some(Ordering::Less);
-            }
-
-            return Some(Ordering::Greater);
-        }
-
-        None
-    }
-
-    /// Compares a private and a pub receipt to know which one is more recent.
-    ///
-    /// Returns `Ordering::Greater` if the public receipt is more recent than
-    /// the private one, and `Ordering::Less` if it is older.
-    fn pub_or_priv_receipt(
-        &self,
-        pub_receipt: Option<&(OwnedEventId, Receipt)>,
-        priv_receipt: Option<&(OwnedEventId, Receipt)>,
+        lhs: Option<&(OwnedEventId, Receipt)>,
+        rhs_or_default: Option<&(OwnedEventId, Receipt)>,
     ) -> Ordering {
         // If we only have one, use it.
-        let Some(pub_receipt) = pub_receipt else {
+        let Some((lhs_event_id, lhs_receipt)) = lhs else {
             return Ordering::Less;
         };
-        let Some(priv_receipt) = priv_receipt else {
+        let Some((rhs_event_id, rhs_receipt)) = rhs_or_default else {
             return Ordering::Greater;
         };
 
-        match self.compare_receipts(pub_receipt, priv_receipt) {
-            Some(cmp) => cmp,
-            _ => {
-                // As a fallback, let's assume that a private read receipt should be more recent
-                // than a public read receipt, otherwise there's no point in the private read
-                // receipt.
-                Ordering::Less
+        // Compare by position in the timeline.
+        if let Some(relative_pos) = self.compare_events_positions(lhs_event_id, rhs_event_id) {
+            if relative_pos == RelativePosition::Before {
+                return Ordering::Greater;
             }
+
+            return Ordering::Less;
         }
+
+        // Compare by timestamp.
+        if let Some((lhs_ts, rhs_ts)) = lhs_receipt.ts.zip(rhs_receipt.ts) {
+            if lhs_ts > rhs_ts {
+                return Ordering::Greater;
+            }
+
+            return Ordering::Less;
+        }
+
+        Ordering::Less
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -466,24 +466,45 @@ impl TimelineInnerState {
         let private_read_receipt =
             self.user_receipt(user_id, ReceiptType::ReadPrivate, room_data_provider).await;
 
-        // If we only have one, return it.
-        let Some(pub_receipt) = &public_read_receipt else {
-            return private_read_receipt;
-        };
-        let Some(priv_receipt) = &private_read_receipt else {
-            return public_read_receipt;
-        };
-
-        match self.compare_receipts(pub_receipt, priv_receipt) {
-            Some(Ordering::Greater) => public_read_receipt,
-            Some(Ordering::Less) => private_read_receipt,
-            _ => {
-                // As a fallback, let's assume that a private read receipt should be more recent
-                // than a public read receipt, otherwise there's no point in the private read
-                // receipt.
-                private_read_receipt
-            }
+        match self.pub_or_priv_receipt(public_read_receipt.as_ref(), private_read_receipt.as_ref())
+        {
+            Ordering::Greater => public_read_receipt,
+            Ordering::Less => private_read_receipt,
+            _ => unreachable!(),
         }
+    }
+
+    pub(super) fn latest_user_read_receipt_timeline_event_id(
+        &self,
+        user_id: &UserId,
+    ) -> Option<OwnedEventId> {
+        // We only need to use the local map. Since receipts for known events are
+        // already loaded from the store.
+        let public_read_receipt = self
+            .read_receipts
+            .users_read_receipts
+            .get(user_id)
+            .and_then(|user_map| user_map.get(&ReceiptType::Read));
+        let private_read_receipt = self
+            .read_receipts
+            .users_read_receipts
+            .get(user_id)
+            .and_then(|user_map| user_map.get(&ReceiptType::ReadPrivate));
+
+        let (latest_receipt_id, _) =
+            match self.pub_or_priv_receipt(public_read_receipt, private_read_receipt) {
+                Ordering::Greater => public_read_receipt?,
+                Ordering::Less => private_read_receipt?,
+                _ => unreachable!(),
+            };
+
+        // Find the corresponding visible event.
+        self.all_events
+            .iter()
+            .rev()
+            .skip_while(|ev| ev.event_id != *latest_receipt_id)
+            .find(|ev| ev.visible)
+            .map(|ev| ev.event_id.clone())
     }
 }
 
@@ -566,5 +587,33 @@ impl TimelineInnerMetadata {
         }
 
         None
+    }
+
+    /// Compares a private and a pub receipt to know which one is more recent.
+    ///
+    /// Returns `Ordering::Greater` if the public receipt is more recent than
+    /// the private one, and `Ordering::Less` if it is older.
+    fn pub_or_priv_receipt(
+        &self,
+        pub_receipt: Option<&(OwnedEventId, Receipt)>,
+        priv_receipt: Option<&(OwnedEventId, Receipt)>,
+    ) -> Ordering {
+        // If we only have one, use it.
+        let Some(pub_receipt) = pub_receipt else {
+            return Ordering::Less;
+        };
+        let Some(priv_receipt) = priv_receipt else {
+            return Ordering::Greater;
+        };
+
+        match self.compare_receipts(pub_receipt, priv_receipt) {
+            Some(cmp) => cmp,
+            _ => {
+                // As a fallback, let's assume that a private read receipt should be more recent
+                // than a public read receipt, otherwise there's no point in the private read
+                // receipt.
+                Ordering::Less
+            }
+        }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -474,11 +474,13 @@ impl TimelineInnerState {
         }
     }
 
+    /// Get the ID of the visible timeline event with the latest read receipt
+    /// for the given user.
     pub(super) fn latest_user_read_receipt_timeline_event_id(
         &self,
         user_id: &UserId,
     ) -> Option<OwnedEventId> {
-        // We only need to use the local map. Since receipts for known events are
+        // We only need to use the local map, since receipts for known events are
         // already loaded from the store.
         let public_read_receipt = self
             .read_receipts

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -563,3 +563,52 @@ async fn initial_private_main_thread_receipt() {
     let (receipt_event_id, _) = timeline.inner.latest_user_read_receipt(*ALICE).await.unwrap();
     assert_eq!(receipt_event_id, event_id);
 }
+
+#[async_test]
+async fn clear_read_receipts() {
+    let room_id = room_id!("!room:localhost");
+    let event_a_id = event_id!("$event_a");
+    let event_b_id = event_id!("$event_b");
+
+    let timeline = TestTimeline::new()
+        .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
+
+    let event_a_content = RoomMessageEventContent::text_plain("A");
+    timeline.handle_live_message_event_with_id(*BOB, event_a_id, event_a_content.clone()).await;
+
+    let items = timeline.inner.items().await;
+    assert_eq!(items.len(), 2);
+
+    // Implicit read receipt of Bob.
+    let event_a = items[1].as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 1);
+    assert!(event_a.read_receipts().get(*BOB).is_some());
+
+    // We received a limited timeline.
+    timeline.inner.clear().await;
+
+    // New message via sync.
+    timeline
+        .handle_live_message_event_with_id(
+            *BOB,
+            event_b_id,
+            RoomMessageEventContent::text_plain("B"),
+        )
+        .await;
+    // Old message via back-pagination.
+    timeline
+        .handle_back_paginated_message_event_with_id(*BOB, room_id, event_a_id, event_a_content)
+        .await;
+
+    let items = timeline.inner.items().await;
+    assert_eq!(items.len(), 3);
+
+    // Old implicit read receipt of Bob is gone.
+    let event_a = items[1].as_event().unwrap();
+    assert_eq!(event_a.read_receipts().len(), 0);
+
+    // New implicit read receipt of Bob.
+    let event_b = items[2].as_event().unwrap();
+    assert_eq!(event_b.read_receipts().len(), 1);
+    assert!(event_b.read_receipts().get(*BOB).is_some());
+}


### PR DESCRIPTION
The other methods give the event ID that the read receipt applies to, but it might not be an event that appears in the `Timeline`. This one always gives us the event ID where the read receipt would appear.

We use it in Fractal to know if there are unread messages after our own user's receipt, by checking if there are other messages after the receipt. It avoids to keep track of all events in our client too.

The first commit is a small bugfix.