### PR TITLE
Groundwork for fixes to one-time-key fetching

### DIFF
--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -491,7 +491,7 @@ mod tests {
             .await
             .expect("We should be able to create a request to upload a dehydrated device");
 
-        let (key_id, one_time_key) = request
+        let (_key_id, one_time_key) = request
             .one_time_keys
             .pop_first()
             .expect("The dehydrated device creation request should contain a one-time key");
@@ -499,7 +499,7 @@ mod tests {
         // Ensure that we know about the public keys of the dehydrated device.
         receive_device_keys(&alice, user_id(), &request.device_id, request.device_keys).await;
         // Create a 1-to-1 Olm session with the dehydrated device.
-        create_session(&alice, user_id(), &request.device_id, key_id, one_time_key).await;
+        create_session(&alice, user_id(), &request.device_id, one_time_key).await;
 
         // Send a room key to the dehydrated device.
         let (event, group_session) = send_room_key(&alice, room_id, user_id()).await;

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -242,13 +242,6 @@ pub enum SessionCreationError {
     )]
     OneTimeKeyNotSigned(OwnedUserId, OwnedDeviceId),
 
-    /// The signed one-time key is missing.
-    #[error(
-        "Tried to create a new Olm session for {0} {1}, but the signed \
-        one-time key is missing"
-    )]
-    OneTimeKeyMissing(OwnedUserId, OwnedDeviceId),
-
     /// The one-time key algorithm is unsupported.
     #[error(
         "Tried to create a new Olm session for {0} {1}, but the one-time \

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2607,7 +2607,6 @@ pub(crate) mod tests {
         machine: &OlmMachine,
         user_id: &UserId,
         device_id: &DeviceId,
-        _key_id: OwnedDeviceKeyId,
         one_time_key: Raw<OneTimeKey>,
     ) {
         let keys = BTreeMap::from([(device_id.to_owned(), &one_time_key)]);
@@ -2619,13 +2618,12 @@ pub(crate) mod tests {
     async fn test_session_creation() {
         let (alice_machine, bob_machine, mut one_time_keys) =
             get_machine_pair(alice_id(), user_id(), false).await;
-        let (device_key_id, one_time_key) = one_time_keys.pop_first().unwrap();
+        let (_key_id, one_time_key) = one_time_keys.pop_first().unwrap();
 
         create_session(
             &alice_machine,
             bob_machine.user_id(),
             bob_machine.device_id(),
-            device_key_id,
             one_time_key,
         )
         .await;
@@ -2646,7 +2644,7 @@ pub(crate) mod tests {
     async fn test_getting_most_recent_session() {
         let (alice_machine, bob_machine, mut one_time_keys) =
             get_machine_pair(alice_id(), user_id(), false).await;
-        let (device_key_id, one_time_key) = one_time_keys.pop_first().unwrap();
+        let (_key_id, one_time_key) = one_time_keys.pop_first().unwrap();
 
         let device = alice_machine
             .get_device(bob_machine.user_id(), bob_machine.device_id(), None)
@@ -2660,19 +2658,17 @@ pub(crate) mod tests {
             &alice_machine,
             bob_machine.user_id(),
             bob_machine.device_id(),
-            device_key_id,
             one_time_key.to_owned(),
         )
         .await;
 
         for _ in 0..10 {
-            let (device_key_id, one_time_key) = one_time_keys.pop_first().unwrap();
+            let (_key_id, one_time_key) = one_time_keys.pop_first().unwrap();
 
             create_session(
                 &alice_machine,
                 bob_machine.user_id(),
                 bob_machine.device_id(),
-                device_key_id,
                 one_time_key.to_owned(),
             )
             .await;

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2142,9 +2142,7 @@ pub(crate) mod tests {
     use ruma::{
         api::{
             client::{
-                keys::{
-                    claim_keys, get_keys, get_keys::v3::Response as KeyQueryResponse, upload_keys,
-                },
+                keys::{get_keys, get_keys::v3::Response as KeyQueryResponse, upload_keys},
                 sync::sync_events::DeviceLists,
                 to_device::send_event_to_device::v3::Response as ToDeviceResponse,
             },
@@ -2305,17 +2303,12 @@ pub(crate) mod tests {
 
         let mut bob_keys = BTreeMap::new();
 
-        let (device_key_id, one_time_key) = one_time_keys.iter().next().unwrap();
-        let mut keys = BTreeMap::new();
-        keys.insert(device_key_id.clone(), one_time_key.clone());
-        bob_keys.insert(bob.device_id().into(), keys);
+        let one_time_key = one_time_keys.values().next().unwrap();
+        bob_keys.insert(bob.device_id().to_owned(), one_time_key);
 
         let mut one_time_keys = BTreeMap::new();
         one_time_keys.insert(bob.user_id().to_owned(), bob_keys);
-
-        let response = claim_keys::v3::Response::new(one_time_keys);
-
-        alice.receive_keys_claim_response(&response).await.unwrap();
+        alice.inner.session_manager.create_sessions(&one_time_keys).await.unwrap();
 
         (alice, bob)
     }
@@ -2614,15 +2607,12 @@ pub(crate) mod tests {
         machine: &OlmMachine,
         user_id: &UserId,
         device_id: &DeviceId,
-        key_id: OwnedDeviceKeyId,
+        _key_id: OwnedDeviceKeyId,
         one_time_key: Raw<OneTimeKey>,
     ) {
-        let keys = BTreeMap::from([(key_id, one_time_key)]);
-        let keys = BTreeMap::from([(device_id.to_owned(), keys)]);
+        let keys = BTreeMap::from([(device_id.to_owned(), &one_time_key)]);
         let one_time_keys = BTreeMap::from([(user_id.to_owned(), keys)]);
-        let response = claim_keys::v3::Response::new(one_time_keys);
-
-        machine.receive_keys_claim_response(&response).await.unwrap();
+        machine.inner.session_manager.create_sessions(&one_time_keys).await.unwrap();
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -27,7 +27,7 @@ use ruma::{
     api::client::{
         dehydrated_device::DehydratedDeviceData,
         keys::{
-            claim_keys::v3::{Request as KeysClaimRequest, Response as KeysClaimResponse},
+            claim_keys::v3::Request as KeysClaimRequest,
             get_keys::v3::Response as KeysQueryResponse,
             upload_keys::v3::{Request as UploadKeysRequest, Response as UploadKeysResponse},
             upload_signatures::v3::Request as UploadSignaturesRequest,
@@ -446,7 +446,7 @@ impl OlmMachine {
                 self.receive_keys_query_response(request_id, response).await?;
             }
             IncomingResponse::KeysClaim(response) => {
-                self.receive_keys_claim_response(response).await?;
+                self.inner.session_manager.receive_keys_claim_response(response).await?;
             }
             IncomingResponse::ToDevice(_) => {
                 self.mark_to_device_request_as_sent(request_id).await?;
@@ -610,16 +610,6 @@ impl OlmMachine {
         users: impl Iterator<Item = &UserId>,
     ) -> StoreResult<Option<(OwnedTransactionId, KeysClaimRequest)>> {
         self.inner.session_manager.get_missing_sessions(users).await
-    }
-
-    /// Receive a successful key claim response and create new Olm sessions with
-    /// the claimed keys.
-    ///
-    /// # Arguments
-    ///
-    /// * `response` - The response containing the claimed one-time keys.
-    async fn receive_keys_claim_response(&self, response: &KeysClaimResponse) -> OlmResult<()> {
-        self.inner.session_manager.receive_keys_claim_response(response).await
     }
 
     /// Receive a successful keys query response.

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -779,7 +779,19 @@ mod tests {
 
     #[async_test]
     async fn failed_devices_handling() {
-        let response_with_invalid_signature = json!({
+        // Alice's device is present but with no keys
+        test_invalid_claim_response(json!({
+            "one_time_keys": {
+                "@alice:example.org": {
+                    "DEVICEID": {}
+                }
+            },
+            "failures": {},
+        }))
+        .await;
+
+        // Alice's device is present with a bad signature
+        test_invalid_claim_response(json!({
             "one_time_keys": {
                 "@alice:example.org": {
                     "DEVICEID": {
@@ -796,9 +808,16 @@ mod tests {
                 }
             },
             "failures": {},
-        });
+        })).await;
+    }
 
-        let response = response_from_file(&response_with_invalid_signature);
+    /// Helper for failed_devices_handling.
+    ///
+    /// Takes an invalid /keys/claim response for Alice's device DEVICEID and
+    /// checks that it is handled correctly. (The device should be marked as
+    /// 'failed'; and once that
+    async fn test_invalid_claim_response(response_json: serde_json::Value) {
+        let response = response_from_file(&response_json);
         let response = KeyClaimResponse::try_from_http_response(response).unwrap();
 
         let alice = user_id!("@alice:example.org");

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -24,6 +24,7 @@ use ruma::{
     },
     assign,
     events::dummy::ToDeviceDummyEventContent,
+    serde::Raw,
     DeviceId, DeviceKeyAlgorithm, OwnedDeviceId, OwnedServerName, OwnedTransactionId, OwnedUserId,
     SecondsSinceUnixEpoch, ServerName, TransactionId, UserId,
 };
@@ -344,6 +345,37 @@ impl SessionManager {
         self.failures.extend(failed_servers);
         self.failures.remove(successful_servers);
 
+        // build a map of user_id -> device_id -> key for each device to we can start
+        // a session with.
+        let mut device_map: BTreeMap<
+            OwnedUserId,
+            BTreeMap<OwnedDeviceId, &Raw<ruma::encryption::OneTimeKey>>,
+        > = BTreeMap::new();
+
+        for (user_id, user_devices) in response.one_time_keys.iter() {
+            for (device_id, key_map) in user_devices {
+                match key_map.values().next() {
+                    Some(k) => {
+                        device_map.entry(user_id.clone()).or_default().insert(device_id.clone(), k);
+                    }
+                    None => {
+                        warn!(
+                            user_id = user_id.as_str(),
+                            device_id = device_id.as_str(),
+                            "Tried to create a new Olm session, but the signed one-time key is missing",
+                        );
+
+                        self.failed_devices
+                            .write()
+                            .unwrap()
+                            .entry(user_id.clone())
+                            .or_default()
+                            .insert(device_id.clone());
+                    }
+                };
+            }
+        }
+
         struct SessionInfo {
             session_id: String,
             algorithm: EventEncryptionAlgorithm,
@@ -364,8 +396,8 @@ impl SessionManager {
         let mut new_sessions: BTreeMap<&UserId, BTreeMap<&DeviceId, SessionInfo>> = BTreeMap::new();
 
         let mut store_transaction = self.store.transaction().await;
-        for (user_id, user_devices) in &response.one_time_keys {
-            for (device_id, key_map) in user_devices {
+        for (user_id, user_devices) in device_map.iter() {
+            for (device_id, one_time_key) in user_devices {
                 let device = match self.store.get_readonly_device(user_id, device_id).await {
                     Ok(Some(d)) => d,
                     Ok(None) => {
@@ -390,7 +422,7 @@ impl SessionManager {
                 };
 
                 let account = store_transaction.account().await?;
-                let session = match account.create_outbound_session(&device, key_map) {
+                let session = match account.create_outbound_session(&device, one_time_key) {
                     Ok(s) => s,
                     Err(e) => {
                         warn!(

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -345,12 +345,16 @@ impl SessionManager {
         self.failures.extend(failed_servers);
         self.failures.remove(successful_servers);
 
-        // build a map of user_id -> device_id -> key for each device to we can start
-        // a session with.
+        // build a map of user_id -> device_id -> key for each device we can start a
+        // session with...
         let mut device_map: BTreeMap<
             OwnedUserId,
             BTreeMap<OwnedDeviceId, &Raw<ruma::encryption::OneTimeKey>>,
         > = BTreeMap::new();
+
+        // ... and a list of (user_id, device_id) pairs where the one-time-key is
+        // missing
+        let mut missing_devices: Vec<(OwnedUserId, OwnedDeviceId)> = Vec::new();
 
         for (user_id, user_devices) in response.one_time_keys.iter() {
             for (device_id, key_map) in user_devices {
@@ -359,20 +363,23 @@ impl SessionManager {
                         device_map.entry(user_id.clone()).or_default().insert(device_id.clone(), k);
                     }
                     None => {
-                        warn!(
-                            user_id = user_id.as_str(),
-                            device_id = device_id.as_str(),
-                            "Tried to create a new Olm session, but the signed one-time key is missing",
-                        );
-
-                        self.failed_devices
-                            .write()
-                            .unwrap()
-                            .entry(user_id.clone())
-                            .or_default()
-                            .insert(device_id.clone());
+                        missing_devices.push((user_id.clone(), device_id.clone()));
                     }
                 };
+            }
+        }
+
+        // process all the missing devices at once to save repeatedly grabbing the lock
+        if !missing_devices.is_empty() {
+            warn!(
+                ?missing_devices,
+                "Tried to create a new sessions, but the signed one-time key was missing for some devices",
+            );
+
+            let mut failed_devices_lock = self.failed_devices.write().unwrap();
+
+            for (user_id, device_id) in missing_devices {
+                failed_devices_lock.entry(user_id).or_default().insert(device_id);
             }
         }
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -376,6 +376,22 @@ impl SessionManager {
             }
         }
 
+        self.create_sessions(&device_map).await
+    }
+
+    /// Create new Olm sessions for the requested devices.
+    ///
+    /// # Arguments
+    ///
+    ///  * `device_map` - a map from user ID, to device ID, to key object, for
+    ///    each device we should create a session for.
+    pub(crate) async fn create_sessions(
+        &self,
+        device_map: &BTreeMap<
+            OwnedUserId,
+            BTreeMap<OwnedDeviceId, &Raw<ruma::encryption::OneTimeKey>>,
+        >,
+    ) -> OlmResult<()> {
         struct SessionInfo {
             session_id: String,
             algorithm: EventEncryptionAlgorithm,


### PR DESCRIPTION
Some non-functional refactoring in preparation for fixing https://github.com/matrix-org/matrix-rust-sdk/issues/281. Suggest review commit-by-commit. The salient changes are:

 * `Account::create_outbound_session` no longer takes an entire list of keys; rather it takes a single key and it is up to the caller to pick a key out of the list. This in turn means that `SessionCreationError` loses one of its reason codes.

 * `SessionManager::create_sessions` is factored out of `receive_keys_claim_response`. This is mostly helpful in tests, where our goal is to establish a session with a given device, rather than actually to test parsing of the entire `/keys/claim` response.