### PR TITLE
room list service: add a new filter to get all rooms but the left ones

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -13,7 +13,7 @@ use matrix_sdk::{
     RoomListEntry as MatrixRoomListEntry,
 };
 use matrix_sdk_ui::room_list_service::filters::{
-    new_filter_all, new_filter_fuzzy_match_room_name, new_filter_none,
+    new_filter_all, new_filter_all_non_left, new_filter_fuzzy_match_room_name, new_filter_none,
     new_filter_normalized_match_room_name,
 };
 use tokio::sync::RwLock;
@@ -376,6 +376,7 @@ impl RoomListDynamicEntriesController {
 
         match kind {
             Kind::All => self.inner.set_filter(new_filter_all()),
+            Kind::AllNonLeft => self.inner.set_filter(new_filter_all_non_left(&self.client)),
             Kind::None => self.inner.set_filter(new_filter_none()),
             Kind::NormalizedMatchRoomName { pattern } => {
                 self.inner.set_filter(new_filter_normalized_match_room_name(&self.client, &pattern))
@@ -398,6 +399,7 @@ impl RoomListDynamicEntriesController {
 #[derive(uniffi::Enum)]
 pub enum RoomListEntriesDynamicFilterKind {
     All,
+    AllNonLeft,
     None,
     NormalizedMatchRoomName { pattern: String },
     FuzzyMatchRoomName { pattern: String },

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/all_non_left.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/all_non_left.rs
@@ -1,0 +1,66 @@
+use matrix_sdk::{Client, RoomListEntry};
+use matrix_sdk_base::RoomState;
+
+struct NonLeftRoomMatcher<F: Fn(&RoomListEntry) -> Option<RoomState>> {
+    get_state: F,
+}
+
+impl<F: Fn(&RoomListEntry) -> Option<RoomState>> NonLeftRoomMatcher<F> {
+    fn matches(&self, room: &RoomListEntry) -> bool {
+        if !matches!(room, RoomListEntry::Filled(_) | RoomListEntry::Invalidated(_)) {
+            return false;
+        }
+
+        if let Some(state) = (self.get_state)(room) {
+            state != RoomState::Left
+        } else {
+            false
+        }
+    }
+}
+
+/// Create a new filter that will accept all filled or invalidated entries, but
+/// filters out left rooms.
+pub fn new_filter(client: &Client) -> impl Fn(&RoomListEntry) -> bool {
+    let client = client.clone();
+
+    let matcher = NonLeftRoomMatcher {
+        get_state: move |room| {
+            let room_id = room.as_room_id()?;
+            let room = client.get_room(room_id)?;
+            Some(room.state())
+        },
+    };
+
+    move |room_list_entry| -> bool { matcher.matches(room_list_entry) }
+}
+
+#[cfg(test)]
+mod tests {
+    use matrix_sdk::RoomListEntry;
+    use matrix_sdk_base::RoomState;
+    use ruma::room_id;
+
+    use crate::room_list_service::filters::all_non_left::NonLeftRoomMatcher;
+
+    #[test]
+    fn test_all_non_left_kind_of_room_list_entry() {
+        // When we can't figure out the room state, nothing matches.
+        let matcher = NonLeftRoomMatcher { get_state: |_| None };
+        assert!(!matcher.matches(&RoomListEntry::Empty));
+        assert!(!matcher.matches(&RoomListEntry::Filled(room_id!("!r0:bar.org").to_owned())));
+        assert!(!matcher.matches(&RoomListEntry::Invalidated(room_id!("!r0:bar.org").to_owned())));
+
+        // When a room has been left, it doesn't match.
+        let matcher = NonLeftRoomMatcher { get_state: |_| Some(RoomState::Left) };
+        assert!(!matcher.matches(&RoomListEntry::Empty));
+        assert!(!matcher.matches(&RoomListEntry::Filled(room_id!("!r0:bar.org").to_owned())));
+        assert!(!matcher.matches(&RoomListEntry::Invalidated(room_id!("!r0:bar.org").to_owned())));
+
+        // When a room has been joined, it does match (unless it's empty).
+        let matcher = NonLeftRoomMatcher { get_state: |_| Some(RoomState::Joined) };
+        assert!(!matcher.matches(&RoomListEntry::Empty));
+        assert!(matcher.matches(&RoomListEntry::Filled(room_id!("!r0:bar.org").to_owned())));
+        assert!(matcher.matches(&RoomListEntry::Invalidated(room_id!("!r0:bar.org").to_owned())));
+    }
+}

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/mod.rs
@@ -1,9 +1,11 @@
 mod all;
+mod all_non_left;
 mod fuzzy_match_room_name;
 mod none;
 mod normalized_match_room_name;
 
 pub use all::new_filter as new_filter_all;
+pub use all_non_left::new_filter as new_filter_all_non_left;
 pub use fuzzy_match_room_name::new_filter as new_filter_fuzzy_match_room_name;
 pub use none::new_filter as new_filter_none;
 pub use normalized_match_room_name::new_filter as new_filter_normalized_match_room_name;


### PR DESCRIPTION
This allows to get a list of all the rooms except for left ones, since they're still part of a sliding sync server response.

This mitigates https://github.com/vector-im/element-x-ios/issues/2005 until we get feedback about what the best behavior should be with respect to all the cases.