### PR TITLE
crypto: add test for 4S keys with no `mac` or `iv`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+
+- Fix bug which caused `SecretStorageKey` to incorrectly reject secret storage
+  keys whose metadata lacked check fields.
+  ([#3046](https://github.com/matrix-org/matrix-rust-sdk/pull/3046))
+
 # 0.7.0
 
 - Add method to mark a list of inbound group sessions as backed up:

--- a/crates/matrix-sdk-crypto/src/secret_storage.rs
+++ b/crates/matrix-sdk-crypto/src/secret_storage.rs
@@ -754,6 +754,22 @@ mod test {
         );
     }
 
+    /// The `iv` and `mac` properties within the `m.secret_storage.key.*`
+    /// content are optional, and the spec says we must assume the
+    /// passphrase is correct in that case.
+    #[test]
+    fn invalid_key_with_no_mac() {
+        let content = SecretStorageKeyEventContent::new(
+            "my_new_key_id".to_owned(),
+            SecretStorageEncryptionAlgorithm::V1AesHmacSha2(
+                SecretStorageV1AesHmacSha2Properties::new(None, None),
+            ),
+        );
+
+        SecretStorageKey::from_account_data("It's a secret to nobody", content.to_owned())
+            .expect("Should accept any passphrase");
+    }
+
     #[test]
     fn base58_parsing() {
         const DECODED_KEY: [u8; 32] = [

--- a/crates/matrix-sdk-crypto/src/secret_storage.rs
+++ b/crates/matrix-sdk-crypto/src/secret_storage.rs
@@ -759,12 +759,14 @@ mod test {
     /// passphrase is correct in that case.
     #[test]
     fn invalid_key_with_no_mac() {
-        let content = SecretStorageKeyEventContent::new(
+        let mut content = SecretStorageKeyEventContent::new(
             "my_new_key_id".to_owned(),
             SecretStorageEncryptionAlgorithm::V1AesHmacSha2(
                 SecretStorageV1AesHmacSha2Properties::new(None, None),
             ),
         );
+        content.passphrase =
+            Some(PassPhrase::new("salty goodness".to_owned(), UInt::new_saturating(100)));
 
         SecretStorageKey::from_account_data("It's a secret to nobody", content.to_owned())
             .expect("Should accept any passphrase");

--- a/crates/matrix-sdk-crypto/src/secret_storage.rs
+++ b/crates/matrix-sdk-crypto/src/secret_storage.rs
@@ -758,7 +758,7 @@ mod test {
     /// content are optional, and the spec says we must assume the
     /// passphrase is correct in that case.
     #[test]
-    fn invalid_key_with_no_mac() {
+    fn accepts_any_passphrase_if_mac_and_iv_are_missing() {
         let mut content = SecretStorageKeyEventContent::new(
             "my_new_key_id".to_owned(),
             SecretStorageEncryptionAlgorithm::V1AesHmacSha2(


### PR DESCRIPTION
A regression test for https://github.com/matrix-org/matrix-rust-sdk/issues/2932.

Also adds a changelog entry.