### PR TITLE
notification settings: Don't error if poll start rule is not found

### DIFF
--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -452,7 +452,7 @@ pub enum NotificationSettingsError {
     #[error("Unable to update push rule")]
     UnableToUpdatePushRule,
     /// Rule not found
-    #[error("Rule not found")]
+    #[error("Rule `{0}` not found")]
     RuleNotFound(String),
     /// Unable to save the push rules
     #[error("Unable to save push rules")]

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -453,7 +453,7 @@ impl NotificationSettings {
                         rule_id.clone(),
                     );
                     self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to delete push rule `{rule_id}`: {error}");
+                        error!("Unable to delete {kind} push rule `{rule_id}`: {error}");
                         NotificationSettingsError::UnableToRemovePushRule
                     })?;
                 }
@@ -461,7 +461,7 @@ impl NotificationSettings {
                     let push_rule = command.to_push_rule()?;
                     let request = set_pushrule::v3::Request::new(scope.clone(), push_rule);
                     self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to set push rule `{room_id}`: {error}");
+                        error!("Unable to set room push rule `{room_id}`: {error}");
                         NotificationSettingsError::UnableToAddPushRule
                     })?;
                 }
@@ -469,7 +469,7 @@ impl NotificationSettings {
                     let push_rule = command.to_push_rule()?;
                     let request = set_pushrule::v3::Request::new(scope.clone(), push_rule);
                     self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to set push rule `{rule_id}`: {error}");
+                        error!("Unable to set override push rule `{rule_id}`: {error}");
                         NotificationSettingsError::UnableToAddPushRule
                     })?;
                 }
@@ -489,7 +489,7 @@ impl NotificationSettings {
                         *enabled,
                     );
                     self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to set push rule `{rule_id}` enabled: {error}");
+                        error!("Unable to set {kind} push rule `{rule_id}` enabled: {error}");
                         NotificationSettingsError::UnableToUpdatePushRule
                     })?;
                 }
@@ -501,7 +501,7 @@ impl NotificationSettings {
                         actions.clone(),
                     );
                     self.client.send(request, request_config).await.map_err(|error| {
-                        error!("Unable to set push rule `{rule_id}` actions: {error}");
+                        error!("Unable to set {kind} push rule `{rule_id}` actions: {error}");
                         NotificationSettingsError::UnableToUpdatePushRule
                     })?;
                 }

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 /// Enum representing the push notification modes for a room.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RoomNotificationMode {
     /// Receive notifications for all messages.
     AllMessages,
