### PR TITLE
Avoid a spurious update when setting the room's latest event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,6 +3092,7 @@ dependencies = [
  "ruma",
  "serde",
  "serde_json",
+ "stream_assert",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -62,6 +62,7 @@ assign = "1.1.1"
 futures-executor = { workspace = true }
 http = { workspace = true }
 matrix-sdk-test = { version = "0.6.0", path = "../../testing/matrix-sdk-test" }
+stream_assert = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -916,7 +916,7 @@ impl BaseClient {
         let sync_lock = self.sync_lock().write().await;
         self.store.save_changes(&changes).await?;
         *self.store.sync_token.write().await = Some(response.next_batch.clone());
-        self.apply_changes(&changes).await;
+        self.apply_changes(&changes);
         drop(sync_lock);
 
         info!("Processed a sync response in {:?}", now.elapsed());
@@ -933,7 +933,7 @@ impl BaseClient {
         Ok(response)
     }
 
-    pub(crate) async fn apply_changes(&self, changes: &StateChanges) {
+    pub(crate) fn apply_changes(&self, changes: &StateChanges) {
         if changes.account_data.contains_key(&GlobalAccountDataEventType::IgnoredUserList) {
             self.ignore_user_list_changes.set(());
         }
@@ -1034,7 +1034,7 @@ impl BaseClient {
             changes.add_room(room_info);
 
             self.store.save_changes(&changes).await?;
-            self.apply_changes(&changes).await;
+            self.apply_changes(&changes);
         }
 
         Ok(MembersResponse {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -607,8 +607,7 @@ impl BaseClient {
         // event. If we found one, set it as the latest and delete any older
         // encrypted events
         if let Some((found, found_index)) = self.decrypt_latest_suitable_event(room).await {
-            room.on_latest_event_decrypted(found, found_index);
-            changes.room_infos.insert(room.room_id().to_owned(), room.clone_info());
+            room.on_latest_event_decrypted(found, found_index, changes);
         }
     }
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -663,7 +663,7 @@ impl BaseClient {
             let mut changes = StateChanges::default();
             changes.add_room(room_info.clone());
             self.store.save_changes(&changes).await?; // Update the store
-            room.update_summary(room_info); // Update the cached room handle
+            room.set_room_info(room_info); // Update the cached room handle
         }
 
         Ok(room)
@@ -684,7 +684,7 @@ impl BaseClient {
             let mut changes = StateChanges::default();
             changes.add_room(room_info.clone());
             self.store.save_changes(&changes).await?; // Update the store
-            room.update_summary(room_info); // Update the cached room handle
+            room.set_room_info(room_info); // Update the cached room handle
         }
 
         Ok(())
@@ -940,7 +940,7 @@ impl BaseClient {
 
         for (room_id, room_info) in &changes.room_infos {
             if let Some(room) = self.store.get_room(room_id) {
-                room.update_summary(room_info.clone())
+                room.set_room_info(room_info.clone())
             }
         }
     }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -431,12 +431,6 @@ impl Room {
         self.inner.read().latest_event.as_deref().cloned()
     }
 
-    /// Update the last event in the room
-    #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
-    pub(crate) fn set_latest_event(&self, latest_event: Option<Box<LatestEvent>>) {
-        self.inner.update(|info| info.latest_event = latest_event);
-    }
-
     /// Return the most recent few encrypted events. When the keys come through
     /// to decrypt these, the most recent relevant one will replace
     /// latest_event. (We can't tell which one is relevant until
@@ -453,6 +447,9 @@ impl Room {
     ///
     /// Panics if index is not a valid index in the latest_encrypted_events
     /// list.
+    ///
+    /// It is the responsibility of the caller to apply the changes into the
+    /// state store after calling this function.
     #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
     pub(crate) fn on_latest_event_decrypted(
         &self,
@@ -460,10 +457,13 @@ impl Room {
         index: usize,
         changes: &mut crate::StateChanges,
     ) {
-        self.set_latest_event(Some(latest_event));
         self.latest_encrypted_events.write().unwrap().drain(0..=index);
 
-        changes.room_infos.insert(self.room_id().to_owned(), self.clone_info());
+        let room_info = changes
+            .room_infos
+            .entry(self.room_id().to_owned())
+            .or_insert_with(|| self.clone_info());
+        room_info.latest_event = Some(latest_event);
     }
 
     /// Get the list of users ids that are considered to be joined members of
@@ -1759,6 +1759,7 @@ mod tests {
         let event = make_latest_event("$A");
         let mut changes = StateChanges::default();
         room.on_latest_event_decrypted(event.clone(), 0, &mut changes);
+        room.update_summary(changes.room_infos.get(room.room_id()).cloned().unwrap());
 
         // Then is it stored
         assert_eq!(room.latest_event().unwrap().event_id(), event.event_id());
@@ -1780,6 +1781,7 @@ mod tests {
         let new_event_index = 1;
         let mut changes = StateChanges::default();
         room.on_latest_event_decrypted(new_event.clone(), new_event_index, &mut changes);
+        room.update_summary(changes.room_infos.get(room.room_id()).cloned().unwrap());
 
         // Then the encrypted events list is shortened to only newer events
         let enc_evs = room.latest_encrypted_events();
@@ -1806,6 +1808,7 @@ mod tests {
         let new_event_index = 3;
         let mut changes = StateChanges::default();
         room.on_latest_event_decrypted(new_event, new_event_index, &mut changes);
+        room.update_summary(changes.room_infos.get(room.room_id()).cloned().unwrap());
 
         // Then the encrypted events list ie empty
         let enc_evs = room.latest_encrypted_events();

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1737,7 +1737,7 @@ mod tests {
         stream_assert::assert_pending!(room_info_subscriber);
 
         // Then updating the room info will store the event,
-        client.apply_changes(&changes).await;
+        client.apply_changes(&changes);
         assert_eq!(room.latest_event().unwrap().event_id(), event.event_id());
 
         // And wake up the subscriber.

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -629,9 +629,10 @@ impl Room {
         self.inner.get()
     }
 
-    /// Update the summary with given RoomInfo
-    pub fn update_summary(&self, summary: RoomInfo) {
-        self.inner.set(summary);
+    /// Update the inner summary with the given RoomInfo, and notify
+    /// subscribers.
+    pub fn set_room_info(&self, room_info: RoomInfo) {
+        self.inner.set(room_info);
     }
 
     /// Get the `RoomMember` with the given `user_id`.
@@ -1759,7 +1760,7 @@ mod tests {
         let event = make_latest_event("$A");
         let mut changes = StateChanges::default();
         room.on_latest_event_decrypted(event.clone(), 0, &mut changes);
-        room.update_summary(changes.room_infos.get(room.room_id()).cloned().unwrap());
+        room.set_room_info(changes.room_infos.get(room.room_id()).cloned().unwrap());
 
         // Then is it stored
         assert_eq!(room.latest_event().unwrap().event_id(), event.event_id());
@@ -1781,7 +1782,7 @@ mod tests {
         let new_event_index = 1;
         let mut changes = StateChanges::default();
         room.on_latest_event_decrypted(new_event.clone(), new_event_index, &mut changes);
-        room.update_summary(changes.room_infos.get(room.room_id()).cloned().unwrap());
+        room.set_room_info(changes.room_infos.get(room.room_id()).cloned().unwrap());
 
         // Then the encrypted events list is shortened to only newer events
         let enc_evs = room.latest_encrypted_events();
@@ -1808,7 +1809,7 @@ mod tests {
         let new_event_index = 3;
         let mut changes = StateChanges::default();
         room.on_latest_event_decrypted(new_event, new_event_index, &mut changes);
-        room.update_summary(changes.room_infos.get(room.room_id()).cloned().unwrap());
+        room.set_room_info(changes.room_infos.get(room.room_id()).cloned().unwrap());
 
         // Then the encrypted events list ie empty
         let enc_evs = room.latest_encrypted_events();

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -454,9 +454,16 @@ impl Room {
     /// Panics if index is not a valid index in the latest_encrypted_events
     /// list.
     #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
-    pub(crate) fn on_latest_event_decrypted(&self, latest_event: Box<LatestEvent>, index: usize) {
+    pub(crate) fn on_latest_event_decrypted(
+        &self,
+        latest_event: Box<LatestEvent>,
+        index: usize,
+        changes: &mut crate::StateChanges,
+    ) {
         self.set_latest_event(Some(latest_event));
         self.latest_encrypted_events.write().unwrap().drain(0..=index);
+
+        changes.room_infos.insert(self.room_id().to_owned(), self.clone_info());
     }
 
     /// Get the list of users ids that are considered to be joined members of
@@ -1695,6 +1702,50 @@ mod tests {
         );
     }
 
+    #[async_test]
+    #[cfg(feature = "experimental-sliding-sync")]
+    async fn test_setting_the_latest_event_doesnt_cause_a_room_info_update() {
+        // Given a room,
+        let client = crate::BaseClient::new();
+
+        client
+            .set_session_meta(crate::SessionMeta {
+                user_id: user_id!("@alice:example.org").into(),
+                device_id: ruma::device_id!("AYEAYEAYE").into(),
+            })
+            .await
+            .unwrap();
+
+        let room_id = room_id!("!test:localhost");
+        let room = client.get_or_create_room(room_id, RoomState::Joined);
+
+        // That has an encrypted event,
+        add_encrypted_event(&room, "$A");
+        // Sanity: it has no latest_event
+        assert!(room.latest_event().is_none());
+
+        // When I set up an observer on the latest_event,
+        let mut room_info_subscriber = room.subscribe_info();
+
+        // And I provide a decrypted event to replace the encrypted one,
+        let event = make_latest_event("$A");
+
+        let mut changes = StateChanges::default();
+        room.on_latest_event_decrypted(event.clone(), 0, &mut changes);
+
+        // The subscriber isn't notified at this point.
+        stream_assert::assert_pending!(room_info_subscriber);
+
+        // Then updating the room info will store the event,
+        client.apply_changes(&changes).await;
+        assert_eq!(room.latest_event().unwrap().event_id(), event.event_id());
+
+        // And wake up the subscriber.
+        use futures_util::FutureExt as _;
+        assert!(room_info_subscriber.next().now_or_never().is_some());
+        stream_assert::assert_pending!(room_info_subscriber);
+    }
+
     #[test]
     #[cfg(feature = "experimental-sliding-sync")]
     fn when_we_provide_a_newly_decrypted_event_it_replaces_latest_event() {
@@ -1706,7 +1757,8 @@ mod tests {
 
         // When I provide a decrypted event to replace the encrypted one
         let event = make_latest_event("$A");
-        room.on_latest_event_decrypted(event.clone(), 0);
+        let mut changes = StateChanges::default();
+        room.on_latest_event_decrypted(event.clone(), 0, &mut changes);
 
         // Then is it stored
         assert_eq!(room.latest_event().unwrap().event_id(), event.event_id());
@@ -1726,7 +1778,8 @@ mod tests {
         // When I provide a latest event
         let new_event = make_latest_event("$1");
         let new_event_index = 1;
-        room.on_latest_event_decrypted(new_event.clone(), new_event_index);
+        let mut changes = StateChanges::default();
+        room.on_latest_event_decrypted(new_event.clone(), new_event_index, &mut changes);
 
         // Then the encrypted events list is shortened to only newer events
         let enc_evs = room.latest_encrypted_events();
@@ -1751,7 +1804,8 @@ mod tests {
         // When I provide a latest event and say it was the very latest
         let new_event = make_latest_event("$3");
         let new_event_index = 3;
-        room.on_latest_event_decrypted(new_event, new_event_index);
+        let mut changes = StateChanges::default();
+        room.on_latest_event_decrypted(new_event, new_event_index, &mut changes);
 
         // Then the encrypted events list ie empty
         let enc_evs = room.latest_encrypted_events();

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1216,7 +1216,7 @@ mod tests {
             rawev_id(event2.clone())
         );
 
-        room.update_summary(room_info);
+        room.set_room_info(room_info);
         assert_eq!(
             ev_id(room.latest_event().map(|latest_event| latest_event.event().clone())),
             rawev_id(event2)
@@ -1238,7 +1238,7 @@ mod tests {
         let room = make_room();
         let mut room_info = room.clone_info();
         cache_latest_events(&room, &mut room_info, events, None, None).await;
-        room.update_summary(room_info);
+        room.set_room_info(room_info);
 
         // The latest message is stored
         assert_eq!(
@@ -1265,7 +1265,7 @@ mod tests {
         let room = make_room();
         let mut room_info = room.clone_info();
         cache_latest_events(&room, &mut room_info, events, None, None).await;
-        room.update_summary(room_info);
+        room.set_room_info(room_info);
 
         // The latest message is stored, ignoring the receipt
         assert_eq!(
@@ -1318,7 +1318,7 @@ mod tests {
         let room = make_room();
         let mut room_info = room.clone_info();
         cache_latest_events(&room, &mut room_info, events, None, None).await;
-        room.update_summary(room_info);
+        room.set_room_info(room_info);
 
         // The latest message is stored, ignoring encrypted and receipts
         assert_eq!(
@@ -1359,7 +1359,7 @@ mod tests {
             None,
         )
         .await;
-        room.update_summary(room_info);
+        room.set_room_info(room_info);
 
         // Sanity: room_info has 10 encrypted events inside it
         assert_eq!(room.latest_encrypted_events.read().unwrap().len(), 10);
@@ -1368,7 +1368,7 @@ mod tests {
         let eventa = make_encrypted_event("$a");
         let mut room_info = room.clone_info();
         cache_latest_events(&room, &mut room_info, &[eventa], None, None).await;
-        room.update_summary(room_info);
+        room.set_room_info(room_info);
 
         // The oldest event is gone
         assert!(!rawevs_ids(&room.latest_encrypted_events).contains(&"$0".to_owned()));
@@ -1390,13 +1390,13 @@ mod tests {
             None,
         )
         .await;
-        room.update_summary(room_info.clone());
+        room.set_room_info(room_info.clone());
 
         // When I ask to cache an unencrypted event, and some more encrypted events
         let eventa = make_event("m.room.message", "$a");
         let eventb = make_encrypted_event("$b");
         cache_latest_events(&room, &mut room_info, &[eventa, eventb], None, None).await;
-        room.update_summary(room_info);
+        room.set_room_info(room_info);
 
         // The only encrypted events stored are the ones after the decrypted one
         assert_eq!(rawevs_ids(&room.latest_encrypted_events), &["$b"]);
@@ -1409,7 +1409,7 @@ mod tests {
         let room = make_room();
         let mut room_info = room.clone_info();
         cache_latest_events(&room, &mut room_info, events, None, None).await;
-        room.update_summary(room_info);
+        room.set_room_info(room_info);
         room.latest_event().map(|latest_event| latest_event.event().clone())
     }
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -100,7 +100,7 @@ impl BaseClient {
 
         trace!("ready to submit changes to store");
         self.store.save_changes(&changes).await?;
-        self.apply_changes(&changes).await;
+        self.apply_changes(&changes);
         trace!("applied changes");
 
         Ok(to_device)
@@ -267,7 +267,7 @@ impl BaseClient {
 
         trace!("ready to submit changes to store");
         store.save_changes(&changes).await?;
-        self.apply_changes(&changes).await;
+        self.apply_changes(&changes);
         trace!("applied changes");
 
         Ok(SyncResponse {

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -421,7 +421,7 @@ impl Room {
                 changes.add_room(room_info.clone());
 
                 self.client.store().save_changes(&changes).await?;
-                self.update_summary(room_info);
+                self.set_room_info(room_info);
 
                 Ok(())
             })


### PR DESCRIPTION
We should mostly not save `RoomInfo` by ourselves when we have a `StateChanges` data structure hanging around, otherwise we may save impartial state to the database, and notify subscribers which could then observe this incomplete state. This PR fixes that by adding a test failing on main first, then fixing it, then doing some small improvements in the neighborhood.