### PR TITLE
Crypto: add new methods for turning off room key requests

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,5 +1,13 @@
 # unreleased
 
+- Add new method `OlmMachine::toggle_room_key_requests` to disable outgoing
+  room key requests, without affecting key forwarding.
+
+  `OlmMachine::toggle_room_key_forwarding` now only controls automatic
+  key forwarding, without affecting whether outgoing requests are sent.
+
+  ([#2902](https://github.com/matrix-org/matrix-rust-sdk/pull/2902))
+
 - Improve performance of `share_room_key`.
   ([#2862](https://github.com/matrix-org/matrix-rust-sdk/pull/2862))
 

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,10 +1,17 @@
 # unreleased
 
-- Add new method `OlmMachine::toggle_room_key_requests` to disable outgoing
-  room key requests, without affecting key forwarding.
+- `OlmMachine::toggle_room_key_forwarding` is replaced by two separate methods:
 
-  `OlmMachine::toggle_room_key_forwarding` now only controls automatic
-  key forwarding, without affecting whether outgoing requests are sent.
+  * `OlmMachine::set_room_key_requests_enabled`, which controls whether
+    outgoing room key requests are enabled, and:
+
+  * `OlmMachine::set_room_key_forwarding_enabled`, which controls whether we
+    automatically reply to incoming room key requests.
+
+  `OlmMachine::is_room_key_forwarding_enabled` is updated to return the setting
+  of `OlmMachine::set_room_key_forwarding_enabled`, while
+  `OlmMachine::are_room_key_requests_enabled` is added to return the setting of
+  `OlmMachine::set_room_key_requests_enabled`.
 
   ([#2902](https://github.com/matrix-org/matrix-rust-sdk/pull/2902))
 

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -117,7 +117,7 @@ impl GossipMachine {
     }
 
     #[cfg(feature = "automatic-room-key-forwarding")]
-    pub fn toggle_room_key_forwarding(&self, enabled: bool) {
+    pub fn set_room_key_forwarding_enabled(&self, enabled: bool) {
         self.inner.room_key_forwarding_enabled.store(enabled, Ordering::SeqCst)
     }
 
@@ -128,7 +128,7 @@ impl GossipMachine {
     /// Configure whether we should send outgoing `m.room_key_request`s on
     /// decryption failure.
     #[cfg(feature = "automatic-room-key-forwarding")]
-    pub fn toggle_room_key_requests(&self, enabled: bool) {
+    pub fn set_room_key_requests_enabled(&self, enabled: bool) {
         self.inner.room_key_requests_enabled.store(enabled, Ordering::SeqCst)
     }
 
@@ -1428,7 +1428,7 @@ mod tests {
 
         // Disable key requests
         assert!(machine.are_room_key_requests_enabled());
-        machine.toggle_room_key_requests(false);
+        machine.set_room_key_requests_enabled(false);
         assert!(!machine.are_room_key_requests_enabled());
 
         let (outbound, session) = account.create_group_session_pair_with_defaults(room_id()).await;

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -352,17 +352,17 @@ impl OlmMachine {
     /// have missed in the original share using `m.room_key_request`
     /// events.
     ///
-    /// See also [`OlmMachine::toggle_room_key_forwarding`] and
+    /// See also [`OlmMachine::set_room_key_forwarding_enabled`] and
     /// [`OlmMachine::are_room_key_requests_enabled`].
     #[cfg(feature = "automatic-room-key-forwarding")]
-    pub fn toggle_room_key_requests(&self, enable: bool) {
-        self.inner.key_request_machine.toggle_room_key_requests(enable)
+    pub fn set_room_key_requests_enabled(&self, enable: bool) {
+        self.inner.key_request_machine.set_room_key_requests_enabled(enable)
     }
 
     /// Query whether we should send outgoing `m.room_key_request`s on
     /// decryption failure.
     ///
-    /// See also [`OlmMachine::toggle_room_key_requests`].
+    /// See also [`OlmMachine::set_room_key_requests_enabled`].
     pub fn are_room_key_requests_enabled(&self) -> bool {
         self.inner.key_request_machine.are_room_key_requests_enabled()
     }
@@ -373,16 +373,16 @@ impl OlmMachine {
     /// incoming `m.room_key_request` messages from verified devices by
     /// forwarding the requested key (if we have it).
     ///
-    /// See also [`OlmMachine::toggle_room_key_requests`] and
+    /// See also [`OlmMachine::set_room_key_requests_enabled`] and
     /// [`OlmMachine::is_room_key_forwarding_enabled`].
     #[cfg(feature = "automatic-room-key-forwarding")]
-    pub fn toggle_room_key_forwarding(&self, enable: bool) {
-        self.inner.key_request_machine.toggle_room_key_forwarding(enable)
+    pub fn set_room_key_forwarding_enabled(&self, enable: bool) {
+        self.inner.key_request_machine.set_room_key_forwarding_enabled(enable)
     }
 
     /// Is room key forwarding enabled?
     ///
-    /// See also [`OlmMachine::toggle_room_key_forwarding`].
+    /// See also [`OlmMachine::set_room_key_forwarding_enabled`].
     pub fn is_room_key_forwarding_enabled(&self) -> bool {
         self.inner.key_request_machine.is_room_key_forwarding_enabled()
     }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -346,17 +346,43 @@ impl OlmMachine {
         Ok(self.inner.identity_manager.key_query_manager.synced(&cache).await?.tracked_users())
     }
 
+    /// Enable or disable room key requests.
+    ///
+    /// Room key requests allow the device to request room keys that it might
+    /// have missed in the original share using `m.room_key_request`
+    /// events.
+    ///
+    /// See also [`OlmMachine::toggle_room_key_forwarding`] and
+    /// [`OlmMachine::are_room_key_requests_enabled`].
+    #[cfg(feature = "automatic-room-key-forwarding")]
+    pub fn toggle_room_key_requests(&self, enable: bool) {
+        self.inner.key_request_machine.toggle_room_key_requests(enable)
+    }
+
+    /// Query whether we should send outgoing `m.room_key_request`s on
+    /// decryption failure.
+    ///
+    /// See also [`OlmMachine::toggle_room_key_requests`].
+    pub fn are_room_key_requests_enabled(&self) -> bool {
+        self.inner.key_request_machine.are_room_key_requests_enabled()
+    }
+
     /// Enable or disable room key forwarding.
     ///
-    /// Room key forwarding allows the device to request room keys that it might
-    /// have missend in the original share using `m.room_key_request`
-    /// events.
+    /// If room key forwarding is enabled, we will automatically reply to
+    /// incoming `m.room_key_request` messages from verified devices by
+    /// forwarding the requested key (if we have it).
+    ///
+    /// See also [`OlmMachine::toggle_room_key_requests`] and
+    /// [`OlmMachine::is_room_key_forwarding_enabled`].
     #[cfg(feature = "automatic-room-key-forwarding")]
     pub fn toggle_room_key_forwarding(&self, enable: bool) {
         self.inner.key_request_machine.toggle_room_key_forwarding(enable)
     }
 
     /// Is room key forwarding enabled?
+    ///
+    /// See also [`OlmMachine::toggle_room_key_forwarding`].
     pub fn is_room_key_forwarding_enabled(&self) -> bool {
         self.inner.key_request_machine.is_room_key_forwarding_enabled()
     }


### PR DESCRIPTION
For Element Web, we want to be able to turn off outgoing room key requests without affecting whether we reply to incoming requests (https://github.com/vector-im/element-web/issues/26524).

Accordingly, we need a separate method to allow us to do that.

This PR also takes the opportunity to rename `toggle_room_key_forwarding` to `set_room_key_forwarding_enabled`, since it's not really a "toggle".

