### PR TITLE
Improve performance of `get_missing_sessions`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,9 @@
 # unreleased
 
+- `get_missing_sessions`: Don't block waiting for `/keys/query` requests on
+  blacklisted servers, and improve performance.
+  ([#2845](https://github.com/matrix-org/matrix-rust-sdk/pull/2845))
+
 - Handle missing devices in `/keys/claim` responses.
   ([#2805](https://github.com/matrix-org/matrix-rust-sdk/pull/2805))
 

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -980,7 +980,7 @@ impl IdentityManager {
 
     /// Helper for get_user_devices_for_encryption.
     ///
-    /// Waits for any pending `/keys/query` for the given device. If one was
+    /// Waits for any pending `/keys/query` for the given user. If one was
     /// pending, reloads the device list and returns `Some(user_id,
     /// device_list)`. If no request was pending, returns `None`.
     async fn get_updated_keys_for_user(

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -227,10 +227,6 @@ impl SessionManager {
 
         let unfailed_users = users.filter(|u| !self.failures.contains(u.server_name()));
 
-        // XXX: You'd think this would be unnecessary, but if you omit it, Rust starts
-        // yelling about lifetimes and Send for reasons that I don't really understand.
-        let unfailed_users: Vec<_> = unfailed_users.collect();
-
         // Get the current list of devices for each user.
         let devices_by_user = Box::pin(
             self.key_request_machine


### PR DESCRIPTION
Two sets of improvements to `get_missing_sessions` here:

 * Currently, for any users who have an empty device list, we call `KeyQueryManager::wait_if_user_key_query_pending`, which waits up to 5 seconds for a `/keys/query` response. (Arguably, we should be waiting longer: it is not unusual for such a request to take a while.)

   The problem is that that user's server may have been blacklisted, in which case we won't even be trying to do `/keys/query` resquests for that user, so we'll be waiting for something that never happens.

   To fix this, let's check the failures list when deciding if we should wait for a user's devices.

 * Separately, but closely related: for each user thus affected, we do the wait *in series*. This is a bit silly: there is no point waiting 50 times. We can parallelise the work.

Fixes #2793.