### PR TITLE
crypto: Use Option instead of JsOption

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -14,7 +14,7 @@
 
 use std::{fmt, sync::Arc};
 
-use ruma::{serde::Raw, JsOption, OwnedDeviceId, OwnedUserId, SecondsSinceUnixEpoch};
+use ruma::{serde::Raw, OwnedDeviceId, OwnedUserId, SecondsSinceUnixEpoch};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::Mutex;
@@ -181,14 +181,14 @@ impl Session {
                 ciphertext,
                 recipient_key: self.sender_key,
                 sender_key: self.our_identity_keys.curve25519,
-                message_id: JsOption::from_implicit_option(message_id),
+                message_id,
             }
             .into(),
             #[cfg(feature = "experimental-algorithms")]
             EventEncryptionAlgorithm::OlmV2Curve25519AesSha2 => OlmV2Curve25519AesSha2Content {
                 ciphertext,
                 sender_key: self.our_identity_keys.curve25519,
-                message_id: JsOption::from_implicit_option(message_id),
+                message_id,
             }
             .into(),
             _ => unreachable!(),

--- a/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
@@ -16,7 +16,7 @@
 
 use std::collections::BTreeMap;
 
-use ruma::{JsOption, OwnedDeviceId, RoomId};
+use ruma::{OwnedDeviceId, RoomId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use vodozemac::{megolm::MegolmMessage, olm::OlmMessage, Curve25519PublicKey};
@@ -126,7 +126,7 @@ pub struct OlmV1Curve25519AesSha2Content {
     pub sender_key: Curve25519PublicKey,
 
     /// The unique ID of this content.
-    pub message_id: JsOption<String>,
+    pub message_id: Option<String>,
 }
 
 /// The event content for events encrypted with the m.olm.v2.curve25519-aes-sha2
@@ -142,8 +142,8 @@ pub struct OlmV2Curve25519AesSha2Content {
     pub sender_key: Curve25519PublicKey,
 
     /// The unique ID of this content.
-    #[serde(default, skip_serializing_if = "JsOption::is_undefined", rename = "org.matrix.msgid")]
-    pub message_id: JsOption<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "org.matrix.msgid")]
+    pub message_id: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -151,8 +151,8 @@ struct OlmHelper {
     #[serde(deserialize_with = "deserialize_curve_key", serialize_with = "serialize_curve_key")]
     sender_key: Curve25519PublicKey,
     ciphertext: BTreeMap<String, OlmMessage>,
-    #[serde(default, skip_serializing_if = "JsOption::is_undefined", rename = "org.matrix.msgid")]
-    message_id: JsOption<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "org.matrix.msgid")]
+    message_id: Option<String>,
 }
 
 impl Serialize for OlmV1Curve25519AesSha2Content {
@@ -503,7 +503,7 @@ pub(crate) mod tests {
         assert_let!(
             ToDeviceEncryptedEventContent::OlmV1Curve25519AesSha2(content) = &event.content
         );
-        assert!(content.message_id.is_undefined());
+        assert!(content.message_id.is_none());
 
         let serialized = serde_json::to_value(event)?;
         assert_eq!(json, serialized);

--- a/crates/matrix-sdk-crypto/src/types/events/room_key_withheld.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key_withheld.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use ruma::{
     exports::ruma_macros::AsStrAsRefStr,
     serde::{AsRefStr, DebugAsRefStr, DeserializeFromCowStr, FromString, SerializeAsRefStr},
-    JsOption, OwnedDeviceId, OwnedRoomId,
+    OwnedDeviceId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -107,7 +107,7 @@ impl RoomKeyWithheldContent {
         sender_key: Curve25519PublicKey,
         from_device: OwnedDeviceId,
     ) -> Self {
-        let from_device = JsOption::Some(from_device);
+        let from_device = Some(from_device);
 
         match algorithm {
             EventEncryptionAlgorithm::MegolmV1AesSha2 => {
@@ -222,7 +222,7 @@ impl std::fmt::Display for WithheldCode {
 #[derive(Debug, Deserialize, Serialize)]
 struct WithheldHelper {
     pub algorithm: EventEncryptionAlgorithm,
-    pub reason: JsOption<String>,
+    pub reason: Option<String>,
     pub code: WithheldCode,
     #[serde(flatten)]
     other: Value,
@@ -259,8 +259,8 @@ pub struct CommonWithheldCodeContent {
 
     /// The device ID of the device sending the m.room_key.withheld message
     /// MSC3735.
-    #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
-    pub from_device: JsOption<OwnedDeviceId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_device: Option<OwnedDeviceId>,
 
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
@@ -278,7 +278,7 @@ impl CommonWithheldCodeContent {
             room_id,
             session_id,
             sender_key,
-            from_device: JsOption::Some(device_id),
+            from_device: Some(device_id),
             other: Default::default(),
         }
     }
@@ -318,8 +318,8 @@ pub struct NoOlmWithheldContent {
 
     /// The device ID of the device sending the m.room_key.withheld message
     /// MSC3735.
-    #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
-    pub from_device: JsOption<OwnedDeviceId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_device: Option<OwnedDeviceId>,
 
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
@@ -358,8 +358,8 @@ pub struct UnknownRoomKeyWithHeld {
     /// The withheld code
     pub code: WithheldCode,
     /// A human-readable reason for why the key was not sent.
-    #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
-    pub reason: JsOption<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
     /// The other data of the unknown room key.
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
@@ -429,7 +429,7 @@ impl Serialize for RoomKeyWithheldContent {
         let helper = match self {
             Self::MegolmV1AesSha2(r) => {
                 let code = r.withheld_code();
-                let reason = JsOption::Some(code.to_string());
+                let reason = Some(code.to_string());
 
                 match r {
                     MegolmV1AesSha2WithheldContent::BlackListed(content)
@@ -452,7 +452,7 @@ impl Serialize for RoomKeyWithheldContent {
             #[cfg(feature = "experimental-algorithms")]
             Self::MegolmV2AesSha2(r) => {
                 let code = r.withheld_code();
-                let reason = JsOption::Some(code.to_string());
+                let reason = Some(code.to_string());
 
                 match r {
                     MegolmV1AesSha2WithheldContent::BlackListed(content)


### PR DESCRIPTION
We don't need to distinguish null from an absent field in any of the places we used JsOption, so a regular Option is better.
