### PR TITLE
Test Media caching, and re-implement it inside `MemoryStore`

### DIFF
--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -180,10 +180,7 @@ impl MediaEventContent for LocationMessageEventContent {
 
 #[cfg(test)]
 mod tests {
-    use ruma::{
-        events::room::{EncryptedFile, JsonWebKey},
-        mxc_uri,
-    };
+    use ruma::mxc_uri;
     use serde_json::json;
 
     use super::*;

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -12,7 +12,7 @@ use ruma::{
         },
         sticker::StickerEventContent,
     },
-    UInt,
+    MxcUri, UInt,
 };
 
 const UNIQUE_SEPARATOR: &str = "_";
@@ -83,11 +83,22 @@ pub struct MediaRequest {
     pub format: MediaFormat,
 }
 
+impl MediaRequest {
+    /// Get the [`MxcUri`] from `Self`.
+    pub fn uri(&self) -> &MxcUri {
+        match &self.source {
+            MediaSource::Plain(url) => url.as_ref(),
+            MediaSource::Encrypted(file) => file.url.as_ref(),
+        }
+    }
+}
+
 impl UniqueKey for MediaRequest {
     fn unique_key(&self) -> String {
         format!("{}{UNIQUE_SEPARATOR}{}", self.source.unique_key(), self.format.unique_key())
     }
 }
