### PR TITLE
Maybe trigger backup at end of sync

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -55,6 +55,10 @@ impl SlidingSyncResponseProcessor {
 
         self.to_device_events =
             self.client.base_client().process_sliding_sync_e2ee(extensions).await?;
+
+        // Some new keys might have been received, so trigger a backup if needed.
+        self.client.encryption().backups().maybe_trigger_backup();
+
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -152,6 +152,7 @@ impl Client {
         let response = Box::pin(self.base_client().receive_sync_response(response)).await?;
 
         // Some new keys might have been received, so trigger a backup if needed.
+        #[cfg(feature = "e2e-encryption")]
         self.encryption().backups().maybe_trigger_backup();
 
         self.handle_sync_response(&response).await?;

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -150,6 +150,10 @@ impl Client {
         response: sync_events::v3::Response,
     ) -> Result<BaseSyncResponse> {
         let response = Box::pin(self.base_client().receive_sync_response(response)).await?;
+
+        // Some new keys might have been received, so trigger a backup if needed.
+        self.encryption().backups().maybe_trigger_backup();
+
         self.handle_sync_response(&response).await?;
         Ok(response)
     }

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -517,9 +517,9 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
 
     let state = json!(
         {
-                "algorithm": "m.megolm.v1.aes-sha2",
-                "rotation_period_ms": 604800000,
-                "rotation_period_msgs": 100
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "rotation_period_ms": 604800000,
+            "rotation_period_msgs": 100
         }
     );
     just_mount(
@@ -556,23 +556,23 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
 
     let members = json!({
         "chunk": [
-        {
-            "content": {
-                "avatar_url": null,
-                "displayname": "example",
-                "membership": "join"
-            },
-            "event_id": "$151800140517rfvjc:localhost",
-            "membership": "join",
-            "origin_server_ts": 151800140,
-            "room_id": "!sefiuhWgwghwWgh:localhost",
-            "sender": "@example:morpheus.localhost",
-            "state_key": "@example:morpheus.localhost",
-            "type": "m.room.member",
-            "unsigned": {
-                "age": 2970366,
+            {
+                "content": {
+                    "avatar_url": null,
+                    "displayname": "example",
+                    "membership": "join"
+                },
+                "event_id": "$151800140517rfvjc:localhost",
+                "membership": "join",
+                "origin_server_ts": 151800140,
+                "room_id": "!sefiuhWgwghwWgh:localhost",
+                "sender": "@example:morpheus.localhost",
+                "state_key": "@example:morpheus.localhost",
+                "type": "m.room.member",
+                "unsigned": {
+                    "age": 2970366,
+                }
             }
-        }
         ]
     });
 
@@ -669,15 +669,15 @@ async fn incremental_upload_of_keys() -> Result<()> {
         "/_matrix/client/r0/sync",
         ResponseTemplate::new(200).set_body_json(json!({
             "next_batch": "sfooBar",
-        "device_one_time_keys_count": {
-            "signed_curve25519": 50
-        },
-        "org.matrix.msc2732.device_unused_fallback_key_types": [
-            "signed_curve25519"
-        ],
-        "device_unused_fallback_key_types": [
-            "signed_curve25519"
-        ]
+            "device_one_time_keys_count": {
+                "signed_curve25519": 50
+            },
+            "org.matrix.msc2732.device_unused_fallback_key_types": [
+                "signed_curve25519"
+            ],
+            "device_unused_fallback_key_types": [
+                "signed_curve25519"
+            ]
         })),
     )
     .await;

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -489,7 +489,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
         .and(path("_matrix/client/unstable/room_keys/version"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "version": "1"})))
-        .mount(&server)
+        .mount(server)
         .await;
 
     Mock::given(method("POST"))
@@ -499,7 +499,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
             ResponseTemplate::new(200)
                 .set_body_json(json!({ "room_id": "!sefiuhWgwghwWgh:localhost"})),
         )
-        .mount(&server)
+        .mount(server)
         .await;
 
     let state = json!(
@@ -514,7 +514,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
         .and(path("_matrix/client/r0/rooms/!sefiuhWgwghwWgh:localhost/state/m.room.encryption/"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(ResponseTemplate::new(200).set_body_json(state))
-        .mount(&server)
+        .mount(server)
         .await;
 
     Mock::given(method("GET"))
@@ -526,7 +526,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
             "error": "Account data not found."
         }))
     )
