### PR TITLE
sdk: Add support for getting a room member's suggested role

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3024,6 +3024,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "uniffi",
  "url",
  "urlencoding",
  "uuid",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -69,6 +69,7 @@ features = [
     "rustls-tls", # note: differ from block below
     "socks",
     "sqlite",
+    "uniffi",
 ]
 
 [target.'cfg(not(target_os = "android"))'.dependencies.matrix-sdk]
@@ -83,4 +84,5 @@ features = [
     "native-tls", # note: differ from block above
     "socks",
     "sqlite",
+    "uniffi",
 ]

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -1,4 +1,4 @@
-use matrix_sdk::room::RoomMember as SdkRoomMember;
+use matrix_sdk::room::{RoomMember as SdkRoomMember, RoomMemberRole};
 
 use super::RUNTIME;
 use crate::ClientError;
@@ -71,6 +71,10 @@ impl RoomMember {
 
     pub fn power_level(&self) -> i64 {
         self.inner.power_level()
+    }
+
+    pub fn suggested_role_for_power_level(&self) -> RoomMemberRole {
+        self.inner.suggested_role_for_power_level()
     }
 
     pub fn normalized_power_level(&self) -> i64 {

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -41,6 +41,8 @@ sso-login = ["dep:hyper", "dep:rand", "dep:tower"]
 image-proc = ["dep:image"]
 image-rayon = ["image-proc", "image?/jpeg_rayon"]
 
+uniffi = ["dep:uniffi"]
+
 experimental-oidc = [
     "ruma/unstable-msc2967",
     "dep:chrono",
@@ -101,6 +103,7 @@ thiserror = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = { workspace = true, features = ["attributes"] }
+uniffi = { workspace = true, optional = true }
 url = "2.2.2"
 urlencoding = "2.1.3"
 uuid = { version = "1.4.1", features = ["serde", "v4"], optional = true }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -82,6 +82,9 @@ pub use sliding_sync::{
     SlidingSyncListLoadingState, SlidingSyncMode, SlidingSyncRoom, UpdateSummary,
 };
 
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -89,7 +89,7 @@ mod member;
 mod messages;
 
 pub use self::{
-    member::RoomMember,
+    member::{RoomMember, RoomMemberRole},
     messages::{Messages, MessagesOptions},
 };
 


### PR DESCRIPTION
https://github.com/matrix-org/matrix-rust-sdk/issues/3033

This PR adds the suggested mapping in the [spec](https://spec.matrix.org/v1.9/client-server-api/#permissions) for power levels to a new enum so we can share the logic to figure out who is an admin, mod or regular member within a room.

In order to do this, I've added uniffi to the SDK crate like we already did for the UI crate.