### PR TITLE
sliding sync: Trigger a `RoomList` update when a room is updated b/o extensions

### DIFF
--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -444,8 +444,8 @@ impl SlidingSyncListInner {
                 // Invalidated rooms must be considered as empty rooms, so let's just filter by
                 // filled rooms.
                 if let RoomListEntry::Filled(room_id) = room_list_entry {
-                    // If room has received an update but that has not been handled by a
-                    // sync operation.
+                    // Some room has received an update but it wasn't caused by a
+                    // sync operation. Force an update for observers.
                     if rooms_that_have_received_an_update.contains(room_id) {
                         rooms_to_update.push((position, room_list_entry.clone()));
                     }

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -260,6 +260,12 @@ impl SlidingSyncList {
     pub fn sync_mode(&self) -> SlidingSyncMode {
         self.inner.sync_mode.read().unwrap().clone()
     }
+
+    /// Sets some rooms in the filled state.
+    pub fn set_filled_rooms(&self, rooms: Vec<OwnedRoomId>) {
+        let mut room_list = self.inner.room_list.write().unwrap();
+        room_list.append(rooms.into_iter().map(RoomListEntry::Filled).collect());
+    }
 }
 
 #[derive(Debug)]

--- a/crates/matrix-sdk/src/sliding_sync/list/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/mod.rs
@@ -200,29 +200,35 @@ impl SlidingSyncList {
         self.inner.cache_policy
     }
 
-    /// Update the list based on the response from the server.
+    /// Update the list based on the server's response.
     ///
-    /// The `maximum_number_of_rooms` is the `lists.$this_list.count` value,
-    /// i.e. maximum number of available rooms as defined by the server. The
-    /// `list_sync_operations` is the `list.$this_list.ops` value
-    /// received from the server for this specific list. It consists of
-    /// operations to “move” rooms' positions. Finally,
-    /// the `rooms_that_have_received_an_update` is the `rooms` value received
-    /// from the server, which represents aggregated rooms that have received an
-    /// update. Maybe their position has changed, maybe they have received a new
-    /// event in their timeline. We need this information to update the
-    /// `room_list` even if the position of the room hasn't be modified: it
-    /// helps the user to know that a room has received an update.
+    /// # Parameters
+    ///
+    /// - `maximum_number_of_rooms`: the `lists.$this_list.count` value, i.e.
+    ///   maximum number of available rooms in this list, as defined by the
+    ///   server.
+    /// - `list_sync_operations` is the `list.$this_list.ops` value received
+    ///   from the server for this specific list. It consists of operations to
+    ///   “move” rooms' positions.
+    /// - `rooms_that_have_received_an_update` is the `rooms` value received
+    ///   from the server, which represents aggregated rooms that have received
+    ///   an update. Maybe their position has changed, maybe they have received
+    ///   a new event in their timeline, maybe their `RoomInfo` has been
+    ///   updated. We need this information to update the `room_list` even if
+    ///   the position of the room hasn't be modified: it helps the user to know
+    ///   that a room has received an update.
     #[instrument(skip(self, list_sync_operations), fields(name = self.name(), list_sync_operations_count = list_sync_operations.len()))]
     pub(super) fn update(
         &mut self,
-        maximum_number_of_rooms: u32,
+        maximum_number_of_rooms: Option<u32>,
         list_sync_operations: &[v4::SyncOp],
         rooms_that_have_received_an_update: &[OwnedRoomId],
     ) -> Result<bool, Error> {
         // Make sure to update the generator state first; ordering matters because
         // `update_room_list` observes the latest ranges in the response.
-        self.inner.update_request_generator_state(maximum_number_of_rooms)?;
+        if let Some(maximum_number_of_rooms) = maximum_number_of_rooms {
+            self.inner.update_request_generator_state(maximum_number_of_rooms)?;
+        }
 
         let new_changes = self.inner.update_room_list(
             maximum_number_of_rooms,
@@ -389,34 +395,41 @@ impl SlidingSyncListInner {
     /// helps the user to know that a room has received an update.
     fn update_room_list(
         &self,
-        maximum_number_of_rooms: u32,
+        maximum_number_of_rooms: Option<u32>,
         list_sync_operations: &[v4::SyncOp],
         rooms_that_have_received_an_update: &[OwnedRoomId],
     ) -> Result<bool, Error> {
         let mut new_changes = false;
 
-        // Adjust room list entries.
-        {
-            let number_of_missing_rooms = (maximum_number_of_rooms as usize)
-                .saturating_sub(self.room_list.read().unwrap().len());
+        if let Some(maximum_number_of_rooms) = maximum_number_of_rooms {
+            // Adjust room list entries.
+            {
+                let number_of_missing_rooms = (maximum_number_of_rooms as usize)
+                    .saturating_sub(self.room_list.read().unwrap().len());
 
-            if number_of_missing_rooms > 0 {
-                self.room_list.write().unwrap().append(
-                    iter::repeat(RoomListEntry::Empty).take(number_of_missing_rooms).collect(),
-                );
+                if number_of_missing_rooms > 0 {
+                    self.room_list.write().unwrap().append(
+                        iter::repeat(RoomListEntry::Empty).take(number_of_missing_rooms).collect(),
+                    );
 
-                new_changes = true;
+                    new_changes = true;
+                }
             }
-        }
 
-        // Update the `maximum_number_of_rooms` if it has changed.
-        {
-            let mut maximum_number_of_rooms_lock = self.maximum_number_of_rooms.write().unwrap();
+            // Update the `maximum_number_of_rooms` if it has changed.
+            {
+                let mut maximum_number_of_rooms_lock =
+                    self.maximum_number_of_rooms.write().unwrap();
 
-            if Observable::get(&maximum_number_of_rooms_lock) != &Some(maximum_number_of_rooms) {
-                Observable::set(&mut maximum_number_of_rooms_lock, Some(maximum_number_of_rooms));
+                if Observable::get(&maximum_number_of_rooms_lock) != &Some(maximum_number_of_rooms)
+                {
+                    Observable::set(
+                        &mut maximum_number_of_rooms_lock,
+                        Some(maximum_number_of_rooms),
+                    );
 
-                new_changes = true;
+                    new_changes = true;
+                }
             }
         }
 
@@ -998,7 +1011,7 @@ mod tests {
         }))
         .unwrap();
 
-        list.update(6, &[sync0], &[]).unwrap();
+        list.update(Some(6), &[sync0], &[]).unwrap();
 
         assert_eq!(list.get_room_id(0), Some(room0.to_owned()));
         assert_eq!(list.get_room_id(1), Some(room1.to_owned()));
@@ -1035,7 +1048,7 @@ mod tests {
                     );
 
                     // Fake a response.
-                    let _ = $list.update($maximum_number_of_rooms, &[], &[]);
+                    let _ = $list.update(Some($maximum_number_of_rooms), &[], &[]);
 
                     assert_eq!(
                         $list.inner.request_generator.read().unwrap().is_fully_loaded(),
@@ -1491,7 +1504,7 @@ mod tests {
             }))
             .unwrap();
 
-            let new_changes = list.update(5, &[sync], &[]).unwrap();
+            let new_changes = list.update(Some(5), &[sync], &[]).unwrap();
 
             assert!(new_changes);
 
@@ -1536,7 +1549,7 @@ mod tests {
 
         let new_changes = list
             .update(
-                5,
+                Some(5),
                 &[sync],
                 // Let's imagine `room2` has received an update, but its position doesn't
                 // change.

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -428,14 +428,15 @@ impl SlidingSync {
                         let maximum_number_of_rooms: u32 =
                             updates.count.try_into().expect("failed to convert `count` to `u32`");
 
-                        if list.update(maximum_number_of_rooms, &updates.ops, &updated_rooms)? {
+                        if list.update(
+                            Some(maximum_number_of_rooms),
+                            &updates.ops,
+                            &updated_rooms,
+                        )? {
                             updated_lists.push(name.clone());
                         }
-                    } else {
-                        let maximum_number_of_rooms = list.maximum_number_of_rooms().unwrap_or(0);
-                        if list.update(maximum_number_of_rooms, &[], &updated_rooms)? {
-                            updated_lists.push(name.clone());
-                        }
+                    } else if list.update(None, &[], &updated_rooms)? {
+                        updated_lists.push(name.clone());
                     }
                 }
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1054,13 +1054,15 @@ mod tests {
     };
 
     use assert_matches::assert_matches;
-    use futures_util::{future::join_all, pin_mut, StreamExt};
+    use assert_matches2::assert_let;
+    use eyeball_im::VectorDiff;
+    use futures_util::{future::join_all, pin_mut, FutureExt as _, StreamExt};
     use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
     use matrix_sdk_test::async_test;
     use ruma::{
         api::client::{
             error::ErrorKind,
-            sync::sync_events::v4::{self, ExtensionsConfig, ToDeviceConfig},
+            sync::sync_events::v4::{self, ExtensionsConfig, ReceiptsConfig, ToDeviceConfig},
         },
         assign, owned_room_id, room_id,
         serde::Raw,
@@ -1068,6 +1070,7 @@ mod tests {
     };
     use serde::Deserialize;
     use serde_json::json;
+    use stream_assert::assert_pending;
     use url::Url;
     use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
 
@@ -1079,6 +1082,7 @@ mod tests {
     };
     use crate::{
         sliding_sync::cache::restore_sliding_sync_state, test_utils::logged_in_client, Result,
+        RoomListEntry,
     };
 
     #[derive(Copy, Clone)]
@@ -2101,6 +2105,85 @@ mod tests {
         assert!(!remote_rooms.get(no_remote_events).unwrap().limited);
         assert!(!remote_rooms.get(no_local_events).unwrap().limited);
         assert!(remote_rooms.get(already_limited).unwrap().limited);
+    }
+
+    #[async_test]
+    async fn test_process_read_receipts() -> Result<()> {
+        let room = owned_room_id!("!pony:example.org");
+
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        let sliding_sync = client
+            .sliding_sync("test")?
+            .with_receipt_extension(assign!(ReceiptsConfig::default(), { enabled: Some(true) }))
+            .add_list(
+                SlidingSyncList::builder("all")
+                    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=100)),
+            )
+            .build()
+            .await?;
+
+        let list =
+            sliding_sync.on_list("all", |list| ready(list.clone())).await.expect("found list all");
+
+        {
+            // Pretend the list knows that one room that will receive the read receipt.
+            list.set_maximum_number_of_rooms(Some(1));
+            list.set_filled_rooms(vec![room.clone()]);
+        }
+
+        let (_, list_stream) = list.room_list_stream();
+
+        pin_mut!(list_stream);
+
+        assert_pending!(list_stream);
+
+        let server_response = assign!(v4::Response::new("1".to_owned()), {
+            extensions: assign!(v4::Extensions::default(), {
+                receipts: assign!(v4::Receipts::default(), {
+                    rooms: BTreeMap::from([
+                        (
+                            room.clone(),
+                            Raw::from_json_string(
+                                json!({
+                                    "room_id": room,
+                                    "type": "m.receipt",
+                                    "content": {
+                                        "$event:bar.org": {
+                                            "m.read": {
+                                                client.user_id().unwrap(): {
+                                                    "ts": 1436451550,
+                                                }
+                                            }
+                                        }
+                                    }
+                                })
+                                .to_string(),
+                            ).unwrap()
+                        )
+                    ])
+                })
+            })
+        });
+
+        let summary = {
+            let mut pos_guard = sliding_sync.inner.position.clone().lock_owned().await;
+            sliding_sync.handle_response(server_response.clone(), &mut pos_guard).await?
+        };
+
+        assert!(summary.rooms.contains(&room));
+        assert!(summary.lists.contains(&String::from("all")));
+
+        // The room has had an update in the room list stream too.
+        assert_let!(Some(Some(updates)) = list_stream.next().now_or_never());
+        assert_eq!(updates.len(), 1);
+        assert_let!(
+            VectorDiff::Set { index: 0, value: RoomListEntry::Filled(updated_room) } = &updates[0]
+        );
+        assert_eq!(*updated_room, room);
+
+        Ok(())
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -196,7 +196,7 @@ impl SlidingSyncRoom {
         {
             let mut timeline_queue = self.inner.timeline_queue.write().unwrap();
 
-            // There is timeline updates.
+            // There are timeline updates.
             if !timeline_updates.is_empty() {
                 if let SlidingSyncRoomState::Preloaded = *state {
                     // If the room has been read from the cache, we overwrite the timeline queue
@@ -216,7 +216,7 @@ impl SlidingSyncRoom {
                     timeline_queue.extend(timeline_updates);
                 }
             } else if limited {
-                // The timeline updates are empty. But `limited` is set to true. It's a way to
+                // No timeline updates, but `limited` is set to true. It's a way to
                 // alert that we are stale. In this case, we should just clear the
                 // existing timeline.
 


### PR DESCRIPTION
Now with a nice test :partying_face: 

Some sliding sync responses may include extension data that will cause an update to the room. For instance, whenever we receive a read receipt for that room, the content of the update lives in the extensions subpart of the response, and it may not involve an entry in the `rooms` or `lists` response fields. This could cause missed updates for rooms, since notifiers wouldn't be notified about those updates, until another response came that mentioned the room in one of the `rooms` or `lists` fields.

This fixes that, by making sure that we take into account room implicitly updated, as observed by the rooms returned in the base client's sync response. The test exhibits the issue (it doesn't pass on main).