### PR TITLE
Move the AuthenticationService from the FFI into the SDK crate.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -1,42 +1,34 @@
-use std::{
-    collections::HashMap,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
+use anyhow::Context;
 use matrix_sdk::{
+    authentication::service::{
+        AuthenticationError, AuthenticationService as SdkAuthenticationService,
+        HomeserverLoginDetails,
+    },
     oidc::{
-        registrations::{ClientId, OidcRegistrations, OidcRegistrationsError},
+        registrations::ClientId,
         types::{
-            client_credentials::ClientCredentials,
-            errors::ClientErrorCode::AccessDenied,
             iana::oauth::OAuthClientAuthenticationMethod,
             oidc::ApplicationType,
-            registration::{ClientMetadata, Localized, VerifiedClientMetadata},
-            requests::{GrantType, Prompt},
+            registration::{ClientMetadata, Localized},
+            requests::GrantType,
         },
-        AuthorizationResponse, Oidc, OidcError,
+        OidcAuthorizationData,
     },
     AuthSession,
 };
-use ruma::{
-    api::client::discovery::discover_homeserver::AuthenticationServerInfo, IdParseError,
-    OwnedUserId,
-};
+use ruma::OwnedUserId;
 use url::Url;
 use zeroize::Zeroize;
 
 use super::{client::Client, client_builder::ClientBuilder, RUNTIME};
-use crate::{client::ClientSessionDelegate, client_builder::UrlScheme, error::ClientError};
+use crate::client::ClientSessionDelegate;
 
 #[derive(uniffi::Object)]
 pub struct AuthenticationService {
-    base_path: String,
+    inner: SdkAuthenticationService,
     passphrase: Option<String>,
-    user_agent: Option<String>,
-    client: RwLock<Option<Arc<Client>>>,
-    homeserver_details: RwLock<Option<Arc<HomeserverLoginDetails>>>,
-    oidc_configuration: Option<OidcConfiguration>,
-    custom_sliding_sync_proxy: RwLock<Option<String>>,
     cross_process_refresh_lock_id: Option<String>,
     session_delegate: Option<Arc<dyn ClientSessionDelegate>>,
 }
@@ -47,86 +39,82 @@ impl Drop for AuthenticationService {
     }
 }
 
-#[derive(Debug, thiserror::Error, uniffi::Error)]
-#[uniffi(flat_error)]
-pub enum AuthenticationError {
-    #[error("A successful call to configure_homeserver must be made first.")]
-    ClientMissing,
-    #[error("{message}")]
-    InvalidServerName { message: String },
-    #[error("The homeserver doesn't provide a trusted sliding sync proxy in its well-known configuration.")]
-    SlidingSyncNotAvailable,
-    #[error("Login was successful but is missing a valid Session to configure the file store.")]
-    SessionMissing,
-    #[error("Failed to use the supplied base path.")]
-    InvalidBasePath,
-    #[error(
-        "The homeserver doesn't provide an authentication issuer in its well-known configuration."
-    )]
-    OidcNotSupported,
-    #[error("Unable to use OIDC as no client metadata has been supplied.")]
-    OidcMetadataMissing,
-    #[error("Unable to use OIDC as the supplied client metadata is invalid.")]
-    OidcMetadataInvalid,
-    #[error("The supplied callback URL used to complete OIDC is invalid.")]
-    OidcCallbackUrlInvalid,
-    #[error("The OIDC login was cancelled by the user.")]
-    OidcCancelled,
-    #[error("An error occurred with OIDC: {message}")]
-    OidcError { message: String },
-    #[error("An error occurred: {message}")]
-    Generic { message: String },
-}
-
-impl From<anyhow::Error> for AuthenticationError {
-    fn from(e: anyhow::Error) -> AuthenticationError {
-        AuthenticationError::Generic { message: e.to_string() }
-    }
-}
-
-impl From<IdParseError> for AuthenticationError {
-    fn from(e: IdParseError) -> AuthenticationError {
-        AuthenticationError::InvalidServerName { message: e.to_string() }
-    }
-}
-
-impl From<OidcRegistrationsError> for AuthenticationError {
-    fn from(e: OidcRegistrationsError) -> AuthenticationError {
-        match e {
-            OidcRegistrationsError::InvalidBasePath => AuthenticationError::InvalidBasePath,
-            _ => AuthenticationError::OidcError { message: e.to_string() },
-        }
-    }
-}
-
-impl From<OidcError> for AuthenticationError {
-    fn from(e: OidcError) -> AuthenticationError {
-        AuthenticationError::OidcError { message: e.to_string() }
-    }
-}
-
 /// The configuration to use when authenticating with OIDC.
-#[derive(uniffi::Record)]
+#[derive(Clone, uniffi::Object)]
 pub struct OidcConfiguration {
-    /// The name of the client that will be shown during OIDC authentication.
-    pub client_name: Option<String>,
-    /// The redirect URI that will be used when OIDC authentication is
-    /// successful.
-    pub redirect_uri: String,
-    /// A URI that contains information about the client.
-    pub client_uri: Option<String>,
-    /// A URI that contains the client's logo.
-    pub logo_uri: Option<String>,
-    /// A URI that contains the client's terms of service.
-    pub tos_uri: Option<String>,
-    /// A URI that contains the client's privacy policy.
-    pub policy_uri: Option<String>,
-    /// An array of e-mail addresses of people responsible for this client.
-    pub contacts: Option<Vec<String>>,
+    pub client_metadata: ClientMetadata,
+    pub static_registrations: HashMap<Url, ClientId>,
+}
 
