### PR TITLE
Use ClientBuilder::server_name_or_homeserver_url directly in the authentication service.

### DIFF
--- a/bindings/apple/Tests/MatrixRustSDKTests/ClientTests.swift
+++ b/bindings/apple/Tests/MatrixRustSDKTests/ClientTests.swift
@@ -23,16 +23,6 @@ final class ClientTests: XCTestCase {
         }
     }
     
-    func testBuildingWithUsername() {
-        do {
-            _ = try ClientBuilder()
-                .username(username: "@test:matrix.org")
-                .build()
-        } catch {
-            XCTFail("The client should build successfully when given a username.")
-        }
-    }
-    
     func testBuildingWithInvalidUsername() {
         do {
             _ = try ClientBuilder()
@@ -40,7 +30,7 @@ final class ClientTests: XCTestCase {
                 .build()
             
             XCTFail("The client should not build when given an invalid username.")
-        } catch ClientError.Generic(let message) {
+        } catch ClientBuildError.Sdk(let message) {
             XCTAssertTrue(message.contains(".well-known"), "The client should fail to do the well-known lookup.")
         } catch {
             XCTFail("Not expecting any other kind of exception")

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -31,15 +31,9 @@ enum HomeserverConfig {
 #[uniffi(flat_error)]
 pub enum ClientBuildError {
     #[error(transparent)]
-    Sdk(MatrixClientBuildError),
+    Sdk(#[from] MatrixClientBuildError),
     #[error("Failed to build the client: {message}")]
     Generic { message: String },
-}
-
-impl From<MatrixClientBuildError> for ClientBuildError {
-    fn from(e: MatrixClientBuildError) -> ClientBuildError {
-        ClientBuildError::Sdk(e)
-    }
 }
 
 impl From<IdParseError> for ClientBuildError {

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -19,18 +19,18 @@ use crate::{client::ClientSessionDelegate, error::ClientError, helpers::unwrap_o
 /// A list of bytes containing a certificate in DER or PEM form.
 pub type CertificateBytes = Vec<u8>;
 
-#[derive(Clone)]
-pub(crate) enum UrlScheme {
-    Http,
-    Https,
+#[derive(Debug, Clone)]
+enum HomeserverConfig {
+    Url(String),
+    ServerName(String),
+    ServerNameOrUrl(String),
 }
 
 #[derive(Clone, uniffi::Object)]
 pub struct ClientBuilder {
     base_path: Option<String>,
     username: Option<String>,
-    server_name: Option<(String, UrlScheme)>,
-    homeserver_url: Option<String>,
+    homeserver_cfg: Option<HomeserverConfig>,
     server_versions: Option<Vec<String>>,
     passphrase: Zeroizing<Option<String>>,
     user_agent: Option<String>,
@@ -51,8 +51,7 @@ impl ClientBuilder {
         Arc::new(Self {
             base_path: None,
             username: None,
-            server_name: None,
-            homeserver_url: None,
+            homeserver_cfg: None,
             server_versions: None,
             passphrase: Zeroizing::new(None),
             user_agent: None,
@@ -108,14 +107,19 @@ impl ClientBuilder {
 
     pub fn server_name(self: Arc<Self>, server_name: String) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        // Assume HTTPS if no protocol is provided.
-        builder.server_name = Some((server_name, UrlScheme::Https));
+        builder.homeserver_cfg = Some(HomeserverConfig::ServerName(server_name));
         Arc::new(builder)
     }
 
     pub fn homeserver_url(self: Arc<Self>, url: String) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
-        builder.homeserver_url = Some(url);
+        builder.homeserver_cfg = Some(HomeserverConfig::Url(url));
+        Arc::new(builder)
+    }
+
+    pub fn server_name_or_homeserver_url(self: Arc<Self>, server_name_or_url: String) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.homeserver_cfg = Some(HomeserverConfig::ServerNameOrUrl(server_name_or_url));
         Arc::new(builder)
     }
 
@@ -200,16 +204,6 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
-    pub(crate) fn server_name_with_protocol(
-        self: Arc<Self>,
-        server_name: String,
-        protocol: UrlScheme,
-    ) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.server_name = Some((server_name, protocol));
-        Arc::new(builder)
-    }
-
     pub(crate) fn build_inner(self: Arc<Self>) -> anyhow::Result<Client> {
         let builder = unwrap_or_clone_arc(self);
         let mut inner_builder = builder.inner;
@@ -223,22 +217,26 @@ impl ClientBuilder {
         }
 
         // Determine server either from URL, server name or user ID.
-        if let Some(homeserver_url) = builder.homeserver_url {
-            inner_builder = inner_builder.homeserver_url(homeserver_url);
-        } else if let Some((server_name, protocol)) = builder.server_name {
-            let server_name = ServerName::parse(server_name)?;
-            inner_builder = match protocol {
-                UrlScheme::Http => inner_builder.insecure_server_name_no_tls(&server_name),
-                UrlScheme::Https => inner_builder.server_name(&server_name),
-            };
-        } else if let Some(username) = builder.username {
-            let user = UserId::parse(username)?;
-            inner_builder = inner_builder.server_name(user.server_name());
-        } else {
-            anyhow::bail!(
-                "Failed to build: One of homeserver_url, server_name or username must be called."
-            );
-        }
+        inner_builder = match builder.homeserver_cfg {
+            Some(HomeserverConfig::Url(url)) => inner_builder.homeserver_url(url),
+            Some(HomeserverConfig::ServerName(server_name)) => {
+                let server_name = ServerName::parse(server_name)?;
+                inner_builder.server_name(&server_name)
+            }
+            Some(HomeserverConfig::ServerNameOrUrl(server_name_or_url)) => {
+                inner_builder.server_name_or_homeserver_url(server_name_or_url)
+            }
+            None => {
+                if let Some(username) = builder.username {
+                    let user = UserId::parse(username)?;
+                    inner_builder.server_name(user.server_name())
+                } else {
+                    anyhow::bail!(
+                        "Failed to build: One of homeserver_url, server_name, server_name_or_homeserver_url or username must be called."
+                    );
+                }
+            }
+        };
 
         let mut certificates = Vec::new();
 

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -522,7 +522,7 @@ impl ClientBuilder {
 /// Creates a server name from a user supplied string. The string is first
 /// sanitized by removing whitespace, the http(s) scheme and any trailing
 /// slashes before being parsed.
-pub(crate) fn sanitize_server_name(s: &str) -> crate::Result<OwnedServerName, IdParseError> {
+fn sanitize_server_name(s: &str) -> crate::Result<OwnedServerName, IdParseError> {
     ServerName::parse(
         s.trim().trim_start_matches("http://").trim_start_matches("https://").trim_end_matches('/'),
     )

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -91,39 +91,3 @@ pub mod test_utils;
 
 #[cfg(test)]
 matrix_sdk_test::init_tracing_for_tests!();
-
-/// Creates a server name from a user supplied string. The string is first
-/// sanitized by removing whitespace, the http(s) scheme and any trailing
-/// slashes before being parsed.
-pub fn sanitize_server_name(s: &str) -> Result<OwnedServerName, IdParseError> {
-    ServerName::parse(
-        s.trim().trim_start_matches("http://").trim_start_matches("https://").trim_end_matches('/'),
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use assert_matches::assert_matches;
-
-    use crate::sanitize_server_name;
-
-    #[test]
-    fn test_sanitize_server_name() {
-        assert_eq!(sanitize_server_name("matrix.org").unwrap().as_str(), "matrix.org");
-        assert_eq!(sanitize_server_name("https://matrix.org").unwrap().as_str(), "matrix.org");
-        assert_eq!(sanitize_server_name("http://matrix.org").unwrap().as_str(), "matrix.org");
-        assert_eq!(
-            sanitize_server_name("https://matrix.server.org").unwrap().as_str(),
-            "matrix.server.org"
-        );
-        assert_eq!(
-            sanitize_server_name("https://matrix.server.org/").unwrap().as_str(),
-            "matrix.server.org"
-        );
-        assert_eq!(
-            sanitize_server_name("  https://matrix.server.org// ").unwrap().as_str(),
-            "matrix.server.org"
-        );
-        assert_matches!(sanitize_server_name("https://matrix.server.org/something"), Err(_))
-    }
-}


### PR DESCRIPTION
This PR builds on top of #3129 and uses the new (and tested) method in the FFI.

As part of this I've added a `ClientBuildError` to the FFI's client builder that passes up the SDK's error so we can match it.

Next part of #3029.