### PR TITLE
Expose changes to user's power levels on the FFI's RoomPowerLevels state struct.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -148,3 +148,9 @@ impl RoomMember {
         RoomMember { inner: room_member }
     }
 }
+
+#[uniffi::export]
+pub fn suggested_role_for_power_level(power_level: i64) -> RoomMemberRole {
+    // It's not possible to expose the constructor on the Enum through Uniffi ☹️
+    RoomMemberRole::suggested_role_for_power_level(power_level)
+}

--- a/crates/matrix-sdk/src/room/member.rs
+++ b/crates/matrix-sdk/src/room/member.rs
@@ -105,7 +105,7 @@ pub enum RoomMemberRole {
 
 impl RoomMemberRole {
     /// Creates the suggested role for a given power level.
-    fn suggested_role_for_power_level(power_level: i64) -> Self {
+    pub fn suggested_role_for_power_level(power_level: i64) -> Self {
         if power_level >= 100 {
             Self::Administrator
         } else if power_level >= 50 {


### PR DESCRIPTION
This PR makes 2 changes:
- Exposes and changes to the power levels of specific users to the FFI to render in the timeline
- Exposes a method to get the suggested role for a given power level.
