### PR TITLE
ffi: Use Android Cleaner implementation if possible

### DIFF
--- a/bindings/matrix-sdk-ffi/uniffi.toml
+++ b/bindings/matrix-sdk-ffi/uniffi.toml
@@ -1,3 +1,4 @@
 [bindings.kotlin]
 package_name = "org.matrix.rustcomponents.sdk"
 cdylib_name = "matrix_sdk_ffi"
+android_cleaner = true


### PR DESCRIPTION
Note that this breaks compatibility with pure JVM environments, meaning the Kotlin library can only be used in Android.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
