### PR TITLE
timeline: mark as read based on the latest folded/invisible event

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -551,22 +551,18 @@ impl Room {
     }
 
     /// Reverts a previously set unread flag and sends a read receipt to the
-    /// latest event in the room. Sending read receipts is useful when
-    /// executing this from the room list but shouldn't be use when entering
-    /// the room, the timeline should be left to its own devices in that
-    /// case.
+    /// latest event in the room.
+    ///
+    /// Sending read receipts is useful when executing this from the room list
+    /// but shouldn't be use when entering the room, the timeline should be
+    /// left to its own devices in that case.
     pub async fn mark_as_read_and_send_read_receipt(
         &self,
         receipt_type: ReceiptType,
     ) -> Result<(), ClientError> {
         let timeline = self.timeline().await?;
 
-        if let Some(event) = timeline.latest_event().await {
-            if let Err(error) = timeline.send_read_receipt(receipt_type, event.event_id().unwrap())
-            {
-                error!("Failed to send read receipt: {error}");
-            }
-        }
+        timeline.mark_as_read(receipt_type).await?;
 
         self.mark_as_read().await
     }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -539,32 +539,21 @@ impl Room {
         })))
     }
 
-    /// Sets a flag on the room to indicate that the user has explicitly marked
-    /// it as unread
-    pub async fn mark_as_unread(&self) -> Result<(), ClientError> {
-        Ok(self.inner.mark_unread(true).await?)
+    /// Set (or unset) a flag on the room to indicate that the user has
+    /// explicitly marked it as unread.
+    pub async fn set_unread_flag(&self, new_value: bool) -> Result<(), ClientError> {
+        Ok(self.inner.set_unread_flag(new_value).await?)
     }
 
-    /// Reverts a previously set unread flag.
-    pub async fn mark_as_read(&self) -> Result<(), ClientError> {
-        Ok(self.inner.mark_unread(false).await?)
-    }
-
-    /// Reverts a previously set unread flag and sends a read receipt to the
-    /// latest event in the room.
+    /// Mark a room as read, by attaching a read receipt on the latest event.
     ///
-    /// Sending read receipts is useful when executing this from the room list
-    /// but shouldn't be use when entering the room, the timeline should be
-    /// left to its own devices in that case.
-    pub async fn mark_as_read_and_send_read_receipt(
-        &self,
-        receipt_type: ReceiptType,
-    ) -> Result<(), ClientError> {
+    /// Note: this does NOT unset the unread flag; it's the caller's
+    /// responsibility to do so, if needs be.
+    pub async fn mark_as_read(&self, receipt_type: ReceiptType) -> Result<(), ClientError> {
         let timeline = self.timeline().await?;
 
         timeline.mark_as_read(receipt_type).await?;
-
-        self.mark_as_read().await
+        Ok(())
     }
 
     pub async fn build_power_level_changes_from_current(

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -196,6 +196,13 @@ impl Timeline {
         })
     }
 
+    /// Mark the room as read by trying to add a read receipt to the latest
+    /// event.
+    pub async fn mark_as_read(&self, receipt_type: ReceiptType) -> Result<(), ClientError> {
+        self.inner.mark_as_read(receipt_type.into(), ReceiptThread::Unthreaded).await?;
+        Ok(())
+    }
+
     pub fn send(self: Arc<Self>, msg: Arc<RoomMessageEventContentWithoutRelation>) {
         RUNTIME.spawn(async move {
             self.inner.send((*msg).to_owned().with_relation(None).into()).await;

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -196,10 +196,14 @@ impl Timeline {
         })
     }
 
-    /// Mark the room as read by trying to add a read receipt to the latest
-    /// event.
+    /// Mark the room as read by trying to attach an *unthreaded* read receipt
+    /// to the latest room event.
+    ///
+    /// This works even if the latest event belongs to a thread, as a threaded
+    /// reply also belongs to the unthreaded timeline. No threaded receipt
+    /// will be sent here (see also #3123).
     pub async fn mark_as_read(&self, receipt_type: ReceiptType) -> Result<(), ClientError> {
-        self.inner.mark_as_read(receipt_type.into(), ReceiptThread::Unthreaded).await?;
+        self.inner.mark_as_read(receipt_type.into()).await?;
         Ok(())
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -1143,6 +1143,13 @@ impl TimelineInner {
         // Let the server handle unknown receipts.
         true
     }
+
+    /// Returns the latest event identifier, even if it's not visible, or if
+    /// it's folded into another timeline item.
+    pub(crate) async fn latest_event_id(&self) -> Option<OwnedEventId> {
+        let state = self.state.read().await;
+        state.all_events.back().map(|event_meta| &event_meta.event_id).cloned()
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -771,6 +771,24 @@ impl Timeline {
 
         self.room().send_multiple_receipts(receipts).await
     }
+
+    /// Mark the room as read by sending a read receipt on the latest event, be
+    /// it visible or not.
+    ///
+    /// Returns a boolean indicating if it sent the request or not.
+    #[instrument(skip(self), fields(room_id = ?self.room().room_id()))]
+    pub async fn mark_as_read(
+        &self,
+        receipt_type: ReceiptType,
+        thread: ReceiptThread,
+    ) -> Result<bool> {
+        if let Some(event_id) = self.inner.latest_event_id().await {
+            self.send_single_receipt(receipt_type, thread, event_id).await
+        } else {
+            trace!("can't mark room as read because there's no latest event id");
+            Ok(false)
+        }
+    }
 }
 
 /// Test helpers, likely not very useful in production.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -934,8 +934,7 @@ async fn test_mark_as_read() {
 
     // But when I mark the room as read by sending a read receipt to the latest
     // event,
-    let has_sent =
-        timeline.mark_as_read(ReceiptType::Read, ReceiptThread::Unthreaded).await.unwrap();
+    let has_sent = timeline.mark_as_read(ReceiptType::Read).await.unwrap();
 
     // It works.
     assert!(has_sent);

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2490,9 +2490,9 @@ impl Room {
         Ok(self.client.send(request, None).await?)
     }
 
-    /// Sets a flag on the room to indicate that the user has explicitly marked
-    /// it as (un)read
-    pub async fn mark_unread(&self, unread: bool) -> Result<()> {
+    /// Set a flag on the room to indicate that the user has explicitly marked
+    /// it as (un)read.
+    pub async fn set_unread_flag(&self, unread: bool) -> Result<()> {
         let user_id =
             self.client.user_id().ok_or_else(|| Error::from(HttpError::AuthenticationRequired))?;
 

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -159,7 +159,7 @@ async fn unban_user() {
 }
 
 #[async_test]
-async fn mark_as_unread() {
+async fn test_mark_as_unread() {
     let (client, server) = logged_in_client().await;
 
     Mock::given(method("PUT"))
@@ -179,9 +179,9 @@ async fn mark_as_unread() {
 
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
 
-    room.mark_unread(true).await.unwrap();
+    room.set_unread_flag(true).await.unwrap();
 
-    room.mark_unread(false).await.unwrap();
+    room.set_unread_flag(false).await.unwrap();
 }
 
 #[async_test]


### PR DESCRIPTION
See commit by commit for an easier review.

TL;DR:

- FFI `mark_as_{un}read` has been changed to `set_unread_flag(bool)`
- a new method `Timeline::mark_as_read` is introduced in both the UI and FFI layers, attaching a read receipt to the latest event (not the event attached to the latest item)
- instead of `mark_as_unread_and_send_receipt`, it's expected of the callers to first call `set_unread_flag(false)` then `mark_as_read`
- instead of using `send_read_receipt` on the latest item's event id, when scrolled to the bottom in a room view, one would call `mark_as_read`

Pinging some app developers so they're aware of the new methods, cc @stefanceriu @ganfra @bmarty

Should fix with stuck unreads like https://github.com/element-hq/element-x-ios-rageshakes/issues/1409.