### PR TITLE
read receipts: don't put receipts on invisible timeline events

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -79,7 +79,10 @@ impl TimelineBuilder {
     ///   return `true` if the event should be added to the `Timeline`.
     ///
     /// If this is not overridden, the timeline uses the default filter that
-    /// allows every event.
+    /// only allows events that are materialized into a `Timeline` item. For
+    /// instance, reactions and edits don't get their own timeline item (as
+    /// they affect another existing one), so they're "filtered out" to
+    /// reflect that.
     ///
     /// Note that currently:
     ///

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -20,7 +20,10 @@ use imbl::Vector;
 use matrix_sdk::{
     deserialized_responses::SyncTimelineEvent, executor::spawn, sync::RoomUpdate, Room,
 };
-use ruma::events::{receipt::ReceiptType, AnySyncTimelineEvent};
+use ruma::{
+    events::{receipt::ReceiptType, AnySyncTimelineEvent},
+    RoomVersionId,
+};
 use tokio::sync::{broadcast, mpsc, Notify};
 use tracing::{info, info_span, trace, warn, Instrument, Span};
 
@@ -92,7 +95,7 @@ impl TimelineBuilder {
     ///   they couldn't be decrypted when the appropriate room key arrives).
     pub fn event_filter<F>(mut self, filter: F) -> Self
     where
-        F: Fn(&AnySyncTimelineEvent) -> bool + Send + Sync + 'static,
+        F: Fn(&AnySyncTimelineEvent, &RoomVersionId) -> bool + Send + Sync + 'static,
     {
         self.settings.event_filter = Arc::new(filter);
         self

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -87,6 +87,12 @@ impl TimelineBuilder {
     /// they affect another existing one), so they're "filtered out" to
     /// reflect that.
     ///
+    /// You can use the default event filter with
+    /// [`crate::timeline::default_event_filter`] so as to chain it with
+    /// your own event filter, if you want to avoid situations where a read
+    /// receipt would be attached to an event that doesn't get its own
+    /// timeline item.
+    ///
     /// Note that currently:
     ///
     /// - Not all event types have a representation as a `TimelineItem` so these

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -542,8 +542,8 @@ impl TimelineInnerStateTransaction<'_> {
         let (event_id, sender, timestamp, txn_id, event_kind, should_add) = match raw.deserialize()
         {
             Ok(event) => {
-                let should_add = (settings.event_filter)(&event);
                 let room_version = room_data_provider.room_version();
+                let should_add = (settings.event_filter)(&event, &room_version);
                 (
                     event.event_id().to_owned(),
                     event.sender().to_owned(),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -90,6 +90,7 @@ pub use self::{
         Message, OtherState, Profile, ReactionGroup, RepliedToEvent, RoomMembershipChange, Sticker,
         TimelineDetails, TimelineItemContent,
     },
+    inner::default_event_filter,
     item::{TimelineItem, TimelineItemKind},
     pagination::{BackPaginationStatus, PaginationOptions, PaginationOutcome},
     polls::PollResult,

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -104,7 +104,7 @@ async fn default_filter() {
 #[async_test]
 async fn filter_always_false() {
     let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
-        event_filter: Arc::new(|_| false),
+        event_filter: Arc::new(|_, _| false),
         ..Default::default()
     });
 
@@ -136,7 +136,7 @@ async fn filter_always_false() {
 async fn custom_filter() {
     // Filter out all state events.
     let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
-        event_filter: Arc::new(|ev| matches!(ev, AnySyncTimelineEvent::MessageLike(_))),
+        event_filter: Arc::new(|ev, _| matches!(ev, AnySyncTimelineEvent::MessageLike(_))),
         ..Default::default()
     });
     let mut stream = timeline.subscribe().await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -23,14 +23,14 @@ use ruma::{
         room::message::{MessageType, RoomMessageEventContent, SyncRoomMessageEvent},
         AnySyncMessageLikeEvent, AnySyncTimelineEvent,
     },
-    owned_event_id, room_id, uint,
+    owned_event_id, room_id, uint, RoomVersionId,
 };
 use stream_assert::{assert_next_matches, assert_pending};
 
 use super::{ReadReceiptMap, TestRoomDataProvider, TestTimeline};
 use crate::timeline::inner::TimelineInnerSettings;
 
-fn filter_notice(ev: &AnySyncTimelineEvent) -> bool {
+fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
     match ev {
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
             SyncRoomMessageEvent::Original(msg),
@@ -341,12 +341,12 @@ async fn read_receipts_updates_on_message_decryption() {
         events::room::encrypted::{
             EncryptedEventScheme, MegolmV1AesSha2ContentInit, RoomEncryptedEventContent,
         },
-        user_id,
+        user_id, RoomVersionId,
     };
 
     use crate::timeline::{EncryptedMessage, TimelineItemContent};
 
-    fn filter_text_msg(ev: &AnySyncTimelineEvent) -> bool {
+    fn filter_text_msg(ev: &AnySyncTimelineEvent, _room_version_id: &RoomVersionId) -> bool {
         match ev {
             AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
                 SyncRoomMessageEvent::Original(msg),

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -70,7 +70,7 @@ impl RoomExt for Room {
 
     async fn poll_history(&self) -> Timeline {
         self.timeline_builder()
-            .event_filter(|e| {
+            .event_filter(|e, _| {
                 matches!(
                     e,
                     AnySyncTimelineEvent::MessageLike(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -32,7 +32,7 @@ use ruma::{
         room::message::{MessageType, SyncRoomMessageEvent},
         AnySyncMessageLikeEvent, AnySyncTimelineEvent,
     },
-    room_id, user_id,
+    room_id, user_id, RoomVersionId,
 };
 use serde_json::json;
 use wiremock::{
@@ -42,7 +42,7 @@ use wiremock::{
 
 use crate::{logged_in_client, mock_sync};
 
-fn filter_notice(ev: &AnySyncTimelineEvent) -> bool {
+fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
     match ev {
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
             SyncRoomMessageEvent::Original(msg),

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -52,7 +52,7 @@ async fn test_batched() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline_builder().event_filter(|_| true).build().await;
+    let timeline = room.timeline_builder().event_filter(|_, _| true).build().await;
     let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     let hdl = tokio::spawn(async move {
@@ -100,7 +100,7 @@ async fn test_event_filter() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline_builder().event_filter(|_| true).build().await;
+    let timeline = room.timeline_builder().event_filter(|_, _| true).build().await;
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let first_event_id = event_id!("$YTQwYl2ply");


### PR DESCRIPTION
The read receipts code is relying on the `visible` boolean on an `EventMeta`, that's present for every event (even those that don't materialize into timeline events). This `visible` boolean was set accordingly to whether the event was filtered out or not, using the user-defined `event_filter` that's available on a timeline builder. Unfortunately, this is not the only thing that determines whether an event will be visible or not: according to its kind (message? poll? reaction? etc.), it may or may not be materialized into a `TimelineEventItem`. So we need to take that into account.

The default `event_filter` for a timeline is now defined as the set of events that can be materialized into a `TimelineEventItem`. Other events, that can't be made visible (edits, reactions and so on), are "filtered out" to reflect what can be materialized. This is a default behavior that can still be overriden.

I didn't even have to write new tests, as existing tests ran into the new behavior. The modifications to tests reflect the following new behaviors:

- if I have a timeline with events A and B, and I edit A, then my read receipt is moved to event B (the edit event is not visible)
- if I add a reaction to event A, then my read receipt is moved to event A (the reaction is not visible)

Fixes #2889, which is exactly the second bullet item in the above list.