### PR TITLE
Provide a limit() method in sqlite to find limit values

### DIFF
--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -15,9 +15,9 @@
 use std::{borrow::Borrow, ops::Deref};
 
 use async_trait::async_trait;
-use rusqlite::{OptionalExtension, Params, Row, Statement, Transaction};
+use rusqlite::{limits::Limit, OptionalExtension, Params, Row, Statement, Transaction};
 
-use crate::OpenStoreError;
+use crate::{error::Result, OpenStoreError};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Key {
@@ -85,6 +85,8 @@ pub(crate) trait SqliteObjectExt {
         T: Send + 'static,
         E: From<rusqlite::Error> + Send + 'static,
         F: FnOnce(&Transaction<'_>) -> Result<T, E> + Send + 'static;
+
+    async fn limit(&self, limit: Limit) -> i32;
 }
 
 #[async_trait]
@@ -144,6 +146,10 @@ impl SqliteObjectExt for deadpool_sqlite::Object {
         })
         .await
         .unwrap()
+    }
+
+    async fn limit(&self, limit: Limit) -> i32 {
+        self.interact(move |conn| conn.limit(limit)).await.expect("Failed to fetch limit")
     }
 }
 


### PR DESCRIPTION
This is needed so we can use it inside `chunk_large_query_over`.