### PR TITLE
room: try restoring from a key backup during backpagination too

### DIFF
--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -586,7 +586,7 @@ async fn cross_signing_status() {
 
 #[cfg(feature = "e2e-encryption")]
 #[async_test]
-async fn encrypt_room_event() {
+async fn test_encrypt_room_event() {
     use std::sync::Arc;
 
     use ruma::events::room::encrypted::RoomEncryptedEventContent;


### PR DESCRIPTION
For most code paths, we'd use `Room::decrypt_event`, which may try to download a key backup if decryption failed. This code path wasn't taken during back-pagination of older events; this new PR makes use of it in that context. I've also checked other code paths. There's one in the base-client that makes direct use of `OlmMachine::decrypt_room_event`, and there we can't use `Room::decrypt_event` because the latter lives in the SDK crate. In this case it's fine, because that one use is the (core) handler of events received from sync, and we have an higher-level UTD event handler in the main crate that will notice the encrypted event, and try to download a room key.

It's a bit hard to test (must run a back-pagination request that resolves to UTDs), but I could add an integration test if we strongly wanted to. 