### PR TITLE
Read receipts: use sync order when computing client-side read receipts

### DIFF
--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -69,8 +69,8 @@ struct LatestReadReceipt {
 
 /// Public data about read receipts collected during processing of that room.
 ///
-/// Remember that each time a field of `RoomReadReceipts` is updated in `compute_notifications`,
-/// this function must return true!
+/// Remember that each time a field of `RoomReadReceipts` is updated in
+/// `compute_notifications`, this function must return true!
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub(crate) struct RoomReadReceipts {
     /// Does the room have unread messages?
@@ -179,11 +179,13 @@ impl PreviousEventsProvider for () {
     }
 }
 
-/// Small helper to select the "best" receipt (that with the biggest sync order).
+/// Small helper to select the "best" receipt (that with the biggest sync
+/// order).
 struct ReceiptSelector {
     /// Mapping of known event IDs to their sync order.
     event_id_to_pos: BTreeMap<OwnedEventId, usize>,
-    /// The event with the biggest sync order, for which we had a user receipt, so far.
+    /// The event with the biggest sync order, for which we had a user receipt,
+    /// so far.
     best_receipt: Option<OwnedEventId>,
     /// The biggest sync order attached to the `best_receipt`.
     best_pos: Option<usize>,
@@ -202,7 +204,8 @@ impl ReceiptSelector {
         Self { best_pos, best_receipt: None, event_id_to_pos }
     }
 
-    /// Create a mapping of `event_id` -> sync order for all events that have an `event_id`.
+    /// Create a mapping of `event_id` -> sync order for all events that have an
+    /// `event_id`.
     fn create_sync_index<'a>(
         events: impl Iterator<Item = &'a SyncTimelineEvent> + 'a,
     ) -> BTreeMap<OwnedEventId, usize> {
@@ -239,7 +242,7 @@ impl ReceiptSelector {
         pending.retain(|event_id| {
             if let Some(event_pos) = self.event_id_to_pos.get(event_id) {
                 // Maybe select this read receipt as it might be better than the ones we had.
-                self.try_select_better(&*event_id, *event_pos);
+                self.try_select_better(event_id, *event_pos);
 
                 // Remove this stashed read receipt from the pending list, as it's been
                 // reconciled with its event.
@@ -253,8 +256,8 @@ impl ReceiptSelector {
 
     /// Try to match new receipts against all (new and old) events.
     ///
-    /// Returns all the new pending receipts (those for which we didn't have a known matching
-    /// event).
+    /// Returns all the new pending receipts (those for which we didn't have a
+    /// known matching event).
     fn handle_new_receipt(
         &mut self,
         user_id: &UserId,
@@ -349,8 +352,9 @@ pub(crate) fn compute_notifications<PEP: PreviousEventsProvider>(
         return Ok(has_changes);
     }
 
-    // If we haven't returned at this point, it means we don't have any new "active" read receipt.
-    // So either there was a previous one further in the past, or none.
+    // If we haven't returned at this point, it means we don't have any new "active"
+    // read receipt. So either there was a previous one further in the past, or
+    // none.
     //
     // In that case, accumulate all events as part of the current batch, and wait
     // for the next receipt.
@@ -860,8 +864,8 @@ mod tests {
         vec![ev1, ev2, ev3, ev4, ev5].into()
     }
 
-    /// Test that when multiple receipts come in a single event, we can still find the latest one
-    /// according to the sync order.
+    /// Test that when multiple receipts come in a single event, we can still
+    /// find the latest one according to the sync order.
     #[test]
     fn test_compute_notifications_multiple_receipts_in_one_event() {
         let user_id = user_id!("@alice:example.org");
@@ -896,7 +900,8 @@ mod tests {
                             ),
                         ]);
 
-                        // Receipt-only sync, no new events, all receipts refered to events that are known.
+                        // Receipt-only sync, no new events, all receipts referred to events that
+                        // are known.
                         let mut read_receipts = RoomReadReceipts::default();
                         assert!(compute_notifications(
                             user_id,
@@ -913,7 +918,8 @@ mod tests {
                         assert_eq!(read_receipts.num_mentions, 0);
                         assert_eq!(read_receipts.num_notifications, 0);
 
-                        // Receipt-only sync, mix of old and new events, all receipts refered to events that are known.
+                        // Receipt-only sync, mix of old and new events, all receipts referred to
+                        // events that are known.
                         let mut read_receipts = RoomReadReceipts::default();
                         assert!(compute_notifications(
                             user_id,
@@ -935,8 +941,8 @@ mod tests {
         }
     }
 
-    /// Updating the pending list will cause a change in the `RoomReadReceipts` fields, thus the
-    /// function must return true.
+    /// Updating the pending list will cause a change in the `RoomReadReceipts`
+    /// fields, thus the function must return true.
     #[test]
     fn test_compute_notifications_updated_after_field_tracking() {
         let user_id = owned_user_id!("@alice:example.org");
@@ -951,7 +957,8 @@ mod tests {
             ReceiptThread::Unthreaded,
         )]);
 
-        // Receipt-only sync, no new events, all receipts refered to events that are known.
+        // Receipt-only sync, no new events, all receipts referred to events that are
+        // known.
         let mut read_receipts = RoomReadReceipts::default();
         assert_eq!(read_receipts.pending.len(), 0);
 
@@ -1047,7 +1054,8 @@ mod tests {
 
         // Each test must be duplicated here:
         // - one time it must run with no active receipt,
-        // - one time it must run with an active receipt (consider that the active receipt may be
+        // - one time it must run with an active receipt (consider that the active
+        //   receipt may be
         // better *or* less good).
 
         {
@@ -1064,7 +1072,8 @@ mod tests {
         }
 
         {
-            // No pending receipt, and there was an active last receipt => no better receipt.
+            // No pending receipt, and there was an active last receipt => no better
+            // receipt.
             let mut selector = ReceiptSelector::new(&events, Some(event_id!("$1")));
 
             let mut pending = BTreeSet::new();
@@ -1118,7 +1127,8 @@ mod tests {
         }
 
         {
-            // Same, and there was an initial receipt that was less good than the one we selected => better receipt.
+            // Same, and there was an initial receipt that was less good than the one we
+            // selected => better receipt.
             let mut selector = ReceiptSelector::new(&events, Some(event_id!("$1")));
 
             let mut pending = BTreeSet::from_iter([owned_event_id!("$2")]);
@@ -1188,7 +1198,8 @@ mod tests {
         for receipt_type in [ReceiptType::Read, ReceiptType::ReadPrivate] {
             for receipt_thread in [ReceiptThread::Main, ReceiptThread::Unthreaded] {
                 {
-                    // Receipt for an event we don't know about => it's pending, and no better receipt.
+                    // Receipt for an event we don't know about => it's pending, and no better
+                    // receipt.
                     let mut selector = ReceiptSelector::new(&events, None);
 
                     let receipt_event = EventBuilder::new().make_receipt_event_content([(
@@ -1207,7 +1218,8 @@ mod tests {
                 }
 
                 {
-                    // Receipt for an event we knew about, no initial active receipt => better receipt.
+                    // Receipt for an event we knew about, no initial active receipt => better
+                    // receipt.
                     let mut selector = ReceiptSelector::new(&events, None);
 
                     let receipt_event = EventBuilder::new().make_receipt_event_content([(
@@ -1225,7 +1237,8 @@ mod tests {
                 }
 
                 {
-                    // Receipt for an event we knew about, initial active receipt was better => no better receipt.
+                    // Receipt for an event we knew about, initial active receipt was better => no
+                    // better receipt.
                     let mut selector = ReceiptSelector::new(&events, Some(event_id!("$4")));
 
                     let receipt_event = EventBuilder::new().make_receipt_event_content([(
@@ -1243,7 +1256,8 @@ mod tests {
                 }
 
                 {
-                    // Receipt for an event we knew about, initial active receipt was less good => new better receipt.
+                    // Receipt for an event we knew about, initial active receipt was less good =>
+                    // new better receipt.
                     let mut selector = ReceiptSelector::new(&events, Some(event_id!("$2")));
 
                     let receipt_event = EventBuilder::new().make_receipt_event_content([(
@@ -1263,7 +1277,8 @@ mod tests {
         } // end for
 
         {
-            // Final boss: multiple receipts in the receipt event, the best one is used => new better receipt.
+            // Final boss: multiple receipts in the receipt event, the best one is used =>
+            // new better receipt.
             let mut selector = ReceiptSelector::new(&events, Some(event_id!("$2")));
 
             let receipt_event = EventBuilder::new().make_receipt_event_content([

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -397,12 +397,12 @@ pub(crate) fn compute_notifications(
 
         // The event for the receipt is in `all_events`, so we'll find it and can count
         // safely from here.
-        if read_receipts.find_and_process_events(&event_id, user_id, all_events.iter()) {
-            has_changes = true;
-        }
+        read_receipts.find_and_process_events(&event_id, user_id, all_events.iter());
 
         trace!(?read_receipts, "after finding a better receipt");
-        return Ok(has_changes);
+
+        // The latest active read receipt has changed, signal that to the caller.
+        return Ok(true);
     }
 
     // If we haven't returned at this point, it means we don't have any new "active"

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1347,7 +1347,8 @@ mod tests {
                 "num_unread": 0,
                 "num_mentions": 0,
                 "num_notifications": 0,
-                "latest_read_receipt_event_id": null,
+                "latest_active": null,
+                "pending": []
             }
         });
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -237,7 +237,7 @@ impl BaseClient {
                     user_id,
                     room_id,
                     changes.receipts.get(room_id),
-                    previous_events_provider,
+                    previous_events_provider.for_room(room_id),
                     &joined_room_update.timeline.events,
                     &mut room_info.read_receipts,
                 )? {

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -425,4 +425,21 @@ mod tests {
         assert_eq!(ring_buffer.len(), 1);
         assert_eq!(ring_buffer.get(0).copied().unwrap(), 2);
     }
+
+    #[test]
+    fn test_default_isnt_zero_capacity() {
+        let mut ring_buffer = RingBuffer::default();
+
+        // If a RingBuffer had a 0 capacity, then the underlying `VecDeque` will
+        // reallocate on the first call to `push()`, and the default capacity
+        // will be the final capacity of that `RingBuffer`. That capacity is an
+        // implementation detail of `VecDequeu`.
+        ring_buffer.push(1);
+        ring_buffer.push(2);
+        ring_buffer.push(3);
+        ring_buffer.push(4);
+        ring_buffer.push(5);
+
+        assert!(!ring_buffer.is_empty());
+    }
 }

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -433,13 +433,14 @@ mod tests {
         // If a RingBuffer had a 0 capacity, then the underlying `VecDeque` will
         // reallocate on the first call to `push()`, and the default capacity
         // will be the final capacity of that `RingBuffer`. That capacity is an
-        // implementation detail of `VecDequeu`.
+        // implementation detail of `VecDeque`.
         ring_buffer.push(1);
         ring_buffer.push(2);
         ring_buffer.push(3);
         ring_buffer.push(4);
         ring_buffer.push(5);
 
+        // If the capacity were zero, it would be empty even after we added things.
         assert!(!ring_buffer.is_empty());
     }
 }

--- a/crates/matrix-sdk-common/src/ring_buffer.rs
+++ b/crates/matrix-sdk-common/src/ring_buffer.rs
@@ -105,6 +105,14 @@ impl<T> RingBuffer<T> {
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
     }
+
+    /// Retains only the elements specified by the predicate.
+    pub fn retain<F>(&mut self, predicate: F)
+    where
+        F: FnMut(&T) -> bool,
+    {
+        self.inner.retain(predicate)
+    }
 }
 
 impl<U> Extend<U> for RingBuffer<U> {
@@ -404,5 +412,17 @@ mod tests {
 
         // Then only the last N items remain
         assert_eq!(ring_buffer.iter().map(String::as_str).collect::<Vec<_>>(), vec!["6", "7"]);
+    }
+
+    #[test]
+    fn test_retain() {
+        let mut ring_buffer = RingBuffer::new(2);
+        ring_buffer.push(1);
+        ring_buffer.push(2);
+
+        ring_buffer.retain(|v| v % 2 == 0);
+
+        assert_eq!(ring_buffer.len(), 1);
+        assert_eq!(ring_buffer.get(0).copied().unwrap(), 2);
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -883,6 +883,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         // Item was previously received from the server. This
                         // should be very rare normally, but with the sliding-
                         // sync proxy, it is actually very common.
+                        // NOTE: SS proxy workaround.
                         trace!(?item, old_item = ?*old_item, "Received duplicate event");
 
                         if old_item.content.is_redacted() && !item.content.is_redacted() {


### PR DESCRIPTION
Read receipts rely on selecting what is the "most recent" read receipts. Beforehand, it was done by selecting *a* receipt for the current user, whenever we found one. And then, crossing our fingers real hard that the receipt we found was indeed the most recent one.

This wasn't sufficient:

- receipts can be received by the client *before* the event they're matching has reached us,
- ditto, with *after*
- a single receipt event can contain multiple receipts for the current user (any combination of (public, private) × (main thread, unthreaded)).

As a matter of fact, we need to take the sync ordering of the matched events into account, and consider "the most recent" is the one that is matching an event that is the most recent, according to the sync ordering. Fortunately, we do have an in-memory cache of recent sync events, so we can use that.

Ideally, this cache would be on disk (full timeline cache). Ideally, the sync ordering would not be recomputed every time we receive a new event, and we'd do something smarter that is properly updated whenever we received a gappy sync. These are optimizations that we can comfortably implement later.