### PR TITLE
Exposing power level overwrites on room creation to FFI

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -949,7 +949,9 @@ impl From<CreateRoomParameters> for create_room::v3::Request {
 
         if let Some(power_levels) = value.power_level_content_override {
             match Raw::new(&power_levels.into()) {
-                Ok(power_levels) => request.power_level_content_override = Some(power_levels),
+                Ok(power_levels) => {
+                    request.power_level_content_override = Some(power_levels);
+                }
                 Err(e) => {
                     error!("Failed to serialize power levels, error: {e}");
                 }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1,13 +1,11 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     mem::ManuallyDrop,
     sync::{Arc, RwLock},
 };
 
 use anyhow::{anyhow, Context as _};
 use matrix_sdk::{
-    crypto::types::events,
-    encryption::vodozemac::sas::InvalidCount,
     media::{MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSize},
     oidc::{
         types::{

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -883,7 +883,7 @@ impl From<PowerLevels> for RoomPowerLevelsEventContent {
             .events
             .iter()
             .map(|(event_type, power_level)| {
-                let event_type: ruma::events::TimelineEventType = event_type.clone().into();
+                let event_type: ruma::events::TimelineEventType = event_type.as_str().into();
                 (event_type, (*power_level).into())
             })
             .collect();

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -39,8 +39,8 @@ use matrix_sdk::{
 use matrix_sdk_ui::notification_client::NotificationProcessSetup as MatrixNotificationProcessSetup;
 use mime::Mime;
 use ruma::{
-    api::client::{discovery::discover_homeserver::AuthenticationServerInfo, membership::ban_user},
-    events::room::power_levels::{self, RoomPowerLevelsEventContent},
+    api::client::discovery::discover_homeserver::AuthenticationServerInfo,
+    events::room::power_levels::RoomPowerLevelsEventContent,
     push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat},
 };
 use serde::{Deserialize, Serialize};
@@ -52,7 +52,6 @@ use url::Url;
 use super::{room::Room, session_verification::SessionVerificationController, RUNTIME};
 use crate::{
     client,
-    event::TimelineEventType,
     notification::NotificationClientBuilder,
     notification_settings::NotificationSettings,
     sync_service::{SyncService, SyncServiceBuilder},

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1,11 +1,13 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     mem::ManuallyDrop,
     sync::{Arc, RwLock},
 };
 
 use anyhow::{anyhow, Context as _};
 use matrix_sdk::{
+    crypto::types::events,
+    encryption::vodozemac::sas::InvalidCount,
     media::{MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSize},
     oidc::{
         types::{
@@ -39,9 +41,8 @@ use matrix_sdk::{
 use matrix_sdk_ui::notification_client::NotificationProcessSetup as MatrixNotificationProcessSetup;
 use mime::Mime;
 use ruma::{
-    api::client::discovery::discover_homeserver::AuthenticationServerInfo,
-    events::{room::power_levels::RoomPowerLevelsEventContent, TimelineEventType},
-    int,
+    api::client::{discovery::discover_homeserver::AuthenticationServerInfo, membership::ban_user},
+    events::room::power_levels::{self, RoomPowerLevelsEventContent},
     push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat},
 };
 use serde::{Deserialize, Serialize};
@@ -53,6 +54,7 @@ use url::Url;
 use super::{room::Room, session_verification::SessionVerificationController, RUNTIME};
 use crate::{
     client,
+    event::TimelineEventType,
     notification::NotificationClientBuilder,
     notification_settings::NotificationSettings,
     sync_service::{SyncService, SyncServiceBuilder},
@@ -811,6 +813,85 @@ impl Client {
 }
 
 #[derive(uniffi::Record)]
+pub struct NotificationPowerLevels {
+    pub room: i32,
+}
+impl From<NotificationPowerLevels> for ruma::power_levels::NotificationPowerLevels {
+    fn from(value: NotificationPowerLevels) -> Self {
+        let mut notification_power_levels = Self::new();
+        notification_power_levels.room = value.room.into();
+        notification_power_levels
+    }
+}
+
+#[derive(uniffi::Record)]
+pub struct PowerLevels {
+    pub users_default: Option<i32>,
+    pub events_default: Option<i32>,
+    pub state_default: Option<i32>,
+    pub ban: Option<i32>,
+    pub kick: Option<i32>,
+    pub redact: Option<i32>,
+    pub invite: Option<i32>,
+    pub notifications: Option<NotificationPowerLevels>,
+    pub users: HashMap<String, i32>,
+    pub events: HashMap<String, i32>,
+}
+
+impl From<PowerLevels> for RoomPowerLevelsEventContent {
+    fn from(value: PowerLevels) -> Self {
+        let mut power_levels = RoomPowerLevelsEventContent::new();
+
+        if let Some(users_default) = value.users_default {
+            power_levels.users_default = users_default.into();
+        }
+        if let Some(state_default) = value.state_default {
+            power_levels.state_default = state_default.into();
+        }
+        if let Some(events_default) = value.events_default {
+            power_levels.events_default = events_default.into();
+        }
+        if let Some(ban) = value.ban {
+            power_levels.ban = ban.into();
+        }
+        if let Some(kick) = value.kick {
+            power_levels.kick = kick.into();
+        }
+        if let Some(redact) = value.redact {
+            power_levels.redact = redact.into();
+        }
+        if let Some(invite) = value.invite {
+            power_levels.invite = invite.into();
+        }
+        if let Some(notifications) = value.notifications {
+            power_levels.notifications = notifications.into()
+        }
+        power_levels.users = value
+            .users
+            .iter()
+            .filter_map(|(user_id, power_level)| match UserId::parse(user_id) {
+                Ok(id) => Some((id, (*power_level).into())),
+                Err(e) => {
+                    error!(user_id, "Skipping invalid user ID, error: {e}");
+                    None
+                }
+            })
+            .collect();
+
+        power_levels.events = value
+            .events
+            .iter()
+            .map(|(event_type, power_level)| {
+                let event_type: ruma::events::TimelineEventType = event_type.clone().into();
+                (event_type, (*power_level).into())
+            })
+            .collect();
+
+        power_levels
+    }
+}
+
+#[derive(uniffi::Record)]
 pub struct CreateRoomParameters {
     pub name: Option<String>,
     #[uniffi(default = None)]
@@ -824,8 +905,8 @@ pub struct CreateRoomParameters {
     pub invite: Option<Vec<String>>,
     #[uniffi(default = None)]
     pub avatar: Option<String>,
-    #[uniffi(default = true)]
-    pub allow_call_to_everyone: bool,
+    #[uniffi(default = None)]
+    pub power_level_content_override: Option<PowerLevels>,
 }
 
 impl From<CreateRoomParameters> for create_room::v3::Request {
@@ -863,12 +944,16 @@ impl From<CreateRoomParameters> for create_room::v3::Request {
             content.url = Some(url.into());
             initial_state.push(InitialStateEvent::new(content).to_raw_any());
         }
-        if value.allow_call_to_everyone {
-            let mut power_levels = RoomPowerLevelsEventContent::new();
-            power_levels.events = BTreeMap::from([(TimelineEventType::CallMember, int!(0))]);
-            initial_state.push(InitialStateEvent::new(power_levels).to_raw_any());
-        }
         request.initial_state = initial_state;
+
+        if let Some(power_levels) = value.power_level_content_override {
+            match Raw::new(&power_levels.into()) {
+                Ok(power_levels) => request.power_level_content_override = Some(power_levels),
+                Err(e) => {
+                    error!("Failed to serialize power levels, error: {e}");
+                }
+            }
+        }
 
         request
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -816,6 +816,7 @@ impl Client {
 pub struct NotificationPowerLevels {
     pub room: i32,
 }
+
 impl From<NotificationPowerLevels> for ruma::power_levels::NotificationPowerLevels {
     fn from(value: NotificationPowerLevels) -> Self {
         let mut notification_power_levels = Self::new();

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     mem::ManuallyDrop,
     sync::{Arc, RwLock},
 };
@@ -39,6 +40,8 @@ use matrix_sdk_ui::notification_client::NotificationProcessSetup as MatrixNotifi
 use mime::Mime;
 use ruma::{
     api::client::discovery::discover_homeserver::AuthenticationServerInfo,
+    events::{room::power_levels::RoomPowerLevelsEventContent, TimelineEventType},
+    int,
     push::{HttpPusherData as RumaHttpPusherData, PushFormat as RumaPushFormat},
 };
 use serde::{Deserialize, Serialize};
@@ -858,7 +861,11 @@ impl From<CreateRoomParameters> for create_room::v3::Request {
             content.url = Some(url.into());
             initial_state.push(InitialStateEvent::new(content).to_raw_any());
         }
-
+        {
+            let mut power_levels = RoomPowerLevelsEventContent::new();
+            power_levels.events = BTreeMap::from([(TimelineEventType::CallMember, int!(0))]);
+            initial_state.push(InitialStateEvent::new(power_levels).to_raw_any());
+        }
         request.initial_state = initial_state;
 
         request

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -824,6 +824,8 @@ pub struct CreateRoomParameters {
     pub invite: Option<Vec<String>>,
     #[uniffi(default = None)]
     pub avatar: Option<String>,
+    #[uniffi(default = true)]
+    pub allow_call_to_everyone: bool,
 }
 
 impl From<CreateRoomParameters> for create_room::v3::Request {
@@ -861,7 +863,7 @@ impl From<CreateRoomParameters> for create_room::v3::Request {
             content.url = Some(url.into());
             initial_state.push(InitialStateEvent::new(content).to_raw_any());
         }
-        {
+        if value.allow_call_to_everyone {
             let mut power_levels = RoomPowerLevelsEventContent::new();
             power_levels.events = BTreeMap::from([(TimelineEventType::CallMember, int!(0))]);
             initial_state.push(InitialStateEvent::new(power_levels).to_raw_any());


### PR DESCRIPTION
This allows to overwrite the power levels on room creation. So the app can set the Power level for m.call.member events to 0.
This is an alternative to: https://github.com/ruma/ruma/pull/1706

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
