### PR TITLE
read receipts: don't update a `RoomInfo` if the read receipts haven't changed

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -233,17 +233,16 @@ impl BaseClient {
                 .cloned()
                 .or_else(|| self.get_room(room_id).map(|r| r.clone_info()))
             {
-                // TODO only add the room if there was an update
-                compute_notifications(
+                if compute_notifications(
                     user_id,
                     room_id,
                     changes.receipts.get(room_id),
                     previous_events_provider,
                     &joined_room_update.timeline.events,
                     &mut room_info.read_receipts,
-                )?;
-
-                changes.add_room(room_info);
+                )? {
+                    changes.add_room(room_info);
+                }
             }
         }
 


### PR DESCRIPTION
This fixes a TODO from #2953, by returning a boolean indicating whether a change happened in the `RoomReadReceipts` and they do need in fact to be saved.