### PR TITLE
Configure `Instant` wasm polyfill to use monotonic time

### DIFF
--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [features]
-js = ["instant/wasm-bindgen", "instant/inaccurate", "wasm-bindgen-futures"]
+js = ["instant/wasm-bindgen", "wasm-bindgen-futures"]
 
 [dependencies]
 async-trait = { workspace = true }


### PR DESCRIPTION
With the `inaccurate` feature, this polyfill uses `Date.now()` to emulate `Instant`, which is not monotonic, causing problems like https://github.com/element-hq/element-web/issues/26416. Without it, it uses `Performance.now()`, which *is* monotonic.

I'm not really sure why we were using `inaccurate` in the first place. It was added in https://github.com/matrix-org/matrix-rust-sdk/pull/414, but that doesn't seem to be giving any clues.

One other point of note: `instant` generally doesn't seem to be very well maintained (cf https://github.com/sebcrozet/instant/issues/52), and maybe we should use `web-time` as that issue suggests.