### PR TITLE
Simple send encrypted to device API

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -12,7 +12,7 @@
   keys whose metadata lacked check fields.
   ([#3046](https://github.com/matrix-org/matrix-rust-sdk/pull/3046))
 
-- Add new API `OlmMachine::create_encrypted_to_device_request` that allows
+- Add new API `Device::create_encrypted_to_device_request` that allows
   to encrypt a to device event to a specific device.
 
 # 0.7.0

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -12,8 +12,8 @@
   keys whose metadata lacked check fields.
   ([#3046](https://github.com/matrix-org/matrix-rust-sdk/pull/3046))
 
-- Add new API `Device::create_encrypted_to_device_request` that allows
-  to encrypt a to device event to a specific device.
+- Add new API `Device::encrypt_event_raw` that allows
+  to encrypt an event to a specific device.
 
 # 0.7.0
 

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -12,6 +12,9 @@
   keys whose metadata lacked check fields.
   ([#3046](https://github.com/matrix-org/matrix-rust-sdk/pull/3046))
 
+- Add new API `OlmMachine::create_encrypted_to_device_request` that allows
+  to encrypt a to device event to a specific device.
+
 # 0.7.0
 
 - Add method to mark a list of inbound group sessions as backed up:

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Add new API `Device::encrypt_event_raw` that allows
   to encrypt an event to a specific device.
+  ([#3091](https://github.com/matrix-org/matrix-rust-sdk/pull/3091))
 
 # 0.7.0
 

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -464,7 +464,7 @@ impl Device {
     ///
     /// # Returns
     ///
-    /// The encrypted raw content to be shared with your prefered transport
+    /// The encrypted raw content to be shared with your preferred transport
     /// layer (usually to-device). [`OlmError::MissingSession`] if there is
     /// no established session with the device.
     pub async fn encrypt_event_raw(

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -36,7 +36,7 @@ use tracing::{instrument, trace, warn};
 use vodozemac::{olm::SessionConfig, Curve25519PublicKey, Ed25519PublicKey};
 
 use super::{atomic_bool_deserializer, atomic_bool_serializer};
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "testing", doc))]
 use crate::OlmMachine;
 use crate::{
     error::{EventError, OlmError, OlmResult, SignatureError},

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -442,20 +442,19 @@ impl Device {
         self.encrypt(event_type, content).await
     }
 
-    /// Encrypt an event for the given device.
+    /// Encrypt an event for this device.
     ///
-    /// Not to be confused with [`OlmMachine::encrypt_room_event`] that
-    /// encrypts the event to a room. The current method is used to
-    /// encrypt an event directly to a device using the peer to peer e2e
-    /// session.
-    ///
-    /// Beware that the peer to peer session must be established prior to this
+    /// Beware that the 1-to-1 session must be established prior to this
     /// call by using the [`OlmMachine::get_missing_sessions`] method.
     ///
     /// Notable limitation: The caller is responsible for sending the encrypted
     /// event to the target device, this encryption method supports out-of-order
-    /// messages to a certain extent (2000 messages), so it's recommended to
-    /// send the encrypted event as soon as possible.
+    /// messages to a certain extent (2000 messages), if multiple messages are
+    /// encrypted using this method they should be sent in the same order as
+    /// they are encrypted.
+    ///
+    /// *Note*: To instead encrypt an event meant for a room use the
+    /// [`OlmMachine::encrypt_room_event()`] method instead.
     ///
     /// # Arguments
     /// * `event_type` - The type of the event to be sent.
@@ -465,7 +464,7 @@ impl Device {
     /// # Returns
     ///
     /// The encrypted raw content to be shared with your preferred transport
-    /// layer (usually to-device). [`OlmError::MissingSession`] if there is
+    /// layer (usually to-device), [`OlmError::MissingSession`] if there is
     /// no established session with the device.
     pub async fn encrypt_event_raw(
         &self,

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -37,14 +37,13 @@ use ruma::{
     assign,
     events::{
         secret::request::SecretName, AnyMessageLikeEvent, AnyMessageLikeEventContent,
-        AnyToDeviceEvent, AnyToDeviceEventContent, MessageLikeEventContent, ToDeviceEventType,
+        AnyToDeviceEvent, MessageLikeEventContent,
     },
     serde::Raw,
-    to_device::DeviceIdOrAllDevices,
     DeviceId, DeviceKeyAlgorithm, OwnedDeviceId, OwnedDeviceKeyId, OwnedTransactionId, OwnedUserId,
     RoomId, TransactionId, UInt, UserId,
 };
-use serde_json::{value::to_raw_value, Value};
+use serde_json::value::to_raw_value;
 use tokio::sync::Mutex;
 use tracing::{
     debug, error,
@@ -902,66 +901,6 @@ impl OlmMachine {
     /// to invalidate.
     pub async fn invalidate_group_session(&self, room_id: &RoomId) -> StoreResult<bool> {
         self.inner.group_session_manager.invalidate_group_session(room_id).await
-    }
-
-    ///
-    /// Creates an encrypted to_device event ready to be sent to that device.
-    /// The caller should ensure that there is an existing Olm session with the
-    /// target device, by calling `get_missing_sessions(user_id)`
-    ///
-    /// # Arguments
-    ///
-    /// * `user_id` - The user ID of the target device.
-    /// * `device_id` - The device ID of the target device.
-    /// * `event_type` - The type of the event to be sent.
-    /// * `content` - The content of the event to be sent. This should be a type
-    ///   that implements the `Serialize` trait.
-    ///
-    /// # Returns
-    /// None if the device is unknown, errors if no olm session is found or
-    /// if an error occurs during encryption.
-    pub async fn create_encrypted_to_device_request(
-        &self,
-        user_id: &UserId,
-        device_id: &DeviceId,
-        event_type: &str,
-        content: &Value,
-    ) -> OlmResult<Option<ToDeviceRequest>> {
-        // Timeout is None since the caller is expected to ensure `get_missing_sessions`
-        // first.
-        let device = self.get_device(user_id, device_id, None).await?;
-
-        if device.is_none() {
-            warn!(
-                "Trying to send an encrypted to-device event to an unknown device {}:{}",
-                user_id, device_id
-            );
-            return Ok(None);
-        }
-
-        let (used_session, raw_encrypted) = device.unwrap().encrypt(event_type, content).await?;
-
-        // perist the used session
-        self.store()
-            .save_changes(Changes { sessions: vec![used_session], ..Default::default() })
-            .await?;
-
-        let mut messages = BTreeMap::new();
-
-        let any_cast: Raw<AnyToDeviceEventContent> = raw_encrypted.cast();
-
-        messages
-            .entry(user_id.to_owned())
-            .or_insert_with(BTreeMap::new)
-            .insert(DeviceIdOrAllDevices::DeviceId(device_id.to_owned()), any_cast);
-
-        let request = ToDeviceRequest {
-            event_type: ToDeviceEventType::RoomEncrypted,
-            txn_id: TransactionId::new(),
-            messages,
-        };
-
-        Ok(Some(request))
     }
 
     /// Get to-device requests to share a room key with users in a room.
@@ -4316,15 +4255,10 @@ pub(crate) mod tests {
                 "rooms": ["!726s6s6q:example.com"]
         });
 
-        let request = alice
-            .create_encrypted_to_device_request(
-                bob.user_id(),
-                bob_device_id(),
-                custom_event_type,
-                &custom_content,
-            )
+        let device = alice.get_device(bob.user_id(), bob.device_id(), None).await.unwrap().unwrap();
+        let request = device
+            .create_encrypted_to_device_request(custom_event_type, &custom_content)
             .await
-            .unwrap()
             .expect("Should have created a request");
 
         assert_eq!("m.room.encrypted", request.event_type.to_string());
@@ -4376,30 +4310,6 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn test_send_encrypted_to_device_unknown_device() {
-        let (alice, bob) = get_machine_pair_with_session(alice_id(), user_id(), false).await;
-
-        let custom_event_type = "m.new_device";
-
-        let custom_content = json!({
-                "device_id": "XYZABCDE",
-                "rooms": ["!726s6s6q:example.com"]
-        });
-
-        let request = alice
-            .create_encrypted_to_device_request(
-                bob.user_id(),
-                device_id!("UNKNOWN"),
-                custom_event_type,
-                &custom_content,
-            )
-            .await
-            .unwrap();
-
-        assert!(request.is_none());
-    }
-
-    #[async_test]
     async fn test_send_encrypted_to_device_no_session() {
         let (alice, bob, _) = get_machine_pair(alice_id(), user_id(), false).await;
 
@@ -4411,12 +4321,11 @@ pub(crate) mod tests {
         });
 
         let request = alice
-            .create_encrypted_to_device_request(
-                bob.user_id(),
-                bob_device_id(),
-                custom_event_type,
-                &custom_content,
-            )
+            .get_device(bob.user_id(), bob_device_id(), None)
+            .await
+            .unwrap()
+            .unwrap()
+            .create_encrypted_to_device_request(custom_event_type, &custom_content)
             .await;
 
         assert_matches!(request, Err(OlmError::MissingSession));


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/1816

Adds a new API on `Device` called `create_encrypted_to_device_request` that allows to encrypt a specific event
to a single target device. 
The caller must call `get_missing_sessions` before calling `create_encrypted_to_device_request`, or he might get an `OlmError::MissingSession`.
For now this will create missing sessions with all devices of the target users, as there is no API to get missing session for a given device, but I think it's acceptable.


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
