### PR TITLE
Improve send-event API, part 1

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -31,8 +31,6 @@ futures-core = { workspace = true }
 futures-util = { workspace = true }
 matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui", default-features = false, features = ["e2e-encryption"] }
 mime = "0.3.16"
-# FIXME: we currently can't feature flag anything in the api.udl, therefore we must enforce experimental-sliding-sync being exposed here..
-# see https://github.com/matrix-org/matrix-rust-sdk/issues/1014
 once_cell = { workspace = true }
 opentelemetry = { version = "0.20.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.13.0", features = ["tokio", "reqwest-client", "http-proto"] }

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -66,3 +66,21 @@ impl<T> SyncOutsideWasm for T {}
 /// implemented, while other targets will.
 pub trait AsyncTraitDeps: std::fmt::Debug + SendOutsideWasm + SyncOutsideWasm {}
 impl<T: std::fmt::Debug + SendOutsideWasm + SyncOutsideWasm> AsyncTraitDeps for T {}
+
+// TODO: Remove in favor of impl Trait once allowed in associated types
+#[macro_export]
+macro_rules! boxed_into_future {
+    () => {
+        $crate::boxed_into_future!(extra_bounds: );
+    };
+    (extra_bounds: $($extra_bounds:tt)*) => {
+        #[cfg(target_arch = "wasm32")]
+        type IntoFuture = ::std::pin::Pin<::std::boxed::Box<
+            dyn ::std::future::Future<Output = Self::Output> + $($extra_bounds)*
+        >>;
+        #[cfg(not(target_arch = "wasm32"))]
+        type IntoFuture = ::std::pin::Pin<::std::boxed::Box<
+            dyn ::std::future::Future<Output = Self::Output> + Send + $($extra_bounds)*
+        >>;
+    };
+}

--- a/crates/matrix-sdk-ui/src/timeline/futures.rs
+++ b/crates/matrix-sdk-ui/src/timeline/futures.rs
@@ -1,12 +1,8 @@
-use std::{
-    fs,
-    future::{Future, IntoFuture},
-    path::Path,
-    pin::Pin,
-};
+use std::{fs, future::IntoFuture, path::Path};
 
 use eyeball::{SharedObservable, Subscriber};
 use matrix_sdk::{attachment::AttachmentConfig, TransmissionProgress};
+use matrix_sdk_base::boxed_into_future;
 use mime::Mime;
 
 use super::{Error, Timeline};
