### PR TITLE
Fix Cargo warning about default-features

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -41,7 +41,6 @@ features = ["lax_deserialize"]
 
 [dependencies.matrix-sdk-crypto]
 workspace = true
-default_features = false
 features = ["qrcode", "automatic-room-key-forwarding"]
 
 [dependencies.matrix-sdk-sqlite]


### PR DESCRIPTION
`default-features = false` was already a no-op prior to workspace dependency change, as `matrix-sdk-crypto` has no default features.
