### PR TITLE
Update logger.rs (Extend the logging callback interface in matrix-sdk-crypto-ffi #1759)

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/logger.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/logger.rs
@@ -21,11 +21,23 @@ pub trait Logger: Send {
     /// Called every time the Rust side wants to post an error log line.
     fn log_error(&self, message: String, data: String);
 }
-
+pub struct LoggerWrapper {
+    inner: Arc<Mutex<Box<dyn Logger>>>,
+    level: tracing_core::Level,
+}
 impl Write for LoggerWrapper {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        let data = String::from_utf8_lossy(buf).to_string();
-        self.inner.lock().unwrap().log(data);
+        let message = String::from_utf8_lossy(buf).to_string();
+  match self.level {
+            tracing_core::Level::ERROR => self.inner.lock().unwrap().log_error(message, String::new()),
+            tracing_core::Level::WARN => self.inner.lock().unwrap().log_warn(message, String::new()),
+            tracing_core::Level::INFO => self.inner.lock().unwrap().log_info(message, String::new()),
+            tracing_core::Level::DEBUG => self.inner.lock().unwrap().log_debug(message, String::new()),
+            tracing_core::Level::TRACE => {
+                // Assuming log_trace method exists in your Logger trait
+                self.inner.lock().unwrap().log_trace(message, String::new())
+            }
+        }
 
         Ok(buf.len())
     }
@@ -39,19 +51,26 @@ impl MakeWriter<'_> for LoggerWrapper {
     type Writer = LoggerWrapper;
 
     fn make_writer(&self) -> Self::Writer {
-        self.clone()
+         // Assuming a default log level of DEBUG
+        Self {
+            inner: self.inner.clone(),
+            level: tracing_core::Level::DEBUG
     }
 }
 
-#[derive(Clone)]
-pub struct LoggerWrapper {
-    inner: Arc<Mutex<Box<dyn Logger>>>,
+    fn make_writer_for(&self, meta: &tracing_core::Metadata<'_>) -> Self::Writer {
+        Self {
+            inner: self.inner.clone(),
+            level: meta.level().clone(),
+        }
+    }
 }
 
 /// Set the logger that should be used to forward Rust logs over FFI.
 #[uniffi::export]
 pub fn set_logger(logger: Box<dyn Logger>) {
-    let logger = LoggerWrapper { inner: Arc::new(Mutex::new(logger)) };
+    let logger = LoggerWrapper { inner: Arc::new(Mutex::new(logger))
+                             level: tracing_core::Level::DEBUG,  };
 
     let filter = EnvFilter::from_default_env()
         .add_directive(

--- a/bindings/matrix-sdk-crypto-ffi/src/logger.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/logger.rs
@@ -2,7 +2,7 @@ use std::{
     io::{Result, Write},
     sync::{Arc, Mutex},
 };
-
+use tracing_core::Level;
 use tracing_subscriber::{fmt::MakeWriter, EnvFilter};
 
 /// Trait that can be used to forward Rust logs over FFI to a language-specific
@@ -69,8 +69,9 @@ impl MakeWriter<'_> for LoggerWrapper {
 /// Set the logger that should be used to forward Rust logs over FFI.
 #[uniffi::export]
 pub fn set_logger(logger: Box<dyn Logger>) {
-    let logger = LoggerWrapper { inner: Arc::new(Mutex::new(logger))
-                             level: tracing_core::Level::DEBUG,  };
+    let logger = LoggerWrapper { 
+        inner: Arc::new(Mutex::new(logger))
+        level: tracing_core::Level::DEBUG,  };
 
     let filter = EnvFilter::from_default_env()
         .add_directive(

--- a/bindings/matrix-sdk-crypto-ffi/src/logger.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/logger.rs
@@ -5,14 +5,21 @@ use std::{
 
 use tracing_subscriber::{fmt::MakeWriter, EnvFilter};
 
-/// Trait that can be used to forward Rust logs over FFI to a language specific
+/// Trait that can be used to forward Rust logs over FFI to a language-specific
 /// logger.
 #[uniffi::export(callback_interface)]
 pub trait Logger: Send {
-    /// Called every time the Rust side wants to post a log line.
-    fn log(&self, log_line: String);
-    // TODO add support for different log levels, do this by adding more methods
-    // to the trait.
+  /// Called every time the Rust side wants to post a debug log line.
+    fn log_debug(&self, message: String, data: String);
+
+    /// Called every time the Rust side wants to post an info log line.
+    fn log_info(&self, message: String, data: String);
+
+    /// Called every time the Rust side wants to post a warning log line.
+    fn log_warn(&self, message: String, data: String);
+
+    /// Called every time the Rust side wants to post an error log line.
+    fn log_error(&self, message: String, data: String);
 }
 
 impl Write for LoggerWrapper {


### PR DESCRIPTION

#1759 
 in this issue, I change according to the description  [matrix-rust-sdk/bindings/matrix-sdk-crypto-ffi/src/logger.rs]
Lines 8 to 15 in [b033508](https://github.com/matrix-org/matrix-rust-sdk/commit/b033508e9bbf6eafa2eaac174ea412cc97a2c640)



Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
660 York Street, Suite 102,
San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Rudraksh <rudrakshladdha@gmail.com>
