### PR TITLE
ui: Update back-pagination token even if chunk is empty or event fails to deserialize

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -1112,7 +1112,7 @@ pub trait BackPaginationStatusListener: Sync + Send {
 
 #[derive(uniffi::Enum)]
 pub enum PaginationOptions {
-    SingleRequest { event_limit: u16, wait_for_token: bool },
+    SimpleRequest { event_limit: u16, wait_for_token: bool },
     UntilNumItems { event_limit: u16, items: u16, wait_for_token: bool },
 }
 
@@ -1120,8 +1120,8 @@ impl From<PaginationOptions> for matrix_sdk_ui::timeline::PaginationOptions<'sta
     fn from(value: PaginationOptions) -> Self {
         use matrix_sdk_ui::timeline::PaginationOptions as Opts;
         let (wait_for_token, mut opts) = match value {
-            PaginationOptions::SingleRequest { event_limit, wait_for_token } => {
-                (wait_for_token, Opts::single_request(event_limit))
+            PaginationOptions::SimpleRequest { event_limit, wait_for_token } => {
+                (wait_for_token, Opts::simple_request(event_limit))
             }
             PaginationOptions::UntilNumItems { event_limit, items, wait_for_token } => {
                 (wait_for_token, Opts::until_num_items(event_limit, items))

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -1010,6 +1010,7 @@ impl TimelineInner {
 pub(super) struct HandleManyEventsResult {
     pub items_added: u16,
     pub items_updated: u16,
+    pub back_pagination_token_updated: bool,
 }
 
 #[derive(Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -611,9 +611,11 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         pagination_tokens: PaginationTokens,
     ) -> Result<HandleManyEventsResult, HandleBackPaginatedEventsError> {
         let mut state = self.state.write().await;
-        if let Some(token) = pagination_tokens.from {
-            if state.back_pagination_token() != Some(&token) {
-                return Err(HandleBackPaginatedEventsError::TokenMismatch);
+        if pagination_tokens.check_from {
+            if let Some(token) = pagination_tokens.from {
+                if state.back_pagination_token() != Some(&token) {
+                    return Err(HandleBackPaginatedEventsError::TokenMismatch);
+                }
             }
         }
 
@@ -1006,7 +1008,7 @@ impl TimelineInner {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(super) struct HandleManyEventsResult {
     pub items_added: u16,
     pub items_updated: u16,
@@ -1014,7 +1016,7 @@ pub(super) struct HandleManyEventsResult {
 }
 
 #[derive(Debug)]
-pub(super) enum HandleBackPaginatedEventsError {
+pub(in crate::timeline) enum HandleBackPaginatedEventsError {
     /// The `from` token is not equal to the first event item's back-pagination
     /// token.
     ///

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -50,6 +50,7 @@ use ruma::{
 use super::{
     event_item::EventItemIdentifier,
     inner::{ReactionAction, TimelineInnerSettings},
+    pagination::PaginationTokens,
     reactions::ReactionToggleResult,
     traits::RoomDataProvider,
     EventTimelineItem, Profile, TimelineInner, TimelineItem,
@@ -62,6 +63,7 @@ mod edit;
 mod encryption;
 mod event_filter;
 mod invalid;
+mod pagination;
 mod polls;
 mod reaction_group;
 mod reactions;
@@ -236,6 +238,14 @@ impl TestTimeline {
             .handle_back_paginated_events(vec![timeline_event], Default::default())
             .await
             .unwrap();
+    }
+
+    async fn handle_back_paginated_events(
+        &self,
+        events: Vec<TimelineEvent>,
+        pagination_tokens: PaginationTokens,
+    ) {
+        self.inner.handle_back_paginated_events(events, pagination_tokens).await.unwrap();
     }
 
     async fn handle_read_receipts(

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -50,7 +50,6 @@ use ruma::{
 use super::{
     event_item::EventItemIdentifier,
     inner::{ReactionAction, TimelineInnerSettings},
-    pagination::PaginationTokens,
     reactions::ReactionToggleResult,
     traits::RoomDataProvider,
     EventTimelineItem, Profile, TimelineInner, TimelineItem,
@@ -238,14 +237,6 @@ impl TestTimeline {
             .handle_back_paginated_events(vec![timeline_event], Default::default())
             .await
             .unwrap();
-    }
-
-    async fn handle_back_paginated_events(
-        &self,
-        events: Vec<TimelineEvent>,
-        pagination_tokens: PaginationTokens,
-    ) {
-        self.inner.handle_back_paginated_events(events, pagination_tokens).await.unwrap();
     }
 
     async fn handle_read_receipts(

--- a/crates/matrix-sdk-ui/src/timeline/tests/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/pagination.rs
@@ -1,0 +1,62 @@
+// Copyright 2023 Kévin Commaille
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk_base::deserialized_responses::TimelineEvent;
+use matrix_sdk_test::async_test;
+use ruma::serde::Raw;
+use serde_json::json;
+
+use super::TestTimeline;
+use crate::timeline::pagination::PaginationTokens;
+
+#[async_test]
+async fn empty_chunk() {
+    let timeline = TestTimeline::new();
+
+    timeline
+        .handle_back_paginated_events(
+            vec![],
+            PaginationTokens { from: None, to: Some("a".to_owned()) },
+        )
+        .await;
+
+    timeline
+        .handle_back_paginated_events(
+            vec![],
+            PaginationTokens { from: Some("a".to_owned()), to: Some("b".to_owned()) },
+        )
+        .await;
+}
+
+#[async_test]
+async fn invalid_event() {
+    let timeline = TestTimeline::new();
+
+    // Invalid empty event.
+    let raw = Raw::new(&json!({})).unwrap();
+
+    timeline
+        .handle_back_paginated_events(
+            vec![TimelineEvent::new(raw.cast())],
+            PaginationTokens { from: None, to: Some("a".to_owned()) },
+        )
+        .await;
+
+    timeline
+        .handle_back_paginated_events(
+            vec![],
+            PaginationTokens { from: Some("a".to_owned()), to: Some("b".to_owned()) },
+        )
+        .await;
+}


### PR DESCRIPTION
Otherwise back-pagination goes in a loop because the token is never updated.

A Fractal user reported that they had the same message about an event failing to deserialize in a loop in the logs, and Fractal was using 30% CPU continuously. In their case, they received an empty chunk (which is valid according to the spec) which was causing the back-pagination to reset in a loop.

Added 2 tests that fail on `main` for the cases where that could happen.
