### PR TITLE
dx: tweak debugging of user/device pairs missing a session

### DIFF
--- a/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/sessions.rs
@@ -18,7 +18,6 @@ use std::{
     time::Duration,
 };
 
-use itertools::Itertools;
 use matrix_sdk_common::failures_cache::FailuresCache;
 use ruma::{
     api::client::keys::claim_keys::v3::{
@@ -295,18 +294,12 @@ impl SessionManager {
 
         if tracing::level_enabled!(tracing::Level::DEBUG) {
             // Reformat the map to skip the encryption algorithm, which isn't very useful.
-            //
-            // Note: we reify the debug string for `missing_session_devices_by_user` to work
-            // around a known footgun of `itertools` (it can be used only once).
-            let missing_session_devices_by_user = format!(
-                "{:?}",
-                missing_session_devices_by_user
-                    .iter()
-                    .map(|(user_id, devices)| (user_id, devices.keys().collect::<Vec<_>>()))
-                    .format(", ")
-            );
+            let missing_session_devices_by_user = missing_session_devices_by_user
+                .iter()
+                .map(|(user_id, devices)| (user_id, devices.keys().collect::<BTreeSet<_>>()))
+                .collect::<BTreeMap<_, _>>();
             debug!(
-                missing_session_devices_by_user,
+                ?missing_session_devices_by_user,
                 ?timed_out_devices_by_user,
                 "Collected user/device pairs that are missing an Olm session"
             );


### PR DESCRIPTION
Noticed by @richvdh, thanks. This makes the formatting better by using the display implementations; we don't need to use `itertools::format` anymore, because the statement had to be guarded with an `if debug log level enabled` anyways.