### PR TITLE
Add `perParticipantE2EE` to element call url.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -119,7 +119,7 @@ pub enum EncryptionSystem {
     /// equivalent to the element call url parameter: `enableE2EE=false`
     Unencrypted,
     /// equivalent to the element call url parameters: `enableE2EE=true&perParticipantE2EE=true`
-    PerSenderKeys,
+    PerParticipantKeys,
     /// equivalent to the element call url parameters: `enableE2EE=true&password={secret}`
     SharedSecret {
         /// The secret/password which is used in the url.
@@ -131,7 +131,7 @@ impl From<EncryptionSystem> for matrix_sdk::widget::EncryptionSystem {
     fn from(value: EncryptionSystem) -> Self {
         match value {
             EncryptionSystem::Unencrypted => Self::Unencrypted,
-            EncryptionSystem::PerSenderKeys => Self::PerParticipantKeys,
+            EncryptionSystem::PerParticipantKeys => Self::PerParticipantKeys,
             EncryptionSystem::SharedSecret { secret } => Self::SharedSecret { secret },
         }
     }

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -179,8 +179,9 @@ pub struct VirtualElementCallWidgetOptions {
     /// If `per_participant_e2ee` is enabled,
     /// this will use matrix to exchange keys.
     /// Otherwise a password in the url is expected.
-    /// (A password should only be used for sharable links and not in embedded mode.
-    /// Passwords are planned to get deprecated and are not supported in the rust sdk.)
+    /// (A password should only be used for sharable links and not in embedded
+    /// mode. Passwords are planned to get deprecated and are not supported
+    /// in the rust sdk.)
     ///
     /// Default: `true`
     pub enable_e2ee: Option<bool>,

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -113,14 +113,17 @@ pub async fn generate_webview_url(
 
 /// Defines if a call is encrypted and which encryption system should be used.
 ///
-/// This controls the url parameters: `enableE2EE`, `perParticipantE2EE`, `password`.
+/// This controls the url parameters: `enableE2EE`, `perParticipantE2EE`,
+/// `password`.
 #[derive(uniffi::Enum, Clone)]
 pub enum EncryptionSystem {
-    /// equivalent to the element call url parameter: `enableE2EE=false`
+    /// Equivalent to the element call url parameter: `enableE2EE=false`
     Unencrypted,
-    /// equivalent to the element call url parameters: `enableE2EE=true&perParticipantE2EE=true`
+    /// Equivalent to the element call url parameters:
+    /// `enableE2EE=true&perParticipantE2EE=true`
     PerParticipantKeys,
-    /// equivalent to the element call url parameters: `enableE2EE=true&password={secret}`
+    /// Equivalent to the element call url parameters:
+    /// `enableE2EE=true&password={secret}`
     SharedSecret {
         /// The secret/password which is used in the url.
         secret: String,

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -174,6 +174,21 @@ pub struct VirtualElementCallWidgetOptions {
 
     /// Can be used to pass a PostHog id to element call.
     pub analytics_id: Option<String>,
+
+    /// Whether to use e2ee.
+    /// If `per_participant_e2ee` is enabled,
+    /// this will use matrix to exchange keys.
+    /// Otherwise a password in the url is expected.
+    /// (A password should only be used for sharable links and not in embedded mode.
+    /// Passwords are planned to get deprecated and are not supported in the rust sdk.)
+    ///
+    /// Default: `true`
+    pub enable_e2ee: Option<bool>,
+
+    /// Use matrix to exchange per participant keys.
+    ///
+    /// Default: `true`
+    pub per_participant_e2ee: Option<bool>,
 }
 
 impl From<VirtualElementCallWidgetOptions> for matrix_sdk::widget::VirtualElementCallWidgetOptions {
@@ -190,6 +205,8 @@ impl From<VirtualElementCallWidgetOptions> for matrix_sdk::widget::VirtualElemen
             confine_to_room: value.confine_to_room,
             font: value.font,
             analytics_id: value.analytics_id,
+            enable_e2ee: value.enable_e2ee,
+            per_participant_e2ee: value.per_participant_e2ee,
         }
     }
 }

--- a/crates/matrix-sdk/src/widget/mod.rs
+++ b/crates/matrix-sdk/src/widget/mod.rs
@@ -39,7 +39,9 @@ mod settings;
 pub use self::{
     capabilities::{Capabilities, CapabilitiesProvider},
     filter::{EventFilter, MessageLikeEventFilter, StateEventFilter},
-    settings::{ClientProperties, VirtualElementCallWidgetOptions, WidgetSettings},
+    settings::{
+        ClientProperties, EncryptionSystem, VirtualElementCallWidgetOptions, WidgetSettings,
+    },
 };
 
 /// An object that handles all interactions of a widget living inside a webview

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -115,11 +115,17 @@ pub struct VirtualElementCallWidgetOptions {
 
     /// Can be used to pass a PostHog id to element call.
     pub analytics_id: Option<String>,
-    /// Whether to use e2ee. If `per_participant_e2ee` is enabled,
+
+    /// Whether to use e2ee.
+    /// If `per_participant_e2ee` is enabled,
     /// this will use matrix to exchange keys.
+    /// Otherwise a password in the url is expected.
+    /// (A password should only be used for sharable links and not in embedded mode.
+    /// Passwords are planned to get deprecated and are not supported in the rust sdk.)
     ///
     /// Default: `true`
     pub enable_e2ee: Option<bool>,
+
     /// Use matrix to exchange per participant keys.
     ///
     /// Default: `true`

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -120,8 +120,9 @@ pub struct VirtualElementCallWidgetOptions {
     /// If `per_participant_e2ee` is enabled,
     /// this will use matrix to exchange keys.
     /// Otherwise a password in the url is expected.
-    /// (A password should only be used for sharable links and not in embedded mode.
-    /// Passwords are planned to get deprecated and are not supported in the rust sdk.)
+    /// (A password should only be used for sharable links and not in embedded
+    /// mode. Passwords are planned to get deprecated and are not supported
+    /// in the rust sdk.)
     ///
     /// Default: `true`
     pub enable_e2ee: Option<bool>,

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -55,14 +55,17 @@ struct ElementCallParams {
 
 /// Defines if a call is encrypted and which encryption system should be used.
 ///
-/// This controls the url parameters: `enableE2EE`, `perParticipantE2EE`, `password`.
+/// This controls the url parameters: `enableE2EE`, `perParticipantE2EE`,
+/// `password`.
 #[derive(Debug, PartialEq)]
 pub enum EncryptionSystem {
-    /// equivalent to the element call url parameter: `enableE2EE=false`
+    /// Equivalent to the element call url parameter: `enableE2EE=false`
     Unencrypted,
-    /// equivalent to the element call url parameters: `enableE2EE=true&perParticipantE2EE=true`
+    /// Equivalent to the element call url parameters:
+    /// `enableE2EE=true&perParticipantE2EE=true`
     PerParticipantKeys,
-    /// equivalent to the element call url parameters: `enableE2EE=true&password={secret}`
+    /// Equivalent to the element call url parameters:
+    /// `enableE2EE=true&password={secret}`
     SharedSecret {
         /// The secret/password which is used in the url.
         secret: String,
@@ -299,7 +302,7 @@ mod tests {
         assert_eq!(get_widget_settings(None).widget_id(), WIDGET_ID);
     }
 
-    fn setting_to_example_url(settings: WidgetSettings) -> String {
+    fn build_url_from_widget_settings(settings: WidgetSettings) -> String {
         settings
             ._generate_webview_url(
                 get_profile::v3::Response::new(Some("some-url".into()), Some("hello".into())),
@@ -338,7 +341,7 @@ mod tests {
                 &perParticipantE2EE=true\
         ";
 
-        let gen = setting_to_example_url(get_widget_settings(None));
+        let gen = build_url_from_widget_settings(get_widget_settings(None));
 
         let mut url = Url::parse(&gen).unwrap();
         let mut gen = Url::parse(CONVERTED_URL).unwrap();
@@ -354,7 +357,7 @@ mod tests {
     fn password_url_props_from_widget_settings() {
         {
             // PerParticipantKeys
-            let url = setting_to_example_url(get_widget_settings(Some(
+            let url = build_url_from_widget_settings(get_widget_settings(Some(
                 EncryptionSystem::PerParticipantKeys,
             )));
             let query_set = get_query_sets(&Url::parse(&url).unwrap()).unwrap().1;
@@ -373,8 +376,9 @@ mod tests {
         }
         {
             // Unencrypted
-            let url =
-                setting_to_example_url(get_widget_settings(Some(EncryptionSystem::Unencrypted)));
+            let url = build_url_from_widget_settings(get_widget_settings(Some(
+                EncryptionSystem::Unencrypted,
+            )));
             let query_set = get_query_sets(&Url::parse(&url).unwrap()).unwrap().1;
             let expected_elements = ("enableE2EE".to_owned(), "false".to_owned());
             assert!(
@@ -386,10 +390,9 @@ mod tests {
         }
         {
             // SharedSecret
-            let url =
-                setting_to_example_url(get_widget_settings(Some(EncryptionSystem::SharedSecret {
-                    secret: "this_surely_is_save".to_owned(),
-                })));
+            let url = build_url_from_widget_settings(get_widget_settings(Some(
+                EncryptionSystem::SharedSecret { secret: "this_surely_is_save".to_owned() },
+            )));
             let query_set = get_query_sets(&Url::parse(&url).unwrap()).unwrap().1;
             let expected_elements = [
                 ("password".to_owned(), "this_surely_is_save".to_owned()),

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -46,6 +46,10 @@ struct ElementCallParams {
     analytics_id: Option<String>,
     font_scale: Option<f64>,
     font: Option<String>,
+    #[serde(rename = "enableE2EE")]
+    enable_e2ee: bool,
+    #[serde(rename = "perParticipantE2EE")]
+    per_participant_e2ee: bool,
 }
 
 /// Properties to create a new virtual Element Call widget.
@@ -111,6 +115,15 @@ pub struct VirtualElementCallWidgetOptions {
 
     /// Can be used to pass a PostHog id to element call.
     pub analytics_id: Option<String>,
+    /// Whether to use e2ee. If `per_participant_e2ee` is enabled,
+    /// this will use matrix to exchange keys.
+    ///
+    /// Default: `true`
+    pub enable_e2ee: Option<bool>,
+    /// Use matrix to exchange per participant keys.
+    ///
+    /// Default: `true`
+    pub per_participant_e2ee: Option<bool>,
 }
 
 impl WidgetSettings {
@@ -152,6 +165,8 @@ impl WidgetSettings {
             analytics_id: props.analytics_id,
             font_scale: props.font_scale,
             font: props.font,
+            enable_e2ee: props.enable_e2ee.unwrap_or(true),
+            per_participant_e2ee: props.per_participant_e2ee.unwrap_or(true),
         };
 
         let query =
@@ -194,6 +209,8 @@ mod tests {
             confine_to_room: Some(true),
             font: None,
             analytics_id: None,
+            enable_e2ee: None,
+            per_participant_e2ee: None,
         })
         .expect("could not parse virtual element call widget")
     }
@@ -247,6 +264,8 @@ mod tests {
                 &appPrompt=true\
                 &hideHeader=true\
                 &preload=true\
+                &enableE2EE=true\
+                &perParticipantE2EE=true\
         ";
 
         let mut url = get_widget_settings().raw_url().clone();
@@ -281,6 +300,8 @@ mod tests {
                 &displayName=hello\
                 &appPrompt=true\
                 &clientId=io.my_matrix.client\
+                &enableE2EE=true\
+                &perParticipantE2EE=true\
         ";
 
         let gen = get_widget_settings()

--- a/crates/matrix-sdk/src/widget/settings/mod.rs
+++ b/crates/matrix-sdk/src/widget/settings/mod.rs
@@ -21,7 +21,7 @@ use crate::Room;
 mod element_call;
 mod url_params;
 
-pub use self::element_call::VirtualElementCallWidgetOptions;
+pub use self::element_call::{EncryptionSystem, VirtualElementCallWidgetOptions};
 
 /// Settings of the widget.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
For e2ee to be enabled we need to allow the mobile clients to set a url flag. This PR adds the flag and creates the FFI for it.

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
