### PR TITLE
event graph: add an initial implementation

### DIFF
--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -4,7 +4,10 @@ use matrix_sdk::{
     self, encryption::CryptoStoreError, oidc::OidcError, HttpError, IdParseError,
     NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
-use matrix_sdk_ui::{encryption_sync_service, notification_client, sync_service, timeline};
+use matrix_sdk_ui::{
+    encryption_sync_service, event_graph::EventGraphError, notification_client, sync_service,
+    timeline,
+};
 use uniffi::UnexpectedUniFFICallbackError;
 
 #[derive(Debug, thiserror::Error)]
@@ -111,6 +114,12 @@ impl From<OidcError> for ClientError {
 
 impl From<RoomError> for ClientError {
     fn from(e: RoomError) -> Self {
+        Self::new(e)
+    }
+}
+
+impl From<EventGraphError> for ClientError {
+    fn from(e: EventGraphError) -> Self {
         Self::new(e)
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -150,10 +150,6 @@ impl Room {
         }
     }
 
-    pub async fn poll_history(&self) -> Result<Arc<Timeline>, ClientError> {
-        Ok(Timeline::new(self.inner.poll_history().await?))
-    }
-
     pub fn display_name(&self) -> Result<String, ClientError> {
         let r = self.inner.clone();
         RUNTIME.block_on(async move { Ok(r.display_name().await?.to_string()) })

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -139,19 +139,19 @@ impl Room {
         }
     }
 
-    pub async fn timeline(&self) -> Arc<Timeline> {
+    pub async fn timeline(&self) -> Result<Arc<Timeline>, ClientError> {
         let mut write_guard = self.timeline.write().await;
         if let Some(timeline) = &*write_guard {
-            timeline.clone()
+            Ok(timeline.clone())
         } else {
-            let timeline = Timeline::new(self.inner.timeline().await);
+            let timeline = Timeline::new(self.inner.timeline().await?);
             *write_guard = Some(timeline.clone());
-            timeline
+            Ok(timeline)
         }
     }
 
-    pub async fn poll_history(&self) -> Arc<Timeline> {
-        Timeline::new(self.inner.poll_history().await)
+    pub async fn poll_history(&self) -> Result<Arc<Timeline>, ClientError> {
+        Ok(Timeline::new(self.inner.poll_history().await?))
     }
 
     pub fn display_name(&self) -> Result<String, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -473,6 +473,7 @@ impl RoomListItem {
     }
 
     /// Initializes the timeline for this room using the provided parameters.
+    ///
     /// * `event_type_filter` - An optional [`TimelineEventTypeFilter`] to be
     ///   used to filter timeline events besides the default timeline filter. If
     ///   `None` is passed, only the default timeline filter will be used.
@@ -480,7 +481,7 @@ impl RoomListItem {
         &self,
         event_type_filter: Option<Arc<TimelineEventTypeFilter>>,
     ) -> Result<(), RoomListError> {
-        let mut timeline_builder = self.inner.default_room_timeline_builder();
+        let mut timeline_builder = self.inner.default_room_timeline_builder().await;
         if let Some(event_type_filter) = event_type_filter {
             timeline_builder = timeline_builder.event_filter(move |event, room_version_id| {
                 // Always perform the default filter first

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -46,8 +46,8 @@ pub enum RoomListError {
     TimelineAlreadyExists { room_name: String },
     #[error("A timeline instance hasn't been initialized for room {room_name}")]
     TimelineNotInitialized { room_name: String },
-    #[error("Timeline couldn't be initialized: {message}")]
-    InitializingTimeline { message: String },
+    #[error("Timeline couldn't be initialized: {error}")]
+    InitializingTimeline { error: String },
 }
 
 impl From<matrix_sdk_ui::room_list_service::Error> for RoomListError {
@@ -63,7 +63,7 @@ impl From<matrix_sdk_ui::room_list_service::Error> for RoomListError {
                 Self::TimelineAlreadyExists { room_name: room_id.to_string() }
             }
             InitializingTimeline(source) => {
-                Self::InitializingTimeline { message: source.to_string() }
+                Self::InitializingTimeline { error: source.to_string() }
             }
         }
     }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -46,6 +46,8 @@ pub enum RoomListError {
     TimelineAlreadyExists { room_name: String },
     #[error("A timeline instance hasn't been initialized for room {room_name}")]
     TimelineNotInitialized { room_name: String },
+    #[error("Timeline couldn't be initialized: {message}")]
+    InitializingTimeline { message: String },
 }
 
 impl From<matrix_sdk_ui::room_list_service::Error> for RoomListError {
@@ -59,6 +61,9 @@ impl From<matrix_sdk_ui::room_list_service::Error> for RoomListError {
             RoomNotFound(room_id) => Self::RoomNotFound { room_name: room_id.to_string() },
             TimelineAlreadyExists(room_id) => {
                 Self::TimelineAlreadyExists { room_name: room_id.to_string() }
+            }
+            InitializingTimeline(source) => {
+                Self::InitializingTimeline { message: source.to_string() }
             }
         }
     }

--- a/crates/matrix-sdk-ui/src/event_graph.rs
+++ b/crates/matrix-sdk-ui/src/event_graph.rs
@@ -1,0 +1,377 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The event graph is an abstraction layer, sitting between the Rust SDK and a
+//! final client, that acts as a global observer of all the rooms, gathering and
+//! inferring some extra useful information about each room. In particular, this
+//! doesn't require subscribing to a specific room to get access to this
+//! information.
+//!
+//! It's intended to be fast, robust and easy to maintain.
+//!
+//! See the [github issue](https://github.com/matrix-org/matrix-rust-sdk/issues/3058) for more details about the historical reasons that led us to start writing this.
+//!
+//! Most of it is still a work-in-progress, as of 2024-01-22.
+//!
+//! The desired set of features it may eventually implement is the following:
+//!
+//! - [ ] compute proper unread room counts, and use backpagination to get
+//!   missing messages/notifications/mentions, if needs be.
+//! - [ ] expose that information with a new data structure similar to the
+//!   `RoomInfo`, and that may update a `RoomListService`.
+//! - [ ] provide read receipts for each message.
+//! - [ ] backwards and forward pagination, and reconcile results with cached
+//!   timelines.
+//! - [ ] retry decryption upon receiving new keys (from an encryption sync
+//!   service or from a key backup).
+//! - [ ] expose the latest event for a given room.
+//! - [ ] caching of events on-disk.
+
+#![forbid(missing_docs)]
+
+use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+
+use async_trait::async_trait;
+use matrix_sdk::{sync::RoomUpdate, Client, Room};
+use matrix_sdk_base::{
+    deserialized_responses::SyncTimelineEvent,
+    sync::{JoinedRoom, LeftRoom, Timeline},
+};
+use ruma::{
+    events::{AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent},
+    serde::Raw,
+    OwnedRoomId, RoomId,
+};
+use tokio::{
+    spawn,
+    sync::{
+        broadcast::{error::RecvError, Receiver, Sender},
+        RwLock,
+    },
+    task::JoinHandle,
+};
+use tracing::{debug, error, trace};
+
+/// An error observed in the `EventGraph`.
+#[derive(thiserror::Error, Debug)]
+pub enum EventGraphError {
+    /// A room hasn't been found, when trying to create a graph view for that
+    /// room.
+    #[error("Room with id {0} not found")]
+    RoomNotFound(OwnedRoomId),
+}
+
+/// A result using the [`EventGraphError`].
+pub type Result<T> = std::result::Result<T, EventGraphError>;
+
+/// Hold handles to the tasks spawn by a [`RoomEventGraph`].
+struct RoomGraphDropHandles {
+    listen_updates_task: JoinHandle<()>,
+}
+
+impl Drop for RoomGraphDropHandles {
+    fn drop(&mut self) {
+        self.listen_updates_task.abort();
+    }
+}
+
+/// An event graph, providing lots of useful functionality for clients.
+///
+/// See also the module-level comment.
+pub struct EventGraph {
+    /// Reference to the client used to navigate this graph.
+    client: Client,
+    /// Lazily-filled cache of live [`RoomEventGraph`], once per room.
+    by_room: BTreeMap<OwnedRoomId, RoomEventGraph>,
+    /// Backend used for storage.
+    store: Arc<dyn EventGraphStore>,
+}
+
+impl Debug for EventGraph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventGraph").finish_non_exhaustive()
+    }
+}
+
+impl EventGraph {
+    /// Create a new [`EventGraph`] for the given client.
+    pub fn new(client: Client) -> Self {
+        let store = Arc::new(MemoryStore::new());
+        Self { client, by_room: Default::default(), store }
+    }
+
+    /// Return a room-specific view over the [`EventGraph`].
+    ///
+    /// It may not be found, if the room isn't known to the client.
+    pub fn for_room(&mut self, room_id: &RoomId) -> Option<RoomEventGraph> {
+        match self.by_room.get(room_id) {
+            Some(room) => Some(room.clone()),
+            None => {
+                let room = self.client.get_room(room_id)?;
+                let room_event_graph = RoomEventGraph::new(room, self.store.clone());
+                self.by_room.insert(room_id.to_owned(), room_event_graph.clone());
+                Some(room_event_graph)
+            }
+        }
+    }
+
+    /// Add an initial set of events to the event graph, reloaded from a cache.
+    ///
+    /// TODO: temporary for API compat, as the event graph should take care of
+    /// its own cache.
+    pub async fn add_initial_events(
+        &mut self,
+        room_id: &RoomId,
+        events: Vec<SyncTimelineEvent>,
+    ) -> Result<()> {
+        let room_graph = self
+            .for_room(room_id)
+            .ok_or_else(|| EventGraphError::RoomNotFound(room_id.to_owned()))?;
+        room_graph.inner.append_events(events).await?;
+        Ok(())
+    }
+}
+
+/// A store that can be remember information about the event graph.
+///
+/// It really acts as a cache, in the sense that clearing the backing data
+/// should not have any irremediable effect, other than providing a lesser user
+/// experience.
+#[async_trait]
+pub trait EventGraphStore: Send + Sync {
+    /// Returns all the known events for the given room.
+    async fn room_events(&self, room: &RoomId) -> Result<Vec<SyncTimelineEvent>>;
+
+    /// Adds all the events to the given room.
+    async fn add_room_events(&self, room: &RoomId, events: Vec<SyncTimelineEvent>) -> Result<()>;
+
+    /// Clear all the events from the given room.
+    async fn clear_room_events(&self, room: &RoomId) -> Result<()>;
+}
+
+struct MemoryStore {
+    /// All the events per room, in sync order.
+    by_room: RwLock<BTreeMap<OwnedRoomId, Vec<SyncTimelineEvent>>>,
+}
+
+impl MemoryStore {
+    fn new() -> Self {
+        Self { by_room: Default::default() }
+    }
+}
+
+#[async_trait]
+impl EventGraphStore for MemoryStore {
+    async fn room_events(&self, room: &RoomId) -> Result<Vec<SyncTimelineEvent>> {
+        Ok(self.by_room.read().await.get(room).cloned().unwrap_or_default())
+    }
+
+    async fn add_room_events(&self, room: &RoomId, events: Vec<SyncTimelineEvent>) -> Result<()> {
+        self.by_room.write().await.entry(room.to_owned()).or_default().extend(events);
+        Ok(())
+    }
+
+    async fn clear_room_events(&self, room: &RoomId) -> Result<()> {
+        let _ = self.by_room.write().await.remove(room);
+        Ok(())
+    }
+}
+
+/// A subset of an event graph, for a room.
+///
+/// Cloning is shallow, and thus is cheap to do.
+#[derive(Clone)]
+pub struct RoomEventGraph {
+    inner: Arc<RoomEventGraphInner>,
+
+    _drop_handles: Arc<RoomGraphDropHandles>,
+}
+
+impl Debug for RoomEventGraph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RoomEventGraph").finish_non_exhaustive()
+    }
+}
+
+impl RoomEventGraph {
+    /// Create a new [`RoomEventGraph`] using the given room and store.
+    fn new(room: Room, store: Arc<dyn EventGraphStore>) -> Self {
+        let (inner, drop_handles) = RoomEventGraphInner::new(room, store);
+        Self { inner, _drop_handles: drop_handles }
+    }
+
+    /// Subscribe to room updates for this room, after getting the initial list
+    /// of events. XXX: Could/should it use some kind of `Observable`
+    /// instead? Or not something async, like explicit handlers as our event
+    /// handlers?
+    pub async fn subscribe(
+        &self,
+    ) -> Result<(Vec<SyncTimelineEvent>, Receiver<RoomEventGraphUpdate>)> {
+        Ok((
+            self.inner.store.room_events(self.inner.room.room_id()).await?,
+            self.inner.sender.subscribe(),
+        ))
+    }
+}
+
+struct RoomEventGraphInner {
+    sender: Sender<RoomEventGraphUpdate>,
+    store: Arc<dyn EventGraphStore>,
+    room: Room,
+}
+
+impl RoomEventGraphInner {
+    /// Creates a new graph for a room, and subscribes to room updates., so as
+    /// to handle new timeline events.
+    fn new(room: Room, store: Arc<dyn EventGraphStore>) -> (Arc<Self>, Arc<RoomGraphDropHandles>) {
+        let sender = Sender::new(32);
+
+        let room_graph = Arc::new(Self { room, store, sender });
+
+        let listen_updates_task = spawn(Self::listen_task(room_graph.clone()));
+
+        (room_graph, Arc::new(RoomGraphDropHandles { listen_updates_task }))
+    }
+
+    async fn handle_joined_room_update(&self, updates: JoinedRoom) -> Result<()> {
+        self.handle_timeline(updates.timeline, updates.ephemeral.clone(), updates.account_data)
+            .await?;
+        Ok(())
+    }
+
+    async fn handle_timeline(
+        &self,
+        timeline: Timeline,
+        ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
+    ) -> Result<()> {
+        let room_id = self.room.room_id();
+
+        if timeline.limited {
+            // Ideally we'd try to reconcile existing events against those received in the
+            // timeline, but we're not there yet. In the meanwhile, clear the
+            // items from the room. TODO: implement Smart Matching™.
+            trace!("limited timeline, clearing all previous events");
+            self.store.clear_room_events(room_id).await?;
+            let _ = self.sender.send(RoomEventGraphUpdate::Clear);
+        }
+
+        // Add all the events to the backend.
+        trace!("adding new events");
+        self.store.add_room_events(room_id, timeline.events.clone()).await?;
+
+        // Propagate events to observers.
+        let _ = self.sender.send(RoomEventGraphUpdate::Append {
+            events: timeline.events,
+            prev_batch: timeline.prev_batch,
+            ephemeral,
+            account_data,
+        });
+
+        Ok(())
+    }
+
+    async fn handle_left_room_update(&self, updates: LeftRoom) -> Result<()> {
+        self.handle_timeline(updates.timeline, Vec::new(), Vec::new()).await?;
+        Ok(())
+    }
+
+    async fn listen_task(this: Arc<Self>) {
+        // TODO for prototyping, i'm spawning a new task to get the room updates.
+        // Ideally we'd have something like the whole sync update, a generalisation of
+        // the room update.
+        trace!("Spawning the listen task");
+
+        let mut update_receiver = this.room.client().subscribe_to_room_updates(this.room.room_id());
+
+        loop {
+            match update_receiver.recv().await {
+                Ok(update) => {
+                    trace!("Listen task received an update");
+
+                    match update {
+                        RoomUpdate::Left { updates, .. } => {
+                            if let Err(err) = this.handle_left_room_update(updates).await {
+                                error!("handling left room update: {err}");
+                            }
+                        }
+                        RoomUpdate::Joined { updates, .. } => {
+                            if let Err(err) = this.handle_joined_room_update(updates).await {
+                                error!("handling joined room update: {err}");
+                            }
+                        }
+                        RoomUpdate::Invited { .. } => {
+                            // We don't do anything for invited rooms at this
+                            // point. TODO should
+                            // we?
+                        }
+                    }
+                }
+
+                Err(RecvError::Closed) => {
+                    // The loop terminated successfully.
+                    debug!("Listen task closed");
+                    break;
+                }
+
+                Err(RecvError::Lagged(_)) => {
+                    // Since we've lagged behind updates to this room, we might be out of
+                    // sync with the events, leading to potentially lost events. Play it
+                    // safe here, and clear the cache. It's fine because we can retrigger
+                    // backpagination from the last event at any time, if needs be.
+                    debug!("Listen task lagged, clearing room");
+                    if let Err(err) = this.store.clear_room_events(this.room.room_id()).await {
+                        error!("unable to clear room after room updates lag: {err}");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Append a set of events to the room graph and storage, notifying
+    /// observers.
+    async fn append_events(&self, events: Vec<SyncTimelineEvent>) -> Result<()> {
+        self.store.add_room_events(self.room.room_id(), events.clone()).await?;
+
+        let _ = self.sender.send(RoomEventGraphUpdate::Append {
+            events,
+            prev_batch: None,
+            account_data: Default::default(),
+            ephemeral: Default::default(),
+        });
+
+        Ok(())
+    }
+}
+
+/// An update related to events happened in a room.
+#[derive(Clone)]
+pub enum RoomEventGraphUpdate {
+    /// The room has been cleared from events.
+    Clear,
+    /// The room has new events.
+    Append {
+        /// All the new events that have been added to the room.
+        events: Vec<SyncTimelineEvent>,
+        /// XXX: this is temporary, until backpagination lives in the event
+        /// graph.
+        prev_batch: Option<String>,
+        /// XXX: this is temporary, until account data lives in the event graph
+        /// — or will it live there?
+        account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
+        /// XXX: this is temporary, until read receipts are handled in the event
+        /// graph
+        ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+    },
+}

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -17,6 +17,7 @@ use ruma::html::HtmlSanitizerMode;
 mod events;
 
 pub mod encryption_sync_service;
+pub mod event_graph;
 pub mod notification_client;
 pub mod room_list_service;
 pub mod sync_service;

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -95,6 +95,8 @@ use tokio::{
     time::timeout,
 };
 
+use crate::event_graph::EventGraphError;
+
 /// The [`RoomListService`] type. See the module's documentation to learn more.
 #[derive(Debug)]
 pub struct RoomListService {
@@ -509,6 +511,9 @@ pub enum Error {
 
     #[error("A timeline instance already exists for room {0}")]
     TimelineAlreadyExists(OwnedRoomId),
+
+    #[error("An error occurred while initializing the timeline")]
+    InitializingTimeline(#[source] EventGraphError),
 }
 
 /// An input for the [`RoomList`]' state machine.

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -134,7 +134,11 @@ impl Room {
         if self.inner.timeline.get().is_some() {
             Err(Error::TimelineAlreadyExists(self.inner.room.room_id().to_owned()))
         } else {
-            self.inner.timeline.get_or_init(async { Arc::new(builder.build().await) }).await;
+            self.inner
+                .timeline
+                .get_or_try_init(async { Ok(Arc::new(builder.build().await?)) })
+                .await
+                .map_err(Error::InitializingTimeline)?;
             Ok(())
         }
     }

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -174,12 +174,13 @@ impl Room {
     }
 
     /// Create a new [`TimelineBuilder`] with the default configuration.
-    pub fn default_room_timeline_builder(&self) -> TimelineBuilder {
+    pub async fn default_room_timeline_builder(&self) -> TimelineBuilder {
         Timeline::builder(&self.inner.room)
             .events(
                 self.inner.sliding_sync_room.prev_batch(),
                 self.inner.sliding_sync_room.timeline_queue(),
             )
+            .await
             .track_read_marker_and_receipts()
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -57,10 +57,11 @@ impl TimelineBuilder {
     }
 
     /// Add initial events to the timeline.
+    ///
     /// TODO: remove this, the EventGraph should hold the events data in the
     /// first place, and we'd provide an existing EventGraph to the
     /// TimelineBuilder.
-    pub(crate) async fn events(
+    pub async fn events(
         mut self,
         prev_token: Option<String>,
         events: Vector<SyncTimelineEvent>,
@@ -75,7 +76,7 @@ impl TimelineBuilder {
 
     /// Enable tracking of the fully-read marker and the read receipts on the
     /// timeline.
-    pub(crate) fn track_read_marker_and_receipts(mut self) -> Self {
+    pub fn track_read_marker_and_receipts(mut self) -> Self {
         self.settings.track_read_receipts = true;
         self
     }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -130,14 +130,11 @@ impl TimelineBuilder {
             prev_token = self.prev_token,
         )
     )]
-    pub async fn build(self) -> Timeline {
+    pub async fn build(self) -> crate::event_graph::Result<Timeline> {
         let Self { room, mut event_graph, prev_token, settings } = self;
 
-        let room_event_graph = event_graph.for_room(room.room_id()).expect("room exists");
-        let (events, mut event_subscriber) = room_event_graph
-            .subscribe()
-            .await
-            .expect("make this function fallible, or allow this for the time being?");
+        let room_event_graph = event_graph.for_room(room.room_id())?;
+        let (events, mut event_subscriber) = room_event_graph.subscribe().await?;
 
         let has_events = !events.is_empty();
         let track_read_marker_and_receipts = settings.track_read_receipts;
@@ -315,6 +312,6 @@ impl TimelineBuilder {
             timeline.retry_decryption_for_all_events().await;
         }
 
-        timeline
+        Ok(timeline)
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -29,7 +29,6 @@ use matrix_sdk::{
     sync::JoinedRoom,
     Error, Result, Room,
 };
-use matrix_sdk_base::sync::Timeline;
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
 #[cfg(all(test, feature = "e2e-encryption"))]
@@ -407,7 +406,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
     pub(super) async fn add_initial_events(
         &mut self,
-        events: Vector<SyncTimelineEvent>,
+        events: Vec<SyncTimelineEvent>,
         back_pagination_token: Option<String>,
     ) {
         if events.is_empty() {
@@ -432,11 +431,6 @@ impl<P: RoomDataProvider> TimelineInner<P> {
     pub(super) async fn handle_joined_room_update(&self, update: JoinedRoom) {
         let mut state = self.state.write().await;
         state.handle_joined_room_update(update, &self.room_data_provider, &self.settings).await;
-    }
-
-    pub(super) async fn handle_sync_timeline(&self, timeline: Timeline) {
-        let mut state = self.state.write().await;
-        state.handle_sync_timeline(timeline, &self.room_data_provider, &self.settings).await;
     }
 
     #[cfg(test)]

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -21,7 +21,6 @@ use std::{
 };
 
 use eyeball_im::{ObservableVector, ObservableVectorTransaction, ObservableVectorTransactionEntry};
-use imbl::Vector;
 use indexmap::IndexMap;
 use matrix_sdk::{deserialized_responses::SyncTimelineEvent, sync::Timeline};
 use matrix_sdk_base::{deserialized_responses::TimelineEvent, sync::JoinedRoom};
@@ -82,7 +81,7 @@ impl TimelineInnerState {
     #[tracing::instrument(skip_all)]
     pub(super) async fn add_initial_events<P: RoomDataProvider>(
         &mut self,
-        events: Vector<SyncTimelineEvent>,
+        events: Vec<SyncTimelineEvent>,
         mut back_pagination_token: Option<String>,
         room_data_provider: &P,
         settings: &TimelineInnerSettings,
@@ -108,17 +107,6 @@ impl TimelineInnerState {
                 }
             }
         }
-        txn.commit();
-    }
-
-    pub(super) async fn handle_sync_timeline<P: RoomDataProvider>(
-        &mut self,
-        timeline: Timeline,
-        room_data_provider: &P,
-        settings: &TimelineInnerSettings,
-    ) {
-        let mut txn = self.transaction();
-        txn.handle_sync_timeline(timeline, room_data_provider, settings).await;
         txn.commit();
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -144,7 +144,8 @@ impl From<&Annotation> for AnnotationKey {
 }
 
 impl Timeline {
-    pub(crate) fn builder(room: &Room) -> TimelineBuilder {
+    /// Create a new [`TimelineBuilder`] for the given room.
+    pub fn builder(room: &Room) -> TimelineBuilder {
         TimelineBuilder::new(room)
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -59,6 +59,7 @@ use tokio::sync::{mpsc::Sender, Mutex, Notify};
 use tracing::{debug, error, info, instrument, trace, warn};
 
 use self::futures::SendAttachment;
+use crate::event_graph::RoomEventGraph;
 
 mod builder;
 mod error;
@@ -796,6 +797,7 @@ struct TimelineDropHandle {
     room_update_join_handle: JoinHandle<()>,
     ignore_user_list_update_join_handle: JoinHandle<()>,
     room_key_from_backups_join_handle: JoinHandle<()>,
+    _event_graph: RoomEventGraph,
 }
 
 impl Drop for TimelineDropHandle {

--- a/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
+++ b/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
@@ -14,17 +14,12 @@
 
 use async_trait::async_trait;
 use matrix_sdk::SlidingSyncRoom;
-use tracing::{error, instrument};
+use tracing::instrument;
 
-use super::{EventTimelineItem, Timeline, TimelineBuilder};
-use crate::event_graph::Result;
+use super::EventTimelineItem;
 
 #[async_trait]
 pub trait SlidingSyncRoomExt {
-    /// Get a `Timeline` for this room.
-    // TODO(bnjbvr): remove from this trait.
-    async fn timeline(&self) -> Result<Option<Timeline>>;
-
     /// Get the latest timeline item of this room, if it is already cached.
     ///
     /// Use `Timeline::latest_event` instead if you already have a timeline for
@@ -34,14 +29,6 @@ pub trait SlidingSyncRoomExt {
 
 #[async_trait]
 impl SlidingSyncRoomExt for SlidingSyncRoom {
-    async fn timeline(&self) -> Result<Option<Timeline>> {
-        if let Some(builder) = sliding_sync_timeline_builder(self).await {
-            Ok(Some(builder.track_read_marker_and_receipts().build().await?))
-        } else {
-            Ok(None)
-        }
-    }
-
     /// Get a timeline item representing the latest event in this room.
     /// This method wraps latest_event, converting the event into an
     /// EventTimelineItem.
@@ -49,19 +36,6 @@ impl SlidingSyncRoomExt for SlidingSyncRoom {
     async fn latest_timeline_item(&self) -> Option<EventTimelineItem> {
         let latest_event = self.latest_event()?;
         EventTimelineItem::from_latest_event(self.client(), self.room_id(), latest_event).await
-    }
-}
-
-async fn sliding_sync_timeline_builder(room: &SlidingSyncRoom) -> Option<TimelineBuilder> {
-    let room_id = room.room_id();
-    match room.client().get_room(room_id) {
-        Some(r) => {
-            Some(Timeline::builder(&r).events(room.prev_batch(), room.timeline_queue()).await)
-        }
-        None => {
-            error!(?room_id, "Room not found in client. Can't provide a timeline for it");
-            None
-        }
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -15,7 +15,6 @@
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
-use imbl::vector;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB, CAROL};
 use ruma::{
@@ -47,7 +46,7 @@ async fn initial_events() {
     timeline
         .inner
         .add_initial_events(
-            vector![
+            vec![
                 SyncTimelineEvent::new(
                     timeline
                         .event_builder
@@ -239,7 +238,7 @@ async fn dedup_initial() {
     timeline
         .inner
         .add_initial_events(
-            vector![
+            vec![
                 // two events
                 event_a.clone(),
                 event_b.clone(),
@@ -247,7 +246,7 @@ async fn dedup_initial() {
                 event_a,
                 event_b,
                 // … and a new event also came in
-                event_c
+                event_c,
             ],
             None,
         )

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -18,7 +18,6 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
-use imbl::vector;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, ALICE, BOB};
 use ruma::{
@@ -248,7 +247,7 @@ async fn initial_reaction_timestamp_is_stored() {
     timeline
         .inner
         .add_initial_events(
-            vector![
+            vec![
                 SyncTimelineEvent::new(timeline.event_builder.make_sync_reaction(
                     *ALICE,
                     &Annotation::new(message_event_id.clone(), REACTION_KEY.to_owned()),
@@ -258,7 +257,7 @@ async fn initial_reaction_timestamp_is_stored() {
                     *ALICE,
                     &message_event_id,
                     RoomMessageEventContent::text_plain("A"),
-                ))
+                )),
             ],
             None,
         )

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -40,7 +40,7 @@ fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bo
 }
 
 #[async_test]
-async fn read_receipts_updates_on_live_events() {
+async fn test_read_receipts_updates_on_live_events() {
     let timeline = TestTimeline::new()
         .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
     let mut stream = timeline.subscribe().await;
@@ -138,7 +138,7 @@ async fn read_receipts_updates_on_back_paginated_events() {
 }
 
 #[async_test]
-async fn read_receipts_updates_on_filtered_events() {
+async fn test_read_receipts_updates_on_filtered_events() {
     let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
         track_read_receipts: true,
         event_filter: Arc::new(filter_notice),

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -15,7 +15,6 @@
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
-use imbl::vector;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use matrix_sdk_test::{async_test, sync_timeline_event, ALICE, BOB};
 use ruma::{
@@ -148,10 +147,10 @@ async fn reaction_redaction_timeline_filter() {
     timeline
         .inner
         .add_initial_events(
-            vector![SyncTimelineEvent::new(
+            vec![SyncTimelineEvent::new(
                 timeline
                     .event_builder
-                    .make_sync_redacted_message_event(*ALICE, RedactedReactionEventContent::new())
+                    .make_sync_redacted_message_event(*ALICE, RedactedReactionEventContent::new()),
             )],
             None,
         )

--- a/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/virt.rs
@@ -94,7 +94,7 @@ async fn day_divider() {
 }
 
 #[async_test]
-async fn update_read_marker() {
+async fn test_update_read_marker() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -42,7 +42,7 @@ pub trait RoomExt {
     /// independent events.
     ///
     /// This is the same as using `room.timeline_builder().build()`.
-    async fn timeline(&self) -> Timeline;
+    async fn timeline(&self) -> crate::event_graph::Result<Timeline>;
 
     /// Get a [`TimelineBuilder`] for this room.
     ///
@@ -55,12 +55,12 @@ pub trait RoomExt {
     fn timeline_builder(&self) -> TimelineBuilder;
 
     /// Get a [`Timeline`] for this room, filtered to only include poll events.
-    async fn poll_history(&self) -> Timeline;
+    async fn poll_history(&self) -> crate::event_graph::Result<Timeline>;
 }
 
 #[async_trait]
 impl RoomExt for Room {
-    async fn timeline(&self) -> Timeline {
+    async fn timeline(&self) -> crate::event_graph::Result<Timeline> {
         self.timeline_builder().build().await
     }
 
@@ -68,7 +68,7 @@ impl RoomExt for Room {
         Timeline::builder(self).track_read_marker_and_receipts()
     }
 
-    async fn poll_history(&self) -> Timeline {
+    async fn poll_history(&self) -> crate::event_graph::Result<Timeline> {
         self.timeline_builder()
             .event_filter(|e, _| {
                 matches!(

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -18,16 +18,13 @@ use matrix_sdk::Room;
 #[cfg(feature = "e2e-encryption")]
 use matrix_sdk::{deserialized_responses::TimelineEvent, Result};
 use matrix_sdk_base::latest_event::LatestEvent;
-#[cfg(feature = "e2e-encryption")]
-use ruma::{events::AnySyncTimelineEvent, serde::Raw};
 use ruma::{
-    events::{
-        receipt::{Receipt, ReceiptThread, ReceiptType},
-        AnySyncMessageLikeEvent,
-    },
+    events::receipt::{Receipt, ReceiptThread, ReceiptType},
     push::{PushConditionRoomCtx, Ruleset},
     EventId, OwnedEventId, OwnedUserId, RoomVersionId, UserId,
 };
+#[cfg(feature = "e2e-encryption")]
+use ruma::{events::AnySyncTimelineEvent, serde::Raw};
 use tracing::{debug, error, warn};
 
 use super::{Profile, TimelineBuilder};
@@ -53,9 +50,6 @@ pub trait RoomExt {
     /// This allows to customize settings of the [`Timeline`] before
     /// constructing it.
     fn timeline_builder(&self) -> TimelineBuilder;
-
-    /// Get a [`Timeline`] for this room, filtered to only include poll events.
-    async fn poll_history(&self) -> crate::event_graph::Result<Timeline>;
 }
 
 #[async_trait]
@@ -66,22 +60,6 @@ impl RoomExt for Room {
 
     fn timeline_builder(&self) -> TimelineBuilder {
         Timeline::builder(self).track_read_marker_and_receipts()
-    }
-
-    async fn poll_history(&self) -> crate::event_graph::Result<Timeline> {
-        self.timeline_builder()
-            .event_filter(|e, _| {
-                matches!(
-                    e,
-                    AnySyncTimelineEvent::MessageLike(
-                        AnySyncMessageLikeEvent::UnstablePollStart(_)
-                            | AnySyncMessageLikeEvent::UnstablePollResponse(_)
-                            | AnySyncMessageLikeEvent::UnstablePollEnd(_)
-                    )
-                )
-            })
-            .build()
-            .await
     }
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2370,7 +2370,7 @@ async fn test_room_timeline() -> Result<(), Error> {
     };
 
     let room = room_list.room(room_id).await?;
-    room.init_timeline_with_builder(room.default_room_timeline_builder()).await?;
+    room.init_timeline_with_builder(room.default_room_timeline_builder().await).await?;
     let timeline = room.timeline().unwrap();
 
     let (previous_timeline_items, mut timeline_items_stream) = timeline.subscribe().await;
@@ -2452,7 +2452,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
     };
 
     let room = room_list.room(room_id).await?;
-    room.init_timeline_with_builder(room.default_room_timeline_builder()).await?;
+    room.init_timeline_with_builder(room.default_room_timeline_builder().await).await?;
 
     // The latest event does not exist.
     assert!(room.latest_event().await.is_none());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -38,7 +38,7 @@ use wiremock::{
 use crate::{logged_in_client, mock_encryption_state, mock_sync};
 
 #[async_test]
-async fn echo() {
+async fn test_echo() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -51,7 +51,7 @@ async fn echo() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     mock_encryption_state(&server, false).await;
@@ -128,7 +128,7 @@ async fn echo() {
 }
 
 #[async_test]
-async fn retry_failed() {
+async fn test_retry_failed() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -143,7 +143,7 @@ async fn retry_failed() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
@@ -184,7 +184,7 @@ async fn retry_failed() {
 }
 
 #[async_test]
-async fn dedup_by_event_id_late() {
+async fn test_dedup_by_event_id_late() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -197,7 +197,7 @@ async fn dedup_by_event_id_late() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let event_id = event_id!("$wWgymRfo7ri1uQx0NXO40vLJ");
@@ -253,7 +253,7 @@ async fn dedup_by_event_id_late() {
 }
 
 #[async_test]
-async fn cancel_failed() {
+async fn test_cancel_failed() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -266,7 +266,7 @@ async fn cancel_failed() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -49,7 +49,7 @@ use wiremock::{
 use crate::{logged_in_client, mock_encryption_state, mock_sync};
 
 #[async_test]
-async fn edit() {
+async fn test_edit() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let event_builder = EventBuilder::new();
@@ -63,7 +63,7 @@ async fn edit() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let event_id = event_id!("$msda7m:localhost");
@@ -154,7 +154,7 @@ async fn edit() {
 }
 
 #[async_test]
-async fn send_edit() {
+async fn test_send_edit() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let event_builder = EventBuilder::new();
@@ -168,7 +168,7 @@ async fn send_edit() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
@@ -225,7 +225,7 @@ async fn send_edit() {
 }
 
 #[async_test]
-async fn send_reply_edit() {
+async fn test_send_reply_edit() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let event_builder = EventBuilder::new();
@@ -239,7 +239,7 @@ async fn send_reply_edit() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
@@ -312,7 +312,7 @@ async fn send_reply_edit() {
 }
 
 #[async_test]
-async fn send_edit_poll() {
+async fn test_send_edit_poll() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let event_builder = EventBuilder::new();
@@ -326,7 +326,7 @@ async fn send_edit_poll() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -40,7 +40,7 @@ mod subscribe;
 pub(crate) mod sliding_sync;
 
 #[async_test]
-async fn reaction() {
+async fn test_reaction() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -53,7 +53,7 @@ async fn reaction() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     ev_builder.add_joined_room(
@@ -149,7 +149,7 @@ async fn reaction() {
 }
 
 #[async_test]
-async fn redacted_message() {
+async fn test_redacted_message() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -162,7 +162,7 @@ async fn redacted_message() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     ev_builder.add_joined_room(
@@ -207,7 +207,7 @@ async fn redacted_message() {
 }
 
 #[async_test]
-async fn read_marker() {
+async fn test_read_marker() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -220,7 +220,7 @@ async fn read_marker() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
@@ -282,7 +282,7 @@ async fn read_marker() {
 }
 
 #[async_test]
-async fn sync_highlighted() {
+async fn test_sync_highlighted() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -301,7 +301,7 @@ async fn sync_highlighted() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -45,7 +45,7 @@ use wiremock::{
 use crate::{logged_in_client, mock_sync};
 
 #[async_test]
-async fn back_pagination() {
+async fn test_back_pagination() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -58,7 +58,7 @@ async fn back_pagination() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
     let mut back_pagination_status = timeline.back_pagination_status();
 
@@ -136,7 +136,7 @@ async fn back_pagination() {
 }
 
 #[async_test]
-async fn back_pagination_highlighted() {
+async fn test_back_pagination_highlighted() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -155,7 +155,7 @@ async fn back_pagination_highlighted() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let response_json = json!({
@@ -223,7 +223,7 @@ async fn back_pagination_highlighted() {
 }
 
 #[async_test]
-async fn wait_for_token() {
+async fn test_wait_for_token() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -237,7 +237,7 @@ async fn wait_for_token() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
 
     let from = "t392-516_47314_0_7_1_1_1_11444_1";
     let mut back_pagination_status = timeline.back_pagination_status();
@@ -284,7 +284,7 @@ async fn wait_for_token() {
 }
 
 #[async_test]
-async fn dedup() {
+async fn test_dedup() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -298,7 +298,7 @@ async fn dedup() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
 
     let from = "t392-516_47314_0_7_1_1_1_11444_1";
 
@@ -340,7 +340,7 @@ async fn dedup() {
 }
 
 #[async_test]
-async fn timeline_reset_while_paginating() {
+async fn test_timeline_reset_while_paginating() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -354,7 +354,7 @@ async fn timeline_reset_while_paginating() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
 
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
@@ -517,7 +517,7 @@ pub static ROOM_MESSAGES_BATCH_2: Lazy<JsonValue> = Lazy::new(|| {
 });
 
 #[async_test]
-async fn empty_chunk() {
+async fn test_empty_chunk() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -530,7 +530,7 @@ async fn empty_chunk() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
     let mut back_pagination_status = timeline.back_pagination_status();
 
@@ -607,7 +607,7 @@ async fn empty_chunk() {
 }
 
 #[async_test]
-async fn until_num_items_with_empty_chunk() {
+async fn test_until_num_items_with_empty_chunk() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -620,7 +620,7 @@ async fn until_num_items_with_empty_chunk() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
     let mut back_pagination_status = timeline.back_pagination_status();
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -34,7 +34,7 @@ use wiremock::{
 use crate::{logged_in_client, mock_sync};
 
 #[async_test]
-async fn update_sender_profiles() {
+async fn test_update_sender_profiles() {
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -47,7 +47,7 @@ async fn update_sender_profiles() {
     server.reset().await;
 
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
 
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID)

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -33,7 +33,7 @@ use wiremock::{
 use crate::{logged_in_client, mock_encryption_state, mock_sync};
 
 #[async_test]
-async fn message_order() {
+async fn test_message_order() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -48,7 +48,7 @@ async fn message_order() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
@@ -105,7 +105,7 @@ async fn message_order() {
 }
 
 #[async_test]
-async fn retry_order() {
+async fn test_retry_order() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -120,7 +120,7 @@ async fn retry_order() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = Arc::new(room.timeline().await);
+    let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
@@ -211,7 +211,7 @@ async fn retry_order() {
 }
 
 #[async_test]
-async fn clear_with_echoes() {
+async fn test_clear_with_echoes() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -227,7 +227,7 @@ async fn clear_with_echoes() {
     mock_encryption_state(&server, false).await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
 
     // Send a message without mocking the server response.
     {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -281,7 +281,7 @@ async fn read_receipts_updates() {
 }
 
 #[async_test]
-async fn read_receipts_updates_on_filtered_events() {
+async fn test_read_receipts_updates_on_filtered_events() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -52,7 +52,7 @@ fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bo
 }
 
 #[async_test]
-async fn read_receipts_updates() {
+async fn test_read_receipts_updates() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -72,7 +72,7 @@ async fn read_receipts_updates() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert!(items.is_empty());
@@ -300,7 +300,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline_builder().event_filter(filter_notice).build().await;
+    let timeline = room.timeline_builder().event_filter(filter_notice).build().await.unwrap();
     let (items, mut timeline_stream) = timeline.subscribe().await;
 
     assert!(items.is_empty());
@@ -493,7 +493,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
 }
 
 #[async_test]
-async fn send_single_receipt() {
+async fn test_send_single_receipt() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -508,7 +508,7 @@ async fn send_single_receipt() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
 
     // Unknown receipts are sent.
     let first_receipts_event_id = event_id!("$first_receipts_event_id");
@@ -840,7 +840,7 @@ async fn send_single_receipt() {
 }
 
 #[async_test]
-async fn send_multiple_receipts() {
+async fn test_send_multiple_receipts() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -855,7 +855,7 @@ async fn send_multiple_receipts() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
 
     // Unknown receipts are sent.
     let first_receipts_event_id = event_id!("$first_receipts_event_id");
@@ -1048,7 +1048,7 @@ async fn send_multiple_receipts() {
 }
 
 #[async_test]
-async fn latest_user_read_receipt() {
+async fn test_latest_user_read_receipt() {
     let room_id = room_id!("!a98sd12bjh:example.org");
     let (client, server) = logged_in_client().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
@@ -1069,7 +1069,7 @@ async fn latest_user_read_receipt() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (items, _) = timeline.subscribe().await;
 
     assert!(items.is_empty());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -48,7 +48,7 @@ async fn in_reply_to_details() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     // The event doesn't exist.
@@ -185,7 +185,7 @@ async fn transfer_in_reply_to_details_to_re_received_item() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
 
     // Given a reply to an event that's not itself in the timeline...
     let event_id_1 = event_id!("$event1");
@@ -267,7 +267,7 @@ async fn send_reply() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 
@@ -358,7 +358,7 @@ async fn send_reply_to_threaded() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) =
         timeline.subscribe_filter_map(|item| item.as_event().cloned()).await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -253,7 +253,7 @@ async fn timeline_test_helper(
         .await
         .unwrap()
         .timeline()
-        .await
+        .await?
         .context("`timeline`")?
         .subscribe()
         .await)

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -14,7 +14,7 @@
 
 use std::{pin::Pin, sync::Arc};
 
-use anyhow::{Context, Result};
+use anyhow::{Context as _, Result};
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::{Vector, VectorDiff};
@@ -23,8 +23,9 @@ use matrix_sdk::{
     SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
 };
 use matrix_sdk_test::async_test;
-use matrix_sdk_ui::timeline::{
-    SlidingSyncRoomExt, TimelineItem, TimelineItemKind, VirtualTimelineItem,
+use matrix_sdk_ui::{
+    timeline::{TimelineItem, TimelineItemKind, VirtualTimelineItem},
+    Timeline,
 };
 use ruma::{room_id, user_id, RoomId};
 use serde_json::json;
@@ -248,15 +249,21 @@ async fn timeline_test_helper(
     sliding_sync: &SlidingSync,
     room_id: &RoomId,
 ) -> Result<(Vector<Arc<TimelineItem>>, impl Stream<Item = VectorDiff<Arc<TimelineItem>>>)> {
-    Ok(sliding_sync
-        .get_room(room_id)
+    let sliding_sync_room = sliding_sync.get_room(room_id).await.unwrap();
+
+    let room_id = sliding_sync_room.room_id();
+    let sdk_room = sliding_sync_room.client().get_room(room_id).ok_or_else(|| {
+        anyhow::anyhow!("Room {room_id} not found in client. Can't provide a timeline for it")
+    })?;
+
+    let timeline = Timeline::builder(&sdk_room)
+        .events(sliding_sync_room.prev_batch(), sliding_sync_room.timeline_queue())
         .await
-        .unwrap()
-        .timeline()
-        .await?
-        .context("`timeline`")?
-        .subscribe()
-        .await)
+        .track_read_marker_and_receipts()
+        .build()
+        .await?;
+
+    Ok(timeline.subscribe().await)
 }
 
 struct SlidingSyncMatcher;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -52,7 +52,7 @@ async fn test_batched() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline_builder().event_filter(|_, _| true).build().await;
+    let timeline = room.timeline_builder().event_filter(|_, _| true).build().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe_batched().await;
 
     let hdl = tokio::spawn(async move {
@@ -100,7 +100,7 @@ async fn test_event_filter() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline_builder().event_filter(|_, _| true).build().await;
+    let timeline = room.timeline_builder().event_filter(|_, _| true).build().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let first_event_id = event_id!("$YTQwYl2ply");
@@ -206,7 +206,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     server.reset().await;
 
     let room = client.get_room(room_id).unwrap();
-    let timeline = room.timeline_builder().build().await;
+    let timeline = room.timeline_builder().build().await.unwrap();
     let (_, timeline_stream) = timeline.subscribe().await;
     pin_mut!(timeline_stream);
 

--- a/examples/timeline/src/main.rs
+++ b/examples/timeline/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
 
     // Get the timeline stream and listen to it.
     let room = client.get_room(&room_id).unwrap();
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (timeline_items, mut timeline_stream) = timeline.subscribe().await;
 
     println!("Initial timeline items: {timeline_items:#?}");

--- a/labs/rrrepl/src/main.rs
+++ b/labs/rrrepl/src/main.rs
@@ -134,7 +134,7 @@ async fn login_and_sync(server_name: String) -> anyhow::Result<()> {
                     let room_id = { rooms.lock().unwrap()[id].as_room_id().map(ToOwned::to_owned) };
                     if let Some(room_id) = &room_id {
                         let room = room_list_service.room(room_id).await?;
-                        room.init_timeline_with_builder(room.default_room_timeline_builder())
+                        room.init_timeline_with_builder(room.default_room_timeline_builder().await)
                             .await?;
                         let timeline = room.timeline().unwrap();
 

--- a/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
@@ -66,7 +66,7 @@ async fn test_toggling_reaction() -> Result<()> {
     let room_id = room.room_id();
 
     // Create a timeline for this room.
-    let timeline = room.timeline().await;
+    let timeline = room.timeline().await.unwrap();
     let (_items, mut stream) = timeline.subscribe().await;
 
     // Send message.


### PR DESCRIPTION
This is mostly a demonstration of how to plug the `EventGraph` with the timeline, add some initial types and documentation, and how little it changes the timeline as a result.

One thing I'm not satisfied with is that the `TimelineBuilder::build()` function should really be fallible eventually, because the `subscribe()` would read events from the storage, which is fallible. I've tried to make it so, but in the sliding sync code we're lazily initializing a `Timeline` using ` TimelineBuilder`, and that can't fail, or we'd need the caller to check the result each time. Needs to be properly solved now, or as the immediate next PR.

I've also started a WIP to move the support for read receipts (not unread counters yet) from the Timeline into the Event graph, as a further proof of concept, and I might wait for it before requesting review here.

I'll move back to draft as soon as I get some test results :-)

Part of #3058.