### PR TITLE
widget: Add missing stuff for read/send requests

### DIFF
--- a/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
+++ b/crates/matrix-sdk/src/widget/machine/tests/capabilities.rs
@@ -136,8 +136,8 @@ fn capabilities_failure_results_into_empty_capabilities() {
     );
 }
 
-/// Performs a capability "dance", if no capability is specified, we assume that it's:
-/// `org.matrix.msc2762.receive.state_event:m.room.member`.
+/// Performs a capability "dance", if no capability is specified, we assume that
+/// it's: `org.matrix.msc2762.receive.state_event:m.room.member`.
 pub(super) fn assert_capabilities_dance(
     machine: &mut WidgetMachine,
     actions: Vec<Action>,


### PR DESCRIPTION
**Summary:**
- Tests for fromWidget read and send event requests that are not allowed (I.e. negotiated, but negotiated capabilities did not allow the types of events that the widget requests).
- Implementation for reading message-like events, the integration test for that has already been written by @jplatte, I just 'activated' it and fixed one minor error there (the test expected 2 events to be returned by the machine, whereas actually 1 matches the filter).

NB: Now, after this implementation, the function that processes the read event contains some of the boilerplate. I have not refactored it yet (given that the rest of the tasks from https://github.com/matrix-org/matrix-rust-sdk/issues/2753 may touch it.