### PR TITLE
Handle missing devices in `/keys/claim` responses

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2310,13 +2310,12 @@ pub(crate) mod tests {
     ) -> (OlmMachine, OlmMachine) {
         let (alice, bob, one_time_keys) = get_machine_pair(alice, bob, use_fallback_key).await;
 
-        let mut bob_keys = BTreeMap::new();
-
         let one_time_key = one_time_keys.values().next().unwrap();
-        bob_keys.insert(bob.device_id().to_owned(), one_time_key);
 
-        let mut one_time_keys = BTreeMap::new();
-        one_time_keys.insert(bob.user_id().to_owned(), bob_keys);
+        let one_time_keys = BTreeMap::from([(
+            (bob.user_id().to_owned(), bob.device_id().to_owned()),
+            one_time_key,
+        )]);
         alice.inner.session_manager.create_sessions(&one_time_keys).await.unwrap();
 
         (alice, bob)
@@ -2618,8 +2617,8 @@ pub(crate) mod tests {
         device_id: &DeviceId,
         one_time_key: Raw<OneTimeKey>,
     ) {
-        let keys = BTreeMap::from([(device_id.to_owned(), &one_time_key)]);
-        let one_time_keys = BTreeMap::from([(user_id.to_owned(), keys)]);
+        let one_time_keys =
+            BTreeMap::from([((user_id.to_owned(), device_id.to_owned()), &one_time_key)]);
         machine.inner.session_manager.create_sessions(&one_time_keys).await.unwrap();
     }
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -452,7 +452,10 @@ impl OlmMachine {
                 Box::pin(self.receive_keys_query_response(request_id, response)).await?;
             }
             IncomingResponse::KeysClaim(response) => {
-                Box::pin(self.inner.session_manager.receive_keys_claim_response(response)).await?;
+                Box::pin(
+                    self.inner.session_manager.receive_keys_claim_response(request_id, response),
+                )
+                .await?;
             }
             IncomingResponse::ToDevice(_) => {
                 Box::pin(self.mark_to_device_request_as_sent(request_id)).await?;

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -826,7 +826,7 @@ impl GroupSessionManager {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::BTreeSet, ops::Deref, sync::Arc};
+    use std::{collections::BTreeSet, iter, ops::Deref, sync::Arc};
 
     use matrix_sdk_test::{async_test, response_from_file};
     use ruma::{
@@ -864,6 +864,7 @@ mod tests {
         device_id!("JLAFKJWSCS")
     }
 
+    /// Returns a /keys/query response for user "@example:localhost"
     fn keys_query_response() -> get_keys::v3::Response {
         let data = include_bytes!("../../../../benchmarks/benches/crypto_bench/keys_query.json");
         let data: Value = serde_json::from_slice(data).unwrap();
@@ -903,6 +904,8 @@ mod tests {
             .expect("Can't parse the keys upload response")
     }
 
+    /// Returns a keys claim response for device `BOBDEVICE` of user
+    /// `@bob:localhost`.
     fn bob_one_time_key() -> claim_keys::v3::Response {
         let data = json!({
             "failures": {},
@@ -927,6 +930,8 @@ mod tests {
             .expect("Can't parse the keys claim response")
     }
 
+    /// Returns a key claim response for device `NMMBNBUSNR` of user
+    /// `@example2:localhost`
     fn keys_claim_response() -> claim_keys::v3::Response {
         let data = include_bytes!("../../../../benchmarks/benches/crypto_bench/keys_claim.json");
         let data: Value = serde_json::from_slice(data).unwrap();
@@ -937,14 +942,27 @@ mod tests {
 
     async fn machine_with_user_test_helper(user_id: &UserId, device_id: &DeviceId) -> OlmMachine {
         let keys_query = keys_query_response();
-        let keys_claim = keys_claim_response();
         let txn_id = TransactionId::new();
 
         let machine = OlmMachine::new(user_id, device_id).await;
 
+        // complete a /keys/query and /keys/claim for @example:localhost
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
+        let (txn_id, _keys_claim_request) = machine
+            .get_missing_sessions(iter::once(user_id!("@example:localhost")))
+            .await
+            .unwrap()
+            .unwrap();
+        let keys_claim = keys_claim_response();
         machine.mark_request_as_sent(&txn_id, &keys_claim).await.unwrap();
+
+        // complete a /keys/query and /keys/claim for @bob:localhost
         machine.mark_request_as_sent(&txn_id, &bob_keys_query_response()).await.unwrap();
+        let (txn_id, _keys_claim_request) = machine
+            .get_missing_sessions(iter::once(user_id!("@bob:localhost")))
+            .await
+            .unwrap()
+            .unwrap();
         machine.mark_request_as_sent(&txn_id, &bob_one_time_key()).await.unwrap();
 
         machine

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -393,7 +393,7 @@ impl SessionManager {
         self.failures.remove(successful_servers);
 
         // build a map of (user_id, device_id) -> key from the response
-        let sessions_to_create: BTreeMap<(OwnedUserId, OwnedDeviceId), _> = response
+        let sessions_to_create: BTreeMap<(_, _), _> = response
             .one_time_keys
             .iter()
             .flat_map(|(user_id, device_map)| {

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -866,6 +866,22 @@ mod tests {
 
     #[async_test]
     async fn failed_devices_handling() {
+        // Alice is missing altogether
+        test_invalid_claim_response(json!({
+            "one_time_keys": {},
+            "failures": {},
+        }))
+        .await;
+
+        // Alice is present but with no devices
+        test_invalid_claim_response(json!({
+            "one_time_keys": {
+                "@alice:example.org": {}
+            },
+            "failures": {},
+        }))
+        .await;
+
         // Alice's device is present but with no keys
         test_invalid_claim_response(json!({
             "one_time_keys": {

--- a/crates/matrix-sdk-crypto/src/utilities.rs
+++ b/crates/matrix-sdk-crypto/src/utilities.rs
@@ -45,6 +45,10 @@ pub struct FailuresCache<T: Eq + Hash> {
 struct FailuresItem {
     insertion_time: Instant,
     duration: Duration,
+
+    /// Number of times that this item has failed after it was first added to
+    /// the cache. (In other words, one less than the total number of
+    /// failures.)
     failure_count: u8,
 }
 
@@ -52,6 +56,15 @@ impl FailuresItem {
     /// Has the item expired.
     fn expired(&self) -> bool {
         self.insertion_time.elapsed() >= self.duration
+    }
+
+    /// Force the expiry of this item.
+    ///
+    /// This doesn't reset the failure count, but does mark the item as ready
+    /// for immediate retry.
+    #[cfg(test)]
+    fn expire(&mut self) {
+        self.duration = Duration::from_secs(0);
     }
 }
 
@@ -77,6 +90,26 @@ where
         let contains = if let Some(item) = lock.get(key) { !item.expired() } else { false };
 
         contains
+    }
+
+    /// Get the failure count for a given key.
+    ///
+    /// # Returns
+    ///
+    ///  * `None` if this key is not in the failure cache. (It has never failed,
+    ///    or it has been [`remove`]d since the last failure.)
+    ///
+    ///  * `Some(u8)`: the number of times it has failed since it was first
+    ///    added to the failure cache. (In other words, one less than the total
+    ///    number of failures.)
+    #[cfg(test)]
+    pub fn failure_count<Q>(&self, key: &Q) -> Option<u8>
+    where
+        T: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let lock = self.inner.read().unwrap();
+        lock.get(key).map(|i| i.failure_count)
     }
 
     /// This will calculate a duration that determines how long an item is
@@ -133,6 +166,16 @@ where
         for item in iterator {
             lock.remove(item);
         }
+    }
+
+    /// Force the expiry of the given item, if it is present in the cache.
+    ///
+    /// This doesn't reset the failure count, but does mark the item as ready
+    /// for immediate retry.
+    #[cfg(test)]
+    pub(crate) fn expire(&self, item: &T) {
+        let mut lock = self.inner.write().unwrap();
+        lock.get_mut(item).map(FailuresItem::expire);
     }
 }
 


### PR DESCRIPTION
Keep a record of devices that were included in a `/keys/claim` request, and then, if they are missing in the response, register them as "failed".

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/281.

~~This PR is currently based on https://github.com/matrix-org/matrix-rust-sdk/pull/2803.~~