-    .mount(&server)
+    .mount(server)
     .await;
 
     Mock::given(method("POST"))
@@ -538,7 +538,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
                 "signed_curve25519": 50
             }
         })))
-        .mount(&server)
+        .mount(server)
         .await;
 
     let members = json!({
@@ -567,7 +567,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
         .and(path("_matrix/client/r0/rooms/!sefiuhWgwghwWgh:localhost/members"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(ResponseTemplate::new(200).set_body_json(members))
-        .mount(&server)
+        .mount(server)
         .await;
 
     Mock::given(method("PUT"))
@@ -589,7 +589,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
                 "@alice:example.org": {}
             }
         })))
-        .mount(&server)
+        .mount(server)
         .await;
 }
 

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -500,7 +500,7 @@ async fn steady_state_waiting() {
 
 async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer) {
     just_mount(
-        &server,
+        server,
         "POST",
         "_matrix/client/unstable/room_keys/version",
         ResponseTemplate::new(200).set_body_json(json!({ "version": "1"})),
@@ -508,7 +508,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
     .await;
 
     just_mount(
-        &server,
+        server,
         "POST",
         "_matrix/client/r0/createRoom",
         ResponseTemplate::new(200).set_body_json(json!({ "room_id": "!sefiuhWgwghwWgh:localhost"})),
@@ -523,7 +523,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
         }
     );
     just_mount(
-        &server,
+        server,
         "GET",
         "_matrix/client/r0/rooms/!sefiuhWgwghwWgh:localhost/state/m.room.encryption/",
         ResponseTemplate::new(200).set_body_json(state),
@@ -531,7 +531,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
     .await;
 
     just_mount(
-        &server,
+        server,
         "GET",
         "_matrix/client/r0/user/@example:morpheus.localhost/account_data/m.secret_storage.default_key",
         ResponseTemplate::new(404).set_body_json(json!({
@@ -542,7 +542,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
     .await;
 
     just_mount(
-        &server,
+        server,
         "POST",
         "/_matrix/client/r0/keys/upload",
         ResponseTemplate::new(404).set_body_json(json!({
@@ -577,7 +577,7 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
     });
 
     just_mount(
-        &server,
+        server,
         "GET",
         "_matrix/client/r0/rooms/!sefiuhWgwghwWgh:localhost/members",
         ResponseTemplate::new(200).set_body_json(members),
@@ -591,12 +591,12 @@ async fn setup_create_room_and_send_message_mocks(server: &wiremock::MockServer)
         {
             "event_id": "$foo:localhost"
         })))
-        .mount(&server)
+        .mount(server)
         .await;
 
     // we can just return an empty response here, we just encrypt to ourself
     just_mount(
-        &server,
+        server,
         "POST",
         "/_matrix/client/r0/keys/query",
         ResponseTemplate::new(200).set_body_json(json!({

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -630,13 +630,12 @@ async fn incremental_upload_of_keys() -> Result<()> {
 
     backups.create().await.expect("We should be able to create a new backup");
 
-    let invite = vec![];
-    let request = assign!(CreateRoomRequest::new(), {
-        invite,
-        is_direct: true,
-    });
-
-    let alice_room = client.create_room(request).await?;
+    let alice_room = client
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![],
+            is_direct: true,
+        }))
+        .await?;
 
     alice_room.enable_encryption().await?;
 

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -746,8 +746,8 @@ async fn incremental_upload_of_keys_sliding_sync() -> Result<()> {
     let txn_id = TransactionId::new();
     let _ = alice_room.send(content).with_transaction_id(&txn_id).await?;
 
-    // Set up sliding sync for Peter.
-    let sliding_peter = client
+    // Set up sliding sync.
+    let sliding = client
         .sliding_sync("main")?
         .with_all_extensions()
         .poll_timeout(std::time::Duration::from_secs(3))
@@ -759,7 +759,7 @@ async fn incremental_upload_of_keys_sliding_sync() -> Result<()> {
         .build()
         .await?;
 
-    let s = sliding_peter.clone();
+    let s = sliding.clone();
     tokio::task::spawn(async move {
         let stream = s.sync();
         pin_mut!(stream);


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2938

There might be other way to do that. On some other client there is signaling when a new key is imported to trigger that.
But doing it after the sync is probably reasonable.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
