### PR TITLE
Use the better Signatures type in the MegolmV1BackupKey type

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/backup_recovery_key.rs
@@ -149,7 +149,22 @@ impl BackupRecoveryKey {
         let signatures: HashMap<String, HashMap<String, String>> = public_key
             .signatures()
             .into_iter()
-            .map(|(k, v)| (k.to_string(), v.into_iter().map(|(k, v)| (k.to_string(), v)).collect()))
+            .map(|(k, v)| {
+                (
+                    k.to_string(),
+                    v.into_iter()
+                        .map(|(k, v)| {
+                            (
+                                k.to_string(),
+                                match v {
+                                    Ok(s) => s.to_base64(),
+                                    Err(s) => s.source,
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
             .collect();
 
         MegolmV1BackupKey {

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,8 @@
 # unreleased
 
+- Use the `Signatures` type as the return value for the
+  `MegolmV1BackupKey::signatures()` method.
+
 - Add two new methods to import room keys,
   `OlmMachine::store()::import_exported_room_keys()` for file exports and
   `OlmMachine::backup_machine()::import_backed_up_room_keys()` for backups. The

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -22,10 +22,7 @@ use vodozemac::Curve25519PublicKey;
 use zeroize::Zeroizing;
 
 use super::{compat::PkEncryption, decryption::DecodeError};
-use crate::{
-    olm::InboundGroupSession,
-    types::{MegolmV1AuthData, RoomKeyBackupInfo, Signatures},
-};
+use crate::{olm::InboundGroupSession, types::Signatures};
 
 #[derive(Debug)]
 struct InnerBackupKey {

--- a/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
+++ b/crates/matrix-sdk-crypto/src/backups/keys/backup.rs
@@ -12,26 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::BTreeMap,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use ruma::{
     api::client::backup::{EncryptedSessionDataInit, KeyBackupData, KeyBackupDataInit},
     serde::Base64,
-    OwnedDeviceKeyId, OwnedUserId,
 };
 use vodozemac::Curve25519PublicKey;
 use zeroize::Zeroizing;
 
 use super::{compat::PkEncryption, decryption::DecodeError};
-use crate::olm::InboundGroupSession;
+use crate::{
+    olm::InboundGroupSession,
+    types::{MegolmV1AuthData, RoomKeyBackupInfo, Signatures},
+};
 
 #[derive(Debug)]
 struct InnerBackupKey {
     key: Curve25519PublicKey,
-    signatures: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>,
+    signatures: Signatures,
     version: Mutex<Option<String>>,
 }
 
@@ -70,7 +69,7 @@ impl MegolmV1BackupKey {
     }
 
     /// Get all the signatures of this `MegolmV1BackupKey`.
-    pub fn signatures(&self) -> BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>> {
+    pub fn signatures(&self) -> Signatures {
         self.inner.signatures.to_owned()
     }
 


### PR DESCRIPTION
This type was added some time ago, but we didn't switch the backups support
towards it.

The serialized format remains the same, but we're offering some stronger typing
on the Rust side.

- [x] Public API changes documented in changelogs (optional)
