### PR TITLE
sdk: Use crates.io release of mas-oidc-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,8 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "mas-http"
-version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=4a0eadccd5c5d74a09f8f454d81a226a01d024f4#4a0eadccd5c5d74a09f8f454d81a226a01d024f4"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da6948721a2bc05e73f8029515e05b0c7deabb6fcec51ee7f033ecbfe60b7818"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2838,8 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "mas-iana"
-version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=4a0eadccd5c5d74a09f8f454d81a226a01d024f4#4a0eadccd5c5d74a09f8f454d81a226a01d024f4"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c48820df73240471efb9fe90f90461b0029e4f0b7915e2df23633523635dfa3"
 dependencies = [
  "schemars",
  "serde",
@@ -2847,8 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "mas-jose"
-version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=4a0eadccd5c5d74a09f8f454d81a226a01d024f4#4a0eadccd5c5d74a09f8f454d81a226a01d024f4"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39a251dfb34fb81d7259e91b368ee3551013406149333484ae30bd7da8c2c74"
 dependencies = [
  "base64ct",
  "chrono",
@@ -2877,8 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "mas-keystore"
-version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=4a0eadccd5c5d74a09f8f454d81a226a01d024f4#4a0eadccd5c5d74a09f8f454d81a226a01d024f4"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75c2a138f5805d21cf62c3947e23743349cb1303e8e3374aad14a5d571d7912"
 dependencies = [
  "aead",
  "base64ct",
@@ -2905,14 +2909,14 @@ dependencies = [
 
 [[package]]
 name = "mas-oidc-client"
-version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=4a0eadccd5c5d74a09f8f454d81a226a01d024f4#4a0eadccd5c5d74a09f8f454d81a226a01d024f4"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3138f9b4240f515c740ec61e27b436f1fd5a24aabb66b51d93346c7d46e2e571"
 dependencies = [
  "base64ct",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
  "futures-util",
  "headers",
  "http",
@@ -2943,8 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "mas-tower"
-version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=4a0eadccd5c5d74a09f8f454d81a226a01d024f4#4a0eadccd5c5d74a09f8f454d81a226a01d024f4"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6beeba7843e755539b582e6240293db1e6bd428e22bc1a6ef4220b1fd2fc53d"
 dependencies = [
  "http",
  "opentelemetry",
@@ -3671,8 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "oauth2-types"
-version = "0.6.1"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=4a0eadccd5c5d74a09f8f454d81a226a01d024f4#4a0eadccd5c5d74a09f8f454d81a226a01d024f4"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0c3fa3366856696f31b0686570dc4a511b499e648a03e433ad8b940ed2f122"
 dependencies = [
  "chrono",
  "data-encoding",

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -83,6 +83,7 @@ hyper = { version = "0.14.20", features = ["http1", "http2", "server"], optional
 imbl = { version = "2.0.0", features = ["serde"] }
 indexmap = "2.0.2"
 language-tags = { version = "0.3.2", optional = true }
+mas-oidc-client = { version = "0.7.0", optional = true }
 matrix-sdk-base = { version = "0.6.0", path = "../matrix-sdk-base", default_features = false }
 matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }
 matrix-sdk-indexeddb = { version = "0.2.0", path = "../matrix-sdk-indexeddb", default-features = false, optional = true }
@@ -123,11 +124,6 @@ features = [
     "dds",
     "farbfeld",
 ]
-optional = true
-
-[dependencies.mas-oidc-client]
-git = "https://github.com/matrix-org/matrix-authentication-service"
-rev = "4a0eadccd5c5d74a09f8f454d81a226a01d024f4"
 optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
No more git dependencies for `crates/`??
Yes, the only ones left are for `bindings/`!

🎉 🚢 🎉