### PR TITLE
sliding sync: include read receipts into room updates so they're handled live by the timeline

### DIFF
--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -96,7 +96,7 @@ impl fmt::Debug for Rooms {
 }
 
 /// Updates to joined rooms.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct JoinedRoom {
     /// Counts of unread notifications for this room.
     pub unread_notifications: UnreadNotificationsCount,


### PR DESCRIPTION
Updates to the timeline happen via updates propagated to room subscribers. It appears that when a sliding sync response was received, ephemeral events in a room update defaulted to an empty set, resulting in read receipts not being handled live. This fixes it by manually copying read receipts received from the sliding sync response into the room update.

Fixes https://github.com/vector-im/element-x-ios/issues/2089.