### PR TITLE
Be consistent about endpoint names

### DIFF
--- a/benchmarks/benches/crypto_bench.rs
+++ b/benchmarks/benches/crypto_bench.rs
@@ -30,7 +30,7 @@ fn keys_query_response() -> get_keys::v3::Response {
     let data: Value = serde_json::from_slice(data).unwrap();
     let data = response_from_file(&data);
     get_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the keys upload response")
+        .expect("Can't parse the `/keys/upload` response")
 }
 
 fn keys_claim_response() -> claim_keys::v3::Response {
@@ -38,7 +38,7 @@ fn keys_claim_response() -> claim_keys::v3::Response {
     let data: Value = serde_json::from_slice(data).unwrap();
     let data = response_from_file(&data);
     claim_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the keys upload response")
+        .expect("Can't parse the `/keys/upload` response")
 }
 
 fn huge_keys_query_response() -> get_keys::v3::Response {
@@ -46,7 +46,7 @@ fn huge_keys_query_response() -> get_keys::v3::Response {
     let data: Value = serde_json::from_slice(data).unwrap();
     let data = response_from_file(&data);
     get_keys::v3::Response::try_from_http_response(data)
-        .expect("Can't parse the keys query response")
+        .expect("Can't parse the `/keys/query` response")
 }
 
 pub fn keys_query(c: &mut Criterion) {

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -567,7 +567,7 @@ impl OlmMachine {
     ///
     /// *Note*: Only users that aren't already tracked will be considered for an
     /// update. It's safe to call this with already tracked users, it won't
-    /// result in excessive keys query requests.
+    /// result in excessive `/keys/query` requests.
     ///
     /// # Arguments
     ///

--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -149,7 +149,7 @@ impl From<OutgoingRequest> for Request {
                 Request::KeysUpload {
                     request_id: r.request_id().to_string(),
                     body: serde_json::to_string(&body)
-                        .expect("Can't serialize keys upload request"),
+                        .expect("Can't serialize `/keys/upload` request"),
                 }
             }
             KeysQuery(k) => {

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -872,14 +872,14 @@ impl ReadOnlyDevice {
 
     /// Create a `ReadOnlyDevice` from an `Account`
     ///
-    /// We will have our own device in the store once we receive a keys/query
+    /// We will have our own device in the store once we receive a `/keys/query`
     /// response, but this is useful to create it before we receive such a
     /// response.
     ///
     /// It also makes it easier to check that the server doesn't lie about our
     /// own device.
     ///
-    /// *Don't* use this after we received a keys/query response, other
+    /// *Don't* use this after we received a `/keys/query` response, other
     /// users/devices might add signatures to our own device, which can't be
     /// replicated locally.
     pub fn from_account(account: &Account) -> ReadOnlyDevice {

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -214,7 +214,7 @@ impl IdentityManager {
             ?deleted_devices,
             ?new_identities,
             ?changed_identities,
-            "Finished handling of the /keys/query response"
+            "Finished handling of the `/keys/query` response"
         );
 
         Ok((devices, identities))

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -106,7 +106,7 @@ impl IdentityManager {
         &self.store.static_account().user_id
     }
 
-    /// Receive a successful keys query response.
+    /// Receive a successful `/keys/query` response.
     ///
     /// Returns a list of devices newly discovered devices and devices that
     /// changed.
@@ -115,7 +115,7 @@ impl IdentityManager {
     ///
     /// * `request_id` - The request_id returned by `users_for_key_query` or
     ///   `build_key_query_for_users`
-    /// * `response` - The keys query response of the request that the client
+    /// * `response` - The response of the `/keys/query` request that the client
     /// performed.
     pub async fn receive_keys_query_response(
         &self,
@@ -126,7 +126,7 @@ impl IdentityManager {
             ?request_id,
             users = ?response.device_keys.keys().collect::<BTreeSet<_>>(),
             failures = ?response.failures,
-            "Handling a keys query response"
+            "Handling a `/keys/query` response"
         );
 
         // Parse the strings into server names and filter out our own server. We should
@@ -214,7 +214,7 @@ impl IdentityManager {
             ?deleted_devices,
             ?new_identities,
             ?changed_identities,
-            "Finished handling of the keys/query response"
+            "Finished handling of the /keys/query response"
         );
 
         Ok((devices, identities))
@@ -958,7 +958,7 @@ impl IdentityManager {
                 "Waiting for `/keys/query` to complete for users who have no devices"
             );
 
-            // For each user with no devices, fire off a task to wait for a keys/query
+            // For each user with no devices, fire off a task to wait for a `/keys/query`
             // result if one is pending.
             //
             // We don't actually update the `devices_by_user` map here since that could
@@ -1115,7 +1115,7 @@ pub(crate) mod testing {
             "user_signing_keys": {}
         }));
         KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the keys upload response")
+            .expect("Can't parse the `/keys/upload` response")
     }
 
     // An updated version of `other_key_query` featuring an additional signature on
@@ -1181,7 +1181,7 @@ pub(crate) mod testing {
             "user_signing_keys": {}
         }));
         KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the keys upload response")
+            .expect("Can't parse the `/keys/upload` response")
     }
 
     /// Mocked response to a /keys/query request.
@@ -1283,7 +1283,7 @@ pub(crate) mod testing {
           }
         }));
         KeyQueryResponse::try_from_http_response(data)
