### PR TITLE
export: Add a streamed way of getting room keys

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -26,6 +26,9 @@ Additions:
   to encrypt an event to a specific device.
   ([#3091](https://github.com/matrix-org/matrix-rust-sdk/pull/3091))
 
+- Add new API `store::Store::export_room_keys_stream` that provides room
+  keys on demand.
+
 # 0.7.0
 
 - Add method to mark a list of inbound group sessions as backed up:

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2317,7 +2317,7 @@ pub(crate) mod tests {
         (machine, otk)
     }
 
-    async fn get_machine_pair(
+    pub async fn get_machine_pair(
         alice: &UserId,
         bob: &UserId,
         use_fallback_key: bool,


### PR DESCRIPTION
This is part of my work on reducing the memory usage of exporting all our room keys https://github.com/matrix-org/matrix-rust-sdk/issues/2914.

It's small part: we offer a streamed method on `OlmMachine` called `export_room_keys_stream` that is similar to `export_room_keys` except it returns a `Stream`, meaning the caller does not need to have all the keys they requested in memory at the same time.

Inside its implementation, it uses `CryptoStore::get_inbound_group_sessions`, which returns a `Vec`, so it doesn't (yet) prevent unbounded memory use.

In a [test](https://github.com/matrix-org/matrix-rust-sdk/pull/3060#issuecomment-1954046982) I did with 10K keys, when I used this method and serialised the result directly to JSON without holding it in an intermediate `Vec` I saw a few MB of memory savings in Element Web during export.

So there is some immediate benefit, but possibly more importantly, this just feels like the right interface to offer: especially when we are exporting **all** keys, we don't want to be forced to hold them all in a `Vec` as `export_room_keys` does.  In future, some PR like https://github.com/matrix-org/matrix-rust-sdk/pull/3060 will allow us to stream properly from the database, and not hold all keys in an intermediate `Vec` as we do now.

I plan to follow this up with a PR in `matrix-rust-sdk-crypto-wasm` that realises the memory saving I referred to above.