### PR TITLE
Expose `is_invite_for_me_enabled` and `set_invite_for_me_enabled` in notification settings

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -363,6 +363,28 @@ impl NotificationSettings {
         Ok(())
     }
 
+    /// Get whether the `.m.rule.invite_for_me` push rule is enabled
+    pub async fn is_invite_for_me_enabled(&self) -> Result<bool, NotificationSettingsError> {
+        let notification_settings = self.sdk_notification_settings.read().await;
+        let enabled = notification_settings
+                .is_push_rule_enabled(RuleKind::Override, PredefinedOverrideRuleId::InviteForMe.as_str())
+            .await?;
+        Ok(enabled)
+    }
+
+    /// Set whether the `.m.rule.invite_for_me` push rule is enabled
+    pub async fn set_invite_for_me_enabled(&self, enabled: bool) -> Result<(), NotificationSettingsError> {
+        let notification_settings = self.sdk_notification_settings.read().await;
+        notification_settings
+            .set_push_rule_enabled(
+                RuleKind::Override,
+                PredefinedOverrideRuleId::InviteForMe.as_str(),
+                enabled,
+            )
+            .await?;
+        Ok(())
+    }
+
     /// Unmute a room.
     ///
     /// # Arguments


### PR DESCRIPTION
Just doing a small copy paste for my first Rust PR.

Tested OK using EXA (PR coming there too)

Let me know if there is something else to do (changelog entry - not sure this is necessary here, since it's a small change, etc.)

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: benoitm@element.io
