### PR TITLE
Prepare our /keys/claim response handling to handle multiple OTKs

### DIFF
--- a/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
+++ b/crates/matrix-sdk-crypto/src/dehydrated_devices.rs
@@ -491,7 +491,7 @@ mod tests {
             .await
             .expect("We should be able to create a request to upload a dehydrated device");
 
-        let (_key_id, one_time_key) = request
+        let (key_id, one_time_key) = request
             .one_time_keys
             .pop_first()
             .expect("The dehydrated device creation request should contain a one-time key");
@@ -499,7 +499,7 @@ mod tests {
         // Ensure that we know about the public keys of the dehydrated device.
         receive_device_keys(&alice, user_id(), &request.device_id, request.device_keys).await;
         // Create a 1-to-1 Olm session with the dehydrated device.
-        create_session(&alice, user_id(), &request.device_id, one_time_key).await;
+        create_session(&alice, user_id(), &request.device_id, key_id, one_time_key).await;
 
         // Send a room key to the dehydrated device.
         let (event, group_session) = send_room_key(&alice, room_id, user_id()).await;

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -242,6 +242,13 @@ pub enum SessionCreationError {
     )]
     OneTimeKeyNotSigned(OwnedUserId, OwnedDeviceId),
 
+    /// The signed one-time key is missing.
+    #[error(
+        "Tried to create a new Olm session for {0} {1}, but the signed \
+        one-time key is missing"
+    )]
+    OneTimeKeyMissing(OwnedUserId, OwnedDeviceId),
+
     /// The one-time key algorithm is unsupported.
     #[error(
         "Tried to create a new Olm session for {0} {1}, but the one-time \

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -843,8 +843,8 @@ impl Account {
     #[instrument(
         skip_all,
         fields(
-            user_id = %device.user_id(),
-            device_id = %device.device_id(),
+            user_id = ?device.user_id(),
+            device_id = ?device.device_id(),
             algorithms = ?device.algorithms()
         )
     )]
