### PR TITLE
indexeddb(perf): don't deserialize data while in an indexeddb transaction

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -835,7 +835,7 @@ impl_crypto_store! {
 
         tx.await.into_result()?;
 
-        // deserialize and decrypt after the transaction is complete
+        // Deserialize and decrypt after the transaction is complete.
         let result = result.into_iter()
             .filter_map(|v| match self.deserialize_inbound_group_session(v) {
                 Ok(session) => Some(session),

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -840,7 +840,7 @@ impl_crypto_store! {
             .filter_map(|v| match self.deserialize_inbound_group_session(v) {
                 Ok(session) => Some(session),
                 Err(e) => {
-                    warn!("Failed to deserialize inbound group session: {:?}", e);
+                    warn!("Failed to deserialize inbound group session: {e}");
                     None
                 }
             })

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -837,7 +837,13 @@ impl_crypto_store! {
 
         // deserialize and decrypt after the transaction is complete
         let result = result.into_iter()
-            .filter_map(|v| self.deserialize_inbound_group_session(v).ok())
+            .filter_map(|v| match self.deserialize_inbound_group_session(v) {
+                Ok(session) => Some(session),
+                Err(e) => {
+                    warn!("Failed to deserialize inbound group session: {:?}", e);
+                    None
+                }
+            })
             .collect::<Vec<InboundGroupSession>>();
 
         Ok(result)

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -825,9 +825,9 @@ impl_crypto_store! {
             return Ok(vec![]);
         };
 
-        let mut result = Vec::new();
+        let mut serialized_sessions = Vec::with_capacity(limit);
         for _ in 0..limit {
-            result.push(cursor.value());
+            serialized_sessions.push(cursor.value());
             if !cursor.continue_cursor()?.await? {
                 break;
             }
@@ -836,7 +836,7 @@ impl_crypto_store! {
         tx.await.into_result()?;
 
         // Deserialize and decrypt after the transaction is complete.
-        let result = result.into_iter()
+        let result = serialized_sessions.into_iter()
             .filter_map(|v| match self.deserialize_inbound_group_session(v) {
                 Ok(session) => Some(session),
                 Err(e) => {


### PR DESCRIPTION
<!-- description of the changes in this PR -->

A quick performance improvement to not do the deserialization/decryption inside the transaction.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
