### PR TITLE
sdk: Add method to report an event

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2506,7 +2506,7 @@ impl ReportedContentScore {
     /// Try to create a `ReportedContentScore` from the provided `i8`.
     ///
     /// Returns `None` if it is smaller than [`ReportedContentScore::MIN`] or
-    /// larger than [`ReportedContentScore::MIN`] .
+    /// larger than [`ReportedContentScore::MAX`] .
     ///
     /// This is the same as the `TryFrom<i8>` implementation for
     /// `ReportedContentScore`, except that it returns an `Option` instead

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -7,7 +7,7 @@ use matrix_sdk::{
         Thumbnail,
     },
     config::SyncSettings,
-    room::Receipts,
+    room::{Receipts, ReportedContentScore},
 };
 use matrix_sdk_base::RoomState;
 use matrix_sdk_test::{async_test, test_json, DEFAULT_TEST_ROOM_ID};
@@ -638,7 +638,7 @@ async fn report_content() {
 
     let event_id = owned_event_id!("$offensive_event");
     let reason = "I am offended".to_owned();
-    let score = int!(-80);
+    let score = ReportedContentScore::new(-80).unwrap();
 
     room.report_content(event_id, Some(score), Some(reason.to_owned())).await.unwrap();
 }


### PR DESCRIPTION
Simply calls the endpoint. Added a test.