### PR TITLE
feat (bindings): `has_mention` in `NotificationItem`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -44,6 +44,7 @@ pub struct NotificationItem {
     /// Can be `None` if we couldn't determine this, because we lacked
     /// information to create a push context.
     pub is_noisy: Option<bool>,
+    pub has_mention: Option<bool>,
 }
 
 impl NotificationItem {
@@ -72,6 +73,7 @@ impl NotificationItem {
                 is_direct: item.is_direct_message_room,
             },
             is_noisy: item.is_noisy,
+            has_mention: item.has_mention,
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -622,6 +622,7 @@ pub struct NotificationItem {
     ///
     /// It is set if and only if the push actions could be determined.
     pub is_noisy: Option<bool>,
+    pub has_mention: Option<bool>,
 }
 
 impl NotificationItem {
@@ -685,6 +686,7 @@ impl NotificationItem {
         }
 
         let is_noisy = push_actions.map(|actions| actions.iter().any(|a| a.sound().is_some()));
+        let has_mention = push_actions.map(|actions| actions.iter().any(|a| a.is_highlight()));
 
         let item = NotificationItem {
             event,
@@ -697,6 +699,7 @@ impl NotificationItem {
             is_room_encrypted: room.is_encrypted().await.ok(),
             joined_members_count: room.joined_members_count(),
             is_noisy,
+            has_mention,
         };
 
         Ok(item)


### PR DESCRIPTION
fixes #2834
I could change the name of the variable to be: `is_highlighted` or `has_highlight` if that sounds more correct from a SDK point of view.