### PR TITLE
ffi: add missing poll events to `FilterMessageLikeEventType`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline_event_filter.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline_event_filter.rs
@@ -114,12 +114,17 @@ pub enum FilterMessageLikeEventType {
     KeyVerificationKey,
     KeyVerificationMac,
     KeyVerificationDone,
-    Poll,
+    PollEnd,
+    PollResponse,
+    PollStart,
     Reaction,
     RoomEncrypted,
     RoomMessage,
     RoomRedaction,
     Sticker,
+    UnstablePollStart,
+    UnstablePollResponse,
+    UnstablePollEnd,
 }
 
 impl From<FilterMessageLikeEventType> for TimelineEventType {
@@ -146,12 +151,17 @@ impl From<FilterMessageLikeEventType> for TimelineEventType {
             FilterMessageLikeEventType::KeyVerificationDone => {
                 TimelineEventType::KeyVerificationDone
             }
-            FilterMessageLikeEventType::Poll => TimelineEventType::PolicyRuleUser,
+            FilterMessageLikeEventType::PollEnd => TimelineEventType::PollEnd,
+            FilterMessageLikeEventType::PollResponse => TimelineEventType::PollResponse,
+            FilterMessageLikeEventType::PollStart => TimelineEventType::PollStart,
             FilterMessageLikeEventType::Reaction => TimelineEventType::Reaction,
             FilterMessageLikeEventType::RoomEncrypted => TimelineEventType::RoomEncrypted,
             FilterMessageLikeEventType::RoomMessage => TimelineEventType::RoomMessage,
             FilterMessageLikeEventType::RoomRedaction => TimelineEventType::RoomRedaction,
             FilterMessageLikeEventType::Sticker => TimelineEventType::Sticker,
+            FilterMessageLikeEventType::UnstablePollEnd => TimelineEventType::UnstablePollEnd,
+            FilterMessageLikeEventType::UnstablePollResponse => TimelineEventType::UnstablePollResponse,
+            FilterMessageLikeEventType::UnstablePollStart => TimelineEventType::UnstablePollStart,
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline_event_filter.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline_event_filter.rs
@@ -160,7 +160,9 @@ impl From<FilterMessageLikeEventType> for TimelineEventType {
             FilterMessageLikeEventType::RoomRedaction => TimelineEventType::RoomRedaction,
             FilterMessageLikeEventType::Sticker => TimelineEventType::Sticker,
             FilterMessageLikeEventType::UnstablePollEnd => TimelineEventType::UnstablePollEnd,
-            FilterMessageLikeEventType::UnstablePollResponse => TimelineEventType::UnstablePollResponse,
+            FilterMessageLikeEventType::UnstablePollResponse => {
+                TimelineEventType::UnstablePollResponse
+            }
             FilterMessageLikeEventType::UnstablePollStart => TimelineEventType::UnstablePollStart,
         }
     }


### PR DESCRIPTION
Added:

- PollEnd
- PollResponse
- PollStart
- UnstablePollStart
- UnstablePollResponse
- UnstablePollEnd

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
