### PR TITLE
ffi: Support for updating room power levels.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "uniffi",
  "url",
  "urlencoding",
  "uuid",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -70,6 +70,7 @@ features = [
     "rustls-tls", # note: differ from block below
     "socks",
     "sqlite",
+    "uniffi",
 ]
 
 [target.'cfg(not(target_os = "android"))'.dependencies.matrix-sdk]
@@ -85,4 +86,5 @@ features = [
     "native-tls", # note: differ from block above
     "socks",
     "sqlite",
+    "uniffi",
 ]

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -1,20 +1,16 @@
 use std::{convert::TryFrom, sync::Arc};
 
 use anyhow::{Context, Result};
-use matrix_sdk::{room::Room as SdkRoom, RoomMemberships, RoomState};
+use matrix_sdk::{
+    room::{power_levels::RoomPowerLevelSettings, Room as SdkRoom},
+    RoomMemberships, RoomState,
+};
 use matrix_sdk_ui::timeline::RoomExt;
 use mime::Mime;
 use ruma::{
     api::client::room::report_content,
     assign,
-    events::{
-        room::{
-            avatar::ImageInfo as RumaAvatarImageInfo,
-            power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
-            MediaSource,
-        },
-        StateEventType as SdkStateEventType,
-    },
+    events::room::{avatar::ImageInfo as RumaAvatarImageInfo, MediaSource},
     EventId, Int, UserId,
 };
 use tokio::sync::RwLock;
@@ -503,20 +499,14 @@ impl Room {
     }
 
     pub async fn power_level_settings(&self) -> Result<RoomPowerLevelSettings, ClientError> {
-        let power_levels = self.inner.get_room_power_levels().await?;
-        Ok(power_levels.into())
+        Ok(self.inner.power_level_settings().await?)
     }
 
     pub async fn update_power_level_settings(
         &self,
         updates: RoomPowerLevelSettings,
     ) -> Result<(), ClientError> {
-        let mut power_levels = self.inner.get_room_power_levels().await?;
-        power_levels.apply(updates)?;
-        self.inner
-            .send_state_event(RoomPowerLevelsEventContent::from(power_levels))
-            .await
-            .map_err(|e| ClientError::Generic { msg: e.to_string() })?;
+        self.inner.update_power_level_settings(updates).await?;
         Ok(())
     }
 
@@ -586,117 +576,5 @@ impl TryFrom<ImageInfo> for RumaAvatarImageInfo {
             thumbnail_url: thumbnail_url,
             blurhash: value.blurhash,
         }))
