### PR TITLE
oidc: use hex logging for the hashed oidc tokens

### DIFF
--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -1062,7 +1062,7 @@ impl Oidc {
         let metadata = data.metadata.clone();
 
         spawn(async move {
-            tracing::trace!(
+            trace!(
                 "Token refresh: attempting to refresh with refresh_token {:x}",
                 hash_str(&refresh_token)
             );

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -1063,7 +1063,7 @@ impl Oidc {
 
         spawn(async move {
             tracing::trace!(
-                "Token refresh: attempting to refresh with refresh_token {:?}",
+                "Token refresh: attempting to refresh with refresh_token {:x}",
                 hash_str(&refresh_token)
             );
 
@@ -1081,8 +1081,12 @@ impl Oidc {
             {
                 Ok(new_tokens) => {
                     trace!(
-                        "Token refresh: new refresh_token: {:?} / access_token: {:?}",
-                        new_tokens.refresh_token.as_deref().map(hash_str),
+                        "Token refresh: new refresh_token: {} / access_token: {:x}",
+                        new_tokens
+                            .refresh_token
+                            .as_deref()
+                            .map(|token| format!("{:x}", hash_str(token)))
+                            .unwrap_or_else(|| "<none>".to_owned()),
                         hash_str(&new_tokens.access_token)
                     );
 
@@ -1474,6 +1478,6 @@ fn rng() -> Result<StdRng, OidcError> {
     StdRng::from_rng(rand::thread_rng()).map_err(OidcError::Rand)
 }
 
-fn hash_str(x: &str) -> impl std::fmt::Debug {
+fn hash_str(x: &str) -> impl std::fmt::LowerHex {
     sha2::Sha256::new().chain_update(x).finalize()
 }


### PR DESCRIPTION
Changes the logging of the return value of the Sha2 types to use `LowerHex` logging, instead of `Debug`. Turns out that the type returned by the hashing was an array of bytes of some sort.