### PR TITLE
Re-expose the reqwest method to add additional root certificates to the HTTP client

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -10,6 +10,11 @@ Breaking changes:
 - Replace `impl MediaEventContent` with `&impl MediaEventContent` in
   `Media::get_file`/`Media::remove_file`/`Media::get_thumbnail`/`Media::remove_thumbnail`
 
+Additions:
+
+- Add the `ClientBuilder::add_root_certificates()` method which re-exposes the
+  `reqwest::ClientBuilder::add_root_certificate()` functionality.
+
 # 0.7.0
 
 Breaking changes:

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -260,6 +260,20 @@ impl ClientBuilder {
         self
     }
 
+    /// Add the given list of certificates to the certificate store of the HTTP
+    /// client.
+    ///
+    /// These additional certificates will be trusted and considered when
+    /// establishing a HTTP request.
+    ///
+    /// Internally this will call the
+    /// [`reqwest::ClientBuilder::add_root_certificate()`] method.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn add_root_certificates(mut self, certificates: Vec<reqwest::Certificate>) -> Self {
+        self.http_settings().additional_root_certificates = certificates;
+        self
+    }
+
     /// Specify a [`reqwest::Client`] instance to handle sending requests and
     /// receiving responses.
     ///


### PR DESCRIPTION
This PR mainly allows clients to add root certificates to the HTTP client without having to build the `reqwest::Client` manually.

We also re-expose this functionality through the bindings.

- [x] Public API changes documented in changelogs (optional)
