### PR TITLE
base-client: Support notifications in invited rooms 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,8 +4718,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2779c38df072964c63476259d9300efb07d0d1a7178c6469893636ce0c547a36"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "assign",
  "js_int",
@@ -4735,8 +4734,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641837258fa214a70823477514954ef0f5d3bc6ae8e1d5d85081856a33103386"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "assign",
  "bytes",
@@ -4754,8 +4752,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bca4c33c50e47b4cdceeac71bdef0c04153b0e29aa992d9030ec14a62323e85"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "as_variant",
  "base64 0.21.5",
@@ -4785,8 +4782,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.27.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20a52770e5a9fb30b7a1c14ba8b3dcf76dadc01674e58e40094f78e6bd5e3f1"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "as_variant",
  "indexmap 2.1.0",
@@ -4810,8 +4806,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1901c1f27bc327652d58af2a130c73acef3198abeccd24cee97f7267fdf3fe7"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4823,8 +4818,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9674a149b1a6965fe2174ba528c89ee201258abd9209bbe74953df7073a83a5b"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4836,8 +4830,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8ad1259274f2f57c20901bd1cc5e4a8f23169d1c1d887b6338b02f058e9b41"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4846,8 +4839,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0280534a4b3e34416f883285fac4f9c408cd0b737890ae66f3e7a7056d14be80"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "once_cell",
  "proc-macro-crate 2.0.1",
@@ -4862,8 +4854,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f343045c4d4a5943f93b5014160af3c7413e6ee32ea47b147e1e91f2a977486b"
+source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.9.4"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "assign",
  "js_int",
@@ -4734,7 +4734,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.17.4"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "assign",
  "bytes",
@@ -4752,7 +4752,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.12.1"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "as_variant",
  "base64 0.21.5",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.27.11"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "as_variant",
  "indexmap 2.1.0",
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4818,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.1.0"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4830,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.3"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.12.0"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "once_cell",
  "proc-macro-crate 2.0.1",
@@ -4854,7 +4854,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=df1a63909ab7cc815ff8d6e292965c82b82d697e#df1a63909ab7cc815ff8d6e292965c82b82d697e"
+source = "git+https://github.com/ruma/ruma?rev=a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4#a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.12.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "df1a63909ab7cc815ff8d6e292965c82b82d697e", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "df1a63909ab7cc815ff8d6e292965c82b82d697e"}
+ruma = { git = "https://github.com/ruma/ruma", rev = "a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "a7e1d7fa49d93f4d9cbc369aa28378a89b3dc9e4"}
 once_cell = "1.16.0"
 rand = "0.8.5"
 serde = "1.0.151"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.12.0"
-ruma = { version = "0.9.3", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
-ruma-common = "0.12.0"
+ruma = { git = "https://github.com/ruma/ruma", rev = "df1a63909ab7cc815ff8d6e292965c82b82d697e", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "df1a63909ab7cc815ff8d6e292965c82b82d697e"}
 once_cell = "1.16.0"
 rand = "0.8.5"
 serde = "1.0.151"

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -414,9 +414,14 @@ impl Room {
         })
     }
 
