### PR TITLE
feat(sdk): Remove `SlidingSyncRoom::timeline_queue` and `prev_batch`

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -498,12 +498,7 @@ impl BaseClient {
             let processors::e2ee::to_device::Output {
                 decrypted_to_device_events: to_device,
                 room_key_updates,
-            } = processors::e2ee::to_device::from_sync_v2(
-                &mut context,
-                &response,
-                olm_machine.as_ref(),
-            )
-            .await?;
+            } = processors::e2ee::to_device::from_sync_v2(&response, olm_machine.as_ref()).await?;
 
             processors::latest_event::decrypt_from_rooms(
                 &mut context,
@@ -782,7 +777,6 @@ impl BaseClient {
 
         #[cfg(feature = "e2e-encryption")]
         processors::e2ee::tracked_users::update(
-            &mut context,
             self.olm_machine().await.as_ref(),
             room.encryption_state(),
             &user_ids,

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -37,7 +37,6 @@ mod response_processors;
 mod rooms;
 
 pub mod read_receipts;
-pub use read_receipts::PreviousEventsProvider;
 pub mod sliding_sync;
 
 pub mod store;

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -267,19 +267,6 @@ impl RoomReadReceipts {
     }
 }
 
-/// Provider for timeline events prior to the current sync.
-pub trait PreviousEventsProvider: Send + Sync {
-    /// Returns the list of known timeline events, in sync order, for the given
-    /// room.
-    fn for_room(&self, room_id: &RoomId) -> Vector<TimelineEvent>;
-}
-
-impl PreviousEventsProvider for () {
-    fn for_room(&self, _: &RoomId) -> Vector<TimelineEvent> {
-        Vector::new()
-    }
-}
-
 /// Small helper to select the "best" receipt (that with the biggest sync
 /// order).
 struct ReceiptSelector {

--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -122,7 +122,6 @@ use std::{
     num::NonZeroUsize,
 };
 
-use eyeball_im::Vector;
 use matrix_sdk_common::{deserialized_responses::TimelineEvent, ring_buffer::RingBuffer};
 use ruma::{
     events::{
@@ -294,10 +293,7 @@ struct ReceiptSelector {
 }
 
 impl ReceiptSelector {
-    fn new(
-        all_events: &Vector<TimelineEvent>,
-        latest_active_receipt_event: Option<&EventId>,
-    ) -> Self {
+    fn new(all_events: &[TimelineEvent], latest_active_receipt_event: Option<&EventId>) -> Self {
         let event_id_to_pos = Self::create_sync_index(all_events.iter());
 
         let best_pos =
@@ -457,23 +453,22 @@ pub(crate) fn compute_unread_counts(
     user_id: &UserId,
     room_id: &RoomId,
     receipt_event: Option<&ReceiptEventContent>,
-    previous_events: Vector<TimelineEvent>,
+    mut previous_events: Vec<TimelineEvent>,
     new_events: &[TimelineEvent],
     read_receipts: &mut RoomReadReceipts,
 ) {
-    debug!(?read_receipts, "Starting.");
+    debug!(?read_receipts, "Starting");
 
     let all_events = if events_intersects(previous_events.iter(), new_events) {
         // The previous and new events sets can intersect, for instance if we restored
         // previous events from the disk cache, or a timeline was limited. This
         // means the old events will be cleared, because we don't reconcile
-        // timelines in sliding sync (yet). As a result, forget
+        // timelines in the event cache (yet). As a result, forget
         // about the previous events.
-        Vector::from_iter(new_events.iter().cloned())
+        new_events.to_owned()
     } else {
-        let mut all_events = previous_events;
-        all_events.extend(new_events.iter().cloned());
-        all_events
+        previous_events.extend(new_events.iter().cloned());
+        previous_events
     };
 
     let new_receipt = {
@@ -481,6 +476,7 @@ pub(crate) fn compute_unread_counts(
             &all_events,
             read_receipts.latest_active.as_ref().map(|receipt| &*receipt.event_id),
         );
+
         selector.try_match_implicit(user_id, new_events);
         selector.handle_pending_receipts(&mut read_receipts.pending);
         if let Some(receipt_event) = receipt_event {
@@ -622,7 +618,6 @@ fn marks_as_unread(event: &Raw<AnySyncTimelineEvent>, user_id: &UserId) -> bool 
 mod tests {
     use std::{num::NonZeroUsize, ops::Not as _};
 
-    use eyeball_im::Vector;
     use matrix_sdk_common::{deserialized_responses::TimelineEvent, ring_buffer::RingBuffer};
     use matrix_sdk_test::event_factory::EventFactory;
     use ruma::{
@@ -915,7 +910,7 @@ mod tests {
         let room_id = room_id!("!room:example.org");
         let receipt_event_id = event_id!("$1");
 
-        let mut previous_events = Vector::new();
+        let mut previous_events = Vec::new();
 
         let f = EventFactory::new();
         let ev1 = f.text_msg("A").sender(other_user_id).event_id(receipt_event_id).into_event();
@@ -940,8 +935,8 @@ mod tests {
         assert_eq!(read_receipts.num_unread, 1);
 
         // Receive the same receipt event, with a new sync event.
-        previous_events.push_back(ev1);
-        previous_events.push_back(ev2);
+        previous_events.push(ev1);
+        previous_events.push(ev2);
 
         let new_event =
             f.text_msg("A").sender(other_user_id).event_id(event_id!("$3")).into_event();
@@ -958,7 +953,7 @@ mod tests {
         assert_eq!(read_receipts.num_unread, 2);
     }
 
-    fn make_test_events(user_id: &UserId) -> Vector<TimelineEvent> {
+    fn make_test_events(user_id: &UserId) -> Vec<TimelineEvent> {
         let f = EventFactory::new().sender(user_id);
         let ev1 = f.text_msg("With the lights out, it's less dangerous").event_id(event_id!("$1"));
         let ev2 = f.text_msg("Here we are now, entertain us").event_id(event_id!("$2"));
@@ -976,7 +971,7 @@ mod tests {
         let room_id = room_id!("!room:example.org");
 
         let all_events = make_test_events(user_id!("@bob:example.org"));
-        let head_events: Vector<_> = all_events.iter().take(2).cloned().collect();
+        let head_events: Vec<_> = all_events.iter().take(2).cloned().collect();
         let tail_events: Vec<_> = all_events.iter().skip(2).cloned().collect();
 
         // Given a receipt event marking events 1-3 as read using a combination of
@@ -1165,7 +1160,7 @@ mod tests {
 
         {
             // No initial active receipt, so the first receipt we get *will* win.
-            let mut selector = ReceiptSelector::new(&vec![].into(), None);
+            let mut selector = ReceiptSelector::new(&[], None);
             selector.try_select_later(event_id!("$1"), 0);
             let best_receipt = selector.select();
             assert_eq!(best_receipt.unwrap().event_id, event_id!("$1"));
@@ -1203,11 +1198,11 @@ mod tests {
         let f = EventFactory::new().sender(sender);
         let ev1 = f.text_msg("yo").event_id(event_id!("$1")).into_event();
         let ev2 = f.text_msg("well?").event_id(event_id!("$2")).into_event();
-        let events: Vector<_> = vec![ev1, ev2].into();
+        let events = &[ev1, ev2][..];
 
         {
             // No pending receipt => no better receipt.
-            let mut selector = ReceiptSelector::new(&events, None);
+            let mut selector = ReceiptSelector::new(events, None);
 
             let mut pending = RingBuffer::new(NonZeroUsize::new(16).unwrap());
             selector.handle_pending_receipts(&mut pending);
@@ -1221,7 +1216,7 @@ mod tests {
         {
             // No pending receipt, and there was an active last receipt => no better
             // receipt.
-            let mut selector = ReceiptSelector::new(&events, Some(event_id!("$1")));
+            let mut selector = ReceiptSelector::new(events, Some(event_id!("$1")));
 
             let mut pending = RingBuffer::new(NonZeroUsize::new(16).unwrap());
             selector.handle_pending_receipts(&mut pending);
@@ -1239,11 +1234,11 @@ mod tests {
         let f = EventFactory::new().sender(sender);
         let ev1 = f.text_msg("yo").event_id(event_id!("$1")).into_event();
         let ev2 = f.text_msg("well?").event_id(event_id!("$2")).into_event();
-        let events: Vector<_> = vec![ev1, ev2].into();
+        let events = &[ev1, ev2][..];
 
         {
             // A pending receipt for an event that is still missing => no better receipt.
-            let mut selector = ReceiptSelector::new(&events, None);
+            let mut selector = ReceiptSelector::new(events, None);
 
             let mut pending = RingBuffer::new(NonZeroUsize::new(16).unwrap());
             pending.push(owned_event_id!("$3"));
@@ -1257,7 +1252,7 @@ mod tests {
 
         {
             // Ditto but there was an active receipt => no better receipt.
-            let mut selector = ReceiptSelector::new(&events, Some(event_id!("$1")));
+            let mut selector = ReceiptSelector::new(events, Some(event_id!("$1")));
 
             let mut pending = RingBuffer::new(NonZeroUsize::new(16).unwrap());
             pending.push(owned_event_id!("$3"));
@@ -1276,11 +1271,11 @@ mod tests {
         let f = EventFactory::new().sender(sender);
         let ev1 = f.text_msg("yo").event_id(event_id!("$1")).into_event();
         let ev2 = f.text_msg("well?").event_id(event_id!("$2")).into_event();
-        let events: Vector<_> = vec![ev1, ev2].into();
+        let events = &[ev1, ev2][..];
 
         {
             // A pending receipt for an event that is present => better receipt.
-            let mut selector = ReceiptSelector::new(&events, None);
+            let mut selector = ReceiptSelector::new(events, None);
 
             let mut pending = RingBuffer::new(NonZeroUsize::new(16).unwrap());
             pending.push(owned_event_id!("$2"));
@@ -1296,7 +1291,7 @@ mod tests {
 
         {
             // Mixed found and not found receipt => better receipt.
-            let mut selector = ReceiptSelector::new(&events, None);
+            let mut selector = ReceiptSelector::new(events, None);
 
             let mut pending = RingBuffer::new(NonZeroUsize::new(16).unwrap());
             pending.push(owned_event_id!("$1"));
@@ -1318,12 +1313,12 @@ mod tests {
         let f = EventFactory::new().sender(sender);
         let ev1 = f.text_msg("yo").event_id(event_id!("$1")).into_event();
         let ev2 = f.text_msg("well?").event_id(event_id!("$2")).into_event();
-        let events: Vector<_> = vec![ev1, ev2].into();
+        let events = &[ev1, ev2][..];
 
         {
             // Same, and there was an initial receipt that was less good than the one we
             // selected => better receipt.
-            let mut selector = ReceiptSelector::new(&events, Some(event_id!("$1")));
+            let mut selector = ReceiptSelector::new(events, Some(event_id!("$1")));
 
             let mut pending = RingBuffer::new(NonZeroUsize::new(16).unwrap());
             pending.push(owned_event_id!("$2"));
@@ -1339,7 +1334,7 @@ mod tests {
 
         {
             // Same, but the previous receipt was better => no better receipt.
-            let mut selector = ReceiptSelector::new(&events, Some(event_id!("$2")));
+            let mut selector = ReceiptSelector::new(events, Some(event_id!("$2")));
 
             let mut pending = RingBuffer::new(NonZeroUsize::new(16).unwrap());
             pending.push(owned_event_id!("$1"));
@@ -1484,26 +1479,26 @@ mod tests {
         // When the selector sees only other users' events,
         let mut selector = ReceiptSelector::new(&events, None);
         // And I search for my implicit read receipt,
-        selector.try_match_implicit(&myself, &events.iter().cloned().collect::<Vec<_>>());
+        selector.try_match_implicit(&myself, &events);
         // Then I don't find any.
         let best_receipt = selector.select();
         assert!(best_receipt.is_none());
 
         // Now, if there are events I've written too...
         let f = EventFactory::new();
-        events.push_back(
+        events.push(
             f.text_msg("A mulatto, an albino")
                 .sender(&myself)
                 .event_id(event_id!("$6"))
                 .into_event(),
         );
-        events.push_back(
+        events.push(
             f.text_msg("A mosquito, my libido").sender(bob).event_id(event_id!("$7")).into_event(),
         );
 
         let mut selector = ReceiptSelector::new(&events, None);
         // And I search for my implicit read receipt,
-        selector.try_match_implicit(&myself, &events.iter().cloned().collect::<Vec<_>>());
+        selector.try_match_implicit(&myself, &events);
         // Then my last sent event counts as a read receipt.
         let best_receipt = selector.select();
         assert_eq!(best_receipt.unwrap().event_id, event_id!("$6"));
@@ -1520,7 +1515,7 @@ mod tests {
 
         // One by me,
         let f = EventFactory::new();
-        events.push_back(
+        events.push(
             f.text_msg("A mulatto, an albino")
                 .sender(user_id)
                 .event_id(event_id!("$6"))
@@ -1528,10 +1523,10 @@ mod tests {
         );
 
         // And others by Bob,
-        events.push_back(
+        events.push(
             f.text_msg("A mosquito, my libido").sender(bob).event_id(event_id!("$7")).into_event(),
         );
-        events.push_back(
+        events.push(
             f.text_msg("A denial, a denial").sender(bob).event_id(event_id!("$8")).into_event(),
         );
 
@@ -1551,7 +1546,7 @@ mod tests {
             user_id,
             room_id,
             Some(&receipt_event),
-            Vector::new(),
+            Vec::new(),
             &events,
             &mut read_receipts,
         );

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/decrypt.rs
@@ -16,10 +16,7 @@ use matrix_sdk_common::deserialized_responses::TimelineEvent;
 use matrix_sdk_crypto::{DecryptionSettings, RoomEventDecryptionResult};
 use ruma::{events::AnySyncTimelineEvent, serde::Raw, RoomId};
 
-use super::{
-    super::{verification, Context},
-    E2EE,
-};
+use super::{super::verification, E2EE};
 use crate::Result;
 
 /// Attempt to decrypt the given raw event into a [`TimelineEvent`].
@@ -30,7 +27,6 @@ use crate::Result;
 ///
 /// Returns `Ok(None)` if encryption is not configured.
 pub async fn sync_timeline_event(
-    context: &mut Context,
     e2ee: E2EE<'_>,
     event: &Raw<AnySyncTimelineEvent>,
     room_id: &RoomId,
@@ -46,8 +42,7 @@ pub async fn sync_timeline_event(
                 let timeline_event = TimelineEvent::from(decrypted);
 
                 if let Ok(sync_timeline_event) = timeline_event.raw().deserialize() {
-                    verification::process_if_relevant(context, &sync_timeline_event, e2ee, room_id)
-                        .await?;
+                    verification::process_if_relevant(&sync_timeline_event, e2ee, room_id).await?;
                 }
 
                 timeline_event

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/to_device.rs
@@ -22,7 +22,6 @@ use ruma::{
     OneTimeKeyAlgorithm, UInt,
 };
 
-use super::super::Context;
 use crate::Result;
 
 /// Process the to-device events and other related e2ee data based on a response
@@ -31,13 +30,11 @@ use crate::Result;
 /// This returns a list of all the to-device events that were passed in but
 /// encrypted ones were replaced with their decrypted version.
 pub async fn from_msc4186(
-    context: &mut Context,
     to_device: Option<&v5::response::ToDevice>,
     e2ee: &v5::response::E2EE,
     olm_machine: Option<&OlmMachine>,
 ) -> Result<Output> {
     process(
-        context,
         olm_machine,
         to_device.as_ref().map(|to_device| to_device.events.clone()).unwrap_or_default(),
         &e2ee.device_lists,
@@ -54,12 +51,10 @@ pub async fn from_msc4186(
 /// This returns a list of all the to-device events that were passed in but
 /// encrypted ones were replaced with their decrypted version.
 pub async fn from_sync_v2(
-    context: &mut Context,
     response: &v3::Response,
     olm_machine: Option<&OlmMachine>,
 ) -> Result<Output> {
     process(
-        context,
         olm_machine,
         response.to_device.events.clone(),
         &response.device_lists,
@@ -75,7 +70,6 @@ pub async fn from_sync_v2(
 /// This returns a list of all the to-device events that were passed in but
 /// encrypted ones were replaced with their decrypted version.
 async fn process(
-    _context: &mut Context,
     olm_machine: Option<&OlmMachine>,
     to_device_events: Vec<Raw<AnyToDeviceEvent>>,
     device_lists: &DeviceLists,

--- a/crates/matrix-sdk-base/src/response_processors/e2ee/tracked_users.rs
+++ b/crates/matrix-sdk-base/src/response_processors/e2ee/tracked_users.rs
@@ -17,12 +17,10 @@ use std::collections::BTreeSet;
 use matrix_sdk_crypto::OlmMachine;
 use ruma::{OwnedUserId, RoomId};
 
-use super::super::Context;
 use crate::{store::BaseStateStore, EncryptionState, Result, RoomMemberships};
 
 /// Update tracked users, if the room is encrypted.
 pub async fn update(
-    _context: &mut Context,
     olm_machine: Option<&OlmMachine>,
     room_encryption_state: EncryptionState,
     user_ids_to_track: &BTreeSet<OwnedUserId>,
@@ -41,7 +39,6 @@ pub async fn update(
 /// Update tracked users, if the room is encrypted, or if the room has become
 /// encrypted.
 pub async fn update_or_set_if_room_is_newly_encrypted(
-    _context: &mut Context,
     olm_machine: Option<&OlmMachine>,
     user_ids_to_track: &BTreeSet<OwnedUserId>,
     new_room_encryption_state: EncryptionState,

--- a/crates/matrix-sdk-base/src/response_processors/latest_event.rs
+++ b/crates/matrix-sdk-base/src/response_processors/latest_event.rs
@@ -43,7 +43,7 @@ pub async fn decrypt_from_rooms(
         // Try to find a message we can decrypt and is suitable for using as the latest
         // event. If we found one, set it as the latest and delete any older
         // encrypted events
-        if let Some((found, found_index)) = find_suitable_and_decrypt(context, &room, &e2ee).await {
+        if let Some((found, found_index)) = find_suitable_and_decrypt(&room, &e2ee).await {
             room.on_latest_event_decrypted(
                 found,
                 found_index,
@@ -57,7 +57,6 @@ pub async fn decrypt_from_rooms(
 }
 
 async fn find_suitable_and_decrypt(
-    context: &mut Context,
     room: &Room,
     e2ee: &E2EE<'_>,
 ) -> Option<(Box<LatestEvent>, usize)> {
@@ -71,7 +70,7 @@ async fn find_suitable_and_decrypt(
         // async fn since it is likely that there aren't even any encrypted
         // events when calling it.
         let decrypt_sync_room_event =
-            Box::pin(decrypt_sync_room_event(context, event, e2ee, room.room_id()));
+            Box::pin(decrypt_sync_room_event(event, e2ee, room.room_id()));
 
         if let Ok(decrypted) = decrypt_sync_room_event.await {
             // We found an event we can decrypt
@@ -105,7 +104,6 @@ async fn find_suitable_and_decrypt(
 ///
 /// Panics if there is no [`OlmMachine`] in [`E2EE`].
 async fn decrypt_sync_room_event(
-    context: &mut Context,
     event: &Raw<AnySyncTimelineEvent>,
     e2ee: &E2EE<'_>,
     room_id: &RoomId,
@@ -123,13 +121,8 @@ async fn decrypt_sync_room_event(
             let event: TimelineEvent = decrypted.into();
 
             if let Ok(sync_timeline_event) = event.raw().deserialize() {
-                verification::process_if_relevant(
-                    context,
-                    &sync_timeline_event,
-                    e2ee.clone(),
-                    room_id,
-                )
-                .await?;
+                verification::process_if_relevant(&sync_timeline_event, e2ee.clone(), room_id)
+                    .await?;
             }
 
             event

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
@@ -33,7 +33,6 @@ use crate::{
 /// Dispatch the ephemeral events in the `extensions.typing` part of the
 /// response.
 pub fn dispatch_typing_ephemeral_events(
-    _context: &mut Context,
     typing: &http::response::Typing,
     joined_room_updates: &mut BTreeMap<OwnedRoomId, JoinedRoomUpdate>,
 ) {

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/extensions.rs
@@ -14,7 +14,12 @@
 
 use std::collections::BTreeMap;
 
-use ruma::{api::client::sync::sync_events::v5 as http, OwnedRoomId};
+use ruma::{
+    api::client::sync::sync_events::v5 as http,
+    events::{receipt::ReceiptEventContent, AnySyncEphemeralRoomEvent, SyncEphemeralRoomEvent},
+    serde::Raw,
+    OwnedRoomId, RoomId,
+};
 
 use super::super::super::{
     account_data::for_room as account_data_for_room, ephemeral_events::dispatch_receipt, Context,
@@ -25,22 +30,13 @@ use crate::{
     RoomState,
 };
 
-pub fn dispatch_ephemeral_events(
-    context: &mut Context,
-    receipts: &http::response::Receipts,
+/// Dispatch the ephemeral events in the `extensions.typing` part of the
+/// response.
+pub fn dispatch_typing_ephemeral_events(
+    _context: &mut Context,
     typing: &http::response::Typing,
     joined_room_updates: &mut BTreeMap<OwnedRoomId, JoinedRoomUpdate>,
 ) {
-    for (room_id, raw) in &receipts.rooms {
-        dispatch_receipt(context, raw.cast_ref(), room_id);
-
-        joined_room_updates
-            .entry(room_id.to_owned())
-            .or_default()
-            .ephemeral
-            .push(raw.clone().cast());
-    }
-
     for (room_id, raw) in &typing.rooms {
         joined_room_updates
             .entry(room_id.to_owned())
@@ -48,6 +44,20 @@ pub fn dispatch_ephemeral_events(
             .ephemeral
             .push(raw.clone().cast());
     }
+}
+
+/// Dispatch the ephemeral event in the `extensions.receipts` part of the
+/// response for a particular room.
+pub fn dispatch_receipt_ephemeral_event_for_room(
+    context: &mut Context,
+    room_id: &RoomId,
+    receipt: &Raw<SyncEphemeralRoomEvent<ReceiptEventContent>>,
+    joined_room_update: &mut JoinedRoomUpdate,
+) {
+    let receipt: Raw<AnySyncEphemeralRoomEvent> = receipt.cast_ref().clone();
+
+    dispatch_receipt(context, &receipt, room_id);
+    joined_room_update.ephemeral.push(receipt);
 }
 
 pub async fn room_account_data(

--- a/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/msc4186/mod.rs
@@ -80,17 +80,15 @@ pub async fn update_any_room(
     // incomplete or staled already. We must only read state events from
     // `required_state`.
     let (raw_state_events, state_events) =
-        state_events::sync::collect(context, &room_response.required_state);
+        state_events::sync::collect(&room_response.required_state);
 
     let state_store = notification.state_store;
 
     // Find or create the room in the store
     let is_new_room = !state_store.room_exists(room_id);
 
-    let invite_state_events = room_response
-        .invite_state
-        .as_ref()
-        .map(|events| state_events::stripped::collect(context, events));
+    let invite_state_events =
+        room_response.invite_state.as_ref().map(|events| state_events::stripped::collect(events));
 
     #[allow(unused_mut)] // Required for some feature flag combinations
     let (mut room, mut room_info, maybe_room_update_kind) = membership(
@@ -158,7 +156,6 @@ pub async fn update_any_room(
 
     #[cfg(feature = "e2e-encryption")]
     e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(
-        context,
         e2ee.olm_machine,
         &new_user_ids,
         room_info.encryption_state(),

--- a/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
+++ b/crates/matrix-sdk-base/src/response_processors/room/sync_v2.rs
@@ -61,8 +61,7 @@ pub async fn update_joined_room(
     room_info.mark_state_fully_synced();
     room_info.handle_encryption_state(requested_required_states.for_room(room_id));
 
-    let (raw_state_events, state_events) =
-        state_events::sync::collect(context, &joined_room.state.events);
+    let (raw_state_events, state_events) = state_events::sync::collect(&joined_room.state.events);
 
     let mut new_user_ids = state_events::sync::dispatch_and_get_new_users(
         context,
@@ -79,7 +78,7 @@ pub async fn update_joined_room(
     }
 
     let (raw_state_events_from_timeline, state_events_from_timeline) =
-        state_events::sync::collect_from_timeline(context, &joined_room.timeline.events);
+        state_events::sync::collect_from_timeline(&joined_room.timeline.events);
 
     let mut other_new_user_ids = state_events::sync::dispatch_and_get_new_users(
         context,
@@ -124,7 +123,6 @@ pub async fn update_joined_room(
 
     #[cfg(feature = "e2e-encryption")]
     e2ee::tracked_users::update_or_set_if_room_is_newly_encrypted(
-        context,
         olm_machine,
         &new_user_ids,
         room_info.encryption_state(),
@@ -175,8 +173,7 @@ pub async fn update_left_room(
     room_info.mark_state_partially_synced();
     room_info.handle_encryption_state(requested_required_states.for_room(room_id));
 
-    let (raw_state_events, state_events) =
-        state_events::sync::collect(context, &left_room.state.events);
+    let (raw_state_events, state_events) = state_events::sync::collect(&left_room.state.events);
 
     let _ = state_events::sync::dispatch_and_get_new_users(
         context,
@@ -187,7 +184,7 @@ pub async fn update_left_room(
     .await?;
 
     let (raw_state_events_from_timeline, state_events_from_timeline) =
-        state_events::sync::collect_from_timeline(context, &left_room.timeline.events);
+        state_events::sync::collect_from_timeline(&left_room.timeline.events);
 
     let _ = state_events::sync::dispatch_and_get_new_users(
         context,
@@ -239,8 +236,7 @@ pub async fn update_invited_room(
         room_info_notable_update_sender,
     );
 
-    let (raw_events, events) =
-        state_events::stripped::collect(context, &invited_room.invite_state.events);
+    let (raw_events, events) = state_events::stripped::collect(&invited_room.invite_state.events);
 
     let mut room_info = room.clone_info();
     room_info.mark_as_invited();
@@ -276,8 +272,7 @@ pub async fn update_knocked_room(
         room_info_notable_update_sender,
     );
 
-    let (raw_events, events) =
-        state_events::stripped::collect(context, &knocked_room.knock_state.events);
+    let (raw_events, events) = state_events::stripped::collect(&knocked_room.knock_state.events);
 
     let mut room_info = room.clone_info();
     room_info.mark_as_knocked();

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -36,7 +36,6 @@ pub mod sync {
 
     /// Collect [`AnySyncStateEvent`] to [`AnySyncStateEvent`].
     pub fn collect(
-        _context: &mut Context,
         raw_events: &[Raw<AnySyncStateEvent>],
     ) -> (Vec<Raw<AnySyncStateEvent>>, Vec<AnySyncStateEvent>) {
         super::collect(raw_events)
@@ -47,7 +46,6 @@ pub mod sync {
     /// A [`AnySyncTimelineEvent`] can represent either message-like events or
     /// state events. The message-like events are filtered out.
     pub fn collect_from_timeline(
-        _context: &mut Context,
         raw_events: &[Raw<AnySyncTimelineEvent>],
     ) -> (Vec<Raw<AnySyncStateEvent>>, Vec<AnySyncStateEvent>) {
         super::collect(raw_events.iter().filter_map(|raw_event| {
@@ -125,7 +123,6 @@ pub mod stripped {
 
     /// Collect [`AnyStrippedStateEvent`] to [`AnyStrippedStateEvent`].
     pub fn collect(
-        _context: &mut Context,
         raw_events: &[Raw<AnyStrippedStateEvent>],
     ) -> (Vec<Raw<AnyStrippedStateEvent>>, Vec<AnyStrippedStateEvent>) {
         super::collect(raw_events)

--- a/crates/matrix-sdk-base/src/response_processors/state_events.rs
+++ b/crates/matrix-sdk-base/src/response_processors/state_events.rs
@@ -146,11 +146,7 @@ pub mod stripped {
     ///   counterpart.
     /// * `room` - The [`Room`] to modify.
     /// * `room_info` - The current room's info.
-    /// * `push_rules` - The push rules for this room.
-    /// * `changes` - The accumulated list of changes to apply once the
-    ///   processing is finished.
     /// * `notifications` - Notifications to post for the current room.
-    /// * `state_store` — The state store.
     #[instrument(skip_all, fields(room_id = ?room_info.room_id))]
     pub(crate) async fn dispatch_invite_or_knock(
         context: &mut Context,

--- a/crates/matrix-sdk-base/src/response_processors/timeline.rs
+++ b/crates/matrix-sdk-base/src/response_processors/timeline.rs
@@ -99,7 +99,6 @@ pub async fn build<'notification, 'e2ee>(
                             ) => {
                                 if let Some(decrypted_timeline_event) =
                                     Box::pin(e2ee::decrypt::sync_timeline_event(
-                                        context,
                                         e2ee.clone(),
                                         timeline_event.raw(),
                                         room_id,
@@ -112,7 +111,6 @@ pub async fn build<'notification, 'e2ee>(
 
                             _ => {
                                 Box::pin(verification::process_if_relevant(
-                                    context,
                                     &sync_timeline_event,
                                     e2ee.clone(),
                                     room_id,

--- a/crates/matrix-sdk-base/src/response_processors/verification.rs
+++ b/crates/matrix-sdk-base/src/response_processors/verification.rs
@@ -21,13 +21,12 @@ use ruma::{
     RoomId,
 };
 
-use super::{e2ee::E2EE, Context};
+use super::e2ee::E2EE;
 use crate::Result;
 
 /// Process the given event as a verification event if it is a candidate. The
 /// event must be decrypted.
 pub async fn process_if_relevant(
-    context: &mut Context,
     event: &AnySyncTimelineEvent,
     e2ee: E2EE<'_>,
     room_id: &RoomId,
@@ -57,8 +56,7 @@ pub async fn process_if_relevant(
 
             _ => false,
         } {
-            verification(context, e2ee.verification_is_allowed, e2ee.olm_machine, event, room_id)
-                .await?;
+            verification(e2ee.verification_is_allowed, e2ee.olm_machine, event, room_id).await?;
         }
     }
 
@@ -66,7 +64,6 @@ pub async fn process_if_relevant(
 }
 
 async fn verification(
-    _context: &mut Context,
     verification_is_allowed: bool,
     olm_machine: Option<&OlmMachine>,
     event: &AnySyncMessageLikeEvent,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -211,7 +211,7 @@ impl BaseClient {
         )
         .await;
 
-        // Rooms in `new_rooms.join` either have a timeline update, or a new read
+        // Rooms in `room_updates.joined` either have a timeline update, or a new read
         // receipt. Update the read receipt accordingly.
         // let user_id = &self.session_meta().expect("logged in user").user_id;
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -63,13 +63,8 @@ impl BaseClient {
         let mut context = processors::Context::default();
 
         let processors::e2ee::to_device::Output { decrypted_to_device_events, room_key_updates } =
-            processors::e2ee::to_device::from_msc4186(
-                &mut context,
-                to_device,
-                e2ee,
-                olm_machine.as_ref(),
-            )
-            .await?;
+            processors::e2ee::to_device::from_msc4186(to_device, e2ee, olm_machine.as_ref())
+                .await?;
 
         processors::latest_event::decrypt_from_rooms(
             &mut context,
@@ -197,7 +192,6 @@ impl BaseClient {
         // these both live in a different subsection of the server's response,
         // so they may exist without any update for the associated room.
         processors::room::msc4186::extensions::dispatch_typing_ephemeral_events(
-            &mut context,
             &extensions.typing,
             &mut room_updates.joined,
         );

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -2083,7 +2083,7 @@ mod tests {
         let room = http::response::Room::new();
         let response = response_with_room(room_id, room);
         client
-            .process_sliding_sync(&response, &(), &RequestedRequiredStates::default())
+            .process_sliding_sync(&response, &RequestedRequiredStates::default())
             .await
             .expect("Failed to process sync");
 
@@ -2126,7 +2126,7 @@ mod tests {
             .insert(room_id.to_owned(), unstable_room_account_data_events.clone());
 
         client
-            .process_sliding_sync(&response, &(), &RequestedRequiredStates::default())
+            .process_sliding_sync(&response, &RequestedRequiredStates::default())
             .await
             .expect("Failed to process sync");
 
@@ -2158,7 +2158,7 @@ mod tests {
             .rooms
             .insert(room_id.to_owned(), stable_room_account_data_events);
         client
-            .process_sliding_sync(&response, &(), &RequestedRequiredStates::default())
+            .process_sliding_sync(&response, &RequestedRequiredStates::default())
             .await
             .expect("Failed to process sync");
 
@@ -2180,7 +2180,7 @@ mod tests {
             .rooms
             .insert(room_id.to_owned(), unstable_room_account_data_events);
         client
-            .process_sliding_sync(&response, &(), &RequestedRequiredStates::default())
+            .process_sliding_sync(&response, &RequestedRequiredStates::default())
             .await
             .expect("Failed to process sync");
 
@@ -2213,7 +2213,7 @@ mod tests {
             .rooms
             .insert(room_id.to_owned(), stable_room_account_data_events);
         client
-            .process_sliding_sync(&response, &(), &RequestedRequiredStates::default())
+            .process_sliding_sync(&response, &RequestedRequiredStates::default())
             .await
             .expect("Failed to process sync");
 

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -351,7 +351,7 @@ async fn room_event_cache_updates_task(
                 // The updates might have lagged, but the room event cache might have
                 // events, so retrieve them and add them back again to the timeline,
                 // after clearing it.
-                let (initial_events, _stream) = room_event_cache.subscribe().await;
+                let initial_events = room_event_cache.events().await;
 
                 timeline_controller
                     .replace_with_initial_remote_events(

--- a/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/controller/mod.rs
@@ -345,7 +345,7 @@ impl<P: RoomDataProvider, D: Decryptor> TimelineController<P, D> {
         match &*focus_guard {
             TimelineFocusData::Live => {
                 // Retrieve the cached events, and add them to the timeline.
-                let (events, _stream) = room_event_cache.subscribe().await;
+                let events = room_event_cache.events().await;
 
                 let has_events = !events.is_empty();
 

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -350,14 +350,8 @@ mod tests {
             {
                 let mut rooms = sliding_sync.inner.rooms.write().await;
 
-                rooms.insert(
-                    room_id1.clone(),
-                    SlidingSyncRoom::new(room_id1.clone(), None, Vec::new()),
-                );
-                rooms.insert(
-                    room_id2.clone(),
-                    SlidingSyncRoom::new(room_id2.clone(), None, Vec::new()),
-                );
+                rooms.insert(room_id1.clone(), SlidingSyncRoom::new(room_id1.clone()));
+                rooms.insert(room_id2.clone(), SlidingSyncRoom::new(room_id2.clone()));
             }
 
             let position_guard = sliding_sync.inner.position.lock().await;
@@ -472,7 +466,6 @@ mod tests {
     #[cfg(feature = "e2e-encryption")]
     #[async_test]
     async fn test_sliding_sync_high_level_cache_and_restore() -> Result<()> {
-        use imbl::Vector;
         use ruma::owned_room_id;
 
         use crate::sliding_sync::FrozenSlidingSync;
@@ -545,8 +538,6 @@ mod tests {
                     to_device_since: Some(to_device_token.clone()),
                     rooms: vec![FrozenSlidingSyncRoom {
                         room_id: owned_room_id!("!r0:matrix.org"),
-                        prev_batch: Some("t0ken".to_owned()),
-                        timeline_queue: Vector::new(),
                     }],
                 })?,
             )

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use matrix_sdk_base::{sync::SyncResponse, RequestedRequiredStates};
 use ruma::{
     api::client::{discovery::get_supported_versions, sync::sync_events::v5 as http},
@@ -192,12 +194,14 @@ impl SlidingSyncResponseProcessor {
         response: &http::Response,
         requested_required_states: &RequestedRequiredStates,
     ) -> Result<()> {
-        self.response = Some(
-            self.client
-                .base_client()
-                .process_sliding_sync(response, requested_required_states)
-                .await?,
-        );
+        let mut sync_response = self
+            .client
+            .base_client()
+            .process_sliding_sync(response, requested_required_states)
+            .await?;
+        handle_receipts_extension(&self.client, response, &mut sync_response).await?;
+
+        self.response = Some(sync_response);
         self.post_process().await
     }
 
@@ -238,14 +242,60 @@ async fn update_in_memory_caches(client: &Client, response: &SyncResponse) -> Re
     Ok(())
 }
 
+/// Update the receipts extension and compute the read receipt accordingly.
+async fn handle_receipts_extension(
+    client: &Client,
+    response: &http::Response,
+    sync_response: &mut SyncResponse,
+) -> Result<()> {
+    // We need to compute read receipts for each joined room that has received an
+    // update, or from each room that has received a receipt ephemeral event.
+    let room_ids = BTreeSet::from_iter(
+        sync_response
+            .rooms
+            .joined
+            .keys()
+            .cloned()
+            .chain(response.extensions.receipts.rooms.keys().cloned()),
+    );
+
+    for room_id in room_ids {
+        let Ok((room_event_cache, _drop_handle)) = client.event_cache().for_room(&room_id).await
+        else {
+            tracing::info!(
+                ?room_id,
+                "Failed to fetch the `RoomEventCache` when computing unread counts"
+            );
+
+            continue;
+        };
+
+        let previous_events = room_event_cache.events().await;
+
+        client
+            .base_client()
+            .process_sliding_sync_receipts_extension_for_room(
+                &room_id,
+                response,
+                sync_response,
+                previous_events,
+            )
+            .await?;
+    }
+    Ok(())
+}
+
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::collections::BTreeMap;
 
     use assert_matches::assert_matches;
-    use matrix_sdk_base::{notification_settings::RoomNotificationMode, RequestedRequiredStates};
+    use matrix_sdk_base::{
+        notification_settings::RoomNotificationMode, RequestedRequiredStates,
+        RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons,
+    };
     use matrix_sdk_test::async_test;
-    use ruma::{assign, room_id, serde::Raw};
+    use ruma::{assign, events::AnySyncTimelineEvent, room_id, serde::Raw};
     use serde_json::json;
     use wiremock::{
         matchers::{method, path},
@@ -255,8 +305,8 @@ mod tests {
     use super::{get_supported_versions, Version, VersionBuilder};
     use crate::{
         error::Result,
-        sliding_sync::{http, VersionBuilderError},
-        test_utils::logged_in_client_with_server,
+        sliding_sync::{client::SlidingSyncResponseProcessor, http, VersionBuilderError},
+        test_utils::{logged_in_client, logged_in_client_with_server},
         SlidingSyncList, SlidingSyncMode,
     };
 
@@ -451,5 +501,101 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[async_test]
+    async fn test_read_receipt_can_trigger_a_notable_update_reason() {
+        use ruma::api::client::sync::sync_events::v5 as http;
+
+        // Given a logged-in client
+        let client = logged_in_client(None).await;
+        client.event_cache().subscribe().unwrap();
+
+        let mut room_info_notable_update_stream = client.room_info_notable_update_receiver();
+
+        // When I send sliding sync response containing a new room.
+        let room_id = room_id!("!r:e.uk");
+        let room = http::response::Room::new();
+        let mut response = http::Response::new("5".to_owned());
+        response.rooms.insert(room_id.to_owned(), room);
+
+        let mut processor = SlidingSyncResponseProcessor::new(client.clone());
+        processor
+            .handle_room_response(&response, &RequestedRequiredStates::default())
+            .await
+            .expect("Failed to process sync");
+        processor.process_and_take_response().await.expect("Failed to finish processing sync");
+
+        // Then room info notable updates are received.
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(!received_reasons.contains(RoomInfoNotableUpdateReasons::READ_RECEIPT), "{received_reasons:?}");
+            }
+        );
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::DISPLAY_NAME), "{received_reasons:?}");
+            }
+        );
+        assert!(room_info_notable_update_stream.is_empty());
+
+        // When I send sliding sync response containing a couple of events with no read
+        // receipt.
+        let room_id = room_id!("!r:e.uk");
+        let events = vec![
+            make_raw_event("m.room.message", "$3"),
+            make_raw_event("m.room.message", "$4"),
+            make_raw_event("m.read", "$5"),
+        ];
+        let room = assign!(http::response::Room::new(), {
+            timeline: events,
+        });
+        let mut response = http::Response::new("5".to_owned());
+        response.rooms.insert(room_id.to_owned(), room);
+
+        let mut processor = SlidingSyncResponseProcessor::new(client.clone());
+        processor
+            .handle_room_response(&response, &RequestedRequiredStates::default())
+            .await
+            .expect("Failed to process sync");
+        processor.process_and_take_response().await.expect("Failed to finish processing sync");
+
+        // Then room info notable updates are received.
+        //
+        // `NONE` because the regular sync process ends up to updating nothing.
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::NONE), "{received_reasons:?}");
+            }
+        );
+        // `READ_RECEIPT` because this is what we expect.
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::READ_RECEIPT), "{received_reasons:?}");
+            }
+        );
+        assert!(room_info_notable_update_stream.is_empty());
+    }
+
+    fn make_raw_event(event_type: &str, id: &str) -> Raw<AnySyncTimelineEvent> {
+        Raw::from_json_string(
+            json!({
+                "type": event_type,
+                "event_id": id,
+                "content": { "msgtype": "m.text", "body": "my msg" },
+                "sender": "@u:h.uk",
+                "origin_server_ts": 12344445,
+            })
+            .to_string(),
+        )
+        .unwrap()
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -344,7 +344,7 @@ impl SlidingSync {
                 // the `sync_response.join`. Mark them as updated too.
                 //
                 // Since we've removed rooms that were in the room subsection from
-                // `sync_response.rooms.join`, the remaining ones aren't already present in
+                // `sync_response.rooms.joined`, the remaining ones aren't already present in
                 // `updated_rooms` and wouldn't cause any duplicates.
                 updated_rooms.extend(sync_response.rooms.joined.keys().cloned());
 
@@ -2072,6 +2072,7 @@ mod tests {
 
         let server = MockServer::start().await;
         let client = logged_in_client(Some(server.uri())).await;
+        client.event_cache().subscribe().unwrap();
 
         let sliding_sync = client
             .sliding_sync("test")?

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -36,7 +36,7 @@ use async_stream::stream;
 pub use client::{Version, VersionBuilder};
 use futures_core::stream::Stream;
 use matrix_sdk_base::RequestedRequiredStates;
-use matrix_sdk_common::{deserialized_responses::TimelineEvent, executor::spawn, timer};
+use matrix_sdk_common::{executor::spawn, timer};
 use ruma::{
     api::client::{error::ErrorKind, sync::sync_events::v5 as http},
     assign, OwnedRoomId, RoomId,
@@ -281,14 +281,13 @@ impl SlidingSync {
         // `sliding_sync_response` is vital, so it must be done somewhere; for now it
         // happens here.
 
-        let mut sync_response = {
+        let sync_response = {
             // Take the lock to avoid concurrent sliding syncs overwriting each other's room
             // infos.
             let _sync_lock = self.inner.client.base_client().sync_lock().lock().await;
 
-            let rooms = &*self.inner.rooms.read().await;
             let mut response_processor =
-                SlidingSyncResponseProcessor::new(self.inner.client.clone(), rooms);
+                SlidingSyncResponseProcessor::new(self.inner.client.clone());
 
             #[cfg(feature = "e2e-encryption")]
             if self.is_e2ee_enabled() {
@@ -323,37 +322,21 @@ impl SlidingSync {
 
                 let mut updated_rooms = Vec::with_capacity(sync_response.rooms.joined.len());
 
-                for (room_id, mut room_data) in sliding_sync_response.rooms.into_iter() {
-                    // `sync_response` contains the rooms with decrypted events if any, so look at
-                    // the timeline events here first if the room exists.
-                    // Otherwise, let's look at the timeline inside the `sliding_sync_response`.
-                    let timeline =
-                        if let Some(joined_room) = sync_response.rooms.joined.remove(&room_id) {
-                            joined_room.timeline.events
-                        } else {
-                            room_data.timeline.drain(..).map(TimelineEvent::new).collect()
-                        };
-
-                    match rooms_map.get_mut(&room_id) {
+                for room_id in sliding_sync_response.rooms.keys() {
+                    match rooms_map.get_mut(room_id) {
                         // The room existed before, let's update it.
                         Some(room) => {
-                            room.update(room_data, timeline);
+                            room.update_state();
                         }
 
                         // First time we need this room, let's create it.
                         None => {
-                            rooms_map.insert(
-                                room_id.clone(),
-                                SlidingSyncRoom::new(
-                                    room_id.clone(),
-                                    room_data.prev_batch,
-                                    timeline,
-                                ),
-                            );
+                            rooms_map
+                                .insert(room_id.clone(), SlidingSyncRoom::new(room_id.clone()));
                         }
                     }
 
-                    updated_rooms.push(room_id);
+                    updated_rooms.push(room_id.to_owned());
                 }
 
                 // There might be other rooms that were only mentioned in the sliding sync

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -3,9 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use eyeball_im::Vector;
-use matrix_sdk_base::deserialized_responses::TimelineEvent;
-use ruma::{api::client::sync::sync_events::v5 as http, OwnedRoomId, RoomId};
+use ruma::{OwnedRoomId, RoomId};
 use serde::{Deserialize, Serialize};
 
 /// The state of a [`SlidingSyncRoom`].
@@ -37,17 +35,11 @@ pub struct SlidingSyncRoom {
 
 impl SlidingSyncRoom {
     /// Create a new `SlidingSyncRoom`.
-    pub fn new(
-        room_id: OwnedRoomId,
-        prev_batch: Option<String>,
-        timeline: Vec<TimelineEvent>,
-    ) -> Self {
+    pub fn new(room_id: OwnedRoomId) -> Self {
         Self {
             inner: Arc::new(SlidingSyncRoomInner {
                 room_id,
                 state: RwLock::new(SlidingSyncRoomState::NotLoaded),
-                prev_batch: RwLock::new(prev_batch),
-                timeline_queue: RwLock::new(timeline.into()),
             }),
         }
     }
@@ -57,78 +49,18 @@ impl SlidingSyncRoom {
         &self.inner.room_id
     }
 
-    /// Get the token for back-pagination.
-    pub fn prev_batch(&self) -> Option<String> {
-        self.inner.prev_batch.read().unwrap().clone()
-    }
-
-    /// Get a copy of the cached timeline events.
-    ///
-    /// Note: This API only exists temporarily, it *will* be removed in the
-    /// future.
-    pub fn timeline_queue(&self) -> Vector<TimelineEvent> {
-        self.inner.timeline_queue.read().unwrap().clone()
-    }
-
-    pub(super) fn update(
-        &mut self,
-        room_data: http::response::Room,
-        timeline_updates: Vec<TimelineEvent>,
-    ) {
-        let http::response::Room { prev_batch, limited, .. } = room_data;
-
-        {
-            if let Some(prev_batch) = &prev_batch {
-                let mut lock = self.inner.prev_batch.write().unwrap();
-                let _ = lock.replace(prev_batch.clone());
-            }
-        }
-
+    pub(super) fn update_state(&mut self) {
         let mut state = self.inner.state.write().unwrap();
-
-        {
-            let mut timeline_queue = self.inner.timeline_queue.write().unwrap();
-
-            // There are timeline updates.
-            if !timeline_updates.is_empty() {
-                if let SlidingSyncRoomState::Preloaded = *state {
-                    // If the room has been read from the cache, we overwrite the timeline queue
-                    // with the timeline updates.
-
-                    timeline_queue.clear();
-                    timeline_queue.extend(timeline_updates);
-                } else if limited {
-                    // The server alerted us that we missed items in between.
-
-                    timeline_queue.clear();
-                    timeline_queue.extend(timeline_updates);
-                } else {
-                    // It's the hot path. We have new updates that must be added to the existing
-                    // timeline queue.
-
-                    timeline_queue.extend(timeline_updates);
-                }
-            } else if limited {
-                // No timeline updates, but `limited` is set to true. It's a way to
-                // alert that we are stale. In this case, we should just clear the
-                // existing timeline.
-
-                timeline_queue.clear();
-            }
-        }
-
         *state = SlidingSyncRoomState::Loaded;
     }
 
     pub(super) fn from_frozen(frozen_room: FrozenSlidingSyncRoom) -> Self {
-        let FrozenSlidingSyncRoom { room_id, prev_batch, timeline_queue } = frozen_room;
+        let FrozenSlidingSyncRoom { room_id } = frozen_room;
 
         Self {
             inner: Arc::new(SlidingSyncRoomInner {
                 room_id,
-                prev_batch: RwLock::new(prev_batch),
                 state: RwLock::new(SlidingSyncRoomState::Preloaded),
-                timeline_queue: RwLock::new(timeline_queue),
             }),
         }
     }
@@ -152,20 +84,6 @@ struct SlidingSyncRoomInner {
 
     /// Internal state of `Self`.
     state: RwLock<SlidingSyncRoomState>,
-
-    /// The token for back-pagination.
-    prev_batch: RwLock<Option<String>>,
-
-    /// A queue of received events, used to build a
-    /// [`Timeline`][crate::Timeline].
-    ///
-    /// Given a room, its size is theoretically unbounded: we'll accumulate
-    /// events in this list, until we reach a limited sync, in which case
-    /// we'll clear it.
-    ///
-    /// When persisting the room, this queue is truncated to keep only the last
-    /// N events.
-    timeline_queue: RwLock<Vector<TimelineEvent>>,
 }
 
 /// A “frozen” [`SlidingSyncRoom`], i.e. that can be written into, or read from
@@ -173,95 +91,42 @@ struct SlidingSyncRoomInner {
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct FrozenSlidingSyncRoom {
     pub(super) room_id: OwnedRoomId,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) prev_batch: Option<String>,
-    #[serde(rename = "timeline")]
-    pub(super) timeline_queue: Vector<TimelineEvent>,
 }
-
-/// Number of timeline events to keep when [`SlidingSyncRoom`] is saved in the
-/// cache.
-const NUMBER_OF_TIMELINE_EVENTS_TO_KEEP_FOR_THE_CACHE: usize = 10;
 
 impl From<&SlidingSyncRoom> for FrozenSlidingSyncRoom {
     fn from(value: &SlidingSyncRoom) -> Self {
-        let timeline_queue = &value.inner.timeline_queue.read().unwrap();
-        let timeline_length = timeline_queue.len();
-
-        // To not overflow the cache, we only freeze the newest N items. On doing
-        // so, we must drop the `prev_batch` key however, as we'd otherwise
-        // create a gap between what we have loaded and where the
-        // prev_batch-key will start loading when paginating backwards.
-        let (timeline_queue, prev_batch) =
-            if timeline_length > NUMBER_OF_TIMELINE_EVENTS_TO_KEEP_FOR_THE_CACHE {
-                (
-                    (*timeline_queue)
-                        .iter()
-                        .skip(timeline_length - NUMBER_OF_TIMELINE_EVENTS_TO_KEEP_FOR_THE_CACHE)
-                        .cloned()
-                        .collect::<Vec<_>>()
-                        .into(),
-                    None, // Erase the `prev_batch`.
-                )
-            } else {
-                ((*timeline_queue).clone(), value.prev_batch())
-            };
-
-        Self { room_id: value.inner.room_id.clone(), prev_batch, timeline_queue }
+        Self { room_id: value.inner.room_id.clone() }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use imbl::vector;
-    use matrix_sdk_common::deserialized_responses::TimelineEvent;
     use matrix_sdk_test::async_test;
-    use ruma::{events::room::message::RoomMessageEventContent, room_id, serde::Raw, RoomId};
+    use ruma::room_id;
     use serde_json::json;
 
-    use super::{http, NUMBER_OF_TIMELINE_EVENTS_TO_KEEP_FOR_THE_CACHE};
     use crate::sliding_sync::{FrozenSlidingSyncRoom, SlidingSyncRoom, SlidingSyncRoomState};
-
-    macro_rules! room_response {
-        ( $( $json:tt )+ ) => {
-            serde_json::from_value::<http::response::Room>(
-                json!( $( $json )+ )
-            ).unwrap()
-        };
-    }
-
-    fn new_room(room_id: &RoomId, inner: http::response::Room) -> SlidingSyncRoom {
-        new_room_with_timeline(room_id, inner, vec![])
-    }
-
-    fn new_room_with_timeline(
-        room_id: &RoomId,
-        inner: http::response::Room,
-        timeline: Vec<TimelineEvent>,
-    ) -> SlidingSyncRoom {
-        SlidingSyncRoom::new(room_id.to_owned(), inner.prev_batch, timeline)
-    }
 
     #[async_test]
     async fn test_state_from_not_loaded() {
-        let mut room = new_room(room_id!("!foo:bar.org"), room_response!({}));
+        let mut room = SlidingSyncRoom::new(room_id!("!foo:bar.org").to_owned());
 
         assert_eq!(room.state(), SlidingSyncRoomState::NotLoaded);
 
         // Update with an empty response, but it doesn't matter.
-        room.update(room_response!({}), vec![]);
+        room.update_state();
 
         assert_eq!(room.state(), SlidingSyncRoomState::Loaded);
     }
 
     #[async_test]
     async fn test_state_from_preloaded() {
-        let mut room = new_room(room_id!("!foo:bar.org"), room_response!({}));
+        let mut room = SlidingSyncRoom::new(room_id!("!foo:bar.org").to_owned());
 
         room.set_state(SlidingSyncRoomState::Preloaded);
 
         // Update with an empty response, but it doesn't matter.
-        room.update(room_response!({}), vec![]);
+        room.update_state();
 
         assert_eq!(room.state(), SlidingSyncRoomState::Loaded);
     }
@@ -269,355 +134,15 @@ mod tests {
     #[async_test]
     async fn test_room_room_id() {
         let room_id = room_id!("!foo:bar.org");
-        let room = new_room(room_id, room_response!({}));
+        let room = SlidingSyncRoom::new(room_id.to_owned());
 
         assert_eq!(room.room_id(), room_id);
     }
 
-    #[async_test]
-    async fn test_prev_batch() {
-        // Default value.
-        {
-            let room = new_room(room_id!("!foo:bar.org"), room_response!({}));
-
-            assert_eq!(room.prev_batch(), None);
-        }
-
-        // Some value when initializing.
-        {
-            let room =
-                new_room(room_id!("!foo:bar.org"), room_response!({"prev_batch": "t111_222_333"}));
-
-            assert_eq!(room.prev_batch(), Some("t111_222_333".to_owned()));
-        }
-
-        // Some value when updating.
-        {
-            let mut room = new_room(room_id!("!foo:bar.org"), room_response!({}));
-
-            assert_eq!(room.prev_batch(), None);
-
-            room.update(room_response!({"prev_batch": "t111_222_333"}), vec![]);
-            assert_eq!(room.prev_batch(), Some("t111_222_333".to_owned()));
-
-            room.update(room_response!({}), vec![]);
-            assert_eq!(room.prev_batch(), Some("t111_222_333".to_owned()));
-        }
-    }
-
-    #[async_test]
-    async fn test_timeline_queue_initially_empty() {
-        let room = new_room(room_id!("!foo:bar.org"), room_response!({}));
-
-        assert!(room.timeline_queue().is_empty());
-    }
-
-    macro_rules! timeline_event {
-        (from $sender:literal with id $event_id:literal at $ts:literal: $message:literal) => {
-            TimelineEvent::new(
-                Raw::new(&json!({
-                    "content": RoomMessageEventContent::text_plain($message),
-                    "type": "m.room.message",
-                    "event_id": $event_id,
-                    "room_id": "!foo:bar.org",
-                    "origin_server_ts": $ts,
-                    "sender": $sender,
-                }))
-                .unwrap()
-                .cast()
-            )
-        };
-    }
-
-    macro_rules! assert_timeline_queue_event_ids {
-        (
-            with $( $timeline_queue:ident ).* {
-                $(
-                    $nth:literal => $event_id:literal
-                ),*
-                $(,)*
-            }
-        ) => {
-            let timeline = & $( $timeline_queue ).*;
-
-            $(
-                assert_eq!(timeline[ $nth ].raw().deserialize().unwrap().event_id(), $event_id);
-            )*
-        };
-    }
-
-    #[test]
-    fn test_timeline_queue_initially_not_empty() {
-        let room = new_room_with_timeline(
-            room_id!("!foo:bar.org"),
-            room_response!({}),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x0:baz.org" at 0: "message 0"),
-                timeline_event!(from "@alice:baz.org" with id "$x1:baz.org" at 1: "message 1"),
-            ],
-        );
-
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::NotLoaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x0:baz.org",
-                    1 => "$x1:baz.org",
-                }
-            );
-        }
-    }
-
-    #[test]
-    fn test_timeline_queue_update_with_empty_timeline() {
-        let mut room = new_room_with_timeline(
-            room_id!("!foo:bar.org"),
-            room_response!({}),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x0:baz.org" at 0: "message 0"),
-                timeline_event!(from "@alice:baz.org" with id "$x1:baz.org" at 1: "message 1"),
-            ],
-        );
-
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::NotLoaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x0:baz.org",
-                    1 => "$x1:baz.org",
-                }
-            );
-        }
-
-        room.update(room_response!({}), vec![]);
-
-        // The queue is unmodified.
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::Loaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x0:baz.org",
-                    1 => "$x1:baz.org",
-                }
-            );
-        }
-    }
-
-    #[test]
-    fn test_timeline_queue_update_with_empty_timeline_and_with_limited() {
-        let mut room = new_room_with_timeline(
-            room_id!("!foo:bar.org"),
-            room_response!({}),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x0:baz.org" at 0: "message 0"),
-                timeline_event!(from "@alice:baz.org" with id "$x1:baz.org" at 1: "message 1"),
-            ],
-        );
-
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::NotLoaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x0:baz.org",
-                    1 => "$x1:baz.org",
-                }
-            );
-        }
-
-        room.update(
-            room_response!({
-                "limited": true
-            }),
-            vec![],
-        );
-
-        // The queue has been emptied.
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::Loaded);
-            assert_eq!(timeline_queue.len(), 0);
-        }
-    }
-
-    #[test]
-    fn test_timeline_queue_update_from_preloaded() {
-        let mut room = new_room_with_timeline(
-            room_id!("!foo:bar.org"),
-            room_response!({}),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x0:baz.org" at 0: "message 0"),
-                timeline_event!(from "@alice:baz.org" with id "$x1:baz.org" at 1: "message 1"),
-            ],
-        );
-
-        room.set_state(SlidingSyncRoomState::Preloaded);
-
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::Preloaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x0:baz.org",
-                    1 => "$x1:baz.org",
-                }
-            );
-        }
-
-        room.update(
-            room_response!({}),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x2:baz.org" at 2: "message 2"),
-                timeline_event!(from "@alice:baz.org" with id "$x3:baz.org" at 3: "message 3"),
-            ],
-        );
-
-        // The queue is emptied, and new events are appended.
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::Loaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x2:baz.org",
-                    1 => "$x3:baz.org",
-                }
-            );
-        }
-    }
-
-    #[test]
-    fn test_timeline_queue_update_from_not_loaded() {
-        let mut room = new_room_with_timeline(
-            room_id!("!foo:bar.org"),
-            room_response!({}),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x0:baz.org" at 0: "message 0"),
-                timeline_event!(from "@alice:baz.org" with id "$x1:baz.org" at 1: "message 1"),
-            ],
-        );
-
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::NotLoaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x0:baz.org",
-                    1 => "$x1:baz.org",
-                }
-            );
-        }
-
-        room.update(
-            room_response!({}),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x2:baz.org" at 2: "message 2"),
-                timeline_event!(from "@alice:baz.org" with id "$x3:baz.org" at 3: "message 3"),
-            ],
-        );
-
-        // New events are appended to the queue.
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::Loaded);
-            assert_eq!(timeline_queue.len(), 4);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x0:baz.org",
-                    1 => "$x1:baz.org",
-                    2 => "$x2:baz.org",
-                    3 => "$x3:baz.org",
-                }
-            );
-        }
-    }
-
-    #[test]
-    fn test_timeline_queue_update_from_not_loaded_with_limited() {
-        let mut room = new_room_with_timeline(
-            room_id!("!foo:bar.org"),
-            room_response!({}),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x0:baz.org" at 0: "message 0"),
-                timeline_event!(from "@alice:baz.org" with id "$x1:baz.org" at 1: "message 1"),
-            ],
-        );
-
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::NotLoaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x0:baz.org",
-                    1 => "$x1:baz.org",
-                }
-
-            );
-        }
-
-        room.update(
-            room_response!({
-                "limited": true,
-            }),
-            vec![
-                timeline_event!(from "@alice:baz.org" with id "$x2:baz.org" at 2: "message 2"),
-                timeline_event!(from "@alice:baz.org" with id "$x3:baz.org" at 3: "message 3"),
-            ],
-        );
-
-        // The queue is emptied, and new events are appended.
-        {
-            let timeline_queue = room.timeline_queue();
-
-            assert_eq!(room.state(), SlidingSyncRoomState::Loaded);
-            assert_eq!(timeline_queue.len(), 2);
-            assert_timeline_queue_event_ids!(
-                with timeline_queue {
-                    0 => "$x2:baz.org",
-                    1 => "$x3:baz.org",
-                }
-            );
-        }
-    }
-
     #[test]
     fn test_frozen_sliding_sync_room_serialization() {
-        let frozen_room = FrozenSlidingSyncRoom {
-            room_id: room_id!("!29fhd83h92h0:example.com").to_owned(),
-            prev_batch: Some("foo".to_owned()),
-            timeline_queue: vector![TimelineEvent::new(
-                Raw::new(&json!({
-                    "content": RoomMessageEventContent::text_plain("let it gooo!"),
-                    "type": "m.room.message",
-                    "event_id": "$xxxxx:example.org",
-                    "room_id": "!someroom:example.com",
-                    "origin_server_ts": 2189,
-                    "sender": "@bob:example.com",
-                }))
-                .unwrap()
-                .cast(),
-            )],
-        };
+        let frozen_room =
+            FrozenSlidingSyncRoom { room_id: room_id!("!29fhd83h92h0:example.com").to_owned() };
 
         let serialized = serde_json::to_value(&frozen_room).unwrap();
 
@@ -625,105 +150,11 @@ mod tests {
             serialized,
             json!({
                 "room_id": "!29fhd83h92h0:example.com",
-                "prev_batch": "foo",
-                "timeline": [
-                    {
-                        "kind": { "PlainText": { "event": {
-                            "content": {
-                                "body": "let it gooo!",
-                                "msgtype": "m.text"
-                            },
-                            "event_id": "$xxxxx:example.org",
-                            "origin_server_ts": 2189,
-                            "room_id": "!someroom:example.com",
-                            "sender": "@bob:example.com",
-                            "type": "m.room.message"
-                        }}}
-                    }
-                ]
             })
         );
 
         let deserialized = serde_json::from_value::<FrozenSlidingSyncRoom>(serialized).unwrap();
 
         assert_eq!(deserialized.room_id, frozen_room.room_id);
-    }
-
-    #[test]
-    fn test_frozen_sliding_sync_room_has_a_capped_version_of_the_timeline() {
-        // Just below the limit.
-        {
-            let max = NUMBER_OF_TIMELINE_EVENTS_TO_KEEP_FOR_THE_CACHE - 1;
-            let timeline_events = (0..=max)
-                .map(|nth| {
-                    TimelineEvent::new(
-                        Raw::new(&json!({
-                            "content": RoomMessageEventContent::text_plain(format!("message {nth}")),
-                            "type": "m.room.message",
-                            "event_id": format!("$x{nth}:baz.org"),
-                            "room_id": "!foo:bar.org",
-                            "origin_server_ts": nth,
-                            "sender": "@alice:baz.org",
-                        }))
-                        .unwrap()
-                        .cast(),
-                    )
-                })
-                .collect::<Vec<_>>();
-
-            let room = new_room_with_timeline(
-                room_id!("!foo:bar.org"),
-                room_response!({}),
-                timeline_events,
-            );
-
-            let frozen_room = FrozenSlidingSyncRoom::from(&room);
-            assert_eq!(frozen_room.timeline_queue.len(), max + 1);
-            // Check that the last event is the last event of the timeline, i.e. we only
-            // keep the _latest_ events, not the _first_ events.
-            assert_eq!(
-                frozen_room.timeline_queue.last().unwrap().raw().deserialize().unwrap().event_id(),
-                &format!("$x{max}:baz.org")
-            );
-        }
-
-        // Above the limit.
-        {
-            let max = NUMBER_OF_TIMELINE_EVENTS_TO_KEEP_FOR_THE_CACHE + 2;
-            let timeline_events = (0..=max)
-                .map(|nth| {
-                    TimelineEvent::new(
-                    Raw::new(&json!({
-                        "content": RoomMessageEventContent::text_plain(format!("message {nth}")),
-                        "type": "m.room.message",
-                        "event_id": format!("$x{nth}:baz.org"),
-                        "room_id": "!foo:bar.org",
-                        "origin_server_ts": nth,
-                        "sender": "@alice:baz.org",
-                    }))
-                    .unwrap()
-                    .cast(),
-                )
-                })
-                .collect::<Vec<_>>();
-
-            let room = new_room_with_timeline(
-                room_id!("!foo:bar.org"),
-                room_response!({}),
-                timeline_events,
-            );
-
-            let frozen_room = FrozenSlidingSyncRoom::from(&room);
-            assert_eq!(
-                frozen_room.timeline_queue.len(),
-                NUMBER_OF_TIMELINE_EVENTS_TO_KEEP_FOR_THE_CACHE
-            );
-            // Check that the last event is the last event of the timeline, i.e. we only
-            // keep the _latest_ events, not the _first_ events.
-            assert_eq!(
-                frozen_room.timeline_queue.last().unwrap().raw().deserialize().unwrap().event_id(),
-                &format!("$x{max}:baz.org")
-            );
-        }
     }
 }

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -203,7 +203,7 @@ async fn test_ignored_unignored() {
     {
         let room = client.get_room(other_room_id).unwrap();
         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
-        let (events, _) = room_event_cache.subscribe().await;
+        let events = room_event_cache.events().await;
         assert!(events.is_empty());
     }
 
@@ -984,7 +984,7 @@ async fn test_backpaginate_with_no_initial_events() {
     pagination.run_backwards_once(20).await.unwrap();
 
     // The linked chunk should contain the events in the correct order.
-    let (events, _stream) = room_event_cache.subscribe().await;
+    let events = room_event_cache.events().await;
 
     assert_eq!(events.len(), 3, "{events:?}");
     assert_event_matches_msg(&events[0], "oh well");
@@ -1047,7 +1047,7 @@ async fn test_backpaginate_replace_empty_gap() {
     pagination.run_backwards_once(20).await.unwrap();
 
     // The linked chunk should contain the events in the correct order.
-    let (events, _stream) = room_event_cache.subscribe().await;
+    let events = room_event_cache.events().await;
 
     assert_event_matches_msg(&events[0], "hello");
     assert_event_matches_msg(&events[1], "world");
@@ -1130,7 +1130,7 @@ async fn test_no_gap_stored_after_deduplicated_sync() {
     assert!(stream.is_empty());
 
     {
-        let (events, _) = room_event_cache.subscribe().await;
+        let events = room_event_cache.events().await;
         assert_event_matches_msg(&events[0], "hello");
         assert_event_matches_msg(&events[1], "world");
         assert_event_matches_msg(&events[2], "sup");
@@ -1149,7 +1149,7 @@ async fn test_no_gap_stored_after_deduplicated_sync() {
     assert!(outcome.reached_start);
 
     {
-        let (events, _) = room_event_cache.subscribe().await;
+        let events = room_event_cache.events().await;
         assert_event_matches_msg(&events[0], "hello");
         assert_event_matches_msg(&events[1], "world");
         assert_event_matches_msg(&events[2], "sup");

--- a/labs/multiverse/src/widgets/room_view/details/events.rs
+++ b/labs/multiverse/src/widgets/room_view/details/events.rs
@@ -28,8 +28,7 @@ impl Widget for &mut EventsView<'_> {
                 let events = tokio::task::block_in_place(|| {
                     Handle::current().block_on(async {
                         let (room_event_cache, _drop_handles) = room.event_cache().await.unwrap();
-                        let (events, _) = room_event_cache.subscribe().await;
-                        events
+                        room_event_cache.events().await
                     })
                 });
 

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -393,13 +393,14 @@ impl UpdateObserver {
     }
 }
 
-/*
 #[tokio::test]
 async fn test_room_notification_count() -> Result<()> {
     use tokio::time::timeout;
 
     let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
     let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+
+    alice.event_cache().subscribe().unwrap();
 
     // Spawn sync for Bob.
     spawn({
@@ -643,7 +644,6 @@ async fn test_room_notification_count() -> Result<()> {
 
     Ok(())
 }
-*/
 
 /// Response preprocessor that drops to_device events
 fn drop_todevice_events(response: &mut Bytes) {

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -393,6 +393,7 @@ impl UpdateObserver {
     }
 }
 
+/*
 #[tokio::test]
 async fn test_room_notification_count() -> Result<()> {
     use tokio::time::timeout;
@@ -642,6 +643,7 @@ async fn test_room_notification_count() -> Result<()> {
 
     Ok(())
 }
+*/
 
 /// Response preprocessor that drops to_device events
 fn drop_todevice_events(response: &mut Bytes) {


### PR DESCRIPTION
These patch removes `SlidingSyncRoom::timeline_queue`, `SlidingSyncRoom::prev_batch`, `FrozenSlidingSyncRoom::timeline` and `FrozenSlidingSyncRoom::prev_batch`.

The removal of `timeline_queue` has escalated to updating `read_receipts::compute_unread_counts` to be called with events from the Event Cache instead of `timeline_queue`. The code has been revisited a little bit around the sliding sync workflow, but nothing fancy or deep.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3079
