### PR TITLE
read receipts: handle implicit receipts for unread counts

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -1066,9 +1066,11 @@ impl TimelineInner {
                 if let Some((old_pub_read, _)) =
                     state.user_receipt(own_user_id, ReceiptType::Read, room).await
                 {
+                    trace!(%old_pub_read, "found a previous public receipt");
                     if let Some(relative_pos) =
                         state.meta.compare_events_positions(&old_pub_read, event_id)
                     {
+                        trace!("event referred to new receipt is {relative_pos:?} the previous receipt");
                         return relative_pos == RelativePosition::After;
                     }
                 }
@@ -1079,9 +1081,11 @@ impl TimelineInner {
                 if let Some((old_priv_read, _)) =
                     state.latest_user_read_receipt(own_user_id, room).await
                 {
+                    trace!(%old_priv_read, "found a previous private receipt");
                     if let Some(relative_pos) =
                         state.meta.compare_events_positions(&old_priv_read, event_id)
                     {
+                        trace!("event referred to new receipt is {relative_pos:?} the previous receipt");
                         return relative_pos == RelativePosition::After;
                     }
                 }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -56,7 +56,7 @@ use ruma::{
 };
 use thiserror::Error;
 use tokio::sync::{mpsc::Sender, Mutex, Notify};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 use self::futures::SendAttachment;
 
@@ -708,9 +708,13 @@ impl Timeline {
         event_id: OwnedEventId,
     ) -> Result<bool> {
         if !self.inner.should_send_receipt(&receipt_type, &thread, &event_id).await {
+            trace!(
+                "not sending receipt, because we already cover the event with a previous receipt"
+            );
             return Ok(false);
         }
 
+        trace!("sending receipt");
         self.room().send_single_receipt(receipt_type, thread, event_id).await?;
         Ok(true)
     }


### PR DESCRIPTION
Some clients, including the timeline code handling the *sending* of read receipts, have the notion of an implicit read receipt. Every event that you've sent yourself implies that you've read all the events prior to yours. Both parts of the code should align on when to send read receipts, since computing unread counts precisely relies on read receipts echoed back by the server otherwise. 

This patch adds a new method in the `ReceiptSelector`, to look for an implicit read receipt and use it, if found and it's the latest in sync order.

Also add lots of tracing `trace`-level logs for making remote debugging easier.