### PR TITLE
Exclude `Store` from tracing

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -70,3 +70,6 @@
 
 - Remove spurious "Unknown outgoing secret request" warning which was logged
   for every outgoing secret request.
+
+- Stop logging large quantities of data about the `Store` during olm
+  decryption.

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -1164,7 +1164,7 @@ impl Account {
     }
 
     /// Decrypt an Olm message, creating a new Olm session if possible.
-    #[instrument(skip(self, message))]
+    #[instrument(skip(self, store, message))]
     async fn decrypt_olm_message(
         &mut self,
         store: &Store,


### PR DESCRIPTION
Debug output for the `Store` is extremely verbose, so we don't want to log it every time we touch this function.