### PR TITLE
Fixes #3141 - Expose ignored users on the FFI layer

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -717,20 +717,16 @@ impl Client {
         Ok(vec![])
     }
 
-    pub fn ignore_user(&self, user_id: String) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move {
-            let user_id = UserId::parse(user_id)?;
-            self.inner.account().ignore_user(&user_id).await?;
-            Ok(())
-        })
+    pub async fn ignore_user(&self, user_id: String) -> Result<(), ClientError> {
+        let user_id = UserId::parse(user_id)?;
+        self.inner.account().ignore_user(&user_id).await?;
+        Ok(())
     }
 
-    pub fn unignore_user(&self, user_id: String) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move {
-            let user_id = UserId::parse(user_id)?;
-            self.inner.account().unignore_user(&user_id).await?;
-            Ok(())
-        })
+    pub async fn unignore_user(&self, user_id: String) -> Result<(), ClientError> {
+        let user_id = UserId::parse(user_id)?;
+        self.inner.account().unignore_user(&user_id).await?;
+        Ok(())
     }
 
     pub fn subscribe_to_ignored_users(

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -524,7 +524,7 @@ impl Room {
         Ok(self.inner.typing_notice(is_typing).await?)
     }
 
-    pub async fn subscribe_to_typing_notifications(
+    pub fn subscribe_to_typing_notifications(
         self: Arc<Self>,
         listener: Box<dyn TypingNotificationsListener>,
     ) -> Arc<TaskHandle> {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -341,13 +341,11 @@ impl Room {
     ///
     /// # Arguments
     ///
-    /// * `event_id` - The ID of the user to ignore.
-    pub fn ignore_user(&self, user_id: String) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move {
-            let user_id = UserId::parse(user_id)?;
-            self.inner.client().account().ignore_user(&user_id).await?;
-            Ok(())
-        })
+    /// * `user_id` - The ID of the user to ignore.
+    pub async fn ignore_user(&self, user_id: String) -> Result<(), ClientError> {
+        let user_id = UserId::parse(user_id)?;
+        self.inner.client().account().ignore_user(&user_id).await?;
+        Ok(())
     }
 
     /// Leave this room.

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1074,11 +1074,16 @@ impl BaseClient {
             if let Some(event) =
                 changes.account_data.get(&GlobalAccountDataEventType::IgnoredUserList)
             {
-                if let Ok(event) = event.deserialize_as::<IgnoredUserListEvent>() {
-                    let user_ids: Vec<String> =
-                        event.content.ignored_users.keys().map(|id| id.to_string()).collect();
+                match event.deserialize_as::<IgnoredUserListEvent>() {
+                    Ok(event) => {
+                        let user_ids: Vec<String> =
+                            event.content.ignored_users.keys().map(|id| id.to_string()).collect();
 
-                    self.ignore_user_list_changes.set(user_ids);
+                        self.ignore_user_list_changes.set(user_ids);
+                    }
+                    Err(error) => {
+                        warn!("Failed to deserialize ignored user list event: {error}")
+                    }
                 }
             }
         }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -352,7 +352,7 @@ impl Client {
 
     /// Returns a subscriber that publishes an event every time the ignore user
     /// list changes.
-    pub fn subscribe_to_ignore_user_list_changes(&self) -> Subscriber<()> {
+    pub fn subscribe_to_ignore_user_list_changes(&self) -> Subscriber<Vec<String>> {
         self.inner.base_client.subscribe_to_ignore_user_list_changes()
     }
 


### PR DESCRIPTION
This PR exposes 2 new methods on the FFI client that will
1) Allow fetching the current list of ignored users from the current account's data
2) Allow subscribing to changes to said list