### PR TITLE
Valere/indexeddb/perf save changes

### DIFF
--- a/crates/matrix-sdk-indexeddb/CHANGELOG.md
+++ b/crates/matrix-sdk-indexeddb/CHANGELOG.md
@@ -1,0 +1,4 @@
+# unreleased
+
+- `save_change` performance improvement, all ecnryption and serialization
+  is done now outside of the db transaction.

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -181,7 +181,7 @@ impl IndexeddbChangesKeyValue {
     }
 
     fn get(&mut self, store: &'static str) -> &mut Vec<DbOperation> {
-        self.store_to_key_values.entry(store).or_insert_with(Vec::new)
+        self.store_to_key_values.entry(store).or_default()
     }
 
     /// Update the store with the stored operation
@@ -431,7 +431,7 @@ impl IndexeddbCryptoStore {
                 let key = self
                     .serializer
                     .encode_key(keys::INBOUND_GROUP_SESSIONS_V2, (room_id, session_id));
-                let value = self.serialize_inbound_group_session(&session).await?;
+                let value = self.serialize_inbound_group_session(session).await?;
                 sessions.push(DbOperation::PutKeyVal { key, value });
             }
         }

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -437,7 +437,6 @@ impl IndexeddbCryptoStore {
         }
 
         if !changes.outbound_group_sessions.is_empty() {
-            // let sessions = tx.object_store(keys::OUTBOUND_GROUP_SESSIONS)?;
             let sessions = indexeddb_changes.get(keys::OUTBOUND_GROUP_SESSIONS);
 
             for session in &changes.outbound_group_sessions {
@@ -475,7 +474,6 @@ impl IndexeddbCryptoStore {
                 let key = self
                     .serializer
                     .encode_key(keys::DEVICES, (device.user_id(), device.device_id()));
-                // device_store.delete(&key)?;
                 device_store.push(DbOperation::Delete(key));
             }
         }
@@ -523,7 +521,6 @@ impl IndexeddbCryptoStore {
                     let key = self
                         .serializer
                         .encode_key(keys::DIRECT_WITHHELD_INFO, (session_id, &room_id));
-                    // withhelds.put_key_val(&key, &self.serializer.serialize_value(&event)?)?;
                     withhelds.push(DbOperation::PutKeyVal {
                         key,
                         value: self.serializer.serialize_value(&event)?,
@@ -538,7 +535,6 @@ impl IndexeddbCryptoStore {
             for (room_id, settings) in room_settings_changes {
                 let key = self.serializer.encode_key(keys::ROOM_SETTINGS, room_id);
                 let value = self.serializer.serialize_value(&settings)?;
-                // settings_store.put_key_val(&key, &value)?;
                 settings_store.push(DbOperation::PutKeyVal { key, value });
             }
         }
@@ -553,7 +549,6 @@ impl IndexeddbCryptoStore {
                 );
                 let value = self.serializer.serialize_value(&secret)?;
 
-                // secrets_store.put_key_val(&key, &value)?;
                 secret_store.push(DbOperation::PutKeyVal { key, value });
             }
         }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Quick performance improvement on `save_change` for indexeddb.
All the serialization/encryption is now done outside the db transaction

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
