### PR TITLE
refactoring: make it clear that notifications aren't persisted in storage

### DIFF
--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -41,7 +41,6 @@ mod traits;
 use matrix_sdk_crypto::store::{DynCryptoStore, IntoCryptoStore};
 pub use matrix_sdk_store_encryption::Error as StoreEncryptionError;
 use ruma::{
-    api::client::push::get_notifications::v3::Notification,
     events::{
         presence::PresenceEvent,
         receipt::ReceiptEventContent,
@@ -291,8 +290,6 @@ pub struct StateChanges {
     /// A map from room id to a map of a display name and a set of user ids that
     /// share that display name in the given room.
     pub ambiguity_maps: BTreeMap<OwnedRoomId, BTreeMap<String, BTreeSet<OwnedUserId>>>,
-    /// A map of `RoomId` to a vector of `Notification`s
-    pub notifications: BTreeMap<OwnedRoomId, Vec<Notification>>,
 }
 
 impl StateChanges {
@@ -377,12 +374,6 @@ impl StateChanges {
             .entry(room_id.to_owned())
             .or_default()
             .insert(redacted_event_id.to_owned(), redaction);
-    }
-
-    /// Update the `StateChanges` struct with the given room with a new
-    /// `Notification`.
-    pub fn add_notification(&mut self, room_id: &RoomId, notification: Notification) {
-        self.notifications.entry(room_id.to_owned()).or_default().push(notification);
     }
 
     /// Update the `StateChanges` struct with the given room with a new

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -932,7 +932,6 @@ impl StateStore for SqliteStateStore {
                     redactions,
                     stripped_state,
                     ambiguity_maps,
-                    notifications: _,
                 } = changes;
 
                 if let Some(sync_token) = sync_token {


### PR DESCRIPTION
`notifications` were stored in the `StateChanges` struct, which made me think that they're then persisted in the database. It's not the case, they were just stored there by convenience. This commit changes it to a parameter that's passed, as it's not too invasive and clearer that this is only transient data.