### PR TITLE
fix(ffi): don't leak Client instances

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -687,10 +687,10 @@ impl Client {
     }
 
     pub fn notification_client(
-        &self,
+        self: Arc<Self>,
         process_setup: NotificationProcessSetup,
     ) -> Result<Arc<NotificationClientBuilder>, ClientError> {
-        NotificationClientBuilder::new(self.inner.clone(), process_setup.into())
+        NotificationClientBuilder::new(self.clone(), process_setup.into())
     }
 
     pub fn sync_service(&self) -> Arc<SyncServiceBuilder> {

--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -7,7 +7,9 @@ use matrix_sdk_ui::notification_client::{
 };
 use ruma::{EventId, RoomId};
 
-use crate::{error::ClientError, event::TimelineEvent, helpers::unwrap_or_clone_arc, RUNTIME};
+use crate::{
+    client::Client, error::ClientError, event::TimelineEvent, helpers::unwrap_or_clone_arc, RUNTIME,
+};
 
 #[derive(uniffi::Enum)]
 pub enum NotificationEvent {
@@ -76,17 +78,19 @@ impl NotificationItem {
 
 #[derive(Clone, uniffi::Object)]
 pub struct NotificationClientBuilder {
+    client: Arc<Client>,
     builder: MatrixNotificationClientBuilder,
 }
 
 impl NotificationClientBuilder {
     pub(crate) fn new(
-        client: matrix_sdk::Client,
+        client: Arc<Client>,
         process_setup: NotificationProcessSetup,
     ) -> Result<Arc<Self>, ClientError> {
-        let builder = RUNTIME
-            .block_on(async { MatrixNotificationClient::builder(client, process_setup).await })?;
-        Ok(Arc::new(Self { builder }))
+        let builder = RUNTIME.block_on(async {
+            MatrixNotificationClient::builder(client.inner.clone(), process_setup).await
+        })?;
+        Ok(Arc::new(Self { builder, client }))
     }
 }
 
@@ -97,18 +101,25 @@ impl NotificationClientBuilder {
     pub fn filter_by_push_rules(self: Arc<Self>) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
         let builder = this.builder.filter_by_push_rules();
-        Arc::new(Self { builder })
+        Arc::new(Self { builder, client: this.client })
     }
 
     pub fn finish(self: Arc<Self>) -> Arc<NotificationClient> {
         let this = unwrap_or_clone_arc(self);
-        Arc::new(NotificationClient { inner: this.builder.build() })
+        Arc::new(NotificationClient { inner: this.builder.build(), _client: this.client })
     }
 }
 
 #[derive(uniffi::Object)]
 pub struct NotificationClient {
     inner: MatrixNotificationClient,
+
+    /// A reference to the FFI client.
+    ///
+    /// Note: we do this to make it so that the FFI `NotificationClient` keeps
+    /// the FFI `Client` and thus the SDK `Client` alive. Otherwise, we
+    /// would need to repeat the hack done in the FFI `Client::drop` method.
+    _client: Arc<Client>,
 }
 
 #[uniffi::export]


### PR DESCRIPTION
A detached task was spawned to react upon session changes, and that task captured a clone of the current `Client`. This caused a leak of the `Client`, because that task would never get aborted, and would not stop by itself. The fix here consists in having `Client::set_delegate` return a task handle that needs to be stashed by the FFI users, and cancelled when the Client gets out of scope. This fixes the leak, by removing the last reference onto the Client.

Then, when dropping the Client, we have to drop the Stores in it. These stores may be sqlite-based stores, which make use of deadpool. Deadpool has a sync wrapper that will call `block_on` in a `drop` method, and as such it requires to be in the scope of a tokio runtime to run properly. To avoid breaking all abstractions and giving access to the inners of the `Client`, the hack used here to properly be in a runtime when dropping the stores is to replace the inner sdk `Client` in the FFI `Client::drop` method (and replace it with a dummy client that is minimally configured and will use in-memory stores).