### PR TITLE
Fix regenerate_olm_machine losing backup state

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -69,9 +69,9 @@ use crate::{
     requests::{IncomingResponse, OutgoingRequest, UploadSigningKeysRequest},
     session_manager::{GroupSessionManager, SessionManager},
     store::{
-        Changes, CryptoStoreWrapper, DeviceChanges, IdentityChanges, IntoCryptoStore,
-        MemoryStore, PendingChanges, Result as StoreResult, RoomKeyInfo, SecretImportError, Store,
-        StoreCache, StoreTransaction,
+        Changes, CryptoStoreWrapper, DeviceChanges, IdentityChanges, IntoCryptoStore, MemoryStore,
+        PendingChanges, Result as StoreResult, RoomKeyInfo, SecretImportError, Store, StoreCache,
+        StoreTransaction,
     },
     types::{
         events::{
@@ -314,18 +314,16 @@ impl OlmMachine {
         };
 
         let saved_keys = store.load_backup_keys().await?;
-        let maybe_backup_keys =
-            saved_keys.decryption_key.map(|k| {
-                if let Some(version) = saved_keys.backup_version {
-                    MegolmV1BackupKey::from_base64(&k.to_base64())
-                        .ok().map(|k| {
-                            k.set_version(version);
-                            k
-                        })
-                } else {
-                    None
-                }
-            }).flatten();
+        let maybe_backup_keys = saved_keys.decryption_key.and_then(|k| {
+            if let Some(version) = saved_keys.backup_version {
+                MegolmV1BackupKey::from_base64(&k.to_base64()).ok().map(|k| {
+                    k.set_version(version);
+                    k
+                })
+            } else {
+                None
+            }
+        });
 
         // warn!("Loading the backup key from the store failed {:?}", backup_keys);
         let identity = Arc::new(Mutex::new(identity));

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1180,10 +1180,6 @@ impl Encryption {
                 drop(olm_machine_guard);
                 // Recreate the OlmMachine.
                 self.client.base_client().regenerate_olm().await?;
-                // we need to trigger that so it gets back the cached key if known
-                // otherwise the new olm machine `BackupMachine#backup_key` will be out of sync
-                // and say backup is disabled.
-                self.client.encryption().backups().setup_and_resume().await?;
             }
         }
         Ok(())

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1180,6 +1180,10 @@ impl Encryption {
                 drop(olm_machine_guard);
                 // Recreate the OlmMachine.
                 self.client.base_client().regenerate_olm().await?;
+                // we need to trigger that so it gets back the cached key if known
+                // otherwise the new olm machine `BackupMachine#backup_key` will be out of sync
+                // and say backup is disabled.
+                self.client.encryption().backups().setup_and_resume().await?;
             }
         }
         Ok(())
@@ -1452,6 +1456,21 @@ mod tests {
         let initial_olm_machine =
             client1.olm_machine().await.clone().expect("must have an olm machine");
 
+        // Also enable backup to check that new machine has the same backup keys.
+        let decryption_key = matrix_sdk_base::crypto::store::BackupDecryptionKey::new()
+            .expect("Can't create new recovery key");
+        let backup_key = decryption_key.megolm_v1_public_key();
+        backup_key.set_version("1".to_owned());
+        initial_olm_machine
+            .backup_machine()
+            .save_decryption_key(Some(decryption_key.to_owned()), Some("1".to_owned()))
+            .await
+            .expect("Should save");
+
+        initial_olm_machine.backup_machine().enable_backup_v1(backup_key.clone()).await.unwrap();
+
+        assert!(client1.encryption().backups().are_enabled().await);
+
         // The other client can't take the lock too.
         let acquired2 = client2.encryption().try_lock_store_once().await.unwrap();
         assert!(acquired2.is_none());
@@ -1486,7 +1505,15 @@ mod tests {
 
         // But now its olm machine has been invalidated and thus regenerated!
         let olm_machine = client1.olm_machine().await.clone().expect("must have an olm machine");
+
+        let backup_key_new = olm_machine.backup_machine().get_backup_keys().await.unwrap();
         assert!(!initial_olm_machine.same_as(&olm_machine));
+        assert!(backup_key_new.decryption_key.is_some());
+        assert_eq!(
+            backup_key_new.decryption_key.unwrap().megolm_v1_public_key().to_base64(),
+            backup_key.to_base64()
+        );
+        assert!(client1.encryption().backups().are_enabled().await);
     }
 
     #[cfg(feature = "sqlite")]

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1502,8 +1502,9 @@ mod tests {
         // But now its olm machine has been invalidated and thus regenerated!
         let olm_machine = client1.olm_machine().await.clone().expect("must have an olm machine");
 
-        let backup_key_new = olm_machine.backup_machine().get_backup_keys().await.unwrap();
         assert!(!initial_olm_machine.same_as(&olm_machine));
+
+        let backup_key_new = olm_machine.backup_machine().get_backup_keys().await.unwrap();
         assert!(backup_key_new.decryption_key.is_some());
         assert_eq!(
             backup_key_new.decryption_key.unwrap().megolm_v1_public_key().to_base64(),


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/element-hq/element-x-ios/issues/2243

- [ ] Public API changes documented in changelogs (optional)

When `regenerate_olm` is called, it creates a new olm machine with a new BackupMachine.
The problem is that the new `BackupMachine` is initialized with no `backup_key`:
`let backup_machine = BackupMachine::new(store.clone(), None);`

As a consequence `client1.encryption().backups().are_enabled()` will sudenly be false.


## Note to reviewer:
- My first solution was to  call again `setup_and_resume()` on the machine after `regenerate_olm`, but it's also re-adding a `add_event_handler`, and I don't think it's needed
- I udpated to modify `with_store` to get the cached key and pass it to the new helper

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