-    pub async fn can_user_redact(&self, user_id: String) -> Result<bool, ClientError> {
+    pub async fn can_user_redact_own(&self, user_id: String) -> Result<bool, ClientError> {
         let user_id = UserId::parse(&user_id)?;
-        Ok(self.inner.can_user_redact(&user_id).await?)
+        Ok(self.inner.can_user_redact_own(&user_id).await?)
+    }
+
+    pub async fn can_user_redact_other(&self, user_id: String) -> Result<bool, ClientError> {
+        let user_id = UserId::parse(&user_id)?;
+        Ok(self.inner.can_user_redact_other(&user_id).await?)
     }
 
     pub async fn can_user_ban(&self, user_id: String) -> Result<bool, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -115,8 +115,12 @@ impl RoomMember {
         self.inner.can_kick()
     }
 
-    pub fn can_redact(&self) -> bool {
-        self.inner.can_redact()
+    pub fn can_redact_own(&self) -> bool {
+        self.inner.can_redact_own()
+    }
+
+    pub fn can_redact_other(&self) -> bool {
+        self.inner.can_redact_other()
     }
 
     pub fn can_send_state(&self, state_event: StateEventType) -> bool {

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Replace the `Notification` type from Ruma in `SyncResponse` and `StateChanges` by a custom one
+
 # 0.7.0
 
 - Rename `RoomType` to `RoomState`
@@ -30,7 +34,6 @@
   - `get_users_with_display_names`
 - Move `Session`, `SessionTokens` and associated methods to the `matrix-sdk` crate.
 - Add `Room::subscribe_info`
-- Replace the `Notification` type from Ruma in `SyncResponse` and `StateChanges` by a custom one
 
 # 0.5.1
 

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -30,6 +30,7 @@
   - `get_users_with_display_names`
 - Move `Session`, `SessionTokens` and associated methods to the `matrix-sdk` crate.
 - Add `Room::subscribe_info`
+- Replace the `Notification` type from Ruma in `SyncResponse` and `StateChanges` by a custom one
 
 # 0.5.1
 

--- a/crates/matrix-sdk-base/src/debug.rs
+++ b/crates/matrix-sdk-base/src/debug.rs
@@ -14,14 +14,10 @@
 
 //! Helpers for creating `std::fmt::Debug` implementations.
 
-use std::{collections::BTreeMap, fmt};
+use std::fmt;
 
 pub use matrix_sdk_common::debug::*;
-use ruma::{
-    api::client::{push::get_notifications::v3::Notification, sync::sync_events::v3::InvitedRoom},
-    serde::Raw,
-    OwnedRoomId,
-};
+use ruma::{api::client::sync::sync_events::v3::InvitedRoom, serde::Raw};
 
 /// A wrapper around a slice of `Raw` events that implements `Debug` in a way
 /// that only prints the event type of each item.
@@ -33,47 +29,6 @@ impl<'a, T> fmt::Debug for DebugListOfRawEventsNoId<'a, T> {
         let mut list = f.debug_list();
         list.entries(self.0.iter().map(DebugRawEventNoId));
         list.finish()
-    }
-}
-
-/// A wrapper around a notification map as found in `/sync` responses that
-/// implements `Debug` in a way that only prints the event ID and event type
-/// for the raw events contained in each notification.
-pub struct DebugNotificationMap<'a>(pub &'a BTreeMap<OwnedRoomId, Vec<Notification>>);
-
-#[cfg(not(tarpaulin_include))]
-impl<'a> fmt::Debug for DebugNotificationMap<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut map = f.debug_map();
-        map.entries(self.0.iter().map(|(room_id, raw)| (room_id, DebugNotificationList(raw))));
-        map.finish()
-    }
-}
-
-struct DebugNotificationList<'a>(&'a [Notification]);
-
-#[cfg(not(tarpaulin_include))]
-impl<'a> fmt::Debug for DebugNotificationList<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut list = f.debug_list();
-        list.entries(self.0.iter().map(DebugNotification));
-        list.finish()
-    }
-}
-
-struct DebugNotification<'a>(&'a Notification);
-
-#[cfg(not(tarpaulin_include))]
-impl<'a> fmt::Debug for DebugNotification<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Notification")
-            .field("actions", &self.0.actions)
-            .field("event", &DebugRawEvent(&self.0.event))
-            .field("profile_tag", &self.0.profile_tag)
-            .field("read", &self.0.read)
-            .field("room_id", &self.0.room_id)
-            .field("ts", &self.0.ts)
-            .finish()
     }
 }
 

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -23,7 +23,7 @@ use ruma::{
             member::{MembershipState, RoomMemberEvent, RoomMemberEventContent},
             power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
         },
-        AnyStrippedStateEvent, AnySyncStateEvent, EventContentFromType,
+        AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, EventContentFromType,
         PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
         StateEventContent, StaticStateEventContent, StrippedStateEvent, SyncStateEvent,
     },
@@ -64,6 +64,16 @@ pub struct MembersResponse {
     pub chunk: Vec<RoomMemberEvent>,
     /// Collection of ambiguity changes that room member events trigger.
     pub ambiguity_changes: AmbiguityChanges,
+}
+
+/// Wrapper around both versions of any event received via sync.
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
+pub enum RawAnySyncOrStrippedTimelineEvent {
+    /// An event from a room in joined or left state.
+    Sync(Raw<AnySyncTimelineEvent>),
+    /// An event from a room in invited state.
+    Stripped(Raw<AnyStrippedStateEvent>),
 }
 
 /// Wrapper around both versions of any raw state event.

--- a/crates/matrix-sdk-base/src/rooms/members.rs
+++ b/crates/matrix-sdk-base/src/rooms/members.rs
@@ -160,11 +160,19 @@ impl RoomMember {
         self.can_do_impl(|pls| pls.user_can_kick(self.user_id()))
     }
 
