### PR TITLE
Migrate inbound_group_session2 to fix keys incorrectly copied from old store version

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -238,7 +238,7 @@ fn migrate_stores_to_v6(db: &IdbDatabase) -> Result<(), DomException> {
     // But copying the data needs to happen outside the database upgrade process
     // (because it needs async calls). So, here we create a new store for
     // inbound group sessions. We don't populate it yet; that happens once we
-    // have done the upgrade to v6, in `prepare_data_for_v6`. Finally we drop the
+    // have done the upgrade to v6, in `prepare_data_for_v7`. Finally we drop the
     // old store in create_stores_for_v7.
 
     let object_store = db.create_object_store(keys::INBOUND_GROUP_SESSIONS_V2)?;
@@ -310,7 +310,7 @@ fn migrate_stores_to_v7(db: &IdbDatabase) -> Result<(), DomException> {
 async fn prepare_data_for_v8(name: &str, serializer: &IndexeddbSerializer) -> Result<()> {
     // In prepare_data_for_v6, we incorrectly copied the keys in
     // inbound_group_sessions verbatim into inbound_group_sessions2. What we
-    // should have done is re-encrypt them using the new table name, so we fix
+    // should have done is re-hash them using the new table name, so we fix
     // them up here.
 
     info!("IndexeddbCryptoStore upgrade data -> v8 starting");

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -387,6 +387,10 @@ mod tests {
         for session in vec![&session1, &session2] {
             let room_id = session.room_id();
             let session_id = session.session_id();
+            // XXX: there is a bug in the migration to v7: it copies the keys directly from the
+            // old store into the new one, but they need to be recalculated because the store name
+            // has changed. Here we populate the old DB with keys that are correct for the new
+            // store name, so that this test can pass despite this bug.
             let key = serializer.encode_key(keys::INBOUND_GROUP_SESSIONS_V2, (room_id, session_id));
             let pickle = session.pickle().await;
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -463,7 +463,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(s.session_id(), backed_up_session.session_id());
-        assert_eq!(s.backed_up(), true);
+        assert!(s.backed_up());
 
         let s = store
             .get_inbound_group_session(room_id, not_backed_up_session.session_id())
@@ -471,7 +471,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(s.session_id(), not_backed_up_session.session_id());
-        assert_eq!(s.backed_up(), false);
+        assert!(!s.backed_up());
     }
 
     fn create_sessions(room_id: &RoomId) -> (InboundGroupSession, InboundGroupSession) {

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -65,7 +65,8 @@ pub async fn open_and_upgrade_db(
         migrate_schema_for_v8(name).await?;
     }
 
-    // We know we've upgraded to v8 now, so we can open the DB at that version and return it
+    // We know we've upgraded to v8 now, so we can open the DB at that version and
+    // return it
     Ok(IdbDatabase::open_u32(name, 8)?.await?)
 }
 
@@ -145,9 +146,9 @@ async fn migrate_schema_for_v7(name: &str) -> Result<(), DomException> {
 async fn migrate_schema_for_v8(name: &str) -> Result<(), DomException> {
     info!("IndexeddbCryptoStore upgrade schema -> v8 starting");
     IdbDatabase::open_u32(name, 8)?.await?;
-    // No actual schema change required for this migration. We do this here because the call to
-    // open_u32 updates the version number, indicating that we have completed the data migration in
-    // migrate_data_for_v8.
+    // No actual schema change required for this migration. We do this here because
+    // the call to open_u32 updates the version number, indicating that we have
+    // completed the data migration in migrate_data_for_v8.
     info!("IndexeddbCryptoStore upgrade schema -> v8 complete");
     Ok(())
 }
@@ -307,9 +308,10 @@ fn migrate_stores_to_v7(db: &IdbDatabase) -> Result<(), DomException> {
 }
 
 async fn migrate_data_for_v8(name: &str, serializer: &IndexeddbSerializer) -> Result<()> {
-    // In migrate_data_for_v6, we incorrectly copied the keys in inbound_group_sessions verbatim into
-    // inbound_group_sessions2. What we should have done is re-encrypt them using the new table
-    // name, so we fix them up here.
+    // In migrate_data_for_v6, we incorrectly copied the keys in
+    // inbound_group_sessions verbatim into inbound_group_sessions2. What we
+    // should have done is re-encrypt them using the new table name, so we fix
+    // them up here.
 
     info!("IndexeddbCryptoStore upgrade data -> v8 starting");
 
@@ -350,7 +352,8 @@ async fn migrate_data_for_v8(name: &str, serializer: &IndexeddbSerializer) -> Re
             }
 
             // Work out what the key should be.
-            // (This is much the same as in `IndexeddbCryptoStore::get_inbound_group_session`)
+            // (This is much the same as in
+            // `IndexeddbCryptoStore::get_inbound_group_session`)
             let new_key = serializer.encode_key(
                 keys::INBOUND_GROUP_SESSIONS_V2,
                 (&session.room_id, session.session_id()),

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -302,14 +302,14 @@ mod tests {
 
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-    /// Test migrating `inbound_group_session` data from store v5 to store v7,
+    /// Test migrating `inbound_group_sessions` data from store v5 to store v7,
     /// on a store with encryption disabled.
     #[async_test]
     async fn test_v7_migration_unencrypted() {
         test_v7_migration_with_cipher("test_v7_migration_unencrypted", None).await
     }
 
-    /// Test migrating `inbound_group_session` data from store v5 to store v7,
+    /// Test migrating `inbound_group_sessions` data from store v5 to store v7,
     /// on a store with encryption enabled.
     #[async_test]
     async fn test_v7_migration_encrypted() {

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -370,16 +370,7 @@ async fn migrate_data_for_v8(name: &str, serializer: &IndexeddbSerializer) -> Re
 
                 // If we didn't find an existing entry, we must create one with the correct key
                 if new_value.is_none() {
-                    // This is much the same as `IndexeddbStore::serialize_inbound_group_session`.
-                    let new_data =
-                        serde_wasm_bindgen::to_value(&InboundGroupSessionIndexedDbObject {
-                            pickled_session: serializer
-                                .serialize_value_as_bytes(&session.pickle().await)?,
-                            needs_backup: !session.backed_up(),
-                        })?;
-
-                    store.add_key_val(&new_key, &new_data)?;
-
+                    store.add_key_val(&new_key, &serde_wasm_bindgen::to_value(&idb_object)?)?;
                     updated += 1;
                 } else {
                     deleted += 1;

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -72,7 +72,9 @@ pub async fn open_and_upgrade_db(
 async fn migrate_schema_for_v8(name: &str) -> Result<(), DomException> {
     info!("IndexeddbCryptoStore upgrade schema -> v8 starting");
     IdbDatabase::open_u32(name, 8)?.await?;
-    // No actual schema change required for this migration
+    // No actual schema change required for this migration. We do this here because the call to
+    // open_u32 updates the version number, indicating that we have completed the data migration in
+    // migrate_data_for_v8.
     info!("IndexeddbCryptoStore upgrade schema -> v8 complete");
     Ok(())
 }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -47,16 +47,14 @@ pub async fn open_and_upgrade_db(
 
     // If we have yet to complete the migration to V7, migrate the schema to V6
     // (if necessary), and then migrate any remaining data.
-    if old_version <= 6 {
+    if old_version < 7 {
         info!(old_version, "IndexeddbCryptoStore upgrade schema & data -> v6 starting");
         let db = migrate_schema_up_to_v6(name).await?;
         migrate_data_for_v6(serializer, &db).await?;
         db.close();
         info!(old_version, "IndexeddbCryptoStore upgrade schema & data -> v6 finished");
-    }
 
-    // Now we can safely complete the migration to V7 which will drop the old store.
-    if old_version < 7 {
+        // Now we can safely complete the migration to V7 which will drop the old store.
         migrate_schema_for_v7(name).await?;
     }
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -139,13 +139,13 @@ async fn migrate_schema_for_v7(name: &str) -> Result<(), DomException> {
 
         Ok(())
     }));
-    db_req.await?;
+    db_req.await?.close();
     Ok(())
 }
 
 async fn migrate_schema_for_v8(name: &str) -> Result<(), DomException> {
     info!("IndexeddbCryptoStore upgrade schema -> v8 starting");
-    IdbDatabase::open_u32(name, 8)?.await?;
+    IdbDatabase::open_u32(name, 8)?.await?.close();
     // No actual schema change required for this migration. We do this here because
     // the call to open_u32 updates the version number, indicating that we have
     // completed the data migration in migrate_data_for_v8.

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -39,6 +39,7 @@ use ruma::{
     RoomId, TransactionId, UserId,
 };
 use tokio::sync::Mutex;
+use tracing::warn;
 use wasm_bindgen::JsValue;
 
 use crate::crypto_store::{
@@ -852,6 +853,8 @@ impl_crypto_store! {
                 let mut idb_object: InboundGroupSessionIndexedDbObject = serde_wasm_bindgen::from_value(idb_object_js)?;
                 idb_object.needs_backup = false;
                 object_store.put_key_val(&key, &serde_wasm_bindgen::to_value(&idb_object)?)?;
+            } else {
+                warn!("Could not find inbound group session to mark it as backed up. key={:?}", key);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-web/issues/26782

In migrate_data_for_v6, we incorrectly copied the keys in inbound_group_sessions verbatim into inbound_group_sessions2. What we should have done is re-encrypt them using the new table name, so we fix that up with a new migration here.

This caused the bug because we were looking for sessions to mark as backed up by calculating their key (from room_id and session_id) but that key did not exist, because the old sessions were stored under the incorrect keys. So no sessions were marked as backed up, and we repeatedly tried to re-mark them.

Depending on your taste you might like to review this commit by commit.