### PR TITLE
ffi: Add extra logs to `Client::process_session_change`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -766,6 +766,7 @@ impl From<&search_users::v3::User> for UserProfile {
 impl Client {
     fn process_session_change(&self, session_change: SessionChange) {
         if let Some(delegate) = self.delegate.read().unwrap().clone() {
+            debug!("Applying session change: {session_change:?}");
             RUNTIME.spawn_blocking(move || match session_change {
                 SessionChange::UnknownToken { soft_logout } => {
                     delegate.did_receive_auth_error(soft_logout);
@@ -774,6 +775,10 @@ impl Client {
                     delegate.did_refresh_tokens();
                 }
             });
+        } else {
+            debug!(
+                "No client delegate found, session change couldn't be applied: {session_change:?}"
+            );
         }
     }
 


### PR DESCRIPTION
This should help us understand why 2 failed requests with invalid access token didn't pass a refreshed token to the client.

I'll also add more detailed logging filters to the app so we can try to track the actual refresh so we can check where this process failed:

- When refreshing the access token: refreshing failed or no refresh happened (is this even possible?).
- When notifying the client: maybe there is no delegate, or it was destroyed.
- At the client somehow: I don't see how, but if we discard every other possibility....

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
