### PR TITLE
fix: is_editable() function for polls

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -296,6 +296,9 @@ impl EventTimelineItem {
                 self.is_own()
                     && matches!(message.msgtype(), MessageType::Text(_) | MessageType::Emote(_))
             }
+            TimelineItemContent::Poll(poll) => {
+                self.is_own() && poll.response_data.is_empty() && poll.end_event_timestamp.is_none()
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
This PR fixes the `EventTimelineItem.is_editable()` function for polls.
Before this changes it always returned false.
Now it consider poll's preconditions for editing:
- The poll has no votes yet
- The poll hasn't an end event
