### PR TITLE
Improving documentation: Can push encrypted events to device 

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -297,10 +297,10 @@ impl NotificationSettings {
         Ok(enabled)
     }
 
-    /// Check if [MSC 4028 push rule][rule] is enabled.
+    /// Returns true if [MSC 4028 push rule][rule] is supported and enabled.
     ///
     /// [rule]: https://github.com/matrix-org/matrix-spec-proposals/blob/giomfo/push_encrypted_events/proposals/4028-push-all-encrypted-events-except-for-muted-rooms.md
-    pub async fn can_homeserver_push_encrypted_event_to_device(&self) -> bool {
+    pub async fn can_push_encrypted_event_to_device(&self) -> bool {
         let notification_settings = self.sdk_notification_settings.read().await;
         // Check stable identifier
         if let Ok(enabled) = notification_settings


### PR DESCRIPTION
Given the following comment:https://github.com/matrix-org/matrix-rust-sdk/pull/2840#issuecomment-1875587994 
The name and the documentation of the API might have been a bit misleading since we are not actively checking the supported state of the homeserver, but just the current state of the account data to verify if encrypted events are pushed to the client or not.