### PR TITLE
sdk: Allow to track ambiguity changes per-room

### DIFF
--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -1,6 +1,8 @@
 # unreleased
 
 - Replace the `Notification` type from Ruma in `SyncResponse` and `StateChanges` by a custom one
+- The ambiguity maps in `SyncResponse` are moved to `JoinedRoom` and `LeftRoom`
+- `AmbiguityCache` contains the room member's user ID
 
 # 0.7.0
 

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -34,9 +34,12 @@ use serde::Serialize;
 
 /// A change in ambiguity of room members that an `m.room.member` event
 /// triggers.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct AmbiguityChange {
+    /// The user ID of the member that is contained in the state key of the
+    /// `m.room.member` event.
+    pub member_id: OwnedUserId,
     /// Is the member that is contained in the state key of the `m.room.member`
     /// event itself ambiguous because of the event.
     pub member_ambiguous: bool,

--- a/crates/matrix-sdk-base/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-base/src/deserialized_responses.rs
@@ -14,7 +14,7 @@
 
 //! SDK-specific variations of response types from Ruma.
 
-use std::{collections::BTreeMap, fmt};
+use std::{collections::BTreeMap, fmt, iter};
 
 pub use matrix_sdk_common::deserialized_responses::*;
 use ruma::{
@@ -47,6 +47,15 @@ pub struct AmbiguityChange {
     pub disambiguated_member: Option<OwnedUserId>,
     /// Has another user become ambiguous because of this event.
     pub ambiguated_member: Option<OwnedUserId>,
+}
+
+impl AmbiguityChange {
+    /// Get an iterator over the user IDs listed in this `AmbiguityChange`.
+    pub fn user_ids(&self) -> impl Iterator<Item = &UserId> {
+        iter::once(&*self.member_id)
+            .chain(self.disambiguated_member.as_deref())
+            .chain(self.ambiguated_member.as_deref())
+    }
 }
 
 /// Collection of ambiguity changes that room member events trigger.

--- a/crates/matrix-sdk-base/src/store/ambiguity_map.rs
+++ b/crates/matrix-sdk-base/src/store/ambiguity_map.rs
@@ -118,6 +118,7 @@ impl AmbiguityCache {
         self.update(room_id, old_map, new_map);
 
         let change = AmbiguityChange {
+            member_id: member_event.state_key().clone(),
             disambiguated_member,
             ambiguated_member,
             member_ambiguous: ambiguous,

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -876,8 +876,8 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         });
     }
 
