### PR TITLE
recovery branch fix: don't send any request before OIDC is fully set up

### DIFF
--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -941,18 +941,6 @@ impl Client {
 
     pub(crate) async fn set_session_meta(&self, session_meta: SessionMeta) -> Result<()> {
         self.base_client().set_session_meta(session_meta).await?;
-
-        #[cfg(feature = "e2e-encryption")]
-        {
-            if let Err(e) = self.encryption().backups().setup_and_resume().await {
-                error!("Couldn't setup and resume backups {e:?}");
-            }
-
-            if let Err(e) = self.encryption().recovery().setup().await {
-                warn!("Couldn't auto enable recovery {e:?}");
-            }
-        }
-
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -827,6 +827,9 @@ impl MatrixAuth {
         self.set_session_tokens(session.tokens);
         self.client.set_session_meta(session.meta).await?;
 
+        #[cfg(feature = "e2e-encryption")]
+        self.client.encryption().enable_backups_and_recovery().await?;
+
         Ok(())
     }
 }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -755,6 +755,8 @@ impl Oidc {
             }
         }
 
+        self.client.encryption().enable_backups_and_recovery().await?;
+
         Ok(())
     }
 
@@ -951,6 +953,8 @@ impl Oidc {
                     .map_err(|err| crate::Error::Oidc(err.into()))?;
             }
         }
+
+        self.client.encryption().enable_backups_and_recovery().await?;
 
         Ok(())
     }


### PR DESCRIPTION
This should fix a few logouts happening for users of the `poljar/recovery` branch.