### PR TITLE
crypto: Strengthen the API of `StoreCache::account`

### DIFF
--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -240,7 +240,7 @@ impl RehydratedDevice {
 
         // Let us first give the events to the rehydrated device, this will decrypt any
         // encrypted to-device events and fetch out the room keys.
-        let mut rehydrated_transaction = self.rehydrated.store().transaction().await?;
+        let mut rehydrated_transaction = self.rehydrated.store().transaction().await;
 
         let (_, changes) = self
             .rehydrated
@@ -315,7 +315,7 @@ impl DehydratedDevice {
         initial_device_display_name: String,
         pickle_key: &[u8; 32],
     ) -> Result<put_dehydrated_device::unstable::Request, DehydrationError> {
-        let mut transaction = self.store.transaction().await?;
+        let mut transaction = self.store.transaction().await;
 
         let account = transaction.account().await?;
         account.generate_fallback_key_helper();

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1163,7 +1163,7 @@ impl OlmMachine {
         &self,
         sync_changes: EncryptionSyncChanges<'_>,
     ) -> OlmResult<(Vec<Raw<AnyToDeviceEvent>>, Vec<RoomKeyInfo>)> {
-        let mut store_transaction = self.inner.store.transaction().await?;
+        let mut store_transaction = self.inner.store.transaction().await;
 
         let (events, changes) =
             self.preprocess_sync_changes(&mut store_transaction, sync_changes).await?;

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -363,7 +363,7 @@ impl SessionManager {
         let mut changes = Changes::default();
         let mut new_sessions: BTreeMap<&UserId, BTreeMap<&DeviceId, SessionInfo>> = BTreeMap::new();
 
-        let mut store_transaction = self.store.transaction().await?;
+        let mut store_transaction = self.store.transaction().await;
         for (user_id, user_devices) in &response.one_time_keys {
             for (device_id, key_map) in user_devices {
                 let device = match self.store.get_readonly_device(user_id, device_id).await {

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -325,14 +325,10 @@ pub struct StoreTransaction {
 
 impl StoreTransaction {
     /// Starts a new `StoreTransaction`.
-    pub async fn new(store: Store) -> Result<Self> {
+    async fn new(store: Store) -> Self {
         let cache = store.inner.cache.clone();
 
-        Ok(Self {
-            store,
-            changes: PendingChanges::default(),
-            cache: cache.clone().write_owned().await,
-        })
+        Self { store, changes: PendingChanges::default(), cache: cache.clone().write_owned().await }
     }
 
     pub(crate) fn cache(&self) -> &StoreCache {
@@ -854,7 +850,7 @@ impl Store {
         Ok(cache)
     }
 
-    pub(crate) async fn transaction(&self) -> Result<StoreTransaction> {
+    pub(crate) async fn transaction(&self) -> StoreTransaction {
         StoreTransaction::new(self.clone()).await
     }
 
@@ -868,7 +864,7 @@ impl Store {
         &self,
         func: F,
     ) -> Result<T, crate::OlmError> {
-        let tr = self.transaction().await?;
+        let tr = self.transaction().await;
         let (tr, res) = func(tr).await?;
         tr.commit().await?;
         Ok(res)


### PR DESCRIPTION
Theoretically, it's possible to misuse the API of `StoreCache::account`:

- one can create a transaction with `Store::transaction()`
- then call `StoreTransaction::account()` on it, which returns a `&mut Account` (after stealing the `Account` from the `StoreCache`) 
- then call the `StoreTransaction::cache() -> StoreCache` method on it
- then call `StoreCache::account()`, which will reload the `Account` in the `StoreCache`

At this point, we have two live copies of the `Account`, which can be different if some changes have been done on the `&mut Account`.

This is bad, because that's duplicated state that can be inconsistent.

We still want to have access to a read-only `Account` when holding a `StoreCacheGuard` (obtained from `Store::cache()`), though.

Fortunately, it's relatively easy to make the problematic situation impossible to happen:

- Since `Store::cache()` returns a `StoreCacheGuard`, put a *public* `account()` method there that calls `StoreCache::account`
- make the `StoreCache::account` method *private*
- have `StoreTransaction::account` use the private method too

With that, it's impossible to have two copies of an `Account` at the same time, because `StoreTransaction` and `StoreCacheGuard` can't exist at the same time (b/o the `RwLock` on the `StoreCache`).

Good news is, we weren't running into the problematic situation at any times.