### PR TITLE
feat: edit poll API 

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -532,7 +532,7 @@ impl Room {
     ) -> Result<(), ClientError> {
         let timeline = match &*RUNTIME.block_on(self.timeline.read()) {
             Some(t) => Arc::clone(t),
-            None => return Err(anyhow!("Timeline not set up, can't send message").into()),
+            None => return Err(anyhow!("Timeline not set up, can't edit poll").into()),
         };
 
         let poll_data = PollData { question, answers, max_selections, poll_kind };

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, fs, sync::Arc};
+use std::{convert::TryFrom, fmt::Write, fs, sync::Arc};
 
 use anyhow::{anyhow, Context, Result};
 use futures_util::{pin_mut, StreamExt};
@@ -1220,8 +1220,9 @@ struct PollData {
 
 impl PollData {
     fn fallback_text(&self) -> String {
-        self.answers.iter().enumerate().fold(self.question.clone(), |acc, (index, answer)| {
-            format!("{acc}\n{}. {answer}", index + 1)
+        self.answers.iter().enumerate().fold(self.question.clone(), |mut acc, (index, answer)| {
+            write!(&mut acc, "\n{}. {answer}", index + 1).unwrap();
+            acc
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -424,15 +424,12 @@ impl Room {
             }
         };
 
-        let poll_data = PollData {
-            question,
-            answers,
-            max_selections,
-            poll_kind,
-        };
+        let poll_data = PollData { question, answers, max_selections, poll_kind };
 
-        let poll_start_event_content =
-            NewUnstablePollStartEventContent::plain_text(poll_data.fallback_text(), poll_data.try_into()?);
+        let poll_start_event_content = NewUnstablePollStartEventContent::plain_text(
+            poll_data.fallback_text(),
+            poll_data.try_into()?,
+        );
         let event_content =
             AnyMessageLikeEventContent::UnstablePollStart(poll_start_event_content.into());
 
@@ -532,21 +529,18 @@ impl Room {
         max_selections: u8,
         poll_kind: PollKind,
         edit_item: Arc<EventTimelineItem>,
-    ) -> Result<(), ClientError>  {
+    ) -> Result<(), ClientError> {
         let timeline = match &*RUNTIME.block_on(self.timeline.read()) {
             Some(t) => Arc::clone(t),
             None => return Err(anyhow!("Timeline not set up, can't send message").into()),
         };
 
-        let poll_data = PollData {
-            question,
-            answers,
-            max_selections,
-            poll_kind,
-        };
-        
+        let poll_data = PollData { question, answers, max_selections, poll_kind };
+
         RUNTIME.block_on(async move {
-            timeline.edit_poll(poll_data.fallback_text(), poll_data.try_into()?,&edit_item.0).await?;
+            timeline
+                .edit_poll(poll_data.fallback_text(), poll_data.try_into()?, &edit_item.0)
+                .await?;
             anyhow::Ok(())
         })?;
 
@@ -1226,10 +1220,9 @@ struct PollData {
 
 impl PollData {
     fn fallback_text(&self) -> String {
-        self.answers
-            .iter()
-            .enumerate()
-            .fold(self.question.clone(), |acc, (index, answer)| format!("{acc}\n{}. {answer}", index + 1))
+        self.answers.iter().enumerate().fold(self.question.clone(), |acc, (index, answer)| {
+            format!("{acc}\n{}. {answer}", index + 1)
+        })
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -508,6 +508,7 @@ pub enum TimelineItemContentKind {
         answers: Vec<PollAnswer>,
         votes: HashMap<String, Vec<String>>,
         end_time: Option<u64>,
+        has_been_edited: bool,
     },
     UnableToDecrypt {
         msg: EncryptedMessage,
@@ -1376,7 +1377,8 @@ impl From<PollResult> for TimelineItemContentKind {
                 .map(|i| PollAnswer { id: i.id, text: i.text })
                 .collect(),
             votes: value.votes,
-            end_time: value.end_time,
+            end_time: value.end_time, 
+            has_been_edited: value.has_been_edited,
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline.rs
@@ -1377,7 +1377,7 @@ impl From<PollResult> for TimelineItemContentKind {
                 .map(|i| PollAnswer { id: i.id, text: i.text })
                 .collect(),
             votes: value.votes,
-            end_time: value.end_time, 
+            end_time: value.end_time,
             has_been_edited: value.has_been_edited,
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -104,6 +104,6 @@ enum UnsupportedEditItemInner {
     MissingEventId,
     #[error("tried to edit a non-message event")]
     NotRoomMessage,
-    #[error("tried to edit a non poll event")]
+    #[error("tried to edit a non-poll event")]
     NotPollEvent,
 }

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -102,7 +102,7 @@ impl fmt::Debug for UnsupportedEditItem {
 enum UnsupportedEditItemInner {
     #[error("local messages whose event ID is not known can't be edited currently")]
     MissingEventId,
-    #[error("tried to edit a non message event")]
+    #[error("tried to edit a non-message event")]
     NotRoomMessage,
     #[error("tried to edit a non poll event")]
     NotPollEvent,

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -88,6 +88,7 @@ pub struct UnsupportedEditItem(UnsupportedEditItemInner);
 impl UnsupportedEditItem {
     pub(super) const MISSING_EVENT_ID: Self = Self(UnsupportedEditItemInner::MissingEventId);
     pub(super) const NOT_ROOM_MESSAGE: Self = Self(UnsupportedEditItemInner::NotRoomMessage);
+    pub(super) const NOT_POLL_EVENT: Self = Self(UnsupportedEditItemInner::NotPollEvent);
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -101,6 +102,8 @@ impl fmt::Debug for UnsupportedEditItem {
 enum UnsupportedEditItemInner {
     #[error("local messages whose event ID is not known can't be edited currently")]
     MissingEventId,
-    #[error("only message events can be edited")]
+    #[error("tried to edit a non message event")]
     NotRoomMessage,
+    #[error("tried to edit a non poll event")]
+    NotPollEvent,
 }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -426,8 +426,6 @@ impl Timeline {
         poll: UnstablePollStartContentBlock,
         edit_item: &EventTimelineItem,
     ) -> Result<(), UnsupportedEditItem> {
-        // Early returns here must be in sync with
-        // `EventTimelineItem::can_be_edited`
         let Some(event_id) = edit_item.event_id() else {
             return Err(UnsupportedEditItem::MISSING_EVENT_ID);
         };

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -35,7 +35,10 @@ use pin_project_lite::pin_project;
 use ruma::{
     api::client::receipt::create_receipt::v3::ReceiptType,
     events::{
-        poll::unstable_start::{UnstablePollStartEventContent, ReplacementUnstablePollStartEventContent, UnstablePollStartContentBlock},
+        poll::unstable_start::{
+            ReplacementUnstablePollStartEventContent, UnstablePollStartContentBlock,
+            UnstablePollStartEventContent,
+        },
         reaction::ReactionEventContent,
         receipt::{Receipt, ReceiptThread},
         relation::Annotation,
@@ -432,7 +435,11 @@ impl Timeline {
             return Err(UnsupportedEditItem::NOT_POLL_EVENT);
         };
 
-        let replacement_poll = ReplacementUnstablePollStartEventContent::plain_text(fallback_text, poll, event_id.into());
+        let replacement_poll = ReplacementUnstablePollStartEventContent::plain_text(
+            fallback_text,
+            poll,
+            event_id.into(),
+        );
         self.send(UnstablePollStartEventContent::from(replacement_poll).into()).await;
         Ok(())
     }

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -26,6 +26,7 @@ pub struct PollState {
     pub(super) start_event_content: NewUnstablePollStartEventContent,
     pub(super) response_data: Vec<ResponseData>,
     pub(super) end_event_timestamp: Option<MilliSecondsSinceUnixEpoch>,
+    pub(super) has_been_edited: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -37,7 +38,7 @@ pub(super) struct ResponseData {
 
 impl PollState {
     pub(super) fn new(content: NewUnstablePollStartEventContent) -> Self {
-        Self { start_event_content: content, response_data: vec![], end_event_timestamp: None }
+        Self { start_event_content: content, response_data: vec![], end_event_timestamp: None, has_been_edited: false }
     }
 
     pub(super) fn edit(
@@ -48,6 +49,7 @@ impl PollState {
             let mut clone = self.clone();
             clone.start_event_content.poll_start = replacement.poll_start.clone();
             clone.start_event_content.text = replacement.text.clone();
+            clone.has_been_edited = true;
             Ok(clone)
         } else {
             Err(())
@@ -113,6 +115,7 @@ impl PollState {
                 .map(|i| ((*i.0).to_owned(), i.1.iter().map(|i| i.to_string()).collect()))
                 .collect(),
             end_time: self.end_event_timestamp.map(|millis| millis.0.into()),
+            has_been_edited: self.has_been_edited
         }
     }
 }
@@ -178,6 +181,7 @@ pub struct PollResult {
     pub answers: Vec<PollResultAnswer>,
     pub votes: HashMap<String, Vec<String>>,
     pub end_time: Option<u64>,
+    pub has_been_edited: bool,
 }
 
 #[derive(Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -44,7 +44,7 @@ impl PollState {
         &self,
         replacement: &NewUnstablePollStartEventContentWithoutRelation,
     ) -> Result<Self, ()> {
-        if self.response_data.is_empty() && self.end_event_timestamp.is_none() {
+        if self.end_event_timestamp.is_none() {
             let mut clone = self.clone();
             clone.start_event_content.poll_start = replacement.poll_start.clone();
             clone.start_event_content.text = replacement.text.clone();

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -38,7 +38,12 @@ pub(super) struct ResponseData {
 
 impl PollState {
     pub(super) fn new(content: NewUnstablePollStartEventContent) -> Self {
-        Self { start_event_content: content, response_data: vec![], end_event_timestamp: None, has_been_edited: false }
+        Self {
+            start_event_content: content,
+            response_data: vec![],
+            end_event_timestamp: None,
+            has_been_edited: false,
+        }
     }
 
     pub(super) fn edit(
@@ -115,7 +120,7 @@ impl PollState {
                 .map(|i| ((*i.0).to_owned(), i.1.iter().map(|i| i.to_string()).collect()))
                 .collect(),
             end_time: self.end_event_timestamp.map(|millis| millis.0.into()),
-            has_been_edited: self.has_been_edited
+            has_been_edited: self.has_been_edited,
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/polls.rs
@@ -37,10 +37,13 @@ async fn edited_poll_is_displayed() {
     let event = timeline.poll_event().await;
     let event_id = event.event_id().unwrap();
     timeline.send_poll_edit(&ALICE, event_id, fakes::poll_b()).await;
+    let poll_state = event.poll_state();
     let edited_poll_state = timeline.poll_state().await;
 
-    assert_poll_start_eq(&event.poll_state().start_event_content.poll_start, &fakes::poll_a());
+    assert_poll_start_eq(&poll_state.start_event_content.poll_start, &fakes::poll_a());
     assert_poll_start_eq(&edited_poll_state.start_event_content.poll_start, &fakes::poll_b());
+    assert!(!poll_state.has_been_edited);
+    assert!(edited_poll_state.has_been_edited);
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -26,6 +26,10 @@ use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails, TimelineItemContent};
 use ruma::{
     assign, event_id,
     events::{
+        poll::unstable_start::{
+            NewUnstablePollStartEventContent, UnstablePollAnswer, UnstablePollAnswers,
+            UnstablePollStartContentBlock,
+        },
         relation::InReplyTo,
         room::message::{MessageType, Relation, ReplacementMetadata, RoomMessageEventContent},
     },
@@ -272,6 +276,94 @@ async fn send_reply_edit() {
     let in_reply_to = reply_message.in_reply_to().unwrap();
     assert_eq!(in_reply_to.event_id, fst_event_id);
     assert_matches!(in_reply_to.event, TimelineDetails::Ready(_));
+
+    // The response to the mocked endpoint does not generate further timeline
+    // updates, so just wait for a bit before verifying that the endpoint was
+    // called.
+    sleep(Duration::from_millis(200)).await;
+
+    server.verify().await;
+}
+
+#[async_test]
+async fn send_edit_poll() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client().await;
+    let event_builder = EventBuilder::new();
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline().await;
+    let (_, mut timeline_stream) =
+        timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
+
+    let poll_answers = UnstablePollAnswers::try_from(vec![
+        UnstablePollAnswer::new("0", "Yes"),
+        UnstablePollAnswer::new("1", "no"),
+    ])
+    .unwrap();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+        event_builder.make_sync_message_event_with_id(
+            // Same user as the logged_in_client
+            user_id!("@example:localhost"),
+            event_id!("$original_event"),
+            NewUnstablePollStartEventContent::new(UnstablePollStartContentBlock::new(
+                "Test",
+                poll_answers,
+            )),
+        ),
+    ));
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let poll_event = assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
+    assert_let!(TimelineItemContent::Poll(poll) = poll_event.content());
+    let poll_results = poll.results();
+    assert_eq!(poll_results.question, "Test");
+    assert_eq!(poll_results.answers.len(), 2);
+    assert!(!poll_results.has_been_edited);
+
+    mock_encryption_state(&server, false).await;
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$edit_event" })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let edited_poll_answers = UnstablePollAnswers::try_from(vec![
+        UnstablePollAnswer::new("0", "Yes"),
+        UnstablePollAnswer::new("1", "no"),
+        UnstablePollAnswer::new("2", "Maybe"),
+    ])
+    .unwrap();
+    let edited_poll =
+        UnstablePollStartContentBlock::new("Edited Test".to_owned(), edited_poll_answers);
+    timeline.edit_poll("poll_fallback_text", edited_poll, &poll_event).await.unwrap();
+
+    let edit_item =
+        assert_next_matches!(timeline_stream, VectorDiff::Set { index: 0, value } => value);
+
+    // The event itself is already known to the server. We don't currently have
+    // a separate edit send state.
+    assert_matches!(edit_item.send_state(), None);
+
+    assert_let!(TimelineItemContent::Poll(edited_poll) = edit_item.content());
+    let edited_poll_results = edited_poll.results();
+    assert_eq!(edited_poll_results.question, "Edited Test");
+    assert_eq!(edited_poll_results.answers.len(), 3);
+    assert!(edited_poll_results.has_been_edited);
 
     // The response to the mocked endpoint does not generate further timeline
     // updates, so just wait for a bit before verifying that the endpoint was


### PR DESCRIPTION
This PR adds the API for editing a poll.
Furthermore refactors `create_poll` to reuse common code. 