### PR TITLE
integration tests: randomize user names better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3318,6 +3318,7 @@ dependencies = [
  "matrix-sdk",
  "matrix-sdk-ui",
  "once_cell",
+ "rand 0.8.5",
  "tempfile",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ itertools = "0.11.0"
 ruma = { version = "0.9.2", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
 ruma-common = "0.12.0"
 once_cell = "1.16.0"
+rand = "0.8.5"
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3.28"
 hmac = "0.12.1"
 http = { workspace = true }
 pbkdf2 = "0.12.2"
-rand = "0.8.5"
+rand = { workspace = true }
 ruma = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -46,7 +46,7 @@ itertools = { workspace = true }
 matrix-sdk-qrcode = { version = "0.4.0", path = "../matrix-sdk-qrcode", optional = true }
 matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 pbkdf2 = { version = "0.12.2", default-features = false }
-rand = "0.8.5"
+rand = { workspace = true }
 rmp-serde = "1.1.1"
 ruma = { workspace = true, features = ["rand", "canonical-json", "unstable-msc3814"] }
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -20,7 +20,7 @@ displaydoc = "0.2.4"
 getrandom = { version = "0.2.10", optional = true }
 hmac = "0.12.1"
 pbkdf2 = "0.12.2"
-rand = "0.8.5"
+rand = { workspace = true }
 rmp-serde = "1.1.2"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -88,7 +88,7 @@ matrix-sdk-indexeddb = { version = "0.2.0", path = "../matrix-sdk-indexeddb", de
 matrix-sdk-sqlite = { version = "0.1.0", path = "../matrix-sdk-sqlite", default-features = false, optional = true }
 mime = "0.3.16"
 mime2ext = "0.1.52"
-rand = { version = "0.8.5", optional = true }
+rand = { workspace = true , optional = true }
 ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc2965", "unstable-msc3930", "unstable-msc3245-v1-compat"] }
 serde = { workspace = true }
 serde_html_form = { workspace = true }

--- a/examples/oidc_cli/Cargo.toml
+++ b/examples/oidc_cli/Cargo.toml
@@ -16,7 +16,7 @@ futures-util = { version = "0.3.21", default-features = false }
 http = { workspace = true }
 hyper = { version = "0.14.20", features = ["http1", "http2", "server"]}
 matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui" }
-rand = "0.8.5"
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }

--- a/examples/persist_session/Cargo.toml
+++ b/examples/persist_session/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 dirs = "5.0.1"
-rand = "0.8.5"
+rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -21,6 +21,7 @@ futures-util = { workspace = true }
 matrix-sdk = { path = "../../crates/matrix-sdk", features = ["testing"] }
 matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui" }
 once_cell = { workspace = true }
+rand = { workspace = true }
 tempfile = "3.3.0"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing = { workspace = true }

--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -14,6 +14,7 @@ use matrix_sdk::{
     Client,
 };
 use once_cell::sync::Lazy;
+use rand::Rng as _;
 use tempfile::{tempdir, TempDir};
 use tokio::sync::Mutex;
 
@@ -41,8 +42,14 @@ pub struct TestClientBuilder {
 }
 
 impl TestClientBuilder {
-    pub fn new(username: String) -> Self {
-        Self { username, use_sqlite: false, bootstrap_cross_signing: false }
+    pub fn new(username: impl Into<String>) -> Self {
+        Self { username: username.into(), use_sqlite: false, bootstrap_cross_signing: false }
+    }
+
+    pub fn randomize_username(mut self) -> Self {
+        let suffix: u128 = rand::thread_rng().gen();
+        self.username = format!("{}{}", self.username, suffix);
+        self
     }
 
     pub fn use_sqlite(mut self) -> Self {
@@ -130,7 +137,11 @@ impl SyncTokenAwareClient {
         }
 
         let response = self.client.sync_once(settings).await?;
-        *self.token.lock().unwrap() = Some(response.next_batch);
+
+        let mut prev_token = self.token.lock().unwrap();
+        if prev_token.as_ref() != Some(&response.next_batch) {
+            *prev_token = Some(response.next_batch);
+        }
         Ok(())
     }
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::{Arc, Mutex},
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use assert_matches::assert_matches;
@@ -27,17 +24,17 @@ use crate::helpers::{SyncTokenAwareClient, TestClientBuilder};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_mutual_verification() -> Result<()> {
-    let time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
-
     let alice = SyncTokenAwareClient::new(
-        TestClientBuilder::new(format!("alice{time}"))
+        TestClientBuilder::new("alice")
+            .randomize_username()
             .use_sqlite()
             .bootstrap_cross_signing()
             .build()
             .await?,
     );
     let bob = SyncTokenAwareClient::new(
-        TestClientBuilder::new(format!("bob{time}"))
+        TestClientBuilder::new("bob")
+            .randomize_username()
             .use_sqlite()
             .bootstrap_cross_signing()
             .build()
@@ -282,12 +279,11 @@ async fn test_mutual_verification() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_encryption_missing_member_keys() -> Result<()> {
-    let time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
     let alice = SyncTokenAwareClient::new(
-        TestClientBuilder::new(format!("alice{time}")).use_sqlite().build().await?,
+        TestClientBuilder::new("alice").randomize_username().use_sqlite().build().await?,
     );
     let bob = SyncTokenAwareClient::new(
-        TestClientBuilder::new(format!("bob{time}")).use_sqlite().build().await?,
+        TestClientBuilder::new("bob").randomize_username().use_sqlite().build().await?,
     );
 
     let invite = vec![bob.user_id().unwrap().to_owned()];
@@ -309,7 +305,7 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
 
     // New person joins the room.
     let carl = SyncTokenAwareClient::new(
-        TestClientBuilder::new(format!("carl{time}")).use_sqlite().build().await?,
+        TestClientBuilder::new("carl").randomize_username().use_sqlite().build().await?,
     );
     alice_room.invite_user_by_id(carl.user_id().unwrap()).await?;
 
@@ -330,7 +326,7 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
     // Alice was in the room when Bob sent the message, so they'll see it.
     let alice_found_event = Arc::new(Mutex::new(false));
     {
-        warn!("alice is looking for decrypted message");
+        warn!("alice is looking for the decrypted message");
 
         let found_event_handler = alice_found_event.clone();
         let bob_message_content = bob_message_content.clone();
@@ -355,7 +351,7 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
     // won't see it first.
     let carl_found_event = Arc::new(Mutex::new(false));
     {
-        warn!("carl is looking for decrypted message");
+        warn!("carl is looking for the decrypted message");
 
         let found_event_handler = carl_found_event.clone();
         let bob_message_content = bob_message_content.clone();
@@ -405,12 +401,11 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_failed_members_response() -> Result<()> {
-    let time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
     let alice = SyncTokenAwareClient::new(
-        TestClientBuilder::new(format!("alice{time}")).use_sqlite().build().await?,
+        TestClientBuilder::new("alice").randomize_username().use_sqlite().build().await?,
     );
     let bob = SyncTokenAwareClient::new(
-        TestClientBuilder::new(format!("bob{time}")).use_sqlite().build().await?,
+        TestClientBuilder::new("bob").randomize_username().use_sqlite().build().await?,
     );
 
     let invite = vec![bob.user_id().unwrap().to_owned()];
@@ -447,7 +442,7 @@ async fn test_failed_members_response() -> Result<()> {
 
     // Alice sees the message.
     let alice_found_event = Arc::new(Mutex::new(false));
-    warn!("alice is looking for decrypted message");
+    warn!("alice is looking for the decrypted message");
 
     let found_event_handler = alice_found_event.clone();
     let bob_message_content = bob_message_content.clone();

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::sync::Arc;
 
 use anyhow::{ensure, Result};
 use assert_matches::assert_matches;
@@ -34,9 +31,8 @@ use crate::helpers::TestClientBuilder;
 async fn test_notification() -> Result<()> {
     // Create new users for each test run, to avoid conflicts with invites existing
     // from previous runs.
-    let time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis();
-    let alice = TestClientBuilder::new(format!("alice{time}")).use_sqlite().build().await?;
-    let bob = TestClientBuilder::new(format!("bob{time}")).use_sqlite().build().await?;
+    let alice = TestClientBuilder::new("alice").randomize_username().use_sqlite().build().await?;
+    let bob = TestClientBuilder::new("bob").randomize_username().use_sqlite().build().await?;
 
     let dummy_sync_service = Arc::new(SyncService::builder(bob.clone()).build().await?);
     let process_setup =


### PR DESCRIPTION
In the previous situation, running the tests with `cargo test` would sometimes fail because despite appending the number of milliseconds since the start of epoch to the user names, some user names would clash across different tests, leading to unexpected results. This fixes it by using an actual RNG in there, so the names don't ever clash.

With this, `cargo test` now seems to pass all tests with a bigger confidence rate.