### PR TITLE
integration-testing: Fix syntax of docker-compose.yml

### DIFF
--- a/testing/matrix-sdk-integration-testing/assets/docker-compose.yml
+++ b/testing/matrix-sdk-integration-testing/assets/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     image: ghcr.io/matrix-org/sliding-sync:v0.99.11
     depends_on:
       synapse:
+        condition: service_started
       postgres:
         condition: service_healthy
     environment:


### PR DESCRIPTION
I am sorry, I actually didn't test the latest commits of #3063, and podman compose complains that the syntax is invalid.