-            .expect("Can't parse the keys upload response")
+            .expect("Can't parse the `/keys/upload` response")
     }
 
     pub fn own_key_query() -> KeyQueryResponse {
@@ -1314,7 +1314,7 @@ pub(crate) mod testing {
         );
 
         KeyQueryResponse::try_from_http_response(response_from_file(&json))
-            .expect("Can't parse the keys upload response")
+            .expect("Can't parse the `/keys/upload` response")
     }
 }
 
@@ -1483,7 +1483,7 @@ pub(crate) mod tests {
         });
 
         let response = KeysQueryResponse::try_from_http_response(response_from_file(&response))
-            .expect("Can't parse the keys query response");
+            .expect("Can't parse the `/keys/query` response");
 
         manager.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();
 
@@ -1533,7 +1533,7 @@ pub(crate) mod tests {
         });
 
         let response = KeysQueryResponse::try_from_http_response(response_from_file(&response))
-            .expect("Can't parse the keys query response");
+            .expect("Can't parse the `/keys/query` response");
 
         let (_, private_identity) = manager.handle_cross_signing_keys(&response).await.unwrap();
 
@@ -1717,7 +1717,7 @@ pub(crate) mod tests {
         let (new_request_id, _) =
             manager.as_ref().unwrap().build_key_query_for_users(vec![user_id()]);
 
-        // A second `keys/query` response with the same result shouldn't fire a change
+        // A second `/keys/query` response with the same result shouldn't fire a change
         // notification: the identity should be unchanged.
         manager
             .as_ref()

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -565,12 +565,12 @@ impl OlmMachine {
         })
     }
 
-    /// Receive a successful keys upload response.
+    /// Receive a successful `/keys/upload` response.
     ///
     /// # Arguments
     ///
