### PR TITLE
Add FFI bindgings for `Room.typing_notice()`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -463,6 +463,10 @@ impl Room {
     pub fn own_user_id(&self) -> String {
         self.inner.own_user_id().to_string()
     }
+
+    pub async fn typing_notice(&self, is_typing: bool) -> Result<(), ClientError> {
+        Ok(self.inner.typing_notice(is_typing).await?)
+    }
 }
 
 #[uniffi::export(callback_interface)]


### PR DESCRIPTION
We'll need them for https://github.com/vector-im/element-meta/issues/2203. 

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
