### PR TITLE
feat(sdk,ui,ffi): Remove `SlidingSyncRoom::has_unread_notifications` and `::unread_notifications`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -507,14 +507,6 @@ impl RoomListItem {
     async fn latest_event(&self) -> Option<Arc<EventTimelineItem>> {
         self.inner.latest_event().await.map(EventTimelineItem).map(Arc::new)
     }
-
-    fn has_unread_notifications(&self) -> bool {
-        self.inner.has_unread_notifications()
-    }
-
-    fn unread_notifications(&self) -> Arc<UnreadNotificationsCount> {
-        Arc::new(self.inner.unread_notifications().into())
-    }
 }
 
 #[derive(Clone, Debug, uniffi::Enum)]

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -167,16 +167,6 @@ impl Room {
         self.inner.sliding_sync_room.latest_timeline_item().await
     }
 
-    /// Is there any unread notifications?
-    pub fn has_unread_notifications(&self) -> bool {
-        self.inner.sliding_sync_room.has_unread_notifications()
-    }
-
-    /// Get unread notifications.
-    pub fn unread_notifications(&self) -> UnreadNotificationsCount {
-        self.inner.sliding_sync_room.unread_notifications()
-    }
-
     /// Create a new [`TimelineBuilder`] with the default configuration.
     pub async fn default_room_timeline_builder(&self) -> TimelineBuilder {
         Timeline::builder(&self.inner.room)

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -18,10 +18,7 @@ use std::{ops::Deref, sync::Arc};
 
 use async_once_cell::OnceCell as AsyncOnceCell;
 use matrix_sdk::{SlidingSync, SlidingSyncRoom};
-use ruma::{
-    api::client::sync::sync_events::{v4::RoomSubscription, UnreadNotificationsCount},
-    RoomId,
-};
+use ruma::{api::client::sync::sync_events::v4::RoomSubscription, RoomId};
 
 use super::Error;
 use crate::{

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -8,6 +8,7 @@ use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, FutureExt, StreamExt};
 use imbl::vector;
 use matrix_sdk::Client;
+use matrix_sdk_base::sync::UnreadNotificationsCount;
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::{
     room_list_service::{
@@ -20,7 +21,7 @@ use matrix_sdk_ui::{
     RoomListService,
 };
 use ruma::{
-    api::client::sync::sync_events::{v4::RoomSubscription, UnreadNotificationsCount},
+    api::client::sync::sync_events::v4::RoomSubscription,
     assign, event_id,
     events::{room::message::RoomMessageEventContent, StateEventType},
     mxc_uri, room_id, uint,
@@ -2287,10 +2288,9 @@ async fn test_room_unread_notifications() -> Result<(), Error> {
 
     let room = room_list.room(room_id).await.unwrap();
 
-    assert!(room.has_unread_notifications().not());
     assert_matches!(
-        room.unread_notifications(),
-        UnreadNotificationsCount { highlight_count: None, notification_count: None, .. }
+        room.unread_notification_counts(),
+        UnreadNotificationsCount { highlight_count: 0, notification_count: 0 }
     );
 
     sync_then_assert_request_and_fake_response! {
@@ -2315,17 +2315,9 @@ async fn test_room_unread_notifications() -> Result<(), Error> {
         },
     };
 
-    assert!(room.has_unread_notifications());
     assert_matches!(
-        room.unread_notifications(),
-        UnreadNotificationsCount {
-            highlight_count,
-            notification_count,
-            ..
-        } => {
-            assert_eq!(highlight_count, Some(uint!(1)));
-            assert_eq!(notification_count, Some(uint!(2)));
-        }
+        room.unread_notification_counts(),
+        UnreadNotificationsCount { highlight_count: 1, notification_count: 2 }
     );
 
     Ok(())

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -306,7 +306,7 @@ mod tests {
     use matrix_sdk_test::async_test;
     use ruma::{
         api::client::sync::sync_events::v4, assign, events::room::message::RoomMessageEventContent,
-        mxc_uri, room_id, serde::Raw, uint, JsOption, RoomId,
+        mxc_uri, room_id, serde::Raw, JsOption, RoomId,
     };
     use serde_json::json;
     use wiremock::MockServer;

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -1,16 +1,12 @@
 use std::{
     fmt::Debug,
-    ops::Not,
     sync::{Arc, RwLock},
 };
 
 use eyeball_im::Vector;
 use matrix_sdk_base::{deserialized_responses::SyncTimelineEvent, latest_event::LatestEvent};
 use ruma::{
-    api::client::sync::sync_events::{v4, UnreadNotificationsCount},
-    events::AnySyncStateEvent,
-    serde::Raw,
-    OwnedRoomId, RoomId,
+    api::client::sync::sync_events::v4, events::AnySyncStateEvent, serde::Raw, OwnedRoomId, RoomId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -86,20 +82,6 @@ impl SlidingSyncRoom {
         let inner = self.inner.inner.read().unwrap();
 
         inner.initial
-    }
-
-    /// Is there any unread notifications?
-    pub fn has_unread_notifications(&self) -> bool {
-        let inner = self.inner.inner.read().unwrap();
-
-        inner.unread_notifications.is_empty().not()
-    }
-
-    /// Get unread notifications.
-    pub fn unread_notifications(&self) -> UnreadNotificationsCount {
-        let inner = self.inner.inner.read().unwrap();
-
-        inner.unread_notifications.clone()
     }
 
     /// Get the required state.
@@ -466,38 +448,6 @@ mod tests {
             _ = Some(true);
             receives nothing;
             _ = Some(true);
-        }
-
-        test_has_unread_notifications_with_notification_count {
-            has_unread_notifications() = false;
-            receives room_response!({"notification_count": 42});
-            _ = true;
-            receives nothing;
-            _ = false;
-        }
-
-        test_has_unread_notifications_with_highlight_count {
-            has_unread_notifications() = false;
-            receives room_response!({"highlight_count": 42});
-            _ = true;
-            receives nothing;
-            _ = false;
-        }
-
-        test_unread_notifications_with_notification_count {
-            unread_notifications().notification_count = None;
-            receives room_response!({"notification_count": 42});
-            _ = Some(uint!(42));
-            receives nothing;
-            _ = None;
-        }
-
-        test_unread_notifications_with_highlight_count {
-            unread_notifications().highlight_count = None;
-            receives room_response!({"highlight_count": 42});
-            _ = Some(uint!(42));
-            receives nothing;
-            _ = None;
         }
     }
 


### PR DESCRIPTION
This PR must be reviewed commit-by-commit.

`matrix_sdk::sliding_sync::SlidingSyncRoom` holds information about the unread notification counts. Unfortunately, it's a duplication of the data synchronized with `Room`. Worst: it hides the new Read Receipt Notification Count API, introduced by @bnjbvr. So this is basically a bad API to use, and almost dead code now.

These patches clean the situation up by removing the `SlidingSyncRoom::has_unread_notifications` and the `::unread_notifications` methods, along with all the chain: `matrix_sdk_ui::room_list_service::Room` and `matrix_sdk_ffi::room_list_service::Room`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3079