### PR TITLE
ffi: Re-enable the correct backup download strategy for the bindings

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf, sync::Arc};
 
 use matrix_sdk::{
-    encryption::EncryptionSettings,
+    encryption::{BackupDownloadStrategy, EncryptionSettings},
     ruma::{
         api::{error::UnknownVersionError, MatrixVersion},
         ServerName, UserId,
@@ -55,7 +55,11 @@ impl ClientBuilder {
             proxy: None,
             disable_ssl_verification: false,
             disable_automatic_token_refresh: false,
-            inner: MatrixClient::builder(),
+            inner: MatrixClient::builder().with_encryption_settings(EncryptionSettings {
+                auto_enable_cross_signing: false,
+                backup_download_strategy: BackupDownloadStrategy::AfterDecryptionFailure,
+                auto_enable_backups: false,
+            }),
             cross_process_refresh_lock_id: None,
             session_delegate: None,
         })


### PR DESCRIPTION
This fixes #3130.

The fact that we have two places where we pass in things to the client builder is pretty annoying and I would call this a broken API. #3126 is also affected by the configure twice and more things will come.

Though let's fix the backup download strategy so we can tackle the API rework in peace.