### PR TITLE
export: Move existing export_room_keys method to Store

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -1013,7 +1013,8 @@ mod tests {
             "JGgPQRuYj3ScMdPS+A0P+k/1qS9Hr3qeKXLscI+hS78"
         );
 
-        let room_keys = machine.runtime.block_on(machine.inner.export_room_keys(|_| true))?;
+        let room_keys =
+            machine.runtime.block_on(machine.inner.store().export_room_keys(|_| true))?;
         assert_eq!(room_keys.len(), 2);
 
         let cross_signing_status = machine.cross_signing_status();

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -965,7 +965,7 @@ impl OlmMachine {
         passphrase: String,
         rounds: i32,
     ) -> Result<String, CryptoStoreError> {
-        let keys = self.runtime.block_on(self.inner.export_room_keys(|_| true))?;
+        let keys = self.runtime.block_on(self.inner.store().export_room_keys(|_| true))?;
 
         let encrypted = encrypt_room_key_export(&keys, &passphrase, rounds as u32)
             .map_err(CryptoStoreError::Serialization)?;

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -5,6 +5,9 @@ Breaking changes:
 - Rename the `OlmMachine::invalidate_group_session` method to
   `OlmMachine::discard_room_key`
 
+- Move `OlmMachine::export_room_keys` to `matrix_sdk_crypto::store::Store`.
+  (Call it with `olm_machine.store().export_room_keys(...)`.)
+
 Additions:
 
 - Expose new methods `OlmMachine::set_room_settings` and

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -130,7 +130,7 @@ pub fn decrypt_room_key_export(
 /// # async {
 /// # let machine = OlmMachine::new(&alice, device_id!("DEVICEID")).await;
 /// let room_id = room_id!("!test:localhost");
-/// let exported_keys = machine.export_room_keys(|s| s.room_id() == room_id).await.unwrap();
+/// let exported_keys = machine.store().export_room_keys(|s| s.room_id() == room_id).await.unwrap();
 /// let encrypted_export = encrypt_room_key_export(&exported_keys, "1234", 1);
 /// # };
 /// ```
@@ -293,7 +293,7 @@ mod tests {
         let room_id = room_id!("!test:localhost");
 
         machine.create_outbound_group_session_with_defaults_test_helper(room_id).await.unwrap();
-        let export = machine.export_room_keys(|s| s.room_id() == room_id).await.unwrap();
+        let export = machine.store().export_room_keys(|s| s.room_id() == room_id).await.unwrap();
 
         assert!(!export.is_empty());
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1807,45 +1807,6 @@ impl OlmMachine {
         self.store().import_room_keys(exported_keys, from_backup, progress_listener).await
     }
 
-    /// Export the keys that match the given predicate.
-    ///
-    /// # Arguments
-    ///
-    /// * `predicate` - A closure that will be called for every known
-    /// `InboundGroupSession`, which represents a room key. If the closure
-    /// returns `true` the `InboundGroupSession` will be included in the export,
-    /// if the closure returns `false` it will not be included.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # use matrix_sdk_crypto::{OlmMachine, encrypt_room_key_export};
-    /// # use ruma::{device_id, user_id, room_id};
-    /// # let alice = user_id!("@alice:example.org");
-    /// # async {
-    /// # let machine = OlmMachine::new(&alice, device_id!("DEVICEID")).await;
-    /// let room_id = room_id!("!test:localhost");
-    /// let exported_keys = machine.export_room_keys(|s| s.room_id() == room_id).await.unwrap();
-    /// let encrypted_export = encrypt_room_key_export(&exported_keys, "1234", 1);
-    /// # };
-    /// ```
-    pub async fn export_room_keys(
-        &self,
-        predicate: impl FnMut(&InboundGroupSession) -> bool,
-    ) -> StoreResult<Vec<ExportedRoomKey>> {
-        let mut exported = Vec::new();
-
-        let mut sessions = self.store().get_inbound_group_sessions().await?;
-        sessions.retain(predicate);
-
-        for session in sessions {
-            let export = session.export().await;
-            exported.push(export);
-        }
-
-        Ok(exported)
-    }
-
     /// Get the status of the private cross signing keys.
     ///
     /// This can be used to check which private cross signing keys we have

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1594,6 +1594,45 @@ impl Store {
     pub(crate) fn crypto_store(&self) -> Arc<CryptoStoreWrapper> {
         self.inner.store.clone()
     }
+
+    /// Export the keys that match the given predicate.
+    ///
+    /// # Arguments
+    ///
+    /// * `predicate` - A closure that will be called for every known
+    /// `InboundGroupSession`, which represents a room key. If the closure
+    /// returns `true` the `InboundGroupSession` will be included in the export,
+    /// if the closure returns `false` it will not be included.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use matrix_sdk_crypto::{OlmMachine, encrypt_room_key_export};
+    /// # use ruma::{device_id, user_id, room_id};
+    /// # let alice = user_id!("@alice:example.org");
+    /// # async {
+    /// # let machine = OlmMachine::new(&alice, device_id!("DEVICEID")).await;
+    /// let room_id = room_id!("!test:localhost");
+    /// let exported_keys = machine.store().export_room_keys(|s| s.room_id() == room_id).await.unwrap();
+    /// let encrypted_export = encrypt_room_key_export(&exported_keys, "1234", 1);
+    /// # };
+    /// ```
+    pub async fn export_room_keys(
+        &self,
+        predicate: impl FnMut(&InboundGroupSession) -> bool,
+    ) -> Result<Vec<ExportedRoomKey>> {
+        let mut exported = Vec::new();
+
+        let mut sessions = self.get_inbound_group_sessions().await?;
+        sessions.retain(predicate);
+
+        for session in sessions {
+            let export = session.export().await;
+            exported.push(export);
+        }
+
+        Ok(exported)
+    }
 }
 
 impl Deref for Store {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1063,7 +1063,7 @@ impl Encryption {
         let olm = self.client.olm_machine().await;
         let olm = olm.as_ref().ok_or(Error::NoOlmMachine)?;
 
-        let keys = olm.export_room_keys(predicate).await?;
+        let keys = olm.store().export_room_keys(predicate).await?;
         let passphrase = zeroize::Zeroizing::new(passphrase.to_owned());
 
         let encrypt = move || -> Result<()> {


### PR DESCRIPTION
As discussed with @poljar in the Matrix room, methods like this should be on the store, not the main `OlmMachine`

- [x] Public API changes documented in changelogs (optional)