### PR TITLE
Improve performance of `share_room_key`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,8 @@
 # unreleased
 
+- Improve performance of `share_room_key`.
+  ([#2862](https://github.com/matrix-org/matrix-rust-sdk/pull/2862))
+
 - `get_missing_sessions`: Don't block waiting for `/keys/query` requests on
   blacklisted servers, and improve performance.
   ([#2845](https://github.com/matrix-org/matrix-rust-sdk/pull/2845))

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -618,7 +618,7 @@ impl GossipMachine {
         // at. For this, we need an outbound session because this
         // information is recorded there.
         } else if let Some(outbound) = outbound_session {
-            match outbound.is_shared_with(device) {
+            match outbound.is_shared_with(&device.inner) {
                 ShareState::Shared(message_index) => Ok(Some(message_index)),
                 ShareState::SharedButChangedSenderKey => Err(KeyForwardDecision::ChangedSenderKey),
                 ShareState::NotShared => Err(KeyForwardDecision::OutboundSessionNotShared),

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -428,23 +428,7 @@ impl Device {
         event_type: &str,
         content: impl Serialize,
     ) -> OlmResult<(Session, Raw<ToDeviceEncryptedEventContent>)> {
-        #[cfg(feature = "message-ids")]
-        let message_id = {
-            #[cfg(not(target_arch = "wasm32"))]
-            let id = ulid::Ulid::new().to_string();
-            #[cfg(target_arch = "wasm32")]
-            let id = ruma::TransactionId::new().to_string();
-
-            tracing::Span::current().record("message_id", &id);
-            Some(id)
-        };
-
-        #[cfg(not(feature = "message-ids"))]
-        let message_id = None;
-
-        self.inner
-            .encrypt(self.verification_machine.store.inner(), event_type, content, message_id)
-            .await
+        self.inner.encrypt(self.verification_machine.store.inner(), event_type, content).await
     }
 
     pub(crate) async fn maybe_encrypt_room_key(
@@ -774,8 +758,21 @@ impl ReadOnlyDevice {
         store: &CryptoStoreWrapper,
         event_type: &str,
         content: impl Serialize,
-        message_id: Option<String>,
     ) -> OlmResult<(Session, Raw<ToDeviceEncryptedEventContent>)> {
+        #[cfg(feature = "message-ids")]
+        let message_id = {
+            #[cfg(not(target_arch = "wasm32"))]
+            let id = ulid::Ulid::new().to_string();
+            #[cfg(target_arch = "wasm32")]
+            let id = ruma::TransactionId::new().to_string();
+
+            tracing::Span::current().record("message_id", &id);
+            Some(id)
+        };
+
+        #[cfg(not(feature = "message-ids"))]
+        let message_id = None;
+
         let session = self.get_most_recent_session(store).await?;
 
         if let Some(mut session) = session {

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -56,7 +56,7 @@ use crate::{
         },
         EventEncryptionAlgorithm,
     },
-    Device, ToDeviceRequest,
+    Device, ReadOnlyDevice, ToDeviceRequest,
 };
 
 const ROTATION_PERIOD: Duration = Duration::from_millis(604800000);
@@ -548,7 +548,7 @@ impl OutboundGroupSession {
         }
     }
 
-    pub(crate) fn is_withheld_to(&self, device: &Device, code: &WithheldCode) -> bool {
+    pub(crate) fn is_withheld_to(&self, device: &ReadOnlyDevice, code: &WithheldCode) -> bool {
         self.shared_with_set
             .read()
             .unwrap()

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -56,7 +56,7 @@ use crate::{
         },
         EventEncryptionAlgorithm,
     },
-    Device, ReadOnlyDevice, ToDeviceRequest,
+    ReadOnlyDevice, ToDeviceRequest,
 };
 
 const ROTATION_PERIOD: Duration = Duration::from_millis(604800000);
@@ -504,7 +504,7 @@ impl OutboundGroupSession {
     }
 
     /// Has or will the session be shared with the given user/device pair.
-    pub(crate) fn is_shared_with(&self, device: &Device) -> ShareState {
+    pub(crate) fn is_shared_with(&self, device: &ReadOnlyDevice) -> ShareState {
         // Check if we shared the session.
         let shared_state =
             self.shared_with_set.read().unwrap().get(device.user_id()).and_then(|d| {

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -285,7 +285,7 @@ impl GroupSessionManager {
         let mut withheld_devices = Vec::new();
 
         // XXX is there a way to do this that doesn't involve cloning the
-        // `Arc<CryptoStoreWrapper>` fore each device?
+        // `Arc<CryptoStoreWrapper>` for each device?
         let encrypt = |store: Arc<CryptoStoreWrapper>,
                        device: ReadOnlyDevice,
                        session: OutboundGroupSession| async move {

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -770,7 +770,7 @@ impl GroupSessionManager {
             .into_iter()
             .flat_map(|(_, d)| {
                 d.into_iter()
-                    .filter(|d| matches!(outbound.is_shared_with(d), ShareState::NotShared))
+                    .filter(|d| matches!(outbound.is_shared_with(&d.inner), ShareState::NotShared))
             })
             .map(|d| d.inner)
             .collect();

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1591,6 +1591,10 @@ impl Store {
     ) -> Result<RoomKeyImportResult> {
         self.import_room_keys(exported_keys, false, progress_listener).await
     }
+
+    pub(crate) fn crypto_store(&self) -> Arc<CryptoStoreWrapper> {
+        self.inner.store.clone()
+    }
 }
 
 impl Deref for Store {

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1069,18 +1069,6 @@ impl Store {
 
     /// Get all devices associated with the given `user_id`
     ///
-    /// *Note*: This doesn't return our own device.
-    pub(crate) async fn get_user_devices_filtered(&self, user_id: &UserId) -> Result<UserDevices> {
-        self.get_user_devices(user_id).await.map(|mut d| {
-            if user_id == self.user_id() {
-                d.inner.remove(self.device_id());
-            }
-            d
-        })
-    }
-
-    /// Get all devices associated with the given `user_id`
-    ///
     /// *Note*: This does also return our own device.
     pub(crate) async fn get_user_devices(&self, user_id: &UserId) -> Result<UserDevices> {
         let devices = self.get_readonly_devices_unfiltered(user_id).await?;


### PR DESCRIPTION
Encryption doesn't usually require access to the user identity, so we can skip loading that from the store.

Unfortunately that means a fair bit of refectoring, in the form of replacing `Device` with `ReadOnlyDevice`.

This reduces the time taken to encrypt a message in a large room from about 3 seconds to 1 second.