### PR TITLE
matrix auth: Await `save_session_callback`

### DIFF
--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -38,7 +38,7 @@ use ruma::{
     serde::JsonObject,
 };
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info, instrument};
+use tracing::{debug, error, info, instrument};
 
 use crate::{
     authentication::AuthData,
@@ -486,7 +486,9 @@ impl MatrixAuth {
                 if let Some(save_session_callback) =
                     self.client.inner.auth_ctx.save_session_callback.get()
                 {
-                    save_session_callback(self.client.clone());
+                    if let Err(err) = save_session_callback(self.client.clone()).await {
+                        error!("when saving session after refresh: {err}");
+                    }
                 }
 
                 _ = self

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -1,5 +1,4 @@
 use std::{
-    future::ready,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -178,8 +177,11 @@ async fn test_refresh_token() {
         .set_session_callbacks(Box::new(|_| panic!("reload session never called")), {
             let num_save_session_callback_calls = num_save_session_callback_calls.clone();
             Box::new(move |_client| {
-                *num_save_session_callback_calls.lock().unwrap() += 1;
-                Box::pin(ready(Ok(())))
+                let num_save_session_callback_calls = num_save_session_callback_calls.clone();
+                Box::pin(async move {
+                    *num_save_session_callback_calls.lock().unwrap() += 1;
+                    Ok(())
+                })
             })
         })
         .unwrap();


### PR DESCRIPTION
Otherwise the future will not run.
Changes the corresponding test to fail with the old behavior.

This was caught by `cargo check` with the nightly toolchain.
