### PR TITLE
docs: add new contribution guidelines + briefly explain release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,43 @@ integration tests that need a running synapse instance. These tests reside in
 [README](./testing/matrix-sdk-integration-testing/README.md) to easily set up a
 synapse for testing purposes.
 
+## Commit messages and PR title guidelines
+
+Ideally, a PR should have a *proper title*, with *atomic logical commits*, and each commit
+should have a *good commit message*.
+
+An *atomic logical commit* is one that is ideally small, can be compiled in isolation, and pass
+tests. This is useful to make the review process easier (help your reviewer), but also when running
+bisections, helping identifying which commit introduced a regression.
+
+A *good commit message* should be composed of:
+
+- a hint to which area/feature is related by the commit
+- a short description that would give sufficient context for a reviewer to guess what the commit is
+  about.
+
+Examples of commit messages that aren't so useful:
+
+- “add new method“
+- “enhance performance“
+- “fix receipts“
+
+Examples of good commit messages:
+
+- “ffi: add new method `frobnicate_the_foos`”
+- “indexeddb: break up the request inside `get_inbound_group_sessions`”
+- “read_receipts: store receipts locally, fixing #12345”
+
+A *proper PR title* would be a one-liner summary of the changes in the PR, following the
+same guidelines of a good commit message.
+
+(An additional bad example of a bad PR title would be `mynickname/branch name`, that is, just the
+branch name.)
+
+Having good commit messages and PR titles help easing the reviews too, scanning the `git log` of
+the project, and writing the [*This week in
+Matrix*](https://matrix.org/category/this-week-in-matrix/) updates for the SDK.
+
 ## Sign off
 
 In order to have a concrete record that your contribution is intentional

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ synapse for testing purposes.
 Ideally, a PR should have a *proper title*, with *atomic logical commits*, and each commit
 should have a *good commit message*.
 
-An *atomic logical commit* is one that is ideally small, can be compiled in isolation, and pass
+An *atomic logical commit* is one that is ideally small, can be compiled in isolation, and passes
 tests. This is useful to make the review process easier (help your reviewer), but also when running
 bisections, helping identifying which commit introduced a regression.
 
@@ -52,9 +52,9 @@ Examples of commit messages that aren't so useful:
 
 Examples of good commit messages:
 
-- “ffi: add new method `frobnicate_the_foos`”
-- “indexeddb: break up the request inside `get_inbound_group_sessions`”
-- “read_receipts: store receipts locally, fixing #12345”
+- “ffi: Add new method `frobnicate_the_foos`”
+- “indexeddb: Break up the request inside `get_inbound_group_sessions`”
+- “read_receipts: Store receipts locally, fixing #12345”
 
 A *proper PR title* would be a one-liner summary of the changes in the PR, following the
 same guidelines of a good commit message.
@@ -62,7 +62,7 @@ same guidelines of a good commit message.
 (An additional bad example of a bad PR title would be `mynickname/branch name`, that is, just the
 branch name.)
 
-Having good commit messages and PR titles help easing the reviews too, scanning the `git log` of
+Having good commit messages and PR titles also helps with reviews, scanning the `git log` of
 the project, and writing the [*This week in
 Matrix*](https://matrix.org/category/this-week-in-matrix/) updates for the SDK.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,21 @@
+# Releasing `matrix-rust-sdk`
+
+- Make sure to bump all the crates to *the same version number*, and commit that (along with the
+  changes to the `Cargo.lock` file).
+- Create a `git tag` for the current version, following the format `major.minor.patch`, e.g. `0.7.0`.
+- Push the tag: `git push origin 0.7.0`
+- Publish all the crates, in topological order of the dependency tree:
+
+```
+`cargo publish -p matrix-sdk-test-macros`
+`cargo publish -p matrix-sdk-test`
+`cargo publish -p matrix-sdk-common`
+`cargo publish -p matrix-sdk-qrcode`
+`cargo publish -p matrix-sdk-store-encryption`
+`cargo publish -p matrix-sdk-crypto`
+`cargo publish -p matrix-sdk-base`
+`cargo publish -p matrix-sdk-sqlite`
+`cargo publish -p matrix-sdk-indexeddb`
+`cargo publish -p matrix-sdk`
+`cargo publish -p matrix-sdk-ui`
+```


### PR DESCRIPTION
- The first commit introduces recommendations for commit messages and PR titles, that we intend to enforce with recurring contributors. These guidelines propose a consensus that's been reached with the core maintainers of the SDK at Element. We don't think they're controversial, and they shouldn't disrupt the flow of external or infrequent contributors.
- The second commit introduces a RELEASE.md file containing all the steps required to perform a release. I tried to compute the topological ordering with my monkey mind, but hopefully it's correct. @jplatte, can you confirm it contains all the steps please? Cheers! 