### PR TITLE
crypto: Improve memory overhead of export_room_keys by using Vec::retain

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1826,13 +1826,12 @@ impl OlmMachine {
     /// ```
     pub async fn export_room_keys(
         &self,
-        mut predicate: impl FnMut(&InboundGroupSession) -> bool,
+        predicate: impl FnMut(&InboundGroupSession) -> bool,
     ) -> StoreResult<Vec<ExportedRoomKey>> {
         let mut exported = Vec::new();
 
         let mut sessions = self.store().get_inbound_group_sessions().await?;
-
-        sessions.retain(|s| predicate(s));
+        sessions.retain(predicate);
 
         for session in sessions {
             let export = session.export().await;

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1830,13 +1830,9 @@ impl OlmMachine {
     ) -> StoreResult<Vec<ExportedRoomKey>> {
         let mut exported = Vec::new();
 
-        let sessions: Vec<InboundGroupSession> = self
-            .store()
-            .get_inbound_group_sessions()
-            .await?
-            .into_iter()
-            .filter(|s| predicate(s))
-            .collect();
+        let mut sessions = self.store().get_inbound_group_sessions().await?;
+
+        sessions.retain(|s| predicate(s));
 
         for session in sessions {
             let export = session.export().await;


### PR DESCRIPTION
As I understand it, `Vec::retain` should do the same job as `into_iter().filter().collect()` but potentially more efficiently. This could help our problem with running out of memory during export ( https://github.com/matrix-org/matrix-rust-sdk/issues/2914 ).