### PR TITLE
feat(sdk,base,ui,ffi): Continue to remove dead code in `SlidingSyncRoom`

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -83,15 +83,9 @@ impl Room {
         self.inner.room.room_id()
     }
 
-    /// Get the best possible name for the room.
-    ///
-    /// If the sliding sync room has received a name from the server, then use
-    /// it, otherwise, let's calculate a name.
+    /// Get the name of the room if it exists.
     pub async fn name(&self) -> Option<String> {
-        Some(match self.inner.sliding_sync_room.name() {
-            Some(name) => name,
-            None => self.inner.room.display_name().await.ok()?.to_string(),
-        })
+        Some(self.inner.room.display_name().await.ok()?.to_string())
     }
 
     /// Get the underlying [`matrix_sdk::Room`].

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -239,8 +239,7 @@ async fn create_one_room(
 
     assert!(update.rooms.contains(&room_id.to_owned()));
 
-    let room = sliding_sync.get_room(room_id).await.context("`get_room`")?;
-    assert_eq!(room.name(), Some(room_name.clone()));
+    let _room = sliding_sync.get_room(room_id).await.context("`get_room`")?;
 
     Ok(())
 }

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -61,13 +61,6 @@ impl SlidingSyncRoom {
         &self.inner.room_id
     }
 
-    /// This rooms name as calculated by the server, if any
-    pub fn name(&self) -> Option<String> {
-        let inner = self.inner.inner.read().unwrap();
-
-        inner.name.to_owned()
-    }
-
     /// Get the token for back-pagination.
     pub fn prev_batch(&self) -> Option<String> {
         self.inner.inner.read().unwrap().prev_batch.clone()
@@ -349,69 +342,6 @@ mod tests {
         let room = new_room(room_id, room_response!({})).await;
 
         assert_eq!(room.room_id(), room_id);
-    }
-
-    macro_rules! test_getters {
-        (
-            $(
-                $test_name:ident {
-                    $getter:ident () $( . $getter_field:ident )? = $default_value:expr;
-                    receives $room_response:expr;
-                    _ = $init_or_updated_value:expr;
-                    receives nothing;
-                    _ = $no_update_value:expr;
-                }
-            )+
-        ) => {
-            $(
-                #[async_test]
-                async fn $test_name () {
-                    // Default value.
-                    {
-                        let room = new_room(room_id!("!foo:bar.org"), room_response!({})).await;
-
-                        assert_eq!(room.$getter() $( . $getter_field )?, $default_value, "default value");
-                    }
-
-                    // Some value when initializing.
-                    {
-                        let room = new_room(room_id!("!foo:bar.org"), $room_response).await;
-
-                        assert_eq!(room.$getter() $( . $getter_field )?, $init_or_updated_value, "init value");
-                    }
-
-                    // Some value when updating.
-                    {
-
-                        let mut room = new_room(room_id!("!foo:bar.org"), room_response!({})).await;
-
-                        // Value is set to the default value.
-                        assert_eq!(room.$getter() $( . $getter_field )?, $default_value, "default value (bis)");
-
-                        room.update($room_response, vec![]);
-
-                        // Value has been updated.
-                        assert_eq!(room.$getter() $( . $getter_field )?, $init_or_updated_value, "updated value");
-
-                        room.update(room_response!({}), vec![]);
-
-                        // Value is kept.
-                        assert_eq!(room.$getter() $( . $getter_field )?, $no_update_value, "not updated value");
-                    }
-
-                }
-            )+
-        };
-    }
-
-    test_getters! {
-        test_room_name {
-            name() = None;
-            receives room_response!({"name": "gordon"});
-            _ = Some("gordon".to_owned());
-            receives nothing;
-            _ = Some("gordon".to_owned());
-        }
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -68,13 +68,6 @@ impl SlidingSyncRoom {
         inner.name.to_owned()
     }
 
-    /// Is this a direct message?
-    pub fn is_dm(&self) -> Option<bool> {
-        let inner = self.inner.inner.read().unwrap();
-
-        inner.is_dm
-    }
-
     /// Get the token for back-pagination.
     pub fn prev_batch(&self) -> Option<String> {
         self.inner.inner.read().unwrap().prev_batch.clone()
@@ -418,14 +411,6 @@ mod tests {
             _ = Some("gordon".to_owned());
             receives nothing;
             _ = Some("gordon".to_owned());
-        }
-
-        test_room_is_dm {
-            is_dm() = None;
-            receives room_response!({"is_dm": true});
-            _ = Some(true);
-            receives nothing;
-            _ = Some(true);
         }
     }
 

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -75,13 +75,6 @@ impl SlidingSyncRoom {
         inner.is_dm
     }
 
-    /// Was this an initial response?
-    pub fn is_initial_response(&self) -> Option<bool> {
-        let inner = self.inner.inner.read().unwrap();
-
-        inner.initial
-    }
-
     /// Get the token for back-pagination.
     pub fn prev_batch(&self) -> Option<String> {
         self.inner.inner.read().unwrap().prev_batch.clone()
@@ -430,14 +423,6 @@ mod tests {
         test_room_is_dm {
             is_dm() = None;
             receives room_response!({"is_dm": true});
-            _ = Some(true);
-            receives nothing;
-            _ = Some(true);
-        }
-
-        test_room_is_initial_response {
-            is_initial_response() = None;
-            receives room_response!({"initial": true});
             _ = Some(true);
             receives nothing;
             _ = Some(true);


### PR DESCRIPTION
This patch continues the clean up of `matrix_sdk::sliding_sync::SlidingSyncRoom`. Please read commit-by-commit. 3 methods are removed, because either they are never used, or because the data they contain are a duplication with the `matrix_sdk_base::Room`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3079