### PR TITLE
event cache: put the `sdk::Room` back in the `RoomEventGraph`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -266,7 +266,7 @@ impl ClientBuilder {
                     inner_builder.server_name(user.server_name())
                 } else {
                     return Err(ClientBuildError::Generic {
-                        message: "Failed to build: One of homeserver_url, server_name, server_name_or_homeserver_url or username must be called.".to_string(),
+                        message: "Failed to build: One of homeserver_url, server_name, server_name_or_homeserver_url or username must be called.".to_owned(),
                     });
                 }
             }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -52,6 +52,8 @@ pub enum RoomListError {
     TimelineNotInitialized { room_name: String },
     #[error("Timeline couldn't be initialized: {error}")]
     InitializingTimeline { error: String },
+    #[error("Event cache ran into an error: {error}")]
+    EventCache { error: String },
 }
 
 impl From<matrix_sdk_ui::room_list_service::Error> for RoomListError {
@@ -69,6 +71,7 @@ impl From<matrix_sdk_ui::room_list_service::Error> for RoomListError {
             InitializingTimeline(source) => {
                 Self::InitializingTimeline { error: source.to_string() }
             }
+            EventCache(error) => Self::EventCache { error: error.to_string() },
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -213,7 +213,7 @@ impl RoomListService {
             .map_err(Error::SlidingSync)?;
 
         // Eagerly subscribe the event cache to sync responses.
-        client.event_cache().subscribe(&client);
+        client.event_cache().subscribe()?;
 
         Ok(Self {
             client,
@@ -518,6 +518,9 @@ pub enum Error {
 
     #[error("An error occurred while initializing the timeline")]
     InitializingTimeline(#[source] EventCacheError),
+
+    #[error("The attached event cache ran into an error")]
+    EventCache(#[from] EventCacheError),
 }
 
 /// An input for the [`RoomList`]' state machine.

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -125,7 +125,7 @@ impl TimelineBuilder {
         let event_cache = client.event_cache();
 
         // Subscribe the event cache to sync responses, in case we hadn't done it yet.
-        event_cache.subscribe(&client);
+        event_cache.subscribe()?;
 
         let (room_event_cache, event_cache_drop) = event_cache.for_room(room.room_id()).await?;
         let (events, mut event_subscriber) = room_event_cache.subscribe().await?;

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -37,8 +37,8 @@ use crate::http_client::HttpSettings;
 #[cfg(feature = "experimental-oidc")]
 use crate::oidc::OidcCtx;
 use crate::{
-    authentication::AuthCtx, config::RequestConfig, error::RumaApiError, event_cache::EventCache,
-    http_client::HttpClient, HttpError, IdParseError,
+    authentication::AuthCtx, config::RequestConfig, error::RumaApiError, http_client::HttpClient,
+    HttpError, IdParseError,
 };
 
 /// Builder that allows creating and configuring various parts of a [`Client`].
@@ -499,6 +499,7 @@ impl ClientBuilder {
             oidc: OidcCtx::new(authentication_server_info, allow_insecure_oidc),
         });
 
+        let event_cache = OnceCell::new();
         let inner = ClientInner::new(
             auth_ctx,
             homeserver,
@@ -508,10 +509,11 @@ impl ClientBuilder {
             base_client,
             self.server_versions,
             self.respect_login_well_known,
-            EventCache::new(),
+            event_cache,
             #[cfg(feature = "e2e-encryption")]
             self.encryption_settings,
-        );
+        )
+        .await;
 
         debug!("Done building the Client");
 


### PR DESCRIPTION
Turns out I've been a bit too eager about removing the `Room` in the event cache; it is needed for the back-pagination, to call `Room::messages()`. This is basically reverting https://github.com/matrix-org/matrix-rust-sdk/pull/3136/commits/f022b405caf3b45d5228032c8156f9136246c59b and putting back the infrastructure for the deferred initialization in the `Client`.