-    /// Whether this user can redact events based on the power levels.
+    /// Whether this user can redact their own events based on the power levels.
     ///
-    /// Same as `member.can_do(PowerLevelAction::Redact)`.
-    pub fn can_redact(&self) -> bool {
-        self.can_do_impl(|pls| pls.user_can_redact(self.user_id()))
+    /// Same as `member.can_do(PowerLevelAction::RedactOwn)`.
+    pub fn can_redact_own(&self) -> bool {
+        self.can_do_impl(|pls| pls.user_can_redact_own_event(self.user_id()))
+    }
+
+    /// Whether this user can redact events of other users based on the power
+    /// levels.
+    ///
+    /// Same as `member.can_do(PowerLevelAction::RedactOther)`.
+    pub fn can_redact_other(&self) -> bool {
+        self.can_do_impl(|pls| pls.user_can_redact_event_of_other(self.user_id()))
     }
 
     /// Whether this user can send message events based on the power levels.

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -16,28 +16,24 @@
 
 use std::{collections::BTreeMap, fmt};
 
-use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
+use matrix_sdk_common::{debug::DebugRawEvent, deserialized_responses::SyncTimelineEvent};
 use ruma::{
-    api::client::{
-        push::get_notifications::v3::Notification,
-        sync::sync_events::{
-            v3::InvitedRoom, UnreadNotificationsCount as RumaUnreadNotificationsCount,
-        },
+    api::client::sync::sync_events::{
+        v3::InvitedRoom, UnreadNotificationsCount as RumaUnreadNotificationsCount,
     },
     events::{
         presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
         AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnyToDeviceEvent,
     },
+    push::Action,
     serde::Raw,
     OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    debug::{
-        DebugInvitedRoom, DebugListOfRawEvents, DebugListOfRawEventsNoId, DebugNotificationMap,
-    },
-    deserialized_responses::AmbiguityChanges,
+    debug::{DebugInvitedRoom, DebugListOfRawEvents, DebugListOfRawEventsNoId},
+    deserialized_responses::{AmbiguityChanges, RawAnySyncOrStrippedTimelineEvent},
 };
 
 /// Internal representation of a `/sync` response.
@@ -68,7 +64,7 @@ impl fmt::Debug for SyncResponse {
             .field("account_data", &DebugListOfRawEventsNoId(&self.account_data))
             .field("to_device", &DebugListOfRawEventsNoId(&self.to_device))
             .field("ambiguity_changes", &self.ambiguity_changes)
-            .field("notifications", &DebugNotificationMap(&self.notifications))
+            .field("notifications", &self.notifications)
             .finish_non_exhaustive()
     }
 }
@@ -221,5 +217,30 @@ struct DebugInvitedRooms<'a>(&'a BTreeMap<OwnedRoomId, InvitedRoom>);
 impl<'a> fmt::Debug for DebugInvitedRooms<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.0.iter().map(|(k, v)| (k, DebugInvitedRoom(v)))).finish()
