### PR TITLE
sdk: Make sure "testing" feature is enabled for integration tests

### DIFF
--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -159,3 +159,7 @@ wasm-bindgen-test = "0.3.33"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 wiremock = "0.5.13"
+
+[[test]]
+name = "integration"
+required-features = ["testing"]


### PR DESCRIPTION
Otherwise `cargo test -p matrix-sdk` will fail with errors like:

```
error[E0599]: no method named `olm_machine_for_testing` found for struct `matrix_sdk::Client` in the current scope
   --> crates/matrix-sdk/tests/integration/encryption/verification.rs:474:31
    |
474 |         let alice_olm = alice.olm_machine_for_testing().await;
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ method not found in `Client`
```