### PR TITLE
Enable backups in the crypto crate by default

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -46,7 +46,7 @@ version = "0.6.0"
 path = "../../crates/matrix-sdk-crypto"
 version = "0.6.0"
 default_features = false
-features = ["qrcode", "backups_v1", "automatic-room-key-forwarding"]
+features = ["qrcode", "automatic-room-key-forwarding"]
 
 [dependencies.matrix-sdk-sqlite]
 path = "../../crates/matrix-sdk-sqlite"

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,7 @@
 # unreleased
 
+- Remove the `backups_v1` feature, backups support is now enabled by default.
+
 - Use the `Signatures` type as the return value for the
   `MegolmV1BackupKey::signatures()` method.
 

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -19,7 +19,6 @@ default = []
 automatic-room-key-forwarding = []
 js = ["ruma/js", "vodozemac/js"]
 qrcode = ["dep:matrix-sdk-qrcode"]
-backups_v1 = ["dep:cbc"]
 message-ids = ["dep:ulid"]
 experimental-algorithms = []
 
@@ -32,7 +31,7 @@ as_variant = { workspace = true }
 async-trait = { workspace = true }
 bs58 = { version = "0.5.0" }
 byteorder = { workspace = true }
-cbc = { version = "0.1.2", features = ["std"], optional = true }
+cbc = { version = "0.1.2", features = ["std"] }
 cfg-if = "1.0"
 ctr = "0.9.1"
 eyeball = { workspace = true }

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -790,8 +790,7 @@ mod tests {
             BTreeMap::from([(session_id.to_owned(), room_key)]),
         )]);
 
-        let session =
-            machine.store().get_inbound_group_session(room_id, &session_id).await.unwrap();
+        let session = machine.store().get_inbound_group_session(room_id, session_id).await.unwrap();
 
         assert!(session.is_none(), "Initially we should not have the session in the store");
 
