### PR TITLE
indexeddb: Clear the object store before deleting it

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations.rs
@@ -317,6 +317,11 @@ async fn prepare_data_for_v7(serializer: &IndexeddbSerializer, db: &IdbDatabase)
         }
     }
 
+    // We have finished with the old store. Clear it, since it is faster to
+    // clear+delete than just delete. See https://www.artificialworlds.net/blog/2024/02/01/deleting-an-indexed-db-store-can-be-incredibly-slow-on-firefox/
+    // for more details.
+    old_store.clear()?.await?;
+
     Ok(txn.await.into_result()?)
 }
 


### PR DESCRIPTION
Since my investigation found that it significantly speeds up deletion of a store on both Firefox and Chromium if you clear() it first, do that in our migration code.

Related: https://github.com/element-hq/element-web/issues/26948