### PR TITLE
sdk: use a Mutex instead of a RwLock for the sync lock

### DIFF
--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -51,7 +51,7 @@ use ruma::{
     serde::Raw,
     EventId, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
 };
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 /// BoxStream of owned Types
 pub type BoxStream<T> = Pin<Box<dyn futures_util::Stream<Item = T> + Send>>;
@@ -144,11 +144,8 @@ pub(crate) struct Store {
     pub(super) sync_token: Arc<RwLock<Option<String>>>,
     rooms: Arc<StdRwLock<BTreeMap<OwnedRoomId, Room>>>,
     /// A lock to synchronize access to the store, such that data by the sync is
-    /// never overwritten. The sync processing is supposed to use write access,
-    /// such that only it is currently accessing the store overall. Other things
-    /// might acquire read access, such that access to different rooms can be
-    /// parallelized.
-    sync_lock: Arc<RwLock<()>>,
+    /// never overwritten.
+    sync_lock: Arc<Mutex<()>>,
 }
 
 impl Store {
@@ -164,7 +161,7 @@ impl Store {
     }
 
     /// Get access to the syncing lock.
-    pub fn sync_lock(&self) -> &RwLock<()> {
+    pub fn sync_lock(&self) -> &Mutex<()> {
         &self.sync_lock
     }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -410,7 +410,7 @@ impl Room {
                     Err(err) => return Err(err.into()),
                 };
 
-                let _sync_lock = self.client.base_client().sync_lock().read().await;
+                let _sync_lock = self.client.base_client().sync_lock().lock().await;
 
                 // Persist the event and the fact that we requested it from the server in
                 // `RoomInfo`.

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -328,7 +328,7 @@ impl SlidingSync {
         let mut sync_response = {
             // Take the lock to avoid concurrent sliding syncs overwriting each other's room
             // infos.
-            let _sync_lock = self.inner.client.base_client().sync_lock().write().await;
+            let _sync_lock = self.inner.client.base_client().sync_lock().lock().await;
 
             let rooms = &*self.inner.rooms.read().await;
             let mut response_processor =


### PR DESCRIPTION
I think the reasoning behind using a RwLock for sync, and notably allowing multiple concurrent `.read()` lock taking was flawed: since there's no way to identify which subpiece of the store we're reading and writing, there could be two concurrent requests to the write to the same thing at the same time. To get rid of this possibility, this commit changes the lock to a single access only Mutex lock.