### PR TITLE
Timeline: add poll history API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -150,6 +150,10 @@ impl Room {
         }
     }
 
+    pub async fn poll_history(&self) -> Arc<Timeline> {
+        Timeline::new(self.inner.poll_history().await)
+    }
+
     pub fn display_name(&self) -> Result<String, ClientError> {
         let r = self.inner.clone();
         RUNTIME.block_on(async move { Ok(r.display_name().await?.to_string()) })

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -18,13 +18,16 @@ use matrix_sdk::Room;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk::{deserialized_responses::TimelineEvent, Result};
 use matrix_sdk_base::latest_event::LatestEvent;
+#[cfg(feature = "e2e-encryption")]
+use ruma::{events::AnySyncTimelineEvent, serde::Raw};
 use ruma::{
-    events::receipt::{Receipt, ReceiptThread, ReceiptType},
+    events::{
+        receipt::{Receipt, ReceiptThread, ReceiptType},
+        AnySyncMessageLikeEvent,
+    },
     push::{PushConditionRoomCtx, Ruleset},
     EventId, OwnedEventId, OwnedUserId, RoomVersionId, UserId,
 };
-#[cfg(feature = "e2e-encryption")]
-use ruma::{events::AnySyncTimelineEvent, serde::Raw};
 use tracing::{debug, error, warn};
 
 use super::{Profile, TimelineBuilder};
@@ -50,6 +53,9 @@ pub trait RoomExt {
     /// This allows to customize settings of the [`Timeline`] before
     /// constructing it.
     fn timeline_builder(&self) -> TimelineBuilder;
+
+    /// Get a [`Timeline`] for this room, filtered to only include poll events.
+    async fn poll_history(&self) -> Timeline;
 }
 
 #[async_trait]
@@ -60,6 +66,23 @@ impl RoomExt for Room {
 
     fn timeline_builder(&self) -> TimelineBuilder {
         Timeline::builder(self).track_read_marker_and_receipts()
+    }
+
+    async fn poll_history(&self) -> Timeline {
+        self.timeline_builder()
+            .event_filter(|e| match e {
+                AnySyncTimelineEvent::MessageLike(m) => {
+                    matches!(
+                        m,
+                        AnySyncMessageLikeEvent::UnstablePollStart(_)
+                            | AnySyncMessageLikeEvent::UnstablePollResponse(_)
+                            | AnySyncMessageLikeEvent::UnstablePollEnd(_)
+                    )
+                }
+                _ => false,
+            })
+            .build()
+            .await
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -70,16 +70,15 @@ impl RoomExt for Room {
 
     async fn poll_history(&self) -> Timeline {
         self.timeline_builder()
-            .event_filter(|e| match e {
-                AnySyncTimelineEvent::MessageLike(m) => {
-                    matches!(
-                        m,
+            .event_filter(|e| {
+                matches!(
+                    e,
+                    AnySyncTimelineEvent::MessageLike(
                         AnySyncMessageLikeEvent::UnstablePollStart(_)
                             | AnySyncMessageLikeEvent::UnstablePollResponse(_)
                             | AnySyncMessageLikeEvent::UnstablePollEnd(_)
                     )
-                }
-                _ => false,
+                )
             })
             .build()
             .await


### PR DESCRIPTION
Allows to retrieve the Poll history of a Room.
The poll history is a Timeline instance that filters on poll events.