### PR TITLE
sliding sync: change read receipts update strategy + take sync lock during response processing

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -38,7 +38,7 @@ use crate::RoomMemberships;
 use crate::{
     deserialized_responses::AmbiguityChanges,
     error::Result,
-    read_receipts::{compute_notifications, PreviousEventsProvider},
+    read_receipts::{compute_unread_counts, PreviousEventsProvider},
     rooms::RoomState,
     store::{ambiguity_map::AmbiguityCache, StateChanges, Store},
     sync::{JoinedRoom, LeftRoom, Notification, Rooms, SyncResponse},
@@ -230,7 +230,7 @@ impl BaseClient {
                 .cloned()
                 .or_else(|| self.get_room(room_id).map(|r| r.clone_info()))
             {
-                if compute_notifications(
+                if compute_unread_counts(
                     user_id,
                     room_id,
                     changes.receipts.get(room_id),

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -230,14 +230,18 @@ impl BaseClient {
                 .cloned()
                 .or_else(|| self.get_room(room_id).map(|r| r.clone_info()))
             {
-                if compute_unread_counts(
+                let prev_read_receipts = room_info.read_receipts.clone();
+
+                compute_unread_counts(
                     user_id,
                     room_id,
                     changes.receipts.get(room_id),
                     previous_events_provider.for_room(room_id),
                     &joined_room_update.timeline.events,
                     &mut room_info.read_receipts,
-                )? {
+                );
+
+                if prev_read_receipts != room_info.read_receipts {
                     changes.add_room(room_info);
                 }
             }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -326,6 +326,10 @@ impl SlidingSync {
         // happens here.
 
         let mut sync_response = {
+            // Take the lock to avoid concurrent sliding syncs overwriting each other's room
+            // infos.
+            let _sync_lock = self.inner.client.base_client().sync_lock().write().await;
+
             let rooms = &*self.inner.rooms.read().await;
             let mut response_processor =
                 SlidingSyncResponseProcessor::new(self.inner.client.clone(), rooms);


### PR DESCRIPTION
- Renamed `compute_notifications` to `compute_unread_counts`, because that's really what this function does. It doesn't generate any new notifications, it computes how many unread messages/notifications/messages there are for a room.
- Changed the strategy to decide whether we need to update a `RoomReadReceipt` after calling `compute_unread_counts`, to let `PartialEq` do the hard work, and not rely on the explicit, error-prone signalling of updates (which was still buggy).
- We're not taking the sync write lock when processing the sliding sync response. @timokoesters has noticed it was an issue in the past for the latest event, and I wonder if `RoomReadReceipt` may be overwritten by the concurrent e2ee sliding sync, so fixing it here now.