### PR TITLE
Add moar unit tests for read receipts

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -31,9 +31,7 @@ pub mod latest_event;
 pub mod media;
 mod rooms;
 
-#[cfg(feature = "experimental-sliding-sync")]
 mod read_receipts;
-#[cfg(feature = "experimental-sliding-sync")]
 pub use read_receipts::PreviousEventsProvider;
 #[cfg(feature = "experimental-sliding-sync")]
 mod sliding_sync;

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -101,6 +101,13 @@ impl RoomReadReceipts {
             }
         }
     }
+
+    #[inline(always)]
+    fn reset(&mut self) {
+        self.num_unread = 0;
+        self.num_notifications = 0;
+        self.num_mentions = 0;
+    }
 }
 
 /// Provider for timeline events prior to the current sync.
@@ -230,9 +237,7 @@ fn find_and_count_events<'a>(
                 // Bingo! Switch over to the counting state, after resetting the
                 // previous counts.
                 trace!("Found the event the receipt was referring to! Starting to count.");
-                room_info.read_receipts.num_unread = 0;
-                room_info.read_receipts.num_notifications = 0;
-                room_info.read_receipts.num_mentions = 0;
+                room_info.read_receipts.reset();
                 counting_receipts = true;
             }
         }

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -79,7 +79,7 @@ impl PreviousEventsProvider for () {
 ///
 /// See this module's documentation for more information.
 #[instrument(skip_all, fields(room_id = %room_info.room_id))]
-pub(crate) async fn compute_notifications<PEP: PreviousEventsProvider>(
+pub(crate) fn compute_notifications<PEP: PreviousEventsProvider>(
     client: &BaseClient,
     changes: &StateChanges,
     previous_events_provider: &PEP,

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -63,6 +63,7 @@ use super::{
 use crate::latest_event::LatestEvent;
 use crate::{
     deserialized_responses::MemberEvent,
+    read_receipts::RoomReadReceipts,
     store::{DynStateStore, Result as StoreResult, StateStoreExt},
     sync::UnreadNotificationsCount,
     MinimalStateEvent, OriginalMinimalStateEvent, RoomMemberships,
@@ -733,25 +734,6 @@ impl Room {
             .get_event_room_receipt_events(self.room_id(), receipt_type, thread, event_id)
             .await
     }
-}
-
-/// Information about read receipts collected during processing of that room.
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct RoomReadReceipts {
-    /// Does the room have unread messages?
-    pub(crate) num_unread: u64,
-
-    /// Does the room have unread events that should notify?
-    pub(crate) num_notifications: u64,
-
-    /// Does the room have messages causing highlights for the users? (aka
-    /// mentions)
-    pub(crate) num_mentions: u64,
-
-    /// The id of the event the last unthreaded (or main-threaded, for better
-    /// compatibility with clients that have thread support) read receipt is
-    /// attached to.
-    pub(crate) latest_read_receipt_event_id: Option<OwnedEventId>,
 }
 
 /// The underlying pure data structure for joined and left rooms.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -238,8 +238,7 @@ impl BaseClient {
                     previous_events_provider,
                     &joined_room_update.timeline.events,
                     &mut room_info,
-                )
-                .await?;
+                )?;
 
                 changes.add_room(room_info);
             }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -224,6 +224,8 @@ impl BaseClient {
 
         // Rooms in `new_rooms.join` either have a timeline update, or a new read
         // receipt. Update the read receipt accordingly.
+        let user_id = &self.session_meta().expect("logged in user").user_id;
+
         for (room_id, joined_room_update) in &mut new_rooms.join {
             if let Some(mut room_info) = changes
                 .room_infos
@@ -233,11 +235,12 @@ impl BaseClient {
             {
                 // TODO only add the room if there was an update
                 compute_notifications(
-                    self,
-                    &changes,
+                    user_id,
+                    room_id,
+                    changes.receipts.get(room_id),
                     previous_events_provider,
                     &joined_room_update.timeline.events,
-                    &mut room_info,
+                    &mut room_info.read_receipts,
                 )?;
 
                 changes.add_room(room_info);


### PR DESCRIPTION
Can be reviewed commit by commit. It's nice that each test caused natural changes in the API shape too :smiling_face_with_three_hearts: 