### PR TITLE
notification settings: Allow to manage keywords

### DIFF
--- a/crates/matrix-sdk/src/notification_settings/command.rs
+++ b/crates/matrix-sdk/src/notification_settings/command.rs
@@ -3,8 +3,8 @@ use std::fmt::Debug;
 use ruma::{
     api::client::push::RuleScope,
     push::{
-        Action, NewConditionalPushRule, NewPushRule, NewSimplePushRule, PushCondition, RuleKind,
-        Tweak,
+        Action, NewConditionalPushRule, NewPatternedPushRule, NewPushRule, NewSimplePushRule,
+        PushCondition, RuleKind, Tweak,
     },
     OwnedRoomId,
 };
@@ -18,6 +18,8 @@ pub(crate) enum Command {
     SetRoomPushRule { scope: RuleScope, room_id: OwnedRoomId, notify: bool },
     /// Set a new `Override` push rule matching a `RoomId`
     SetOverridePushRule { scope: RuleScope, rule_id: String, room_id: OwnedRoomId, notify: bool },
+    /// Set a new push rule for a keyword.
+    SetKeywordPushRule { scope: RuleScope, keyword: String },
     /// Set whether a push rule is enabled
     SetPushRuleEnabled { scope: RuleScope, kind: RuleKind, rule_id: String, enabled: bool },
     /// Delete a push rule
@@ -55,6 +57,16 @@ impl Command {
                     get_notify_actions(*notify),
                 );
                 Ok(NewPushRule::Override(new_rule))
+            }
+
+            Self::SetKeywordPushRule { scope: _, keyword } => {
+                // `Content` push rule matching this keyword
+                let new_rule = NewPatternedPushRule::new(
+                    keyword.clone(),
+                    keyword.clone(),
+                    get_notify_actions(true),
+                );
+                Ok(NewPushRule::Content(new_rule))
             }
 
             Self::SetPushRuleEnabled { .. }

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use indexmap::IndexSet;
 use ruma::{
     api::client::push::{
         delete_pushrule, set_pushrule, set_pushrule_actions, set_pushrule_enabled,
@@ -352,6 +353,72 @@ impl NotificationSettings {
         }
     }
 
+    /// Get the keywords which have enabled rules.
+    pub async fn enabled_keywords(&self) -> IndexSet<String> {
+        self.rules.read().await.enabled_keywords()
+    }
+
+    /// Add or enable a rule for the given keyword.
+    ///
+    /// # Arguments
+    ///
+    /// * `keyword` - The keyword to match.
+    pub async fn add_keyword(&self, keyword: String) -> Result<(), NotificationSettingsError> {
+        let rules = self.rules.read().await.clone();
+
+        let mut rule_commands = RuleCommands::new(rules.clone().ruleset);
+
+        let existing_rules = rules.keyword_rules(&keyword);
+
+        if existing_rules.is_empty() {
+            // Create a rule.
+            rule_commands.insert_keyword_rule(keyword)?;
+        } else {
+            if existing_rules.iter().any(|r| r.enabled) {
+                // Nothing to do.
+                return Ok(());
+            }
+
+            // Enable one of the rules.
+            rule_commands.set_rule_enabled(RuleKind::Content, &existing_rules[0].rule_id, true)?;
+        }
+
+        self.run_server_commands(&rule_commands).await?;
+
+        let rules = &mut *self.rules.write().await;
+        rules.apply(rule_commands);
+
+        Ok(())
+    }
+
+    /// Remove the rules for the given keyword.
+    ///
+    /// # Arguments
+    ///
+    /// * `keyword` - The keyword to match.
+    pub async fn remove_keyword(&self, keyword: &str) -> Result<(), NotificationSettingsError> {
+        let rules = self.rules.read().await.clone();
+
+        let mut rule_commands = RuleCommands::new(rules.clone().ruleset);
+
+        let existing_rules = rules.keyword_rules(keyword);
+
+        if existing_rules.is_empty() {
+            return Ok(());
+        }
+
+        for rule in existing_rules {
+            rule_commands.delete_rule(RuleKind::Content, rule.rule_id.clone())?;
+        }
+
+        self.run_server_commands(&rule_commands).await?;
+
+        let rules = &mut *self.rules.write().await;
+        rules.apply(rule_commands);
+
+        Ok(())
+    }
+
     /// Convert commands into requests to the server, and run them.
     async fn run_server_commands(
         &self,
@@ -380,6 +447,14 @@ impl NotificationSettings {
                         .map_err(|_| NotificationSettingsError::UnableToAddPushRule)?;
                 }
                 Command::SetOverridePushRule { scope, rule_id: _, room_id: _, notify: _ } => {
+                    let push_rule = command.to_push_rule()?;
+                    let request = set_pushrule::v3::Request::new(scope.clone(), push_rule);
+                    self.client
+                        .send(request, request_config)
+                        .await
+                        .map_err(|_| NotificationSettingsError::UnableToAddPushRule)?;
+                }
+                Command::SetKeywordPushRule { scope, keyword: _ } => {
                     let push_rule = command.to_push_rule()?;
                     let request = set_pushrule::v3::Request::new(scope.clone(), push_rule);
                     self.client
@@ -1148,5 +1223,261 @@ mod tests {
             settings.get_default_room_notification_mode(IsEncrypted::No, IsOneToOne::Yes).await,
             RoomNotificationMode::AllMessages
         );
+    }
+
+    #[async_test]
+    async fn list_keywords() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        // Initial state: No keywords
+        let ruleset = get_server_default_ruleset();
+        let settings = NotificationSettings::new(client.clone(), ruleset);
+
+        let keywords = settings.enabled_keywords().await;
+
+        assert!(keywords.is_empty());
+
+        // Initial state: 3 rules, 2 keywords
+        let mut ruleset = get_server_default_ruleset();
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "a".to_owned(),
+                    "a".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+        // Test deduplication.
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "a_bis".to_owned(),
+                    "a".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "b".to_owned(),
+                    "b".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+
+        let settings = NotificationSettings::new(client, ruleset);
+
+        let keywords = settings.enabled_keywords().await;
+        assert_eq!(keywords.len(), 2);
+        assert!(keywords.get("a").is_some());
+        assert!(keywords.get("b").is_some())
+    }
+
+    #[async_test]
+    async fn add_keyword_missing() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let settings = client.notification_settings().await;
+
+        Mock::given(method("PUT"))
+            .and(path("/_matrix/client/r0/pushrules/global/content/banana"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        settings.add_keyword("banana".to_owned()).await.unwrap();
+
+        // The ruleset must have been updated.
+        let keywords = settings.enabled_keywords().await;
+        assert_eq!(keywords.len(), 1);
+        assert!(keywords.get("banana").is_some());
+
+        // Rule exists.
+        let rule_enabled =
+            settings.is_push_rule_enabled(RuleKind::Content, "banana").await.unwrap();
+        assert!(rule_enabled)
+    }
+
+    #[async_test]
+    async fn add_keyword_disabled() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = get_server_default_ruleset();
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "banana_two".to_owned(),
+                    "banana".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+        ruleset.set_enabled(RuleKind::Content, "banana_two", false).unwrap();
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "banana_one".to_owned(),
+                    "banana".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+        ruleset.set_enabled(RuleKind::Content, "banana_one", false).unwrap();
+
+        let settings = NotificationSettings::new(client, ruleset);
+        Mock::given(method("PUT"))
+            .and(path("/_matrix/client/r0/pushrules/global/content/banana_one/enabled"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        settings.add_keyword("banana".to_owned()).await.unwrap();
+
+        // The ruleset must have been updated.
+        let keywords = settings.enabled_keywords().await;
+
+        assert_eq!(keywords.len(), 1);
+        assert!(keywords.get("banana").is_some());
+
+        // The first rule was enabled.
+        let first_rule_enabled =
+            settings.is_push_rule_enabled(RuleKind::Content, "banana_one").await.unwrap();
+        assert!(first_rule_enabled);
+        let second_rule_enabled =
+            settings.is_push_rule_enabled(RuleKind::Content, "banana_two").await.unwrap();
+        assert!(!second_rule_enabled);
+    }
+
+    #[async_test]
+    async fn add_keyword_noop() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = get_server_default_ruleset();
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "banana_two".to_owned(),
+                    "banana".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "banana_one".to_owned(),
+                    "banana".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+        ruleset.set_enabled(RuleKind::Content, "banana_one", false).unwrap();
+
+        let settings = NotificationSettings::new(client, ruleset);
+        settings.add_keyword("banana".to_owned()).await.unwrap();
+
+        // Nothing changed.
+        let keywords = settings.enabled_keywords().await;
+
+        assert_eq!(keywords.len(), 1);
+        assert!(keywords.get("banana").is_some());
+
+        let first_rule_enabled =
+            settings.is_push_rule_enabled(RuleKind::Content, "banana_one").await.unwrap();
+        assert!(!first_rule_enabled);
+        let second_rule_enabled =
+            settings.is_push_rule_enabled(RuleKind::Content, "banana_two").await.unwrap();
+        assert!(second_rule_enabled);
+    }
+
+    #[async_test]
+    async fn remove_keyword_all() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let mut ruleset = get_server_default_ruleset();
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "banana_two".to_owned(),
+                    "banana".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+        ruleset
+            .insert(
+                NewPushRule::Content(NewPatternedPushRule::new(
+                    "banana_one".to_owned(),
+                    "banana".to_owned(),
+                    vec![],
+                )),
+                None,
+                None,
+            )
+            .unwrap();
+        ruleset.set_enabled(RuleKind::Content, "banana_one", false).unwrap();
+
+        let settings = NotificationSettings::new(client, ruleset);
+
+        Mock::given(method("DELETE"))
+            .and(path("/_matrix/client/r0/pushrules/global/content/banana_one"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path("/_matrix/client/r0/pushrules/global/content/banana_two"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        settings.remove_keyword("banana").await.unwrap();
+
+        // The ruleset must have been updated.
+        let keywords = settings.enabled_keywords().await;
+        assert!(keywords.is_empty());
+
+        // Rules we removed.
+        let first_rule_error =
+            settings.is_push_rule_enabled(RuleKind::Content, "banana_one").await.unwrap_err();
+        assert_matches!(first_rule_error, NotificationSettingsError::RuleNotFound(_));
+        let second_rule_error =
+            settings.is_push_rule_enabled(RuleKind::Content, "banana_two").await.unwrap_err();
+        assert_matches!(second_rule_error, NotificationSettingsError::RuleNotFound(_));
+    }
+
+    #[async_test]
+    async fn remove_keyword_noop() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        let settings = client.notification_settings().await;
+
+        settings.remove_keyword("banana").await.unwrap();
     }
 }

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -395,7 +395,7 @@ impl NotificationSettings {
     ///
     /// # Arguments
     ///
-    /// * `keyword` - The keyword to match.
+    /// * `keyword` - The keyword to unmatch.
     pub async fn remove_keyword(&self, keyword: &str) -> Result<(), NotificationSettingsError> {
         let rules = self.rules.read().await.clone();
 

--- a/crates/matrix-sdk/src/notification_settings/rule_commands.rs
+++ b/crates/matrix-sdk/src/notification_settings/rule_commands.rs
@@ -55,6 +55,19 @@ impl RuleCommands {
         Ok(())
     }
 
+    /// Insert a new rule for a keyword.
+    pub(crate) fn insert_keyword_rule(
+        &mut self,
+        keyword: String,
+    ) -> Result<(), NotificationSettingsError> {
+        let command = Command::SetKeywordPushRule { scope: RuleScope::Global, keyword };
+
+        self.rules.insert(command.to_push_rule()?, None, None)?;
+        self.commands.push(command);
+
+        Ok(())
+    }
+
     /// Delete a rule
     pub(crate) fn delete_rule(
         &mut self,


### PR DESCRIPTION
Adds a simple API to list, add or remove keywords that trigger notifications.