-    pub(super) async fn update_sender_profiles(&self) {
-        trace!("Updating sender profiles");
+    pub(super) async fn update_missing_sender_profiles(&self) {
+        trace!("Updating missing sender profiles");
 
         let mut state = self.state.write().await;
         let mut entries = state.items.entries();
@@ -913,7 +913,52 @@ impl<P: RoomDataProvider> TimelineInner<P> {
             }
         }
 
-        trace!("Done updating sender profiles");
+        trace!("Done updating missing sender profiles");
+    }
+
+    /// Update the profiles of the given senders, even if they are ready.
+    pub(super) async fn force_update_sender_profiles(&self, sender_ids: &BTreeSet<&UserId>) {
+        trace!("Forcing update of sender profiles: {sender_ids:?}");
+
+        let mut state = self.state.write().await;
+        let mut entries = state.items.entries();
+        while let Some(mut entry) = entries.next() {
+            let Some(event_item) = entry.as_event() else { continue };
+            if !sender_ids.contains(event_item.sender()) {
+                continue;
+            }
+
+            let event_id = event_item.event_id().map(debug);
+            let transaction_id = event_item.transaction_id().map(debug);
+
+            match self.room_data_provider.profile_from_user_id(event_item.sender()).await {
+                Some(profile) => {
+                    if matches!(event_item.sender_profile(), TimelineDetails::Ready(old_profile) if *old_profile == profile)
+                    {
+                        debug!(event_id, transaction_id, "Profile already up-to-date");
+                    } else {
+                        trace!(event_id, transaction_id, "Updating profile");
+                        let updated_item =
+                            event_item.with_sender_profile(TimelineDetails::Ready(profile));
+                        let new_item = entry.with_kind(updated_item);
+                        ObservableVectorEntry::set(&mut entry, new_item);
+                    }
+                }
+                None => {
+                    if !event_item.sender_profile().is_unavailable() {
+                        trace!(event_id, transaction_id, "Marking profile unavailable");
+                        let updated_item =
+                            event_item.with_sender_profile(TimelineDetails::Unavailable);
+                        let new_item = entry.with_kind(updated_item);
+                        ObservableVectorEntry::set(&mut entry, new_item);
+                    } else {
+                        debug!(event_id, transaction_id, "Profile already marked unavailable");
+                    }
+                }
+            }
+        }
+
+        trace!("Done forcing update of sender profiles");
     }
 
     #[cfg(test)]

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -659,7 +659,7 @@ impl Timeline {
         self.inner.set_sender_profiles_pending().await;
         match self.room().sync_members().await {
             Ok(_) => {
-                self.inner.update_sender_profiles().await;
+                self.inner.update_missing_sender_profiles().await;
             }
             Err(e) => {
                 self.inner.set_sender_profiles_error(Arc::new(e)).await;

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -5,6 +5,8 @@ Breaking changes:
 - Replace the `Notification` type from Ruma in `SyncResponse` and `Client::register_notification_handler`
   by a custom one
 - `Room::can_user_redact` and `Member::can_redact` are split between `*_redact_own` and `*_redact_other`
+- `RoomUpdate` also contains the ambiguity changes of a `Room` with `AmbiguityCache` containing the
+  room member's user ID.
 
 # 0.7.0
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -5,8 +5,8 @@ Breaking changes:
 - Replace the `Notification` type from Ruma in `SyncResponse` and `Client::register_notification_handler`
   by a custom one
 - `Room::can_user_redact` and `Member::can_redact` are split between `*_redact_own` and `*_redact_other`
-- `RoomUpdate` also contains the ambiguity changes of a `Room` with `AmbiguityCache` containing the
-  room member's user ID.
+- The ambiguity maps in `SyncResponse` are moved to `JoinedRoom` and `LeftRoom`
+- `AmbiguityCache` contains the room member's user ID
 
 # 0.7.0
 

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -923,7 +923,7 @@ async fn ambiguity_changes() {
 
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
 
-    let changes = response.ambiguity_changes.changes.get(*DEFAULT_TEST_ROOM_ID).unwrap();
+    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // A new member always triggers an ambiguity change.
     let example_change = changes.get(event_id!("$151800140517rfvjc:localhost")).unwrap();
@@ -943,7 +943,7 @@ async fn ambiguity_changes() {
     let example_2 = room.get_member_no_sync(example_2_id).await.unwrap().unwrap();
     assert!(!example_2.name_ambiguous());
 
-    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { ambiguity_changes, .. }) => ambiguity_changes);
+    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { updates, .. }) => updates.ambiguity_changes);
 
     let example_change = changes.get(event_id!("$151800140517rfvjc:localhost")).unwrap();
     assert_eq!(example_change.member_id, example_id);
@@ -994,7 +994,7 @@ async fn ambiguity_changes() {
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
     server.reset().await;
 
-    let changes = response.ambiguity_changes.changes.get(*DEFAULT_TEST_ROOM_ID).unwrap();
+    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // First joined member made both members ambiguous.
     let example_2_change = changes.get(example_2_rename_1_event_id).unwrap();
@@ -1017,7 +1017,7 @@ async fn ambiguity_changes() {
     let example_3 = room.get_member_no_sync(example_3_id).await.unwrap().unwrap();
     assert!(example_3.name_ambiguous());
 
-    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { ambiguity_changes, .. }) => ambiguity_changes);
+    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { updates, .. }) => updates.ambiguity_changes);
 
     let example_2_change = changes.get(example_2_rename_1_event_id).unwrap();
     assert_eq!(example_2_change.member_id, example_2_id);