-    /// Pre-configured registrations for use with issuers that don't support
-    /// dynamic client registration.
-    pub static_registrations: HashMap<String, String>,
+#[uniffi::export]
+impl OidcConfiguration {
+    /// Creates a new service to authenticate a user with.
+    ///
+    /// # Arguments
+    ///
+    /// * `client_name` - The name of the client that will be shown during OIDC
+    ///   authentication.
+    /// * `redirect_uri` - The redirect URI that will be used when OIDC
+    ///   authentication is successful.
+    /// * `client_uri` - A URI that contains information about the client.
+    /// * `logo_uri` - A URI that contains the client's logo.
+    /// * `tos_uri` - A URI that contains the client's terms of service.
+    /// * `policy_uri` - A URI that contains the client's privacy policy.
+    /// * `contacts` - An array of e-mail addresses of people responsible for
+    ///   this client.
+    /// * `static_registrations` - Pre-configured registrations for use with
+    ///   issuers that don't support dynamic client registration.
+    #[uniffi::constructor]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        client_name: Option<String>,
+        redirect_uri: String,
+        client_uri: Option<String>,
+        logo_uri: Option<String>,
+        tos_uri: Option<String>,
+        policy_uri: Option<String>,
+        contacts: Option<Vec<String>>,
+        static_registrations: HashMap<String, String>,
+    ) -> Result<Self, AuthenticationError> {
+        let redirect_uri = Url::parse(&redirect_uri).map_err(|_| {
+            matrix_sdk::authentication::service::AuthenticationError::OidcCallbackUrlInvalid
+        })?;
+        let client_name = client_name.as_ref().map(|n| Localized::new(n.to_owned(), []));
+        let client_uri = client_uri.localized_url()?;
+        let logo_uri = logo_uri.localized_url()?;
+        let policy_uri = policy_uri.localized_url()?;
+        let tos_uri = tos_uri.localized_url()?;
+        let contacts = contacts.clone();
+
+        let client_metadata = ClientMetadata {
+            application_type: Some(ApplicationType::Native),
+            redirect_uris: Some(vec![redirect_uri]),
+            grant_types: Some(vec![GrantType::RefreshToken, GrantType::AuthorizationCode]),
+            // A native client shouldn't use authentication as the credentials could be intercepted.
+            token_endpoint_auth_method: Some(OAuthClientAuthenticationMethod::None),
+            // The server should display the following fields when getting the user's consent.
+            client_name,
+            contacts,
+            client_uri,
+            logo_uri,
+            policy_uri,
+            tos_uri,
+            ..Default::default()
+        };
+
+        let static_registrations = static_registrations
+            .iter()
+            .filter_map(|(issuer, client_id)| {
+                let Ok(issuer) = Url::parse(issuer) else {
+                    tracing::error!("Failed to parse {:?}", issuer);
+                    return None;
+                };
+                Some((issuer, ClientId(client_id.clone())))
+            })
+            .collect();
+
+        Ok(Self { client_metadata, static_registrations })
+    }
 }
 
 /// The data required to authenticate against an OIDC server.
@@ -147,31 +135,6 @@ impl OidcAuthenticationData {
     }
 }
 
