### PR TITLE
fix(crypto): Upload keys before signing

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -72,7 +72,7 @@ impl From<RustUploadSigningKeysRequest> for UploadSigningKeysRequest {
 #[derive(uniffi::Record)]
 pub struct BootstrapCrossSigningResult {
     pub upload_signing_keys_request: UploadSigningKeysRequest,
-    pub signature_request: SignatureUploadRequest,
+    pub upload_signature_request: SignatureUploadRequest,
 }
 
 impl From<(RustUploadSigningKeysRequest, RustSignatureUploadRequest)>
@@ -81,7 +81,7 @@ impl From<(RustUploadSigningKeysRequest, RustSignatureUploadRequest)>
     fn from(requests: (RustUploadSigningKeysRequest, RustSignatureUploadRequest)) -> Self {
         Self {
             upload_signing_keys_request: requests.0.into(),
-            signature_request: requests.1.into(),
+            upload_signature_request: requests.1.into(),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -73,3 +73,6 @@
 
 - Stop logging large quantities of data about the `Store` during olm
   decryption.
+
+- Change the return value of `bootstrap_cross_signing` so it returns an extra keys upload request.
+  The three requests must be sent in the order they appear in the return tuple.

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -912,7 +912,7 @@ pub(crate) mod testing {
         user_id: &UserId,
         device_id: &DeviceId,
     ) -> IdentityManager {
-        let identity = PrivateCrossSigningIdentity::new(user_id.into()).await;
+        let identity = PrivateCrossSigningIdentity::new(user_id.into());
         let identity = Arc::new(Mutex::new(identity));
         let user_id = user_id.to_owned();
         let account = Account::with_device_id(&user_id, device_id);
@@ -1358,7 +1358,7 @@ pub(crate) mod tests {
         assert!(identity.is_verified());
 
         let identity_request = {
-            let private_identity = PrivateCrossSigningIdentity::new(user_id.into()).await;
+            let private_identity = PrivateCrossSigningIdentity::new(user_id.into());
             private_identity.as_upload_request().await
         };
 

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -753,7 +753,7 @@ pub(crate) mod testing {
     /// Generate default other "own" identity for tests
     #[cfg(test)]
     pub async fn get_other_own_identity() -> ReadOnlyOwnUserIdentity {
-        let private_identity = PrivateCrossSigningIdentity::new(other_user_id().into()).await;
+        let private_identity = PrivateCrossSigningIdentity::new(other_user_id().into());
         ReadOnlyOwnUserIdentity::from_private(&private_identity).await
     }
 

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -81,7 +81,7 @@ pub use identities::{
     Device, LocalTrust, OwnUserIdentity, ReadOnlyDevice, ReadOnlyOwnUserIdentity,
     ReadOnlyUserIdentities, ReadOnlyUserIdentity, UserDevices, UserIdentities, UserIdentity,
 };
-pub use machine::{EncryptionSyncChanges, OlmMachine};
+pub use machine::{CrossSigningBootstrapRequests, EncryptionSyncChanges, OlmMachine};
 #[cfg(feature = "qrcode")]
 pub use matrix_sdk_qrcode;
 pub use olm::{Account, CrossSigningStatus, EncryptionSettings, Session};

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -505,9 +505,10 @@ impl OlmMachine {
             info!("Creating new cross signing identity");
             let cache = self.inner.store.cache().await?;
             let account = cache.account().await?;
-            let (id, request, signature_request) = account.bootstrap_cross_signing().await;
+            let (new_identity, upload_signing_keys_req, upload_signatures_req) =
+                account.bootstrap_cross_signing().await;
 
-            *identity = id;
+            *identity = new_identity;
 
             let public = identity.to_public_identity().await.expect(
                 "Couldn't create a public version of the identity from a new private identity",
@@ -521,15 +522,15 @@ impl OlmMachine {
 
             self.store().save_changes(changes).await?;
 
-            Ok((request, signature_request))
+            Ok((upload_signing_keys_req, upload_signatures_req))
         } else {
             info!("Trying to upload the existing cross signing identity");
-            let request = identity.as_upload_request().await;
+            let upload_signing_keys_req = identity.as_upload_request().await;
             let account = self.inner.store.static_account();
             // TODO remove this expect.
-            let signature_request =
+            let upload_signatures_req =
                 identity.sign_account(account).await.expect("Can't sign device keys");
-            Ok((request, signature_request))
+            Ok((upload_signing_keys_req, upload_signatures_req))
         }
     }
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -373,13 +373,12 @@ impl OlmMachine {
         let mut requests = Vec::new();
 
         {
-            let mut store_transaction = self.inner.store.transaction().await?;
-            let account = store_transaction.account().await?;
-            if let Some(r) = self.keys_for_upload(account).await.map(|r| OutgoingRequest {
+            let store_cache = self.inner.store.cache().await?;
+            let account = store_cache.account().await?;
+            if let Some(r) = self.keys_for_upload(&*account).await.map(|r| OutgoingRequest {
                 request_id: TransactionId::new(),
                 request: Arc::new(r.into()),
             }) {
-                store_transaction.commit().await?; // Note: this saves the account.
                 requests.push(r);
             }
         }

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -526,7 +526,7 @@ impl PrivateCrossSigningIdentity {
             .try_into()
             .expect("We can always convert our own CrossSignigKey into a MasterPubkey");
 
-        let identity = Self::new_helper(account.user_id(), master).await;
+        let identity = Self::new_helper(account.user_id(), master);
         let signature_request = identity
             .sign_account(account.static_data())
             .await
@@ -537,7 +537,7 @@ impl PrivateCrossSigningIdentity {
         (identity, request, signature_request)
     }
 
-    async fn new_helper(user_id: &UserId, master: MasterSigning) -> Self {
+    fn new_helper(user_id: &UserId, master: MasterSigning) -> Self {
         let user = Signing::new();
         let mut public_key = user.cross_signing_key(user_id.to_owned(), KeyUsage::UserSigning);
         master.sign_subkey(&mut public_key);
@@ -574,17 +574,17 @@ impl PrivateCrossSigningIdentity {
     /// created it.
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
-    pub async fn new(user_id: OwnedUserId) -> Self {
+    pub fn new(user_id: OwnedUserId) -> Self {
         let master = MasterSigning::new(user_id.to_owned());
-        Self::new_helper(&user_id, master).await
+        Self::new_helper(&user_id, master)
     }
 
     #[cfg(any(test, feature = "testing"))]
     #[allow(dead_code)]
     /// Testing helper to reset this CrossSigning with a fresh one using the
     /// local identity
-    pub async fn reset(&mut self) {
-        let new = Self::new(self.user_id().to_owned()).await;
+    pub fn reset(&mut self) {
+        let new = Self::new(self.user_id().to_owned());
         *self = new
     }
 
@@ -713,7 +713,7 @@ mod tests {
 
     #[async_test]
     async fn test_private_identity_creation() {
-        let identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
+        let identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
 
         let master_key = identity.master_key.lock().await;
         let master_key = master_key.as_ref().unwrap();
@@ -731,7 +731,7 @@ mod tests {
 
     #[async_test]
     async fn test_identity_pickling() {
-        let identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
+        let identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
 
         let pickled = identity.pickle().await;
 

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -283,6 +283,12 @@ impl From<SignatureUploadRequest> for OutgoingRequest {
     }
 }
 
+impl From<KeysUploadRequest> for OutgoingRequest {
+    fn from(r: KeysUploadRequest) -> Self {
+        Self { request_id: TransactionId::new(), request: Arc::new(r.into()) }
+    }
+}
+
 /// Enum over all the incoming responses we need to receive.
 #[derive(Debug)]
 pub enum IncomingResponse<'a> {

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -556,7 +556,7 @@ macro_rules! cryptostore_integration_tests {
             async fn private_identity_saving() {
                 let (_, store) = get_loaded_store("private_identity_saving").await;
                 assert!(store.load_identity().await.unwrap().is_none());
-                let identity = PrivateCrossSigningIdentity::new(alice_id().to_owned()).await;
+                let identity = PrivateCrossSigningIdentity::new(alice_id().to_owned());
 
                 let changes =
                     Changes { private_identity: Some(identity.clone()), ..Default::default() };

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -850,7 +850,7 @@ impl Store {
     #[cfg(test)]
     /// test helper to reset the cross signing identity
     pub(crate) async fn reset_cross_signing_identity(&self) {
-        self.inner.identity.lock().await.reset().await;
+        self.inner.identity.lock().await.reset();
     }
 
     /// PrivateCrossSigningIdentity associated with this store

--- a/crates/matrix-sdk-crypto/src/verification/qrcode.rs
+++ b/crates/matrix-sdk-crypto/src/verification/qrcode.rs
@@ -916,7 +916,7 @@ mod tests {
         let account = Account::with_device_id(user_id(), device_id());
         let store = memory_store(account.user_id());
 
-        let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
+        let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
         let master_key = private_identity.master_public_key().await.unwrap();
         let master_key = master_key.get_first_key().unwrap().to_owned();
 
@@ -959,8 +959,7 @@ mod tests {
         assert_eq!(verification.inner.first_key(), master_key);
         assert_eq!(verification.inner.second_key(), device_key);
 
-        let bob_identity =
-            PrivateCrossSigningIdentity::new(user_id!("@bob:example").to_owned()).await;
+        let bob_identity = PrivateCrossSigningIdentity::new(user_id!("@bob:example").to_owned());
         let bob_master_key = bob_identity.master_public_key().await.unwrap();
         let bob_master_key = bob_master_key.get_first_key().unwrap().to_owned();
 
@@ -981,7 +980,7 @@ mod tests {
             let alice_account = Account::with_device_id(user_id(), device_id());
             let store = memory_store(alice_account.user_id());
 
-            let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
+            let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
 
             let store = VerificationStore {
                 account: alice_account.static_data.clone(),
@@ -992,7 +991,7 @@ mod tests {
             let bob_account =
                 Account::with_device_id(alice_account.user_id(), device_id!("BOBDEVICE"));
 
-            let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
+            let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
             let identity = private_identity.to_public_identity().await.unwrap();
 
             let master_key = private_identity.master_public_key().await.unwrap();
@@ -1020,7 +1019,7 @@ mod tests {
 
             let bob_store = memory_store(bob_account.user_id());
 
-            let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned()).await;
+            let private_identity = PrivateCrossSigningIdentity::new(user_id().to_owned());
             let bob_store = VerificationStore {
                 account: bob_account.static_data.clone(),
                 inner: bob_store,

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -814,17 +814,18 @@ impl Encryption {
         let olm = self.client.olm_machine().await;
         let olm = olm.as_ref().ok_or(Error::NoOlmMachine)?;
 
-        let (request, signature_request) = olm.bootstrap_cross_signing(false).await?;
+        let (upload_signing_keys_req, upload_signatures_req) =
+            olm.bootstrap_cross_signing(false).await?;
 
-        let request = assign!(UploadSigningKeysRequest::new(), {
+        let upload_signing_keys_req = assign!(UploadSigningKeysRequest::new(), {
             auth: auth_data,
-            master_key: request.master_key.map(|c| c.to_raw()),
-            self_signing_key: request.self_signing_key.map(|c| c.to_raw()),
-            user_signing_key: request.user_signing_key.map(|c| c.to_raw()),
+            master_key: upload_signing_keys_req.master_key.map(|c| c.to_raw()),
+            self_signing_key: upload_signing_keys_req.self_signing_key.map(|c| c.to_raw()),
+            user_signing_key: upload_signing_keys_req.user_signing_key.map(|c| c.to_raw()),
         });
 
-        self.client.send(request, None).await?;
-        self.client.send(signature_request, None).await?;
+        self.client.send(upload_signing_keys_req, None).await?;
+        self.client.send(upload_signatures_req, None).await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -547,6 +547,14 @@ async fn cross_signing_status() {
         .mount(&server)
         .await;
 
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/r0/keys/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "one_time_key_counts": {}
+        })))
+        .mount(&server)
+        .await;
+
     let status = client
         .encryption()
         .cross_signing_status()

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -341,6 +341,14 @@ async fn test_login_with_cross_signing_bootstrapping() {
         .mount(&server)
         .await;
 
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/r0/keys/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "one_time_key_counts": {}
+        })))
+        .mount(&server)
+        .await;
+
     let num_calls = Mutex::new(0);
     Mock::given(method("POST"))
         .and(path("/_matrix/client/unstable/keys/device_signing/upload"))


### PR DESCRIPTION
During bootstrapping of cross-signing, we first upload the cross-signing keys, then upload signatures for keys in general. The set of signatures may include a signature for a device key we haven't uploaded yet, in particular if we're creating the account and set it up for bootstrapping. This fixes it by having `bootstrap_cross_signing` return a key upload request, that must be executed after the cross-signing keys upload and the keys signatures upload (this is properly documented, fwiw).

This also updates the verification test that made us aware of this issue.