### PR TITLE
Add support for MSC2867 - Manually marking rooms as unread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4738,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.9.4"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "assign",
  "js_int",
@@ -4754,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.17.4"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "as_variant",
  "assign",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.12.1"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "as_variant",
  "base64 0.21.5",
@@ -4803,7 +4803,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.27.11"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "as_variant",
  "indexmap 2.1.0",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.1.0"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -4851,7 +4851,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.3"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "js_int",
  "thiserror",
@@ -4860,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.12.0"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "once_cell",
  "proc-macro-crate 2.0.1",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=684ffc789877355bd25269451b2356817c17cc3f#684ffc789877355bd25269451b2356817c17cc3f"
+source = "git+https://github.com/ruma/ruma?rev=68c9bb0930f2195fa8672fbef9633ef62737df5d#68c9bb0930f2195fa8672fbef9633ef62737df5d"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.12.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "68c9bb0930f2195fa8672fbef9633ef62737df5d", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401", "unstable-msc2867"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "68c9bb0930f2195fa8672fbef9633ef62737df5d", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
 ruma-common = { git = "https://github.com/ruma/ruma", rev = "68c9bb0930f2195fa8672fbef9633ef62737df5d"}
 once_cell = "1.16.0"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ futures-executor = "0.3.21"
 futures-util = { version = "0.3.26", default-features = false, features = ["alloc"] }
 http = "0.2.6"
 itertools = "0.12.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "684ffc789877355bd25269451b2356817c17cc3f", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "684ffc789877355bd25269451b2356817c17cc3f"}