-#[derive(uniffi::Object)]
-pub struct HomeserverLoginDetails {
-    url: String,
-    supports_oidc_login: bool,
-    supports_password_login: bool,
-}
-
-#[uniffi::export]
-impl HomeserverLoginDetails {
-    /// The URL of the currently configured homeserver.
-    pub fn url(&self) -> String {
-        self.url.clone()
-    }
-
-    /// Whether the current homeserver supports login using OIDC.
-    pub fn supports_oidc_login(&self) -> bool {
-        self.supports_oidc_login
-    }
-
-    /// Whether the current homeserver supports the password login flow.
-    pub fn supports_password_login(&self) -> bool {
-        self.supports_password_login
-    }
-}
-
 #[uniffi::export]
 impl AuthenticationService {
     /// Creates a new service to authenticate a user with.
@@ -180,26 +143,36 @@ impl AuthenticationService {
         base_path: String,
         passphrase: Option<String>,
         user_agent: Option<String>,
-        oidc_configuration: Option<OidcConfiguration>,
+        oidc_configuration: Option<Arc<OidcConfiguration>>,
         custom_sliding_sync_proxy: Option<String>,
         session_delegate: Option<Box<dyn ClientSessionDelegate>>,
         cross_process_refresh_lock_id: Option<String>,
     ) -> Arc<Self> {
-        Arc::new(AuthenticationService {
-            base_path,
-            passphrase,
+        let (oidc_client_metadata, oidc_static_registrations) =
+            if let Some(oidc_configuration) = oidc_configuration {
+                let oidc_configuration = (*oidc_configuration).clone();
+                (Some(oidc_configuration.client_metadata), oidc_configuration.static_registrations)
+            } else {
+                (None, HashMap::new())
+            };
+
+        let inner = SdkAuthenticationService::new(
+            PathBuf::from(base_path),
             user_agent,
-            client: RwLock::new(None),
-            homeserver_details: RwLock::new(None),
-            oidc_configuration,
-            custom_sliding_sync_proxy: RwLock::new(custom_sliding_sync_proxy),
+            oidc_client_metadata,
+            oidc_static_registrations,
+            custom_sliding_sync_proxy,
+        );
+        Arc::new(AuthenticationService {
+            inner,
+            passphrase,
             session_delegate: session_delegate.map(Into::into),
             cross_process_refresh_lock_id,
         })
     }
 
     pub fn homeserver_details(&self) -> Option<Arc<HomeserverLoginDetails>> {
-        self.homeserver_details.read().unwrap().clone()
+        self.inner.homeserver_details().map(Arc::new)
     }
 
     /// Updates the service to authenticate with the homeserver for the
@@ -208,58 +181,7 @@ impl AuthenticationService {
         &self,
         server_name_or_homeserver_url: String,
     ) -> Result<(), AuthenticationError> {
-        let mut builder = self.new_client_builder();
-
-        // Attempt discovery as a server name first.
-        let result = matrix_sdk::sanitize_server_name(&server_name_or_homeserver_url);
-
-        match result {
-            Ok(server_name) => {
-                let protocol = if server_name_or_homeserver_url.starts_with("http://") {
-                    UrlScheme::Http
-                } else {
-                    UrlScheme::Https
-                };
-                builder = builder.server_name_with_protocol(server_name.to_string(), protocol);
-            }
-
-            Err(e) => {
-                // When the input isn't a valid server name check it is a URL.
-                // If this is the case, build the client with a homeserver URL.
-                if Url::parse(&server_name_or_homeserver_url).is_ok() {
-                    builder = builder.homeserver_url(server_name_or_homeserver_url.clone());
-                } else {
-                    return Err(e.into());
-                }
-            }
-        }
-
-        let client = builder.build_inner().or_else(|e| {
-            if !server_name_or_homeserver_url.starts_with("http://")
-                && !server_name_or_homeserver_url.starts_with("https://")
-            {
-                return Err(e);
-            }
-            // When discovery fails, fallback to the homeserver URL if supplied.
-            let mut builder = self.new_client_builder();
-            builder = builder.homeserver_url(server_name_or_homeserver_url);
-            builder.build_inner()
-        })?;
-
-        let details = RUNTIME.block_on(self.details_from_client(&client))?;
-
-        // Now we've verified that it's a valid homeserver, make sure
-        // there's a sliding sync proxy available one way or another.
-        if self.custom_sliding_sync_proxy.read().unwrap().is_none()
-            && client.discovered_sliding_sync_proxy().is_none()
-        {
-            return Err(AuthenticationError::SlidingSyncNotAvailable);
-        }
-
-        *self.client.write().unwrap() = Some(client);
-        *self.homeserver_details.write().unwrap() = Some(Arc::new(details));
-
-        Ok(())
+        RUNTIME.block_on(self.inner.configure_homeserver(server_name_or_homeserver_url))
     }
 
     /// Performs a password login using the current homeserver.
@@ -270,18 +192,20 @@ impl AuthenticationService {
         initial_device_name: Option<String>,
         device_id: Option<String>,
     ) -> Result<Arc<Client>, AuthenticationError> {
-        let Some(client) = self.client.read().unwrap().clone() else {
-            return Err(AuthenticationError::ClientMissing);
-        };
-
         // Login and ask the server for the full user ID as this could be different from
         // the username that was entered.
-        client.login(username, password, initial_device_name, device_id).map_err(|e| match e {
-            ClientError::Generic { msg } => AuthenticationError::Generic { message: msg },
-        })?;
-        let whoami = client.whoami()?;
-        let session =
-            client.inner.matrix_auth().session().ok_or(AuthenticationError::SessionMissing)?;
+        let client = RUNTIME.block_on(self.inner.login(
+            username,
+            password,
+            initial_device_name,
+            device_id,
+        ))?;
+        let whoami = RUNTIME
+            .block_on(client.whoami())
+            .map_err(|error| AuthenticationError::Generic { message: error.to_string() })?;
+        let session = client.matrix_auth().session().context(
+            "Login was successful but is missing a valid Session to configure the file store.",
+        )?;
 
         self.finalize_client(client, session, whoami.user_id)
     }
@@ -290,33 +214,8 @@ impl AuthenticationService {
     /// view has succeeded, call `login_with_oidc_callback` with the callback it
     /// returns.
     pub fn url_for_oidc_login(&self) -> Result<Arc<OidcAuthenticationData>, AuthenticationError> {
-        let Some(client) = self.client.read().unwrap().clone() else {
-            return Err(AuthenticationError::ClientMissing);
-        };
-
-        let Some(authentication_server) = client.discovered_authentication_server() else {
-            return Err(AuthenticationError::OidcNotSupported);
-        };
-
-        let Some(oidc_configuration) = &self.oidc_configuration else {
-            return Err(AuthenticationError::OidcMetadataMissing);
-        };
-
-        let redirect_url = Url::parse(&oidc_configuration.redirect_uri)
-            .map_err(|_e| AuthenticationError::OidcMetadataInvalid)?;
-
-        let oidc = client.inner.oidc();
-
-        RUNTIME.block_on(async {
-            self.configure_oidc(&oidc, authentication_server, oidc_configuration).await?;
-
-            let mut data_builder = oidc.login(redirect_url, None)?;
-            // TODO: Add a check for the Consent prompt when MAS is updated.
-            data_builder = data_builder.prompt(vec![Prompt::Consent]);
-            let data = data_builder.build().await?;
-
-            Ok(Arc::new(OidcAuthenticationData { url: data.url, state: data.state }))
-        })
+        let data = RUNTIME.block_on(self.inner.url_for_oidc_login())?;
+        Ok(Arc::new(OidcAuthenticationData { url: data.url, state: data.state }))
     }
 
     /// Completes the OIDC login process.
@@ -325,254 +224,58 @@ impl AuthenticationService {
         authentication_data: Arc<OidcAuthenticationData>,
         callback_url: String,
     ) -> Result<Arc<Client>, AuthenticationError> {
-        let Some(client) = self.client.read().unwrap().clone() else {
-            return Err(AuthenticationError::ClientMissing);
-        };
-
-        let oidc = client.inner.oidc();
-
-        let url =
+        let callback_url =
             Url::parse(&callback_url).map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
 
-        let response = AuthorizationResponse::parse_uri(&url)
-            .map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
+        // Login and get the user ID that was resolved by the authentication server.
+        let client = RUNTIME.block_on(self.inner.login_with_oidc_callback(
+            OidcAuthorizationData {
+                url: authentication_data.url.clone(),
+                state: authentication_data.state.clone(),
+            },
+            callback_url,
+        ))?;
 
-        let code = match response {
-            AuthorizationResponse::Success(code) => code,
-            AuthorizationResponse::Error(err) => {
-                if err.error.error == AccessDenied {
-                    // The user cancelled the login in the web view.
-                    return Err(AuthenticationError::OidcCancelled);
-                }
-                return Err(AuthenticationError::OidcError {
-                    message: err.error.error.to_string(),
-                });
-            }
-        };
-
-        if code.state != authentication_data.state {
-            return Err(AuthenticationError::OidcCallbackUrlInvalid);
-        };
-
-        RUNTIME.block_on(async move {
-            oidc.finish_authorization(code).await?;
-
-            oidc.finish_login()
-                .await
-                .map_err(|e| AuthenticationError::OidcError { message: e.to_string() })
-        })?;
-
-        let user_id = client.inner.user_id().unwrap().to_owned();
-        let session =
-            client.inner.oidc().full_session().ok_or(AuthenticationError::SessionMissing)?;
+        let user_id = client.user_id().unwrap().to_owned();
+        let session = client.oidc().full_session().context(
+            "Login was successful but is missing a valid Session to configure the file store.",
+        )?;
         self.finalize_client(client, session, user_id)
     }
 }
 
 impl AuthenticationService {
-    /// A new client builder pre-configured with the service's base path and
-    /// user agent if specified
-    fn new_client_builder(&self) -> Arc<ClientBuilder> {
-        let mut builder = ClientBuilder::new().base_path(self.base_path.clone());
-
-        if let Some(user_agent) = self.user_agent.clone() {
-            builder = builder.user_agent(user_agent);
-        }
-
-        builder
-    }
-
-    /// Get the homeserver login details from a client.
-    async fn details_from_client(
-        &self,
-        client: &Arc<Client>,
-    ) -> Result<HomeserverLoginDetails, AuthenticationError> {
-        let supports_oidc_login = client.discovered_authentication_server().is_some();
-        let supports_password_login = client.supports_password_login().await.ok().unwrap_or(false);
-        let url = client.homeserver();
-
-        Ok(HomeserverLoginDetails { url, supports_oidc_login, supports_password_login })
-    }
-
-    /// Handle any necessary configuration in order for login via OIDC to
-    /// succeed. This includes performing dynamic client registration against
-    /// the homeserver's issuer or restoring a previous registration if one has
-    /// been stored.
-    async fn configure_oidc(
-        &self,
-        oidc: &Oidc,
-        authentication_server: AuthenticationServerInfo,
-        configuration: &OidcConfiguration,
-    ) -> Result<(), AuthenticationError> {
-        if oidc.client_credentials().is_some() {
-            tracing::info!("OIDC is already configured.");
-            return Ok(());
-        };
-
-        let oidc_metadata = self.oidc_metadata(configuration)?;
-
-        if self.load_client_registration(oidc, &authentication_server, oidc_metadata.clone()).await
-        {
-            tracing::info!("OIDC configuration loaded from disk.");
-            return Ok(());
-        }
-
-        tracing::info!("Registering this client for OIDC.");
-        let registration_response = oidc
-            .register_client(&authentication_server.issuer, oidc_metadata.clone(), None)
-            .await?;
-
-        // The format of the credentials changes according to the client metadata that
-        // was sent. Public clients only get a client ID.
-        let credentials =
-            ClientCredentials::None { client_id: registration_response.client_id.clone() };
-        oidc.restore_registered_client(authentication_server, oidc_metadata, credentials);
-
-        tracing::info!("Persisting OIDC registration data.");
-        self.store_client_registration(oidc).await?;
-
-        Ok(())
-    }
-
-    /// Stores the current OIDC dynamic client registration so it can be re-used
-    /// if we ever log in via the same issuer again.
-    async fn store_client_registration(&self, oidc: &Oidc) -> Result<(), AuthenticationError> {
-        let issuer = Url::parse(oidc.issuer().ok_or(AuthenticationError::OidcNotSupported)?)
-            .map_err(|_| AuthenticationError::OidcError {
-                message: String::from("Failed to parse issuer URL."),
-            })?;
-        let client_id = oidc
-            .client_credentials()
-            .ok_or(AuthenticationError::OidcError {
-                message: String::from("Missing client registration."),
-            })?
-            .client_id()
-            .to_owned();
-
-        let metadata = oidc.client_metadata().ok_or(AuthenticationError::OidcError {
-            message: String::from("Missing client metadata."),
-        })?;
-
-        let registrations = OidcRegistrations::new(
-            &self.base_path,
-            metadata.clone(),
-            self.oidc_static_registrations(),
-        )?;
-        registrations.set_and_write_client_id(ClientId(client_id), issuer)?;
-
-        Ok(())
-    }
-
-    /// Attempts to load an existing OIDC dynamic client registration for the
-    /// currently configured issuer.
-    async fn load_client_registration(
-        &self,
-        oidc: &Oidc,
-        authentication_server: &AuthenticationServerInfo,
-        oidc_metadata: VerifiedClientMetadata,
-    ) -> bool {
-        let Ok(issuer) = Url::parse(&authentication_server.issuer) else {
-            tracing::error!("Failed to parse {:?}", authentication_server.issuer);
-            return false;
-        };
-        let Some(registrations) = OidcRegistrations::new(
-            &self.base_path,
-            oidc_metadata.clone(),
-            self.oidc_static_registrations(),
-        )
-        .ok() else {
-            return false;
-        };
-        let Some(client_id) = registrations.client_id(&issuer) else {
-            return false;
-        };
-
-        oidc.restore_registered_client(
-            authentication_server.clone(),
-            oidc_metadata,
-            ClientCredentials::None { client_id: client_id.0 },
-        );
-
-        true
-    }
-
-    /// Creates and verifies OIDC client metadata for the supplied OIDC
-    /// configuration.
-    fn oidc_metadata(
-        &self,
-        configuration: &OidcConfiguration,
-    ) -> Result<VerifiedClientMetadata, AuthenticationError> {
-        let redirect_uri = Url::parse(&configuration.redirect_uri)
-            .map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
-        let client_name =
-            configuration.client_name.as_ref().map(|n| Localized::new(n.to_owned(), []));
-        let client_uri = configuration.client_uri.localized_url()?;
-        let logo_uri = configuration.logo_uri.localized_url()?;
-        let policy_uri = configuration.policy_uri.localized_url()?;
-        let tos_uri = configuration.tos_uri.localized_url()?;
-        let contacts = configuration.contacts.clone();
-
-        ClientMetadata {
-            application_type: Some(ApplicationType::Native),
-            redirect_uris: Some(vec![redirect_uri]),
-            grant_types: Some(vec![GrantType::RefreshToken, GrantType::AuthorizationCode]),
-            // A native client shouldn't use authentication as the credentials could be intercepted.
-            token_endpoint_auth_method: Some(OAuthClientAuthenticationMethod::None),
-            // The server should display the following fields when getting the user's consent.
-            client_name,
-            contacts,
-            client_uri,
-            logo_uri,
-            policy_uri,
-            tos_uri,
-            ..Default::default()
-        }
-        .validate()
-        .map_err(|_| AuthenticationError::OidcMetadataInvalid)
-    }
-
-    fn oidc_static_registrations(&self) -> HashMap<Url, ClientId> {
-        let registrations = self
-            .oidc_configuration
-            .as_ref()
-            .map(|c| c.static_registrations.clone())
-            .unwrap_or_default();
-        registrations
-            .iter()
-            .filter_map(|(issuer, client_id)| {
-                let Ok(issuer) = Url::parse(issuer) else {
-                    tracing::error!("Failed to parse {:?}", issuer);
-                    return None;
-                };
-                Some((issuer, ClientId(client_id.clone())))
-            })
-            .collect()
-    }
-
     /// Creates a new client to setup the store path now the user ID is known.
     fn finalize_client(
         &self,
-        client: Arc<Client>,
+        client: matrix_sdk::Client,
         session: impl Into<AuthSession>,
         user_id: OwnedUserId,
     ) -> Result<Arc<Client>, AuthenticationError> {
         let homeserver_url = client.homeserver();
 
         let sliding_sync_proxy: Option<String>;
-        if let Some(custom_proxy) = self.custom_sliding_sync_proxy.read().unwrap().clone() {
+        if let Some(custom_proxy) = self.inner.custom_sliding_sync_proxy.read().unwrap().clone() {
             sliding_sync_proxy = Some(custom_proxy);
-        } else if let Some(discovered_proxy) = client.discovered_sliding_sync_proxy() {
+        } else if let Some(discovered_proxy) = client.sliding_sync_proxy() {
             sliding_sync_proxy = Some(discovered_proxy.to_string());
         } else {
             sliding_sync_proxy = None;
         }
 
-        let mut client = self
-            .new_client_builder()
+        let base_path =
+            self.inner.base_path.to_str().ok_or(AuthenticationError::InvalidBasePath)?.to_owned();
+
+        let mut builder = ClientBuilder::new()
+            .base_path(base_path)
             .passphrase(self.passphrase.clone())
-            .homeserver_url(homeserver_url)
+            .homeserver_url(homeserver_url.to_string())
             .sliding_sync_proxy(sliding_sync_proxy)
             .username(user_id.to_string());
+
+        if let Some(user_agent) = self.inner.user_agent.clone() {
+            builder = builder.user_agent(user_agent);
+        }
 
         if let Some(id) = &self.cross_process_refresh_lock_id {
             let Some(ref session_delegate) = self.session_delegate else {
@@ -580,13 +283,13 @@ impl AuthenticationService {
                     message: "cross-process refresh lock requires session delegate".to_owned(),
                 });
             };
-            client = client
+            builder = builder
                 .enable_cross_process_refresh_lock_inner(id.clone(), session_delegate.clone());
         } else if let Some(ref session_delegate) = self.session_delegate {
-            client = client.set_session_delegate_inner(session_delegate.clone());
+            builder = builder.set_session_delegate_inner(session_delegate.clone());
         }
 
-        let client = client.build_inner()?;
+        let client = builder.build_inner()?;
 
         // Restore the client using the session from the login request.
         client.restore_session_inner(session)?;

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -18,11 +18,9 @@ use matrix_sdk::{
     },
     ruma::{
         api::client::{
-            account::whoami,
             media::get_content_thumbnail::v3::Method,
             push::{EmailPusherData, PusherIds, PusherInit, PusherKind as RumaPusherKind},
             room::{create_room, Visibility},
-            session::get_login_types,
             user_directory::search_users,
         },
         events::{
@@ -313,38 +311,6 @@ impl Client {
             self.inner.restore_session(session).await?;
             Ok(())
         })
-    }
-
-    /// The homeserver's trusted OIDC Provider that was discovered in the
-    /// well-known.
-    ///
-    /// This will only be set if the homeserver supports authenticating via
-    /// OpenID Connect and this `Client` was constructed using auto-discovery by
-    /// setting the homeserver with [`ClientBuilder::server_name()`].
-    pub(crate) fn discovered_authentication_server(&self) -> Option<AuthenticationServerInfo> {
-        self.inner.oidc().authentication_server_info().cloned()
-    }
-
-    /// The sliding sync proxy that is trusted by the homeserver. `None` when
-    /// not configured.
-    pub fn discovered_sliding_sync_proxy(&self) -> Option<Url> {
-        self.inner.sliding_sync_proxy()
-    }
-
-    /// Whether or not the client's homeserver supports the password login flow.
-    pub(crate) async fn supports_password_login(&self) -> anyhow::Result<bool> {
-        let login_types = self.inner.matrix_auth().get_login_types().await?;
-        let supports_password = login_types
-            .flows
-            .iter()
-            .any(|login_type| matches!(login_type, get_login_types::v3::LoginType::Password(_)));
-        Ok(supports_password)
-    }
-
-    /// Gets information about the owner of a given access token.
-    pub(crate) fn whoami(&self) -> anyhow::Result<whoami::v3::Response> {
-        RUNTIME
-            .block_on(async move { self.inner.whoami().await.map_err(|e| anyhow!(e.to_string())) })
     }
 }
 

--- a/crates/matrix-sdk/src/authentication/mod.rs
+++ b/crates/matrix-sdk/src/authentication/mod.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(pixlwave) Move AuthenticationService from the FFI into this module.
+//! Authentication data and services.
+
+pub mod service;
 
 use std::pin::Pin;
 

--- a/crates/matrix-sdk/src/authentication/service.rs
+++ b/crates/matrix-sdk/src/authentication/service.rs
@@ -1,0 +1,566 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! High-level authentication APIs.
+#[cfg(feature = "experimental-oidc")]
+use std::collections::HashMap;
+use std::{fmt::Debug, path::PathBuf, sync::RwLock};
+
+#[cfg(feature = "experimental-oidc")]
+use mas_oidc_client::types::{
+    client_credentials::ClientCredentials,
+    errors::ClientErrorCode::AccessDenied,
+    registration::{ClientMetadata, VerifiedClientMetadata},
+    requests::Prompt,
+};
+#[cfg(feature = "experimental-oidc")]
+use ruma::api::client::discovery::discover_homeserver::AuthenticationServerInfo;
+use ruma::api::client::session::get_login_types;
+use url::Url;
+
+#[cfg(feature = "experimental-oidc")]
+use crate::oidc::{
+    registrations::{ClientId, OidcRegistrations, OidcRegistrationsError},
+    AuthorizationResponse, Oidc, OidcAuthorizationData, OidcError,
+};
+use crate::{sanitize_server_name, Client, ClientBuilder, IdParseError};
+
+/// A high-level service for authenticating a user with a homeserver.
+/// TODO: Add an example code snippet.
+pub struct AuthenticationService {
+    /// The base path to use for storing data. This could be the same path used
+    /// for the client, or the client might be placed within a subdirectory of
+    /// the base path.
+    pub base_path: PathBuf,
+    /// The user agent sent when making requests to the homeserver.
+    pub user_agent: Option<String>,
+    /// The client used to make requests to the homeserver.
+    client: RwLock<Option<Client>>,
+    /// Details about the currently configured homeserver.
+    homeserver_details: RwLock<Option<HomeserverLoginDetails>>,
+    /// Metadata about the current client that will be used for dynamic OIDC
+    /// client registration and likely shown to the user during login.
+    #[cfg(feature = "experimental-oidc")]
+    oidc_client_metadata: Option<ClientMetadata>,
+    /// Any static client registrations that have been made for this client
+    /// against particular authentication issuers.
+    #[cfg(feature = "experimental-oidc")]
+    oidc_static_registrations: HashMap<Url, ClientId>,
+    /// A sliding sync proxy URL that will override any proxy discovered from
+    /// the homeserver. Setting this value allows you to use a proxy against a
+    /// homeserver that hasn't yet been configured with one.
+    #[cfg(feature = "experimental-sliding-sync")]
+    pub custom_sliding_sync_proxy: RwLock<Option<String>>,
+}
+
+impl Debug for AuthenticationService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthenticationService")
+            .field("homeserver_details", &self.homeserver_details)
+            .finish()
+    }
+}
+
+/// Errors related to authentication through the `AuthenticationService`.
+#[derive(Debug, thiserror::Error)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error), uniffi(flat_error))]
+pub enum AuthenticationError {
+    /// Developer error, the call made on the service has been performed before
+    /// the service has been configured with a homeserver.
+    #[error("A successful call to configure_homeserver must be made first.")]
+    ClientMissing,
+    /// The supplied string couldn't be parsed as either a server name or a
+    /// homeserver URL.
+    #[error("Failed to construct a server name or homeserver URL: {message}")]
+    InvalidServerName {
+        /// The underlying error message.
+        message: String,
+    },
+    /// Sliding sync is required, but isn't configured in the homeserver's
+    /// well-known file.
+    #[error("The homeserver doesn't provide a trusted sliding sync proxy in its well-known configuration.")]
+    SlidingSyncNotAvailable,
+    /// An error occurred whilst trying to use the supplied base path.
+    #[error("Failed to use the supplied base path.")]
+    InvalidBasePath,
+    /// Developer error, attempting to use OIDC when the homeserver doesn't
+    /// support it.
+    #[error(
+        "The homeserver doesn't provide an authentication issuer in its well-known configuration."
+    )]
+    OidcNotSupported,
+    /// Developer error, attempting to use OIDC without supplying the relevant
+    /// client metadata.
+    #[error("Unable to use OIDC as no client metadata has been supplied.")]
+    OidcMetadataMissing,
+    /// Failed to validate the supplied OIDC metadata.
+    #[error("Unable to use OIDC as the supplied client metadata is invalid.")]
+    OidcMetadataInvalid,
+    /// Failed to complete OIDC login due to an invalid callback URL.
+    #[error("The supplied callback URL used to complete OIDC is invalid.")]
+    OidcCallbackUrlInvalid,
+    /// The OIDC login was cancelled by the user.
+    #[error("The OIDC login was cancelled by the user.")]
+    OidcCancelled,
+    /// An unknown error occurred whilst trying to use OIDC.
+    #[error("An error occurred with OIDC: {message}")]
+    OidcError {
+        /// The underlying error message.
+        message: String,
+    },
+    /// An unknown error occurred.
+    #[error("An error occurred: {message}")]
+    Generic {
+        /// The underlying error message.
+        message: String,
+    },
+}
+
+#[cfg(feature = "uniffi")]
+impl From<anyhow::Error> for AuthenticationError {
+    fn from(e: anyhow::Error) -> AuthenticationError {
+        AuthenticationError::Generic { message: e.to_string() }
+    }
+}
+
+impl From<IdParseError> for AuthenticationError {
+    fn from(e: IdParseError) -> AuthenticationError {
+        AuthenticationError::InvalidServerName { message: e.to_string() }
+    }
+}
+
+#[cfg(feature = "experimental-oidc")]
+impl From<OidcRegistrationsError> for AuthenticationError {
+    fn from(e: OidcRegistrationsError) -> AuthenticationError {
+        match e {
+            OidcRegistrationsError::InvalidBasePath => AuthenticationError::InvalidBasePath,
+            _ => AuthenticationError::OidcError { message: e.to_string() },
+        }
+    }
+}
+
+#[cfg(feature = "experimental-oidc")]
+impl From<OidcError> for AuthenticationError {
+    fn from(e: OidcError) -> AuthenticationError {
+        AuthenticationError::OidcError { message: e.to_string() }
+    }
+}
+
+/// Details about a homeserver's login capabilities.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
+pub struct HomeserverLoginDetails {
+    /// The URL of the homeserver.
+    pub url: Url,
+    /// Whether the homeserver supports login using OIDC as defined by MSC3861.
+    #[cfg(feature = "experimental-oidc")]
+    pub supports_oidc_login: bool,
+    /// Whether the homeserver supports the password login flow.
+    pub supports_password_login: bool,
+}
+
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
+impl HomeserverLoginDetails {
+    /// The URL of the homeserver.
+    pub fn url(&self) -> String {
+        self.url.to_string()
+    }
+
+    /// Whether the homeserver supports login using OIDC as defined by MSC3861.
+    #[cfg(feature = "experimental-oidc")]
+    pub fn supports_oidc_login(&self) -> bool {
+        self.supports_oidc_login
+    }
+
+    /// Whether the homeserver supports the password login flow.
+    pub fn supports_password_login(&self) -> bool {
+        self.supports_password_login
+    }
+}
+
+impl AuthenticationService {
+    /// Creates a new service to authenticate a user with.
+    pub fn new(
+        base_path: PathBuf,
+        user_agent: Option<String>,
+        #[cfg(feature = "experimental-oidc")] oidc_client_metadata: Option<ClientMetadata>,
+        #[cfg(feature = "experimental-oidc")] oidc_static_registrations: HashMap<Url, ClientId>,
+        #[cfg(feature = "experimental-sliding-sync")] custom_sliding_sync_proxy: Option<String>,
+    ) -> Self {
+        AuthenticationService {
+            base_path,
+            user_agent,
+            client: RwLock::new(None),
+            homeserver_details: RwLock::new(None),
+            #[cfg(feature = "experimental-oidc")]
+            oidc_client_metadata,
+            #[cfg(feature = "experimental-oidc")]
+            oidc_static_registrations,
+            #[cfg(feature = "experimental-sliding-sync")]
+            custom_sliding_sync_proxy: RwLock::new(custom_sliding_sync_proxy),
+        }
+    }
+
+    /// Returns the homeserver details for the currently configured homeserver,
+    /// or `None` if a successful call to `configure_homeserver` is yet to be
+    /// made.
+    pub fn homeserver_details(&self) -> Option<HomeserverLoginDetails> {
+        self.homeserver_details.read().unwrap().clone()
+    }
+
+    /// Updates the service to authenticate with the homeserver for the
+    /// specified address.
+    pub async fn configure_homeserver(
+        &self,
+        server_name_or_homeserver_url: String,
+    ) -> Result<(), AuthenticationError> {
+        let mut builder = self.new_client_builder();
+
+        // Attempt discovery as a server name first.
+        let result = sanitize_server_name(&server_name_or_homeserver_url);
+
+        match result {
+            Ok(server_name) => {
+                if server_name_or_homeserver_url.starts_with("http://") {
+                    builder = builder.insecure_server_name_no_tls(&server_name);
+                } else {
+                    builder = builder.server_name(&server_name);
+                }
+            }
+
+            Err(e) => {
+                // When the input isn't a valid server name check it is a URL.
+                // If this is the case, build the client with a homeserver URL.
+                if Url::parse(&server_name_or_homeserver_url).is_ok() {
+                    builder = builder.homeserver_url(server_name_or_homeserver_url.clone());
+                } else {
+                    return Err(e.into());
+                }
+            }
+        }
+
+        let client = match builder.build().await {
+            Ok(client) => Ok(client),
+            Err(e) => {
+                if !server_name_or_homeserver_url.starts_with("http://")
+                    && !server_name_or_homeserver_url.starts_with("https://")
+                {
+                    Err(e)
+                } else {
+                    // When discovery fails, fallback to the homeserver URL if supplied.
+                    let mut builder = self.new_client_builder();
+                    builder = builder.homeserver_url(server_name_or_homeserver_url);
+                    builder.build().await
+                }
+            }
+        }
+        .map_err(|e| AuthenticationError::Generic { message: e.to_string() })?;
+
+        let details = self.details_from_client(&client).await?;
+
+        // Now we've verified that it's a valid homeserver, make sure
+        // there's a sliding sync proxy available one way or another.
+        #[cfg(feature = "experimental-sliding-sync")]
+        if self.custom_sliding_sync_proxy.read().unwrap().is_none()
+            && client.sliding_sync_proxy().is_none()
+        {
+            return Err(AuthenticationError::SlidingSyncNotAvailable);
+        }
+
+        *self.client.write().unwrap() = Some(client);
+        *self.homeserver_details.write().unwrap() = Some(details);
+
+        Ok(())
+    }
+
+    /// Performs a password login using the current homeserver.
+    pub async fn login(
+        &self,
+        username: String,
+        password: String,
+        initial_device_name: Option<String>,
+        device_id: Option<String>,
+    ) -> Result<Client, AuthenticationError> {
+        let Some(client) = self.client.read().unwrap().clone() else {
+            return Err(AuthenticationError::ClientMissing);
+        };
+
+        // Login and ask the server for the full user ID as this could be different from
+        // the username that was entered.
+        client
+            .login(username, password, initial_device_name, device_id)
+            .await
+            .map_err(|e| AuthenticationError::Generic { message: e.to_string() })?;
+
+        Ok(client)
+    }
+
+    /// Requests the URL needed for login in a web view using OIDC. Once the web
+    /// view has succeeded, call `login_with_oidc_callback` with the callback it
+    /// returns.
+    #[cfg(feature = "experimental-oidc")]
+    pub async fn url_for_oidc_login(&self) -> Result<OidcAuthorizationData, AuthenticationError> {
+        let Some(client) = self.client.read().unwrap().clone() else {
+            return Err(AuthenticationError::ClientMissing);
+        };
+        let oidc = client.oidc();
+
+        let Some(authentication_server) = oidc.authentication_server_info() else {
+            return Err(AuthenticationError::OidcNotSupported);
+        };
+
+        let Some(oidc_client_metadata) = &self.oidc_client_metadata else {
+            return Err(AuthenticationError::OidcMetadataMissing);
+        };
+
+        let Some(redirect_uris) = &oidc_client_metadata.redirect_uris else {
+            return Err(AuthenticationError::OidcMetadataInvalid);
+        };
+        let Some(redirect_url) = redirect_uris.first() else {
+            return Err(AuthenticationError::OidcMetadataInvalid);
+        };
+
+        self.configure_oidc(&oidc, authentication_server, oidc_client_metadata.clone()).await?;
+
+        let mut data_builder = oidc.login(redirect_url.clone(), None)?;
+        // TODO: Add a check for the Consent prompt when MAS is updated.
+        data_builder = data_builder.prompt(vec![Prompt::Consent]);
+        let data = data_builder.build().await?;
+
+        Ok(data)
+    }
+
+    /// Completes the OIDC login process.
+    #[cfg(feature = "experimental-oidc")]
+    pub async fn login_with_oidc_callback(
+        &self,
+        authentication_data: OidcAuthorizationData,
+        callback_url: Url,
+    ) -> Result<Client, AuthenticationError> {
+        let Some(client) = self.client.read().unwrap().clone() else {
+            return Err(AuthenticationError::ClientMissing);
+        };
+
+        let oidc = client.oidc();
+
+        let response = AuthorizationResponse::parse_uri(&callback_url)
+            .map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
+
+        let code = match response {
+            AuthorizationResponse::Success(code) => code,
+            AuthorizationResponse::Error(err) => {
+                if err.error.error == AccessDenied {
+                    // The user cancelled the login in the web view.
+                    return Err(AuthenticationError::OidcCancelled);
+                }
+                return Err(AuthenticationError::OidcError {
+                    message: err.error.error.to_string(),
+                });
+            }
+        };
+
+        if code.state != authentication_data.state {
+            return Err(AuthenticationError::OidcCallbackUrlInvalid);
+        };
+
+        oidc.finish_authorization(code).await?;
+
+        oidc.finish_login()
+            .await
+            .map_err(|e| AuthenticationError::OidcError { message: e.to_string() })?;
+
+        Ok(client)
+    }
+}
+
+// TODO: Is it normal to split up the implementation into public and private
+// like this?
+impl AuthenticationService {
+    /// A new client builder pre-configured with a user agent if specified
+    fn new_client_builder(&self) -> ClientBuilder {
+        let mut builder = ClientBuilder::new();
+
+        if let Some(user_agent) = self.user_agent.clone() {
+            builder = builder.user_agent(user_agent);
+        }
+
+        builder
+    }
+
+    /// Get the homeserver login details from a client.
+    async fn details_from_client(
+        &self,
+        client: &Client,
+    ) -> Result<HomeserverLoginDetails, AuthenticationError> {
+        #[cfg(feature = "experimental-oidc")]
+        let supports_oidc_login = client.oidc().authentication_server_info().is_some();
+        let supports_password_login = client.supports_password_login().await.ok().unwrap_or(false);
+        let url = client.homeserver();
+
+        Ok(HomeserverLoginDetails {
+            url,
+            #[cfg(feature = "experimental-oidc")]
+            supports_oidc_login,
+            supports_password_login,
+        })
+    }
+
+    /// Handle any necessary configuration in order for login via OIDC to
+    /// succeed. This includes performing dynamic client registration against
+    /// the homeserver's issuer or restoring a previous registration if one has
+    /// been stored.
+    #[cfg(feature = "experimental-oidc")]
+    async fn configure_oidc(
+        &self,
+        oidc: &Oidc,
+        authentication_server: &AuthenticationServerInfo,
+        oidc_metadata: ClientMetadata,
+    ) -> Result<(), AuthenticationError> {
+        if oidc.client_credentials().is_some() {
+            tracing::info!("OIDC is already configured.");
+            return Ok(());
+        };
+
+        let oidc_metadata =
+            oidc_metadata.validate().map_err(|_| AuthenticationError::OidcMetadataInvalid)?;
+
+        if self.load_client_registration(oidc, authentication_server, oidc_metadata.clone()).await {
+            tracing::info!("OIDC configuration loaded from disk.");
+            return Ok(());
+        }
+
+        tracing::info!("Registering this client for OIDC.");
+        let registration_response = oidc
+            .register_client(&authentication_server.issuer, oidc_metadata.clone(), None)
+            .await?;
+
+        // The format of the credentials changes according to the client metadata that
+        // was sent. Public clients only get a client ID.
+        let credentials =
+            ClientCredentials::None { client_id: registration_response.client_id.clone() };
+        oidc.restore_registered_client(authentication_server.clone(), oidc_metadata, credentials);
+
+        tracing::info!("Persisting OIDC registration data.");
+        self.store_client_registration(oidc).await?;
+
+        Ok(())
+    }
+
+    /// Stores the current OIDC dynamic client registration so it can be re-used
+    /// if we ever log in via the same issuer again.
+    #[cfg(feature = "experimental-oidc")]
+    async fn store_client_registration(&self, oidc: &Oidc) -> Result<(), AuthenticationError> {
+        let issuer = Url::parse(oidc.issuer().ok_or(AuthenticationError::OidcNotSupported)?)
+            .map_err(|_| AuthenticationError::OidcError {
+                message: String::from("Failed to parse issuer URL."),
+            })?;
+        let client_id = oidc
+            .client_credentials()
+            .ok_or(AuthenticationError::OidcError {
+                message: String::from("Missing client registration."),
+            })?
+            .client_id()
+            .to_owned();
+
+        let metadata = oidc.client_metadata().ok_or(AuthenticationError::OidcError {
+            message: String::from("Missing client metadata."),
+        })?;
+
+        let registrations = OidcRegistrations::new(
+            &self.base_path,
+            metadata.clone(),
+            self.oidc_static_registrations.clone(),
+        )?;
+        registrations.set_and_write_client_id(ClientId(client_id), issuer)?;
+
+        Ok(())
+    }
+
+    /// Attempts to load an existing OIDC dynamic client registration for the
+    /// currently configured issuer.
+    #[cfg(feature = "experimental-oidc")]
+    async fn load_client_registration(
+        &self,
+        oidc: &Oidc,
+        authentication_server: &AuthenticationServerInfo,
+        oidc_metadata: VerifiedClientMetadata,
+    ) -> bool {
+        let Ok(issuer) = Url::parse(&authentication_server.issuer) else {
+            tracing::error!("Failed to parse {:?}", authentication_server.issuer);
+            return false;
+        };
+        let Some(registrations) = OidcRegistrations::new(
+            &self.base_path,
+            oidc_metadata.clone(),
+            self.oidc_static_registrations.clone(),
+        )
+        .ok() else {
+            return false;
+        };
+        let Some(client_id) = registrations.client_id(&issuer) else {
+            return false;
+        };
+
+        oidc.restore_registered_client(
+            authentication_server.clone(),
+            oidc_metadata,
+            ClientCredentials::None { client_id: client_id.0 },
+        );
+
+        true
+    }
+}
+
+trait ClientExt {
+    /// Whether or not the client's homeserver supports the password login flow.
+    async fn supports_password_login(&self) -> crate::Result<bool>;
+    /// Login using a username and password.
+    async fn login(
+        &self,
+        username: String,
+        password: String,
+        initial_device_name: Option<String>,
+        device_id: Option<String>,
+    ) -> crate::Result<()>;
+}
+
+impl ClientExt for Client {
+    async fn supports_password_login(&self) -> crate::Result<bool> {
+        let login_types = self.matrix_auth().get_login_types().await?;
+        let supports_password = login_types
+            .flows
+            .iter()
+            .any(|login_type| matches!(login_type, get_login_types::v3::LoginType::Password(_)));
+        Ok(supports_password)
+    }
+
+    async fn login(
+        &self,
+        username: String,
+        password: String,
+        initial_device_name: Option<String>,
+        device_id: Option<String>,
+    ) -> crate::Result<()> {
+        let mut builder = self.matrix_auth().login_username(&username, &password);
+        if let Some(initial_device_name) = initial_device_name.as_ref() {
+            builder = builder.initial_device_display_name(initial_device_name);
+        }
+        if let Some(device_id) = device_id.as_ref() {
+            builder = builder.device_id(device_id);
+        }
+        builder.send().await?;
+        Ok(())
+    }
+}

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -520,7 +520,7 @@ async fn build_indexeddb_store_config(
 }
 
 #[derive(Clone, Copy, Debug)]
