### PR TITLE
crypto(cleanup): introduce a `KeyQueryManager`

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -333,9 +333,9 @@ impl GossipMachine {
                 user_id = event.sender.as_str(),
                 device_id = event.content.requesting_device_id.as_str(),
                 ?secret_name,
-                "Received a secret request form an unknown device",
+                "Received a secret request from an unknown device",
             );
-            cache.mark_user_as_changed(&self.inner.store, &event.sender).await?;
+            cache.keys_query_manager().await?.mark_user_as_changed(&event.sender).await?;
 
             None
         })
@@ -395,7 +395,7 @@ impl GossipMachine {
 
         let Some(device) = device else {
             warn!("Received a key request from an unknown device");
-            cache.mark_user_as_changed(&self.inner.store, &event.sender).await?;
+            cache.keys_query_manager().await?.mark_user_as_changed(&event.sender).await?;
 
             return Ok(None);
         };
@@ -857,7 +857,7 @@ impl GossipMachine {
         } else {
             warn!("Received a m.secret.send event from an unknown device");
 
-            cache.mark_user_as_changed(&self.inner.store, &secret.event.sender).await?;
+            cache.keys_query_manager().await?.mark_user_as_changed(&secret.event.sender).await?;
         }
 
         Ok(())

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -184,6 +184,10 @@ impl SessionManager {
         let user_devices = if user_devices.is_empty() {
             match self
                 .store
+                .cache()
+                .await?
+                .keys_query_manager()
+                .await?
                 .wait_if_user_key_query_pending(Self::KEYS_QUERY_WAIT_TIME, user_id)
                 .await
             {
@@ -601,7 +605,13 @@ mod tests {
         let bob_device = ReadOnlyDevice::from_account(&bob);
         {
             let cache = manager.store.cache().await.unwrap();
-            cache.update_tracked_users(&manager.store, iter::once(bob.user_id())).await.unwrap();
+            cache
+                .keys_query_manager()
+                .await
+                .unwrap()
+                .update_tracked_users(iter::once(bob.user_id()))
+                .await
+                .unwrap();
         }
 
         // ... and start off an attempt to get the missing sessions. This should block

--- a/crates/matrix-sdk-crypto/src/store/caches.rs
+++ b/crates/matrix-sdk-crypto/src/store/caches.rs
@@ -245,7 +245,7 @@ pub(super) struct KeysQueryWaiter {
 /// which each user was last invalidated. Then, we attach the current sequence
 /// number to each `/keys/query` request, and when we get the response we can
 /// tell if any users have been invalidated more recently than that request.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(super) struct UsersForKeyQuery {
     /// The sequence number we will assign to the next addition to user_map
     next_sequence_number: SequenceNumber,
@@ -262,15 +262,6 @@ pub(super) struct UsersForKeyQuery {
 }
 
 impl UsersForKeyQuery {
-    /// Create a new, empty, `UsersForKeyQueryCache`
-    pub(super) fn new() -> Self {
-        UsersForKeyQuery {
-            next_sequence_number: Default::default(),
-            user_map: Default::default(),
-            tasks_awaiting_key_query: Default::default(),
-        }
-    }
-
     /// Record a new user that requires a key query
     pub(super) fn insert_user(&mut self, user: &UserId) {
         let sequence_number = self.next_sequence_number;

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -210,14 +210,14 @@ impl KeyQueryManager {
     /// concurrent calls to this method get deduplicated.
     async fn ensure_sync_tracked_users(&self, cache: &StoreCache) -> Result<()> {
         // Check if the users are loaded, and in that case do nothing.
-        let loaded = cache.tracked_user_loading_lock.read().await;
+        let loaded = cache.loaded_tracked_users.read().await;
         if *loaded {
             return Ok(());
         }
 
         // Otherwise, we may load the users.
         drop(loaded);
-        let mut loaded = cache.tracked_user_loading_lock.write().await;
+        let mut loaded = cache.loaded_tracked_users.write().await;
 
         // Check again if the users have been loaded, in case another call to this
         // method loaded the tracked users between the time we tried to
@@ -402,7 +402,7 @@ pub(crate) struct StoreCache {
     key_query_manager: KeyQueryManager,
 
     tracked_users: StdRwLock<BTreeSet<OwnedUserId>>,
-    tracked_user_loading_lock: RwLock<bool>,
+    loaded_tracked_users: RwLock<bool>,
     account: Mutex<Option<Account>>,
 }
 
@@ -960,7 +960,7 @@ impl Store {
                     store,
                     key_query_manager: Default::default(),
                     tracked_users: Default::default(),
-                    tracked_user_loading_lock: Default::default(),
+                    loaded_tracked_users: Default::default(),
                     account: Default::default(),
                 })),
             }),


### PR DESCRIPTION
This removes some logic from the `Store` and `StoreCache`, and put it into a new structure called `KeyQueryManager` which is tightly coupled to the `StoreCache` itself. With this change, the `StoreCache` is now mostly pure data.

Also the public API of the `KeyQueryManager` makes it impossible to interact with pending key queries without syncing first with the database, potentially fixing a few issues introduced in recent refactorings around this.

A note to simplify review: the bodies of methods that were on the `Store` or `StoreCache` have **not** changed, except for data access (some data is now parameters, some data is now owned fields). The logic hasn't changed at all otherwise.