### PR TITLE
test: add an integration test for left rooms

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -3,16 +3,103 @@ use std::time::Duration;
 use anyhow::Result;
 use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
+    config::SyncSettings,
     ruma::{
         api::client::room::create_room::v3::Request as CreateRoomRequest, assign,
         events::room::message::RoomMessageEventContent, mxc_uri,
     },
-    RoomState, SlidingSyncList, SlidingSyncMode,
+    RoomListEntry, RoomState, SlidingSyncList, SlidingSyncMode,
 };
 use tokio::time::sleep;
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::helpers::TestClientBuilder;
+
+#[tokio::test]
+async fn test_left_room() -> Result<()> {
+    let peter = TestClientBuilder::new("peter".to_owned())
+        .randomize_username()
+        .use_sqlite()
+        .build()
+        .await?;
+    let steven = TestClientBuilder::new("steven".to_owned())
+        .randomize_username()
+        .use_sqlite()
+        .build()
+        .await?;
+
+    // Set up sliding sync for Peter.
+    let sliding_peter = peter
+        .sliding_sync("main")?
+        .with_all_extensions()
+        .poll_timeout(Duration::from_secs(3))
+        .network_timeout(Duration::from_secs(3))
+        .add_list(
+            SlidingSyncList::builder("all")
+                .sync_mode(SlidingSyncMode::new_selective().add_range(0..=20)),
+        )
+        .build()
+        .await?;
+
+    let s = sliding_peter.clone();
+    tokio::task::spawn(async move {
+        let stream = s.sync();
+        pin_mut!(stream);
+        while let Some(up) = stream.next().await {
+            warn!("received update: {up:?}");
+        }
+    });
+
+    // Set up regular sync for Steven.
+    let steven2 = steven.clone();
+    tokio::task::spawn(async move {
+        if let Err(err) = steven2.sync(SyncSettings::default()).await {
+            error!("steven couldn't sync: {err}");
+        }
+    });
+
+    // Peter creates a room and invites Steven.
+    let peter_room = peter
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![steven.user_id().unwrap().to_owned()],
+            is_direct: true,
+        }))
+        .await?;
+
+    // Steven joins it.
+    let mut joined = false;
+    for _ in 0..3 {
+        sleep(Duration::from_secs(1)).await;
+        if let Some(room) = steven.get_room(peter_room.room_id()) {
+            room.join().await?;
+            joined = true;
+            break;
+        }
+    }
+    anyhow::ensure!(joined, "steven couldn't join after 3 seconds");
+
+    // Now Peter is just being rude.
+    peter_room.leave().await?;
+
+    sleep(Duration::from_secs(1)).await;
+    let peter_room = peter.get_room(peter_room.room_id()).unwrap();
+    assert_eq!(peter_room.state(), RoomState::Left);
+
+    let list = sliding_peter
+        .on_list("all", |l| {
+            let list = l.clone();
+            async { list }
+        })
+        .await
+        .expect("must found room list");
+
+    // Even though we left the room, the server still includes the room in the list,
+    // so the SDK doesn't receive a DELETE sync op for this room entry.
+    // See also https://github.com/vector-im/element-x-ios/issues/2005.
+    assert_eq!(list.room_list::<RoomListEntry>().len(), 1);
+
+    Ok(())
+}
 
 #[tokio::test]
 async fn test_room_avatar_group_conversation() -> Result<()> {


### PR DESCRIPTION
This adds a test documenting the current behavior of the proxy with respect to left rooms.

See also https://github.com/vector-im/element-x-ios/issues/2005