### PR TITLE
Bump tracing and update API usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6067,11 +6067,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -6091,9 +6090,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6102,9 +6101,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",

--- a/crates/matrix-sdk-common/src/tracing_timer.rs
+++ b/crates/matrix-sdk-common/src/tracing_timer.rs
@@ -81,7 +81,7 @@ impl TracingTimer {
 #[macro_export]
 macro_rules! timer {
     ($level:expr, $string:expr) => {{
-        static CALLSITE: tracing::callsite::DefaultCallsite = tracing::callsite2! {
+        static __CALLSITE: tracing::callsite::DefaultCallsite = tracing::callsite2! {
             name: tracing::__macro_support::concat!(
                 "event ",
                 file!(),
@@ -94,7 +94,7 @@ macro_rules! timer {
             fields: []
         };
 
-        $crate::tracing_timer::TracingTimer::new_debug(&CALLSITE, $string.into(), $level)
+        $crate::tracing_timer::TracingTimer::new_debug(&__CALLSITE, $string.into(), $level)
     }};
 
     ($string:expr) => {
@@ -109,7 +109,9 @@ mod tests {
     async fn test_timer_name() {
         use tracing::{span, Level};
 
-        tracing_subscriber::fmt::init();
+        tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).init();
+
+        tracing::warn!("Starting test...");
 
         mod time123 {
             pub async fn run() {
@@ -128,6 +130,8 @@ mod tests {
 
         let _timer_guard = timer!("in span");
         tokio::time::sleep(instant::Duration::from_millis(256)).await;
+
+        tracing::warn!("Test about to finish.");
         // Displays: 2023-08-25T15:18:31.427070Z DEBUG le 256ms span:
         // matrix_sdk_common::tracing_timer::tests: in span finished in 257ms
     }


### PR DESCRIPTION
Should fix the build with a more recent `tracing` version. Maybe we shouldn't rely on internal `tracing` APIs :eyes: 