### PR TITLE
Reduce async fn stack size

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -620,7 +620,10 @@ impl BaseClient {
     /// decrypted event if we found one, along with its index in the
     /// latest_encrypted_events list, or None if we didn't find one.
     #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
-    async fn decrypt_latest_suitable_event(&self, room: &Room) -> Option<(LatestEvent, usize)> {
+    async fn decrypt_latest_suitable_event(
+        &self,
+        room: &Room,
+    ) -> Option<(Box<LatestEvent>, usize)> {
         let enc_events = room.latest_encrypted_events();
 
         // Walk backwards through the encrypted events, looking for one we can decrypt
@@ -633,7 +636,7 @@ impl BaseClient {
                         is_suitable_for_latest_event(&any_sync_event)
                     {
                         // The event is the right type for us to use as latest_event
-                        return Some((LatestEvent::new(decrypted), i));
+                        return Some((Box::new(LatestEvent::new(decrypted)), i));
                     }
                 }
             }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -524,11 +524,11 @@ async fn cache_latest_events(
                         }
                     }
 
-                    let latest_event = LatestEvent::new_with_sender_details(
+                    let latest_event = Box::new(LatestEvent::new_with_sender_details(
                         event.clone(),
                         sender_profile,
                         sender_name_is_ambiguous,
-                    );
+                    ));
 
                     // Store it in the return RoomInfo, and in the Room, to make sure they are
                     // consistent

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -117,7 +117,7 @@ impl RoomInfoV1 {
             sync_info,
             encryption_state_synced,
             #[cfg(feature = "experimental-sliding-sync")]
-            latest_event: latest_event.map(LatestEvent::new),
+            latest_event: latest_event.map(|ev| Box::new(LatestEvent::new(ev))),
             base_info: base_info.migrate(create),
         }
     }
@@ -157,7 +157,10 @@ struct BaseRoomInfoV1 {
 
 impl BaseRoomInfoV1 {
     /// Migrate this to a [`BaseRoomInfo`].
-    fn migrate(self, create: Option<&SyncOrStrippedState<RoomCreateEventContent>>) -> BaseRoomInfo {
+    fn migrate(
+        self,
+        create: Option<&SyncOrStrippedState<RoomCreateEventContent>>,
+    ) -> Box<BaseRoomInfo> {
         let BaseRoomInfoV1 {
             avatar,
             canonical_alias,
@@ -186,7 +189,7 @@ impl BaseRoomInfoV1 {
             MinimalStateEvent::Redacted(ev) => MinimalStateEvent::Redacted(ev),
         });
 
-        BaseRoomInfo {
+        Box::new(BaseRoomInfo {
             avatar,
             canonical_alias,
             create,
@@ -200,7 +203,7 @@ impl BaseRoomInfoV1 {
             tombstone,
             topic,
             rtc_member: BTreeMap::new(),
-        }
+        })
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -754,7 +754,10 @@ impl GossipMachine {
     ) -> Result<bool, CryptoStoreError> {
         if let Some(info) = event.room_key_info(room_id).map(|i| i.into()) {
             if self.should_request_key(&info).await? {
-                self.request_key_helper(info).await?;
+                // Size of the request_key_helper future should not impact this
+                // async fn since it is likely enough that this branch won't be
+                // entered.
+                Box::pin(self.request_key_helper(info)).await?;
                 return Ok(true);
             }
         }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -446,19 +446,19 @@ impl OlmMachine {
     ) -> OlmResult<()> {
         match response.into() {
             IncomingResponse::KeysUpload(response) => {
-                self.receive_keys_upload_response(response).await?;
+                Box::pin(self.receive_keys_upload_response(response)).await?;
             }
             IncomingResponse::KeysQuery(response) => {
-                self.receive_keys_query_response(request_id, response).await?;
+                Box::pin(self.receive_keys_query_response(request_id, response)).await?;
             }
             IncomingResponse::KeysClaim(response) => {
-                self.inner.session_manager.receive_keys_claim_response(response).await?;
+                Box::pin(self.inner.session_manager.receive_keys_claim_response(response)).await?;
             }
             IncomingResponse::ToDevice(_) => {
-                self.mark_to_device_request_as_sent(request_id).await?;
+                Box::pin(self.mark_to_device_request_as_sent(request_id)).await?;
             }
             IncomingResponse::SigningKeysUpload(_) => {
-                self.receive_cross_signing_upload_response().await?;
+                Box::pin(self.receive_cross_signing_upload_response()).await?;
             }
             IncomingResponse::SignatureUpload(_) => {
                 self.inner.verification_machine.mark_request_as_sent(request_id);
@@ -468,7 +468,7 @@ impl OlmMachine {
             }
             IncomingResponse::KeysBackup(_) => {
                 #[cfg(feature = "backups_v1")]
-                self.inner.backup_machine.mark_request_as_sent(request_id).await?;
+                Box::pin(self.inner.backup_machine.mark_request_as_sent(request_id)).await?;
             }
         };
 

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -314,7 +314,7 @@ impl StaticAccountData {
 pub struct Account {
     pub(crate) static_data: StaticAccountData,
     /// `vodozemac` account.
-    inner: InnerAccount,
+    inner: Box<InnerAccount>,
     /// Is this account ready to encrypt messages? (i.e. has it shared keys with
     /// a homeserver)
     shared: bool,
@@ -397,7 +397,7 @@ impl Account {
                 identity_keys: Arc::new(identity_keys),
                 creation_local_time: MilliSecondsSinceUnixEpoch::now(),
             },
-            inner: account,
+            inner: Box::new(account),
             shared: false,
             uploaded_signed_key_count: 0,
         }
@@ -644,7 +644,7 @@ impl Account {
                 identity_keys: Arc::new(identity_keys),
                 creation_local_time: pickle.creation_local_time,
             },
-            inner: account,
+            inner: Box::new(account),
             shared: pickle.shared,
             uploaded_signed_key_count: pickle.uploaded_signed_key_count,
         })

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -238,7 +238,7 @@ impl SessionManager {
         // Add the list of devices that the user wishes to establish sessions
         // right now.
         for user_id in users.filter(|u| !self.failures.contains(u.server_name())) {
-            let user_devices = self.get_user_devices(user_id).await?;
+            let user_devices = Box::pin(self.get_user_devices(user_id)).await?;
 
             for (device_id, device) in user_devices {
                 if !(device.supports_olm()) {

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -741,7 +741,7 @@ impl Oidc {
             // hash. Otherwise, we save our hash into the database.
 
             if guard.hash_mismatch {
-                self.handle_session_hash_mismatch(&mut guard)
+                Box::pin(self.handle_session_hash_mismatch(&mut guard))
                     .await
                     .map_err(|err| crate::Error::Oidc(err.into()))?;
             } else {
@@ -1175,7 +1175,7 @@ impl Oidc {
                 };
 
                 if cross_process_guard.hash_mismatch {
-                    self.handle_session_hash_mismatch(&mut cross_process_guard)
+                    Box::pin(self.handle_session_hash_mismatch(&mut cross_process_guard))
                         .await
                         .map_err(|err| RefreshTokenError::Oidc(Arc::new(err.into())))?;
                     // Optimistic exit: assume that the underlying process did update fast enough.


### PR DESCRIPTION
(by a few kilobytes for some functions)

This is not just segmenting the stack but also reducing the overall allocation size in some cases when it's not the code path with the highest stack requirement that is taken.