### PR TITLE
Add missing "room_id" to test_json::MEMBERS

### DIFF
--- a/testing/matrix-sdk-test/src/test_json/members.rs
+++ b/testing/matrix-sdk-test/src/test_json/members.rs
@@ -3,6 +3,8 @@
 use once_cell::sync::Lazy;
 use serde_json::{json, Value as JsonValue};
 
+use super::DEFAULT_TEST_ROOM_ID;
+
 pub static MEMBERS: Lazy<JsonValue> = Lazy::new(|| {
     json!({
         "chunk": [
@@ -15,6 +17,7 @@ pub static MEMBERS: Lazy<JsonValue> = Lazy::new(|| {
             "event_id": "$151800140517rfvjc:localhost",
             "membership": "join",
             "origin_server_ts": 151800140,
+            "room_id": *DEFAULT_TEST_ROOM_ID,
             "sender": "@example:localhost",
             "state_key": "@example:localhost",
             "type": "m.room.member",


### PR DESCRIPTION
It doesn't matter at the moment as the only test using `test_json::MEMBERS` does not rely on the event being valid, but it shows this error nonetheless:

```
2023-11-10T08:54:29.920782Z DEBUG receive_members{room_id="!hIMjEx205EXNyjVPCV:localhost"}: matrix_sdk_base::client: Failed to deserialize member event: missing field `room_id` at line 1 column 297 event_id="$151800140517rfvjc:localhost"
```

and https://spec.matrix.org/v1.8/client-server-api/#get_matrixclientv3roomsroomidmembers says it is a required key.

- [ ] Public API changes documented in changelogs (optional)