### PR TITLE
ffi: have at most one `Client` alive at any time during login and don't run e2ee tasks for the login client

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -591,6 +591,12 @@ impl AuthenticationService {
             .passphrase(self.passphrase.clone())
             .homeserver_url(homeserver_url)
             .sliding_sync_proxy(sliding_sync_proxy)
+            .with_encryption_settings(matrix_sdk::encryption::EncryptionSettings {
+                auto_enable_cross_signing: true,
+                backup_download_strategy:
+                    matrix_sdk::encryption::BackupDownloadStrategy::AfterDecryptionFailure,
+                auto_enable_backups: true,
+            })
             .username(user_id.to_string());
 
         if let Some(id) = &self.cross_process_refresh_lock_id {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -179,7 +179,7 @@ impl Client {
         sdk_client: MatrixClient,
         cross_process_refresh_lock_id: Option<String>,
         session_delegate: Option<Arc<dyn ClientSessionDelegate>>,
-    ) -> Result<Arc<Self>, ClientError> {
+    ) -> Result<Self, ClientError> {
         let session_verification_controller: Arc<
             tokio::sync::RwLock<Option<SessionVerificationController>>,
         > = Default::default();
@@ -193,11 +193,11 @@ impl Client {
             }
         });
 
-        let client = Arc::new(Client {
+        let client = Client {
             inner: ManuallyDrop::new(sdk_client),
             delegate: RwLock::new(None),
             session_verification_controller,
-        });
+        };
 
         if let Some(process_id) = cross_process_refresh_lock_id {
             if session_delegate.is_none() {

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -131,7 +131,7 @@ impl ClientBuilder {
     }
 
     pub fn build(self: Arc<Self>) -> Result<Arc<Client>, ClientError> {
-        Ok(self.build_inner()?)
+        Ok(Arc::new(self.build_inner()?))
     }
 }
 
@@ -166,7 +166,7 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
-    pub(crate) fn build_inner(self: Arc<Self>) -> anyhow::Result<Arc<Client>> {
+    pub(crate) fn build_inner(self: Arc<Self>) -> anyhow::Result<Client> {
         let builder = unwrap_or_clone_arc(self);
         let mut inner_builder = builder.inner;
 

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -634,11 +634,13 @@ impl Backups {
         info!("Setting up secret listeners and trying to resume backups");
 
         self.client.add_event_handler(Self::secret_send_event_handler);
+
         if self.client.inner.encryption_settings.backup_download_strategy
             == BackupDownloadStrategy::AfterDecryptionFailure
         {
             self.client.add_event_handler(Self::utd_event_handler);
         }
+
         self.maybe_resume_backups().await?;
 
         Ok(())

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1269,7 +1269,8 @@ impl Encryption {
         Ok(())
     }
 
-    /// Waits for end-to-end encryption initialization tasks to finish.
+    /// Waits for end-to-end encryption initialization tasks to finish, if any
+    /// was running in the background.
     pub async fn wait_for_e2ee_initialization_tasks(&self) {
         let task = self.client.inner.tasks.lock().unwrap().setup_e2ee.take();
 

--- a/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
+++ b/crates/matrix-sdk/src/encryption/secret_storage/mod.rs
@@ -269,7 +269,7 @@ impl SecretStorage {
         CreateStore { secret_storage: self, passphrase: None }
     }
 
-    /// Is secret storage set up for this user?
+    /// Run a network request to find if secret storage is set up for this user.
     pub async fn is_enabled(&self) -> crate::Result<bool> {
         if let Some(content) = self
             .client

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -176,19 +176,6 @@ async fn recovery_status_secret_storage_set_up() {
 
     mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
 
-    Mock::given(method("GET"))
-        .and(path(format!(
-            "_matrix/client/r0/user/{user_id}/account_data/m.org.matrix.custom.backup_disabled"
-        )))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
-            "errcode": "M_NOT_FOUND",
-            "error": "Account data not found"
-        })))
-        .expect(1..)
-        .mount(&server)
-        .await;
-
     client.restore_session(session).await.unwrap();
     client.encryption().wait_for_e2ee_initialization_tasks().await;
 
@@ -723,19 +710,6 @@ async fn recover_and_reset() {
     let (client, server) = no_retry_test_client().await;
 
     mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
-
-    Mock::given(method("GET"))
-        .and(path(format!(
-            "_matrix/client/r0/user/{user_id}/account_data/m.org.matrix.custom.backup_disabled"
-        )))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
-            "errcode": "M_NOT_FOUND",
-            "error": "Account data not found"
-        })))
-        .expect(1..)
-        .mount(&server)
-        .await;
 
     Mock::given(method("GET"))
         .and(path("_matrix/client/r0/room_keys/version"))


### PR DESCRIPTION
The first commit makes it so that there can't be two clients living at the same time.

The second commit changes the default configuration of FFI clients, so they don't try to enable backup and cross-signing bootstrap for the first client that's used only to figure out what's the user's `user_id()`. Only the second client may do that.

This should avoid a race condition at startup at the FFI level, where multiple clients try to initialize encryption at the same time, or would send one-time-keys racily.

The third commit is me figuring out the effect of setting up backup and recovery: mostly it adds event handlers, recovers state by reading from the store. For a fresh in-memory client, it will do nothing interesting.