@@ -39,7 +39,7 @@ pub enum RoomNotificationMode {
 }
 
 /// Whether or not a room is encrypted
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum IsEncrypted {
     /// The room is encrypted
     Yes,
@@ -58,7 +58,7 @@ impl From<bool> for IsEncrypted {
 }
 
 /// Whether or not a room is a `one-to-one`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum IsOneToOne {
     /// A room is a `one-to-one` room if it has exactly two members.
     Yes,
@@ -198,7 +198,7 @@ impl NotificationSettings {
         mode: RoomNotificationMode,
     ) -> Result<(), NotificationSettingsError> {
         let rule_ids = vec![
-            rules::get_predefined_underride_room_rule_id(is_encrypted, is_one_to_one.clone()),
+            rules::get_predefined_underride_room_rule_id(is_encrypted, is_one_to_one),
             rules::get_predefined_underride_poll_start_rule_id(is_one_to_one),
         ];
 
@@ -260,7 +260,7 @@ impl NotificationSettings {
         let rules = self.rules.read().await.clone();
 
         // Check that the current mode is not already the target mode.
-        if rules.get_user_defined_room_notification_mode(room_id) == Some(mode.clone()) {
+        if rules.get_user_defined_room_notification_mode(room_id) == Some(mode) {
             return Ok(());
         }
 
@@ -853,16 +853,16 @@ mod tests {
         let mode = settings.get_user_defined_room_notification_mode(&room_id).await;
         assert!(mode.is_none());
 
-        let new_modes = &[
+        let new_modes = [
             RoomNotificationMode::AllMessages,
             RoomNotificationMode::MentionsAndKeywordsOnly,
             RoomNotificationMode::Mute,
         ];
         for new_mode in new_modes {
-            settings.set_room_notification_mode(&room_id, new_mode.clone()).await.unwrap();
+            settings.set_room_notification_mode(&room_id, new_mode).await.unwrap();
 
             assert_eq!(
-                new_mode.clone(),
+                new_mode,
                 settings.get_user_defined_room_notification_mode(&room_id).await.unwrap()
             );
         }

--- a/crates/matrix-sdk/src/notification_settings/mod.rs
+++ b/crates/matrix-sdk/src/notification_settings/mod.rs
@@ -199,7 +199,7 @@ impl NotificationSettings {
     ) -> Result<(), NotificationSettingsError> {
         let rule_ids = vec![
             rules::get_predefined_underride_room_rule_id(is_encrypted, is_one_to_one.clone()),
-            is_one_to_one.into(),
+            rules::get_predefined_underride_poll_start_rule_id(is_one_to_one),
         ];
 
         let actions = match mode {

--- a/crates/matrix-sdk/src/notification_settings/rules.rs
+++ b/crates/matrix-sdk/src/notification_settings/rules.rs
@@ -275,7 +275,7 @@ impl Rules {
     }
 }
 
-/// Gets the `PredefinedUnderrideRuleId` corresponding to the given
+/// Gets the `PredefinedUnderrideRuleId` for rooms corresponding to the given
 /// criteria.
 ///
 /// # Arguments
@@ -294,12 +294,18 @@ pub(crate) fn get_predefined_underride_room_rule_id(
     }
 }
 
-impl From<IsOneToOne> for PredefinedUnderrideRuleId {
-    fn from(is_one_to_one: IsOneToOne) -> Self {
-        match is_one_to_one {
-            IsOneToOne::Yes => Self::PollStartOneToOne,
-            IsOneToOne::No => Self::PollStart,
-        }
+/// Gets the `PredefinedUnderrideRuleId` for poll start events corresponding to
+/// the given criteria.
+///
+/// # Arguments
+///
+/// * `is_one_to_one` - `Yes` if the room is a direct chat involving two people
+pub(crate) fn get_predefined_underride_poll_start_rule_id(
+    is_one_to_one: IsOneToOne,
+) -> PredefinedUnderrideRuleId {
+    match is_one_to_one {
+        IsOneToOne::Yes => PredefinedUnderrideRuleId::PollStartOneToOne,
+        IsOneToOne::No => PredefinedUnderrideRuleId::PollStart,
     }
 }
 
@@ -433,6 +439,18 @@ pub(crate) mod tests {
         assert_eq!(
             rules::get_predefined_underride_room_rule_id(IsEncrypted::Yes, IsOneToOne::Yes),
             PredefinedUnderrideRuleId::EncryptedRoomOneToOne
+        );
+    }
+
+    #[async_test]
+    async fn test_get_predefined_underride_poll_start_rule_id() {
+        assert_eq!(
+            rules::get_predefined_underride_poll_start_rule_id(IsOneToOne::No),
+            PredefinedUnderrideRuleId::PollStart
+        );
+        assert_eq!(
+            rules::get_predefined_underride_poll_start_rule_id(IsOneToOne::Yes),
+            PredefinedUnderrideRuleId::PollStartOneToOne
         );
     }
 


### PR DESCRIPTION
This contains several small refactoring commits before the "main" one, each can be reviewed separately:

1. Use private method to get poll start rule ID: A `From` implementation is part of the public API
and this conversion does not make sense outside of the module. Even in the module, when I encountered `one_to_one.into()` I was wondering what we were getting. Added a test for the private method.
2. Derive `Copy` for enum types: this a good practice for inexpensive types and avoids to have to call `.clone()` explicitly in the code. There is also one type where we derive `Eq` because `PartialEq` is already derived.
3. Rely more on Ruma methods: it simplifies the code / reduces boilerplate.
4. Use `NotificationSettingsError::RuleNotFound`'s rule ID in`Display` impl: otherwise its not possible to know what rule is the problem when using high-level APIs that select the rule IDs themselves.
5. Log errors from requests: should be helpful if there is some debugging needed at some point.
6. Don't error if poll start rules are not found: these rules are unstable so they might not be
found in every ruleset, so let's just log the error and ignore it. That's actually an issue I stumbled upon in Fractal with a test account. Another solution could be to create the push rules if they don't exist. Added a test that failed before this commit.