### PR TITLE
sdk: a few renamings in the sync processing area

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -67,7 +67,7 @@ use crate::{
         ambiguity_map::AmbiguityCache, DynStateStore, MemoryStore, Result as StoreResult,
         StateChanges, StateStoreDataKey, StateStoreDataValue, StateStoreExt, Store, StoreConfig,
     },
-    sync::{JoinedRoom, LeftRoom, Notification, RoomUpdates, SyncResponse, Timeline},
+    sync::{JoinedRoomUpdate, LeftRoomUpdate, Notification, RoomUpdates, SyncResponse, Timeline},
     RoomNotableTags, RoomStateFilter, SessionMeta,
 };
 #[cfg(feature = "e2e-encryption")]
@@ -867,7 +867,7 @@ impl BaseClient {
 
             new_rooms.join.insert(
                 room_id,
-                JoinedRoom::new(
+                JoinedRoomUpdate::new(
                     timeline,
                     new_info.state.events,
                     new_info.account_data.events,
@@ -923,7 +923,7 @@ impl BaseClient {
             changes.add_room(room_info);
             new_rooms.leave.insert(
                 room_id,
-                LeftRoom::new(
+                LeftRoomUpdate::new(
                     timeline,
                     new_info.state.events,
                     new_info.account_data.events,

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -67,7 +67,7 @@ use crate::{
         ambiguity_map::AmbiguityCache, DynStateStore, MemoryStore, Result as StoreResult,
         StateChanges, StateStoreDataKey, StateStoreDataValue, StateStoreExt, Store, StoreConfig,
     },
-    sync::{JoinedRoom, LeftRoom, Notification, Rooms, SyncResponse, Timeline},
+    sync::{JoinedRoom, LeftRoom, Notification, RoomUpdates, SyncResponse, Timeline},
     RoomNotableTags, RoomStateFilter, SessionMeta,
 };
 #[cfg(feature = "e2e-encryption")]
@@ -779,7 +779,7 @@ impl BaseClient {
 
         let push_rules = self.get_push_rules(&changes).await?;
 
-        let mut new_rooms = Rooms::default();
+        let mut new_rooms = RoomUpdates::default();
         let mut notifications = Default::default();
 
         for (room_id, new_info) in response.rooms.join {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1391,7 +1391,7 @@ mod tests {
     use crate::{store::StateStoreExt, DisplayName, Room, RoomState, SessionMeta, StateChanges};
 
     #[async_test]
-    async fn invite_after_leaving() {
+    async fn test_invite_after_leaving() {
         let user_id = user_id!("@alice:example.org");
         let room_id = room_id!("!test:example.org");
 
@@ -1435,7 +1435,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn invite_displayname_integration_test() {
+    async fn test_invite_displayname() {
         let user_id = user_id!("@alice:example.org");
         let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
 
@@ -1529,7 +1529,7 @@ mod tests {
         let user_id = user_id!("@u:u.to");
         let room_id = room_id!("!r:u.to");
         let client = logged_in_client(user_id).await;
-        let room = process_room_join(&client, room_id, "$1", user_id).await;
+        let room = process_room_join_test_helper(&client, room_id, "$1", user_id).await;
 
         // Sanity: it has no latest_encrypted_events or latest_event
         assert!(room.latest_encrypted_events().is_empty());
@@ -1563,7 +1563,7 @@ mod tests {
     }
 
     #[cfg(feature = "e2e-encryption")]
-    async fn process_room_join(
+    async fn process_room_join_test_helper(
         client: &BaseClient,
         room_id: &RoomId,
         event_id: &str,
@@ -1585,13 +1585,14 @@ mod tests {
                 }),
             ))
             .build_sync_response();
+
         client.receive_sync_response(response).await.unwrap();
 
         client.get_room(room_id).expect("Just-created room not found!")
     }
 
     #[async_test]
-    async fn deserialization_failure_test() {
+    async fn test_deserialization_failure() {
         let user_id = user_id!("@alice:example.org");
         let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -40,7 +40,7 @@ use crate::{
     read_receipts::{compute_unread_counts, PreviousEventsProvider},
     rooms::RoomState,
     store::{ambiguity_map::AmbiguityCache, StateChanges, Store},
-    sync::{JoinedRoom, LeftRoom, Notification, Rooms, SyncResponse},
+    sync::{JoinedRoom, LeftRoom, Notification, RoomUpdates, SyncResponse},
     Room, RoomInfo,
 };
 
@@ -149,7 +149,7 @@ impl BaseClient {
             self.handle_account_data(&account_data.global, &mut changes).await;
         }
 
-        let mut new_rooms = Rooms::default();
+        let mut new_rooms = RoomUpdates::default();
         let mut notifications = Default::default();
         let mut rooms_account_data = account_data.rooms.clone();
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -40,7 +40,7 @@ use crate::{
     read_receipts::{compute_unread_counts, PreviousEventsProvider},
     rooms::RoomState,
     store::{ambiguity_map::AmbiguityCache, StateChanges, Store},
-    sync::{JoinedRoom, LeftRoom, Notification, RoomUpdates, SyncResponse},
+    sync::{JoinedRoomUpdate, LeftRoomUpdate, Notification, RoomUpdates, SyncResponse},
     Room, RoomInfo,
 };
 
@@ -204,7 +204,7 @@ impl BaseClient {
             new_rooms
                 .join
                 .entry(room_id.to_owned())
-                .or_insert_with(JoinedRoom::default)
+                .or_insert_with(JoinedRoomUpdate::default)
                 .ephemeral
                 .push(raw.clone().cast());
         }
@@ -214,7 +214,7 @@ impl BaseClient {
             new_rooms
                 .join
                 .entry(room_id.to_owned())
-                .or_insert_with(JoinedRoom::default)
+                .or_insert_with(JoinedRoomUpdate::default)
                 .ephemeral
                 .push(raw.clone().cast());
         }
@@ -228,13 +228,13 @@ impl BaseClient {
                     RoomState::Joined => new_rooms
                         .join
                         .entry(room_id.to_owned())
-                        .or_insert_with(JoinedRoom::default)
+                        .or_insert_with(JoinedRoomUpdate::default)
                         .account_data
                         .append(&mut raw.to_vec()),
                     RoomState::Left => new_rooms
                         .leave
                         .entry(room_id.to_owned())
-                        .or_insert_with(LeftRoom::default)
+                        .or_insert_with(LeftRoomUpdate::default)
                         .account_data
                         .append(&mut raw.to_vec()),
                     RoomState::Invited => {}
@@ -315,7 +315,8 @@ impl BaseClient {
         changes: &mut StateChanges,
         notifications: &mut BTreeMap<OwnedRoomId, Vec<Notification>>,
         ambiguity_cache: &mut AmbiguityCache,
-    ) -> Result<(RoomInfo, Option<JoinedRoom>, Option<LeftRoom>, Option<InvitedRoom>)> {
+    ) -> Result<(RoomInfo, Option<JoinedRoomUpdate>, Option<LeftRoomUpdate>, Option<InvitedRoom>)>
+    {
         let (raw_state_events, state_events): (Vec<_>, Vec<_>) = {
             let mut state_events = Vec::new();
 
@@ -417,7 +418,7 @@ impl BaseClient {
 
                 Ok((
                     room_info,
-                    Some(JoinedRoom::new(
+                    Some(JoinedRoomUpdate::new(
                         timeline,
                         raw_state_events,
                         room_account_data.unwrap_or_default(),
@@ -433,7 +434,7 @@ impl BaseClient {
             RoomState::Left => Ok((
                 room_info,
                 None,
-                Some(LeftRoom::new(
+                Some(LeftRoomUpdate::new(
                     timeline,
                     raw_state_events,
                     room_account_data.unwrap_or_default(),

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -19,7 +19,8 @@ use std::{collections::BTreeMap, fmt};
 use matrix_sdk_common::{debug::DebugRawEvent, deserialized_responses::SyncTimelineEvent};
 use ruma::{
     api::client::sync::sync_events::{
-        v3::InvitedRoom, UnreadNotificationsCount as RumaUnreadNotificationsCount,
+        v3::InvitedRoom as InvitedRoomUpdate,
+        UnreadNotificationsCount as RumaUnreadNotificationsCount,
     },
     events::{
         presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
@@ -70,11 +71,11 @@ impl fmt::Debug for SyncResponse {
 #[derive(Clone, Default)]
 pub struct RoomUpdates {
     /// The rooms that the user has left or been banned from.
-    pub leave: BTreeMap<OwnedRoomId, LeftRoom>,
+    pub leave: BTreeMap<OwnedRoomId, LeftRoomUpdate>,
     /// The rooms that the user has joined.
-    pub join: BTreeMap<OwnedRoomId, JoinedRoom>,
+    pub join: BTreeMap<OwnedRoomId, JoinedRoomUpdate>,
     /// The rooms that the user has been invited to.
-    pub invite: BTreeMap<OwnedRoomId, InvitedRoom>,
+    pub invite: BTreeMap<OwnedRoomId, InvitedRoomUpdate>,
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -83,14 +84,14 @@ impl fmt::Debug for RoomUpdates {
         f.debug_struct("Rooms")
             .field("leave", &self.leave)
             .field("join", &self.join)
-            .field("invite", &DebugInvitedRooms(&self.invite))
+            .field("invite", &DebugInvitedRoomUpdates(&self.invite))
             .finish()
     }
 }
 
 /// Updates to joined rooms.
 #[derive(Clone, Default)]
-pub struct JoinedRoom {
+pub struct JoinedRoomUpdate {
     /// Counts of unread notifications for this room.
     pub unread_notifications: UnreadNotificationsCount,
     /// The timeline of messages and state changes in the room.
@@ -113,7 +114,7 @@ pub struct JoinedRoom {
 }
 
 #[cfg(not(tarpaulin_include))]
-impl fmt::Debug for JoinedRoom {
+impl fmt::Debug for JoinedRoomUpdate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("JoinedRoom")
             .field("unread_notifications", &self.unread_notifications)
@@ -126,7 +127,7 @@ impl fmt::Debug for JoinedRoom {
     }
 }
 
-impl JoinedRoom {
+impl JoinedRoomUpdate {
     pub(crate) fn new(
         timeline: Timeline,
         state: Vec<Raw<AnySyncStateEvent>>,
@@ -160,7 +161,7 @@ impl From<RumaUnreadNotificationsCount> for UnreadNotificationsCount {
 
 /// Updates to left rooms.
 #[derive(Clone, Default)]
-pub struct LeftRoom {
+pub struct LeftRoomUpdate {
     /// The timeline of messages and state changes in the room up to the point
     /// when the user left.
     pub timeline: Timeline,
@@ -178,7 +179,7 @@ pub struct LeftRoom {
     pub ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
 }
 
-impl LeftRoom {
+impl LeftRoomUpdate {
     pub(crate) fn new(
         timeline: Timeline,
         state: Vec<Raw<AnySyncStateEvent>>,
@@ -190,7 +191,7 @@ impl LeftRoom {
 }
 
 #[cfg(not(tarpaulin_include))]
-impl fmt::Debug for LeftRoom {
+impl fmt::Debug for LeftRoomUpdate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("JoinedRoom")
             .field("timeline", &self.timeline)
@@ -222,10 +223,10 @@ impl Timeline {
     }
 }
 
-struct DebugInvitedRooms<'a>(&'a BTreeMap<OwnedRoomId, InvitedRoom>);
+struct DebugInvitedRoomUpdates<'a>(&'a BTreeMap<OwnedRoomId, InvitedRoomUpdate>);
 
 #[cfg(not(tarpaulin_include))]
-impl<'a> fmt::Debug for DebugInvitedRooms<'a> {
+impl<'a> fmt::Debug for DebugInvitedRoomUpdates<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.0.iter().map(|(k, v)| (k, DebugInvitedRoom(v)))).finish()
     }

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -36,7 +36,7 @@ use crate::{
     deserialized_responses::{AmbiguityChange, RawAnySyncOrStrippedTimelineEvent},
 };
 
-/// Internal representation of a `/sync` response.
+/// Generalized representation of a `/sync` response.
 ///
 /// This type is intended to be applicable regardless of the endpoint used for
 /// syncing.

--- a/crates/matrix-sdk-base/src/sync.rs
+++ b/crates/matrix-sdk-base/src/sync.rs
@@ -43,7 +43,7 @@ use crate::{
 #[derive(Clone, Default)]
 pub struct SyncResponse {
     /// Updates to rooms.
-    pub rooms: Rooms,
+    pub rooms: RoomUpdates,
     /// Updates to the presence status of other users.
     pub presence: Vec<Raw<PresenceEvent>>,
     /// The global private data created by this user.
@@ -68,7 +68,7 @@ impl fmt::Debug for SyncResponse {
 
 /// Updates to rooms in a [`SyncResponse`].
 #[derive(Clone, Default)]
-pub struct Rooms {
+pub struct RoomUpdates {
     /// The rooms that the user has left or been banned from.
     pub leave: BTreeMap<OwnedRoomId, LeftRoom>,
     /// The rooms that the user has joined.
@@ -78,7 +78,7 @@ pub struct Rooms {
 }
 
 #[cfg(not(tarpaulin_include))]
-impl fmt::Debug for Rooms {
+impl fmt::Debug for RoomUpdates {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Rooms")
             .field("leave", &self.leave)

--- a/crates/matrix-sdk-ui/src/event_graph.rs
+++ b/crates/matrix-sdk-ui/src/event_graph.rs
@@ -46,7 +46,7 @@ use async_trait::async_trait;
 use matrix_sdk::{sync::RoomUpdate, Client, Room};
 use matrix_sdk_base::{
     deserialized_responses::{AmbiguityChange, SyncTimelineEvent},
-    sync::{JoinedRoom, LeftRoom, Timeline},
+    sync::{JoinedRoomUpdate, LeftRoomUpdate, Timeline},
 };
 use ruma::{
     events::{AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent},
@@ -245,7 +245,7 @@ impl RoomEventGraphInner {
         (room_graph, Arc::new(RoomGraphDropHandles { listen_updates_task }))
     }
 
-    async fn handle_joined_room_update(&self, updates: JoinedRoom) -> Result<()> {
+    async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
         self.handle_timeline(
             updates.timeline,
             updates.ephemeral.clone(),
@@ -290,7 +290,7 @@ impl RoomEventGraphInner {
         Ok(())
     }
 
-    async fn handle_left_room_update(&self, updates: LeftRoom) -> Result<()> {
+    async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
         self.handle_timeline(updates.timeline, Vec::new(), Vec::new(), updates.ambiguity_changes)
             .await?;
         Ok(())

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -18,7 +18,7 @@ use eyeball::SharedObservable;
 use futures_util::{pin_mut, StreamExt};
 use imbl::Vector;
 use matrix_sdk::{deserialized_responses::SyncTimelineEvent, executor::spawn, Room};
-use matrix_sdk_base::sync::JoinedRoom;
+use matrix_sdk_base::sync::JoinedRoomUpdate;
 use ruma::{
     events::{receipt::ReceiptType, AnySyncTimelineEvent},
     RoomVersionId,
@@ -206,7 +206,7 @@ impl TimelineBuilder {
                                 prev_batch,
                                 events,
                             };
-                            let update = JoinedRoom {
+                            let update = JoinedRoomUpdate {
                                 unread_notifications: Default::default(),
                                 timeline,
                                 state: Default::default(),

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -26,7 +26,7 @@ use itertools::Itertools;
 use matrix_sdk::crypto::OlmMachine;
 use matrix_sdk::{
     deserialized_responses::{SyncTimelineEvent, TimelineEvent},
-    sync::JoinedRoom,
+    sync::JoinedRoomUpdate,
     Error, Result, Room,
 };
 #[cfg(test)]
@@ -428,7 +428,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         self.state.write().await.clear();
     }
 
-    pub(super) async fn handle_joined_room_update(&self, update: JoinedRoom) {
+    pub(super) async fn handle_joined_room_update(&self, update: JoinedRoomUpdate) {
         let mut state = self.state.write().await;
         state.handle_joined_room_update(update, &self.room_data_provider, &self.settings).await;
     }

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -23,7 +23,7 @@ use std::{
 use eyeball_im::{ObservableVector, ObservableVectorTransaction, ObservableVectorTransactionEntry};
 use indexmap::IndexMap;
 use matrix_sdk::{deserialized_responses::SyncTimelineEvent, sync::Timeline};
-use matrix_sdk_base::{deserialized_responses::TimelineEvent, sync::JoinedRoom};
+use matrix_sdk_base::{deserialized_responses::TimelineEvent, sync::JoinedRoomUpdate};
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
 use ruma::{
@@ -113,7 +113,7 @@ impl TimelineInnerState {
     #[instrument(skip_all)]
     pub(super) async fn handle_joined_room_update<P: RoomDataProvider>(
         &mut self,
-        update: JoinedRoom,
+        update: JoinedRoomUpdate,
         room_data_provider: &P,
         settings: &TimelineInnerSettings,
     ) {

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -30,7 +30,7 @@ impl Client {
         let response = self.base_client().process_sliding_sync(response, &()).await?;
 
         tracing::debug!("done processing on base_client");
-        self.handle_sync_response(&response).await?;
+        self.call_sync_response_handlers(&response).await?;
 
         Ok(response)
     }
@@ -95,7 +95,7 @@ impl<'a> SlidingSyncResponseProcessor<'a> {
 
         response.to_device.extend(self.to_device_events);
 
-        self.client.handle_sync_response(&response).await?;
+        self.client.call_sync_response_handlers(&response).await?;
 
         Ok(response)
     }

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -136,7 +136,7 @@ impl Client {
         #[cfg(feature = "e2e-encryption")]
         self.encryption().backups().maybe_trigger_backup();
 
-        self.handle_sync_response(&response).await?;
+        self.call_sync_response_handlers(&response).await?;
 
         Ok(response)
     }
@@ -148,7 +148,10 @@ impl Client {
     /// persisted in the store, if needs be. This function is only calling
     /// the event, room update and notification handlers.
     #[tracing::instrument(skip(self, response))]
-    pub(crate) async fn handle_sync_response(&self, response: &BaseSyncResponse) -> Result<()> {
+    pub(crate) async fn call_sync_response_handlers(
+        &self,
+        response: &BaseSyncResponse,
+    ) -> Result<()> {
         let BaseSyncResponse { rooms, presence, account_data, to_device, notifications } = response;
 
         let now = Instant::now();

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -84,14 +84,14 @@ pub enum RoomUpdate {
         /// Room object with general information on the room.
         room: Room,
         /// Updates to the room.
-        updates: LeftRoom,
+        updates: LeftRoomUpdate,
     },
     /// Updates to a room the user is currently in.
     Joined {
         /// Room object with general information on the room.
         room: Room,
         /// Updates to the room.
-        updates: JoinedRoom,
+        updates: JoinedRoomUpdate,
     },
     /// Updates to a room the user is invited to.
     Invited {
@@ -167,7 +167,7 @@ impl Client {
                 updates: room_info.clone(),
             });
 
-            let JoinedRoom {
+            let JoinedRoomUpdate {
                 unread_notifications: _,
                 timeline,
                 state,
@@ -196,7 +196,7 @@ impl Client {
                 updates: room_info.clone(),
             });
 
-            let LeftRoom { timeline, state, account_data, ambiguity_changes: _ } = room_info;
+            let LeftRoomUpdate { timeline, state, account_data, ambiguity_changes: _ } = room_info;
 
             let room = Some(&room);
             self.handle_sync_events(HandlerKind::RoomAccountData, room, account_data).await?;

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -124,6 +124,8 @@ impl fmt::Debug for RoomUpdate {
 /// Internal functionality related to getting events from the server
 /// (`sync_events` endpoint)
 impl Client {
+    /// Receive a sync response, compute extra information out of it and store
+    /// the interesting bits in the database, then call all the handlers.
     pub(crate) async fn process_sync(
         &self,
         response: sync_events::v3::Response,
@@ -135,6 +137,7 @@ impl Client {
         self.encryption().backups().maybe_trigger_backup();
 
         self.handle_sync_response(&response).await?;
+
         Ok(response)
     }
 

--- a/crates/matrix-sdk/src/sync.rs
+++ b/crates/matrix-sdk/src/sync.rs
@@ -43,7 +43,7 @@ pub struct SyncResponse {
     /// request.
     pub next_batch: String,
     /// Updates to rooms.
-    pub rooms: Rooms,
+    pub rooms: RoomUpdates,
     /// Updates to the presence status of other users.
     pub presence: Vec<Raw<PresenceEvent>>,
     /// The global private data created by this user.


### PR DESCRIPTION
A few renamings for things that confused me at least once in the past. Each commit can be reviewed/accepted in isolation. 