### PR TITLE
Simplify main crate user identity types

### DIFF
--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -15,10 +15,7 @@
 use std::collections::BTreeMap;
 
 use matrix_sdk_base::{
-    crypto::{
-        types::MasterPubkey, OwnUserIdentity as CryptoOwnUserIdentity,
-        UserIdentities as CryptoUserIdentities, UserIdentity as CryptoUserIdentity,
-    },
+    crypto::{types::MasterPubkey, UserIdentities as CryptoUserIdentities},
     RoomMemberships,
 };
 use ruma::{
@@ -106,20 +103,8 @@ pub struct UserIdentity {
 }
 
 impl UserIdentity {
-    fn new(client: Client, identity: CryptoUserIdentities) -> Self {
-        match identity {
-            CryptoUserIdentities::Own(i) => Self::new_own(client, i),
-            CryptoUserIdentities::Other(i) => Self::new_other(client, i),
-        }
-    }
-
-    pub(crate) fn new_own(client: Client, identity: CryptoOwnUserIdentity) -> Self {
-        let inner = UserIdentities { client, identity: identity.into() };
-        Self { inner }
-    }
-
-    pub(crate) fn new_other(client: Client, identity: CryptoUserIdentity) -> Self {
-        let inner = UserIdentities { client, identity: identity.into() };
+    pub(crate) fn new(client: Client, identity: CryptoUserIdentities) -> Self {
+        let inner = UserIdentities { client, identity };
         Self { inner }
     }
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -731,14 +731,7 @@ impl Encryption {
         let Some(olm) = olm.as_ref() else { return Ok(None) };
         let identity = olm.get_identity(user_id, None).await?;
 
-        Ok(identity.map(|i| match i {
-            matrix_sdk_base::crypto::UserIdentities::Own(i) => {
-                UserIdentity::new_own(self.client.clone(), i)
-            }
-            matrix_sdk_base::crypto::UserIdentities::Other(i) => {
-                UserIdentity::new_other(self.client.clone(), i)
-            }
-        }))
+        Ok(identity.map(|i| UserIdentity::new(self.client.clone(), i)))
     }
 
     /// Returns a stream of device updates, allowing users to listen for


### PR DESCRIPTION
The message of the first commit should explain the change well, so I'm pasting it inline:

> Specifically, this removes the following redundant types in the main
> crate:
> 
> - enum UserIdentities
> - struct OwnUserIdentity
> - struct OtherUserIdentity
> 
> This is possible because `OwnUserIdentity` and `OtherUserIdentity` are
> exactly the same as their crypto crate counterparts, except they also
> wrap a `Client`.
> 
> As a consequence, the main crate enum `UserIdentities` is isomorphic to
> a struct containing:
> 
> 1. the crypto crate `UserIdentities`
> 2. a `Client`

This then allows us to further simplify the construction of the main crate `UserIdentity` type, requiring only one constructor instead of three. The rest of changes are purely cosmetic, e.g. renaming of variables and imports.

In addition, I offer this colourised schema of what's happening:

![image](https://github.com/matrix-org/matrix-rust-sdk/assets/463342/e70fb8ac-0415-4209-a6d6-bb863dec81bb)

