### PR TITLE
Add debug logging when sessions get rotated

### DIFF
--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -452,7 +452,7 @@ impl GroupSessionManager {
         if should_rotate {
             debug!(
                 should_rotate,
-                user_left, visibility_changed, algorithm_changed, "collect_session_recipients",
+                user_left, visibility_changed, algorithm_changed, "Rotating room key to protect room history",
             );
         }
         trace!(should_rotate, "Done calculating group session recipients");

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -438,8 +438,7 @@ impl GroupSessionManager {
                     should_rotate = !newly_deleted_or_blacklisted.is_empty();
                     if should_rotate {
                         debug!(
-                            "collect_session_recipients: {} rotating due to these devices being deleted/blacklisted {:?}",
-                            outbound.session_id(),
+                            "collect_session_recipients: rotating due to these devices being deleted/blacklisted {:?}",
                             newly_deleted_or_blacklisted,
                         );
                     }
@@ -451,11 +450,7 @@ impl GroupSessionManager {
         }
         debug!(
             should_rotate,
-            user_left,
-            visibility_changed,
-            algorithm_changed,
-            "collect_session_recipients {}",
-            outbound.session_id(),
+            user_left, visibility_changed, algorithm_changed, "collect_session_recipients",
         );
         trace!(should_rotate, "Done calculating group session recipients");
 

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -436,13 +436,27 @@ impl GroupSessionManager {
                         shared.difference(&recipient_device_ids).collect::<BTreeSet<_>>();
 
                     should_rotate = !newly_deleted_or_blacklisted.is_empty();
+                    if should_rotate {
+                        debug!(
+                            "collect_session_recipients: {} rotating due to these devices being deleted/blacklisted {:?}",
+                            outbound.session_id(),
+                            newly_deleted_or_blacklisted,
+                        );
+                    }
                 };
             }
 
             devices.entry(user_id.to_owned()).or_default().extend(recipients);
             withheld_devices.extend(withheld_recipients);
         }
-
+        debug!(
+            should_rotate,
+            user_left,
+            visibility_changed,
+            algorithm_changed,
+            "collect_session_recipients {}",
+            outbound.session_id(),
+        );
         trace!(should_rotate, "Done calculating group session recipients");
 
         Ok(CollectRecipientsResult { should_rotate, devices, withheld_devices })

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -453,7 +453,10 @@ impl GroupSessionManager {
         if should_rotate {
             debug!(
                 should_rotate,
-                user_left, visibility_changed, algorithm_changed, "Rotating room key to protect room history",
+                user_left,
+                visibility_changed,
+                algorithm_changed,
+                "Rotating room key to protect room history",
             );
         }
         trace!(should_rotate, "Done calculating group session recipients");

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -438,7 +438,7 @@ impl GroupSessionManager {
                     should_rotate = !newly_deleted_or_blacklisted.is_empty();
                     if should_rotate {
                         debug!(
-                            "collect_session_recipients: rotating due to these devices being deleted/blacklisted {:?}",
+                            "Rotating a room key due to these devices being deleted/blacklisted {:?}",
                             newly_deleted_or_blacklisted,
                         );
                     }

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -343,6 +343,7 @@ impl GroupSessionManager {
     /// Returns information indicating whether the session needs to be rotated
     /// and the list of users/devices that should receive or not the session
     /// (with withheld reason).
+    #[instrument(skip_all)]
     pub async fn collect_session_recipients(
         &self,
         users: impl Iterator<Item = &UserId>,

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -448,10 +448,13 @@ impl GroupSessionManager {
             devices.entry(user_id.to_owned()).or_default().extend(recipients);
             withheld_devices.extend(withheld_recipients);
         }
-        debug!(
-            should_rotate,
-            user_left, visibility_changed, algorithm_changed, "collect_session_recipients",
-        );
+
+        if should_rotate {
+            debug!(
+                should_rotate,
+                user_left, visibility_changed, algorithm_changed, "collect_session_recipients",
+            );
+        }
         trace!(should_rotate, "Done calculating group session recipients");
 
         Ok(CollectRecipientsResult { should_rotate, devices, withheld_devices })


### PR DESCRIPTION
Critically, explain _why_ the session is being rotated. Ends up looking like:

`2024-02-07T17:41:15.683374Z DEBUG matrix_sdk_crypto::session_manager::group_sessions: collect_session_recipients should_rotate=true user_left=true visibility_changed=false algorithm_changed=false | crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs:453 | spans: send_raw{room_id="!OERZwnPnwtzHsOxJIo:hs1" transaction_id="a894c3b5214a4b6c935623b8f75ccee5" encrypted=true} > preshare_room_key{room_id="!OERZwnPnwtzHsOxJIo:hs1"} > share_room_key > share_room_key{room_id="!OERZwnPnwtzHsOxJIo:hs1" session_id="KITTxcvy/BUM+F4Htlf5zfAeoV4KXUsuYFgoGIZx9SI"}`

and

`2024-02-07T17:41:40.203132Z DEBUG matrix_sdk_crypto::session_manager::group_sessions: collect_session_recipients: rotating due to these devices being deleted/blacklisted {"OTHER_DEVICE"} | crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs:440 | spans: send_raw{room_id="!YbBToodWaBOyKaXGsc:hs1" transaction_id="2b03c064437a4a1aa0d9796c85811895" encrypted=true} > preshare_room_key{room_id="!YbBToodWaBOyKaXGsc:hs1"} > share_room_key > share_room_key{room_id="!YbBToodWaBOyKaXGsc:hs1" session_id="OY2JKsFIEmK3oPOGxNrztkA++uV9aXYPvKz6Twmo4Zg"}`
