### PR TITLE
room list service: add `$ME` as a required state for the `all_rooms` sliding sync list

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1233,6 +1233,7 @@ impl BaseClient {
         } else if let Some(member) = Box::pin(room.get_member(user_id)).await? {
             member.name().to_owned()
         } else {
+            trace!("Couldn't get push context because of missing own member information");
             return Ok(None);
         };
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -178,6 +178,7 @@ impl RoomListService {
                         (StateEventType::RoomAvatar, "".to_owned()),
                         (StateEventType::RoomEncryption, "".to_owned()),
                         (StateEventType::RoomMember, "$LAZY".to_owned()),
+                        (StateEventType::RoomMember, "$ME".to_owned()),
                         (StateEventType::RoomPowerLevels, "".to_owned()),
                     ]),
             ))

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -275,6 +275,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.avatar", ""],
                         ["m.room.encryption", ""],
                         ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
                         ["m.room.power_levels", ""],
                     ],
                     "filters": {


### PR DESCRIPTION
Without this, we wouldn't ever have the member information for the logged-in user, the first time they log in, if they don't happen to be the last user sending a message in a room (a case covered by `$LAZY`).

---

It's a very edge case, because we'd receive the current user's member information as soon as we subscribe to any room where the current user wrote a message, *or* we saw any room in `all_rooms` where the current user was the latest event's author, *or* the client received an invite. The member info for the current user is only returned the first time, and whenever it changes afterwards, so it won't make every single response heavier.