+    }
+}
+
+/// A notification triggered by a sync response.
+#[derive(Clone)]
+pub struct Notification {
+    /// The actions to perform when the conditions for this rule are met.
+    pub actions: Vec<Action>,
+
+    /// The event that triggered the notification.
+    pub event: RawAnySyncOrStrippedTimelineEvent,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl fmt::Debug for Notification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let event_debug = match &self.event {
+            RawAnySyncOrStrippedTimelineEvent::Sync(ev) => DebugRawEvent(ev),
+            RawAnySyncOrStrippedTimelineEvent::Stripped(ev) => DebugRawEvent(ev.cast_ref()),
+        };
+
+        f.debug_struct("Notification")
+            .field("actions", &self.actions)
+            .field("event", &event_debug)
+            .finish()
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -40,7 +40,7 @@ use ruma::{
     },
     int,
     power_levels::NotificationPowerLevels,
-    push::{PushConditionRoomCtx, Ruleset},
+    push::{PushConditionPowerLevelsCtx, PushConditionRoomCtx, Ruleset},
     room_id,
     serde::Raw,
     server_name, uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId,
@@ -318,14 +318,17 @@ impl RoomDataProvider for TestRoomDataProvider {
 
     async fn push_rules_and_context(&self) -> Option<(Ruleset, PushConditionRoomCtx)> {
         let push_rules = Ruleset::server_default(&ALICE);
+        let power_levels = PushConditionPowerLevelsCtx {
+            users: BTreeMap::new(),
+            users_default: int!(0),
+            notifications: NotificationPowerLevels::new(),
+        };
         let push_context = PushConditionRoomCtx {
             room_id: room_id!("!my_room:server.name").to_owned(),
             member_count: uint!(2),
             user_id: ALICE.to_owned(),
             user_display_name: "Alice".to_owned(),
-            users_power_levels: BTreeMap::new(),
-            default_power_level: int!(0),
-            notification_power_levels: NotificationPowerLevels::new(),
+            power_levels: Some(power_levels),
         };
 
         Some((push_rules, push_context))

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -1,3 +1,10 @@
+# unreleased
+
+Breaking changes:
+
+- Replace the `Notification` type from Ruma in `SyncResponse` and `Client::register_notification_handler`
+  by a custom one
+
 # 0.7.0
 
 Breaking changes:

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -4,6 +4,7 @@ Breaking changes:
 
 - Replace the `Notification` type from Ruma in `SyncResponse` and `Client::register_notification_handler`
   by a custom one
+- `Room::can_user_redact` and `Member::can_redact` are split between `*_redact_own` and `*_redact_other`
 
 # 0.7.0
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -27,8 +27,8 @@ use futures_core::Stream;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk_base::crypto::store::LockableCryptoStore;
 use matrix_sdk_base::{
-    store::DynStateStore, BaseClient, RoomState, RoomStateFilter, SendOutsideWasm, SessionMeta,
-    SyncOutsideWasm,
+    store::DynStateStore, sync::Notification, BaseClient, RoomState, RoomStateFilter,
+    SendOutsideWasm, SessionMeta, SyncOutsideWasm,
 };
 use matrix_sdk_common::instant::Instant;
 #[cfg(feature = "e2e-encryption")]
@@ -47,7 +47,7 @@ use ruma::{
             filter::{create_filter::v3::Request as FilterUploadRequest, FilterDefinition},
             membership::{join_room_by_id, join_room_by_id_or_alias},
             profile::get_profile,
-            push::{get_notifications::v3::Notification, set_pusher, Pusher},
+            push::{set_pusher, Pusher},
             room::create_room,
             session::login::v3::DiscoveryInfo,
             sync::sync_events,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1982,11 +1982,19 @@ impl Room {
     }
 
     /// Returns true if the user with the given user_id is able to redact
-    /// messages in the room.
+    /// their own messages in the room.
     ///
     /// The call may fail if there is an error in getting the power levels.
-    pub async fn can_user_redact(&self, user_id: &UserId) -> Result<bool> {
-        Ok(self.get_room_power_levels().await?.user_can_redact(user_id))
+    pub async fn can_user_redact_own(&self, user_id: &UserId) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_redact_own_event(user_id))
+    }
+
+    /// Returns true if the user with the given user_id is able to redact
+    /// messages of other users in the room.
+    ///
+    /// The call may fail if there is an error in getting the power levels.
+    pub async fn can_user_redact_other(&self, user_id: &UserId) -> Result<bool> {
+        Ok(self.get_room_power_levels().await?.user_can_redact_event_of_other(user_id))
     }
 
     /// Returns true if the user with the given user_id is able to ban in the

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2242,24 +2242,18 @@ impl Room {
             return Ok(None);
         };
 
-        let room_power_levels = if let Some(event) = self
+        let power_levels = self
             .get_state_event_static::<RoomPowerLevelsEventContent>()
             .await?
             .and_then(|e| e.deserialize().ok())
-        {
-            event.power_levels()
-        } else {
-            return Ok(None);
-        };
+            .map(|e| e.power_levels().into());
 
         Ok(Some(PushConditionRoomCtx {
             user_id: user_id.to_owned(),
             room_id: room_id.to_owned(),
             member_count: UInt::new(member_count).unwrap_or(UInt::MAX),
             user_display_name,
-            users_power_levels: room_power_levels.users,
-            default_power_level: room_power_levels.users_default,
-            notification_power_levels: room_power_levels.notifications,
+            power_levels,
         }))
     }
 

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -22,16 +22,13 @@ use std::{
 
 pub use matrix_sdk_base::sync::*;
 use matrix_sdk_base::{
-    debug::{DebugInvitedRoom, DebugListOfRawEventsNoId, DebugNotificationMap},
+    debug::{DebugInvitedRoom, DebugListOfRawEventsNoId},
     deserialized_responses::AmbiguityChanges,
     instant::Instant,
     sync::SyncResponse as BaseSyncResponse,
 };
 use ruma::{
-    api::client::{
-        push::get_notifications::v3::Notification,
-        sync::sync_events::{self, v3::InvitedRoom},
-    },
+    api::client::sync::sync_events::{self, v3::InvitedRoom},
     events::{presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyToDeviceEvent},
     serde::Raw,
     OwnedRoomId, RoomId,
@@ -92,7 +89,7 @@ impl fmt::Debug for SyncResponse {
             .field("account_data", &DebugListOfRawEventsNoId(&self.account_data))
             .field("to_device", &DebugListOfRawEventsNoId(&self.to_device))
             .field("ambiguity_changes", &self.ambiguity_changes)
-            .field("notifications", &DebugNotificationMap(&self.notifications))
+            .field("notifications", &self.notifications)
             .finish_non_exhaustive()
     }
 }

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -19,6 +19,7 @@ mod client;
 #[cfg(feature = "e2e-encryption")]
 mod encryption;
 mod matrix_auth;
+mod notification;
 mod refresh_token;
 mod room;
 #[cfg(feature = "experimental-widgets")]

--- a/crates/matrix-sdk/tests/integration/notification.rs
+++ b/crates/matrix-sdk/tests/integration/notification.rs
@@ -1,0 +1,157 @@
+use assert_matches2::assert_matches;
+use matrix_sdk::{config::SyncSettings, sync::Notification};
+use matrix_sdk_base::deserialized_responses::RawAnySyncOrStrippedTimelineEvent;
+use matrix_sdk_test::{
+    async_test, stripped_state_event, sync_state_event, sync_timeline_event, test_json,
+    InvitedRoomBuilder, JoinedRoomBuilder, SyncResponseBuilder,
+};
+use ruma::{
+    events::{room::message::RoomMessageEventContent, Mentions, StateEventType},
+    room_id,
+    serde::Raw,
+    OwnedRoomId,
+};
+use stream_assert::{assert_pending, assert_ready};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::{logged_in_client, mock_sync};
+
+#[async_test]
+async fn notifications_joined() {
+    let (client, server) = logged_in_client().await;
+    let room_id = room_id!("!joined_room:localhost");
+    let user_id = client.user_id().unwrap();
+
+    let (sender, receiver) = mpsc::channel::<(OwnedRoomId, Notification)>(10);
+    let mut receiver_stream = ReceiverStream::new(receiver);
+
+    client
+        .register_notification_handler(move |notification, room, _client| {
+            let sender = sender.clone();
+            async move {
+                sender.send((room.room_id().to_owned(), notification)).await.unwrap();
+            }
+        })
+        .await;
+
+    // Set up the room state, no notifications.
+    let mut sync_builder = SyncResponseBuilder::new();
+    let joined_room = JoinedRoomBuilder::new(room_id).add_state_bulk([
+        Raw::new(&*test_json::POWER_LEVELS).unwrap().cast(),
+        sync_state_event!({
+            "content": {
+                "avatar_url": null,
+                "displayname": "example",
+                "membership": "join"
+            },
+            "event_id": "$join_example",
+            "origin_server_ts": 151800140,
+            "sender": user_id,
+            "state_key": user_id,
+            "type": "m.room.member",
+        }),
+    ]);
+    sync_builder.add_joined_room(joined_room);
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    client.sync_once(SyncSettings::default()).await.unwrap();
+    server.reset().await;
+
+    assert_pending!(receiver_stream);
+
+    // Sync with two notifications.
+    let first_message = RoomMessageEventContent::text_plain("Hello example!")
+        .add_mentions(Mentions::with_user_ids([client.user_id().unwrap().to_owned()]));
+    let second_message = RoomMessageEventContent::text_plain("How are you?");
+
+    let joined_room = JoinedRoomBuilder::new(room_id).add_timeline_bulk([
+        sync_timeline_event!({
+            "content": first_message,
+            "type": "m.room.message",
+            "event_id": "$aaa",
+            "origin_server_ts": 2189,
+            "sender": "@bob:example.com",
+        }),
+        sync_timeline_event!({
+            "content": second_message,
+            "type": "m.room.message",
+            "event_id": "$bbb",
+            "origin_server_ts": 3189,
+            "sender": "@bob:example.com",
+        }),
+    ]);
+    sync_builder.add_joined_room(joined_room);
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    client.sync_once(SyncSettings::default()).await.unwrap();
+
+    let (notif_room_id, notification) = assert_ready!(receiver_stream);
+    assert_eq!(notif_room_id, room_id);
+    assert_matches!(notification.event, RawAnySyncOrStrippedTimelineEvent::Sync(raw_event));
+    let event = raw_event.deserialize().unwrap();
+    assert_eq!(event.event_id(), "$aaa");
+
+    let (notif_room_id, notification) = assert_ready!(receiver_stream);
+    assert_eq!(notif_room_id, room_id);
+    assert_matches!(notification.event, RawAnySyncOrStrippedTimelineEvent::Sync(raw_event));
+    let event = raw_event.deserialize().unwrap();
+    assert_eq!(event.event_id(), "$bbb");
+
+    assert_pending!(receiver_stream);
+}
+
+#[async_test]
+async fn notifications_invite() {
+    let (client, server) = logged_in_client().await;
+    let room_id = room_id!("!invited_room:localhost");
+    let user_id = client.user_id().unwrap();
+
+    let (sender, receiver) = mpsc::channel::<(OwnedRoomId, Notification)>(10);
+    let mut receiver_stream = ReceiverStream::new(receiver);
+
+    client
+        .register_notification_handler(move |notification, room, _client| {
+            let sender = sender.clone();
+            async move {
+                sender.send((room.room_id().to_owned(), notification)).await.unwrap();
+            }
+        })
+        .await;
+
+    let mut sync_builder = SyncResponseBuilder::new();
+    let invited_room = InvitedRoomBuilder::new(room_id).add_state_bulk([
+        Raw::new(&*test_json::POWER_LEVELS).unwrap().cast(),
+        stripped_state_event!({
+            "content": {
+                "membership": "join"
+            },
+            "sender": "@bob:localhost",
+            "state_key": "@bob:localhost",
+            "type": "m.room.member",
+        }),
+        stripped_state_event!({
+            "content": {
+                "avatar_url": null,
+                "displayname": "example",
+                "membership": "invite"
+            },
+            "sender": "@bob:localhost",
+            "state_key": user_id,
+            "type": "m.room.member",
+        }),
+    ]);
+    sync_builder.add_invited_room(invited_room);
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    client.sync_once(SyncSettings::default()).await.unwrap();
+
+    let (notif_room_id, notification) = assert_ready!(receiver_stream);
+    assert_eq!(notif_room_id, room_id);
+    assert_matches!(notification.event, RawAnySyncOrStrippedTimelineEvent::Stripped(raw_event));
+    let event = raw_event.deserialize().unwrap();
+    assert_eq!(event.event_type(), StateEventType::RoomMember);
+    assert_eq!(event.state_key(), user_id);
+
+    assert_pending!(receiver_stream);
+}

--- a/testing/matrix-sdk-test/src/lib.rs
+++ b/testing/matrix-sdk-test/src/lib.rs
@@ -43,6 +43,30 @@ macro_rules! sync_timeline_event {
     }
 }
 
+/// Create a `Raw<AnySyncStateEvent>` from arbitrary JSON.
+///
+/// Forwards all arguments to [`serde_json::json`].
+#[macro_export]
+macro_rules! sync_state_event {
+    ($( $tt:tt )*) => {
+        ::ruma::serde::Raw::new(&::serde_json::json!( $($tt)* ))
+            .unwrap()
+            .cast::<::ruma::events::AnySyncStateEvent>()
+    }
+}
+
+/// Create a `Raw<AnyStrippedStateEvent>` from arbitrary JSON.
+///
+/// Forwards all arguments to [`serde_json::json`].
+#[macro_export]
+macro_rules! stripped_state_event {
+    ($( $tt:tt )*) => {
+        ::ruma::serde::Raw::new(&::serde_json::json!( $($tt)* ))
+            .unwrap()
+            .cast::<::ruma::events::AnyStrippedStateEvent>()
+    }
+}
+
 /// Initialize a tracing subscriber if the target architecture is not WASM.
 ///
 /// Uses a sensible default filter that can be overridden through the `RUST_LOG`


### PR DESCRIPTION
Necessary for the `.m.rule.invite_for_me` rule that should only happen in invited rooms.

Requires to create a `Notification` type that accepts stripped state events. It is simpler than Ruma's type because it lacks fields with data that is made up or redundant.

Tested locally with Fractal.

Fixes #1912.