### PR TITLE
crypto: put the enabling of backup and recovery in the background

### DIFF
--- a/crates/matrix-sdk/src/client/tasks.rs
+++ b/crates/matrix-sdk/src/client/tasks.rs
@@ -24,18 +24,11 @@ use crate::{
     Client,
 };
 
+#[derive(Default)]
 pub(crate) struct ClientTasks {
     #[cfg(feature = "e2e-encryption")]
-    pub(crate) upload_room_keys: BackupUploadingTask,
-}
-
-impl ClientTasks {
-    pub(crate) fn new(client: Weak<ClientInner>) -> Self {
-        Self {
-            #[cfg(feature = "e2e-encryption")]
-            upload_room_keys: BackupUploadingTask::new(client),
-        }
-    }
+    pub(crate) upload_room_keys: Option<BackupUploadingTask>,
+    pub(crate) auto_enable_backup_and_recovery: Option<JoinHandle<()>>,
 }
 
 #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -206,7 +206,7 @@ impl Backups {
         let result = future.await;
 
         if result.is_err() {
-            self.set_state(BackupState::Unknown)
+            self.set_state(BackupState::Unknown);
         }
 
         result
@@ -491,9 +491,8 @@ impl Backups {
 
     pub(crate) fn maybe_trigger_backup(&self) {
         let tasks = self.client.inner.tasks.lock().unwrap();
-
-        if let Some(tasks) = tasks.as_ref() {
-            tasks.upload_room_keys.trigger_upload();
+        if let Some(upload_room_keys) = tasks.upload_room_keys.as_ref() {
+            upload_room_keys.trigger_upload();
         }
     }
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1055,7 +1055,7 @@ impl Encryption {
     /// );
     /// # anyhow::Ok(()) };
     /// ```
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_arch = "wasm32"), test))]
     pub async fn import_room_keys(
         &self,
         path: PathBuf,
@@ -1210,14 +1210,29 @@ impl Encryption {
     }
 
     /// Enables automated backup and recovery.
-    pub async fn enable_backups_and_recovery(&self) -> Result<()> {
-        if let Err(e) = self.backups().setup_and_resume().await {
-            error!("Couldn't setup and resume backups {e:?}");
+    pub async fn enable_backups_and_recovery(&self) {
+        let mut tasks = self.client.inner.tasks.lock().unwrap();
+
+        let this = self.clone();
+        tasks.auto_enable_backup_and_recovery = Some(tokio::spawn(async move {
+            if let Err(e) = this.backups().setup_and_resume().await {
+                error!("Couldn't setup and resume backups {e:?}");
+            }
+            if let Err(e) = this.recovery().setup().await {
+                warn!("Couldn't auto enable recovery {e:?}");
+            }
+        }));
+    }
+
+    /// Waits for the backup and recovery enabling to finish, if requested with
+    /// [`Self::enable_backups_and_recovery`].
+    pub async fn wait_for_backups_and_recovery(&self) {
+        let task = self.client.inner.tasks.lock().unwrap().auto_enable_backup_and_recovery.take();
+        if let Some(task) = task {
+            if let Err(err) = task.await {
+                warn!("error when initializing backups and recovery: {err}");
+            }
         }
-        if let Err(e) = self.recovery().setup().await {
-            warn!("Couldn't auto enable recovery {e:?}");
-        }
-        Ok(())
     }
 }
 

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -828,7 +828,7 @@ impl MatrixAuth {
         self.client.set_session_meta(session.meta).await?;
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().enable_backups_and_recovery().await?;
+        self.client.encryption().enable_backups_and_recovery().await;
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -755,7 +755,7 @@ impl Oidc {
             }
         }
 
-        self.client.encryption().enable_backups_and_recovery().await?;
+        self.client.encryption().enable_backups_and_recovery().await;
 
         Ok(())
     }
@@ -954,7 +954,7 @@ impl Oidc {
             }
         }
 
-        self.client.encryption().enable_backups_and_recovery().await?;
+        self.client.encryption().enable_backups_and_recovery().await;
 
         Ok(())
     }


### PR DESCRIPTION
This doesn't await for the startup tasks to finish, but it's not clear where it should do that.