-    }
-}
-
-#[derive(uniffi::Record)]
-/// The power level settings required for various operations within a room.
-/// When updating these settings, any levels that are `None` will remain
-/// unchanged.
-pub struct RoomPowerLevelSettings {
-    // Actions
-    /// The level required to ban a user.
-    pub ban: Option<i64>,
-    /// The level required to invite a user.
-    pub invite: Option<i64>,
-    /// The level required to kick a user.
-    pub kick: Option<i64>,
-    /// The level required to redact an event.
-    pub redact: Option<i64>,
-
-    // Events
-    /// The default level required to send message events.
-    pub events_default: Option<i64>,
-    /// The default level required to send state events.
-    pub state_default: Option<i64>,
-    /// The default power level for every user in the room.
-    pub users_default: Option<i64>,
-    /// The level required to change the room's name.
-    pub room_name: Option<i64>,
-    /// The level required to change the room's avatar.
-    pub room_avatar: Option<i64>,
-    /// The level required to change the room's topic.
-    pub room_topic: Option<i64>,
-}
-
-impl From<RoomPowerLevels> for RoomPowerLevelSettings {
-    fn from(value: RoomPowerLevels) -> Self {
-        Self {
-            ban: Some(value.ban.into()),
-            invite: Some(value.invite.into()),
-            kick: Some(value.kick.into()),
-            redact: Some(value.redact.into()),
-            events_default: Some(value.events_default.into()),
-            state_default: Some(value.state_default.into()),
-            users_default: Some(value.users_default.into()),
-            room_name: value.events.get(&SdkStateEventType::RoomName.into()).map(|v| (*v).into()),
-            room_avatar: value
-                .events
-                .get(&SdkStateEventType::RoomAvatar.into())
-                .map(|v| (*v).into()),
-            room_topic: value.events.get(&SdkStateEventType::RoomTopic.into()).map(|v| (*v).into()),
-        }
-    }
-}
-
-trait RoomPowerLevelsExt {
-    /// Applies the updated settings to the power levels. Any levels that are
-    /// `None` will remain unchanged.
-    fn apply(&mut self, settings: RoomPowerLevelSettings) -> Result<(), anyhow::Error>;
-    fn update_state_event(
-        &mut self,
-        event_type: SdkStateEventType,
-        new_level: i64,
-    ) -> Result<(), anyhow::Error>;
-}
-
-impl RoomPowerLevelsExt for RoomPowerLevels {
-    fn apply(&mut self, settings: RoomPowerLevelSettings) -> Result<(), anyhow::Error> {
-        if let Some(ban) = settings.ban {
-            self.ban = ban.try_into()?;
-        }
-        if let Some(invite) = settings.invite {
-            self.invite = invite.try_into()?;
-        }
-        if let Some(kick) = settings.kick {
-            self.kick = kick.try_into()?;
-        }
-        if let Some(redact) = settings.redact {
-            self.redact = redact.try_into()?;
-        }
-        if let Some(events_default) = settings.events_default {
-            self.events_default = events_default.try_into()?;
-        }
-        if let Some(state_default) = settings.state_default {
-            self.state_default = state_default.try_into()?;
-        }
-        if let Some(users_default) = settings.users_default {
-            self.users_default = users_default.try_into()?;
-        }
-        if let Some(room_name) = settings.room_name {
-            self.update_state_event(SdkStateEventType::RoomName, room_name)?;
-        }
-        if let Some(room_avatar) = settings.room_avatar {
-            self.update_state_event(SdkStateEventType::RoomAvatar, room_avatar)?;
-        }
-        if let Some(room_topic) = settings.room_topic {
-            self.update_state_event(SdkStateEventType::RoomTopic, room_topic)?;
-        }
-
-        Ok(())
-    }
-
-    fn update_state_event(
-        &mut self,
-        event_type: SdkStateEventType,
-        new_level: i64,
-    ) -> Result<(), anyhow::Error> {
-        let new_level = new_level.try_into()?;
-        if new_level == self.state_default {
-            self.events.remove(&event_type.into());
-        } else {
-            self.events.insert(event_type.into(), new_level);
-        }
-        Ok(())
     }
 }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -41,6 +41,8 @@ sso-login = ["dep:hyper", "dep:rand", "dep:tower"]
 image-proc = ["dep:image"]
 image-rayon = ["image-proc", "image?/jpeg_rayon"]
 
