### PR TITLE
sync: Avoid crash on invalid state events

### DIFF
--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -50,8 +50,8 @@ pub use http;
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{
-    DisplayName, Room, RoomCreateWithCreatorEventContent, RoomInfo, RoomInfoUpdate, RoomMember,
-    RoomMemberships, RoomState, RoomStateFilter,
+    DisplayName, RawRoomInfo, Room, RoomCreateWithCreatorEventContent, RoomInfo, RoomInfoUpdate,
+    RoomMember, RoomMemberships, RoomState, RoomStateFilter,
 };
 pub use store::{StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError};
 pub use utils::{

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -718,7 +718,7 @@ async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         let room_info = room_info_v1.migrate(create.as_ref());
         room_infos_store.put_key_val(
             &encode_key(store_cipher, keys::ROOM_INFOS, room_info.room_id()),
-            &serialize_event(store_cipher, &room_info)?,
+            &serialize_event(store_cipher, &room_info.into_raw_lossy())?,
         )?;
     }
 

--- a/crates/matrix-sdk-sqlite/migrations/state_store/003_create_raw_room_info.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/003_create_raw_room_info.sql
@@ -1,0 +1,4 @@
+CREATE TABLE "raw_room_info" (
+    "room_id" BLOB PRIMARY KEY NOT NULL,
+    "data" BLOB NOT NULL
+);

--- a/crates/matrix-sdk-sqlite/migrations/state_store/003_create_raw_room_info.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/003_create_raw_room_info.sql
@@ -1,4 +1,0 @@
-CREATE TABLE "raw_room_info" (
-    "room_id" BLOB PRIMARY KEY NOT NULL,
-    "data" BLOB NOT NULL
-);

--- a/testing/matrix-sdk-integration-testing/src/tests.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests.rs
@@ -5,3 +5,4 @@ mod reactions;
 mod redaction;
 mod repeated_join;
 mod sliding_sync;
+mod state;

--- a/testing/matrix-sdk-integration-testing/src/tests/state.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/state.rs
@@ -1,0 +1,94 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use matrix_sdk::{
+    ruma::{
+        api::client::{
+            room::create_room::v3::Request as CreateRoomRequest, state::send_state_event,
+        },
+        assign,
+        events::{room::join_rules::RoomJoinRulesEventContent, StateEventType},
+        serde::Raw,
+    },
+    RoomState,
+};
+use serde_json::{json, value::to_raw_value};
+use tokio::{spawn, time::sleep};
+
+use crate::helpers::TestClientBuilder;
+
+/// This makes sure the sync worker does not panic. However this does not check
+/// if the raw event values are recovered when the roominfo is loaded from the
+/// database
+#[tokio::test]
+async fn test_send_bad_join_rules() -> Result<()> {
+    let alice = TestClientBuilder::new("alice".to_owned())
+        .randomize_username()
+        .use_sqlite()
+        .build()
+        .await?;
+    let bob =
+        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+
+    // The sync tasks will panic when there is a problem. At the end of this test,
+    // we will check if they are still running
+    let a = alice.clone();
+    let alice_handle = spawn(async move {
+        if let Err(err) = a.sync(Default::default()).await {
+            panic!("alice sync errored: {err}");
+        }
+    });
+
+    let b = bob.clone();
+    let bob_handle = spawn(async move {
+        if let Err(err) = b.sync(Default::default()).await {
+            panic!("bob sync errored: {err}");
+        }
+    });
+
+    // Alice creates a room.
+    let alice_room = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            invite: vec![],
+            is_direct: false,
+        }))
+        .await?;
+
+    let alice_room = alice.get_room(alice_room.room_id()).unwrap();
+    assert_eq!(alice_room.state(), RoomState::Joined);
+
+    // This join rule cannot be serialized:
+    let content = RoomJoinRulesEventContent::new(
+        serde_json::from_value(json!({ "join_rule": "test!"})).unwrap(),
+    );
+    assert_eq!(
+        to_raw_value(&content).unwrap_err().to_string(),
+        "the enum variant JoinRule::_Custom cannot be serialized"
+    );
+
+    // This will lead to a sync response for alice with a stateevent that fails to
+    // serialize.
+    let request = send_state_event::v3::Request::new_raw(
+        alice_room.room_id().to_owned(),
+        StateEventType::RoomJoinRules,
+        "".to_owned(),
+        Raw::from_json(to_raw_value(&json!({ "join_rule": "test!"})).unwrap()),
+    );
+    let response = alice.send(request, None).await?;
+    dbg!(response);
+
+    // This will lead to a sync response for bob with a strippedstateevent that
+    // fails to serialize
+    alice_room.invite_user_by_id(bob.user_id().unwrap()).await?;
+
+    sleep(Duration::from_secs(1)).await;
+
+    // The sync handlers should not have crashed
+    assert!(!alice_handle.is_finished());
+    assert!(!bob_handle.is_finished());
+
+    alice_handle.abort();
+    bob_handle.abort();
+
+    Ok(())
+}


### PR DESCRIPTION
The problem was in matrix_sdk_sqlite::state_store::SqliteStateStore save_changes, which saved the RoomInfo to the disk by serializing it.

- [ ] Public API changes documented in changelogs (optional)

Fixes #2949 