### PR TITLE
Use rustls for Swift to support TLS 1.3

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -13,8 +13,11 @@ repository = "https://github.com/matrix-org/matrix-rust-sdk"
 crate-type = ["cdylib", "staticlib"]
 
 [features]
-default = ["bundled-sqlite"]
+default = ["bundled-sqlite", "rustls-tls"]
+
 bundled-sqlite = ["matrix-sdk/bundled-sqlite"]
+native-tls = ["matrix-sdk/native-tls"]
+rustls-tls = ["matrix-sdk/rustls-tls"]
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
@@ -29,7 +32,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-matrix-sdk = { workspace = true, features = ["anyhow", "e2e-encryption", "experimental-oidc", "experimental-sliding-sync", "experimental-widgets", "markdown", "rustls-tls", "socks", "sqlite", "uniffi"] }
+matrix-sdk = { workspace = true, features = ["anyhow", "e2e-encryption", "experimental-oidc", "experimental-sliding-sync", "experimental-widgets", "markdown", "socks", "sqlite", "uniffi"] }
 matrix-sdk-ui = { workspace = true, features = ["e2e-encryption", "uniffi"] }
 mime = "0.3.16"
 once_cell = { workspace = true }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -57,7 +57,7 @@ language-tags = "0.3.2"
 log-panics = { version = "2", features = ["with-backtrace"] }
 paranoid-android = "0.2.1"
 
-[target.'cfg(target_os = "android")'.dependencies.matrix-sdk]
+[target.'cfg(any(target_os = "android", target_os = "ios", target_os = "macos"))'.dependencies.matrix-sdk]
 workspace = true
 features = [
     "anyhow",
@@ -72,7 +72,7 @@ features = [
     "uniffi",
 ]
 
-[target.'cfg(not(target_os = "android"))'.dependencies.matrix-sdk]
+[target.'cfg(not(any(target_os = "android", target_os = "ios", target_os = "macos")))'.dependencies.matrix-sdk]
 workspace = true
 features = [
     "anyhow",

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -29,6 +29,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }
 futures-util = { workspace = true }
+matrix-sdk = { workspace = true, features = ["anyhow", "e2e-encryption", "experimental-oidc", "experimental-sliding-sync", "experimental-widgets", "markdown", "rustls-tls", "socks", "sqlite", "uniffi"] }
 matrix-sdk-ui = { workspace = true, features = ["e2e-encryption", "uniffi"] }
 mime = "0.3.16"
 once_cell = { workspace = true }
@@ -56,33 +57,3 @@ language-tags = "0.3.2"
 [target.'cfg(target_os = "android")'.dependencies]
 log-panics = { version = "2", features = ["with-backtrace"] }
 paranoid-android = "0.2.1"
-
-[target.'cfg(any(target_os = "android", target_os = "ios", target_os = "macos"))'.dependencies.matrix-sdk]
-workspace = true
-features = [
-    "anyhow",
-    "e2e-encryption",
-    "experimental-oidc",
-    "experimental-sliding-sync",
-    "experimental-widgets",
-    "markdown",
-    "rustls-tls", # note: differ from block below
-    "socks",
-    "sqlite",
-    "uniffi",
-]
-
-[target.'cfg(not(any(target_os = "android", target_os = "ios", target_os = "macos")))'.dependencies.matrix-sdk]
-workspace = true
-features = [
-    "anyhow",
-    "e2e-encryption",
-    "experimental-oidc",
-    "experimental-sliding-sync",
-    "experimental-widgets",
-    "markdown",
-    "native-tls", # note: differ from block above
-    "socks",
-    "sqlite",
-    "uniffi",
-]

--- a/crates/matrix-sdk/build.rs
+++ b/crates/matrix-sdk/build.rs
@@ -25,10 +25,6 @@ fn main() {
         native_tls_set || rustls_tls_set,
         "one of the features 'native-tls' or 'rustls-tls' must be enabled",
     );
-    ensure(
-        !native_tls_set || !rustls_tls_set,
-        "only one of the features 'native-tls' or 'rustls-tls' can be enabled",
-    );
 
     let is_wasm = env::var_os("CARGO_CFG_TARGET_ARCH").is_some_and(|arch| arch == "wasm32");
     if is_wasm {


### PR DESCRIPTION
Currently Element X iOS does not support TLS 1.3, this PR shall fix that.

Explanation:

There is an official recommendation from Apple, that boils down to the following if you use cross-platform code with sockets (as we do with the rust sdk):

> To use TLS in that case [BSD Sockets], add your own TLS implementation.

> Don’t use Secure Transport for your TLS implementation. It’s been deprecated since 2019
> and doesn’t support TLS 1.3. If you have existing code that uses Secure Transport, make
> a plan to migrate off it.

Modern TLS implementations including TLS 1.3 on macOS are only available as a builtin via the Apple-specific URLSession / Network framework APIs, so APIs where you feed in an URL and get the response back. They are not available in combination with a generic sockets-based cross-platform code.

With that in mind, there is currently no hope that rust-native-tls would support TLS 1.3 in the forseeable future as there is simply no native TLS implementation in current macOS/iOS that could be used by rust-native-tls.

See https://developer.apple.com/documentation/technotes/tn3151-choosing-the-right-networking-api#TLS-best-practices

Fixes: element-hq/element-x-ios#786

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Christoph Settgast <csett86_git@quicksands.de>
