### PR TITLE
integration test: make `test_toggling_reaction` fail fast

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
@@ -31,7 +31,7 @@ use matrix_sdk::{
     Client, LoopCtrl,
 };
 use matrix_sdk_ui::timeline::{EventTimelineItem, RoomExt, TimelineItem};
-use tokio::{spawn, time::timeout};
+use tokio::time::timeout;
 
 use crate::helpers::TestClientBuilder;
 
@@ -77,8 +77,8 @@ async fn test_toggling_reaction() -> Result<()> {
     let reaction_key = "👍";
     let reaction = Annotation::new(event_id.clone(), reaction_key.into());
 
-    // Toggle reaction multiple times
-    let all_tests = spawn(async move {
+    // Toggle reaction multiple times.
+    let all_tests = async move {
         for _ in 0..3 {
             // Add
             timeline.toggle_reaction(&reaction).await.expect("toggling reaction");
@@ -124,9 +124,9 @@ async fn test_toggling_reaction() -> Result<()> {
             assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
             assert_redacted(&mut stream, &event_id, message_position).await;
         }
-    });
+    };
 
-    timeout(Duration::from_secs(10), all_tests).await.expect("timed out").expect("couldn't join");
+    timeout(Duration::from_secs(10), all_tests).await.expect("timed out");
 
     Ok(())
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use anyhow::{Ok, Result};
 use assert_matches::assert_matches;
@@ -31,28 +31,31 @@ use matrix_sdk::{
     Client, LoopCtrl,
 };
 use matrix_sdk_ui::timeline::{EventTimelineItem, RoomExt, TimelineItem};
+use tokio::{spawn, time::timeout};
 
 use crate::helpers::TestClientBuilder;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_toggling_reaction() -> Result<()> {
-    // Set up
+    // Set up sync for user Alice, and create a room.
     let alice = TestClientBuilder::new("alice".to_owned()).use_sqlite().build().await?;
-    let user_id = alice.user_id().unwrap();
+    let user_id = alice.user_id().unwrap().to_owned();
     let room = alice
         .create_room(assign!(CreateRoomRequest::new(), {
             is_direct: true,
         }))
         .await?;
     let room_id = room.room_id();
+
+    // Create a timeline for this room.
     let timeline = room.timeline().await;
-    let reaction_key = "👍";
     let (_items, mut stream) = timeline.subscribe().await;
 
-    // Send message
+    // Send message.
     timeline.send(RoomMessageEventContent::text_plain("hi!").into()).await;
 
-    // Sync until the remote echo arrives
+    // Sync until the remote echo arrives.
+    let mut num_attempts = 0;
     let event_id = loop {
         sync_room(&alice, room_id).await?;
         let items = timeline.items().await;
@@ -60,57 +63,70 @@ async fn test_toggling_reaction() -> Result<()> {
         if !last_item.is_local_echo() {
             break last_item.event_id().unwrap().to_owned();
         }
+        if num_attempts == 2 {
+            panic!("had 3 sync responses and no echo of our own event");
+        }
+        num_attempts += 1;
     };
 
-    // Skip all stream updates that have happened so far
+    // Skip all stream updates that have happened so far.
     while stream.next().now_or_never().is_some() {}
 
     let message_position = timeline.items().await.len() - 1;
+
+    let reaction_key = "👍";
     let reaction = Annotation::new(event_id.clone(), reaction_key.into());
 
     // Toggle reaction multiple times
-    for _ in 0..3 {
-        // Add
-        timeline.toggle_reaction(&reaction).await?;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_remote_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
+    let all_tests = spawn(async move {
+        for _ in 0..3 {
+            // Add
+            timeline.toggle_reaction(&reaction).await.expect("toggling reaction");
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_remote_added(&mut stream, &user_id, &event_id, &reaction, message_position)
+                .await;
 
-        // Redact
-        timeline.toggle_reaction(&reaction).await?;
-        assert_redacted(&mut stream, &event_id, message_position).await;
+            // Redact
+            timeline.toggle_reaction(&reaction).await.expect("toggling reaction the second time");
+            assert_redacted(&mut stream, &event_id, message_position).await;
 
-        // Add, redact, add, redact, add
-        join_all((0..5).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_remote_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
+            // Add, redact, add, redact, add
+            join_all((0..5).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_remote_added(&mut stream, &user_id, &event_id, &reaction, message_position)
+                .await;
 
-        // Redact, add, redact, add
-        join_all((0..4).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_remote_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
+            // Redact, add, redact, add
+            join_all((0..4).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_remote_added(&mut stream, &user_id, &event_id, &reaction, message_position)
+                .await;
 
-        // Redact, add, redact, add, redact
-        join_all((0..5).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
+            // Redact, add, redact, add, redact
+            join_all((0..5).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
 
-        // Add, redact, add, redact
-        join_all((0..4).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
-        assert_local_added(&mut stream, user_id, &event_id, &reaction, message_position).await;
-        assert_redacted(&mut stream, &event_id, message_position).await;
-    }
+            // Add, redact, add, redact
+            join_all((0..4).map(|_| timeline.toggle_reaction(&reaction)).collect::<Vec<_>>()).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
+            assert_local_added(&mut stream, &user_id, &event_id, &reaction, message_position).await;
+            assert_redacted(&mut stream, &event_id, message_position).await;
+        }
+    });
+
+    timeout(Duration::from_secs(10), all_tests).await.expect("timed out").expect("couldn't join");
 
     Ok(())
 }
@@ -185,7 +201,9 @@ async fn assert_event_is_updated(
 ) -> EventTimelineItem {
     assert_let!(Some(VectorDiff::Set { index: i, value: event }) = stream.next().await);
     assert_eq!(i, index);
+
     let event = event.as_event().unwrap();
     assert_eq!(event.event_id().unwrap(), event_id);
+
     event.to_owned()
 }


### PR DESCRIPTION
It's started failing with timeouts in multiple PRs, so this PR should help spot where the issues specifically are, since codecov test failures are so hard to reproduce locally.