### PR TITLE
Session verification fixes

### DIFF
--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -55,13 +55,10 @@ pub struct SessionVerificationController {
 #[uniffi::export(async_runtime = "tokio")]
 impl SessionVerificationController {
     pub async fn is_verified(&self) -> Result<bool, ClientError> {
-        let identity = self
-            .encryption
-            .get_user_identity(self.user_identity.user_id())
-            .await?
-            .context("Failed retrieving user identity")?;
+        let device =
+            self.encryption.get_own_device().await?.context("Failed retrieving own device")?;
 
-        Ok(identity.is_verified())
+        Ok(device.is_cross_signed_by_owner())
     }
 
     pub fn set_delegate(&self, delegate: Option<Box<dyn SessionVerificationControllerDelegate>>) {

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -56,7 +56,7 @@ pub struct SessionVerificationController {
 impl SessionVerificationController {
     pub async fn is_verified(&self) -> Result<bool, ClientError> {
         let device =
-            self.encryption.get_own_device().await?.context("Failed retrieving own device")?;
+            self.encryption.get_own_device().await?.context("Our own device is missing")?;
 
         Ok(device.is_cross_signed_by_owner())
     }

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, RwLock};
 
-use anyhow::{anyhow, Context as _};
+use anyhow::Context as _;
 use futures_util::StreamExt;
 use matrix_sdk::{
     encryption::{


### PR DESCRIPTION
Fixes vector-im/element-x-ios/issues/1868 Incorrect `is_verified` flag after successfully running verification flow
- the inner user_identity isn't automatically updated when the flow finishes, needs to be fetched again from encryption
- also replaces `UserIdentity.is_verified` with `Device.is_cross_signed_by_owner`