-enum UrlScheme {
+pub(crate) enum UrlScheme {
     Http,
     Https,
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -94,7 +94,7 @@ use crate::{
     store_locks::CrossProcessStoreLock,
 };
 
-mod builder;
+pub(crate) mod builder;
 pub(crate) mod futures;
 #[cfg(feature = "e2e-encryption")]
 mod tasks;

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -32,7 +32,7 @@ pub use reqwest;
 
 mod account;
 pub mod attachment;
-mod authentication;
+pub mod authentication;
 mod client;
 pub mod config;
 mod deduplicating_handler;

--- a/crates/matrix-sdk/src/oidc/backend/mock.rs
+++ b/crates/matrix-sdk/src/oidc/backend/mock.rs
@@ -117,7 +117,9 @@ impl OidcBackend for MockImpl {
         issuer: &str,
         insecure: bool,
     ) -> Result<VerifiedProviderMetadata, OidcError> {
-        if insecure != self.is_insecure {
+        // There isn't a UrlNonHttpScheme error, so it's a good enough approximation to
+        // only throw when expecting a secure connection, but getting an insecure one.
+        if !insecure && self.is_insecure {
             return Err(OidcError::Oidc(Discovery(DiscoveryError::Validation(
                 ProviderMetadataVerificationError::UrlNonHttpsScheme(
                     "mocking backend",

--- a/crates/matrix-sdk/src/oidc/backend/mod.rs
+++ b/crates/matrix-sdk/src/oidc/backend/mod.rs
@@ -41,7 +41,7 @@ pub(super) struct RefreshedSessionTokens {
 }
 
 #[async_trait::async_trait]
-pub(super) trait OidcBackend: std::fmt::Debug + Send + Sync {
+pub(crate) trait OidcBackend: std::fmt::Debug + Send + Sync {
     async fn discover(
         &self,
         issuer: &str,

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -194,13 +194,16 @@ use tracing::{error, trace, warn};
 use url::Url;
 
 mod auth_code_builder;
+#[cfg(not(test))]
 mod backend;
+#[cfg(test)]
+pub(crate) mod backend;
 mod cross_process;
 mod data_serde;
 mod end_session_builder;
 pub mod registrations;
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 pub use self::{
     auth_code_builder::{OidcAuthCodeUrlBuilder, OidcAuthorizationData},
@@ -267,10 +270,10 @@ impl fmt::Debug for OidcAuthData {
 #[derive(Debug, Clone)]
 pub struct Oidc {
     /// The underlying Matrix API client.
-    client: Client,
+    pub(crate) client: Client, // TODO: This is bad…
 
     /// The implementation of the OIDC backend.
-    backend: Arc<dyn OidcBackend>,
+    pub(crate) backend: Arc<dyn OidcBackend>, // TODO: This is also bad
 }
 
 impl Oidc {


### PR DESCRIPTION
This PR moves the AuthenticationService from the FFI into the SDK crate and transforms the FFI layer into a light wrapping around it. Closes #3029.

It would be best to review this PR commit by commit.

**Todo**
- [x] Add tests for existing functionality
- [ ] Consider what we should do with `finalise_client` in the FFI (given the FFI builder is somewhat different to the SDK builder).
- [ ] Expose some of the common configuration errors we've seen in the community to improve the error messages in Element X - possibly this is a separate PR, I'll see based on writing tests.