### PR TITLE
sdk: Fix double bootstrap

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -247,7 +247,11 @@ impl Client {
         device_id: Option<String>,
     ) -> Result<(), ClientError> {
         RUNTIME.block_on(async move {
-            let mut builder = self.inner.matrix_auth().login_username(&username, &password);
+            let mut builder = self
+                .inner
+                .matrix_auth()
+                .with_initialize_e2e_by_default(false)
+                .login_username(&username, &password);
             if let Some(initial_device_name) = initial_device_name.as_ref() {
                 builder = builder.initial_device_display_name(initial_device_name);
             }

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -183,24 +183,7 @@ impl LoginBuilder {
         });
 
         let response = client.send(request, Some(RequestConfig::short_retry())).await?;
-        self.auth.receive_login_response(&response).await?;
-
-        // This may block login for a while, but the user asked for it!
-        // TODO: (#2763) put this into a background task.
-        #[cfg(feature = "e2e-encryption")]
-        {
-            use ruma::api::client::uiaa::{AuthData, Password};
-
-            let auth_data = match login_info {
-                login::v3::LoginInfo::Password(p) => {
-                    Some(AuthData::Password(Password::new(p.identifier, p.password)))
-                }
-                // Other methods can't be immediately translated to an auth.
-                _ => None,
-            };
-
-            client.post_login_cross_signing(auth_data).await;
-        }
+        self.auth.receive_login_response(&response, Some(login_info)).await?;
 
         Ok(response)
     }

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -24,14 +24,17 @@ use eyeball::SharedObservable;
 use futures_core::Stream;
 use futures_util::StreamExt;
 use matrix_sdk_base::SessionMeta;
-#[cfg(feature = "e2e-encryption")]
-use ruma::api::client::uiaa::{AuthData as RumaUiaaAuthData, Password as RumaUiaaPassword};
 use ruma::{
     api::{
         client::{
             account::register,
             session::{
-                get_login_types, login, logout, refresh_token, sso_login, sso_login_with_provider,
+                get_login_types,
+                login::{
+                    self,
+                    v3::{LoginInfo, Password},
+                },
+                logout, refresh_token, sso_login, sso_login_with_provider,
             },
             uiaa::UserIdentifier,
         },
@@ -547,19 +550,18 @@ impl MatrixAuth {
     pub async fn register(&self, request: register::v3::Request) -> Result<register::v3::Response> {
         let homeserver = self.client.homeserver();
         info!("Registering to {homeserver}");
-        #[cfg(feature = "e2e-encryption")]
-        let auth_data = match (&request.username, &request.password) {
-            (Some(u), Some(p)) => Some(RumaUiaaAuthData::Password(RumaUiaaPassword::new(
-                UserIdentifier::UserIdOrLocalpart(u.clone()),
+
+        let login_info = match (&request.username, &request.password) {
+            (Some(u), Some(p)) => Some(LoginInfo::Password(Password::new(
+                UserIdentifier::UserIdOrLocalpart(u.into()),
                 p.clone(),
             ))),
             _ => None,
         };
+
         let response = self.client.send(request, None).await?;
         if let Some(session) = MatrixSession::from_register_response(&response) {
-            let _ = self.set_session(session).await;
-            #[cfg(feature = "e2e-encryption")]
-            self.client.post_login_cross_signing(auth_data).await;
+            let _ = self.set_session(session, login_info).await;
         }
         Ok(response)
     }
@@ -819,7 +821,7 @@ impl MatrixAuth {
     #[instrument(skip_all)]
     pub async fn restore_session(&self, session: MatrixSession) -> Result<()> {
         debug!("Restoring Matrix auth session");
-        self.set_session(session).await?;
+        self.set_session(session, None).await?;
         debug!("Done restoring Matrix auth session");
         Ok(())
     }
@@ -833,35 +835,39 @@ impl MatrixAuth {
     pub(crate) async fn receive_login_response(
         &self,
         response: &login::v3::Response,
+        login_info: Option<LoginInfo>,
     ) -> Result<()> {
         self.client.maybe_update_login_well_known(response.well_known.as_ref());
 
-        self.set_session(response.into()).await?;
+        self.set_session(response.into(), login_info).await?;
 
         Ok(())
     }
 
-    async fn set_session(&self, session: MatrixSession) -> Result<()> {
+    async fn set_session(
+        &self,
+        session: MatrixSession,
+        login_info: Option<LoginInfo>,
+    ) -> Result<()> {
         self.set_session_tokens(session.tokens);
         self.client.set_session_meta(session.meta).await?;
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks().await?;
+        {
+            use ruma::api::client::uiaa::{AuthData, Password};
+
+            let auth_data = match login_info {
+                Some(login::v3::LoginInfo::Password(p)) => {
+                    Some(AuthData::Password(Password::new(p.identifier, p.password)))
+                }
+                // Other methods can't be immediately translated to an auth.
+                _ => None,
+            };
+
+            self.client.encryption().run_initialization_tasks(auth_data).await?;
+        }
 
         Ok(())
-    }
-}
-
-// Internal client helpers
-impl Client {
-    #[cfg(feature = "e2e-encryption")]
-    pub(crate) async fn post_login_cross_signing(&self, auth_data: Option<RumaUiaaAuthData>) {
-        let encryption = self.encryption();
-        if encryption.settings().auto_enable_cross_signing {
-            if let Err(err) = encryption.bootstrap_cross_signing_if_needed(auth_data).await {
-                tracing::warn!("cross-signing bootstrapping failed: {err}");
-            }
-        }
     }
 }
 

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -756,7 +756,7 @@ impl Oidc {
         }
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks().await?;
+        self.client.encryption().run_initialization_tasks(None).await?;
 
         Ok(())
     }
@@ -920,11 +920,6 @@ impl Oidc {
         // Enable the cross-process lock for refreshes, if needs be.
         self.deferred_enable_cross_process_refresh_lock().await?;
 
-        // Bootstrap cross signing, if needs be.
-        // TODO: (#2763) put this into a background task.
-        #[cfg(feature = "e2e-encryption")]
-        self.client.post_login_cross_signing(None).await;
-
         if let Some(cross_process_manager) = self.ctx().cross_process_token_refresh_manager.get() {
             if let Some(tokens) = self.session_tokens() {
                 let mut cross_process_guard = cross_process_manager
@@ -950,7 +945,7 @@ impl Oidc {
         }
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks().await?;
+        self.client.encryption().run_initialization_tasks(None).await?;
 
         Ok(())
     }

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -452,6 +452,8 @@ async fn test_login_with_cross_signing_bootstrapping() {
         assert!(client.logged_in(), "Client should be logged in");
         assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
+        client.encryption().wait_for_e2ee_initialization_tasks().await;
+
         let me = client.user_id().expect("we are now logged in");
         let own_identity =
             client.encryption().get_user_identity(me).await.expect("succeeds").expect("is present");
@@ -502,6 +504,8 @@ async fn test_login_with_cross_signing_bootstrapping() {
 
         assert!(client.logged_in(), "Client should be logged in");
         assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
+
+        client.encryption().wait_for_e2ee_initialization_tasks().await;
 
         let me = client.user_id().expect("we are now logged in");
         let own_identity =
@@ -578,6 +582,8 @@ async fn test_login_doesnt_fail_if_cross_signing_bootstrapping_failed() {
     assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");
 
     let me = client.user_id().expect("we are now logged in");
+
+    client.encryption().wait_for_e2ee_initialization_tasks().await;
 
     let own_identity = client.encryption().get_user_identity(me).await.expect("succeeds");
     let identity = own_identity.expect("created local default identity");


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/2998

Changes:
 - First commit: [init cross-signing with other e2e initial task](https://github.com/matrix-org/matrix-rust-sdk/commit/07daf7d0b7cc375a1f05d20c68bf0ebaf9c81764)
     In existing code the bootstraping is done in different places, `bootstrap_cross_signing_if_needed` or `run_intialization_tasks` and both are based on the same `EncryptionSettings`. `bootstrap_cross_signing_if_needed` was done by `LoginBuilder` but `run_intialization_tasks` by `MatrixAuth`. I propose to move all under `run_intialization_tasks` that has already support to do it in background, and to call it in one place only: `MatrixA
uth`
 - Second commit quick fix (dirty) to avoid having the auth client bootstraping with an in memory olmMachine before creating the final client (`finalize_client`)


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
