### PR TITLE
crypto: Silence compiler warning

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -892,6 +892,7 @@ enum InnerRequest {
     Ready(RequestState<Ready>),
     Transitioned(RequestState<Transitioned>),
     Passive(RequestState<Passive>),
+    #[allow(dead_code)] // The `RequestState` field within `Done` is not currently used.
     Done(RequestState<Done>),
     Cancelled(RequestState<Cancelled>),
 }


### PR DESCRIPTION
Fixes a compiler warning:

```
warning: field `0` is never read
```

As far as I can tell, this has happened for ever. We *could* turn `Done` into a unit variant, but that's quite a lot of changes, would make `Done` asymmetric with the other variants, and would have to be undone if we ever needed that data.