+uniffi = ["dep:uniffi"]
+
 experimental-oidc = [
     "ruma/unstable-msc2967",
     "dep:chrono",
@@ -101,6 +103,7 @@ thiserror = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
+uniffi = { workspace = true, optional = true }
 url = "2.2.2"
 urlencoding = "2.1.3"
 uuid = { version = "1.4.1", features = ["serde", "v4"], optional = true }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -80,6 +80,9 @@ pub use sliding_sync::{
     SlidingSyncListLoadingState, SlidingSyncMode, SlidingSyncRoom, UpdateSummary,
 };
 
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1704,7 +1704,8 @@ impl Room {
         self.send_state_event(RoomPowerLevelsEventContent::from(power_levels)).await
     }
 
-    async fn get_room_power_levels(&self) -> Result<RoomPowerLevels> {
+    /// Get the current power levels of this room.
+    pub async fn get_room_power_levels(&self) -> Result<RoomPowerLevels> {
         Ok(self
             .get_state_event_static::<RoomPowerLevelsEventContent>()
             .await?

--- a/crates/matrix-sdk/src/room/power_levels.rs
+++ b/crates/matrix-sdk/src/room/power_levels.rs
@@ -1,0 +1,289 @@
+//! Power level configuration types used in [the `room` module][super].
+
+use ruma::events::{room::power_levels::RoomPowerLevels, StateEventType};
+
+/// The power level settings required for various operations within a room.
+/// When updating these settings, any levels that are `None` will remain
+/// unchanged.
+#[derive(Debug)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct RoomPowerLevelSettings {
+    // Actions
+    /// The level required to ban a user.
+    pub ban: Option<i64>,
+    /// The level required to invite a user.
+    pub invite: Option<i64>,
+    /// The level required to kick a user.
+    pub kick: Option<i64>,
+    /// The level required to redact an event.
+    pub redact: Option<i64>,
+
+    // Events
+    /// The default level required to send message events.
+    pub events_default: Option<i64>,
+    /// The default level required to send state events.
+    pub state_default: Option<i64>,
+    /// The default power level for every user in the room.
+    pub users_default: Option<i64>,
+    /// The level required to change the room's name.
+    pub room_name: Option<i64>,
+    /// The level required to change the room's avatar.
+    pub room_avatar: Option<i64>,
+    /// The level required to change the room's topic.
+    pub room_topic: Option<i64>,
+}
+
+impl From<RoomPowerLevels> for RoomPowerLevelSettings {
+    fn from(value: RoomPowerLevels) -> Self {
+        Self {
+            ban: Some(value.ban.into()),
+            invite: Some(value.invite.into()),
+            kick: Some(value.kick.into()),
+            redact: Some(value.redact.into()),
+            events_default: Some(value.events_default.into()),
+            state_default: Some(value.state_default.into()),
+            users_default: Some(value.users_default.into()),
+            room_name: value
+                .events
+                .get(&StateEventType::RoomName.into())
+                .map(|v| (*v).into())
+                .or(Some(value.state_default.into())),
+            room_avatar: value
+                .events
+                .get(&StateEventType::RoomAvatar.into())
+                .map(|v| (*v).into())
+                .or(Some(value.state_default.into())),
+            room_topic: value
+                .events
+                .get(&StateEventType::RoomTopic.into())
+                .map(|v| (*v).into())
+                .or(Some(value.state_default.into())),
+        }
+    }
+}
+
+pub(crate) trait RoomPowerLevelsExt {
+    /// Applies the updated settings to the power levels. Any levels that are
+    /// `None` will remain unchanged.
+    fn apply(&mut self, settings: RoomPowerLevelSettings) -> anyhow::Result<(), anyhow::Error>;
+    /// Updates the power level for a specific state event. If the new level is
+    /// the default level, then the event will be removed.
+    fn update_state_event(
+        &mut self,
+        event_type: StateEventType,
+        new_level: i64,
+    ) -> anyhow::Result<(), anyhow::Error>;
+}
+
+impl RoomPowerLevelsExt for RoomPowerLevels {
+    fn apply(&mut self, settings: RoomPowerLevelSettings) -> anyhow::Result<(), anyhow::Error> {
+        if let Some(ban) = settings.ban {
+            self.ban = ban.try_into()?;
+        }
+        if let Some(invite) = settings.invite {
+            self.invite = invite.try_into()?;
+        }
+        if let Some(kick) = settings.kick {
+            self.kick = kick.try_into()?;
+        }
+        if let Some(redact) = settings.redact {
+            self.redact = redact.try_into()?;
+        }
+        if let Some(events_default) = settings.events_default {
+            self.events_default = events_default.try_into()?;
+        }
+        if let Some(state_default) = settings.state_default {
+            self.state_default = state_default.try_into()?;
+        }
+        if let Some(users_default) = settings.users_default {
+            self.users_default = users_default.try_into()?;
+        }
+        if let Some(room_name) = settings.room_name {
+            self.update_state_event(StateEventType::RoomName, room_name)?;
+        }
+        if let Some(room_avatar) = settings.room_avatar {
+            self.update_state_event(StateEventType::RoomAvatar, room_avatar)?;
+        }
+        if let Some(room_topic) = settings.room_topic {
+            self.update_state_event(StateEventType::RoomTopic, room_topic)?;
+        }
+
+        Ok(())
+    }
+
+    fn update_state_event(
+        &mut self,
+        event_type: StateEventType,
+        new_level: i64,
+    ) -> anyhow::Result<(), anyhow::Error> {
+        let new_level = new_level.try_into()?;
+        if new_level == self.state_default {
+            self.events.remove(&event_type.into());
+        } else {
+            self.events.insert(event_type.into(), new_level);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use ruma::{
+        events::room::power_levels::{RoomPowerLevels, RoomPowerLevelsEventContent},
+        int,
+        power_levels::NotificationPowerLevels,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_apply_actions() {
+        // Given a set of power levels and some settings that only change the
+        // actions.
+        let mut power_levels = default_power_levels();
+
+        let new_level = int!(100);
+        let settings = RoomPowerLevelSettings {
+            ban: Some(new_level.into()),
+            invite: Some(new_level.into()),
+            kick: Some(new_level.into()),
+            redact: Some(new_level.into()),
+            events_default: None,
+            state_default: None,
+            users_default: None,
+            room_name: None,
+            room_avatar: None,
+            room_topic: None,
+        };
+
+        // When applying the settings to the power levels.
+        let original_levels = power_levels.clone();
+        power_levels.apply(settings).unwrap();
+
+        // Then the levels for the actions should be updated.
+        assert_eq!(power_levels.ban, new_level);
+        assert_eq!(power_levels.invite, new_level);
+        assert_eq!(power_levels.kick, new_level);
+        assert_eq!(power_levels.redact, new_level);
+        // And the rest should remain unchanged.
+        assert_eq!(power_levels.events_default, original_levels.events_default);
+        assert_eq!(power_levels.state_default, original_levels.state_default);
+        assert_eq!(power_levels.users_default, original_levels.users_default);
+        assert_eq!(power_levels.events, original_levels.events);
+    }
+
+    #[test]
+    fn test_apply_room_settings() {
+        // Given a set of power levels and some settings that only change the specific
+        // state event levels.
+        let mut power_levels = default_power_levels();
+
+        let new_level = int!(100);
+        let settings = RoomPowerLevelSettings {
+            ban: None,
+            invite: None,
+            kick: None,
+            redact: None,
+            events_default: None,
+            state_default: None,
+            users_default: None,
+            room_name: Some(new_level.into()),
+            room_avatar: Some(new_level.into()),
+            room_topic: Some(new_level.into()),
+        };
+
+        // When applying the settings to the power levels.
+        let original_levels = power_levels.clone();
+        power_levels.apply(settings).unwrap();
+
+        // Then levels for the necessary state events should be added.
+        assert_eq!(
+            power_levels.events,
+            BTreeMap::from_iter(
+                vec![
+                    (StateEventType::RoomName.into(), new_level),
+                    (StateEventType::RoomAvatar.into(), new_level),
+                    (StateEventType::RoomTopic.into(), new_level),
+                ]
+                .into_iter()
+            )
+        );
+        // And the rest should remain unchanged.
+        assert_eq!(power_levels.ban, original_levels.ban);
+        assert_eq!(power_levels.invite, original_levels.invite);
+        assert_eq!(power_levels.kick, original_levels.kick);
+        assert_eq!(power_levels.redact, original_levels.redact);
+        assert_eq!(power_levels.events_default, original_levels.events_default);
+        assert_eq!(power_levels.state_default, original_levels.state_default);
+        assert_eq!(power_levels.users_default, original_levels.users_default);
+    }
+
+    #[test]
+    fn test_apply_remove_single_room_setting() {
+        // Given a set of power levels and some settings that change the room name level
+        // back to the default level.
+        let original_level = int!(100);
+        let mut power_levels = default_power_levels();
+        power_levels.events = BTreeMap::from_iter(
+            vec![
+                (StateEventType::RoomName.into(), original_level),
+                (StateEventType::RoomAvatar.into(), original_level),
+                (StateEventType::RoomTopic.into(), original_level),
+            ]
+            .into_iter(),
+        );
+
+        let settings = RoomPowerLevelSettings {
+            ban: None,
+            invite: None,
+            kick: None,
+            redact: None,
+            events_default: None,
+            state_default: None,
+            users_default: None,
+            room_name: Some(power_levels.state_default.into()),
+            room_avatar: None,
+            room_topic: None,
+        };
+
+        // When applying the settings to the power levels.
+        let original_levels = power_levels.clone();
+        power_levels.apply(settings).unwrap();
+
+        // Then the room name level should be removed without updating any other state
+        // events.
+        assert_eq!(
+            power_levels.events,
+            BTreeMap::from_iter(
+                vec![
+                    (StateEventType::RoomAvatar.into(), original_level),
+                    (StateEventType::RoomTopic.into(), original_level),
+                ]
+                .into_iter()
+            )
+        );
+        // And the rest should remain unchanged.
+        assert_eq!(power_levels.ban, original_levels.ban);
+        assert_eq!(power_levels.invite, original_levels.invite);
+        assert_eq!(power_levels.kick, original_levels.kick);
+        assert_eq!(power_levels.redact, original_levels.redact);
+        assert_eq!(power_levels.events_default, original_levels.events_default);
+        assert_eq!(power_levels.state_default, original_levels.state_default);
+        assert_eq!(power_levels.users_default, original_levels.users_default);
+    }
+
+    fn default_power_levels() -> RoomPowerLevels {
+        let mut content = RoomPowerLevelsEventContent::new();
+        content.ban = int!(50);
+        content.invite = int!(50);
+        content.kick = int!(50);
+        content.redact = int!(50);
+        content.events_default = int!(0);
+        content.state_default = int!(50);
+        content.users_default = int!(0);
+        content.notifications = NotificationPowerLevels::default();
+        content.into()
+    }
+}

--- a/xtask/src/kotlin.rs
+++ b/xtask/src/kotlin.rs
@@ -2,7 +2,7 @@ use std::fs::create_dir_all;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Args, Subcommand, ValueEnum};
-use uniffi_bindgen::bindings::TargetLanguage;
+use uniffi_bindgen::{bindings::TargetLanguage, library_mode::generate_bindings};
 use xshell::{cmd, pushd};
 
 use crate::{workspace, Result};
@@ -93,7 +93,6 @@ fn build_android_library(
 
     let package_values = package.values();
     let package_name = package_values.name;
-    let udl_path = root_dir.join(package_values.udl_path);
 
     let jni_libs_dir = src_dir.join("jniLibs");
     let jni_libs_dir_str = jni_libs_dir.as_str();
@@ -121,26 +120,21 @@ fn build_android_library(
     };
 
     println!("-- Generate uniffi files");
-    generate_uniffi_bindings(&udl_path, &uniffi_lib_path, &kotlin_generated_dir)?;
+    generate_uniffi_bindings(&uniffi_lib_path, &kotlin_generated_dir)?;
 
     println!("-- All done and hunky dory. Enjoy!");
     Ok(())
 }
 
-fn generate_uniffi_bindings(
-    udl_path: &Utf8Path,
-    library_path: &Utf8Path,
-    ffi_generated_dir: &Utf8Path,
-) -> Result<()> {
+fn generate_uniffi_bindings(library_path: &Utf8Path, ffi_generated_dir: &Utf8Path) -> Result<()> {
     println!("-- library_path = {library_path}");
 
-    uniffi_bindgen::generate_bindings(
-        udl_path,
+    generate_bindings(
+        library_path,
         None,
-        vec![TargetLanguage::Kotlin],
-        Some(ffi_generated_dir),
-        Some(library_path),
+        &[TargetLanguage::Kotlin],
         None,
+        ffi_generated_dir,
         false,
     )?;
     Ok(())


### PR DESCRIPTION
Adds support for updating power level settings (the PL required for various operations) and the power levels of individual users.

Requires: https://github.com/matrix-org/matrix-rust-sdk/pull/2918