### PR TITLE
sdk: Enable indexeddb in docsrs feature

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -57,7 +57,7 @@ experimental-sliding-sync = [
 ]
 experimental-widgets = ["dep:language-tags", "dep:uuid"]
 
-docsrs = ["e2e-encryption", "sqlite", "sso-login", "qrcode", "image-proc"]
+docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "image-proc"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }


### PR DESCRIPTION
… so `ClientBuilder::indexeddb_store` is visible on docs.rs.

I think this wasn't initially possible because the `matrix-sdk-indexeddb` crate only compiled on wasm. It has long been compiling on non-wasm though (it will panic if one attempts to use it, but at least most documentation can be generated on non-wasm).

Fixes #1518.
