### PR TITLE
Fix resume backup from cache

### DIFF
--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -792,15 +792,10 @@ impl Backups {
         let backup_keys = olm_machine.store().load_backup_keys().await?;
 
         if let Some(decryption_key) = backup_keys.decryption_key {
-            if let Some(version) = backup_keys.backup_version {
-                let backup_key = decryption_key.megolm_v1_public_key();
-
-                self.enable(olm_machine, backup_key, version).await?;
-
-                Ok(true)
-            } else {
-                Ok(false)
-            }
+            // we can't just use the stored version and enable for that version because
+            // the backup version might have been deleted or changed on the server.
+            // We need to check if the backup keys & version we have stored is still valid.
+            self.maybe_enable_backups(decryption_key.to_base64().as_str()).await
         } else {
             Ok(false)
         }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

During the initialization tasks of the olm machine, the sdk tries to setup the backup using the existing stored values.
The problem is that the saved backup version might have been deleted or replaced by the server, so we need to check 
against the server to ensure validity (just like we do for `maybe_resume_from_secret_inbox`).

Fixes https://github.com/element-hq/element-x-ios/issues/2236



- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
