### PR TITLE
element call: Remove `E2EEenabled` flag

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -118,10 +118,10 @@ pub async fn generate_webview_url(
 pub enum EncryptionSystem {
     /// Equivalent to the element call url parameter: `enableE2EE=false`
     Unencrypted,
-    /// Equivalent to the element call url parameters:
+    /// Equivalent to the element call url parameter:
     /// `perParticipantE2EE=true`
     PerParticipantKeys,
-    /// Equivalent to the element call url parameters:
+    /// Equivalent to the element call url parameter:
     /// `password={secret}`
     SharedSecret {
         /// The secret/password which is used in the url.

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -113,17 +113,16 @@ pub async fn generate_webview_url(
 
 /// Defines if a call is encrypted and which encryption system should be used.
 ///
-/// This controls the url parameters: `enableE2EE`, `perParticipantE2EE`,
-/// `password`.
+/// This controls the url parameters: `perParticipantE2EE`, `password`.
 #[derive(uniffi::Enum, Clone)]
 pub enum EncryptionSystem {
     /// Equivalent to the element call url parameter: `enableE2EE=false`
     Unencrypted,
     /// Equivalent to the element call url parameters:
-    /// `enableE2EE=true&perParticipantE2EE=true`
+    /// `perParticipantE2EE=true`
     PerParticipantKeys,
     /// Equivalent to the element call url parameters:
-    /// `enableE2EE=true&password={secret}`
+    /// `password={secret}`
     SharedSecret {
         /// The secret/password which is used in the url.
         secret: String,

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -46,8 +46,6 @@ struct ElementCallParams {
     analytics_id: Option<String>,
     font_scale: Option<f64>,
     font: Option<String>,
-    #[serde(rename = "enableE2EE")]
-    enable_e2ee: bool,
     #[serde(rename = "perParticipantE2EE")]
     per_participant_e2ee: bool,
     password: Option<String>,
@@ -55,17 +53,16 @@ struct ElementCallParams {
 
 /// Defines if a call is encrypted and which encryption system should be used.
 ///
-/// This controls the url parameters: `enableE2EE`, `perParticipantE2EE`,
-/// `password`.
+/// This controls the url parameters: `perParticipantE2EE`, `password`.
 #[derive(Debug, PartialEq)]
 pub enum EncryptionSystem {
-    /// Equivalent to the element call url parameter: `enableE2EE=false`
+    /// Equivalent to the element call url parameter: `perParticipantE2EE=false` and no password.
     Unencrypted,
     /// Equivalent to the element call url parameters:
-    /// `enableE2EE=true&perParticipantE2EE=true`
+    /// `perParticipantE2EE=true`
     PerParticipantKeys,
     /// Equivalent to the element call url parameters:
-    /// `enableE2EE=true&password={secret}`
+    /// `password={secret}`
     SharedSecret {
         /// The secret/password which is used in the url.
         secret: String,
@@ -181,7 +178,6 @@ impl WidgetSettings {
             analytics_id: props.analytics_id,
             font_scale: props.font_scale,
             font: props.font,
-            enable_e2ee: { props.encryption != EncryptionSystem::Unencrypted },
             per_participant_e2ee: props.encryption == EncryptionSystem::PerParticipantKeys,
             password: match props.encryption {
                 EncryptionSystem::SharedSecret { secret } => Some(secret),
@@ -283,7 +279,6 @@ mod tests {
                 &appPrompt=true\
                 &hideHeader=true\
                 &preload=true\
-                &enableE2EE=true\
                 &perParticipantE2EE=true\
         ";
 
@@ -337,7 +332,6 @@ mod tests {
                 &displayName=hello\
                 &appPrompt=true\
                 &clientId=io.my_matrix.client\
-                &enableE2EE=true\
                 &perParticipantE2EE=true\
         ";
 
@@ -361,10 +355,7 @@ mod tests {
                 EncryptionSystem::PerParticipantKeys,
             )));
             let query_set = get_query_sets(&Url::parse(&url).unwrap()).unwrap().1;
-            let expected_elements = [
-                ("perParticipantE2EE".to_owned(), "true".to_owned()),
-                ("enableE2EE".to_owned(), "true".to_owned()),
-            ];
+            let expected_elements = [("perParticipantE2EE".to_owned(), "true".to_owned())];
             for e in expected_elements {
                 assert!(
                     query_set.contains(&e),
@@ -380,9 +371,9 @@ mod tests {
                 EncryptionSystem::Unencrypted,
             )));
             let query_set = get_query_sets(&Url::parse(&url).unwrap()).unwrap().1;
-            let expected_elements = ("enableE2EE".to_owned(), "false".to_owned());
+            let expected_elements = ("perParticipantE2EE".to_owned(), "true".to_owned());
             assert!(
-                query_set.contains(&expected_elements),
+                !query_set.contains(&expected_elements),
                 "The query elements: \n{:?}\nDid not contain: \n{:?}",
                 query_set,
                 expected_elements
@@ -394,10 +385,7 @@ mod tests {
                 EncryptionSystem::SharedSecret { secret: "this_surely_is_save".to_owned() },
             )));
             let query_set = get_query_sets(&Url::parse(&url).unwrap()).unwrap().1;
-            let expected_elements = [
-                ("password".to_owned(), "this_surely_is_save".to_owned()),
-                ("enableE2EE".to_owned(), "true".to_owned()),
-            ];
+            let expected_elements = [("password".to_owned(), "this_surely_is_save".to_owned())];
             for e in expected_elements {
                 assert!(
                     query_set.contains(&e),

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -56,7 +56,8 @@ struct ElementCallParams {
 /// This controls the url parameters: `perParticipantE2EE`, `password`.
 #[derive(Debug, PartialEq)]
 pub enum EncryptionSystem {
-    /// Equivalent to the element call url parameter: `perParticipantE2EE=false` and no password.
+    /// Equivalent to the element call url parameter: `perParticipantE2EE=false`
+    /// and no password.
     Unencrypted,
     /// Equivalent to the element call url parameters:
     /// `perParticipantE2EE=true`

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -372,10 +372,10 @@ mod tests {
                 EncryptionSystem::Unencrypted,
             )));
             let query_set = get_query_sets(&Url::parse(&url).unwrap()).unwrap().1;
-            let expected_elements = ("perParticipantE2EE".to_owned(), "true".to_owned());
+            let expected_elements = ("perParticipantE2EE".to_owned(), "false".to_owned());
             assert!(
-                !query_set.contains(&expected_elements),
-                "The query elements: \n{:?}\nDid not contain: \n{:?}",
+                query_set.contains(&expected_elements),
+                "The url query elements for an unencrypted call: \n{:?}\nDid not contain: \n{:?}",
                 query_set,
                 expected_elements
             );


### PR DESCRIPTION
This is a deprecated flag for element call using livekit. It was used to enable/disable matrix signalling event encryption. This is not relevant for embedded mode at all since there the hosting client is taking care of encryption.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
