### PR TITLE
Rename `message` since it clashes with Kotlin's `message` property in exceptions

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -67,8 +67,8 @@ pub enum RecoveryError {
     Client { source: crate::ClientError },
 
     /// Error in the secret storage subsystem.
-    #[error("Error in the secret-storage subsystem: {message}")]
-    SecretStorage { message: String },
+    #[error("Error in the secret-storage subsystem: {error_message}")]
+    SecretStorage { error_message: String },
 }
 
 impl From<matrix_sdk::encryption::recovery::RecoveryError> for RecoveryError {
@@ -77,7 +77,7 @@ impl From<matrix_sdk::encryption::recovery::RecoveryError> for RecoveryError {
             recovery::RecoveryError::BackupExistsOnServer => Self::BackupExistsOnServer,
             recovery::RecoveryError::Sdk(e) => Self::Client { source: ClientError::from(e) },
             recovery::RecoveryError::SecretStorage(e) => {
-                Self::SecretStorage { message: e.to_string() }
+                Self::SecretStorage { error_message: e.to_string() }
             }
         }
     }


### PR DESCRIPTION
The title is kind of self-explanatory. It fixes this issue:

```
> Task :sdk:sdk-android:compileDebugKotlin
e: file:///Users/jorge/Developer/Element/matrix-rust-components-kotlin/sdk/sdk-android/src/main/kotlin/org/matrix/rustcomponents/sdk/matrix_sdk_ffi.kt:14690:13 Conflicting declarations: public open val message: String, public final val message: String
e: file:///Users/jorge/Developer/Element/matrix-rust-components-kotlin/sdk/sdk-android/src/main/kotlin/org/matrix/rustcomponents/sdk/matrix_sdk_ffi.kt:14690:13 'message' hides member of supertype 'RecoveryException' and needs 'override' modifier
e: file:///Users/jorge/Developer/Element/matrix-rust-components-kotlin/sdk/sdk-android/src/main/kotlin/org/matrix/rustcomponents/sdk/matrix_sdk_ffi.kt:14692:22 Conflicting declarations: public open val message: String, public final val message: String
e: file:///Users/jorge/Developer/Element/matrix-rust-components-kotlin/sdk/sdk-android/src/main/kotlin/org/matrix/rustcomponents/sdk/matrix_sdk_ffi.kt:14693:33 Type checking has run into a recursive problem. Easiest workaround: specify types of your declarations explicitly
```