@@ -800,8 +799,7 @@ mod tests {
             .await
             .expect("We should be able to import a room key");
 
-        let session =
-            machine.store().get_inbound_group_session(room_id, &session_id).await.unwrap();
+        let session = machine.store().get_inbound_group_session(room_id, session_id).await.unwrap();
 
         assert_let!(Some(session) = session);
         assert!(

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1103,12 +1103,12 @@ mod tests {
         identities::{IdentityManager, LocalTrust, ReadOnlyDevice},
         olm::{Account, PrivateCrossSigningIdentity},
         session_manager::GroupSessionCache,
-        store::{CryptoStoreWrapper, MemoryStore, PendingChanges, Store},
-        types::events::room::encrypted::{EncryptedEvent, RoomEncryptedEventContent},
+        store::{Changes, CryptoStoreWrapper, MemoryStore, PendingChanges, Store},
+        types::events::room::encrypted::{
+            EncryptedEvent, EncryptedToDeviceEvent, RoomEncryptedEventContent,
+        },
         verification::VerificationMachine,
     };
-    #[cfg(any(feature = "automatic-room-key-forwarding", feature = "backups_v1"))]
-    use crate::{store::Changes, types::events::room::encrypted::EncryptedToDeviceEvent};
 
     fn alice_id() -> &'static UserId {
         user_id!("@alice:example.org")
@@ -1278,7 +1278,6 @@ mod tests {
         (alice_machine, group_session, bob_machine)
     }
 
-    #[cfg(any(feature = "automatic-room-key-forwarding", feature = "backups_v1"))]
     fn extract_content<'a>(
         recipient: &UserId,
         request: &'a crate::OutgoingRequest,
@@ -1311,7 +1310,6 @@ mod tests {
         }
     }
 
-    #[cfg(any(feature = "automatic-room-key-forwarding", feature = "backups_v1"))]
     fn request_to_event<C>(
         recipient: &UserId,
         sender: &UserId,
@@ -1871,7 +1869,6 @@ mod tests {
     }
 
     #[async_test]
-    #[cfg(feature = "backups_v1")]
     async fn test_secret_broadcasting() {
         use futures_util::{pin_mut, FutureExt};
         use ruma::api::client::to_device::send_event_to_device::v3::Response as ToDeviceResponse;

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -825,7 +825,6 @@ impl ReadOnlyDevice {
     /// **Note**: Use this method with caution, the `canonical_json` needs to be
     /// correctly canonicalized and make sure that the object you are checking
     /// the signature for is allowed to be signed by a device.
-    #[cfg(feature = "backups_v1")]
     pub(crate) fn has_signed_raw(
         &self,
         signatures: &Signatures,

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -16,7 +16,6 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, missing_debug_implementations)]
 
-#[cfg(feature = "backups_v1")]
 pub mod backups;
 mod ciphers;
 pub mod dehydrated_devices;

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -245,7 +245,6 @@ impl StaticAccountData {
     /// **Note**: Use this method with caution, the `canonical_json` needs to be
     /// correctly canonicalized and make sure that the object you are checking
     /// the signature for is allowed to be signed by our own device.
-    #[cfg(any(test, feature = "backups_v1"))]
     pub fn has_signed_raw(
         &self,
         signatures: &crate::types::Signatures,

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -398,7 +398,6 @@ impl InboundGroupSession {
 
     /// Export the inbound group session into a format that can be uploaded to
     /// the server as a backup.
-    #[cfg(feature = "backups_v1")]
     pub async fn to_backup(&self) -> BackedUpRoomKey {
         self.export().await.into()
     }

--- a/crates/matrix-sdk-crypto/src/olm/utility.rs
+++ b/crates/matrix-sdk-crypto/src/olm/utility.rs
@@ -192,7 +192,6 @@ impl SignedJsonObject for CrossSigningKey {
     }
 }
 
-#[cfg(feature = "backups_v1")]
 impl SignedJsonObject for crate::types::MegolmV1AuthData {
     fn signatures(&self) -> &Signatures {
         &self.signatures

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/master.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/master.rs
@@ -80,7 +80,6 @@ impl MasterPubkey {
     /// **Note**: Use this method with caution, the `canonical_json` needs to be
     /// correctly canonicalized and make sure that the object you are checking
     /// the signature for is allowed to be signed by a master key.
-    #[cfg(any(feature = "backups_v1", test))]
     pub(crate) fn has_signed_raw(
         &self,
         signatures: &Signatures,

--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -609,10 +609,8 @@ impl IdentitiesBeingVerified {
     }
 
     async fn request_missing_secrets(&self) -> Result<Vec<GossipRequest>, CryptoStoreError> {
-        #[allow(unused_mut)]
         let mut secrets = self.private_identity.get_missing_secrets().await;
 
-        #[cfg(feature = "backups_v1")]
         if self.store.inner.load_backup_keys().await?.decryption_key.is_none() {
             secrets.push(ruma::events::secret::request::SecretName::RecoveryKey);
         }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -239,15 +239,10 @@ fn run_feature_tests(cmd: Option<FeatureSet>) -> Result<()> {
 }
 
 fn run_crypto_tests() -> Result<()> {
-    cmd!(
-        "rustup run stable cargo clippy -p matrix-sdk-crypto --features=backups_v1 -- -D warnings"
-    )
-    .run()?;
+    cmd!("rustup run stable cargo clippy -p matrix-sdk-crypto -- -D warnings").run()?;
     cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --no-default-features --features testing").run()?;
-    cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --features=backups_v1,testing")
-        .run()?;
-    cmd!("rustup run stable cargo test --doc -p matrix-sdk-crypto --features=backups_v1,testing")
-        .run()?;
+    cmd!("rustup run stable cargo nextest run -p matrix-sdk-crypto --features=testing").run()?;
+    cmd!("rustup run stable cargo test --doc -p matrix-sdk-crypto --features=testing").run()?;
     cmd!(
         "rustup run stable cargo clippy -p matrix-sdk-crypto --features=experimental-algorithms -- -D warnings"
     )


### PR DESCRIPTION
This PR enables backups in the crypto crate by default and removes the
`backups_v1` feature, for better or worse.

- [x] Public API changes documented in changelogs (optional)