@@ -39,10 +35,7 @@ impl<'a> SendAttachment<'a> {
 
 impl<'a> IntoFuture for SendAttachment<'a> {
     type Output = Result<(), Error>;
-    #[cfg(target_arch = "wasm32")]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
-    #[cfg(not(target_arch = "wasm32"))]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
+    boxed_into_future!(extra_bounds: 'a);
 
     fn into_future(self) -> Self::IntoFuture {
         let Self { timeline, url, mime_type, config, send_progress } = self;

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -55,11 +55,13 @@ use thiserror::Error;
 use tokio::sync::{mpsc::Sender, Mutex, Notify};
 use tracing::{error, info, instrument, warn};
 
+use self::futures::SendAttachment;
+
 mod builder;
 mod error;
 mod event_handler;
 mod event_item;
-mod futures;
+pub mod futures;
 mod inner;
 mod item;
 mod pagination;
@@ -85,7 +87,6 @@ pub use self::{
         Message, OtherState, Profile, ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker,
         TimelineDetails, TimelineItemContent,
     },
-    futures::SendAttachment,
     item::{TimelineItem, TimelineItemKind},
     pagination::{BackPaginationStatus, PaginationOptions, PaginationOutcome},
     polls::PollResult,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -484,7 +484,7 @@ impl Timeline {
 
         let event_content =
             AnyMessageLikeEventContent::Reaction(ReactionEventContent::from(annotation.clone()));
-        let response = room.send(event_content, Some(&txn_id)).await;
+        let response = room.send(event_content).with_transaction_id(&txn_id).await;
 
         match response {
             Ok(response) => {

--- a/crates/matrix-sdk-ui/src/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/src/timeline/queue.rs
@@ -200,7 +200,7 @@ impl SendMessageTask {
         debug!("Spawning message-sending task");
         let txn_id = msg.txn_id.clone();
         let join_handle = spawn(async move {
-            let result = room.send(msg.content, Some(&msg.txn_id)).await;
+            let result = room.send(msg.content).with_transaction_id(&msg.txn_id).await;
             let (room, send_state) = match result {
                 Ok(response) => (Some(room), EventSendState::Sent { event_id: response.event_id }),
                 Err(error) => (None, EventSendState::SendingFailed { error: Arc::new(error) }),

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -14,11 +14,7 @@
 
 #![deny(unreachable_pub)]
 
-use std::{
-    fmt::Debug,
-    future::{Future, IntoFuture},
-    pin::Pin,
-};
+use std::{fmt::Debug, future::IntoFuture};
 
 use cfg_vis::cfg_vis;
 use eyeball::SharedObservable;
@@ -32,6 +28,7 @@ use mas_oidc_client::{
     },
     types::errors::ClientErrorCode,
 };
+use matrix_sdk_common::boxed_into_future;
 use ruma::api::{client::error::ErrorKind, error::FromHttpResponseError, OutgoingRequest};
 #[cfg(feature = "experimental-oidc")]
 use tracing::error;
@@ -87,10 +84,7 @@ where
     HttpError: From<FromHttpResponseError<R::EndpointError>>,
 {
     type Output = HttpResult<R::IncomingResponse>;
-    #[cfg(target_arch = "wasm32")]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output>>>;
-    #[cfg(not(target_arch = "wasm32"))]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    boxed_into_future!();
 
     fn into_future(self) -> Self::IntoFuture {
         let Self { client, request, config, send_progress, sliding_sync_proxy_url } = self;

--- a/crates/matrix-sdk/src/client/futures.rs
+++ b/crates/matrix-sdk/src/client/futures.rs
@@ -1,3 +1,19 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![deny(unreachable_pub)]
+
 use std::{
     fmt::Debug,
     future::{Future, IntoFuture},

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -65,6 +65,7 @@ use tokio::sync::{broadcast, Mutex, OnceCell, RwLock, RwLockReadGuard};
 use tracing::{debug, error, instrument, trace, Instrument, Span};
 use url::Url;
 
+use self::futures::SendRequest;
 #[cfg(feature = "experimental-oidc")]
 use crate::oidc::Oidc;
 use crate::{
@@ -89,12 +90,9 @@ use crate::{
 };
 
 mod builder;
-mod futures;
+pub(crate) mod futures;
 
-pub use self::{
-    builder::{ClientBuildError, ClientBuilder},
-    futures::SendRequest,
-};
+pub use self::builder::{ClientBuildError, ClientBuilder};
 
 #[cfg(not(target_arch = "wasm32"))]
 type NotificationHandlerFut = Pin<Box<dyn Future<Output = ()> + Send>>;

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -17,16 +17,13 @@
 
 #![deny(unreachable_pub)]
 
-use std::{
-    future::{Future, IntoFuture},
-    io::Read,
-    pin::Pin,
-};
+use std::{future::IntoFuture, io::Read};
 
 use cfg_vis::cfg_vis;
 use eyeball::SharedObservable;
 #[cfg(not(target_arch = "wasm32"))]
 use eyeball::Subscriber;
+use matrix_sdk_common::boxed_into_future;
 use ruma::events::room::{EncryptedFile, EncryptedFileInit};
 
 use crate::{Client, Result, TransmissionProgress};
@@ -73,10 +70,7 @@ where
     R: Read + Send + ?Sized + 'a,
 {
     type Output = Result<EncryptedFile>;
-    #[cfg(target_arch = "wasm32")]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
-    #[cfg(not(target_arch = "wasm32"))]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
+    boxed_into_future!(extra_bounds: 'a);
 
     fn into_future(self) -> Self::IntoFuture {
         let Self { client, content_type, reader, send_progress } = self;

--- a/crates/matrix-sdk/src/encryption/futures.rs
+++ b/crates/matrix-sdk/src/encryption/futures.rs
@@ -1,3 +1,22 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Named futures returned from methods on types in
+//! [the `encryption` module][super].
+
+#![deny(unreachable_pub)]
+
 use std::{
     future::{Future, IntoFuture},
     io::Read,

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -514,7 +514,7 @@ impl OtherUserIdentity {
         };
 
         let response = room
-            .send(RoomMessageEventContent::new(MessageType::VerificationRequest(content)), None)
+            .send(RoomMessageEventContent::new(MessageType::VerificationRequest(content)))
             .await?;
 
         let verification =

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -57,6 +57,10 @@ use ruma::{
 use tokio::sync::RwLockReadGuard;
 use tracing::{debug, instrument, trace, warn};
 
+use self::{
+    futures::PrepareEncryptedFile,
+    identities::{DeviceUpdates, IdentityUpdates},
+};
 use crate::{
     attachment::{AttachmentInfo, Thumbnail},
     encryption::{
@@ -68,7 +72,7 @@ use crate::{
     Client, Error, Result, Room, TransmissionProgress,
 };
 
-mod futures;
+pub mod futures;
 pub mod identities;
 pub mod verification;
 
@@ -82,8 +86,6 @@ pub use matrix_sdk_base::crypto::{
     SessionCreationError, SignatureError, VERSION,
 };
 
-pub use self::futures::PrepareEncryptedFile;
-use self::identities::{DeviceUpdates, IdentityUpdates};
 pub use crate::error::RoomKeyImportError;
 
 /// Settings for end-to-end encryption features.

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -169,7 +169,7 @@ impl Client {
     /// let mut reader = std::io::Cursor::new(b"Hello, world!");
     /// let encrypted_file = client.prepare_encrypted_file(&mime::TEXT_PLAIN, &mut reader).await?;
     ///
-    /// room.send(CustomEventContent { encrypted_file }, None).await?;
+    /// room.send(CustomEventContent { encrypted_file }).await?;
     /// # anyhow::Ok(()) };
     /// ```
     pub fn prepare_encrypted_file<'a, R: Read + ?Sized + 'a>(
@@ -339,7 +339,8 @@ impl Client {
 
         self.get_room(room_id)
             .expect("Can't send a message to a room that isn't known to the store")
-            .send(content, Some(txn_id))
+            .send(content)
+            .with_transaction_id(txn_id)
             .await
     }
 
@@ -1237,11 +1238,9 @@ mod tests {
 
         let event_id = event_id!("$1:example.org");
         let reaction = ReactionEventContent::new(Annotation::new(event_id.into(), "🐈".to_owned()));
-        room.send(reaction, None).await.expect("Sending the reaction should not fail");
+        room.send(reaction).await.expect("Sending the reaction should not fail");
 
-        room.send_raw(json!({}), "m.reaction", None)
-            .await
-            .expect("Sending the reaction should not fail");
+        room.send_raw(json!({}), "m.reaction").await.expect("Sending the reaction should not fail");
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1240,7 +1240,7 @@ mod tests {
         let reaction = ReactionEventContent::new(Annotation::new(event_id.into(), "🐈".to_owned()));
         room.send(reaction).await.expect("Sending the reaction should not fail");
 
-        room.send_raw(json!({}), "m.reaction").await.expect("Sending the reaction should not fail");
+        room.send_raw("m.reaction", json!({})).await.expect("Sending the reaction should not fail");
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -47,7 +47,11 @@ pub mod notification_settings;
 #[cfg(feature = "experimental-oidc")]
 pub mod oidc;
 pub mod room;
+pub mod futures {
+    //! Named futures returned from methods on types in [the crate root][crate].
 
+    pub use super::client::futures::SendRequest;
+}
 #[cfg(feature = "experimental-sliding-sync")]
 pub mod sliding_sync;
 pub mod sync;
@@ -56,7 +60,7 @@ pub mod widget;
 
 pub use account::Account;
 pub use authentication::{AuthApi, AuthSession, SessionTokens};
-pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SendRequest, SessionChange};
+pub use client::{Client, ClientBuildError, ClientBuilder, LoopCtrl, SessionChange};
 #[cfg(feature = "image-proc")]
 pub use error::ImageError;
 pub use error::{

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -14,11 +14,9 @@
 // limitations under the License.
 #![cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
 
-use std::{
-    future::{Future, IntoFuture},
-    pin::Pin,
-};
+use std::future::{Future, IntoFuture};
 
+use matrix_sdk_common::boxed_into_future;
 use ruma::{
     api::client::{session::login, uiaa::UserIdentifier},
     assign,
@@ -212,8 +210,7 @@ impl LoginBuilder {
 
 impl IntoFuture for LoginBuilder {
     type Output = Result<login::v3::Response>;
-    // TODO: Use impl Trait once allowed in this position on stable
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output>>>;
+    boxed_into_future!();
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
@@ -479,8 +476,7 @@ where
     Fut: Future<Output = Result<()>> + Send + 'static,
 {
     type Output = Result<login::v3::Response>;
-    // TODO: Use impl Trait once allowed in this position on stable
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output>>>;
+    boxed_into_future!();
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -14,7 +14,9 @@
 // limitations under the License.
 #![cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
 
-use std::future::{Future, IntoFuture};
+#[cfg(feature = "sso-login")]
+use std::future::Future;
+use std::future::IntoFuture;
 
 use matrix_sdk_common::boxed_into_future;
 use ruma::{

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -47,7 +47,8 @@ use tokio::{fs::File as TokioFile, io::AsyncWriteExt};
 
 use crate::{
     attachment::{AttachmentInfo, Thumbnail},
-    Client, Result, SendRequest, TransmissionProgress,
+    futures::SendRequest,
+    Client, Result, TransmissionProgress,
 };
 
 /// A conservative upload speed of 1Mbps

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -23,8 +23,13 @@ use std::io::Cursor;
 use eyeball::SharedObservable;
 use matrix_sdk_common::boxed_into_future;
 use mime::Mime;
-use ruma::api::client::message::send_message_event;
-use tracing::{Instrument, Span};
+#[cfg(doc)]
+use ruma::events::{MessageLikeUnsigned, SyncMessageLikeEvent};
+use ruma::{
+    api::client::message::send_message_event, assign, events::MessageLikeEventContent, serde::Raw,
+    OwnedTransactionId, TransactionId,
+};
+use tracing::{debug, Instrument, Span};
 
 use super::Room;
 use crate::{attachment::AttachmentConfig, Result, TransmissionProgress};
@@ -33,6 +38,167 @@ use crate::{
     attachment::{generate_image_thumbnail, Thumbnail},
     error::ImageError,
 };
+
+/// Future returned by [`Room::send`].
+#[allow(missing_debug_implementations)]
+pub struct SendMessageLikeEvent<'a> {
+    room: &'a Room,
+    event_type: String,
+    content: serde_json::Result<serde_json::Value>,
+    transaction_id: Option<OwnedTransactionId>,
+}
+
+impl<'a> SendMessageLikeEvent<'a> {
+    pub(crate) fn new(room: &'a Room, content: impl MessageLikeEventContent) -> Self {
+        let event_type = content.event_type().to_string();
+        let content = serde_json::to_value(&content);
+        Self { room, event_type, content, transaction_id: None }
+    }
+
+    /// Set a transaction ID for this event.
+    ///
+    /// Since sending message-like events always requires a transaction ID, one
+    /// is generated if this method is not called.
+    ///
+    /// The transaction ID is a locally-unique ID describing a message
+    /// transaction with the homeserver.
+    ///
+    /// * On the sending side, this field is used for re-trying earlier failed
+    ///   transactions. Subsequent messages *must never* re-use an earlier
+    ///   transaction ID.
+    /// * On the receiving side, the field is used for recognizing our own
+    ///   messages when they arrive down the sync: the server includes the ID in
+    ///   the [`MessageLikeUnsigned`] field `transaction_id` of the
+    ///   corresponding [`SyncMessageLikeEvent`], but only for the *sending*
+    ///   device. Other devices will not see it. This is then used to ignore
+    ///   events sent by our own device and/or to implement local echo.
+    pub fn with_transaction_id(mut self, txn_id: &TransactionId) -> Self {
+        self.transaction_id = Some(txn_id.to_owned());
+        self
+    }
+}
+
+impl<'a> IntoFuture for SendMessageLikeEvent<'a> {
+    type Output = Result<send_message_event::v3::Response>;
+    boxed_into_future!(extra_bounds: 'a);
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self { room, event_type, content, transaction_id } = self;
+        Box::pin(async move {
+            let content = content?;
+            assign!(room.send_raw(content, &event_type), { transaction_id }).await
+        })
+    }
+}
+
+/// Future returned by [`Room::send_raw`].
+#[allow(missing_debug_implementations)]
+pub struct SendRawMessageLikeEvent<'a> {
+    room: &'a Room,
+    event_type: &'a str,
+    content: serde_json::Value,
+    tracing_span: Span,
+    transaction_id: Option<OwnedTransactionId>,
+}
+
+impl<'a> SendRawMessageLikeEvent<'a> {
+    pub(crate) fn new(room: &'a Room, event_type: &'a str, content: serde_json::Value) -> Self {
+        Self { room, event_type, content, tracing_span: Span::current(), transaction_id: None }
+    }
+
+    /// Set a transaction ID for this event.
+    ///
+    /// Since sending message-like events always requires a transaction ID, one
+    /// is generated if this method is not called.
+    ///
+    /// * On the sending side, this field is used for re-trying earlier failed
+    ///   transactions. Subsequent messages *must never* re-use an earlier
+    ///   transaction ID.
+    /// * On the receiving side, the field is used for recognizing our own
+    ///   messages when they arrive down the sync: the server includes the ID in
+    ///   the [`MessageLikeUnsigned`] field `transaction_id` of the
+    ///   corresponding [`SyncMessageLikeEvent`], but only for the *sending*
+    ///   device. Other devices will not see it. This is then used to ignore
+    ///   events sent by our own device and/or to implement local echo.
+    pub fn with_transaction_id(mut self, txn_id: &TransactionId) -> Self {
+        self.transaction_id = Some(txn_id.to_owned());
+        self
+    }
+}
+
+impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
+    type Output = Result<send_message_event::v3::Response>;
+    boxed_into_future!(extra_bounds: 'a);
+
+    fn into_future(self) -> Self::IntoFuture {
+        let Self { room, event_type, content, tracing_span, transaction_id } = self;
+        let fut = async move {
+            room.ensure_room_joined()?;
+
+            let txn_id = transaction_id.unwrap_or_else(TransactionId::new);
+            tracing::Span::current().record("transaction_id", tracing::field::debug(&txn_id));
+
+            #[cfg(not(feature = "e2e-encryption"))]
+            let content = {
+                debug!("Sending plaintext event to room because we don't have encryption support.");
+                Raw::new(&content)?.cast()
+            };
+
+            #[cfg(feature = "e2e-encryption")]
+            let (content, event_type) = if room.is_encrypted().await? {
+                tracing::Span::current().record("encrypted", tracing::field::debug(&txn_id));
+                // Reactions are currently famously not encrypted, skip encrypting
+                // them until they are.
+                if event_type == "m.reaction" {
+                    debug!("Sending plaintext event because of the event type.");
+                    (Raw::new(&content)?.cast(), event_type)
+                } else {
+                    debug!(
+                        room_id = room.room_id().as_str(),
+                        "Sending encrypted event because the room is encrypted.",
+                    );
+
+                    if !room.are_members_synced() {
+                        room.sync_members().await?;
+                    }
+
+                    // Query keys in case we don't have them for newly synced members.
+                    //
+                    // Note we do it all the time, because we might have sync'd members before
+                    // sending a message (so didn't enter the above branch), but
+                    // could have not query their keys ever.
+                    room.query_keys_for_untracked_users().await?;
+
+                    room.preshare_room_key().await?;
+
+                    let olm = room.client.olm_machine().await;
+                    let olm = olm.as_ref().expect("Olm machine wasn't started");
+
+                    let encrypted_content =
+                        olm.encrypt_room_event_raw(room.room_id(), content, event_type).await?;
+
+                    (encrypted_content.cast(), "m.room.encrypted")
+                }
+            } else {
+                debug!("Sending plaintext event because the room is NOT encrypted.",);
+
+                (Raw::new(&content)?.cast(), event_type)
+            };
+
+            let request = send_message_event::v3::Request::new_raw(
+                room.room_id().to_owned(),
+                txn_id,
+                event_type.into(),
+                content,
+            );
+
+            let response = room.client.send(request, None).await?;
+            Ok(response)
+        };
+
+        Box::pin(fut.instrument(tracing_span))
+    }
+}
 
 /// Future returned by [`Room::send_attachment`].
 #[allow(missing_debug_implementations)]

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -86,7 +86,7 @@ impl<'a> IntoFuture for SendMessageLikeEvent<'a> {
         let Self { room, event_type, content, transaction_id } = self;
         Box::pin(async move {
             let content = content?;
-            assign!(room.send_raw(content, &event_type), { transaction_id }).await
+            assign!(room.send_raw(&event_type, content), { transaction_id }).await
         })
     }
 }

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -16,14 +16,12 @@
 
 #![deny(unreachable_pub)]
 
+use std::future::IntoFuture;
 #[cfg(feature = "image-proc")]
 use std::io::Cursor;
-use std::{
-    future::{Future, IntoFuture},
-    pin::Pin,
-};
 
 use eyeball::SharedObservable;
+use matrix_sdk_common::boxed_into_future;
 use mime::Mime;
 use ruma::api::client::message::send_message_event;
 use tracing::{Instrument, Span};
@@ -81,10 +79,7 @@ impl<'a> SendAttachment<'a> {
 
 impl<'a> IntoFuture for SendAttachment<'a> {
     type Output = Result<send_message_event::v3::Response>;
-    #[cfg(target_arch = "wasm32")]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + 'a>>;
-    #[cfg(not(target_arch = "wasm32"))]
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + 'a>>;
+    boxed_into_future!(extra_bounds: 'a);
 
     fn into_future(self) -> Self::IntoFuture {
         let Self { room, body, content_type, data, config, tracing_span, send_progress } = self;

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -146,7 +146,7 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
 
             #[cfg(feature = "e2e-encryption")]
             let (content, event_type) = if room.is_encrypted().await? {
-                tracing::Span::current().record("encrypted", tracing::field::debug(&txn_id));
+                tracing::Span::current().record("encrypted", true);
                 // Reactions are currently famously not encrypted, skip encrypting
                 // them until they are.
                 if event_type == "m.reaction" {
@@ -180,6 +180,7 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
                     (encrypted_content.cast(), "m.room.encrypted")
                 }
             } else {
+                tracing::Span::current().record("encrypted", false);
                 debug!("Sending plaintext event because the room is NOT encrypted.",);
 
                 (Raw::new(&content)?.cast(), event_type)

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -1,3 +1,21 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Named futures returned from methods on types in [the `room` module][super].
+
+#![deny(unreachable_pub)]
+
 #[cfg(feature = "image-proc")]
 use std::io::Cursor;
 use std::{

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1778,12 +1778,12 @@ impl Room {
     ///
     /// # Arguments
     ///
-    /// * `content` - The raw content of the state event.
-    ///
     /// * `event_type` - The type of the event that we're sending out.
     ///
     /// * `state_key` - A unique key which defines the overwriting semantics for
     /// this piece of room state. This value is often a zero-length string.
+    ///
+    /// * `content` - The raw content of the state event.
     ///
     /// # Examples
     ///
@@ -1794,23 +1794,22 @@ impl Room {
     /// # let homeserver = url::Url::parse("http://localhost:8080")?;
     /// # let mut client = matrix_sdk::Client::new(homeserver).await?;
     /// # let room_id = matrix_sdk::ruma::room_id!("!test:localhost");
-    /// let content = json!({
-    ///     "avatar_url": "mxc://example.org/SEsfnsuifSDFSSEF",
-    ///     "displayname": "Alice Margatroid",
-    ///     "membership": "join"
-    /// });
     ///
     /// if let Some(room) = client.get_room(&room_id) {
-    ///     room.send_state_event_raw(content, "m.room.member", "").await?;
+    ///     room.send_state_event_raw("m.room.member", "", json!({
+    ///         "avatar_url": "mxc://example.org/SEsfnsuifSDFSSEF",
+    ///         "displayname": "Alice Margatroid",
+    ///         "membership": "join",
+    ///     })).await?;
     /// }
     /// # anyhow::Ok(()) };
     /// ```
     #[instrument(skip_all)]
     pub async fn send_state_event_raw(
         &self,
-        content: serde_json::Value,
         event_type: &str,
         state_key: &str,
+        content: serde_json::Value,
     ) -> Result<send_state_event::v3::Response> {
         self.ensure_room_joined()?;
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -69,6 +69,7 @@ use thiserror::Error;
 use tokio::sync::broadcast;
 use tracing::{debug, instrument, warn};
 
+use self::futures::SendAttachment;
 use crate::{
     attachment::AttachmentConfig,
     error::WrongRoomState,
@@ -79,12 +80,11 @@ use crate::{
     BaseRoom, Client, Error, HttpError, HttpResult, Result, RoomState, TransmissionProgress,
 };
 
-mod futures;
+pub mod futures;
 mod member;
 mod messages;
 
 pub use self::{
-    futures::SendAttachment,
     member::RoomMember,
     messages::{Messages, MessagesOptions},
 };

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1404,9 +1404,9 @@ impl Room {
     ///
     /// # Arguments
     ///
-    /// * `content` - The content of the event as a json `Value`.
-    ///
     /// * `event_type` - The type of the event.
+    ///
+    /// * `content` - The content of the event as a json `Value`.
     ///
     /// # Examples
     ///
@@ -1421,20 +1421,16 @@ impl Room {
     /// # let room_id = room_id!("!test:localhost");
     /// use serde_json::json;
     ///
-    /// let content = json!({
-    ///     "body": "Hello world",
-    /// });
-    ///
     /// if let Some(room) = client.get_room(&room_id) {
-    ///     room.send_raw(content, "m.room.message").await?;
+    ///     room.send_raw("m.room.message", json!({ "body": "Hello world" })).await?;
     /// }
     /// # anyhow::Ok(()) };
     /// ```
     #[instrument(skip_all, fields(event_type, room_id = ?self.room_id(), transaction_id, encrypted))]
     pub fn send_raw<'a>(
         &'a self,
-        content: serde_json::Value,
         event_type: &'a str,
+        content: serde_json::Value,
     ) -> SendRawMessageLikeEvent<'a> {
         SendRawMessageLikeEvent::new(self, event_type, content)
     }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1281,15 +1281,16 @@ impl Room {
         }
     }
 
-    /// Send a room message to this room.
+    /// Send a message-like event to this room.
     ///
     /// Returns the parsed response from the server.
     ///
     /// If the encryption feature is enabled this method will transparently
-    /// encrypt the room message if this room is encrypted.
+    /// encrypt the event if this room is encrypted (except for `m.reaction`
+    /// events, which are never encrypted).
     ///
-    /// **Note**: If you just want to send a custom JSON payload to a room, you
-    /// can use the [`send_raw()`][Self::send_raw] method for that.
+    /// **Note**: If you just want to send an event with custom JSON content to
+    /// a room, you can use the [`send_raw()`][Self::send_raw] method for that.
     ///
     /// If you want to set a transaction ID for the event, use
     /// [`.with_transaction_id()`][SendMessageLikeEvent::with_transaction_id]
@@ -1387,12 +1388,13 @@ impl Room {
         Ok(())
     }
 
-    /// Send a room message to this room from a json `Value`.
+    /// Send a message-like event with custom JSON content to this room.
     ///
     /// Returns the parsed response from the server.
     ///
     /// If the encryption feature is enabled this method will transparently
-    /// encrypt the room message if this room is encrypted.
+    /// encrypt the event if this room is encrypted (except for `m.reaction`
+    /// events, which are never encrypted).
     ///
     /// This method is equivalent to the [`send()`][Self::send] method but
     /// allows sending custom JSON payloads, e.g. constructed using the

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1464,7 +1464,7 @@ impl Room {
     /// [`SyncMessageLikeEvent`]: ruma::events::SyncMessageLikeEvent
     /// [`StateUnsigned`]: ruma::events::StateUnsigned
     /// [`transaction_id`]: ruma::events::StateUnsigned#structfield.transaction_id
-    #[instrument(skip_all, fields(event_type, room_id = %self.room_id(), transaction_id, encrypted))]
+    #[instrument(skip_all, fields(event_type, room_id = ?self.room_id(), transaction_id, encrypted))]
     pub async fn send_raw(
         &self,
         content: serde_json::Value,
@@ -1478,10 +1478,7 @@ impl Room {
 
         #[cfg(not(feature = "e2e-encryption"))]
         let content = {
-            debug!(
-                room_id = ?self.room_id(),
-                "Sending plaintext event to room because we don't have encryption support.",
-            );
+            debug!("Sending plaintext event to room because we don't have encryption support.");
             Raw::new(&content)?.cast()
         };
 
@@ -1491,10 +1488,7 @@ impl Room {
             // Reactions are currently famously not encrypted, skip encrypting
             // them until they are.
             if event_type == "m.reaction" {
-                debug!(
-                    room_id = ?self.room_id(),
-                    "Sending plaintext event because the event type is {event_type}",
-                );
+                debug!("Sending plaintext event because of the event type.");
                 (Raw::new(&content)?.cast(), event_type)
             } else {
                 debug!(
@@ -1524,10 +1518,7 @@ impl Room {
                 (encrypted_content.cast(), "m.room.encrypted")
             }
         } else {
-            debug!(
-                room_id = ?self.room_id(),
-                "Sending plaintext event because the room is NOT encrypted.",
-            );
+            debug!("Sending plaintext event because the room is NOT encrypted.",);
 
             (Raw::new(&content)?.cast(), event_type)
         };

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -115,7 +115,7 @@ impl MatrixDriver {
     ) -> Result<OwnedEventId> {
         let type_str = event_type.to_string();
         Ok(match state_key {
-            Some(key) => self.room.send_state_event_raw(content, &type_str, &key).await?.event_id,
+            Some(key) => self.room.send_state_event_raw(&type_str, &key, content).await?.event_id,
             None => self.room.send_raw(&type_str, content).await?.event_id,
         })
     }

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -116,7 +116,7 @@ impl MatrixDriver {
         let type_str = event_type.to_string();
         Ok(match state_key {
             Some(key) => self.room.send_state_event_raw(content, &type_str, &key).await?.event_id,
-            None => self.room.send_raw(content, &type_str).await?.event_id,
+            None => self.room.send_raw(&type_str, content).await?.event_id,
         })
     }
 

--- a/crates/matrix-sdk/src/widget/matrix.rs
+++ b/crates/matrix-sdk/src/widget/matrix.rs
@@ -116,7 +116,7 @@ impl MatrixDriver {
         let type_str = event_type.to_string();
         Ok(match state_key {
             Some(key) => self.room.send_state_event_raw(content, &type_str, &key).await?.event_id,
-            None => self.room.send_raw(content, &type_str, None).await?.event_id,
+            None => self.room.send_raw(content, &type_str).await?.event_id,
         })
     }
 

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -273,7 +273,7 @@ async fn room_message_send() {
 
     let content = RoomMessageEventContent::text_plain("Hello world");
     let txn_id = TransactionId::new();
-    let response = room.send(content, Some(&txn_id)).await.unwrap();
+    let response = room.send(content).with_transaction_id(&txn_id).await.unwrap();
 
     assert_eq!(event_id!("$h29iv0s8:example.com"), response.event_id)
 }

--- a/examples/command_bot/src/main.rs
+++ b/examples/command_bot/src/main.rs
@@ -22,9 +22,7 @@ async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {
         println!("sending");
 
         // send our message to the room we found the "!party" command in
-        // the last parameter is an optional transaction id which we don't
-        // care about.
-        room.send(content, None).await.unwrap();
+        room.send(content).await.unwrap();
 
         println!("message sent");
     }

--- a/examples/custom_events/src/main.rs
+++ b/examples/custom_events/src/main.rs
@@ -59,7 +59,7 @@ async fn on_regular_room_message(event: OriginalSyncRoomMessageEvent, room: Room
         let content = PingEventContent {};
 
         println!("sending ping");
-        room.send(content, None).await.unwrap();
+        room.send(content).await.unwrap();
         println!("ping sent");
     }
 }
@@ -75,7 +75,7 @@ async fn on_ping_event(event: SyncPingEvent, room: Room) {
     // Send an ack with the event_id of the ping, as our 'protocol' demands
     let content = AckEventContent { ping_id: event_id };
     println!("sending ack");
-    room.send(content, None).await.unwrap();
+    room.send(content).await.unwrap();
 
     println!("ack sent");
 }

--- a/examples/getting_started/src/main.rs
+++ b/examples/getting_started/src/main.rs
@@ -161,9 +161,7 @@ async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {
         println!("sending");
 
         // send our message to the room we found the "!party" command in
-        // the last parameter is an optional transaction id which we don't
-        // care about.
-        room.send(content, None).await.unwrap();
+        room.send(content).await.unwrap();
 
         println!("message sent");
     }

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -324,7 +324,7 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
     let bob_room = bob.get_room(alice_room.room_id()).unwrap();
     let message = "Hello world!";
     let bob_message_content = Arc::new(Mutex::new(message));
-    bob_room.send(RoomMessageEventContent::text_plain(message), None).await?;
+    bob_room.send(RoomMessageEventContent::text_plain(message)).await?;
     warn!("bob is done sending the message");
 
     // Alice was in the room when Bob sent the message, so they'll see it.
@@ -383,7 +383,7 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
     let bob_room = bob.get_room(alice_room.room_id()).unwrap();
     let message = "Wassup";
     *bob_message_content.lock().unwrap() = message;
-    bob_room.send(RoomMessageEventContent::text_plain(message), None).await?;
+    bob_room.send(RoomMessageEventContent::text_plain(message)).await?;
     warn!("bob is done sending another message");
 
     {
@@ -442,7 +442,7 @@ async fn test_failed_members_response() -> Result<()> {
     let bob_room = bob.get_room(alice_room.room_id()).unwrap();
     let message = "Hello world!";
     let bob_message_content = Arc::new(Mutex::new(message));
-    bob_room.send(RoomMessageEventContent::text_plain(message), None).await?;
+    bob_room.send(RoomMessageEventContent::text_plain(message)).await?;
     warn!("bob is done sending the message");
 
     // Alice sees the message.

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -141,7 +141,7 @@ async fn test_notification() -> Result<()> {
     bob.get_room(alice_room.room_id()).unwrap().join().await?;
 
     // Now Alice sends a message to Bob.
-    alice_room.send(RoomMessageEventContent::text_plain("Hello world!"), None).await?;
+    alice_room.send(RoomMessageEventContent::text_plain("Hello world!")).await?;
 
     // In this sync, bob receives the message from Alice.
     let bob_response = bob.sync_once(SyncSettings::default().token(sync_token)).await?;


### PR DESCRIPTION
A bunch of improvements around sending events. I'll follow up with allowing the `_raw` methods to take different content types than `serde_json::Value` tomorrow.