### PR TITLE
fix(base): Rewrite `RoomNotableTags`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,9 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitmaps"

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -3,7 +3,7 @@ use std::{convert::TryFrom, sync::Arc};
 use anyhow::{Context, Result};
 use matrix_sdk::{
     room::{power_levels::RoomPowerLevelChanges, Room as SdkRoom},
-    RoomMemberships, RoomNotableTags, RoomState,
+    RoomMemberships, RoomState,
 };
 use matrix_sdk_ui::timeline::RoomExt;
 use mime::Mime;
@@ -252,21 +252,6 @@ impl Room {
                         error!("Failed to compute new RoomInfo: {e}");
                     }
                 }
-            }
-        })))
-    }
-
-    pub fn subscribe_to_notable_tags(
-        self: Arc<Self>,
-        listener: Box<dyn RoomNotableTagsListener>,
-    ) -> Arc<TaskHandle> {
-        Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
-            let (initial, mut subscriber) = self.inner.notable_tags_stream().await;
-            // Send the initial value
-            listener.call(initial);
-            // Then wait for changes
-            while let Some(notable_tags) = subscriber.next().await {
-                listener.call(notable_tags);
             }
         })))
     }
@@ -624,11 +609,6 @@ pub trait RoomInfoListener: Sync + Send {
 #[uniffi::export(callback_interface)]
 pub trait TypingNotificationsListener: Sync + Send {
     fn call(&self, typing_user_ids: Vec<String>);
-}
-
-#[uniffi::export(callback_interface)]
-pub trait RoomNotableTagsListener: Sync + Send {
-    fn call(&self, notable_tags: RoomNotableTags);
 }
 
 #[derive(uniffi::Object)]

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -258,10 +258,10 @@ impl Room {
 
     pub async fn set_is_favourite(
         &self,
-        is_favorite: bool,
+        is_favourite: bool,
         tag_order: Option<f64>,
     ) -> Result<(), ClientError> {
-        self.inner.set_is_favourite(is_favorite, tag_order).await?;
+        self.inner.set_is_favourite(is_favourite, tag_order).await?;
         Ok(())
     }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -256,12 +256,12 @@ impl Room {
         })))
     }
 
