### PR TITLE
test: reenable the unread count test in code coverage

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -432,19 +432,7 @@ async fn test_room_notification_count() -> Result<()> {
 
     bob_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
 
-    for _ in 0..1 {
-        assert!(info_updates.next().await.is_some());
-        if !alice_room
-            .members_no_sync(RoomMemberships::JOIN)
-            .await?
-            .iter()
-            .any(|member| member.user_id() == alice.user_id().unwrap())
-        {
-            // The proxy may send another update that contains the membership information
-            // soonish.
-            continue;
-        }
-    }
+    assert!(info_updates.next().await.is_some());
 
     assert_eq!(alice_room.num_unread_messages(), 1);
     assert_eq!(alice_room.num_unread_notifications(), 1);

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -324,7 +324,6 @@ async fn test_joined_user_can_create_push_context_with_room_list_service() -> Re
     Ok(())
 }
 
-#[cfg(not(tarpaulin))]
 #[tokio::test]
 async fn test_room_notification_count() -> Result<()> {
     use tokio::time::timeout;

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -15,7 +15,7 @@ use matrix_sdk::{
         assign,
         events::{
             receipt::ReceiptThread, room::message::RoomMessageEventContent,
-            AnySyncMessageLikeEvent, Mentions,
+            AnySyncMessageLikeEvent, Mentions, StateEventType,
         },
         mxc_uri,
     },
@@ -360,7 +360,8 @@ async fn test_room_notification_count() -> Result<()> {
             .with_to_device_extension(assign!(ToDeviceConfig::default(), { enabled: Some(true) }))
             .add_list(
                 SlidingSyncList::builder("all")
-                    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=20)),
+                    .sync_mode(SlidingSyncMode::new_selective().add_range(0..=20))
+                    .required_state(vec![(StateEventType::RoomMember, "$ME".to_owned())]),
             )
             .build()
             .await?;

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -431,7 +431,19 @@ async fn test_room_notification_count() -> Result<()> {
 
     bob_room.send(RoomMessageEventContent::text_plain("hello world")).await?;
 
-    assert!(info_updates.next().await.is_some());
+    for _ in 0..1 {
+        assert!(info_updates.next().await.is_some());
+        if !alice_room
+            .members_no_sync(RoomMemberships::JOIN)
+            .await?
+            .iter()
+            .any(|member| member.user_id() == alice.user_id().unwrap())
+        {
+            // The proxy may send another update that contains the membership information
+            // soonish.
+            continue;
+        }
+    }
 
     assert_eq!(alice_room.num_unread_messages(), 1);
     assert_eq!(alice_room.num_unread_notifications(), 1);


### PR DESCRIPTION
Let's see if the test correctly passes, now that all the racy behaviors should have been fixed with https://github.com/matrix-org/matrix-rust-sdk/pull/2978.

Fixes #2963.