### PR TITLE
Enable the future_not_send lint in our main crates

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -16,6 +16,7 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs, missing_debug_implementations)]
+#![cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
 
 pub use matrix_sdk_common::*;
 use ruma::{OwnedDeviceId, OwnedUserId};

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
+
 use ruma::html::HtmlSanitizerMode;
 
 mod events;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1116,7 +1116,6 @@ impl Client {
     /// client.public_rooms(limit, since, server).await;
     /// # };
     /// ```
-    #[cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
     pub async fn public_rooms(
         &self,
         limit: Option<u32>,

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -15,6 +15,7 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
 
 pub use async_trait::async_trait;
 pub use bytes;

--- a/crates/matrix-sdk/src/matrix_auth/login_builder.rs
+++ b/crates/matrix-sdk/src/matrix_auth/login_builder.rs
@@ -12,8 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![cfg_attr(not(target_arch = "wasm32"), deny(clippy::future_not_send))]
-
 #[cfg(feature = "sso-login")]
 use std::future::Future;
 use std::future::IntoFuture;


### PR DESCRIPTION
Please note that this excludes the matrix-sdk-crypto crate, this crate uses generic functions in a bunch of places without having a Send bound.

We would either need to add a bound or add exceptions for them.
