### PR TITLE
Bump tracing in cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ sha2 = "0.10.8"
 stream_assert = "0.1.1"
 thiserror = "1.0.38"
 tokio = { version = "1.30.0", default-features = false, features = ["sync"] }
-tracing = { version = "0.1.36", default-features = false, features = ["std"] }
-tracing-core = "0.1.30"
+tracing = { version = "0.1.40", default-features = false, features = ["std"] }
+tracing-core = "0.1.32"
 uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "48b1f51f6e5406cab20f502f535b30a589a5b140" }
 uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "48b1f51f6e5406cab20f502f535b30a589a5b140" }
 vodozemac = "0.5.0"


### PR DESCRIPTION
In https://github.com/matrix-org/matrix-rust-sdk/commit/1f534821f6ec2287ec581435a7e6ae52195a3944, only the lock file was updated.

Cargo in projects that depend on this library will not be aware that tracing should be bumped when this crate is bumped though, causing compiling errors.