### PR TITLE
ffi(bindings): check if MSC 4028 is enabled on the homeserver

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -303,8 +303,9 @@ impl NotificationSettings {
         Ok(enabled)
     }
 
-    /// Check if MSC 4028 push rule is enabled
-    /// https://github.com/matrix-org/matrix-spec-proposals/blob/giomfo/push_encrypted_events/proposals/4028-push-all-encrypted-events-except-for-muted-rooms.md
+    /// Check if [MSC 4028 push rule][rule] is enabled.
+    ///
+    /// [rule]: https://github.com/matrix-org/matrix-spec-proposals/blob/giomfo/push_encrypted_events/proposals/4028-push-all-encrypted-events-except-for-muted-rooms.md
     pub async fn can_homeserver_push_encrypted_event_to_device(&self) -> bool {
         let notification_settings = self.sdk_notification_settings.read().await;
         // Check stable identifier
@@ -312,15 +313,16 @@ impl NotificationSettings {
             .is_push_rule_enabled(RuleKind::Override, ".m.rule.encrypted_event")
             .await
         {
-            return enabled;
+            enabled
         // Check unstable identifier
         } else if let Ok(enabled) = notification_settings
             .is_push_rule_enabled(RuleKind::Override, ".org.matrix.msc4028.encrypted_event")
             .await
         {
-            return enabled;
+            enabled
+        } else {
+            false
         }
-        false
     }
 
     /// Set whether user mentions are enabled.

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -303,6 +303,26 @@ impl NotificationSettings {
         Ok(enabled)
     }
 
+    /// Check if MSC 4028 push rule is enabled
+    /// https://github.com/matrix-org/matrix-spec-proposals/blob/giomfo/push_encrypted_events/proposals/4028-push-all-encrypted-events-except-for-muted-rooms.md
+    pub async fn can_homeserver_push_encrypted_event_to_device(&self) -> bool {
+        let notification_settings = self.sdk_notification_settings.read().await;
+        // Check stable identifier
+        if let Ok(enabled) = notification_settings
+            .is_push_rule_enabled(RuleKind::Override, ".m.rule.encrypted_event")
+            .await
+        {
+            return enabled;
+        // Check unstable identifier
+        } else if let Ok(enabled) = notification_settings
+            .is_push_rule_enabled(RuleKind::Override, ".org.matrix.msc4028.encrypted_event")
+            .await
+        {
+            return enabled;
+        }
+        false
+    }
+
     /// Set whether user mentions are enabled.
     pub async fn set_user_mention_enabled(
         &self,


### PR DESCRIPTION
Added a function that returns true if the current homeserver has the msc 4028 push rule and is enabled.

Since I don't see Ruma having a specific push rule id for it yet, I am using an hardcoded string for now, is that okay?