### PR TITLE
sliding sync: correctly set/unset a group avatar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4676,9 +4676,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2428ee1488551cbc2bc4ef936c9452ac35ccd5c7e4e4df12c54b67afa6b262fb"
+checksum = "641837258fa214a70823477514954ef0f5d3bc6ae8e1d5d85081856a33103386"
 dependencies = [
  "assign",
  "bytes",

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -460,6 +460,14 @@ mod tests {
             _ = Some(mxc_uri!("mxc://homeserver/media").to_owned());
         }
 
+        test_avatar_unset {
+            avatar_url() = None;
+            receives room_response!({"avatar": null});
+            _ = None;
+            receives nothing;
+            _ = None;
+        }
+
         test_room_is_dm {
             is_dm() = None;
             receives room_response!({"is_dm": true});
@@ -1043,5 +1051,22 @@ mod tests {
                 &format!("$x{max}:baz.org")
             );
         }
+    }
+
+    #[async_test]
+    async fn test_avatar_set_then_unset() {
+        let mut room = new_room(room_id!("!foo:bar.org"), room_response!({})).await;
+        assert_eq!(room.avatar_url(), None);
+
+        room.update(room_response!({ "avatar": "mxc://homeserver/media" }), vec![]);
+        assert_eq!(room.avatar_url().as_deref(), Some(mxc_uri!("mxc://homeserver/media")));
+
+        // avatar is undefined.
+        room.update(room_response!({}), vec![]);
+        assert_eq!(room.avatar_url().as_deref(), Some(mxc_uri!("mxc://homeserver/media")));
+
+        // avatar is null => reset it to None.
+        room.update(room_response!({ "avatar": null }), vec![]);
+        assert_eq!(room.avatar_url().as_deref(), None);
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -78,7 +78,7 @@ impl SlidingSyncRoom {
     pub fn avatar_url(&self) -> Option<OwnedMxcUri> {
         let inner = self.inner.inner.read().unwrap();
 
-        inner.avatar.clone()
+        inner.avatar.clone().into_option()
     }
 
     /// Is this a direct message?
@@ -167,7 +167,10 @@ impl SlidingSyncRoom {
                 inner.name = name;
             }
 
-            if avatar.is_some() {
+            // Note: in the server specification, the avatar is undefined when it hasn't
+            // changed, and it's set to null when it's been unset, so we
+            // distinguish the two here.
+            if !avatar.is_undefined() {
                 inner.avatar = avatar;
             }
 
@@ -321,7 +324,7 @@ mod tests {
     use matrix_sdk_test::async_test;
     use ruma::{
         api::client::sync::sync_events::v4, assign, events::room::message::RoomMessageEventContent,
-        mxc_uri, room_id, serde::Raw, uint, RoomId,
+        mxc_uri, room_id, serde::Raw, uint, JsOption, RoomId,
     };
     use serde_json::json;
     use wiremock::MockServer;
@@ -906,7 +909,7 @@ mod tests {
                 v4::SlidingSyncRoom::default(),
                 {
                     name: Some("foobar".to_owned()),
-                    avatar: Some(mxc_uri!("mxc://homeserver/media").to_owned()),
+                    avatar: JsOption::Some(mxc_uri!("mxc://homeserver/media").to_owned()),
                 }
             ),
             timeline_queue: vector![TimelineEvent::new(

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -462,7 +462,7 @@ mod tests {
 
         test_avatar_unset {
             avatar_url() = None;
-            receives room_response!({"avatar": null});
+            receives room_response!({ "avatar": null });
             _ = None;
             receives nothing;
             _ = None;

--- a/room.rs
+++ b/room.rs
@@ -1,0 +1,114 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use futures_util::{pin_mut, StreamExt};
+use matrix_sdk::{
+    config::SyncSettings,
+    ruma::{
+        api::client::room::create_room::v3::Request as CreateRoomRequest, assign,
+        events::room::message::RoomMessageEventContent, mxc_uri,
+    },
+    RoomState, SlidingSyncList, SlidingSyncMode,
+};
+use tokio::time::sleep;
+use tracing::{error, warn};
+
+use crate::helpers::TestClientBuilder;
+
+#[tokio::test]
+async fn test_room_avatar_group_conversation() -> Result<()> {
+    let alice = TestClientBuilder::new("alice".to_owned())
+        .randomize_username()
+        .use_sqlite()
+        .build()
+        .await?;
+    let bob =
+        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+    let celine = TestClientBuilder::new("celine".to_owned())
+        .randomize_username()
+        .use_sqlite()
+        .build()
+        .await?;
+
+    // Bob and Celine set their avatars.
+    bob.account().set_avatar_url(Some(mxc_uri!("mxc://localhost/bob"))).await?;
+    celine.account().set_avatar_url(Some(mxc_uri!("mxc://localhost/celine"))).await?;
+
+    // Set up sliding sync for alice.
+    let sliding_alice = alice
+        .sliding_sync("main")?
+        .with_all_extensions()
+        .poll_timeout(Duration::from_secs(2))
+        .network_timeout(Duration::from_secs(2))
+        .add_list(
+            SlidingSyncList::builder("all")
+                .sync_mode(SlidingSyncMode::new_selective().add_range(0..=20)),
+        )
+        .build()
+        .await?;
+
+    let s = sliding_alice.clone();
+    tokio::task::spawn(async move {
+        let stream = s.sync();
+        pin_mut!(stream);
+        while let Some(up) = stream.next().await {
+            warn!("received update: {up:?}");
+        }
+    });
+
+    // alice creates a room and invites bob and celine.
+    let alice_room = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![bob.user_id().unwrap().to_owned(), celine.user_id().unwrap().to_owned()],
+            is_direct: true,
+        }))
+        .await?;
+
+    sleep(Duration::from_secs(1)).await;
+
+    let alice_room = alice.get_room(alice_room.room_id()).unwrap();
+    assert_eq!(alice_room.state(), RoomState::Joined);
+
+    let sliding_room = sliding_alice
+        .get_room(alice_room.room_id())
+        .await
+        .expect("sliding sync finds alice's own room");
+
+    // Here, there should be no avatar (group conversation and no avatar has been
+    // set in the room).
+    for _ in 0..3 {
+        sleep(Duration::from_secs(1)).await;
+        assert_eq!(alice_room.avatar_url(), None);
+        assert_eq!(sliding_room.avatar_url(), None);
+
+        // Force a new server response.
+        alice_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
+    }
+
+    // Alice sets an avatar for the room.
+    let group_avatar_uri = mxc_uri!("mxc://localhost/group");
+    alice_room.set_avatar_url(group_avatar_uri, None).await?;
+
+    for _ in 0..3 {
+        sleep(Duration::from_secs(1)).await;
+        assert_eq!(alice_room.avatar_url().as_deref(), Some(group_avatar_uri));
+        assert_eq!(sliding_room.avatar_url().as_deref(), Some(group_avatar_uri));
+
+        // Force a new server response.
+        alice_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
+    }
+
+    // And eventually Alice unsets it.
+    alice_room.remove_avatar().await?;
+
+    for _ in 0..3 {
+        sleep(Duration::from_secs(1)).await;
+        assert_eq!(alice_room.avatar_url(), None);
+        assert_eq!(sliding_room.avatar_url(), None);
+
+        // Force a new server response.
+        alice_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
+    }
+
+    Ok(())
+}

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/mod.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/mod.rs
@@ -1,1 +1,2 @@
 mod notification_client;
+mod room;

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -1,0 +1,113 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use futures_util::{pin_mut, StreamExt};
+use matrix_sdk::{
+    ruma::{
+        api::client::room::create_room::v3::Request as CreateRoomRequest, assign,
+        events::room::message::RoomMessageEventContent, mxc_uri,
+    },
+    RoomState, SlidingSyncList, SlidingSyncMode,
+};
+use tokio::time::sleep;
+use tracing::warn;
+
+use crate::helpers::TestClientBuilder;
+
+#[tokio::test]
+async fn test_room_avatar_group_conversation() -> Result<()> {
+    let alice = TestClientBuilder::new("alice".to_owned())
+        .randomize_username()
+        .use_sqlite()
+        .build()
+        .await?;
+    let bob =
+        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+    let celine = TestClientBuilder::new("celine".to_owned())
+        .randomize_username()
+        .use_sqlite()
+        .build()
+        .await?;
+
+    // Bob and Celine set their avatars.
+    bob.account().set_avatar_url(Some(mxc_uri!("mxc://localhost/bob"))).await?;
+    celine.account().set_avatar_url(Some(mxc_uri!("mxc://localhost/celine"))).await?;
+
+    // Set up sliding sync for alice.
+    let sliding_alice = alice
+        .sliding_sync("main")?
+        .with_all_extensions()
+        .poll_timeout(Duration::from_secs(2))
+        .network_timeout(Duration::from_secs(2))
+        .add_list(
+            SlidingSyncList::builder("all")
+                .sync_mode(SlidingSyncMode::new_selective().add_range(0..=20)),
+        )
+        .build()
+        .await?;
+
+    let s = sliding_alice.clone();
+    tokio::task::spawn(async move {
+        let stream = s.sync();
+        pin_mut!(stream);
+        while let Some(up) = stream.next().await {
+            warn!("received update: {up:?}");
+        }
+    });
+
+    // alice creates a room and invites bob and celine.
+    let alice_room = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![bob.user_id().unwrap().to_owned(), celine.user_id().unwrap().to_owned()],
+            is_direct: true,
+        }))
+        .await?;
+
+    sleep(Duration::from_secs(1)).await;
+
+    let alice_room = alice.get_room(alice_room.room_id()).unwrap();
+    assert_eq!(alice_room.state(), RoomState::Joined);
+
+    let sliding_room = sliding_alice
+        .get_room(alice_room.room_id())
+        .await
+        .expect("sliding sync finds alice's own room");
+
+    // Here, there should be no avatar (group conversation and no avatar has been
+    // set in the room).
+    for _ in 0..3 {
+        sleep(Duration::from_secs(1)).await;
+        assert_eq!(alice_room.avatar_url(), None);
+        assert_eq!(sliding_room.avatar_url(), None);
+
+        // Force a new server response.
+        alice_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
+    }
+
+    // Alice sets an avatar for the room.
+    let group_avatar_uri = mxc_uri!("mxc://localhost/group");
+    alice_room.set_avatar_url(group_avatar_uri, None).await?;
+
+    for _ in 0..3 {
+        sleep(Duration::from_secs(1)).await;
+        assert_eq!(alice_room.avatar_url().as_deref(), Some(group_avatar_uri));
+        assert_eq!(sliding_room.avatar_url().as_deref(), Some(group_avatar_uri));
+
+        // Force a new server response.
+        alice_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
+    }
+
+    // And eventually Alice unsets it.
+    alice_room.remove_avatar().await?;
+
+    for _ in 0..3 {
+        sleep(Duration::from_secs(1)).await;
+        assert_eq!(alice_room.avatar_url(), None);
+        assert_eq!(sliding_room.avatar_url(), None);
+
+        // Force a new server response.
+        alice_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
According to the sliding sync MSC, an `avatar` field in a room response set to `null` means it's been unset, and when it's not set (aka `undefined`), then it's not changed since the previous sync. The meaning of "null" and "undefined" were conflated by Ruma, previously, and both would deserialize to a Rust's `None` — which was ignored by sliding sync, interpreting it as "there's no update to the avatar".

This PR updates to the latest Ruma, which allows us to distinguish both cases, and the logic in sliding sync is tweaked to take that change into account, allowing us to see the effect of unsetting avatars with sliding sync.