### PR TITLE
Remove an expensive database call only used for tracing prupose

### DIFF
--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -484,10 +484,7 @@ impl BackupMachine {
 
                 self.store.mark_inbound_group_sessions_as_backed_up(&room_and_session_ids).await?;
 
-                let counts = self.store.inbound_group_session_counts().await?;
-
                 trace!(
-                    room_key_counts = ?counts,
                     request_id = ?r.request_id,
                     keys = ?r.sessions,
                     "Marked room keys as backed up"


### PR DESCRIPTION
<!-- description of the changes in this PR -->

`mark_request_as_sent` of the `BackupMachine` was doing a call to `store_inbound_group_session_count` just for tracing purpose.
On a test setup with 100k room keys, this call to count is taking 1955ms, in comparison `mark_inbound_group_sessions_as_backed_up` is taking `300ms`.
It's making mark as sent for backup take long for nothing


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
