### PR TITLE
Align FFI timeline API more with the Rust API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -177,16 +177,6 @@ impl Room {
         }
     }
 
-    /// Removes the timeline.
-    ///
-    /// Timeline items cached in memory as well as timeline listeners are
-    /// dropped.
-    pub fn remove_timeline(&self) {
-        RUNTIME.block_on(async {
-            *self.timeline.write().await = None;
-        });
-    }
-
     pub fn retry_decryption(&self, session_ids: Vec<String>) {
         let timeline = match &*RUNTIME.block_on(self.timeline.read()) {
             Some(t) => Arc::clone(t),

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -19,8 +19,11 @@ use matrix_sdk_ui::room_list_service::filters::{
 use tokio::sync::RwLock;
 
 use crate::{
-    error::ClientError, room::Room, room_info::RoomInfo, timeline::EventTimelineItem, TaskHandle,
-    RUNTIME,
+    error::ClientError,
+    room::Room,
+    room_info::RoomInfo,
+    timeline::{EventTimelineItem, Timeline},
+    TaskHandle, RUNTIME,
 };
 
 #[derive(Debug, thiserror::Error, uniffi::Error)]
@@ -445,7 +448,7 @@ impl RoomListItem {
     async fn full_room(&self) -> Arc<Room> {
         Arc::new(Room::with_timeline(
             self.inner.inner_room().clone(),
-            Arc::new(RwLock::new(Some(self.inner.timeline().await))),
+            Arc::new(RwLock::new(Some(Timeline::from_arc(self.inner.timeline().await)))),
         ))
     }
 

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -12,22 +12,541 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Write as _, fs, sync::Arc};
 
+use anyhow::{Context, Result};
 use as_variant::as_variant;
 use eyeball_im::VectorDiff;
-use matrix_sdk_ui::timeline::{EventItemOrigin, Profile, TimelineDetails};
-use tracing::warn;
+use futures_util::{pin_mut, StreamExt};
+use matrix_sdk::attachment::{
+    AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
+    BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
+};
+use matrix_sdk_ui::timeline::{BackPaginationStatus, EventItemOrigin, Profile, TimelineDetails};
+use mime::Mime;
+use ruma::{
+    api::client::receipt::create_receipt::v3::ReceiptType,
+    events::{
+        location::{AssetType as RumaAssetType, LocationContent, ZoomLevel},
+        poll::{
+            unstable_end::UnstablePollEndEventContent,
+            unstable_response::UnstablePollResponseEventContent,
+            unstable_start::{
+                NewUnstablePollStartEventContent, UnstablePollAnswer, UnstablePollAnswers,
+                UnstablePollStartContentBlock,
+            },
+        },
+        receipt::ReceiptThread,
+        relation::Annotation,
+        room::message::{
+            ForwardThread, LocationMessageEventContent, MessageType,
+            RoomMessageEventContentWithoutRelation,
+        },
+        AnyMessageLikeEventContent,
+    },
+    EventId,
+};
+use tokio::{
+    sync::Mutex,
+    task::{AbortHandle, JoinHandle},
+};
+use tracing::{error, info, warn};
+use uuid::Uuid;
 
-use crate::helpers::unwrap_or_clone_arc;
+use crate::{
+    client::ProgressWatcher,
+    error::{ClientError, RoomError},
+    helpers::unwrap_or_clone_arc,
+    ruma::{AssetType, AudioInfo, FileInfo, ImageInfo, PollKind, ThumbnailInfo, VideoInfo},
+    task_handle::TaskHandle,
+    RUNTIME,
+};
 
 mod content;
 
 pub use self::content::{Reaction, ReactionSenderData, TimelineItemContent};
 
+#[derive(uniffi::Object)]
+#[repr(transparent)]
+pub struct Timeline {
+    pub(crate) inner: matrix_sdk_ui::timeline::Timeline,
+}
+
+impl Timeline {
+    pub(crate) fn new(inner: matrix_sdk_ui::timeline::Timeline) -> Arc<Self> {
+        Arc::new(Self { inner })
+    }
+
+    pub(crate) fn from_arc(inner: Arc<matrix_sdk_ui::timeline::Timeline>) -> Arc<Self> {
+        // SAFETY: repr(transparent) means transmuting the arc this way is allowed
+        unsafe { Arc::from_raw(Arc::into_raw(inner) as _) }
+    }
+
+    fn build_thumbnail_info(
+        &self,
+        thumbnail_url: String,
+        thumbnail_info: ThumbnailInfo,
+    ) -> Result<Thumbnail, RoomError> {
+        let thumbnail_data =
+            fs::read(thumbnail_url).map_err(|_| RoomError::InvalidThumbnailData)?;
+
+        let base_thumbnail_info = BaseThumbnailInfo::try_from(&thumbnail_info)
+            .map_err(|_| RoomError::InvalidAttachmentData)?;
+
+        let mime_str =
+            thumbnail_info.mimetype.as_ref().ok_or(RoomError::InvalidAttachmentMimeType)?;
+        let mime_type =
+            mime_str.parse::<Mime>().map_err(|_| RoomError::InvalidAttachmentMimeType)?;
+
+        Ok(Thumbnail {
+            data: thumbnail_data,
+            content_type: mime_type,
+            info: Some(base_thumbnail_info),
+        })
+    }
+
+    async fn send_attachment(
+        &self,
+        url: String,
+        mime_type: Mime,
+        attachment_config: AttachmentConfig,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
+    ) -> Result<(), RoomError> {
+        let request = self.inner.send_attachment(url, mime_type, attachment_config);
+        if let Some(progress_watcher) = progress_watcher {
+            let mut subscriber = request.subscribe_to_send_progress();
+            RUNTIME.spawn(async move {
+                while let Some(progress) = subscriber.next().await {
+                    progress_watcher.transmission_progress(progress.into());
+                }
+            });
+        }
+
+        request.await.map_err(|_| RoomError::FailedSendingAttachment)?;
+        Ok(())
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl Timeline {
+    pub async fn add_listener(
+        &self,
+        listener: Box<dyn TimelineListener>,
+    ) -> RoomTimelineListenerResult {
+        let (timeline_items, timeline_stream) = self.inner.subscribe_batched().await;
+        let timeline_stream = TaskHandle::new(RUNTIME.spawn(async move {
+            pin_mut!(timeline_stream);
+
+            while let Some(diffs) = timeline_stream.next().await {
+                listener
+                    .on_update(diffs.into_iter().map(|d| Arc::new(TimelineDiff::new(d))).collect());
+            }
+        }));
+
+        RoomTimelineListenerResult {
+            items: timeline_items.into_iter().map(TimelineItem::from_arc).collect(),
+            items_stream: Arc::new(timeline_stream),
+        }
+    }
+
+    pub fn retry_decryption(self: Arc<Self>, session_ids: Vec<String>) {
+        RUNTIME.spawn(async move {
+            self.inner.retry_decryption(&session_ids).await;
+        });
+    }
+
+    pub async fn fetch_members(&self) {
+        self.inner.fetch_members().await
+    }
+
+    pub fn subscribe_to_back_pagination_status(
+        &self,
+        listener: Box<dyn BackPaginationStatusListener>,
+    ) -> Result<Arc<TaskHandle>, ClientError> {
+        let mut subscriber = self.inner.back_pagination_status();
+
+        Ok(Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
+            // Send the current state even if it hasn't changed right away.
+            listener.on_update(subscriber.next_now());
+
+            while let Some(status) = subscriber.next().await {
+                listener.on_update(status);
+            }
+        }))))
+    }
+
+    /// Loads older messages into the timeline.
+    ///
+    /// Raises an exception if there are no timeline listeners.
+    pub fn paginate_backwards(&self, opts: PaginationOptions) -> Result<(), ClientError> {
+        RUNTIME.block_on(async { Ok(self.inner.paginate_backwards(opts.into()).await?) })
+    }
+
+    pub fn send_read_receipt(&self, event_id: String) -> Result<(), ClientError> {
+        let event_id = EventId::parse(event_id)?;
+
+        RUNTIME.block_on(async {
+            self.inner
+                .send_single_receipt(ReceiptType::Read, ReceiptThread::Unthreaded, event_id)
+                .await?;
+            Ok(())
+        })
+    }
+
+    pub fn send(self: Arc<Self>, msg: Arc<RoomMessageEventContentWithoutRelation>) {
+        RUNTIME.spawn(async move {
+            self.inner.send((*msg).to_owned().with_relation(None).into()).await;
+        });
+    }
+
+    pub fn send_image(
+        self: Arc<Self>,
+        url: String,
+        thumbnail_url: String,
+        image_info: ImageInfo,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
+    ) -> Arc<SendAttachmentJoinHandle> {
+        SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
+            let mime_str =
+                image_info.mimetype.as_ref().ok_or(RoomError::InvalidAttachmentMimeType)?;
+            let mime_type =
+                mime_str.parse::<Mime>().map_err(|_| RoomError::InvalidAttachmentMimeType)?;
+
+            let base_image_info = BaseImageInfo::try_from(&image_info)
+                .map_err(|_| RoomError::InvalidAttachmentData)?;
+
+            let attachment_info = AttachmentInfo::Image(base_image_info);
+
+            let attachment_config = match image_info.thumbnail_info {
+                Some(thumbnail_image_info) => {
+                    let thumbnail =
+                        self.build_thumbnail_info(thumbnail_url, thumbnail_image_info)?;
+                    AttachmentConfig::with_thumbnail(thumbnail).info(attachment_info)
+                }
+                None => AttachmentConfig::new().info(attachment_info),
+            };
+
+            self.send_attachment(url, mime_type, attachment_config, progress_watcher).await
+        }))
+    }
+
+    pub fn send_video(
+        self: Arc<Self>,
+        url: String,
+        thumbnail_url: String,
+        video_info: VideoInfo,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
+    ) -> Arc<SendAttachmentJoinHandle> {
+        SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
+            let mime_str =
+                video_info.mimetype.as_ref().ok_or(RoomError::InvalidAttachmentMimeType)?;
+            let mime_type =
+                mime_str.parse::<Mime>().map_err(|_| RoomError::InvalidAttachmentMimeType)?;
+
+            let base_video_info: BaseVideoInfo = BaseVideoInfo::try_from(&video_info)
+                .map_err(|_| RoomError::InvalidAttachmentData)?;
+
+            let attachment_info = AttachmentInfo::Video(base_video_info);
+
+            let attachment_config = match video_info.thumbnail_info {
+                Some(thumbnail_image_info) => {
+                    let thumbnail =
+                        self.build_thumbnail_info(thumbnail_url, thumbnail_image_info)?;
+                    AttachmentConfig::with_thumbnail(thumbnail).info(attachment_info)
+                }
+                None => AttachmentConfig::new().info(attachment_info),
+            };
+
+            self.send_attachment(url, mime_type, attachment_config, progress_watcher).await
+        }))
+    }
+
+    pub fn send_audio(
+        self: Arc<Self>,
+        url: String,
+        audio_info: AudioInfo,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
+    ) -> Arc<SendAttachmentJoinHandle> {
+        SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
+            let mime_str =
+                audio_info.mimetype.as_ref().ok_or(RoomError::InvalidAttachmentMimeType)?;
+            let mime_type =
+                mime_str.parse::<Mime>().map_err(|_| RoomError::InvalidAttachmentMimeType)?;
+
+            let base_audio_info: BaseAudioInfo = BaseAudioInfo::try_from(&audio_info)
+                .map_err(|_| RoomError::InvalidAttachmentData)?;
+
+            let attachment_info = AttachmentInfo::Audio(base_audio_info);
+            let attachment_config = AttachmentConfig::new().info(attachment_info);
+
+            self.send_attachment(url, mime_type, attachment_config, progress_watcher).await
+        }))
+    }
+
+    pub fn send_voice_message(
+        self: Arc<Self>,
+        url: String,
+        audio_info: AudioInfo,
+        waveform: Vec<u16>,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
+    ) -> Arc<SendAttachmentJoinHandle> {
+        SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
+            let mime_str =
+                audio_info.mimetype.as_ref().ok_or(RoomError::InvalidAttachmentMimeType)?;
+            let mime_type =
+                mime_str.parse::<Mime>().map_err(|_| RoomError::InvalidAttachmentMimeType)?;
+
+            let base_audio_info: BaseAudioInfo = BaseAudioInfo::try_from(&audio_info)
+                .map_err(|_| RoomError::InvalidAttachmentData)?;
+
+            let attachment_info =
+                AttachmentInfo::Voice { audio_info: base_audio_info, waveform: Some(waveform) };
+            let attachment_config = AttachmentConfig::new().info(attachment_info);
+
+            self.send_attachment(url, mime_type, attachment_config, progress_watcher).await
+        }))
+    }
+
+    pub fn send_file(
+        self: Arc<Self>,
+        url: String,
+        file_info: FileInfo,
+        progress_watcher: Option<Box<dyn ProgressWatcher>>,
+    ) -> Arc<SendAttachmentJoinHandle> {
+        SendAttachmentJoinHandle::new(RUNTIME.spawn(async move {
+            let mime_str =
+                file_info.mimetype.as_ref().ok_or(RoomError::InvalidAttachmentMimeType)?;
+            let mime_type =
+                mime_str.parse::<Mime>().map_err(|_| RoomError::InvalidAttachmentMimeType)?;
+
+            let base_file_info: BaseFileInfo =
+                BaseFileInfo::try_from(&file_info).map_err(|_| RoomError::InvalidAttachmentData)?;
+
+            let attachment_info = AttachmentInfo::File(base_file_info);
+            let attachment_config = AttachmentConfig::new().info(attachment_info);
+
+            self.send_attachment(url, mime_type, attachment_config, progress_watcher).await
+        }))
+    }
+
+    pub fn create_poll(
+        self: Arc<Self>,
+        question: String,
+        answers: Vec<String>,
+        max_selections: u8,
+        poll_kind: PollKind,
+    ) -> Result<(), ClientError> {
+        let poll_data = PollData { question, answers, max_selections, poll_kind };
+
+        let poll_start_event_content = NewUnstablePollStartEventContent::plain_text(
+            poll_data.fallback_text(),
+            poll_data.try_into()?,
+        );
+        let event_content =
+            AnyMessageLikeEventContent::UnstablePollStart(poll_start_event_content.into());
+
+        RUNTIME.spawn(async move {
+            self.inner.send(event_content).await;
+        });
+
+        Ok(())
+    }
+
+    pub fn send_poll_response(
+        self: Arc<Self>,
+        poll_start_id: String,
+        answers: Vec<String>,
+    ) -> Result<(), ClientError> {
+        let poll_start_event_id =
+            EventId::parse(poll_start_id).context("Failed to parse EventId")?;
+        let poll_response_event_content =
+            UnstablePollResponseEventContent::new(answers, poll_start_event_id);
+        let event_content =
+            AnyMessageLikeEventContent::UnstablePollResponse(poll_response_event_content);
+
+        RUNTIME.spawn(async move {
+            self.inner.send(event_content).await;
+        });
+
+        Ok(())
+    }
+
+    pub fn end_poll(
+        self: Arc<Self>,
+        poll_start_id: String,
+        text: String,
+    ) -> Result<(), ClientError> {
+        let poll_start_event_id =
+            EventId::parse(poll_start_id).context("Failed to parse EventId")?;
+        let poll_end_event_content = UnstablePollEndEventContent::new(text, poll_start_event_id);
+        let event_content = AnyMessageLikeEventContent::UnstablePollEnd(poll_end_event_content);
+
+        RUNTIME.spawn(async move {
+            self.inner.send(event_content).await;
+        });
+
+        Ok(())
+    }
+
+    pub fn send_reply(
+        &self,
+        msg: Arc<RoomMessageEventContentWithoutRelation>,
+        reply_item: Arc<EventTimelineItem>,
+    ) -> Result<(), ClientError> {
+        RUNTIME.block_on(async {
+            self.inner.send_reply((*msg).clone(), &reply_item.0, ForwardThread::Yes).await?;
+            anyhow::Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    pub fn edit(
+        &self,
+        new_content: Arc<RoomMessageEventContentWithoutRelation>,
+        edit_item: Arc<EventTimelineItem>,
+    ) -> Result<(), ClientError> {
+        RUNTIME.block_on(async {
+            self.inner.edit((*new_content).clone().with_relation(None), &edit_item.0).await?;
+            anyhow::Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    pub async fn edit_poll(
+        &self,
+        question: String,
+        answers: Vec<String>,
+        max_selections: u8,
+        poll_kind: PollKind,
+        edit_item: Arc<EventTimelineItem>,
+    ) -> Result<(), ClientError> {
+        let poll_data = PollData { question, answers, max_selections, poll_kind };
+
+        RUNTIME.block_on(async {
+            self.inner
+                .edit_poll(poll_data.fallback_text(), poll_data.try_into()?, &edit_item.0)
+                .await?;
+            anyhow::Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    pub fn send_location(
+        self: Arc<Self>,
+        body: String,
+        geo_uri: String,
+        description: Option<String>,
+        zoom_level: Option<u8>,
+        asset_type: Option<AssetType>,
+    ) {
+        let mut location_event_message_content =
+            LocationMessageEventContent::new(body, geo_uri.clone());
+
+        if let Some(asset_type) = asset_type {
+            location_event_message_content =
+                location_event_message_content.with_asset_type(RumaAssetType::from(asset_type));
+        }
+
+        let mut location_content = LocationContent::new(geo_uri);
+        location_content.description = description;
+        location_content.zoom_level = zoom_level.and_then(ZoomLevel::new);
+        location_event_message_content.location = Some(location_content);
+
+        let room_message_event_content = RoomMessageEventContentWithoutRelation::new(
+            MessageType::Location(location_event_message_content),
+        );
+        self.send(Arc::new(room_message_event_content))
+    }
+
+    pub fn toggle_reaction(&self, event_id: String, key: String) -> Result<(), ClientError> {
+        let event_id = EventId::parse(event_id)?;
+        RUNTIME.block_on(async {
+            self.inner.toggle_reaction(&Annotation::new(event_id, key)).await?;
+            Ok(())
+        })
+    }
+
+    pub fn fetch_details_for_event(&self, event_id: String) -> Result<(), ClientError> {
+        let event_id = <&EventId>::try_from(event_id.as_str())?;
+        RUNTIME.block_on(async {
+            self.inner.fetch_details_for_event(event_id).await.context("Fetching event details")?;
+            Ok(())
+        })
+    }
+
+    pub fn retry_send(self: Arc<Self>, txn_id: String) {
+        RUNTIME.spawn(async move {
+            if let Err(e) = self.inner.retry_send(txn_id.as_str().into()).await {
+                error!(txn_id, "Failed to retry sending: {e}");
+            }
+        });
+    }
+
+    pub fn cancel_send(self: Arc<Self>, txn_id: String) {
+        RUNTIME.spawn(async move {
+            if !self.inner.cancel_send(txn_id.as_str().into()).await {
+                info!(txn_id, "Failed to discard local echo: Not found");
+            }
+        });
+    }
+
+    pub fn get_event_timeline_item_by_event_id(
+        &self,
+        event_id: String,
+    ) -> Result<Arc<EventTimelineItem>, ClientError> {
+        let event_id = EventId::parse(event_id)?;
+        RUNTIME.block_on(async {
+            let item = self
+                .inner
+                .item_by_event_id(&event_id)
+                .await
+                .context("Item with given event ID not found")?;
+
+            Ok(Arc::new(EventTimelineItem(item)))
+        })
+    }
+
+    pub fn get_timeline_event_content_by_event_id(
+        &self,
+        event_id: String,
+    ) -> Result<Arc<RoomMessageEventContentWithoutRelation>, ClientError> {
+        let event_id = EventId::parse(event_id)?;
+        RUNTIME.block_on(async {
+            let item = self
+                .inner
+                .item_by_event_id(&event_id)
+                .await
+                .context("Item with given event ID not found")?;
+
+            let msgtype = item
+                .content()
+                .as_message()
+                .context("Item with given event ID is not a message")?
+                .msgtype()
+                .to_owned();
+
+            Ok(Arc::new(RoomMessageEventContentWithoutRelation::new(msgtype)))
+        })
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct RoomTimelineListenerResult {
+    pub items: Vec<Arc<TimelineItem>>,
+    pub items_stream: Arc<TaskHandle>,
+}
+
 #[uniffi::export(callback_interface)]
 pub trait TimelineListener: Sync + Send {
     fn on_update(&self, diff: Vec<Arc<TimelineDiff>>);
+}
+
+#[uniffi::export(callback_interface)]
+pub trait BackPaginationStatusListener: Sync + Send {
+    fn on_update(&self, status: BackPaginationStatus);
 }
 
 #[derive(Clone, uniffi::Object)]
@@ -350,6 +869,96 @@ impl From<&TimelineDetails<Profile>> for ProfileDetails {
             },
             TimelineDetails::Error(e) => Self::Error { message: e.to_string() },
         }
+    }
+}
+
+struct PollData {
+    question: String,
+    answers: Vec<String>,
+    max_selections: u8,
+    poll_kind: PollKind,
+}
+
+impl PollData {
+    fn fallback_text(&self) -> String {
+        self.answers.iter().enumerate().fold(self.question.clone(), |mut acc, (index, answer)| {
+            write!(&mut acc, "\n{}. {answer}", index + 1).unwrap();
+            acc
+        })
+    }
+}
+
+impl TryFrom<PollData> for UnstablePollStartContentBlock {
+    type Error = ClientError;
+
+    fn try_from(value: PollData) -> Result<Self, Self::Error> {
+        let poll_answers_vec: Vec<UnstablePollAnswer> = value
+            .answers
+            .iter()
+            .map(|answer| UnstablePollAnswer::new(Uuid::new_v4().to_string(), answer))
+            .collect();
+
+        let poll_answers = UnstablePollAnswers::try_from(poll_answers_vec)
+            .context("Failed to create poll answers")?;
+
+        let mut poll_content_block =
+            UnstablePollStartContentBlock::new(value.question.clone(), poll_answers);
+        poll_content_block.kind = value.poll_kind.into();
+        poll_content_block.max_selections = value.max_selections.into();
+
+        Ok(poll_content_block)
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct SendAttachmentJoinHandle {
+    join_hdl: Arc<Mutex<JoinHandle<Result<(), RoomError>>>>,
+    abort_hdl: AbortHandle,
+}
+
+impl SendAttachmentJoinHandle {
+    fn new(join_hdl: JoinHandle<Result<(), RoomError>>) -> Arc<Self> {
+        let abort_hdl = join_hdl.abort_handle();
+        let join_hdl = Arc::new(Mutex::new(join_hdl));
+        Arc::new(Self { join_hdl, abort_hdl })
+    }
+}
+
+#[uniffi::export(async_runtime = "tokio")]
+impl SendAttachmentJoinHandle {
+    pub async fn join(&self) -> Result<(), RoomError> {
+        let join_hdl = self.join_hdl.clone();
+        RUNTIME.spawn(async move { (&mut *join_hdl.lock().await).await.unwrap() }).await.unwrap()
+    }
+
+    pub fn cancel(&self) {
+        self.abort_hdl.abort();
+    }
+}
+
+#[derive(uniffi::Enum)]
+pub enum PaginationOptions {
+    SimpleRequest { event_limit: u16, wait_for_token: bool },
+    UntilNumItems { event_limit: u16, items: u16, wait_for_token: bool },
+}
+
+impl From<PaginationOptions> for matrix_sdk_ui::timeline::PaginationOptions<'static> {
+    fn from(value: PaginationOptions) -> Self {
+        use matrix_sdk_ui::timeline::PaginationOptions as Opts;
+        let (wait_for_token, mut opts) = match value {
+            PaginationOptions::SimpleRequest { event_limit, wait_for_token } => {
+                (wait_for_token, Opts::simple_request(event_limit))
+            }
+            PaginationOptions::UntilNumItems { event_limit, items, wait_for_token } => {
+                (wait_for_token, Opts::until_num_items(event_limit, items))
+            }
+        };
+
+        if wait_for_token {
+            opts = opts.wait_for_token();
+        }
+
+        opts
     }
 }
 


### PR DESCRIPTION
We had a very different API for FFI consumers than for Rust consumers for way too long. Now it required to first explicitly initialize a `Timeline` object before being able to call any methods that would require it.

Based on #2880.