### PR TITLE
fix: reify reformat of `missing_session_devices_by_user`

### DIFF
--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -293,15 +293,24 @@ impl SessionManager {
             );
         }
 
-        debug!(
+        if tracing::level_enabled!(tracing::Level::DEBUG) {
             // Reformat the map to skip the encryption algorithm, which isn't very useful.
-            missing_session_devices_by_user = ?missing_session_devices_by_user
-                .iter()
-                .map(|(user_id, devices)| (user_id, devices.keys().collect::<Vec<_>>()))
-                .format(", "),
-            ?timed_out_devices_by_user,
-            "Collected user/device pairs that are missing an Olm session"
-        );
+            //
+            // Note: we reify the debug string for `missing_session_devices_by_user` to work
+            // around a known footgun of `itertools` (it can be used only once).
+            let missing_session_devices_by_user = format!(
+                "{:?}",
+                missing_session_devices_by_user
+                    .iter()
+                    .map(|(user_id, devices)| (user_id, devices.keys().collect::<Vec<_>>()))
+                    .format(", ")
+            );
+            debug!(
+                missing_session_devices_by_user,
+                ?timed_out_devices_by_user,
+                "Collected user/device pairs that are missing an Olm session"
+            );
+        }
 
         if !failed_devices_by_user.is_empty() {
             warn!(

--- a/crates/matrix-sdk/src/sliding_sync/error.rs
+++ b/crates/matrix-sdk/src/sliding_sync/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
     InvalidSlidingSyncIdentifier,
 
     /// A task failed to execute to completion.
-    #[error("A task failed to execute to completion; task description: {task_description}")]
+    #[error("A task failed to execute to completion; task description: {task_description}, error: {error}")]
     JoinError {
         /// Task description.
         task_description: String,


### PR DESCRIPTION
`itertools::format` is known to cause issues when its display implementation is being used multiple times, as it consumes the iterator it was given (and that can only happen once, unless caching it). This is bad, as our production apps may have multiple subscribers they will run into a panic.

The fix is to reify the debug string before it's logged, so the tracing consumer will only see a string, and not the display implementation that would panic on the second use.