### PR TITLE
Add vscode settings.json recommandation in contrib/ide

### DIFF
--- a/contrib/ide/vscode/settings.json
+++ b/contrib/ide/vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "rust-analyzer.checkOnSave.command": "clippy",
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"]
+}


### PR DESCRIPTION
Since we need `cargo +nightly fmt` to pass ci `"rust-analyzer.rustfmt.extraArgs": ["+nightly"]` is very helpful.
`"rust-analyzer.checkOnSave.command": "clippy",` is copied from ruma since it also applies to the rust sdk if i am not mistaking.

This adds a file in `contrib/ide` that collects recommanded settings to copy over for vscode users. (The same concept that is used in ruma)

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