+ruma = { git = "https://github.com/ruma/ruma", rev = "68c9bb0930f2195fa8672fbef9633ef62737df5d", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401", "unstable-msc2867"] }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "68c9bb0930f2195fa8672fbef9633ef62737df5d"}
 once_cell = "1.16.0"
 rand = "0.8.5"
 serde = "1.0.151"

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -21,7 +21,7 @@ use crate::{
     room_info::RoomInfo,
     room_member::RoomMember,
     ruma::ImageInfo,
-    timeline::{EventTimelineItem, Timeline},
+    timeline::{EventTimelineItem, ReceiptType, Timeline},
     utils::u64_to_uint,
     TaskHandle,
 };
@@ -516,6 +516,38 @@ impl Room {
 
     pub async fn typing_notice(&self, is_typing: bool) -> Result<(), ClientError> {
         Ok(self.inner.typing_notice(is_typing).await?)
+    }
+
+    /// Sets a flag on the room to indicate that the user has explicitly marked
+    /// it as unread
+    pub async fn mark_as_unread(&self) -> Result<(), ClientError> {
+        Ok(self.inner.mark_unread(true).await?)
+    }
+
+    /// Reverts a previously set unread flag.
+    pub async fn mark_as_read(&self) -> Result<(), ClientError> {
+        Ok(self.inner.mark_unread(false).await?)
+    }
+
+    /// Reverts a previously set unread flag and sends a read receipt to the
+    /// latest event in the room. Sending read receipts is useful when
+    /// executing this from the room list but shouldn't be use when entering
+    /// the room, the timeline should be left to its own devices in that
+    /// case.
+    pub async fn mark_as_read_and_send_read_receipt(
+        &self,
+        receipt_type: ReceiptType,
+    ) -> Result<(), ClientError> {
+        let timeline = self.timeline().await?;
+
+        if let Some(event) = timeline.latest_event().await {
+            if let Err(error) = timeline.send_read_receipt(receipt_type, event.event_id().unwrap())
+            {
+                error!("Failed to send read receipt: {error}");
+            }
+        }
+
+        self.mark_as_read().await
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -31,6 +31,8 @@ pub struct RoomInfo {
     user_defined_notification_mode: Option<RoomNotificationMode>,
     has_room_call: bool,
     active_room_call_participants: Vec<String>,
+    /// Whether this room has been explicitly marked as unread
+    is_marked_unread: bool,
     /// "Interesting" messages received in that room, independently of the
     /// notification settings.
     num_unread_messages: u64,
@@ -84,6 +86,7 @@ impl RoomInfo {
                 .iter()
                 .map(|u| u.to_string())
                 .collect(),
+            is_marked_unread: room.is_marked_unread(),
             num_unread_messages: room.num_unread_messages(),
             num_unread_notifications: room.num_unread_notifications(),
             num_unread_mentions: room.num_unread_mentions(),

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -534,6 +534,12 @@ impl Timeline {
             Ok(Arc::new(RoomMessageEventContentWithoutRelation::new(msgtype)))
         })
     }
+
+    pub async fn latest_event(&self) -> Option<Arc<EventTimelineItem>> {
+        let latest_event = self.inner.latest_event().await;
+
+        latest_event.map(|item| Arc::new(EventTimelineItem(item)))
+    }
 }
 
 #[derive(uniffi::Record)]

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -49,7 +49,7 @@ matrix-sdk-crypto = { workspace = true, optional = true }
 matrix-sdk-store-encryption = { workspace = true }
 matrix-sdk-test = { workspace = true, optional = true }
 once_cell = { workspace = true }
-ruma = { workspace = true, features = ["canonical-json", "unstable-msc3381"] }
+ruma = { workspace = true, features = ["canonical-json", "unstable-msc3381", "unstable-msc2867"] }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -540,7 +540,21 @@ impl BaseClient {
     ) {
         for raw_event in events {
             if let Ok(event) = raw_event.deserialize() {
-                changes.add_room_account_data(room_id, event, raw_event.clone());
+                changes.add_room_account_data(room_id, event.clone(), raw_event.clone());
+
+                // Rooms can either appear in the current request or already be
+                // known to the store. If neither of
+                // those are true then the room is `unknown` and we cannot
+                // process its account data
+                if let AnyRoomAccountDataEvent::MarkedUnread(e) = event {
+                    if let Some(room) = changes.room_infos.get_mut(room_id) {
+                        room.base_info.is_marked_unread = e.content.unread;
+                    } else if let Some(room) = self.store.get_room(room_id) {
+                        let mut info = room.clone_info();
+                        info.base_info.is_marked_unread = e.content.unread;
+                        changes.add_room(info);
+                    }
+                }
             }
         }
     }

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -104,6 +104,9 @@ pub struct BaseRoomInfo {
     /// memberships.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub(crate) rtc_member: BTreeMap<OwnedUserId, MinimalStateEvent<CallMemberEventContent>>,
+    // Whether this room has been manually marked as unread
+    #[serde(default)]
+    pub(crate) is_marked_unread: bool,
 }
 
 impl BaseRoomInfo {
@@ -317,6 +320,7 @@ impl Default for BaseRoomInfo {
             tombstone: None,
             topic: None,
             rtc_member: BTreeMap::new(),
+            is_marked_unread: false,
         }
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -769,6 +769,12 @@ impl Room {
             .get_event_room_receipt_events(self.room_id(), receipt_type, thread, event_id)
             .await
     }
+
+    /// Returns a boolean indicating if this room has been manually marked as
+    /// unread
+    pub fn is_marked_unread(&self) -> bool {
+        self.inner.read().base_info.is_marked_unread
+    }
 }
 
 /// The underlying pure data structure for joined and left rooms.
@@ -1393,6 +1399,7 @@ mod tests {
                 "encryption": null,
                 "guest_access": null,
                 "history_visibility": null,
+                "is_marked_unread": false,
                 "join_rules": null,
                 "max_power_level": 100,
                 "name": null,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -219,8 +219,7 @@ impl BaseClient {
                 .push(raw.clone().cast());
         }
 
-        // Handles the remaining rooms account data not handled by
-        // process_sliding_sync_room.
+        // Handle room account data
         for (room_id, raw) in &rooms_account_data {
             self.handle_room_account_data(room_id, raw, &mut changes).await;
 
@@ -363,13 +362,6 @@ impl BaseClient {
             .await?;
         }
 
-        let room_account_data = if let Some(events) = rooms_account_data.remove(room_id) {
-            self.handle_room_account_data(room_id, &events, changes).await;
-            Some(events)
-        } else {
-            None
-        };
-
         process_room_properties(room_data, &mut room_info);
 
         let timeline = self
@@ -414,6 +406,7 @@ impl BaseClient {
         room_info.update_notification_count(notification_count);
 
         let ambiguity_changes = ambiguity_cache.changes.remove(room_id).unwrap_or_default();
+        let room_account_data = rooms_account_data.get(room_id).cloned();
 
         match room_info.state() {
             RoomState::Joined => {

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -204,6 +204,7 @@ impl BaseRoomInfoV1 {
             tombstone,
             topic,
             rtc_member: BTreeMap::new(),
+            is_marked_unread: false,
         })
     }
 }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -93,7 +93,7 @@ matrix-sdk-sqlite = { workspace = true, optional = true }
 mime = "0.3.16"
 mime2ext = "0.1.52"
 rand = { workspace = true , optional = true }
-ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc2965", "unstable-msc3930", "unstable-msc3245-v1-compat"] }
+ruma = { workspace = true, features = ["rand", "unstable-msc2448", "unstable-msc2965", "unstable-msc3930", "unstable-msc3245-v1-compat", "unstable-msc2867"] }
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -17,8 +17,8 @@ use matrix_sdk_common::timeout::timeout;
 use mime::Mime;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::{
-    marked_unread::MarkedUnreadEventContent, room::encrypted::OriginalSyncRoomEncryptedEvent,
-    AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent,
+    room::encrypted::OriginalSyncRoomEncryptedEvent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+    SyncMessageLikeEvent,
 };
 use ruma::{
     api::client::{
@@ -43,6 +43,7 @@ use ruma::{
     assign,
     events::{
         direct::DirectEventContent,
+        marked_unread::MarkedUnreadEventContent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
         room::{
             avatar::{self, RoomAvatarEventContent},

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -153,6 +153,32 @@ async fn unban_user() {
 }
 
 #[async_test]
+async fn mark_as_unread() {
+    let (client, server) = logged_in_client().await;
+
+    Mock::given(method("PUT"))
+        .and(path_regex(
+            r"^/_matrix/client/r0/user/.*/rooms/.*/account_data/com.famedly.marked_unread",
+        ))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
+        .mount(&server)
+        .await;
+
+    mock_sync(&server, &*test_json::SYNC, None).await;
+
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let _response = client.sync_once(sync_settings).await.unwrap();
+
+    let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
+
+    room.mark_unread(true).await.unwrap();
+
+    room.mark_unread(false).await.unwrap();
+}
+
+#[async_test]
 async fn kick_user() {
     let (client, server) = logged_in_client().await;
 


### PR DESCRIPTION
Requires https://github.com/ruma/ruma/pull/1721

This PR add support for manually marking rooms as unread through the means of [MSC2867](https://github.com/matrix-org/matrix-spec-proposals/pull/2867) which introduces a new room account data flag.

Rooms now have a new `mark_unread(unread: bool)` method for setting the flag as well as a `is_marked_unread` property, which is also exposed on RoomInfo

On the FFI layer the method above is used in conjucture with `send_read_receipt` to fully mark a room as read, which the client should do from the room list (outside of the timeline)