### PR TITLE
read receipts: add the room id in the instrumentation of `send_single_receipt`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -704,7 +704,7 @@ impl Timeline {
     /// recent than the current ones, to avoid unnecessary requests.
     ///
     /// Returns a boolean indicating if it sent the request or not.
-    #[instrument(skip(self))]
+    #[instrument(skip(self), fields(room_id = ?self.room().room_id()))]
     pub async fn send_single_receipt(
         &self,
         receipt_type: ReceiptType,


### PR DESCRIPTION
This didn't show up, and it's quite useful to know for which room we're trying to send a receipt, without having to look up the room based on the target event id.