-    /// * `response` - The keys upload response of the request that the client
-    /// performed.
+    /// * `response` - The response of the `/keys/upload` request that the
+    ///   client performed.
     async fn receive_keys_upload_response(&self, response: &UploadKeysResponse) -> OlmResult<()> {
         self.inner
             .store
@@ -616,15 +616,15 @@ impl OlmMachine {
         self.inner.session_manager.get_missing_sessions(users).await
     }
 
-    /// Receive a successful keys query response.
+    /// Receive a successful `/keys/query` response.
     ///
     /// Returns a list of devices newly discovered devices and devices that
     /// changed.
     ///
     /// # Arguments
     ///
-    /// * `response` - The keys query response of the request that the client
-    /// performed.
+    /// * `response` - The response of the `/keys/query` request that the client
+    ///   performed.
     async fn receive_keys_query_response(
         &self,
         request_id: &TransactionId,
@@ -2146,13 +2146,13 @@ pub(crate) mod tests {
     fn keys_upload_response() -> upload_keys::v3::Response {
         let data = response_from_file(&test_json::KEYS_UPLOAD);
         upload_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the keys upload response")
+            .expect("Can't parse the `/keys/upload` response")
     }
 
     fn keys_query_response() -> get_keys::v3::Response {
         let data = response_from_file(&test_json::KEYS_QUERY);
         get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the keys upload response")
+            .expect("Can't parse the `/keys/upload` response")
     }
 
     pub fn to_device_requests_to_content(
@@ -3191,7 +3191,7 @@ pub(crate) mod tests {
         );
 
         let kq_response = KeyQueryResponse::try_from_http_response(response_from_file(&json))
-            .expect("Can't parse the keys upload response");
+            .expect("Can't parse the `/keys/upload` response");
 
         alice.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
         bob.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
@@ -3259,7 +3259,7 @@ pub(crate) mod tests {
         );
 
         let kq_response = KeyQueryResponse::try_from_http_response(response_from_file(&json))
-            .expect("Can't parse the keys upload response");
+            .expect("Can't parse the `/keys/upload` response");
 
         alice.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
         bob.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
@@ -3324,7 +3324,7 @@ pub(crate) mod tests {
         );
 
         let kq_response = KeyQueryResponse::try_from_http_response(response_from_file(&json))
-            .expect("Can't parse the keys upload response");
+            .expect("Can't parse the `/keys/upload` response");
 
         alice.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
         bob.receive_keys_query_response(&TransactionId::new(), &kq_response).await.unwrap();
@@ -3349,7 +3349,7 @@ pub(crate) mod tests {
 
         let data = response_from_file(&test_json::KEYS_QUERY_TWO_DEVICES_ONE_SIGNED);
         let response = get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the keys upload response");
+            .expect("Can't parse the `/keys/upload` response");
 
         let (device_change, identity_change) =
             bob.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -199,9 +199,9 @@ impl KeysQueryRequest {
 /// Enum over the different outgoing requests we can have.
 #[derive(Debug)]
 pub enum OutgoingRequests {
-    /// The keys upload request, uploading device and one-time keys.
+    /// The `/keys/upload` request, uploading device and one-time keys.
     KeysUpload(KeysUploadRequest),
-    /// The keys query request, fetching the device and cross signing keys of
+    /// The `/keys/query` request, fetching the device and cross signing keys of
     /// other users.
     KeysQuery(KeysQueryRequest),
     /// The request to claim one-time keys for a user/device pair from the
@@ -292,18 +292,18 @@ impl From<KeysUploadRequest> for OutgoingRequest {
 /// Enum over all the incoming responses we need to receive.
 #[derive(Debug)]
 pub enum IncomingResponse<'a> {
-    /// The keys upload response, notifying us about the amount of uploaded
+    /// The `/keys/upload` response, notifying us about the amount of uploaded
     /// one-time keys.
     KeysUpload(&'a KeysUploadResponse),
-    /// The keys query response, giving us the device and cross signing keys of
-    /// other users.
+    /// The `/keys/query` response, giving us the device and cross signing keys
+    /// of other users.
     KeysQuery(&'a KeysQueryResponse),
     /// The to-device response, an empty response.
     ToDevice(&'a ToDeviceResponse),
     /// The key claiming requests, giving us new one-time keys of other users so
     /// new Olm sessions can be created.
     KeysClaim(&'a KeysClaimResponse),
-    /// The cross signing keys upload response, marking our private cross
+    /// The cross signing `/keys/upload` response, marking our private cross
     /// signing identity as shared.
     SigningKeysUpload(&'a SigningKeysUploadResponse),
     /// The cross signing signature upload response.

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -856,7 +856,7 @@ mod tests {
         let data: Value = serde_json::from_slice(data).unwrap();
         let data = response_from_file(&data);
         get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the keys upload response")
+            .expect("Can't parse the `/keys/upload` response")
     }
 
     fn bob_keys_query_response() -> get_keys::v3::Response {
@@ -887,7 +887,7 @@ mod tests {
         let data = response_from_file(&data);
 
         get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the keys upload response")
+            .expect("Can't parse the `/keys/upload` response")
     }
 
     /// Returns a keys claim response for device `BOBDEVICE` of user

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -688,8 +688,8 @@ mod tests {
     async fn test_session_creation_waits_for_keys_query() {
         let (manager, identity_manager) = session_manager_test_helper().await;
 
-        // start a keys query request. At this point, we are only interested in our own
-        // devices.
+        // start a `/keys/query` request. At this point, we are only interested in our
+        // own devices.
         let (key_query_txn_id, key_query_request) =
             identity_manager.users_for_key_query().await.unwrap().pop_first().unwrap();
         info!("Initial key query: {:?}", key_query_request);
@@ -721,7 +721,7 @@ mod tests {
             })
         };
 
-        // the initial keys query completes, and we start another
+        // the initial `/keys/query` completes, and we start another
         let response_json =
             json!({ "device_keys": { manager.store.static_account().user_id.to_owned(): {}}});
         let response =
@@ -766,7 +766,7 @@ mod tests {
                 .unwrap();
         }
 
-        // Do a keys query request, in which Bob's server is a failure.
+        // Do a `/keys/query` request, in which Bob's server is a failure.
         let (key_query_txn_id, _key_query_request) =
             identity_manager.users_for_key_query().await.unwrap().pop_first().unwrap();
         let response = KeysQueryResponse::try_from_http_response(response_from_file(


### PR DESCRIPTION
Sometimes, we called this `keys query`, sometimes `/keys/query`, and sometimes, just for variety, `keys/query`. Generally in Matrix we talk about `/keys/query` so let's standardise on that.