-    pub async fn set_is_favorite(
+    pub async fn set_is_favourite(
         &self,
         is_favorite: bool,
         tag_order: Option<f64>,
     ) -> Result<(), ClientError> {
-        self.inner.set_is_favorite(is_favorite, tag_order).await?;
+        self.inner.set_is_favourite(is_favorite, tag_order).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -39,7 +39,7 @@ as_variant = { workspace = true }
 assert_matches = { workspace = true, optional = true }
 assert_matches2 = { workspace = true, optional = true }
 async-trait = { workspace = true }
-bitflags = "2.4.0"
+bitflags = { version = "2.4.0", features = ["serde"] }
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -39,7 +39,7 @@ as_variant = { workspace = true }
 assert_matches = { workspace = true, optional = true }
 assert_matches2 = { workspace = true, optional = true }
 async-trait = { workspace = true }
-bitflags = "2.1.0"
+bitflags = "2.4.0"
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }
 futures-util = { workspace = true }

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1407,17 +1407,17 @@ impl Default for BaseClient {
 #[cfg(test)]
 mod tests {
     use matrix_sdk_test::{
-        async_test, response_from_file, sync_timeline_event, InvitedRoomBuilder, JoinedRoomBuilder,
-        LeftRoomBuilder, StrippedStateTestEvent, SyncResponseBuilder,
+        async_test, response_from_file, sync_timeline_event, InvitedRoomBuilder, LeftRoomBuilder,
+        StrippedStateTestEvent, SyncResponseBuilder,
     };
     use ruma::{
         api::{client as api, IncomingResponse},
-        room_id, user_id, RoomId, UserId,
+        room_id, user_id, UserId,
     };
     use serde_json::json;
 
     use super::BaseClient;
-    use crate::{store::StateStoreExt, DisplayName, Room, RoomState, SessionMeta, StateChanges};
+    use crate::{store::StateStoreExt, DisplayName, RoomState, SessionMeta};
 
     #[async_test]
     async fn invite_after_leaving() {
@@ -1565,7 +1565,7 @@ mod tests {
         assert!(room.latest_event().is_none());
 
         // When I tell it to do some decryption
-        let mut changes = StateChanges::default();
+        let mut changes = crate::StateChanges::default();
         client.decrypt_latest_events(&room, &mut changes).await;
 
         // Then nothing changed
@@ -1594,13 +1594,13 @@ mod tests {
     #[cfg(feature = "e2e-encryption")]
     async fn process_room_join(
         client: &BaseClient,
-        room_id: &RoomId,
+        room_id: &ruma::RoomId,
         event_id: &str,
         user_id: &UserId,
-    ) -> Room {
+    ) -> crate::Room {
         let mut ev_builder = SyncResponseBuilder::new();
         let response = ev_builder
-            .add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+            .add_joined_room(matrix_sdk_test::JoinedRoomBuilder::new(room_id).add_timeline_event(
                 sync_timeline_event!({
                     "content": {
                         "displayname": "Alice",

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -542,7 +542,7 @@ impl BaseClient {
         //
         // It finds the appropriate `RoomInfo`, allowing the caller to modify it, and
         // save it in the correct place.
-        fn on_rooms_infos<F>(
+        fn on_room_info<F>(
             room_id: &RoomId,
             changes: &mut StateChanges,
             client: &BaseClient,
@@ -568,14 +568,21 @@ impl BaseClient {
             }
         }
 
+        // Handle new events.
         for raw_event in events {
             if let Ok(event) = raw_event.deserialize() {
                 changes.add_room_account_data(room_id, event.clone(), raw_event.clone());
 
                 match event {
                     AnyRoomAccountDataEvent::MarkedUnread(event) => {
-                        on_rooms_infos(room_id, changes, self, |room_info| {
+                        on_room_info(room_id, changes, self, |room_info| {
                             room_info.base_info.is_marked_unread = event.content.unread;
+                        });
+                    }
+
+                    AnyRoomAccountDataEvent::Tag(event) => {
+                        on_room_info(room_id, changes, self, |room_info| {
+                            room_info.base_info.handle_notable_tags(&event.content.tags);
                         });
                     }
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -44,7 +44,7 @@ use ruma::{
         },
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
         AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent, AnySyncStateEvent,
-        AnySyncTimelineEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
+        AnySyncTimelineEvent, GlobalAccountDataEventType, StateEventType,
     },
     push::{Action, PushConditionRoomCtx, Ruleset},
     serde::Raw,
@@ -68,7 +68,7 @@ use crate::{
         StateChanges, StateStoreDataKey, StateStoreDataValue, StateStoreExt, Store, StoreConfig,
     },
     sync::{JoinedRoom, LeftRoom, Notification, Rooms, SyncResponse, Timeline},
-    RoomNotableTags, RoomStateFilter, SessionMeta,
+    RoomStateFilter, SessionMeta,
 };
 #[cfg(feature = "e2e-encryption")]
 use crate::{error::Error, RoomMemberships};
@@ -1033,23 +1033,6 @@ impl BaseClient {
         for (room_id, room_info) in &changes.room_infos {
             if let Some(room) = self.store.get_room(room_id) {
                 room.set_room_info(room_info.clone())
-            }
-        }
-
-        for (room_id, room_account_data) in &changes.room_account_data {
-            if let Some(room) = self.store.get_room(room_id) {
-                let tags = room_account_data.get(&RoomAccountDataEventType::Tag).and_then(|r| {
-                    match r.deserialize() {
-                        Ok(AnyRoomAccountDataEvent::Tag(event)) => Some(event.content.tags),
-                        Err(e) => {
-                            warn!("Room account data tag event failed to deserialize : {e}");
-                            None
-                        }
-                        Ok(_) => None,
-                    }
-                });
-                let notable_tags = RoomNotableTags::new(tags);
-                room.set_notable_tags(notable_tags)
             }
         }
     }

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -51,7 +51,7 @@ pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{
     DisplayName, Room, RoomCreateWithCreatorEventContent, RoomInfo, RoomMember, RoomMemberships,
-    RoomNotableTags, RoomState, RoomStateFilter,
+    RoomState, RoomStateFilter,
 };
 pub use store::{StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError};
 pub use utils::{

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -105,7 +105,7 @@ pub struct BaseRoomInfo {
     /// memberships.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub(crate) rtc_member: BTreeMap<OwnedUserId, MinimalStateEvent<CallMemberEventContent>>,
-    // Whether this room has been manually marked as unread
+    /// Whether this room has been manually marked as unread.
     #[serde(default)]
     pub(crate) is_marked_unread: bool,
     /// Some notable tags.
@@ -318,7 +318,7 @@ bitflags! {
     /// others, and this struct describe them.
     #[repr(transparent)]
     #[derive(Debug, Default, Clone, Copy, Deserialize, Serialize)]
-    pub struct NotableTags: u8 {
+    pub(crate) struct NotableTags: u8 {
         /// The `m.favourite` tag.
         const FAVOURITE = 0b0000_0001;
 

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -562,7 +562,11 @@ impl RoomMemberships {
 
 #[cfg(test)]
 mod tests {
-    use super::{calculate_room_name, DisplayName};
+    use std::ops::Not;
+
+    use ruma::events::tag::{TagInfo, TagName, Tags};
+
+    use super::{calculate_room_name, BaseRoomInfo, DisplayName, RoomNotableTags};
 
     #[test]
     fn test_calculate_room_name() {
@@ -595,5 +599,35 @@ mod tests {
 
         actual = calculate_room_name(1, 0, vec!["a", "b", "c"]);
         assert_eq!(DisplayName::EmptyWas("a, b, c".to_owned()), actual);
+    }
+
+    #[test]
+    fn test_handle_notable_tags_favourite() {
+        let mut base_room_info = BaseRoomInfo::default();
+
+        let mut tags = Tags::new();
+        tags.insert(TagName::Favorite, TagInfo::default());
+
+        assert!(base_room_info.notable_tags.contains(RoomNotableTags::FAVOURITE).not());
+        base_room_info.handle_notable_tags(&tags);
+        assert!(base_room_info.notable_tags.contains(RoomNotableTags::FAVOURITE));
+        tags.clear();
+        base_room_info.handle_notable_tags(&tags);
+        assert!(base_room_info.notable_tags.contains(RoomNotableTags::FAVOURITE).not());
+    }
+
+    #[test]
+    fn test_handle_notable_tags_low_priority() {
+        let mut base_room_info = BaseRoomInfo::default();
+
+        let mut tags = Tags::new();
+        tags.insert(TagName::LowPriority, TagInfo::default());
+
+        assert!(base_room_info.notable_tags.contains(RoomNotableTags::LOW_PRIORITY).not());
+        base_room_info.handle_notable_tags(&tags);
+        assert!(base_room_info.notable_tags.contains(RoomNotableTags::LOW_PRIORITY));
+        tags.clear();
+        base_room_info.handle_notable_tags(&tags);
+        assert!(base_room_info.notable_tags.contains(RoomNotableTags::LOW_PRIORITY).not());
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -315,7 +315,7 @@ bitflags! {
     /// Notable tags, i.e. subset of tags that we are more interested by.
     ///
     /// We are not interested by all the tags. Some tags are more important than
-    /// others, and this struct describe them.
+    /// others, and this struct describes them.
     #[repr(transparent)]
     #[derive(Debug, Default, Clone, Copy, Deserialize, Serialize)]
     pub(crate) struct RoomNotableTags: u8 {

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -112,8 +112,8 @@ pub struct BaseRoomInfo {
     ///
     /// We are not interested by all the tags. Some tags are more important than
     /// others, and this field collects them.
-    #[serde(skip_serializing_if = "NotableTags::is_empty", default)]
-    pub(crate) notable_tags: NotableTags,
+    #[serde(skip_serializing_if = "RoomNotableTags::is_empty", default)]
+    pub(crate) notable_tags: RoomNotableTags,
 }
 
 impl BaseRoomInfo {
@@ -297,14 +297,14 @@ impl BaseRoomInfo {
     }
 
     pub fn handle_notable_tags(&mut self, tags: &Tags) {
-        let mut notable_tags = NotableTags::empty();
+        let mut notable_tags = RoomNotableTags::empty();
 
         if tags.contains_key(&TagName::Favorite) {
-            notable_tags.insert(NotableTags::FAVOURITE);
+            notable_tags.insert(RoomNotableTags::FAVOURITE);
         }
 
         if tags.contains_key(&TagName::LowPriority) {
-            notable_tags.insert(NotableTags::LOW_PRIORITY);
+            notable_tags.insert(RoomNotableTags::LOW_PRIORITY);
         }
 
         self.notable_tags = notable_tags;
@@ -318,7 +318,7 @@ bitflags! {
     /// others, and this struct describe them.
     #[repr(transparent)]
     #[derive(Debug, Default, Clone, Copy, Deserialize, Serialize)]
-    pub(crate) struct NotableTags: u8 {
+    pub(crate) struct RoomNotableTags: u8 {
         /// The `m.favourite` tag.
         const FAVOURITE = 0b0000_0001;
 
@@ -358,7 +358,7 @@ impl Default for BaseRoomInfo {
             topic: None,
             rtc_member: BTreeMap::new(),
             is_marked_unread: false,
-            notable_tags: NotableTags::empty(),
+            notable_tags: RoomNotableTags::empty(),
         }
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -11,7 +11,7 @@ use std::{
 
 use bitflags::bitflags;
 pub use members::RoomMember;
-pub use normal::{Room, RoomInfo, RoomNotableTags, RoomState, RoomStateFilter};
+pub use normal::{Room, RoomInfo, RoomState, RoomStateFilter};
 use ruma::{
     assign,
     events::{

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -732,10 +732,17 @@ impl Room {
         }
     }
 
+    /// Check whether the room is marked as favourite.
+    ///
+    /// A room is considered favourite if it has received the `m.favourite` tag.
     pub fn is_favourite(&self) -> bool {
         self.inner.read().base_info.notable_tags.contains(RoomNotableTags::FAVOURITE)
     }
 
+    /// Check whether the room is marked as low priority.
+    ///
+    /// A room is considered low priority if it has received the `m.lowpriority`
+    /// tag.
     pub fn is_low_priority(&self) -> bool {
         self.inner.read().base_info.notable_tags.contains(RoomNotableTags::LOW_PRIORITY)
     }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -58,7 +58,7 @@ use tracing::{debug, field::debug, info, instrument, trace, warn};
 
 use super::{
     members::{MemberInfo, MemberRoomInfo},
-    BaseRoomInfo, DisplayName, NotableTags, RoomCreateWithCreatorEventContent, RoomMember,
+    BaseRoomInfo, DisplayName, RoomCreateWithCreatorEventContent, RoomMember, RoomNotableTags,
 };
 #[cfg(feature = "experimental-sliding-sync")]
 use crate::latest_event::LatestEvent;
@@ -733,11 +733,11 @@ impl Room {
     }
 
     pub fn is_favourite(&self) -> bool {
-        self.inner.read().base_info.notable_tags.contains(NotableTags::FAVOURITE)
+        self.inner.read().base_info.notable_tags.contains(RoomNotableTags::FAVOURITE)
     }
 
     pub fn is_low_priority(&self) -> bool {
-        self.inner.read().base_info.notable_tags.contains(NotableTags::LOW_PRIORITY)
+        self.inner.read().base_info.notable_tags.contains(RoomNotableTags::LOW_PRIORITY)
     }
 
     /// Get the receipt as an `OwnedEventId` and `Receipt` tuple for the given

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -58,7 +58,7 @@ use tracing::{debug, field::debug, info, instrument, trace, warn};
 
 use super::{
     members::{MemberInfo, MemberRoomInfo},
-    BaseRoomInfo, DisplayName, RoomCreateWithCreatorEventContent, RoomMember,
+    BaseRoomInfo, DisplayName, NotableTags, RoomCreateWithCreatorEventContent, RoomMember,
 };
 #[cfg(feature = "experimental-sliding-sync")]
 use crate::latest_event::LatestEvent;

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -44,7 +44,7 @@ use crate::{
     deserialized_responses::SyncOrStrippedState,
     rooms::{
         normal::{RoomSummary, SyncInfo},
-        BaseRoomInfo,
+        BaseRoomInfo, NotableTags,
     },
     sync::UnreadNotificationsCount,
     MinimalStateEvent, OriginalMinimalStateEvent, RoomInfo, RoomState,
@@ -205,6 +205,7 @@ impl BaseRoomInfoV1 {
             topic,
             rtc_member: BTreeMap::new(),
             is_marked_unread: false,
+            notable_tags: NotableTags::empty(),
         })
     }
 }

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -44,7 +44,7 @@ use crate::{
     deserialized_responses::SyncOrStrippedState,
     rooms::{
         normal::{RoomSummary, SyncInfo},
-        BaseRoomInfo, NotableTags,
+        BaseRoomInfo, RoomNotableTags,
     },
     sync::UnreadNotificationsCount,
     MinimalStateEvent, OriginalMinimalStateEvent, RoomInfo, RoomState,
@@ -205,7 +205,7 @@ impl BaseRoomInfoV1 {
             topic,
             rtc_member: BTreeMap::new(),
             is_marked_unread: false,
-            notable_tags: NotableTags::empty(),
+            notable_tags: RoomNotableTags::empty(),
         })
     }
 }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -24,8 +24,8 @@ pub use matrix_sdk_base::{
     deserialized_responses,
     store::{DynStateStore, MemoryStore, StateStoreExt},
     DisplayName, Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomInfo,
-    RoomMember as BaseRoomMember, RoomMemberships, RoomNotableTags, RoomState, SessionMeta,
-    StateChanges, StateStore, StoreError,
+    RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
+    StateStore, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -968,16 +968,17 @@ impl Room {
         self.client.send(request, None).await
     }
 
-    /// Update the is_favorite flag from the room by calling set_tag or
-    /// remove_tag method on `m.favourite` tag.
-    /// If `is_favorite` is `true`, and `m.low_priority` tag is set on the room,
-    /// the tag will be removed too.
+    /// Add or remove the `m.favourite` flag for this room.
+    ///
+    /// If `is_favourite` is `true`, and the `m.low_priority` tag is set on the
+    /// room, the tag will be removed too.
+    ///
     /// # Arguments
     ///
-    /// * `is_favorite` - Whether to mark this room as favorite or not.
+    /// * `is_favourite` - Whether to mark this room as favourite.
     /// * `tag_order` - The order of the tag if any.
-    pub async fn set_is_favorite(&self, is_favorite: bool, tag_order: Option<f64>) -> Result<()> {
-        if is_favorite {
+    pub async fn set_is_favourite(&self, is_favourite: bool, tag_order: Option<f64>) -> Result<()> {
+        if is_favourite {
             let tag_info = assign!(TagInfo::new(), { order: tag_order });
 
             self.set_tag(TagName::Favorite, tag_info).await?;
@@ -991,10 +992,11 @@ impl Room {
         Ok(())
     }
 
-    /// Update the is_low_priority flag from the room by calling set_tag or
-    /// remove_tag method on `m.low_priority` tag.
-    /// If `is_low_priority` is `true`, and `m.favourite` tag is set on the
+    /// Add or remove the `m.lowpriority` flag for this room.
+    ///
+    /// If `is_low_priority` is `true`, and the `m.favourite` tag is set on the
     /// room, the tag will be removed too.
+    ///
     /// # Arguments
     ///
     /// * `is_low_priority` - Whether to mark this room as low_priority or not.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -979,8 +979,10 @@ impl Room {
     pub async fn set_is_favorite(&self, is_favorite: bool, tag_order: Option<f64>) -> Result<()> {
         if is_favorite {
             let tag_info = assign!(TagInfo::new(), { order: tag_order });
+
             self.set_tag(TagName::Favorite, tag_info).await?;
-            if self.current_notable_tags().await.is_low_priority {
+
+            if self.is_low_priority() {
                 self.remove_tag(TagName::LowPriority).await?;
             }
         } else {
@@ -1004,8 +1006,10 @@ impl Room {
     ) -> Result<()> {
         if is_low_priority {
             let tag_info = assign!(TagInfo::new(), { order: tag_order });
+
             self.set_tag(TagName::LowPriority, tag_info).await?;
-            if self.current_notable_tags().await.is_favorite {
+
+            if self.is_favourite() {
                 self.remove_tag(TagName::Favorite).await?;
             }
         } else {

--- a/crates/matrix-sdk/tests/integration/room/tags.rs
+++ b/crates/matrix-sdk/tests/integration/room/tags.rs
@@ -81,20 +81,20 @@ async fn synced_client_with_room(
 }
 
 #[async_test]
-async fn when_set_is_favorite_is_run_with_true_then_set_tag_api_is_called() {
+async fn when_set_is_favourite_is_run_with_true_then_set_tag_api_is_called() {
     let room_id = room_id!("!test:example.org");
     let mut ev_builder = SyncResponseBuilder::new();
     let (_client, room, server) = synced_client_with_room(&mut ev_builder, room_id).await;
 
     mock_tag_api(&server, TagName::Favorite, TagOperation::Set, 1).await;
 
-    room.set_is_favorite(true, Option::default()).await.unwrap();
+    room.set_is_favourite(true, Option::default()).await.unwrap();
 
     server.verify().await;
 }
 
 #[async_test]
-async fn when_set_is_favorite_is_run_with_true_and_low_priority_tag_was_set_then_set_tag_and_remove_tag_apis_are_called(
+async fn when_set_is_favourite_is_run_with_true_and_low_priority_tag_was_set_then_set_tag_and_remove_tag_apis_are_called(
 ) {
     let room_id = room_id!("!test:example.org");
     let mut ev_builder = SyncResponseBuilder::new();
@@ -106,20 +106,20 @@ async fn when_set_is_favorite_is_run_with_true_and_low_priority_tag_was_set_then
     mock_tag_api(&server, TagName::Favorite, TagOperation::Set, 1).await;
     mock_tag_api(&server, TagName::LowPriority, TagOperation::Remove, 1).await;
 
-    room.set_is_favorite(true, Option::default()).await.unwrap();
+    room.set_is_favourite(true, Option::default()).await.unwrap();
 
     server.verify().await;
 }
 
 #[async_test]
-async fn when_set_is_favorite_is_run_with_false_then_delete_tag_api_is_called() {
+async fn when_set_is_favourite_is_run_with_false_then_delete_tag_api_is_called() {
     let room_id = room_id!("!test:example.org");
     let mut ev_builder = SyncResponseBuilder::new();
     let (_client, room, server) = synced_client_with_room(&mut ev_builder, room_id).await;
 
     mock_tag_api(&server, TagName::Favorite, TagOperation::Remove, 1).await;
 
-    room.set_is_favorite(false, Option::default()).await.unwrap();
+    room.set_is_favourite(false, Option::default()).await.unwrap();
 
     server.verify().await;
 }
@@ -169,14 +169,12 @@ async fn when_set_is_low_priority_is_run_with_false_then_delete_tag_api_is_calle
 }
 
 #[async_test]
-async fn when_favorite_tag_is_set_in_sync_response_then_notable_tags_is_favorite_is_true() {
+async fn when_favorite_tag_is_set_in_sync_response_then_notable_tags_is_favourite_is_true() {
     let room_id = room_id!("!test:example.org");
     let mut ev_builder = SyncResponseBuilder::new();
     let (client, room, server) = synced_client_with_room(&mut ev_builder, room_id).await;
 
-    let (initial_notable_tags, mut notable_tags_stream) = room.notable_tags_stream().await;
-
-    assert!(!initial_notable_tags.is_favorite);
+    assert!(!room.is_favourite());
 
     // Ensure the notable tags stream is updated when the favorite tag is set on
     // sync
@@ -184,7 +182,7 @@ async fn when_favorite_tag_is_set_in_sync_response_then_notable_tags_is_favorite
     mock_sync_with_tags(&server, &mut ev_builder, room_id, tags).await;
     sync_once(&client, &server).await;
 
-    assert!(notable_tags_stream.next().await.unwrap().is_favorite);
+    assert!(room.is_favourite());
 }
 
 #[async_test]
@@ -193,9 +191,7 @@ async fn when_low_priority_tag_is_set_in_sync_response_then_notable_tags_is_low_
     let mut ev_builder = SyncResponseBuilder::new();
     let (client, room, server) = synced_client_with_room(&mut ev_builder, room_id).await;
 
-    let (initial_notable_tags, mut notable_tags_stream) = room.notable_tags_stream().await;
-
-    assert!(!initial_notable_tags.is_low_priority);
+    assert!(!room.is_low_priority());
 
     // Ensure the notable tags stream is updated when the low_priority tag is set on
     // sync
@@ -203,5 +199,5 @@ async fn when_low_priority_tag_is_set_in_sync_response_then_notable_tags_is_low_
     mock_sync_with_tags(&server, &mut ev_builder, room_id, tags).await;
     sync_once(&client, &server).await;
 
-    assert!(notable_tags_stream.next().await.unwrap().is_low_priority);
+    assert!(room.is_low_priority());
 }


### PR DESCRIPTION
This PR must be reviewed commit-by-commit.

This PR entirely revisits the `RoomNotableTags` API (introduced in #3071 and #3075). The idea is to compute the notable tags as a single 8-bits unsigned integer (`u8`) and to store it inside `RoomInfo`. The benefits are numerous:

1. The type and the API is noticeably smaller that the existing `RoomNotableTags`,
2. It's part of `RoomInfo` so:
    - We don't need an async API to fetch the tags from the store and to compute the notable tags,
    - It can be put in the store,
    - The observable/subscribe mechanism is supported by `RoomInfo` behind observable instead of introducing a new subscribe mechanism.

The PR ends up providing `Room::is_favourite` and `Room::is_low_priority` as simple non-async getters, which is needed by #3021.

---

* Address #3005
* Address #3021