### PR TITLE
Allow references to MediaEventContent

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ Breaking changes:
 - `Room::can_user_redact` and `Member::can_redact` are split between `*_redact_own` and `*_redact_other`
 - The ambiguity maps in `SyncResponse` are moved to `JoinedRoom` and `LeftRoom`
 - `AmbiguityCache` contains the room member's user ID
+- Replace `impl MediaEventContent` with `&impl MediaEventContent` in
+  `Media::get_file`/`Media::remove_file`/`Media::get_thumbnail`/`Media::remove_thumbnail`
 
 # 0.7.0
 

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -347,7 +347,7 @@ impl Media {
     /// * `use_cache` - If we should use the media cache for this file.
     pub async fn get_file(
         &self,
-        event_content: impl MediaEventContent,
+        event_content: &impl MediaEventContent,
         use_cache: bool,
     ) -> Result<Option<Vec<u8>>> {
         let Some(source) = event_content.source() else { return Ok(None) };
@@ -365,7 +365,7 @@ impl Media {
     /// # Arguments
     ///
     /// * `event_content` - The media event content.
-    pub async fn remove_file(&self, event_content: impl MediaEventContent) -> Result<()> {
+    pub async fn remove_file(&self, event_content: &impl MediaEventContent) -> Result<()> {
         if let Some(source) = event_content.source() {
             self.remove_media_content(&MediaRequest { source, format: MediaFormat::File }).await?;
         }
@@ -393,7 +393,7 @@ impl Media {
     /// * `use_cache` - If we should use the media cache for this thumbnail.
     pub async fn get_thumbnail(
         &self,
-        event_content: impl MediaEventContent,
+        event_content: &impl MediaEventContent,
         size: MediaThumbnailSize,
         use_cache: bool,
     ) -> Result<Option<Vec<u8>>> {
@@ -420,7 +420,7 @@ impl Media {
     ///   requested with [`get_thumbnail`](#method.get_thumbnail).
     pub async fn remove_thumbnail(
         &self,
-        event_content: impl MediaEventContent,
+        event_content: &impl MediaEventContent,
         size: MediaThumbnailSize,
     ) -> Result<()> {
         if let Some(source) = event_content.source() {

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -374,7 +374,7 @@ async fn get_media_file() {
         .mount(&server)
         .await;
 
-    client.media().get_file(event_content.clone(), false).await.unwrap();
+    client.media().get_file(&event_content, false).await.unwrap();
 
     Mock::given(method("GET"))
         .and(path("/_matrix/media/r0/thumbnail/example.org/image"))
@@ -389,7 +389,7 @@ async fn get_media_file() {
     client
         .media()
         .get_thumbnail(
-            event_content,
+            &event_content,
             MediaThumbnailSize { method: Method::Scale, width: uint!(100), height: uint!(100) },
             false,
         )


### PR DESCRIPTION
`matrix_sdk_ui::timeline::Message::msgtype` returns `&MessageType`, and variants of `MessageType` implement `MediaEventContent`, so it is allowing references here avoids cloning message content.
