### PR TITLE
ui: Improvements to toggle reaction failures

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -622,6 +622,13 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             }
         };
 
+        if matches!(
+            result,
+            ReactionToggleResult::AddFailure { .. } | ReactionToggleResult::RedactFailure { .. }
+        ) {
+            return Err(super::Error::FailedToToggleReaction);
+        }
+
         Ok(follow_up_action)
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -273,8 +273,10 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
         let related_event = {
             let items = state.items.clone();
-            let (_, item) = rfind_event_by_id(&items, &annotation.event_id)
-                .ok_or(super::Error::FailedToToggleReaction)?;
+            let Some((_, item)) = rfind_event_by_id(&items, &annotation.event_id) else {
+                warn!("Timeline item not found, can't update reaction ID");
+                return Err(super::Error::FailedToToggleReaction);
+            };
             item.to_owned()
         };
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -483,6 +483,7 @@ impl Timeline {
     async fn redact_reaction(&self, event_id: &EventId) -> ReactionToggleResult {
         let room = self.room();
         if room.state() != RoomState::Joined {
+            warn!("Cannot redact a reaction in a room that is not joined");
             return ReactionToggleResult::RedactFailure { event_id: event_id.to_owned() };
         }
 
@@ -493,7 +494,10 @@ impl Timeline {
 
         match response {
             Ok(_) => ReactionToggleResult::RedactSuccess,
-            Err(_) => ReactionToggleResult::RedactFailure { event_id: event_id.to_owned() },
+            Err(error) => {
+                error!("Failed to redact reaction: {error}");
+                ReactionToggleResult::RedactFailure { event_id: event_id.to_owned() }
+            }
         }
     }
 
@@ -505,6 +509,7 @@ impl Timeline {
     ) -> ReactionToggleResult {
         let room = self.room();
         if room.state() != RoomState::Joined {
+            warn!("Cannot send a reaction in a room that is not joined");
             return ReactionToggleResult::AddFailure { txn_id };
         }
 
@@ -516,7 +521,10 @@ impl Timeline {
             Ok(response) => {
                 ReactionToggleResult::AddSuccess { event_id: response.event_id, txn_id }
             }
-            Err(_) => ReactionToggleResult::AddFailure { txn_id },
+            Err(error) => {
+                error!("Failed to send reaction: {error}");
+                ReactionToggleResult::AddFailure { txn_id }
+            }
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -51,7 +51,7 @@ async fn add_reaction_failed() {
     timeline
         .handle_reaction_response(&reaction, &ReactionToggleResult::AddFailure { txn_id })
         .await
-        .unwrap();
+        .unwrap_err();
     assert_reactions_are_removed(&mut stream, &msg_id, msg_pos).await;
 
     assert_no_more_updates(&mut stream).await;
@@ -135,7 +135,7 @@ async fn redact_reaction_failure() {
             &ReactionToggleResult::RedactFailure { event_id: event_id.clone() },
         )
         .await
-        .unwrap();
+        .unwrap_err();
     assert_reaction_is_updated(&mut stream, &msg_id, msg_pos, Some(&event_id), None).await;
 
     assert_no_more_updates(&mut stream).await;
@@ -229,7 +229,7 @@ async fn reactions_store_timestamp() {
             &ReactionToggleResult::RedactFailure { event_id: msg_id.clone() },
         )
         .await
-        .unwrap();
+        .unwrap_err();
 
     // Restores an event with a valid timestamp.
     let event = assert_event_is_updated(&mut stream, &msg_id, msg_pos).await;


### PR DESCRIPTION
Before this, if an error occurred while making the request to the server, the error would be dropped and it wouldn't even be forwarded to the user of the method.

This makes sure:
- We forward server request errors as failures to the output of `Timeline::toggle_reaction`,
- We have logging in place everytime we return a `TimelineError::FailedToToggleReaction`.