### PR TITLE
Process rooms' read status client-side

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,6 +3080,7 @@ dependencies = [
  "async-trait",
  "bitflags 2.4.1",
  "eyeball",
+ "eyeball-im",
  "futures-executor",
  "futures-util",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "matrix-sdk-ui",
  "once_cell",
  "rand 0.8.5",
+ "stream_assert",
  "tempfile",
  "tokio",
  "tracing",

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -31,6 +31,8 @@ pub struct RoomInfo {
     user_defined_notification_mode: Option<RoomNotificationMode>,
     has_room_call: bool,
     active_room_call_participants: Vec<String>,
+    num_unread_messages: u64,
+    num_unread_mentions: u64,
 }
 
 impl RoomInfo {
@@ -75,6 +77,8 @@ impl RoomInfo {
                 .iter()
                 .map(|u| u.to_string())
                 .collect(),
+            num_unread_messages: room.num_unread_messages(),
+            num_unread_mentions: room.num_unread_mentions(),
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -31,7 +31,14 @@ pub struct RoomInfo {
     user_defined_notification_mode: Option<RoomNotificationMode>,
     has_room_call: bool,
     active_room_call_participants: Vec<String>,
+    /// "Interesting" messages received in that room, independently of the
+    /// notification settings.
     num_unread_messages: u64,
+    /// Events that will notify the user, according to their
+    /// notification settings.
+    num_unread_notifications: u64,
+    /// Events causing mentions/highlights for the user, according to their
+    /// notification settings.
     num_unread_mentions: u64,
 }
 
@@ -78,6 +85,7 @@ impl RoomInfo {
                 .map(|u| u.to_string())
                 .collect(),
             num_unread_messages: room.num_unread_messages(),
+            num_unread_notifications: room.num_unread_notifications(),
             num_unread_mentions: room.num_unread_mentions(),
         })
     }

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -40,6 +40,7 @@ assert_matches2 = { workspace = true, optional = true }
 async-trait = { workspace = true }
 bitflags = "2.1.0"
 eyeball = { workspace = true }
+eyeball-im = { workspace = true }
 futures-util = { workspace = true }
 http = { workspace = true, optional = true }
 matrix-sdk-common = { version = "0.6.0", path = "../matrix-sdk-common" }

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -30,8 +30,14 @@ mod error;
 pub mod latest_event;
 pub mod media;
 mod rooms;
+
+#[cfg(feature = "experimental-sliding-sync")]
+mod read_receipts;
+#[cfg(feature = "experimental-sliding-sync")]
+pub use read_receipts::PreviousEventsProvider;
 #[cfg(feature = "experimental-sliding-sync")]
 mod sliding_sync;
+
 pub mod store;
 pub mod sync;
 mod utils;

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -1,3 +1,4 @@
+use eyeball_im::Vector;
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 use ruma::{
     events::{
@@ -19,13 +20,12 @@ use crate::{error::Result, store::StateChanges, RoomInfo};
 pub trait PreviousEventsProvider: Send + Sync {
     /// Returns the list of known timeline events, in sync order, for the given
     /// room.
-    // TODO: return a reference or some kind of iterator
-    fn for_room(&self, room_id: &RoomId) -> Vec<SyncTimelineEvent>;
+    fn for_room(&self, room_id: &RoomId) -> Vector<SyncTimelineEvent>;
 }
 
 impl PreviousEventsProvider for () {
-    fn for_room(&self, _: &RoomId) -> Vec<SyncTimelineEvent> {
-        Vec::new()
+    fn for_room(&self, _: &RoomId) -> Vector<SyncTimelineEvent> {
+        Vector::new()
     }
 }
 

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -1,0 +1,395 @@
+use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
+use ruma::{
+    events::{
+        poll::{start::PollStartEventContent, unstable_start::UnstablePollStartEventContent},
+        receipt::{ReceiptThread, ReceiptType},
+        room::message::Relation,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, OriginalSyncMessageLikeEvent,
+        SyncMessageLikeEvent,
+    },
+    serde::Raw,
+    EventId, OwnedEventId, RoomId, UserId,
+};
+use tracing::{field::display, instrument, trace};
+
+use super::BaseClient;
+use crate::{error::Result, store::StateChanges, RoomInfo};
+
+/// Provider for timeline events prior to the current sync.
+pub trait PreviousEventsProvider: Send + Sync {
+    /// Returns the list of known timeline events, in sync order, for the given
+    /// room.
+    // TODO: return a reference or some kind of iterator
+    fn for_room(&self, room_id: &RoomId) -> Vec<SyncTimelineEvent>;
+}
+
+impl PreviousEventsProvider for () {
+    fn for_room(&self, _: &RoomId) -> Vec<SyncTimelineEvent> {
+        Vec::new()
+    }
+}
+
+#[instrument(skip_all, fields(room_id))]
+pub(crate) async fn compute_notifications(
+    client: &BaseClient,
+    changes: &StateChanges,
+    previous_events_provider: &dyn PreviousEventsProvider,
+    new_events: &[SyncTimelineEvent],
+    room_info: &mut RoomInfo,
+) -> Result<()> {
+    // Only apply the algorithm to encrypted rooms, since unencrypted rooms' unread
+    // notification counts ought to be properly computed by the server.
+    if !room_info.is_encrypted() {
+        return Ok(());
+    }
+
+    tracing::Span::current().record("room_id", display(&room_info.room_id));
+
+    let user_id = &client.session_meta().unwrap().user_id;
+    let prev_latest_receipt_event_id = room_info.latest_read_receipt_event_id.clone();
+
+    if let Some(receipt_event) = changes.receipts.get(room_info.room_id()) {
+        trace!("Got a new receipt event!");
+
+        // Find a private or public read receipt for the current user.
+        let mut receipt_event_id = None;
+        if let Some((event_id, receipt)) =
+            receipt_event.user_receipt(user_id, ReceiptType::ReadPrivate)
+        {
+            if receipt.thread == ReceiptThread::Unthreaded || receipt.thread == ReceiptThread::Main
+            {
+                receipt_event_id = Some(event_id.to_owned());
+            }
+        } else if let Some((event_id, receipt)) =
+            receipt_event.user_receipt(user_id, ReceiptType::Read)
+        {
+            if receipt.thread == ReceiptThread::Unthreaded || receipt.thread == ReceiptThread::Main
+            {
+                receipt_event_id = Some(event_id.to_owned());
+            }
+        }
+
+        if let Some(receipt_event_id) = receipt_event_id {
+            // We've found the id of an event to which the receipt attaches. The associated
+            // event may either come from the new batch of events associated to
+            // this sync, or it may live in the past timeline events we know
+            // about.
+
+            // First, save the event id as the latest one that has a read receipt.
+            room_info.latest_read_receipt_event_id = Some(receipt_event_id.clone());
+
+            // Try to find if the read receipts refers to an event from the current sync, to
+            // avoid searching the cached timeline events.
+            trace!("We got a new event with a read receipt: {receipt_event_id}. Search in new events...");
+            if find_and_count_events(&receipt_event_id, user_id, new_events.iter(), room_info) {
+                // It did, so our work here is done.
+                return Ok(());
+            }
+
+            // We didn't find the event attached to the receipt in the new batches of
+            // events. It's possible it's referring to an event we've already
+            // seen. In that case, try to find it.
+            let previous_events = previous_events_provider.for_room(&room_info.room_id);
+
+            trace!("Couldn't find the event attached to the receipt in the new events; looking in past events too now...");
+            if find_and_count_events(
+                &receipt_event_id,
+                user_id,
+                previous_events.iter().chain(new_events.iter()),
+                room_info,
+            ) {
+                // It did refer to an old event, so our work here is done.
+                return Ok(());
+            }
+        }
+    }
+
+    if let Some(receipt_event_id) = prev_latest_receipt_event_id {
+        // There's no new read-receipt here. We assume the cached events have been
+        // properly processed, and we only need to process the new events based
+        // on the previous receipt.
+        trace!("Couldn't find the event attached to the latest receipt; looking if the past latest known receipt refers to a new event...");
+        if find_and_count_events(&receipt_event_id, user_id, new_events.iter(), room_info) {
+            // We found the event to which the previous receipt attached to, so our work is
+            // done here.
+            return Ok(());
+        }
+    }
+
+    // If we haven't returned at this point, it means that either we had no previous
+    // read receipt, or the previous read receipt was not attached to any new
+    // event.
+    //
+    // In that case, accumulate all events as part of the current batch, and wait
+    // for the next receipt.
+    trace!("All other ways failed, including all new events for the receipts count.");
+    for event in new_events {
+        if event.push_actions.iter().any(ruma::push::Action::is_highlight) {
+            room_info.notification_counts.highlight_count += 1;
+        }
+        if marks_as_unread(&event.event, user_id) {
+            room_info.notification_counts.notification_count += 1;
+        }
+    }
+
+    Ok(())
+}
+
+/// Try to find the event to which the receipt attaches to, and if found, will
+/// update the notification count in the room.
+///
+/// Returns a boolean indicating if it's found the event and updated the count.
+fn find_and_count_events<'a>(
+    receipt_event_id: &EventId,
+    user_id: &UserId,
+    events: impl Iterator<Item = &'a SyncTimelineEvent>,
+    room_info: &mut RoomInfo,
+) -> bool {
+    let mut counting_receipts = false;
+    for event in events {
+        if counting_receipts {
+            for action in &event.push_actions {
+                if action.is_highlight() {
+                    room_info.notification_counts.highlight_count += 1;
+                }
+                if action.should_notify() && marks_as_unread(&event.event, user_id) {
+                    room_info.notification_counts.notification_count += 1;
+                }
+            }
+        } else if let Ok(Some(event_id)) = event.event.get_field::<OwnedEventId>("event_id") {
+            if event_id == receipt_event_id {
+                // Bingo! Switch over to the counting state, after resetting the
+                // previous counts.
+                trace!("Found the event the receipt was referring to! Starting to count.");
+                room_info.notification_counts = Default::default();
+                counting_receipts = true;
+            }
+        }
+    }
+    counting_receipts
+}
+
+/// Is the event worth marking a room as unread?
+fn marks_as_unread(event: &Raw<AnySyncTimelineEvent>, user_id: &UserId) -> bool {
+    let event = match event.deserialize() {
+        Ok(event) => event,
+        Err(err) => {
+            tracing::debug!(
+                "couldn't deserialize event {:?}: {err}",
+                event.get_field::<String>("event_id").ok().flatten()
+            );
+            return false;
+        }
+    };
+
+    if event.sender() == user_id {
+        // Not interested in one's own events.
+        return false;
+    }
+
+    match event {
+        ruma::events::AnySyncTimelineEvent::MessageLike(event) => {
+            // Filter out redactions.
+            let Some(content) = event.original_content() else {
+                tracing::trace!("not interesting because redacted");
+                return false;
+            };
+
+            // Filter out edits.
+            if matches!(
+                content.relation(),
+                Some(ruma::events::room::encrypted::Relation::Replacement(..))
+            ) {
+                tracing::trace!("not interesting because edited");
+                return false;
+            }
+
+            match event {
+                AnySyncMessageLikeEvent::CallAnswer(_)
+                | AnySyncMessageLikeEvent::CallInvite(_)
+                | AnySyncMessageLikeEvent::CallHangup(_)
+                | AnySyncMessageLikeEvent::CallCandidates(_)
+                | AnySyncMessageLikeEvent::CallNegotiate(_)
+                | AnySyncMessageLikeEvent::CallReject(_)
+                | AnySyncMessageLikeEvent::CallSelectAnswer(_)
+                | AnySyncMessageLikeEvent::PollResponse(_)
+                | AnySyncMessageLikeEvent::UnstablePollResponse(_)
+                | AnySyncMessageLikeEvent::Reaction(_)
+                | AnySyncMessageLikeEvent::RoomRedaction(_)
+                | AnySyncMessageLikeEvent::KeyVerificationStart(_)
+                | AnySyncMessageLikeEvent::KeyVerificationReady(_)
+                | AnySyncMessageLikeEvent::KeyVerificationCancel(_)
+                | AnySyncMessageLikeEvent::KeyVerificationAccept(_)
+                | AnySyncMessageLikeEvent::KeyVerificationDone(_)
+                | AnySyncMessageLikeEvent::KeyVerificationMac(_)
+                | AnySyncMessageLikeEvent::KeyVerificationKey(_) => false,
+
+                // For some reason, Ruma doesn't handle these two in `content.relation()` above.
+                AnySyncMessageLikeEvent::PollStart(SyncMessageLikeEvent::Original(
+                    OriginalSyncMessageLikeEvent {
+                        content:
+                            PollStartEventContent { relates_to: Some(Relation::Replacement(_)), .. },
+                        ..
+                    },
+                ))
+                | AnySyncMessageLikeEvent::UnstablePollStart(SyncMessageLikeEvent::Original(
+                    OriginalSyncMessageLikeEvent {
+                        content: UnstablePollStartEventContent::Replacement(_),
+                        ..
+                    },
+                )) => false,
+
+                AnySyncMessageLikeEvent::Message(_)
+                | AnySyncMessageLikeEvent::PollStart(_)
+                | AnySyncMessageLikeEvent::UnstablePollStart(_)
+                | AnySyncMessageLikeEvent::PollEnd(_)
+                | AnySyncMessageLikeEvent::UnstablePollEnd(_)
+                | AnySyncMessageLikeEvent::RoomEncrypted(_)
+                | AnySyncMessageLikeEvent::RoomMessage(_)
+                | AnySyncMessageLikeEvent::Sticker(_) => true,
+
+                _ => {
+                    // What I don't know about, I don't care about.
+                    tracing::debug!("unhandled timeline event type: {}", event.event_type());
+                    false
+                }
+            }
+        }
+
+        ruma::events::AnySyncTimelineEvent::State(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Not as _;
+
+    use matrix_sdk_test::sync_timeline_event;
+    use ruma::{event_id, user_id};
+
+    use crate::read_receipts::marks_as_unread;
+
+    #[test]
+    fn test_room_message_marks_as_unread() {
+        let user_id = user_id!("@alice:example.org");
+        let other_user_id = user_id!("@bob:example.org");
+
+        // A message from somebody else marks the room as unread...
+        let ev = sync_timeline_event!({
+            "sender": other_user_id,
+            "type": "m.room.message",
+            "event_id": "$ida",
+            "origin_server_ts": 12344446,
+            "content": { "body":"A", "msgtype": "m.text" },
+        });
+        assert!(marks_as_unread(&ev, user_id));
+
+        // ... but a message from ourselves doesn't.
+        let ev = sync_timeline_event!({
+            "sender": user_id,
+            "type": "m.room.message",
+            "event_id": "$ida",
+            "origin_server_ts": 12344446,
+            "content": { "body":"A", "msgtype": "m.text" },
+        });
+        assert!(marks_as_unread(&ev, user_id).not());
+    }
+
+    #[test]
+    fn test_room_edit_doesnt_mark_as_unread() {
+        let user_id = user_id!("@alice:example.org");
+        let other_user_id = user_id!("@bob:example.org");
+
+        // An edit to a message from somebody else doesn't mark the room as unread.
+        let ev = sync_timeline_event!({
+            "sender": other_user_id,
+            "type": "m.room.message",
+            "event_id": "$ida",
+            "origin_server_ts": 12344446,
+            "content": {
+                "body": " * edited message",
+                "m.new_content": {
+                    "body": "edited message",
+                    "msgtype": "m.text"
+                },
+                "m.relates_to": {
+                    "event_id": "$someeventid:localhost",
+                    "rel_type": "m.replace"
+                },
+                "msgtype": "m.text"
+            },
+        });
+        assert!(marks_as_unread(&ev, user_id).not());
+    }
+
+    #[test]
+    fn test_redaction_doesnt_mark_room_as_unread() {
+        let user_id = user_id!("@alice:example.org");
+        let other_user_id = user_id!("@bob:example.org");
+
+        // A redact of a message from somebody else doesn't mark the room as unread.
+        let ev = sync_timeline_event!({
+            "content": {
+                "reason": "🛑"
+            },
+            "event_id": "$151957878228ssqrJ:localhost",
+            "origin_server_ts": 151957878000000_u64,
+            "sender": other_user_id,
+            "type": "m.room.redaction",
+            "redacts": "$151957878228ssqrj:localhost",
+            "unsigned": {
+                "age": 85
+            }
+        });
+
+        assert!(marks_as_unread(&ev, user_id).not());
+    }
+
+    #[test]
+    fn test_reaction_doesnt_mark_room_as_unread() {
+        let user_id = user_id!("@alice:example.org");
+        let other_user_id = user_id!("@bob:example.org");
+
+        // A reaction from somebody else to a message doesn't mark the room as unread.
+        let ev = sync_timeline_event!({
+            "content": {
+                "m.relates_to": {
+                    "event_id": "$15275047031IXQRi:localhost",
+                    "key": "👍",
+                    "rel_type": "m.annotation"
+                }
+            },
+            "event_id": "$15275047031IXQRi:localhost",
+            "origin_server_ts": 159027581000000_u64,
+            "sender": other_user_id,
+            "type": "m.reaction",
+            "unsigned": {
+                "age": 85
+            }
+        });
+
+        assert!(marks_as_unread(&ev, user_id).not());
+    }
+
+    #[test]
+    fn test_state_event_doesnt_mark_as_unread() {
+        let user_id = user_id!("@alice:example.org");
+        let event_id = event_id!("$1");
+        let ev = sync_timeline_event!({
+            "content": {
+                "displayname": "Alice",
+                "membership": "join",
+            },
+            "event_id": event_id,
+            "origin_server_ts": 1432135524678u64,
+            "sender": user_id,
+            "state_key": user_id,
+            "type": "m.room.member",
+        });
+
+        assert!(marks_as_unread(&ev, user_id).not());
+
+        let other_user_id = user_id!("@bob:example.org");
+        assert!(marks_as_unread(&ev, other_user_id).not());
+    }
+}

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -100,7 +100,7 @@ pub struct BaseRoomInfo {
     pub(crate) tombstone: Option<MinimalStateEvent<RoomTombstoneEventContent>>,
     /// The topic of this room.
     pub(crate) topic: Option<MinimalStateEvent<RoomTopicEventContent>>,
-    /// All Minimal state events that containing one or more running matrixRTC
+    /// All minimal state events that containing one or more running matrixRTC
     /// memberships.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub(crate) rtc_member: BTreeMap<OwnedUserId, MinimalStateEvent<CallMemberEventContent>>,

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -717,23 +717,38 @@ impl Room {
 pub struct RoomInfo {
     /// The unique room id of the room.
     pub(crate) room_id: OwnedRoomId,
+
     /// The state of the room.
     pub(crate) room_state: RoomState,
+
     /// The unread notifications counts.
     pub(crate) notification_counts: UnreadNotificationsCount,
+
     /// The summary of this room.
     pub(crate) summary: RoomSummary,
+
     /// Flag remembering if the room members are synced.
     pub(crate) members_synced: bool,
+
     /// The prev batch of this room we received during the last sync.
     pub(crate) last_prev_batch: Option<String>,
+
     /// How much we know about this room.
     pub(crate) sync_info: SyncInfo,
+
     /// Whether or not the encryption info was been synced.
     pub(crate) encryption_state_synced: bool,
+
     /// The last event send by sliding sync
     #[cfg(feature = "experimental-sliding-sync")]
     pub(crate) latest_event: Option<Box<LatestEvent>>,
+
+    /// The id of the event the last unthreaded (or main-threaded, for better
+    /// compatibility with clients that have thread support) read receipt is
+    /// attached to.
+    #[serde(default)]
+    pub(crate) latest_read_receipt_event_id: Option<OwnedEventId>,
+
     /// Base room info which holds some basic event contents important for the
     /// room state.
     pub(crate) base_info: Box<BaseRoomInfo>,
@@ -770,6 +785,7 @@ impl RoomInfo {
             encryption_state_synced: false,
             #[cfg(feature = "experimental-sliding-sync")]
             latest_event: None,
+            latest_read_receipt_event_id: None,
             base_info: Box::new(BaseRoomInfo::new()),
         }
     }
@@ -1251,6 +1267,7 @@ mod tests {
                 Raw::from_json_string(json!({"sender": "@u:i.uk"}).to_string()).unwrap().into(),
             ))),
             base_info: Box::new(BaseRoomInfo::new()),
+            latest_read_receipt_event_id: None,
         };
 
         let info_json = json!({

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -195,6 +195,14 @@ impl Room {
         self.inner.read().read_receipts.num_unread
     }
 
+    /// Get the number of unread notifications (computed client-side).
+    ///
+    /// This might be more precise than [`Self::unread_notification_counts`] for
+    /// encrypted rooms.
+    pub fn num_unread_notifications(&self) -> u64 {
+        self.inner.read().read_receipts.num_notifications
+    }
+
     /// Get the number of unread mentions (computed client-side), that is,
     /// messages causing a highlight in a room.
     ///
@@ -732,6 +740,9 @@ impl Room {
 pub struct RoomReadReceipts {
     /// Does the room have unread messages?
     pub(crate) num_unread: u64,
+
+    /// Does the room have unread events that should notify?
+    pub(crate) num_notifications: u64,
 
     /// Does the room have messages causing highlights for the users? (aka
     /// mentions)
@@ -1345,6 +1356,7 @@ mod tests {
             "read_receipts": {
                 "num_unread": 0,
                 "num_mentions": 0,
+                "num_notifications": 0,
                 "latest_read_receipt_event_id": null,
             }
         });

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -113,10 +113,10 @@ impl BaseClient {
     /// * `response` - The response that we received after a successful sliding
     ///   sync.
     #[instrument(skip_all, level = "trace")]
-    pub async fn process_sliding_sync(
+    pub async fn process_sliding_sync<PEP: PreviousEventsProvider>(
         &self,
         response: &v4::Response,
-        previous_events_provider: &dyn PreviousEventsProvider,
+        previous_events_provider: &PEP,
     ) -> Result<SyncResponse> {
         let v4::Response {
             // FIXME not yet supported by sliding sync. see

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -118,7 +118,7 @@ impl RoomInfoV1 {
             encryption_state_synced,
             #[cfg(feature = "experimental-sliding-sync")]
             latest_event: latest_event.map(|ev| Box::new(LatestEvent::new(ev))),
-            latest_read_receipt_event_id: None,
+            read_receipts: Default::default(),
             base_info: base_info.migrate(create),
         }
     }

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -118,6 +118,7 @@ impl RoomInfoV1 {
             encryption_state_synced,
             #[cfg(feature = "experimental-sliding-sync")]
             latest_event: latest_event.map(|ev| Box::new(LatestEvent::new(ev))),
+            latest_read_receipt_event_id: None,
             base_info: base_info.migrate(create),
         }
     }

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -140,7 +140,7 @@ impl JoinedRoom {
 }
 
 /// Counts of unread notifications for a room.
-#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct UnreadNotificationsCount {
     /// The number of unread notifications for this room with the highlight flag
     /// set.

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -560,7 +560,8 @@ mod tests {
     }
 
     #[async_test]
-    async fn latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_storage() {
+    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_storage(
+    ) {
         // Given a sync event that is suitable to be used as a latest_event, and a room
         // with a member event for the sender
 
@@ -574,7 +575,7 @@ mod tests {
 
         // And the room is stored in the client so it can be extracted when needed
         let response = response_with_room(room_id, room).await;
-        client.process_sliding_sync(&response).await.unwrap();
+        client.process_sliding_sync_test_helper(&response).await.unwrap();
 
         // When we construct a timeline event from it
         let timeline_item =
@@ -595,7 +596,8 @@ mod tests {
     }
 
     #[async_test]
-    async fn latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_cache() {
+    async fn test_latest_message_event_can_be_wrapped_as_a_timeline_item_with_sender_from_the_cache(
+    ) {
         // Given a sync event that is suitable to be used as a latest_event, a room, and
         // a member event for the sender (which isn't part of the room yet).
 
@@ -617,7 +619,7 @@ mod tests {
 
         // And the room is stored in the client so it can be extracted when needed
         let response = response_with_room(room_id, room).await;
-        client.process_sliding_sync(&response).await.unwrap();
+        client.process_sliding_sync_test_helper(&response).await.unwrap();
 
         // When we construct a timeline event from it
         let timeline_item = EventTimelineItem::from_latest_event(

--- a/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
+++ b/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
@@ -87,13 +87,13 @@ mod tests {
     }
 
     #[async_test]
-    async fn latest_message_event_is_wrapped_as_a_timeline_item() {
+    async fn test_latest_message_event_is_wrapped_as_a_timeline_item() {
         // Given a room exists, and an event came in through a sync
         let room_id = room_id!("!r:x.uk");
         let user_id = user_id!("@s:o.uk");
         let client = logged_in_client(None).await;
         let event = message_event(room_id, user_id, "**My msg**", "<b>My msg</b>", 122343);
-        process_event_via_sync(room_id, event, &client).await;
+        process_event_via_sync_test_helper(room_id, event, &client).await;
 
         // When we ask for the latest event in the room
         let room = SlidingSyncRoom::new(
@@ -118,11 +118,15 @@ mod tests {
         }
     }
 
-    async fn process_event_via_sync(room_id: &RoomId, event: SyncTimelineEvent, client: &Client) {
+    async fn process_event_via_sync_test_helper(
+        room_id: &RoomId,
+        event: SyncTimelineEvent,
+        client: &Client,
+    ) {
         let mut room = v4::SlidingSyncRoom::new();
         room.timeline.push(event.event);
         let response = response_with_room(room_id, room).await;
-        client.process_sliding_sync(&response).await.unwrap();
+        client.process_sliding_sync_test_helper(&response).await.unwrap();
     }
 
     fn message_event(

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use imbl::Vector;
 use matrix_sdk_base::{sync::SyncResponse, PreviousEventsProvider};
 use ruma::{api::client::sync::sync_events::v4, events::AnyToDeviceEvent, serde::Raw, OwnedRoomId};
 use tracing::{debug, instrument};
@@ -41,11 +42,8 @@ impl<'a> PreviousEventsProvider for SlidingSyncPreviousEventsProvider<'a> {
     fn for_room(
         &self,
         room_id: &ruma::RoomId,
-    ) -> Vec<matrix_sdk_common::deserialized_responses::SyncTimelineEvent> {
-        self.0
-            .get(room_id)
-            .map(|room| room.timeline_queue().into_iter().collect())
-            .unwrap_or_default()
+    ) -> Vector<matrix_sdk_common::deserialized_responses::SyncTimelineEvent> {
+        self.0.get(room_id).map(|room| room.timeline_queue()).unwrap_or_default()
     }
 }
 

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 use imbl::Vector;
 use matrix_sdk_base::{sync::SyncResponse, PreviousEventsProvider};
 use ruma::{api::client::sync::sync_events::v4, events::AnyToDeviceEvent, serde::Raw, OwnedRoomId};
-use tracing::{debug, instrument};
 
 use super::{SlidingSync, SlidingSyncBuilder};
 use crate::{Client, Result, SlidingSyncRoom};
@@ -22,14 +21,15 @@ impl Client {
     ///
     /// If you need to handle encryption too, use the internal
     /// `SlidingSyncResponseProcessor` instead.
-    #[instrument(skip(self, response))]
+    #[cfg(any(test, feature = "testing"))]
+    #[tracing::instrument(skip(self, response))]
     pub async fn process_sliding_sync_test_helper(
         &self,
         response: &v4::Response,
     ) -> Result<SyncResponse> {
         let response = self.base_client().process_sliding_sync(response, &()).await?;
 
-        debug!("done processing on base_client");
+        tracing::debug!("done processing on base_client");
         self.handle_sync_response(&response).await?;
 
         Ok(response)

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -22,7 +22,10 @@ impl Client {
     /// If you need to handle encryption too, use the internal
     /// `SlidingSyncResponseProcessor` instead.
     #[instrument(skip(self, response))]
-    pub async fn process_sliding_sync(&self, response: &v4::Response) -> Result<SyncResponse> {
+    pub async fn process_sliding_sync_test_helper(
+        &self,
+        response: &v4::Response,
+    ) -> Result<SyncResponse> {
         let response = self.base_client().process_sliding_sync(response, &()).await?;
 
         debug!("done processing on base_client");

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -1,9 +1,11 @@
-use matrix_sdk_base::sync::SyncResponse;
-use ruma::{api::client::sync::sync_events::v4, events::AnyToDeviceEvent, serde::Raw};
+use std::collections::BTreeMap;
+
+use matrix_sdk_base::{sync::SyncResponse, PreviousEventsProvider};
+use ruma::{api::client::sync::sync_events::v4, events::AnyToDeviceEvent, serde::Raw, OwnedRoomId};
 use tracing::{debug, instrument};
 
 use super::{SlidingSync, SlidingSyncBuilder};
-use crate::{Client, Result};
+use crate::{Client, Result, SlidingSyncRoom};
 
 impl Client {
     /// Create a [`SlidingSyncBuilder`] tied to this client, with the given
@@ -21,12 +23,26 @@ impl Client {
     /// `SlidingSyncResponseProcessor` instead.
     #[instrument(skip(self, response))]
     pub async fn process_sliding_sync(&self, response: &v4::Response) -> Result<SyncResponse> {
-        let response = self.base_client().process_sliding_sync(response).await?;
+        let response = self.base_client().process_sliding_sync(response, &()).await?;
 
         debug!("done processing on base_client");
         self.handle_sync_response(&response).await?;
 
         Ok(response)
+    }
+}
+
+struct SlidingSyncPreviousEventsProvider<'a>(&'a BTreeMap<OwnedRoomId, SlidingSyncRoom>);
+
+impl<'a> PreviousEventsProvider for SlidingSyncPreviousEventsProvider<'a> {
+    fn for_room(
+        &self,
+        room_id: &ruma::RoomId,
+    ) -> Vec<matrix_sdk_common::deserialized_responses::SyncTimelineEvent> {
+        self.0
+            .get(room_id)
+            .map(|room| room.timeline_queue().into_iter().collect())
+            .unwrap_or_default()
     }
 }
 
@@ -36,15 +52,16 @@ impl Client {
 /// independently, if needs be, making sure that both are properly processed by
 /// event handlers.
 #[must_use]
-pub(crate) struct SlidingSyncResponseProcessor {
+pub(crate) struct SlidingSyncResponseProcessor<'a> {
     client: Client,
     to_device_events: Vec<Raw<AnyToDeviceEvent>>,
     response: Option<SyncResponse>,
+    rooms: &'a BTreeMap<OwnedRoomId, SlidingSyncRoom>,
 }
 
-impl SlidingSyncResponseProcessor {
-    pub fn new(client: Client) -> Self {
-        Self { client, to_device_events: Vec::new(), response: None }
+impl<'a> SlidingSyncResponseProcessor<'a> {
+    pub fn new(client: Client, rooms: &'a BTreeMap<OwnedRoomId, SlidingSyncRoom>) -> Self {
+        Self { client, to_device_events: Vec::new(), response: None, rooms }
     }
 
     #[cfg(feature = "e2e-encryption")]
@@ -63,7 +80,12 @@ impl SlidingSyncResponseProcessor {
     }
 
     pub async fn handle_room_response(&mut self, response: &v4::Response) -> Result<()> {
-        self.response = Some(self.client.base_client().process_sliding_sync(response).await?);
+        self.response = Some(
+            self.client
+                .base_client()
+                .process_sliding_sync(response, &SlidingSyncPreviousEventsProvider(self.rooms))
+                .await?,
+        );
         Ok(())
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -271,6 +271,13 @@ struct SlidingSyncRoomInner {
 
     /// A queue of received events, used to build a
     /// [`Timeline`][crate::Timeline].
+    ///
+    /// Given a room, its size is theoretically unbounded: we'll accumulate
+    /// events in this list, until we reach a limited sync, in which case
+    /// we'll clear it.
+    ///
+    /// When persisting the room, this queue is truncated to keep only the last
+    /// N events.
     timeline_queue: RwLock<Vector<SyncTimelineEvent>>,
 }
 

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -18,6 +18,7 @@ matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui" }
 matrix-sdk-test = { path = "../matrix-sdk-test" }
 once_cell = { workspace = true }
 rand = { workspace = true }
+stream_assert = "0.1.1"
 tempfile = "3.3.0"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing = { workspace = true }

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -212,6 +212,7 @@ async fn test_room_avatar_group_conversation() -> Result<()> {
     Ok(())
 }
 
+#[ignore = "times out or fails assertions in code coverage builds (#2963)"]
 #[tokio::test]
 async fn test_room_notification_count() -> Result<()> {
     let bob =
@@ -360,7 +361,6 @@ async fn test_room_notification_count() -> Result<()> {
         // The highlight also counts as a notification.
         assert_eq!(alice_room.num_unread_messages(), 2);
         assert_eq!(alice_room.num_unread_notifications(), 2);
-        // One new highlight.
         assert_eq!(alice_room.num_unread_mentions(), 1);
         break;
     }
@@ -434,7 +434,6 @@ async fn test_room_notification_count() -> Result<()> {
     // exists.
     assert_eq!(alice_room.num_unread_messages(), 1);
     assert_eq!(alice_room.num_unread_notifications(), 0);
-    // One new highlight.
     assert_eq!(alice_room.num_unread_mentions(), 0);
 
     assert_pending!(info_updates);

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -1,16 +1,27 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
-use futures_util::{pin_mut, StreamExt};
+use assert_matches2::assert_let;
+use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::{
     config::SyncSettings,
     ruma::{
-        api::client::room::create_room::v3::Request as CreateRoomRequest, assign,
-        events::room::message::RoomMessageEventContent, mxc_uri,
+        api::client::{
+            receipt::create_receipt::v3::ReceiptType,
+            room::create_room::v3::Request as CreateRoomRequest,
+            sync::sync_events::v4::{E2EEConfig, ReceiptsConfig, ToDeviceConfig},
+        },
+        assign,
+        events::{
+            receipt::ReceiptThread, room::message::RoomMessageEventContent,
+            AnySyncMessageLikeEvent, Mentions,
+        },
+        mxc_uri,
     },
     RoomListEntry, RoomState, SlidingSyncList, SlidingSyncMode,
 };
-use tokio::time::sleep;
+use stream_assert::assert_pending;
+use tokio::{sync::Mutex, time::sleep};
 use tracing::{error, warn};
 
 use crate::helpers::TestClientBuilder;
@@ -195,6 +206,207 @@ async fn test_room_avatar_group_conversation() -> Result<()> {
         // Force a new server response.
         alice_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_room_notification_count() -> Result<()> {
+    let bob =
+        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+
+    // Spawn sync for bob.
+    let b = bob.clone();
+    tokio::task::spawn(async move {
+        let bob = b;
+        loop {
+            if let Err(err) = bob.sync(Default::default()).await {
+                tracing::error!("bob sync error: {err}");
+            }
+        }
+    });
+
+    // Set up sliding sync for alice.
+    let alice = TestClientBuilder::new("alice".to_owned())
+        .randomize_username()
+        .use_sqlite()
+        .build()
+        .await?;
+
+    tokio::task::spawn({
+        let sync = alice
+            .sliding_sync("main")?
+            .with_receipt_extension(assign!(ReceiptsConfig::default(), { enabled: Some(true) }))
+            .add_list(
+                SlidingSyncList::builder("all")
+                    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=20)),
+            )
+            .build()
+            .await?;
+
+        async move {
+            let stream = sync.sync();
+            pin_mut!(stream);
+            while let Some(up) = stream.next().await {
+                warn!("received update: {up:?}");
+            }
+        }
+    });
+
+    tokio::task::spawn({
+        let sync = alice
+            .sliding_sync("e2ee")?
+            .with_e2ee_extension(assign!(E2EEConfig::default(), { enabled: Some(true) }))
+            .with_to_device_extension(assign!(ToDeviceConfig::default(), { enabled: Some(true) }))
+            .build()
+            .await?;
+
+        async move {
+            let stream = sync.sync();
+            pin_mut!(stream);
+            while let Some(up) = stream.next().await {
+                warn!("received update: {up:?}");
+            }
+        }
+    });
+
+    let latest_event = Arc::new(Mutex::new(None));
+    let l = latest_event.clone();
+    alice.add_event_handler(|ev: AnySyncMessageLikeEvent| async move {
+        let mut latest_event = l.lock().await;
+        *latest_event = Some(ev);
+    });
+
+    // alice creates a room and invites bob.
+    let room_id = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![bob.user_id().unwrap().to_owned()],
+            is_direct: true,
+        }))
+        .await?
+        .room_id()
+        .to_owned();
+
+    let mut alice_room = None;
+    for i in 1..=4 {
+        sleep(Duration::from_millis(30 * i)).await;
+        alice_room = alice.get_room(&room_id);
+        if alice_room.is_some() {
+            break;
+        }
+    }
+
+    let alice_room = alice_room.unwrap();
+    assert_eq!(alice_room.state(), RoomState::Joined);
+
+    alice_room.enable_encryption().await?;
+
+    let mut info_updates = alice_room.subscribe_info();
+
+    // At first, nothing has happened, so we shouldn't have any notifications.
+    let count = alice_room.unread_notification_counts();
+    assert_eq!(count.highlight_count, 0);
+    assert_eq!(count.notification_count, 0);
+
+    assert_pending!(info_updates);
+
+    // Bob joins, nothing happens.
+    bob.join_room_by_id(&room_id).await?;
+
+    assert!(info_updates.next().await.is_some());
+
+    let count = alice_room.unread_notification_counts();
+    assert_eq!(count.highlight_count, 0);
+    assert_eq!(count.notification_count, 0);
+    assert!(alice_room.latest_event().is_none());
+
+    assert_pending!(info_updates);
+
+    // Bob sends a non-mention message.
+    let bob_room = bob.get_room(&room_id).expect("bob knows about alice's room");
+
+    bob_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
+
+    assert!(info_updates.next().await.is_some());
+
+    let count = alice_room.unread_notification_counts();
+    assert_eq!(count.highlight_count, 0);
+    assert_eq!(count.notification_count, 1);
+    let mut prev_count = count;
+
+    assert_pending!(info_updates);
+
+    // Bob sends a mention message.
+    let bob_room = bob.get_room(&room_id).expect("bob knows about alice's room");
+    bob_room
+        .send(
+            RoomMessageEventContent::text_plain("Hello my dear friend Alice!")
+                .set_mentions(Mentions::with_user_ids([alice.user_id().unwrap().to_owned()])),
+        )
+        .await?;
+
+    loop {
+        assert!(info_updates.next().await.is_some());
+
+        let count = alice_room.unread_notification_counts();
+        if count == prev_count {
+            // Sometimes we get notified for changes to unrelated, other fields of
+            // `info_updates`.
+            tracing::warn!("ignoring");
+            continue;
+        }
+
+        assert_eq!(count.highlight_count, 1); // one new highlight
+        assert_eq!(count.notification_count, 2); // the highlight counts as a new notification
+        prev_count = count;
+        break;
+    }
+
+    assert_pending!(info_updates);
+
+    // Alice marks the room as read.
+    let event_id = latest_event.lock().await.take().unwrap().event_id().to_owned();
+    alice_room.send_single_receipt(ReceiptType::Read, ReceiptThread::Unthreaded, event_id).await?;
+
+    // Remote echo of marking the room as read.
+    assert_let!(Some(_room_info) = info_updates.next().await);
+
+    loop {
+        assert!(info_updates.next().await.is_some());
+
+        let count = alice_room.unread_notification_counts();
+        if count == prev_count {
+            // Sometimes we get notified for changes to unrelated, other fields of
+            // `info_updates`.
+            tracing::warn!("ignoring");
+            continue;
+        }
+
+        assert_eq!(count.highlight_count, 0, "{count:?}");
+        assert_eq!(count.notification_count, 0, "{count:?}");
+        break;
+    }
+
+    assert_pending!(info_updates);
+
+    // Alice sends a message.
+    alice_room.send(RoomMessageEventContent::text_plain("hello bob")).await?;
+
+    // Local echo for our own message.
+    assert!(info_updates.next().await.is_some());
+
+    let count = alice_room.unread_notification_counts();
+    assert_eq!(count.highlight_count, 0, "{count:?}");
+    assert_eq!(count.notification_count, 0, "{count:?}");
+
+    // Remote echo for our own message.
+    assert!(info_updates.next().await.is_some());
+
+    let count = alice_room.unread_notification_counts();
+    assert_eq!(count.highlight_count, 0, "{count:?}");
+    assert_eq!(count.notification_count, 0, "{count:?}");
+
+    assert_pending!(info_updates);
 
     Ok(())
 }


### PR DESCRIPTION
This adds support for processing the number of unread messages and mentions (highlights) client-side. This can be used to know whether a room has unread content or not (if any count > 0), or if there are mentions (highlights > 0) for the user in a given room. Or, it can also be used as a high-level approximation of the number of unread messages/mentions for recently visited rooms.

This implementation is not final, but attempts to be useful in the short-term. It's relatively simple. It is an improvement over the status quo, in that it can handle events from encrypted rooms, and it has a short-term memory to reconcile read receipts received at a different time than the events they relate to.

Some implementation notes:

- Historically, there's `UnreadNotificationCounts` which returns information as computed by the server. While it's reliable for non-encrypted rooms, it is not for encrypted rooms. A previous version of this PR overrode that, but it was indicated that this field was still useful to have per se, so it's untouched in this new version.
- each `RoomInfo` gets a new field `ReadReceipts`. This is used to contain both the event id to which attaches the latest read receipt we've observed, and to contain the number of unread messages and highlights. This is only computed for sliding sync, but with some effort we could port it over to regular sync v2 as well. The `num_unread_messages` field reflects the number of unread messages, while `num_unread_mentions` reflects the number of highlights, according to push rules. *Note: this relies on push rules being available and the push context being properly computed, and mentions won't work properly if any of these is missing.*
  - this is *not* updated during back-pagination/messages/context queries: here we're focusing on events received from sync.
- to mark a room as unread, an event must have the following properties:
  - be valid according to the Matrix protocol (deserializable)
  - be a message-like event (not a state event)
  - and even a subset of message-likes (we don't want to mark a room as unread when somebody reacts to somebody else's message)
  - not be a redaction or an edit
  - be sent from somebody else
- After sending a read receipt, we'll receive a read receipt echo from the server. Using that information, we can then clear up the counts, and start counting unread messages and mentions from the next event.
- It could be that a read receipt comes for an event that was in a previous sync batch. This implementation can handle that, by looking at the previously known events (those kept in the `timeline_queue` in-memory cache, that's partially persisted to disk), and reconciling a read receipt against those. It can also handle read-receipts for events that come in future syncs (which is possible because: federation :partying_face:), since it's possible to save the receipt as soon as it's seen, and reconcile it later.

There's an integration test that was used to ensure that the approach is viable. There are units tests for determining interesting events that would mark a room as unread.