@@ -864,7 +864,7 @@ impl Account {
         let first_key_id = first_key.0.to_owned();
         let first_key = OneTimeKey::deserialize(first_key_id.algorithm(), first_key.1)?;
 
-        let ret = match first_key {
+        let result = match first_key {
             OneTimeKey::SignedKey(key) => Ok(PrekeyBundle::Olm3DH { key }),
             _ => Err(SessionCreationError::OneTimeKeyUnknown(
                 device.user_id().to_owned(),
@@ -872,9 +872,9 @@ impl Account {
             )),
         };
 
-        trace!(result = ?ret, "Finished searching for a valid pre-key bundle");
+        trace!(?result, "Finished searching for a valid pre-key bundle");
 
-        ret
+        result
     }
 
     /// Create a new session with another account given a one-time key and a

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -74,6 +74,11 @@ use crate::{
     OlmError, SignatureError,
 };
 
+#[derive(Debug)]
+enum PrekeyBundle {
+    Olm3DH { key: SignedKey },
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum SessionType {
     New(Session),
@@ -835,6 +840,43 @@ impl Account {
         }
     }
 
+    #[instrument(
+        skip_all,
+        fields(
+            user_id = %device.user_id(),
+            device_id = %device.device_id(),
+            algorithms = ?device.algorithms()
+        )
+    )]
+    fn find_pre_key_bundle(
+        device: &ReadOnlyDevice,
+        key_map: &BTreeMap<OwnedDeviceKeyId, Raw<ruma::encryption::OneTimeKey>>,
+    ) -> Result<PrekeyBundle, SessionCreationError> {
+        let mut keys = key_map.iter();
+
+        let first_key = keys.next().ok_or_else(|| {
+            SessionCreationError::OneTimeKeyMissing(
+                device.user_id().to_owned(),
+                device.device_id().into(),
+            )
+        })?;
+
+        let first_key_id = first_key.0.to_owned();
+        let first_key = OneTimeKey::deserialize(first_key_id.algorithm(), first_key.1)?;
+
+        let ret = match first_key {
+            OneTimeKey::SignedKey(key) => Ok(PrekeyBundle::Olm3DH { key }),
+            _ => Err(SessionCreationError::OneTimeKeyUnknown(
+                device.user_id().to_owned(),
+                device.device_id().into(),
+            )),
+        };
+
+        trace!(result = ?ret, "Finished searching for a valid pre-key bundle");
+
+        ret
+    }
+
     /// Create a new session with another account given a one-time key and a
     /// device.
     ///
@@ -850,45 +892,39 @@ impl Account {
     pub fn create_outbound_session(
         &self,
         device: &ReadOnlyDevice,
-        one_time_key: &Raw<ruma::encryption::OneTimeKey>,
+        key_map: &BTreeMap<OwnedDeviceKeyId, Raw<ruma::encryption::OneTimeKey>>,
     ) -> Result<Session, SessionCreationError> {
-        let one_time_key: SignedKey = match one_time_key.deserialize_as() {
-            Ok(OneTimeKey::SignedKey(k)) => k,
-            Ok(OneTimeKey::Key(_)) => {
-                return Err(SessionCreationError::OneTimeKeyNotSigned(
-                    device.user_id().to_owned(),
-                    device.device_id().into(),
-                ));
+        let pre_key_bundle = Self::find_pre_key_bundle(device, key_map)?;
+
+        match pre_key_bundle {
+            PrekeyBundle::Olm3DH { key } => {
+                device.verify_one_time_key(&key).map_err(|error| {
+                    SessionCreationError::InvalidSignature {
+                        signing_key: device.ed25519_key(),
+                        one_time_key: key.clone(),
+                        error,
+                    }
+                })?;
+
+                let identity_key = device.curve25519_key().ok_or_else(|| {
+                    SessionCreationError::DeviceMissingCurveKey(
+                        device.user_id().to_owned(),
+                        device.device_id().into(),
+                    )
+                })?;
+
+                let is_fallback = key.fallback();
+                let one_time_key = key.key();
+                let config = device.olm_session_config();
+
+                Ok(self.create_outbound_session_helper(
+                    config,
+                    identity_key,
+                    one_time_key,
+                    is_fallback,
+                ))
             }
-            Ok(_) => {
-                return Err(SessionCreationError::OneTimeKeyUnknown(
-                    device.user_id().to_owned(),
-                    device.device_id().into(),
-                ));
-            }
-            Err(e) => return Err(SessionCreationError::InvalidJson(e)),
-        };
-
-        device.verify_one_time_key(&one_time_key).map_err(|error| {
-            SessionCreationError::InvalidSignature {
-                signing_key: device.ed25519_key(),
-                one_time_key: one_time_key.clone(),
-                error,
-            }
-        })?;
-
-        let identity_key = device.curve25519_key().ok_or_else(|| {
-            SessionCreationError::DeviceMissingCurveKey(
-                device.user_id().to_owned(),
-                device.device_id().into(),
-            )
-        })?;
-
-        let is_fallback = one_time_key.fallback();
-        let one_time_key = one_time_key.key();
-        let config = device.olm_session_config();
-
-        Ok(self.create_outbound_session_helper(config, identity_key, one_time_key, is_fallback))
+        }
     }
 
     /// Create a new session with another account given a pre-key Olm message.
@@ -949,11 +985,9 @@ impl Account {
 
         other.generate_one_time_keys_helper(1);
         let one_time_map = other.signed_one_time_keys();
-        let one_time = one_time_map.values().next().unwrap();
-
         let device = ReadOnlyDevice::from_account(other);
 
-        let mut our_session = self.create_outbound_session(&device, one_time).unwrap();
+        let mut our_session = self.create_outbound_session(&device, &one_time_map).unwrap();
 
         other.mark_keys_as_published();
 

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -24,9 +24,8 @@ use ruma::{
     },
     assign,
     events::dummy::ToDeviceDummyEventContent,
-    serde::Raw,
-    DeviceId, DeviceKeyAlgorithm, OwnedDeviceId, OwnedServerName, OwnedTransactionId, OwnedUserId,
-    SecondsSinceUnixEpoch, ServerName, TransactionId, UserId,
+    DeviceId, DeviceKeyAlgorithm, OwnedDeviceId, OwnedDeviceKeyId, OwnedServerName,
+    OwnedTransactionId, OwnedUserId, SecondsSinceUnixEpoch, ServerName, TransactionId, UserId,
 };
 use tracing::{debug, error, info, instrument, warn};
 use vodozemac::Curve25519PublicKey;
@@ -313,21 +312,30 @@ impl SessionManager {
         self.failed_devices.read().unwrap().get(user_id).is_some_and(|d| d.contains(device_id))
     }
 
-    /// Receive a successful key claim response and create new Olm sessions with
-    /// the claimed keys.
+    /// This method will try to figure out for which devices a one-time key was
+    /// requested but is not present in the response.
     ///
-    /// # Arguments
+    /// As per [spec], if a user/device pair does not have any one-time keys on
+    /// the homeserver, the server will just omit the user/device pair from
+    /// the response:
+    ///     > If the homeserver could be reached, but the user or device was
+    ///     > unknown, no failure is recorded. Instead, the corresponding user
+    ///     > or device is missing from the one_time_keys result.
     ///
-    /// * `request_id` - The unique id of the request that was sent out. This is
-    ///   needed to couple the response with the sent out request.
+    /// The user/device pairs which are missing from the response are going to
+    /// be put in the failures cache so we don't retry to claim a one-time
+    /// key right away next time the user tries to send a message.
     ///
-    /// * `response` - The response containing the claimed one-time keys.
-    #[instrument(skip(self, response))]
-    pub async fn receive_keys_claim_response(
+    /// [spec]: https://spec.matrix.org/unstable/client-server-api/#post_matrixclientv3keysclaim
+    fn handle_otk_exhaustion_failure(
         &self,
         request_id: &TransactionId,
-        response: &KeysClaimResponse,
-    ) -> OlmResult<()> {
+        failed_servers: &BTreeSet<OwnedServerName>,
+        one_time_keys: &BTreeMap<
+            &OwnedUserId,
+            BTreeMap<&OwnedDeviceId, BTreeSet<&OwnedDeviceKeyId>>,
+        >,
+    ) {
         // First check that the response is for the request we were expecting.
         let request = {
             let mut guard = self.current_key_claim_request.write().unwrap();
@@ -347,6 +355,65 @@ impl SessionManager {
             }
         };
 
+        // If we were able to pair this response with a request, look for devices that
+        // were present in the request but did not elicit a successful response.
+        if let Some(request) = request {
+            let devices_in_response: BTreeSet<_> = one_time_keys
+                .iter()
+                .flat_map(|(u, d)| d.keys().map(|d| (*u, *d)).collect::<BTreeSet<_>>())
+                .collect();
+
+            let devices_in_request: BTreeSet<(_, _)> = request
+                .one_time_keys
+                .iter()
+                .flat_map(|(u, d)| d.keys().map(|d| (u, d)).collect::<BTreeSet<_>>())
+                .collect();
+
+            let missing_devices: BTreeSet<_> = devices_in_request
+                .difference(&devices_in_response)
+                .filter(|(user_id, _)| {
+                    // Skip over users whose homeservers were in the "failed servers" list: we don't
+                    // want to mark individual devices as broken *as well as* the server.
+                    !failed_servers.contains(user_id.server_name())
+                })
+                .collect();
+
+            if !missing_devices.is_empty() {
+                let mut missing_devices_by_user: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+
+                for &(user_id, device_id) in missing_devices {
+                    missing_devices_by_user.entry(user_id).or_default().insert(device_id.clone());
+                }
+
+                warn!(
+                    ?missing_devices_by_user,
+                    "Tried to create new Olm sessions, but the signed one-time key was missing for some devices",
+                );
+
+                let mut failed_devices_lock = self.failed_devices.write().unwrap();
+
+                for (user_id, device_set) in missing_devices_by_user {
+                    failed_devices_lock.entry(user_id.clone()).or_default().extend(device_set);
+                }
+            }
+        };
+    }
+
+    /// Receive a successful key claim response and create new Olm sessions with
+    /// the claimed keys.
+    ///
+    /// # Arguments
+    ///
+    /// * `request_id` - The unique id of the request that was sent out. This is
+    ///   needed to couple the response with the sent out request.
+    ///
+    /// * `response` - The response containing the claimed one-time keys.
+    #[instrument(skip(self, response))]
+    pub async fn receive_keys_claim_response(
+        &self,
+        request_id: &TransactionId,
+        response: &KeysClaimResponse,
+    ) -> OlmResult<()> {
         // Collect the (user_id, device_id, device_key_id) triple for logging reasons.
         let one_time_keys: BTreeMap<_, BTreeMap<_, BTreeSet<_>>> = response
             .one_time_keys
@@ -366,6 +433,7 @@ impl SessionManager {
 
         debug!(?request_id, ?one_time_keys, failures = ?response.failures, "Received a `/keys/claim` response");
 
+        // Collect all the servers in the `failures` field of the response.
         let failed_servers: BTreeSet<_> = response
             .failures
             .keys()
@@ -374,66 +442,16 @@ impl SessionManager {
             .collect();
         let successful_servers = response.one_time_keys.keys().map(|u| u.server_name());
 
-        self.failures.extend(failed_servers.iter().cloned());
+        // Add the user/device pairs that don't have any one-time keys to the failures
+        // cache.
+        self.handle_otk_exhaustion_failure(request_id, &failed_servers, &one_time_keys);
+        // Add the failed servers to the failures cache.
+        self.failures.extend(failed_servers);
+        // Remove the servers we successfully contacted from the failures cache.
         self.failures.remove(successful_servers);
 
-        // build a map of (user_id, device_id) -> key from the response
-        let sessions_to_create: BTreeMap<(_, _), _> = response
-            .one_time_keys
-            .iter()
-            .flat_map(|(user_id, device_map)| {
-                device_map.iter().filter_map(|(device_id, key_map)| {
-                    // For devices that returned at least one key, this will yield
-                    // `Some((user_id, device_id), first_key)`. For devices that returned an
-                    // empty map, this will yield `None`.
-                    //
-                    // The `None` entries are then filtered out by `filter_map`.
-                    key_map.values().next().map(|key| ((user_id.clone(), device_id.clone()), key))
-                })
-            })
-            .collect();
-
-        // if we were able to pair this response with a request, look for devices that
-        // were present in the request but did not elicit a successful response.
-        if let Some(request) = request {
-            let devices_in_response: BTreeSet<_> =
-                sessions_to_create.iter().map(|((u, d), _)| (u, d)).collect();
-
-            let devices_in_request: BTreeSet<(_, _)> = request
-                .one_time_keys
-                .iter()
-                .flat_map(|(u, d)| d.keys().map(|d| (u, d)).collect::<BTreeSet<_>>())
-                .collect();
-
-            let missing_devices: BTreeSet<_> = devices_in_request
-                .difference(&devices_in_response)
-                .filter(|(user_id, _)| {
-                    // skip over users whose homeservers were in the "failed servers" list: we don't
-                    // want to mark individual devices as broken *as well as* the server.
-                    !failed_servers.contains(user_id.server_name())
-                })
-                .collect();
-
-            if !missing_devices.is_empty() {
-                let mut missing_devices_by_user: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
-                for &(user_id, device_id) in missing_devices {
-                    missing_devices_by_user.entry(user_id).or_default().insert(device_id.clone());
-                }
-
-                warn!(
-                    ?missing_devices_by_user,
-                    "Tried to create new Olm sessions, but the signed one-time key was missing for some devices",
-                );
-
-                let mut failed_devices_lock = self.failed_devices.write().unwrap();
-
-                for (user_id, device_set) in missing_devices_by_user {
-                    failed_devices_lock.entry(user_id.clone()).or_default().extend(device_set);
-                }
-            }
-        };
-
-        self.create_sessions(&sessions_to_create).await
+        // Finally, create some 1-to-1 sessions.
+        self.create_sessions(response).await
     }
 
     /// Create new Olm sessions for the requested devices.
@@ -442,10 +460,7 @@ impl SessionManager {
     ///
     ///  * `device_map` - a map from (user ID, device ID) pairs to key object,
     ///    for each device we should create a session for.
-    pub(crate) async fn create_sessions(
-        &self,
-        device_map: &BTreeMap<(OwnedUserId, OwnedDeviceId), &Raw<ruma::encryption::OneTimeKey>>,
-    ) -> OlmResult<()> {
+    pub(crate) async fn create_sessions(&self, response: &KeysClaimResponse) -> OlmResult<()> {
         struct SessionInfo {
             session_id: String,
             algorithm: EventEncryptionAlgorithm,
@@ -465,63 +480,65 @@ impl SessionManager {
 
         let mut changes = Changes::default();
         let mut new_sessions: BTreeMap<&UserId, BTreeMap<&DeviceId, SessionInfo>> = BTreeMap::new();
-
         let mut store_transaction = self.store.transaction().await;
-        for ((user_id, device_id), one_time_key) in device_map {
-            let device = match self.store.get_readonly_device(user_id, device_id).await {
-                Ok(Some(d)) => d,
-                Ok(None) => {
-                    warn!(
-                        ?user_id,
-                        ?device_id,
-                        "Tried to create an Olm session but the device is unknown",
-                    );
-                    continue;
+
+        for (user_id, user_devices) in &response.one_time_keys {
+            for (device_id, key_map) in user_devices {
+                let device = match self.store.get_readonly_device(user_id, device_id).await {
+                    Ok(Some(d)) => d,
+                    Ok(None) => {
+                        warn!(
+                            ?user_id,
+                            ?device_id,
+                            "Tried to create an Olm session but the device is unknown",
+                        );
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!(
+                            ?user_id, ?device_id, error = ?e,
+                            "Tried to create an Olm session, but we can't \
+                            fetch the device from the store",
+                        );
+                        continue;
+                    }
+                };
+
+                let account = store_transaction.account().await?;
+                let session = match account.create_outbound_session(&device, key_map) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!(
+                            ?user_id, ?device_id, error = ?e,
+                            "Error creating Olm session"
+                        );
+
+                        self.failed_devices
+                            .write()
+                            .unwrap()
+                            .entry(user_id.to_owned())
+                            .or_default()
+                            .insert(device_id.to_owned());
+
+                        continue;
+                    }
+                };
+
+                self.key_request_machine.retry_keyshare(user_id, device_id);
+
+                if let Err(e) = self.check_if_unwedged(user_id, device_id).await {
+                    error!(?user_id, ?device_id, "Error while treating an unwedged device: {e:?}");
                 }
-                Err(e) => {
-                    warn!(
-                        ?user_id, ?device_id, error = ?e,
-                        "Tried to create an Olm session, but we can't \
-                        fetch the device from the store",
-                    );
-                    continue;
-                }
-            };
 
-            let account = store_transaction.account().await?;
-            let session = match account.create_outbound_session(&device, one_time_key) {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!(
-                        ?user_id, ?device_id, error = ?e,
-                        "Error creating Olm session"
-                    );
+                let session_info = SessionInfo {
+                    session_id: session.session_id().to_owned(),
+                    algorithm: session.algorithm().await,
+                    fallback_key_used: session.created_using_fallback_key,
+                };
 
-                    self.failed_devices
-                        .write()
-                        .unwrap()
-                        .entry(user_id.to_owned())
-                        .or_default()
-                        .insert(device_id.to_owned());
-
-                    continue;
-                }
-            };
-
-            self.key_request_machine.retry_keyshare(user_id, device_id);
-
-            if let Err(e) = self.check_if_unwedged(user_id, device_id).await {
-                error!(?user_id, ?device_id, "Error while treating an unwedged device: {e:?}");
+                changes.sessions.push(session);
+                new_sessions.entry(user_id).or_default().insert(device_id, session_info);
             }
-
-            let session_info = SessionInfo {
-                session_id: session.session_id().to_owned(),
-                algorithm: session.algorithm().await,
-                fallback_key_used: session.created_using_fallback_key,
-            };
-
-            changes.sessions.push(session);
-            new_sessions.entry(user_id).or_default().insert(device_id, session_info);
         }
 
         store_transaction.commit().await?;

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -318,9 +318,10 @@ impl SessionManager {
     /// As per [spec], if a user/device pair does not have any one-time keys on
     /// the homeserver, the server will just omit the user/device pair from
     /// the response:
-    ///     > If the homeserver could be reached, but the user or device was
-    ///     > unknown, no failure is recorded. Instead, the corresponding user
-    ///     > or device is missing from the one_time_keys result.
+    ///
+    /// > If the homeserver could be reached, but the user or device was
+    /// > unknown, no failure is recorded. Instead, the corresponding user
+    /// > or device is missing from the one_time_keys result.
     ///
     /// The user/device pairs which are missing from the response are going to
     /// be put in the failures cache so we don't retry to claim a one-time
@@ -360,7 +361,7 @@ impl SessionManager {
         if let Some(request) = request {
             let devices_in_response: BTreeSet<_> = one_time_keys
                 .iter()
-                .flat_map(|(u, d)| d.keys().map(|d| (*u, *d)).collect::<BTreeSet<_>>())
+                .flat_map(|&(u, d)| d.keys().map(|d| (u, d)).collect::<BTreeSet<_>>())
                 .collect();
 
             let devices_in_request: BTreeSet<(_, _)> = request

--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -361,13 +361,23 @@ impl SessionManager {
         if let Some(request) = request {
             let devices_in_response: BTreeSet<_> = one_time_keys
                 .iter()
-                .flat_map(|&(u, d)| d.keys().map(|d| (u, d)).collect::<BTreeSet<_>>())
+                .flat_map(|(user_id, device_key_map)| {
+                    device_key_map
+                        .keys()
+                        .map(|device_id| (*user_id, *device_id))
+                        .collect::<BTreeSet<_>>()
+                })
                 .collect();
 
             let devices_in_request: BTreeSet<(_, _)> = request
                 .one_time_keys
                 .iter()
-                .flat_map(|(u, d)| d.keys().map(|d| (u, d)).collect::<BTreeSet<_>>())
+                .flat_map(|(user_id, device_key_map)| {
+                    device_key_map
+                        .keys()
+                        .map(|device_id| (user_id, device_id))
+                        .collect::<BTreeSet<_>>()
+                })
                 .collect();
 
             let missing_devices: BTreeSet<_> = devices_in_request

--- a/crates/matrix-sdk-crypto/src/types/one_time_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/one_time_keys.rs
@@ -20,8 +20,8 @@
 
 use std::collections::BTreeMap;
 
-use ruma::serde::Raw;
-use serde::{Deserialize, Serialize};
+use ruma::{serde::Raw, DeviceKeyAlgorithm};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{value::to_raw_value, Value};
 use vodozemac::Curve25519PublicKey;
 
@@ -48,7 +48,7 @@ pub struct SignedKey {
 fn double_option<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
 where
     T: Deserialize<'de>,
-    D: serde::Deserializer<'de>,
+    D: Deserializer<'de>,
 {
     Deserialize::deserialize(de).map(Some)
 }
@@ -98,29 +98,60 @@ impl SignedKey {
 }
 
 /// A one-time public key for "pre-key" messages.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum OneTimeKey {
     /// A signed Curve25519 one-time key.
     SignedKey(SignedKey),
 
     /// An unsigned Curve25519 one-time key.
-    #[serde(deserialize_with = "deserialize_curve_key", serialize_with = "serialize_curve_key")]
+    #[serde(serialize_with = "serialize_curve_key")]
     Key(Curve25519PublicKey),
+}
 
-    /// An unknown one-time key type.
-    Unknown(Value),
+impl OneTimeKey {
+    /// Deserialize the [`OneTimeKey`] from a [`DeviceKeyAlgorithm`] and a Raw
+    /// JSON value.
+    ///
+    /// The [`DeviceKeyAlgorithm`] is needed because multiple algorithms might
+    /// have the same JSON representation.
+    pub fn deserialize(
+        algorithm: DeviceKeyAlgorithm,
+        key: &Raw<ruma::encryption::OneTimeKey>,
+    ) -> Result<Self, serde_json::Error> {
+        match algorithm {
+            DeviceKeyAlgorithm::Curve25519 => {
+                let key: String = key.deserialize_as()?;
+                Ok(OneTimeKey::Key(
+                    Curve25519PublicKey::from_base64(&key).map_err(serde::de::Error::custom)?,
+                ))
+            }
+            DeviceKeyAlgorithm::SignedCurve25519 => {
+                let key: SignedKey = key.deserialize_as()?;
+                Ok(OneTimeKey::SignedKey(key))
+            }
+            _ => Err(serde::de::Error::custom(format!("Unsupported key algorithm {algorithm}"))),
+        }
+    }
+}
+
+impl OneTimeKey {
+    /// Is the key considered to be a fallback key.
+    pub fn fallback(&self) -> bool {
+        match self {
+            OneTimeKey::SignedKey(s) => s.fallback(),
+            OneTimeKey::Key(_) => false,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_let;
     use ruma::{device_id, user_id, DeviceKeyAlgorithm, DeviceKeyId};
     use serde_json::json;
     use vodozemac::{Curve25519PublicKey, Ed25519Signature};
 
-    use super::OneTimeKey;
-    use crate::types::Signature;
+    use crate::types::{Signature, SignedKey};
 
     #[test]
     fn serialization() {
@@ -148,20 +179,19 @@ mod tests {
 
         let custom_signature = Signature::Other("UnknownSignature".to_owned());
 
-        let key: OneTimeKey =
+        let key: SignedKey =
             serde_json::from_value(json.clone()).expect("Can't deserialize a valid one-time key");
 
-        assert_let!(OneTimeKey::SignedKey(k) = &key);
-        assert_eq!(k.key, curve_key);
+        assert_eq!(key.key(), curve_key);
         assert_eq!(
-            k.signatures().get_signature(
+            key.signatures().get_signature(
                 user_id,
                 &DeviceKeyId::from_parts(DeviceKeyAlgorithm::Ed25519, device_id)
             ),
             Some(signature)
         );
         assert_eq!(
-            k.signatures()
+            key.signatures()
                 .get(user_id)
                 .unwrap()
                 .get(&DeviceKeyId::from_parts("other".into(), device_id)),

--- a/crates/matrix-sdk-crypto/src/types/one_time_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/one_time_keys.rs
@@ -112,9 +112,6 @@ pub enum OneTimeKey {
 impl OneTimeKey {
     /// Deserialize the [`OneTimeKey`] from a [`DeviceKeyAlgorithm`] and a Raw
     /// JSON value.
-    ///
-    /// The [`DeviceKeyAlgorithm`] is needed because multiple algorithms might
-    /// have the same JSON representation.
     pub fn deserialize(
         algorithm: DeviceKeyAlgorithm,
         key: &Raw<ruma::encryption::OneTimeKey>,


### PR DESCRIPTION
This is useful if we ever decide to switch to X3DH for the session establishment. It also refactors a bit the /keys/claim response handling method.