@@ -1053,7 +1053,7 @@ async fn ambiguity_changes() {
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
     server.reset().await;
 
-    let changes = response.ambiguity_changes.changes.get(*DEFAULT_TEST_ROOM_ID).unwrap();
+    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // example 2 is not ambiguous anymore.
     let example_2_change = changes.get(example_2_rename_2_event_id).unwrap();
@@ -1069,7 +1069,7 @@ async fn ambiguity_changes() {
     let example_3 = room.get_member_no_sync(example_3_id).await.unwrap().unwrap();
     assert!(example_3.name_ambiguous());
 
-    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { ambiguity_changes, .. }) => ambiguity_changes);
+    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { updates, .. }) => updates.ambiguity_changes);
 
     let example_2_change = changes.get(example_2_rename_2_event_id).unwrap();
     assert_eq!(example_2_change.member_id, example_2_id);
@@ -1099,7 +1099,7 @@ async fn ambiguity_changes() {
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
     server.reset().await;
 
-    let changes = response.ambiguity_changes.changes.get(*DEFAULT_TEST_ROOM_ID).unwrap();
+    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // example 3 is now ambiguous with example 2, not example.
     let example_3_change = changes.get(example_3_rename_event_id).unwrap();
@@ -1115,7 +1115,7 @@ async fn ambiguity_changes() {
     let example_3 = room.get_member_no_sync(example_3_id).await.unwrap().unwrap();
     assert!(example_3.name_ambiguous());
 
-    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { ambiguity_changes, .. }) => ambiguity_changes);
+    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { updates, .. }) => updates.ambiguity_changes);
 
     let example_3_change = changes.get(example_3_rename_event_id).unwrap();
     assert_eq!(example_3_change.member_id, example_3_id);
@@ -1145,7 +1145,7 @@ async fn ambiguity_changes() {
     let response = client.sync_once(SyncSettings::default()).await.unwrap();
     server.reset().await;
 
-    let changes = response.ambiguity_changes.changes.get(*DEFAULT_TEST_ROOM_ID).unwrap();
+    let changes = &response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes;
 
     // name change, even if still not ambiguous, triggers ambiguity change.
     let example_change = changes.get(example_rename_event_id).unwrap();
@@ -1161,7 +1161,7 @@ async fn ambiguity_changes() {
     let example_3 = room.get_member_no_sync(example_3_id).await.unwrap().unwrap();
     assert!(example_3.name_ambiguous());
 
-    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { ambiguity_changes, .. }) => ambiguity_changes);
+    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { updates, .. }) => updates.ambiguity_changes);
 
     let example_change = changes.get(example_rename_event_id).unwrap();
     assert_eq!(example_change.member_id, example_id);
@@ -1192,9 +1192,9 @@ async fn ambiguity_changes() {
     server.reset().await;
 
     // Avatar change does not trigger ambiguity change.
-    assert!(response.ambiguity_changes.changes.get(*DEFAULT_TEST_ROOM_ID).is_none());
+    assert!(response.rooms.join.get(*DEFAULT_TEST_ROOM_ID).unwrap().ambiguity_changes.is_empty());
 
-    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { ambiguity_changes, .. }) => ambiguity_changes);
+    let changes = assert_next_matches!(updates, Ok(RoomUpdate::Joined { updates, .. }) => updates.ambiguity_changes);
     assert!(changes.is_empty());
 
     assert_pending!(updates);


### PR DESCRIPTION
This PR had the main goal to allow to follow ambiguity changes per-room, without relying on the `SyncResponse`. We need this because we keep the members list of the current room in memory for mention autocompletion in Fractal.

As a bonus, we use that to update profiles in the `Timeline` when there is an ambiguity change (ticks one of the boxes in https://github.com/matrix-org/matrix-rust-sdk/issues/1103).

- [x] Public API changes documented in changelogs (optional)