+
 /// Trait for media event content.
 pub trait MediaEventContent {
     /// Get the source of the file for `Self`.
@@ -164,5 +175,52 @@ impl MediaEventContent for LocationMessageEventContent {
 
     fn thumbnail_source(&self) -> Option<MediaSource> {
         self.info.as_ref()?.thumbnail_source.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma::{
+        events::room::{EncryptedFile, JsonWebKey},
+        mxc_uri,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_media_request_url() {
+        let mxc_uri = mxc_uri!("mxc://homeserver/media");
+
+        let plain = MediaRequest {
+            source: MediaSource::Plain(mxc_uri.to_owned()),
+            format: MediaFormat::File,
+        };
+
+        assert_eq!(plain.uri(), mxc_uri);
+
+        let file = MediaRequest {
+            source: MediaSource::Encrypted(Box::new(
+                serde_json::from_value(json!({
+                    "url": mxc_uri,
+                    "key": {
+                        "kty": "oct",
+                        "key_ops": ["encrypt", "decrypt"],
+                        "alg": "A256CTR",
+                        "k": "b50ACIv6LMn9AfMCFD1POJI_UAFWIclxAN1kWrEO2X8",
+                        "ext": true,
+                    },
+                    "iv": "AK1wyzigZtQAAAABAAAAKK",
+                    "hashes": {
+                        "sha256": "foobar",
+                    },
+                    "v": "v2",
+                }))
+                .unwrap(),
+            )),
+            format: MediaFormat::File,
+        };
+
+        assert_eq!(file.uri(), mxc_uri);
     }
 }

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -200,11 +200,8 @@ impl StateStoreIntegrationTests for DynStateStore {
 
     async fn test_media_content(&self) {
         let uri = mxc_uri!("mxc://localhost/media");
-        let content: Vec<u8> = "somebinarydata".into();
-
         let request_file =
             MediaRequest { source: MediaSource::Plain(uri.to_owned()), format: MediaFormat::File };
-
         let request_thumbnail = MediaRequest {
             source: MediaSource::Plain(uri.to_owned()),
             format: MediaFormat::Thumbnail(MediaThumbnailSize {
@@ -214,6 +211,17 @@ impl StateStoreIntegrationTests for DynStateStore {
             }),
         };
 
+        let other_uri = mxc_uri!("mxc://localhost/media-other");
+        let request_other_file = MediaRequest {
+            source: MediaSource::Plain(other_uri.to_owned()),
+            format: MediaFormat::File,
+        };
+
+        let content: Vec<u8> = "hello".into();
+        let thumbnail_content: Vec<u8> = "world".into();
+        let other_content: Vec<u8> = "foo".into();
+
+        // Media isn't present in the cache.
         assert!(
             self.get_media_content(&request_file).await.unwrap().is_none(),
             "unexpected media found"
@@ -223,35 +231,63 @@ impl StateStoreIntegrationTests for DynStateStore {
             "media not found"
         );
 
+        // Let's add the media.
         self.add_media_content(&request_file, content.clone()).await.expect("adding media failed");
-        assert!(
-            self.get_media_content(&request_file).await.unwrap().is_some(),
+
+        // Media is present in the cache.
+        assert_eq!(
+            self.get_media_content(&request_file).await.unwrap().as_ref(),
+            Some(&content),
             "media not found though added"
         );
 
+        // Let's remove the media.
         self.remove_media_content(&request_file).await.expect("removing media failed");
+
+        // Media isn't present in the cache.
         assert!(
             self.get_media_content(&request_file).await.unwrap().is_none(),
             "media still there after removing"
         );
 
+        // Let's add the media again.
         self.add_media_content(&request_file, content.clone())
             .await
             .expect("adding media again failed");
-        assert!(
-            self.get_media_content(&request_file).await.unwrap().is_some(),
+
+        assert_eq!(
+            self.get_media_content(&request_file).await.unwrap().as_ref(),
+            Some(&content),
             "media not found after adding again"
         );
 
-        self.add_media_content(&request_thumbnail, content.clone())
+        // Let's add the thumbnail media.
+        self.add_media_content(&request_thumbnail, thumbnail_content.clone())
             .await
             .expect("adding thumbnail failed");
-        assert!(
-            self.get_media_content(&request_thumbnail).await.unwrap().is_some(),
+
+        // Media's thumbnail is present.
+        assert_eq!(
+            self.get_media_content(&request_thumbnail).await.unwrap().as_ref(),
+            Some(&thumbnail_content),
             "thumbnail not found"
         );
 
+        // Let's add another media with a different URI.
+        self.add_media_content(&request_other_file, other_content.clone())
+            .await
+            .expect("adding other media failed");
+
+        // Other file is present.
+        assert_eq!(
+            self.get_media_content(&request_other_file).await.unwrap().as_ref(),
+            Some(&other_content),
+            "other file not found"
+        );
+
+        // Let's remove media based on URI.
         self.remove_media_content_for_uri(uri).await.expect("removing all media for uri failed");
+
         assert!(
             self.get_media_content(&request_file).await.unwrap().is_none(),
             "media wasn't removed"
@@ -259,6 +295,10 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert!(
             self.get_media_content(&request_thumbnail).await.unwrap().is_none(),
             "thumbnail wasn't removed"
+        );
+        assert!(
+            self.get_media_content(&request_other_file).await.unwrap().is_some(),
+            "other media was removed"
         );
     }
 

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -715,13 +715,9 @@ impl StateStore for MemoryStore {
         let media = self.media.read().unwrap();
         let expected_key = request.unique_key();
 
-        for (_media_uri, media_key, media_content) in media.iter() {
-            if media_key == &expected_key {
-                return Ok(Some(media_content.to_owned()));
-            }
-        }
-
-        Ok(None)
+        Ok(media.iter().find_map(|(_media_uri, media_key, media_content)| {
+            (media_key == &expected_key).then(|| media_content.to_owned())
+        }))
     }
 
     async fn remove_media_content(&self, request: &MediaRequest) -> Result<()> {

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -75,6 +75,12 @@ impl<T> RingBuffer<T> {
         self.inner.pop_front()
     }
 
+    /// Removes and returns one specific element at `index` if it exists,
+    /// otherwise it returns `None`.
+    pub fn remove(&mut self, index: usize) -> Option<T> {
+        self.inner.remove(index)
+    }
+
     /// Returns an iterator that provides elements in front-to-back order, i.e.
     /// the same order you would get if you repeatedly called pop().
     pub fn iter(&self) -> Iter<'_, T> {
@@ -156,7 +162,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_push_and_pop_and_length() {
+    pub fn test_push_and_pop_and_remove_and_length() {
         let mut ring_buffer = RingBuffer::new(3);
 
         ring_buffer.push(1);
@@ -168,23 +174,48 @@ mod tests {
         ring_buffer.push(3);
         assert_eq!(ring_buffer.len(), 3);
 
-        ring_buffer.pop();
+        assert_eq!(ring_buffer.pop(), Some(1));
         assert_eq!(ring_buffer.len(), 2);
         assert_eq!(ring_buffer.get(0), Some(&2));
         assert_eq!(ring_buffer.get(1), Some(&3));
         assert_eq!(ring_buffer.get(2), None);
 
-        ring_buffer.pop();
+        assert_eq!(ring_buffer.pop(), Some(2));
         assert_eq!(ring_buffer.len(), 1);
         assert_eq!(ring_buffer.get(0), Some(&3));
         assert_eq!(ring_buffer.get(1), None);
         assert_eq!(ring_buffer.get(2), None);
 
-        ring_buffer.pop();
+        assert_eq!(ring_buffer.pop(), Some(3));
         assert_eq!(ring_buffer.len(), 0);
         assert_eq!(ring_buffer.get(0), None);
         assert_eq!(ring_buffer.get(1), None);
         assert_eq!(ring_buffer.get(2), None);
+
+        assert_eq!(ring_buffer.pop(), None);
+
+        ring_buffer.push(1);
+        ring_buffer.push(2);
+        ring_buffer.push(3);
+        assert_eq!(ring_buffer.len(), 3);
+        assert_eq!(ring_buffer.get(0), Some(&1));
+        assert_eq!(ring_buffer.get(1), Some(&2));
+        assert_eq!(ring_buffer.get(2), Some(&3));
+
+        assert_eq!(ring_buffer.remove(1), Some(2));
+        assert_eq!(ring_buffer.len(), 2);
+        assert_eq!(ring_buffer.get(0), Some(&1));
+        assert_eq!(ring_buffer.get(1), Some(&3));
+        assert_eq!(ring_buffer.get(2), None);
+
+        assert_eq!(ring_buffer.remove(0), Some(1));
+        assert_eq!(ring_buffer.len(), 1);
+        assert_eq!(ring_buffer.get(0), Some(&3));
+        assert_eq!(ring_buffer.get(1), None);
+        assert_eq!(ring_buffer.get(2), None);
+
+        assert_eq!(ring_buffer.remove(1), None);
+        assert_eq!(ring_buffer.remove(10), None);
     }
 
     #[test]

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -81,6 +81,7 @@ impl<T> RingBuffer<T> {
         self.inner.iter()
     }
 
+    /// Returns an iterator that drains its items.
     pub fn drain<R>(&mut self, range: R) -> Drain<'_, T>
     where
         R: RangeBounds<usize>,

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -264,12 +264,12 @@ impl Media {
         request: &MediaRequest,
         use_cache: bool,
     ) -> Result<Vec<u8>> {
-        let content =
-            if use_cache { self.client.store().get_media_content(request).await? } else { None };
-
-        if let Some(content) = content {
-            return Ok(content);
-        }
+        // Read from the cache.
+        if use_cache {
+            if let Some(content) = self.client.store().get_media_content(request).await? {
+                return Ok(content);
+            }
+        };
 
         let content: Vec<u8> = match &request.source {
             MediaSource::Encrypted(file) => {


### PR DESCRIPTION
This PR should be reviewed commit-by-commit. All commits have a description message.

The idea is to re-implement media support inside `MemoryStore`. It's a quick and dirty implementation but it works. The PR also clean up a bit of code and improve testing.

---

* Follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/1247/