### PR TITLE
indexeddb, sqlite: Avoid dependency on `matrix-sdk-base`

### DIFF
--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["e2e-encryption", "state-store"]
 state-store = ["dep:matrix-sdk-base"]
-e2e-encryption = ["matrix-sdk-base?/e2e-encryption", "dep:matrix-sdk-crypto"]
+e2e-encryption = ["dep:matrix-sdk-crypto"]
 testing = ["matrix-sdk-crypto?/testing"]
 
 [dependencies]

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -12,17 +12,14 @@ default = ["state-store"]
 testing = ["matrix-sdk-crypto?/testing"]
 
 bundled = ["rusqlite/bundled"]
-crypto-store = [
-    "dep:matrix-sdk-crypto",
-    "matrix-sdk-base/e2e-encryption",
-]
-state-store = []
+crypto-store = ["dep:matrix-sdk-crypto"]
+state-store = ["dep:matrix-sdk-base"]
 
 [dependencies]
 async-trait = { workspace = true }
 deadpool-sqlite = "0.7.0"
 itertools = { workspace = true }
-matrix-sdk-base = { workspace = true }
+matrix-sdk-base = { workspace = true, optional = true }
 matrix-sdk-crypto = { workspace = true, optional = true }
 matrix-sdk-store-encryption = { workspace = true }
 rmp-serde = "1.1.1"

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -16,10 +16,7 @@
     allow(dead_code, unused_imports)
 )]
 
-use std::path::Path;
-
 use deadpool_sqlite::Object as SqliteConn;
-use matrix_sdk_base::store::StoreConfig;
 use matrix_sdk_store_encryption::StoreCipher;
 
 #[cfg(feature = "crypto-store")]
@@ -59,26 +56,3 @@ async fn get_or_create_store_cipher(
 
 #[cfg(test)]
 matrix_sdk_test::init_tracing_for_tests!();
-
-/// Create a [`StoreConfig`] with an opened [`SqliteStateStore`] in the given
-/// directory and using the given passphrase. If the `crypto-store` feature is
-/// enabled, a [`SqliteCryptoStore`] with the same parameters is also opened.
-#[cfg(feature = "state-store")]
-pub async fn make_store_config(
-    path: &Path,
-    passphrase: Option<&str>,
-) -> Result<StoreConfig, OpenStoreError> {
-    let state_store = SqliteStateStore::open(path, passphrase).await?;
-    let config = StoreConfig::new().state_store(state_store);
-
-    #[cfg(feature = "crypto-store")]
-    {
-        let crypto_store = SqliteCryptoStore::open(path, passphrase).await?;
-        Ok(config.crypto_store(crypto_store))
-    }
-
-    #[cfg(not(feature = "crypto-store"))]
-    {
-        Ok(config)
-    }
-}


### PR DESCRIPTION
Currently, `matrix-rust-sdk-crypto-wasm` builds `matrix-sdk-base` despite having no dependency on it. (None of the `matrix-sdk-base` is used when `matrix_sdk_indexeddb` is built without the `state-store` feature.)

I think this is because the dependency graph is *complicated*. The problem is `matrix-sdk-indexeddb`'s dependency on the `e2e-encryption` feature of `matrix-sdk-base`. That feature is only used in `matrix_sdk_indexeddb::make_store_config`. By moving that logic into `matrix-sdk`, we can remove the conditional dependency on ` matrix-sdk-indexeddb/e2e-encryption`.

Since I'm doing `matrix-sdk-indexeddb`, I thought I'd better do `matrix-sdk-sqlite` to keep it in step.

Should be reviewable commit-by-commit.