### PR TITLE
feat(sdk,ui): Remove `SlidingSyncRoom::latest_event`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
+++ b/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
@@ -34,7 +34,9 @@ impl SlidingSyncRoomExt for SlidingSyncRoom {
     /// EventTimelineItem.
     #[instrument(skip_all)]
     async fn latest_timeline_item(&self) -> Option<EventTimelineItem> {
-        let latest_event = self.latest_event()?;
+        let latest_event =
+            self.client().get_room(self.room_id()).and_then(|room| room.latest_event())?;
+
         EventTimelineItem::from_latest_event(self.client(), self.room_id(), latest_event).await
     }
 }

--- a/crates/matrix-sdk/src/sliding_sync/room.rs
+++ b/crates/matrix-sdk/src/sliding_sync/room.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use eyeball_im::Vector;
-use matrix_sdk_base::{deserialized_responses::SyncTimelineEvent, latest_event::LatestEvent};
+use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
 use ruma::{api::client::sync::sync_events::v4, OwnedRoomId, RoomId};
 use serde::{Deserialize, Serialize};
 
@@ -77,11 +77,6 @@ impl SlidingSyncRoom {
     /// Get a clone of the associated client.
     pub fn client(&self) -> Client {
         self.inner.client.clone()
-    }
-
-    /// Find the latest event in this room
-    pub fn latest_event(&self) -> Option<LatestEvent> {
-        self.inner.client.get_room(&self.inner.room_id).and_then(|room| room.latest_event())
     }
 
     pub(super) fn update(


### PR DESCRIPTION
This patch inlines `SlidingSyncRoom::latest_event` into its unique call site: `SlidingSyncRoomExt::latest_timeline_item`.

`SlidingSyncRoom::latest_event` is not using any data from `SlidingSyncRoom`, except the `Client`. So it can easily live somewhere else. Our goal is to clean up `SlidingSyncRoom` as much as possible, and to remove any kind of logic from it.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3079