### PR TITLE
test: rationalize `logged_in_clients` methods

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1479,7 +1479,7 @@ mod tests {
         let user_id = user_id!("@alice:example.org");
         let room_id = room_id!("!test:example.org");
 
-        let client = logged_in_client(user_id).await;
+        let client = logged_in_base_client(user_id).await;
 
         let mut ev_builder = SyncResponseBuilder::new();
 
@@ -1523,7 +1523,7 @@ mod tests {
         let user_id = user_id!("@alice:example.org");
         let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
 
-        let client = logged_in_client(user_id).await;
+        let client = logged_in_base_client(user_id).await;
 
         let response = api::sync::sync_events::v3::Response::try_from_http_response(response_from_file(&json!({
             "next_batch": "asdkl;fjasdkl;fj;asdkl;f",
@@ -1608,11 +1608,11 @@ mod tests {
 
     #[cfg(all(feature = "e2e-encryption", feature = "experimental-sliding-sync"))]
     #[async_test]
-    async fn when_there_are_no_latest_encrypted_events_decrypting_them_does_nothing() {
+    async fn test_when_there_are_no_latest_encrypted_events_decrypting_them_does_nothing() {
         // Given a room
         let user_id = user_id!("@u:u.to");
         let room_id = room_id!("!r:u.to");
-        let client = logged_in_client(user_id).await;
+        let client = logged_in_base_client(user_id).await;
         let room = process_room_join_test_helper(&client, room_id, "$1", user_id).await;
 
         // Sanity: it has no latest_encrypted_events or latest_event
@@ -1634,7 +1634,7 @@ mod tests {
     // events. In the meantime, there are tests for the most difficult logic
     // inside Room.  --andyb
 
-    async fn logged_in_client(user_id: &UserId) -> BaseClient {
+    async fn logged_in_base_client(user_id: &UserId) -> BaseClient {
         let client = BaseClient::new();
         client
             .set_session_meta(SessionMeta {

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1472,14 +1472,17 @@ mod tests {
     use serde_json::json;
 
     use super::BaseClient;
-    use crate::{store::StateStoreExt, DisplayName, RoomState, SessionMeta};
+    use crate::{
+        store::StateStoreExt, test_utils::logged_in_base_client, DisplayName, RoomState,
+        SessionMeta,
+    };
 
     #[async_test]
     async fn test_invite_after_leaving() {
         let user_id = user_id!("@alice:example.org");
         let room_id = room_id!("!test:example.org");
 
-        let client = logged_in_base_client(user_id).await;
+        let client = logged_in_base_client(Some(user_id)).await;
 
         let mut ev_builder = SyncResponseBuilder::new();
 
@@ -1523,7 +1526,7 @@ mod tests {
         let user_id = user_id!("@alice:example.org");
         let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
 
-        let client = logged_in_base_client(user_id).await;
+        let client = logged_in_base_client(Some(user_id)).await;
 
         let response = api::sync::sync_events::v3::Response::try_from_http_response(response_from_file(&json!({
             "next_batch": "asdkl;fjasdkl;fj;asdkl;f",
@@ -1612,7 +1615,7 @@ mod tests {
         // Given a room
         let user_id = user_id!("@u:u.to");
         let room_id = room_id!("!r:u.to");
-        let client = logged_in_base_client(user_id).await;
+        let client = logged_in_base_client(Some(user_id)).await;
         let room = process_room_join_test_helper(&client, room_id, "$1", user_id).await;
 
         // Sanity: it has no latest_encrypted_events or latest_event
@@ -1633,18 +1636,6 @@ mod tests {
     // lost trying to set up my OlmMachine to be able to encrypt and decrypt
     // events. In the meantime, there are tests for the most difficult logic
     // inside Room.  --andyb
-
-    async fn logged_in_base_client(user_id: &UserId) -> BaseClient {
-        let client = BaseClient::new();
-        client
-            .set_session_meta(SessionMeta {
-                user_id: user_id.to_owned(),
-                device_id: "FOOBAR".into(),
-            })
-            .await
-            .expect("set_session_meta failed!");
-        client
-    }
 
     #[cfg(feature = "e2e-encryption")]
     async fn process_room_join_test_helper(

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -38,6 +38,8 @@ mod sliding_sync;
 
 pub mod store;
 pub mod sync;
+#[cfg(any(test, feature = "testing"))]
+mod test_utils;
 mod utils;
 
 #[cfg(feature = "uniffi")]

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -728,7 +728,7 @@ mod tests {
     use matrix_sdk_test::async_test;
     use ruma::{
         api::client::sync::sync_events::{v4, UnreadNotificationsCount},
-        assign, device_id, event_id,
+        assign, event_id,
         events::{
             direct::DirectEventContent,
             room::{
@@ -747,11 +747,13 @@ mod tests {
     use serde_json::json;
 
     use super::cache_latest_events;
-    use crate::{store::MemoryStore, BaseClient, Room, RoomState, SessionMeta};
+    use crate::{
+        store::MemoryStore, test_utils::logged_in_base_client, BaseClient, Room, RoomState,
+    };
 
     #[async_test]
     async fn test_notification_count_set() {
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
 
         let mut response = v4::Response::new("42".to_owned());
         let room_id = room_id!("!room:example.org");
@@ -781,7 +783,7 @@ mod tests {
 
     #[async_test]
     async fn can_process_empty_sliding_sync_response() {
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let empty_response = v4::Response::new("5".to_owned());
         client.process_sliding_sync(&empty_response, &()).await.expect("Failed to process sync");
     }
@@ -789,7 +791,7 @@ mod tests {
     #[async_test]
     async fn room_with_unspecified_state_is_added_to_client_and_joined_list() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
 
         // When I send sliding sync response containing a room (with identifiable data
@@ -815,7 +817,7 @@ mod tests {
     #[async_test]
     async fn room_name_is_found_when_processing_sliding_sync_response() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
 
         // When I send sliding sync response containing a room with a name
@@ -839,7 +841,7 @@ mod tests {
     #[async_test]
     async fn invited_room_name_is_found_when_processing_sliding_sync_response() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@w:e.uk");
 
@@ -865,7 +867,7 @@ mod tests {
     #[async_test]
     async fn left_a_room_from_required_state_event() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
 
@@ -895,7 +897,7 @@ mod tests {
     #[async_test]
     async fn left_a_room_from_timeline_state_event() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
 
@@ -921,7 +923,7 @@ mod tests {
         // See https://github.com/matrix-org/matrix-rust-sdk/issues/1834
 
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
 
@@ -958,7 +960,7 @@ mod tests {
         let user_b_id = user_id!("@b:e.uk");
 
         // Given we have a DM with B, who is joined
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         create_dm(&client, room_id, user_a_id, user_b_id, MembershipState::Join).await;
 
         // (Sanity: B is a direct target, and is in Join state)
@@ -983,7 +985,7 @@ mod tests {
         let user_b_id = user_id!("@b:e.uk");
 
         // Given I have invited B to a DM
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         create_dm(&client, room_id, user_a_id, user_b_id, MembershipState::Invite).await;
 
         // (Sanity: B is a direct target, and is in Invite state)
@@ -1007,7 +1009,7 @@ mod tests {
         let user_b_id = user_id!("@b:bar.org");
 
         // Given we have a DM with B, who is joined
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         create_dm(&client, room_id, user_a_id, user_b_id, MembershipState::Join).await;
 
         // (Sanity: A is in Join state)
@@ -1031,7 +1033,7 @@ mod tests {
         let user_b_id = user_id!("@b:bar.org");
 
         // Given we have a DM with B, who is joined
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         create_dm(&client, room_id, user_a_id, user_b_id, MembershipState::Invite).await;
 
         // (Sanity: A is in Join state)
@@ -1051,7 +1053,7 @@ mod tests {
     #[async_test]
     async fn avatar_is_found_when_processing_sliding_sync_response() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
 
         // When I send sliding sync response containing a room with an avatar
@@ -1075,7 +1077,7 @@ mod tests {
     #[async_test]
     async fn avatar_can_be_unset_when_processing_sliding_sync_response() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
 
         // Set the avatar.
@@ -1131,7 +1133,7 @@ mod tests {
     #[async_test]
     async fn avatar_is_found_from_required_state_when_processing_sliding_sync_response() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
 
@@ -1151,7 +1153,7 @@ mod tests {
     #[async_test]
     async fn invitation_room_is_added_to_client_and_invite_list() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
 
@@ -1175,7 +1177,7 @@ mod tests {
     #[async_test]
     async fn avatar_is_found_in_invitation_room_when_processing_sliding_sync_response() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
 
@@ -1196,7 +1198,7 @@ mod tests {
     #[async_test]
     async fn canonical_alias_is_found_in_invitation_room_when_processing_sliding_sync_response() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
         let room_alias_id = room_alias_id!("#myroom:e.uk");
@@ -1215,7 +1217,7 @@ mod tests {
     #[async_test]
     async fn display_name_from_sliding_sync_overrides_alias() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let user_id = user_id!("@u:e.uk");
         let room_alias_id = room_alias_id!("#myroom:e.uk");
@@ -1238,7 +1240,7 @@ mod tests {
     #[async_test]
     async fn last_event_from_sliding_sync_is_cached() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let event_a = json!({
             "sender":"@alice:example.com",
@@ -1272,7 +1274,7 @@ mod tests {
     #[async_test]
     async fn cached_latest_event_can_be_redacted() {
         // Given a logged-in client
-        let client = logged_in_client().await;
+        let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
         let event_a = json!({
             "sender": "@alice:example.com",
@@ -1724,18 +1726,6 @@ mod tests {
             .account_data
             .global
             .push(make_global_account_data_event(DirectEventContent(direct_content)));
-    }
-
-    async fn logged_in_client() -> BaseClient {
-        let client = BaseClient::new();
-        client
-            .set_session_meta(SessionMeta {
-                user_id: user_id!("@u:e.uk").to_owned(),
-                device_id: device_id!("XYZ").to_owned(),
-            })
-            .await
-            .expect("Failed to set session meta");
-        client
     }
 
     async fn response_with_room(room_id: &RoomId, room: v4::SlidingSyncRoom) -> v4::Response {

--- a/crates/matrix-sdk-base/src/test_utils.rs
+++ b/crates/matrix-sdk-base/src/test_utils.rs
@@ -1,0 +1,34 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Testing utilities - DO NOT USE IN PRODUCTION.
+
+#![allow(dead_code)]
+
+use ruma::{owned_user_id, UserId};
+
+use crate::{BaseClient, SessionMeta};
+
+/// Create a [`BaseClient`] with the given user id, if provided, or an hardcoded
+/// one otherwise.
+pub(crate) async fn logged_in_base_client(user_id: Option<&UserId>) -> BaseClient {
+    let client = BaseClient::new();
+    let user_id =
+        user_id.map(|user_id| user_id.to_owned()).unwrap_or_else(|| owned_user_id!("@u:e.uk"));
+    client
+        .set_session_meta(SessionMeta { user_id: user_id.to_owned(), device_id: "FOOBAR".into() })
+        .await
+        .expect("set_session_meta failed!");
+    client
+}

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -507,15 +507,14 @@ pub enum EventItemOrigin {
 mod tests {
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
-    use matrix_sdk::{config::RequestConfig, test_utils::test_client_builder, Client};
+    use matrix_sdk::test_utils::logged_in_client;
     use matrix_sdk_base::{
-        deserialized_responses::SyncTimelineEvent, latest_event::LatestEvent, BaseClient,
-        MinimalStateEvent, OriginalMinimalStateEvent, SessionMeta,
+        deserialized_responses::SyncTimelineEvent, latest_event::LatestEvent, MinimalStateEvent,
+        OriginalMinimalStateEvent,
     };
     use matrix_sdk_test::{async_test, sync_timeline_event};
     use ruma::{
         api::client::sync::sync_events::v4,
-        device_id,
         events::{
             room::{
                 member::RoomMemberEventContent,
@@ -696,24 +695,5 @@ mod tests {
             },
         })
         .into()
-    }
-
-    /// Copied from matrix_sdk_base::sliding_sync::test
-    async fn logged_in_client(homeserver_url: Option<String>) -> Client {
-        let base_client = BaseClient::new();
-        base_client
-            .set_session_meta(SessionMeta {
-                user_id: user_id!("@u:e.uk").to_owned(),
-                device_id: device_id!("XYZ").to_owned(),
-            })
-            .await
-            .expect("Failed to set session meta");
-
-        test_client_builder(homeserver_url)
-            .request_config(RequestConfig::new().disable_retry())
-            .base_client(base_client)
-            .build()
-            .await
-            .unwrap()
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -507,14 +507,14 @@ pub enum EventItemOrigin {
 mod tests {
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;
-    use matrix_sdk::{config::RequestConfig, Client, ClientBuilder};
+    use matrix_sdk::{config::RequestConfig, test_utils::test_client_builder, Client};
     use matrix_sdk_base::{
         deserialized_responses::SyncTimelineEvent, latest_event::LatestEvent, BaseClient,
         MinimalStateEvent, OriginalMinimalStateEvent, SessionMeta,
     };
     use matrix_sdk_test::{async_test, sync_timeline_event};
     use ruma::{
-        api::{client::sync::sync_events::v4, MatrixVersion},
+        api::client::sync::sync_events::v4,
         device_id,
         events::{
             room::{
@@ -715,10 +715,5 @@ mod tests {
             .build()
             .await
             .unwrap()
-    }
-
-    fn test_client_builder(homeserver_url: Option<String>) -> ClientBuilder {
-        let homeserver = homeserver_url.as_deref().unwrap_or("http://localhost:1234");
-        Client::builder().homeserver_url(homeserver).server_versions([MatrixVersion::V1_0])
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
+++ b/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
@@ -44,11 +44,13 @@ impl SlidingSyncRoomExt for SlidingSyncRoom {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use matrix_sdk::{config::RequestConfig, Client, ClientBuilder, SlidingSyncRoom};
+    use matrix_sdk::{
+        config::RequestConfig, test_utils::test_client_builder, Client, SlidingSyncRoom,
+    };
     use matrix_sdk_base::{deserialized_responses::SyncTimelineEvent, BaseClient, SessionMeta};
     use matrix_sdk_test::async_test;
     use ruma::{
-        api::{client::sync::sync_events::v4, MatrixVersion},
+        api::client::sync::sync_events::v4,
         device_id,
         events::room::message::{MessageFormat, MessageType},
         room_id,
@@ -159,10 +161,5 @@ mod tests {
             .build()
             .await
             .unwrap()
-    }
-
-    fn test_client_builder(homeserver_url: Option<String>) -> ClientBuilder {
-        let homeserver = homeserver_url.as_deref().unwrap_or("http://localhost:1234");
-        Client::builder().homeserver_url(homeserver).server_versions([MatrixVersion::V1_0])
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
+++ b/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
@@ -44,14 +44,11 @@ impl SlidingSyncRoomExt for SlidingSyncRoom {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use matrix_sdk::{
-        config::RequestConfig, test_utils::test_client_builder, Client, SlidingSyncRoom,
-    };
-    use matrix_sdk_base::{deserialized_responses::SyncTimelineEvent, BaseClient, SessionMeta};
+    use matrix_sdk::{test_utils::logged_in_client, Client, SlidingSyncRoom};
+    use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
     use matrix_sdk_test::async_test;
     use ruma::{
         api::client::sync::sync_events::v4,
-        device_id,
         events::room::message::{MessageFormat, MessageType},
         room_id,
         serde::Raw,
@@ -142,24 +139,5 @@ mod tests {
         let mut response = v4::Response::new("6".to_owned());
         response.rooms.insert(room_id.to_owned(), room);
         response
-    }
-
-    /// Copied from matrix_sdk_base::sliding_sync::test
-    async fn logged_in_client(homeserver_url: Option<String>) -> Client {
-        let base_client = BaseClient::new();
-        base_client
-            .set_session_meta(SessionMeta {
-                user_id: user_id!("@u:e.uk").to_owned(),
-                device_id: device_id!("XYZ").to_owned(),
-            })
-            .await
-            .expect("Failed to set session meta");
-
-        test_client_builder(homeserver_url)
-            .request_config(RequestConfig::new().disable_retry())
-            .base_client(base_client)
-            .build()
-            .await
-            .unwrap()
     }
 }

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -10,14 +10,14 @@ use tokio::sync::Mutex as AsyncMutex;
 use wiremock::{Mock, MockGuard, MockServer, Request, ResponseTemplate};
 
 use crate::{
-    logged_in_client,
+    logged_in_client_with_server,
     sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
     sliding_sync_then_assert_request_and_fake_response,
 };
 
 #[async_test]
 async fn test_smoke_encryption_sync_works() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
     let sync_permit_guard = sync_permit.clone().lock_owned().await;
@@ -161,7 +161,7 @@ async fn setup_mocking_sliding_sync_server(server: &MockServer) -> MockGuard {
 
 #[async_test]
 async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let _guard = setup_mocking_sliding_sync_server(&server).await;
 
@@ -193,7 +193,7 @@ async fn test_encryption_sync_one_fixed_iteration() -> anyhow::Result<()> {
 
 #[async_test]
 async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let _guard = setup_mocking_sliding_sync_server(&server).await;
 
@@ -230,7 +230,7 @@ async fn test_encryption_sync_two_fixed_iterations() -> anyhow::Result<()> {
 
 #[async_test]
 async fn test_encryption_sync_always_reloads_todevice_token() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let sync_permit = Arc::new(AsyncMutex::new(EncryptionSyncPermit::new_for_testing()));
     let sync_permit_guard = sync_permit.lock_owned().await;

--- a/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/encryption_sync_service.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use futures_util::{pin_mut, StreamExt as _};
+use matrix_sdk::test_utils::logged_in_client_with_server;
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::encryption_sync_service::{
     EncryptionSyncPermit, EncryptionSyncService, WithLocking,
@@ -10,7 +11,6 @@ use tokio::sync::Mutex as AsyncMutex;
 use wiremock::{Mock, MockGuard, MockServer, Request, ResponseTemplate};
 
 use crate::{
-    logged_in_client_with_server,
     sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
     sliding_sync_then_assert_request_and_fake_response,
 };

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk::{
-    config::RequestConfig,
-    matrix_auth::{MatrixSession, MatrixSessionTokens},
-    Client, ClientBuilder,
-};
-use matrix_sdk_base::SessionMeta;
+use matrix_sdk::{test_utils, Client};
 use matrix_sdk_test::test_json;
-use ruma::{api::MatrixVersion, device_id, user_id};
 use serde::Serialize;
 use wiremock::{
     matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
@@ -35,31 +29,9 @@ mod timeline;
 
 matrix_sdk_test::init_tracing_for_tests!();
 
-async fn test_client_builder() -> (ClientBuilder, MockServer) {
-    let server = MockServer::start().await;
-    let builder =
-        Client::builder().homeserver_url(server.uri()).server_versions([MatrixVersion::V1_0]);
-    (builder, server)
-}
-
-async fn no_retry_test_client() -> (Client, MockServer) {
-    let (builder, server) = test_client_builder().await;
-    let client =
-        builder.request_config(RequestConfig::new().disable_retry()).build().await.unwrap();
-    (client, server)
-}
-
 async fn logged_in_client() -> (Client, MockServer) {
-    let session = MatrixSession {
-        meta: SessionMeta {
-            user_id: user_id!("@example:localhost").to_owned(),
-            device_id: device_id!("DEVICEID").to_owned(),
-        },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
-    let (client, server) = no_retry_test_client().await;
-    client.restore_session(session).await.unwrap();
-
+    let server = MockServer::start().await;
+    let client = test_utils::logged_in_client(Some(server.uri().to_string())).await;
     (client, server)
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -29,7 +29,7 @@ mod timeline;
 
 matrix_sdk_test::init_tracing_for_tests!();
 
-async fn logged_in_client() -> (Client, MockServer) {
+async fn logged_in_client_with_server() -> (Client, MockServer) {
     let server = MockServer::start().await;
     let client = test_utils::logged_in_client(Some(server.uri().to_string())).await;
     (client, server)

--- a/crates/matrix-sdk-ui/tests/integration/main.rs
+++ b/crates/matrix-sdk-ui/tests/integration/main.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk::{test_utils, Client};
 use matrix_sdk_test::test_json;
 use serde::Serialize;
 use wiremock::{
@@ -28,12 +27,6 @@ mod sync_service;
 mod timeline;
 
 matrix_sdk_test::init_tracing_for_tests!();
-
-async fn logged_in_client_with_server() -> (Client, MockServer) {
-    let server = MockServer::start().await;
-    let client = test_utils::logged_in_client(Some(server.uri().to_string())).await;
-    (client, server)
-}
 
 /// Mount a Mock on the given server to handle the `GET /sync` endpoint with
 /// an optional `since` param that returns a 200 status code with the given

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use assert_matches::assert_matches;
-use matrix_sdk::config::SyncSettings;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{async_test, sync_timeline_event, JoinedRoomBuilder, SyncResponseBuilder};
 use matrix_sdk_ui::{
     notification_client::{
@@ -20,7 +20,7 @@ use wiremock::{
 };
 
 use crate::{
-    logged_in_client_with_server, mock_encryption_state, mock_sync,
+    mock_encryption_state, mock_sync,
     sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
 };
 

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -20,14 +20,14 @@ use wiremock::{
 };
 
 use crate::{
-    logged_in_client, mock_encryption_state, mock_sync,
+    logged_in_client_with_server, mock_encryption_state, mock_sync,
     sliding_sync::{check_requests, PartialSlidingSyncRequest, SlidingSyncMatcher},
 };
 
 #[async_test]
 async fn test_notification_client_with_context() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -113,7 +113,7 @@ async fn test_notification_client_with_context() {
 #[async_test]
 async fn test_notification_client_sliding_sync() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let event_id = event_id!("$example_event_id");
     let sender = user_id!("@user:example.org");

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -32,12 +32,12 @@ use tokio::{spawn, sync::mpsc::channel, task::yield_now};
 use wiremock::MockServer;
 
 use crate::{
-    logged_in_client,
+    logged_in_client_with_server,
     timeline::sliding_sync::{assert_timeline_stream, timeline_event},
 };
 
 async fn new_room_list_service() -> Result<(Client, MockServer, RoomListService), Error> {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let room_list = RoomListService::new(client.clone()).await?;
 
     Ok((client, server, room_list))

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -7,7 +7,7 @@ use assert_matches::assert_matches;
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, FutureExt, StreamExt};
 use imbl::vector;
-use matrix_sdk::Client;
+use matrix_sdk::{test_utils::logged_in_client_with_server, Client};
 use matrix_sdk_base::sync::UnreadNotificationsCount;
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::{
@@ -31,10 +31,7 @@ use stream_assert::{assert_next_matches, assert_pending};
 use tokio::{spawn, sync::mpsc::channel, task::yield_now};
 use wiremock::MockServer;
 
-use crate::{
-    logged_in_client_with_server,
-    timeline::sliding_sync::{assert_timeline_stream, timeline_event},
-};
+use crate::timeline::sliding_sync::{assert_timeline_stream, timeline_event};
 
 async fn new_room_list_service() -> Result<(Client, MockServer, RoomListService), Error> {
     let (client, server) = logged_in_client_with_server().await;

--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -17,16 +17,14 @@ use std::{
     time::Duration,
 };
 
+use matrix_sdk::test_utils::logged_in_client_with_server;
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::sync_service::{State, SyncService};
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 use wiremock::{Match as _, Mock, MockGuard, MockServer, Request, ResponseTemplate};
 
-use crate::{
-    logged_in_client_with_server,
-    sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher},
-};
+use crate::sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher};
 
 /// Sets up a sliding sync server that use different `pos` values for the
 /// encrptyion and the room sync.

--- a/crates/matrix-sdk-ui/tests/integration/sync_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sync_service.rs
@@ -24,7 +24,7 @@ use stream_assert::{assert_next_matches, assert_pending};
 use wiremock::{Match as _, Mock, MockGuard, MockServer, Request, ResponseTemplate};
 
 use crate::{
-    logged_in_client,
+    logged_in_client_with_server,
     sliding_sync::{PartialSlidingSyncRequest, SlidingSyncMatcher},
 };
 
@@ -61,7 +61,7 @@ async fn setup_mocking_sliding_sync_server(
 
 #[async_test]
 async fn test_sync_service_state() -> anyhow::Result<()> {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let encryption_pos = Arc::new(Mutex::new(0));
     let room_pos = Arc::new(Mutex::new(0));

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -35,12 +35,12 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_encryption_state, mock_sync};
+use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_echo() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -130,7 +130,7 @@ async fn test_echo() {
 #[async_test]
 async fn test_retry_failed() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -186,7 +186,7 @@ async fn test_retry_failed() {
 #[async_test]
 async fn test_dedup_by_event_id_late() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -255,7 +255,7 @@ async fn test_dedup_by_event_id_late() {
 #[async_test]
 async fn test_cancel_failed() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -18,7 +18,10 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::{config::SyncSettings, executor::spawn, ruma::MilliSecondsSinceUnixEpoch};
+use matrix_sdk::{
+    config::SyncSettings, executor::spawn, ruma::MilliSecondsSinceUnixEpoch,
+    test_utils::logged_in_client_with_server,
+};
 use matrix_sdk_test::{async_test, sync_timeline_event, JoinedRoomBuilder, SyncResponseBuilder};
 use matrix_sdk_ui::timeline::{
     EventSendState, RoomExt, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
@@ -35,7 +38,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
+use crate::{mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_echo() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -18,7 +18,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::config::SyncSettings;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
     async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
 };
@@ -46,7 +46,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
+use crate::{mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_edit() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -46,12 +46,12 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_encryption_state, mock_sync};
+use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_edit() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -156,7 +156,7 @@ async fn test_edit() {
 #[async_test]
 async fn test_send_edit() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -227,7 +227,7 @@ async fn test_send_edit() {
 #[async_test]
 async fn test_send_reply_edit() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -314,7 +314,7 @@ async fn test_send_reply_edit() {
 #[async_test]
 async fn test_send_edit_poll() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -26,7 +26,7 @@ use matrix_sdk_test::{
 use matrix_sdk_ui::timeline::{RoomExt, TimelineItemContent, VirtualTimelineItem};
 use ruma::{room_id, user_id};
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 mod echo;
 mod edit;
@@ -42,7 +42,7 @@ pub(crate) mod sliding_sync;
 #[async_test]
 async fn test_reaction() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -151,7 +151,7 @@ async fn test_reaction() {
 #[async_test]
 async fn test_redacted_message() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -209,7 +209,7 @@ async fn test_redacted_message() {
 #[async_test]
 async fn test_read_marker() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -284,7 +284,7 @@ async fn test_read_marker() {
 #[async_test]
 async fn test_sync_highlighted() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -18,7 +18,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::config::SyncSettings;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
     async_test, sync_timeline_event, JoinedRoomBuilder, RoomAccountDataTestEvent, StateTestEvent,
     SyncResponseBuilder,
@@ -26,7 +26,7 @@ use matrix_sdk_test::{
 use matrix_sdk_ui::timeline::{RoomExt, TimelineItemContent, VirtualTimelineItem};
 use ruma::{room_id, user_id};
 
-use crate::{logged_in_client_with_server, mock_sync};
+use crate::mock_sync;
 
 mod echo;
 mod edit;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -42,12 +42,12 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
 async fn test_back_pagination() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -138,7 +138,7 @@ async fn test_back_pagination() {
 #[async_test]
 async fn test_back_pagination_highlighted() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -225,7 +225,7 @@ async fn test_back_pagination_highlighted() {
 #[async_test]
 async fn test_wait_for_token() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let event_builder = EventBuilder::new();
@@ -286,7 +286,7 @@ async fn test_wait_for_token() {
 #[async_test]
 async fn test_dedup() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let event_builder = EventBuilder::new();
@@ -342,7 +342,7 @@ async fn test_dedup() {
 #[async_test]
 async fn test_timeline_reset_while_paginating() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let event_builder = EventBuilder::new();
@@ -519,7 +519,7 @@ pub static ROOM_MESSAGES_BATCH_2: Lazy<JsonValue> = Lazy::new(|| {
 #[async_test]
 async fn test_empty_chunk() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -609,7 +609,7 @@ async fn test_empty_chunk() {
 #[async_test]
 async fn test_until_num_items_with_empty_chunk() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -18,7 +18,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::future::{join, join3};
-use matrix_sdk::config::SyncSettings;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
     async_test, EventBuilder, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder, ALICE, BOB,
 };
@@ -42,7 +42,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_back_pagination() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -31,11 +31,11 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
 async fn test_update_sender_profiles() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let event_builder = EventBuilder::new();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/profiles.rs
@@ -15,7 +15,7 @@
 use std::{sync::Arc, time::Duration};
 
 use assert_matches::assert_matches;
-use matrix_sdk::config::SyncSettings;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
     async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB, CAROL,
     DEFAULT_TEST_ROOM_ID,
@@ -31,7 +31,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_update_sender_profiles() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -30,12 +30,12 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_encryption_state, mock_sync};
+use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_message_order() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -107,7 +107,7 @@ async fn test_message_order() {
 #[async_test]
 async fn test_retry_order() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -213,7 +213,7 @@ async fn test_retry_order() {
 #[async_test]
 async fn test_clear_with_echoes() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let event_builder = EventBuilder::new();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -18,7 +18,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::config::SyncSettings;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE};
 use matrix_sdk_ui::timeline::{EventItemOrigin, EventSendState, RoomExt};
 use ruma::{events::room::message::RoomMessageEventContent, room_id};
@@ -30,7 +30,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
+use crate::{mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn test_message_order() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -18,7 +18,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::{config::SyncSettings, room::Receipts};
+use matrix_sdk::{config::SyncSettings, room::Receipts, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
     async_test, sync_timeline_event, EphemeralTestEvent, JoinedRoomBuilder,
     RoomAccountDataTestEvent, SyncResponseBuilder, ALICE, BOB,
@@ -40,7 +40,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_sync};
+use crate::mock_sync;
 
 fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
     match ev {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -40,7 +40,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bool {
     match ev {
@@ -54,7 +54,7 @@ fn filter_notice(ev: &AnySyncTimelineEvent, _room_version: &RoomVersionId) -> bo
 #[async_test]
 async fn test_read_receipts_updates() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let own_user_id = client.user_id().unwrap();
@@ -283,7 +283,7 @@ async fn test_read_receipts_updates() {
 #[async_test]
 async fn test_read_receipts_updates_on_filtered_events() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let own_user_id = client.user_id().unwrap();
@@ -495,7 +495,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
 #[async_test]
 async fn test_send_single_receipt() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let own_user_id = client.user_id().unwrap();
@@ -842,7 +842,7 @@ async fn test_send_single_receipt() {
 #[async_test]
 async fn test_mark_as_read() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let own_user_id = client.user_id().unwrap();
@@ -945,7 +945,7 @@ async fn test_mark_as_read() {
 #[async_test]
 async fn test_send_multiple_receipts() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let own_user_id = client.user_id().unwrap();
@@ -1153,7 +1153,7 @@ async fn test_send_multiple_receipts() {
 #[async_test]
 async fn test_latest_user_read_receipt() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let own_user_id = client.user_id().unwrap();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -31,12 +31,12 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_encryption_state, mock_sync};
+use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn in_reply_to_details() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -173,7 +173,7 @@ async fn in_reply_to_details() {
 #[async_test]
 async fn transfer_in_reply_to_details_to_re_received_item() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -255,7 +255,7 @@ async fn transfer_in_reply_to_details_to_re_received_item() {
 #[async_test]
 async fn send_reply() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
@@ -346,7 +346,7 @@ async fn send_reply() {
 #[async_test]
 async fn send_reply_to_threaded() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -4,7 +4,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::StreamExt;
-use matrix_sdk::config::SyncSettings;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_base::timeout::timeout;
 use matrix_sdk_test::{
     async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB, CAROL,
@@ -31,7 +31,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
+use crate::{mock_encryption_state, mock_sync};
 
 #[async_test]
 async fn in_reply_to_details() {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -20,7 +20,8 @@ use assert_matches2::assert_let;
 use eyeball_im::{Vector, VectorDiff};
 use futures_util::{pin_mut, FutureExt, Stream, StreamExt};
 use matrix_sdk::{
-    SlidingSync, SlidingSyncList, SlidingSyncListBuilder, SlidingSyncMode, UpdateSummary,
+    test_utils::logged_in_client_with_server, SlidingSync, SlidingSyncList, SlidingSyncListBuilder,
+    SlidingSyncMode, UpdateSummary,
 };
 use matrix_sdk_test::async_test;
 use matrix_sdk_ui::{
@@ -30,8 +31,6 @@ use matrix_sdk_ui::{
 use ruma::{room_id, user_id, RoomId};
 use serde_json::json;
 use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
-
-use crate::logged_in_client_with_server;
 
 macro_rules! receive_response {
     (

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -31,7 +31,7 @@ use ruma::{room_id, user_id, RoomId};
 use serde_json::json;
 use wiremock::{http::Method, Match, Mock, MockServer, Request, ResponseTemplate};
 
-use crate::logged_in_client;
+use crate::logged_in_client_with_server;
 
 macro_rules! receive_response {
     (
@@ -201,7 +201,7 @@ macro_rules! assert_timeline_stream {
 pub(crate) use assert_timeline_stream;
 
 async fn new_sliding_sync(lists: Vec<SlidingSyncListBuilder>) -> Result<(MockServer, SlidingSync)> {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let mut sliding_sync_builder = client.sliding_sync("integration-test")?;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -35,12 +35,12 @@ use ruma::{
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
 async fn test_batched() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let event_builder = EventBuilder::new();
@@ -89,7 +89,7 @@ async fn test_batched() {
 #[async_test]
 async fn test_event_filter() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -195,7 +195,7 @@ async fn test_event_filter() {
 #[async_test]
 async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();
@@ -339,7 +339,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
 #[async_test]
 async fn test_profile_updates() {
     let room_id = room_id!("!a98sd12bjh:example.org");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -18,7 +18,7 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt};
-use matrix_sdk::config::SyncSettings;
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
     async_test, sync_timeline_event, EventBuilder, GlobalAccountDataTestEvent, JoinedRoomBuilder,
     SyncResponseBuilder, ALICE, BOB,
@@ -35,7 +35,7 @@ use ruma::{
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
 
-use crate::{logged_in_client_with_server, mock_sync};
+use crate::mock_sync;
 
 #[async_test]
 async fn test_batched() {

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["e2e-encryption", "automatic-room-key-forwarding", "sqlite", "native-tls"]
-testing = ["matrix-sdk-sqlite?/testing", "matrix-sdk-indexeddb?/testing", "matrix-sdk-base/testing"]
+testing = ["matrix-sdk-sqlite?/testing", "matrix-sdk-indexeddb?/testing", "matrix-sdk-base/testing", "wiremock"]
 
 e2e-encryption = [
     "matrix-sdk-base/e2e-encryption",
@@ -142,6 +142,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 reqwest = { version = "0.11.10", default_features = false, features = ["stream"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
 tokio-util = "0.7.9"
+wiremock = { version = "0.5.13", optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -162,7 +163,6 @@ wasm-bindgen-test = "0.3.33"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
-wiremock = "0.5.13"
 
 [[test]]
 name = "integration"

--- a/crates/matrix-sdk/src/test_utils.rs
+++ b/crates/matrix-sdk/src/test_utils.rs
@@ -51,3 +51,27 @@ pub async fn logged_in_client(homeserver_url: Option<String>) -> Client {
 
     client
 }
+
+/// Like [`test_client_builder`], but with a mocked server too.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn test_client_builder_with_server() -> (ClientBuilder, wiremock::MockServer) {
+    let server = wiremock::MockServer::start().await;
+    let builder = test_client_builder(Some(server.uri().to_string()));
+    (builder, server)
+}
+
+/// Like [`no_retry_test_client`], but with a mocked server too.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn no_retry_test_client_with_server() -> (Client, wiremock::MockServer) {
+    let server = wiremock::MockServer::start().await;
+    let client = no_retry_test_client(Some(server.uri().to_string())).await;
+    (client, server)
+}
+
+/// Like [`logged_in_client`], but with a mocked server too.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn logged_in_client_with_server() -> (Client, wiremock::MockServer) {
+    let server = wiremock::MockServer::start().await;
+    let client = logged_in_client(Some(server.uri().to_string())).await;
+    (client, server)
+}

--- a/crates/matrix-sdk/src/test_utils.rs
+++ b/crates/matrix-sdk/src/test_utils.rs
@@ -1,9 +1,10 @@
-//!  Testing utilities - DO NOT USE IN PRODUCTION.
+//! Testing utilities - DO NOT USE IN PRODUCTION.
 
 #![allow(dead_code)]
 
 use matrix_sdk_base::SessionMeta;
 use ruma::{api::MatrixVersion, device_id, user_id};
+use url::Url;
 
 use crate::{
     config::RequestConfig,
@@ -11,12 +12,18 @@ use crate::{
     Client, ClientBuilder,
 };
 
-pub(crate) fn test_client_builder(homeserver_url: Option<String>) -> ClientBuilder {
-    let homeserver = homeserver_url.as_deref().unwrap_or("http://localhost:1234");
+/// A [`ClientBuilder`] fit for testing, using the given `homeserver_url` (or
+/// localhost:1234).
+pub fn test_client_builder(homeserver_url: Option<String>) -> ClientBuilder {
+    let homeserver = homeserver_url
+        .map(|url| Url::try_from(url.as_str()).unwrap())
+        .unwrap_or_else(|| Url::try_from("http://localhost:1234").unwrap());
     Client::builder().homeserver_url(homeserver).server_versions([MatrixVersion::V1_0])
 }
 
-pub(crate) async fn no_retry_test_client(homeserver_url: Option<String>) -> Client {
+/// A [`Client`] using the given `homeserver_url` (or localhost:1234), that will
+/// never retry any failed requests.
+pub async fn no_retry_test_client(homeserver_url: Option<String>) -> Client {
     test_client_builder(homeserver_url)
         .request_config(RequestConfig::new().disable_retry())
         .build()
@@ -24,16 +31,23 @@ pub(crate) async fn no_retry_test_client(homeserver_url: Option<String>) -> Clie
         .unwrap()
 }
 
-pub(crate) async fn logged_in_client(homeserver_url: Option<String>) -> Client {
-    let session = MatrixSession {
-        meta: SessionMeta {
-            user_id: user_id!("@example:localhost").to_owned(),
-            device_id: device_id!("DEVICEID").to_owned(),
-        },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
+/// A [`Client`] using the given `homeserver_url` (or localhost:1234), that will
+/// never retry any failed requests, and already logged in with an hardcoded
+/// Matrix authentication session (the user id and device id are hardcoded too).
+pub async fn logged_in_client(homeserver_url: Option<String>) -> Client {
     let client = no_retry_test_client(homeserver_url).await;
-    client.matrix_auth().restore_session(session).await.unwrap();
+
+    client
+        .matrix_auth()
+        .restore_session(MatrixSession {
+            meta: SessionMeta {
+                user_id: user_id!("@example:localhost").to_owned(),
+                device_id: device_id!("DEVICEID").to_owned(),
+            },
+            tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+        })
+        .await
+        .unwrap();
 
     client
 }

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -45,7 +45,7 @@ use wiremock::{
     Mock, Request, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync, no_retry_test_client};
+use crate::{logged_in_client, mock_sync, no_retry_test_client_with_server};
 
 #[async_test]
 async fn sync() {
@@ -75,7 +75,7 @@ async fn devices() {
 
 #[async_test]
 async fn delete_devices() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/delete_devices"))
@@ -141,7 +141,7 @@ async fn delete_devices() {
 
 #[async_test]
 async fn resolve_room_alias() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("GET"))
         .and(path("/_matrix/client/r0/directory/room/%23alias:example.org"))
@@ -223,7 +223,7 @@ async fn join_room_by_id_or_alias() {
 
 #[async_test]
 async fn room_search_all() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("GET"))
         .and(path("/_matrix/client/r0/publicRooms"))

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -45,11 +45,11 @@ use wiremock::{
     Mock, Request, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync, no_retry_test_client_with_server};
+use crate::{logged_in_client_with_server, mock_sync, no_retry_test_client_with_server};
 
 #[async_test]
 async fn sync() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
 
@@ -62,7 +62,7 @@ async fn sync() {
 
 #[async_test]
 async fn devices() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("GET"))
         .and(path("/_matrix/client/r0/devices"))
@@ -155,7 +155,7 @@ async fn resolve_room_alias() {
 
 #[async_test]
 async fn join_leave_room() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
 
@@ -178,7 +178,7 @@ async fn join_leave_room() {
 
 #[async_test]
 async fn join_room_by_id() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/join"))
@@ -197,7 +197,7 @@ async fn join_room_by_id() {
 
 #[async_test]
 async fn join_room_by_id_or_alias() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/join/"))
@@ -238,7 +238,7 @@ async fn room_search_all() {
 
 #[async_test]
 async fn room_search_filtered() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/publicRooms"))
@@ -258,7 +258,7 @@ async fn room_search_filtered() {
 
 #[async_test]
 async fn invited_rooms() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::INVITE_SYNC, None).await;
 
@@ -274,7 +274,7 @@ async fn invited_rooms() {
 
 #[async_test]
 async fn left_rooms() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::LEAVE_SYNC, None).await;
 
@@ -290,7 +290,7 @@ async fn left_rooms() {
 
 #[async_test]
 async fn get_media_content() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let media = client.media();
 
@@ -358,7 +358,7 @@ async fn get_media_content() {
 
 #[async_test]
 async fn get_media_file() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let event_content = ImageMessageEventContent::plain(
         "filename.jpg".into(),
@@ -403,7 +403,7 @@ async fn get_media_file() {
 
 #[async_test]
 async fn whoami() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("GET"))
         .and(path("/_matrix/client/r0/account/whoami"))
@@ -419,7 +419,7 @@ async fn whoami() {
 
 #[async_test]
 async fn test_room_update_channel() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let mut rx = client.subscribe_to_room_updates(&DEFAULT_TEST_ROOM_ID);
 
@@ -444,7 +444,7 @@ async fn test_room_update_channel() {
 
 #[async_test]
 async fn test_subscribe_all_room_updates() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let mut rx = client.subscribe_to_all_room_updates();
 
@@ -504,7 +504,7 @@ async fn test_subscribe_all_room_updates() {
 #[cfg(all(feature = "e2e-encryption", not(target_arch = "wasm32")))]
 #[async_test]
 async fn request_encryption_event_before_sending() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
     client
@@ -555,7 +555,7 @@ async fn request_encryption_event_before_sending() {
 // a DM.
 #[async_test]
 async fn marking_room_as_dm() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
     client
@@ -626,7 +626,7 @@ async fn marking_room_as_dm() {
 #[cfg(feature = "e2e-encryption")]
 #[async_test]
 async fn get_own_device() {
-    let (client, _) = logged_in_client().await;
+    let (client, _) = logged_in_client_with_server().await;
 
     let device = client
         .encryption()
@@ -649,7 +649,7 @@ async fn get_own_device() {
 #[cfg(feature = "e2e-encryption")]
 #[async_test]
 async fn cross_signing_status() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/unstable/keys/device_signing/upload"))
@@ -710,7 +710,7 @@ async fn test_encrypt_room_event() {
 
     use ruma::events::room::encrypted::RoomEncryptedEventContent;
 
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let user_id = client.user_id().unwrap();
 
     Mock::given(method("POST"))
@@ -844,7 +844,7 @@ async fn test_encrypt_room_event() {
 #[cfg(not(feature = "e2e-encryption"))]
 #[async_test]
 async fn create_dm_non_encrypted() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let user_id = user_id!("@invitee:localhost");
 
     Mock::given(method("POST"))
@@ -893,7 +893,7 @@ async fn create_dm_non_encrypted() {
 #[cfg(feature = "e2e-encryption")]
 #[async_test]
 async fn create_dm_encrypted() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let user_id = user_id!("@invitee:localhost");
 
     Mock::given(method("POST"))
@@ -955,7 +955,7 @@ async fn create_dm_encrypted() {
 
 #[async_test]
 async fn create_dm_error() {
-    let (client, _server) = logged_in_client().await;
+    let (client, _server) = logged_in_client_with_server().await;
     let user_id = user_id!("@invitee:localhost");
 
     // The endpoint is not mocked so we encounter a 404.
@@ -967,7 +967,7 @@ async fn create_dm_error() {
 
 #[async_test]
 async fn test_ambiguity_changes() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let example_id = user_id!("@example:localhost");
     let example_2_id = user_id!("@example2:localhost");

--- a/crates/matrix-sdk/tests/integration/client.rs
+++ b/crates/matrix-sdk/tests/integration/client.rs
@@ -6,6 +6,7 @@ use matrix_sdk::{
     config::SyncSettings,
     media::{MediaFormat, MediaRequest, MediaThumbnailSize},
     sync::RoomUpdate,
+    test_utils::no_retry_test_client_with_server,
 };
 use matrix_sdk_base::{sync::RoomUpdates, RoomState};
 use matrix_sdk_test::{
@@ -45,7 +46,7 @@ use wiremock::{
     Mock, Request, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_sync, no_retry_test_client_with_server};
+use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
 async fn sync() {

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -44,7 +44,7 @@ use wiremock::{
 
 use crate::{
     encryption::mock_secret_store_with_backup_key, mock_sync, no_retry_test_client,
-    test_client_builder,
+    test_client_builder_with_server,
 };
 
 const ROOM_KEY: &[u8] = b"\
@@ -329,7 +329,7 @@ async fn backup_resumption() {
 
     let user_id = user_id!("@example:morpheus.localhost");
 
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .sqlite_store(dir.path(), None)
@@ -875,7 +875,7 @@ async fn enable_from_secret_storage() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::OneShot,
         ..Default::default()
@@ -1042,7 +1042,7 @@ async fn enable_from_secret_storage_no_existing_backup() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::OneShot,
         ..Default::default()
@@ -1095,7 +1095,7 @@ async fn enable_from_secret_storage_mismatched_key() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::OneShot,
         ..Default::default()
@@ -1156,7 +1156,7 @@ async fn enable_from_secret_storage_manual_download() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client =
         builder.request_config(RequestConfig::new().disable_retry()).build().await.unwrap();
 
@@ -1198,7 +1198,7 @@ async fn enable_from_secret_storage_and_manual_download() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::Manual,
         ..Default::default()
@@ -1349,7 +1349,7 @@ async fn enable_from_secret_storage_and_download_after_utd() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let encryption_settings = EncryptionSettings {
         backup_download_strategy: BackupDownloadStrategy::AfterDecryptionFailure,
         ..Default::default()

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -43,7 +43,7 @@ use wiremock::{
 };
 
 use crate::{
-    encryption::mock_secret_store_with_backup_key, mock_sync, no_retry_test_client,
+    encryption::mock_secret_store_with_backup_key, mock_sync, no_retry_test_client_with_server,
     test_client_builder_with_server,
 };
 
@@ -85,7 +85,7 @@ async fn create() {
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
 
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     assert!(
         !client.encryption().backups().are_enabled().await,
@@ -160,7 +160,7 @@ async fn creation_failure() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
     mount_once(
@@ -241,7 +241,7 @@ async fn disabling() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
     mount_once(
@@ -423,7 +423,7 @@ async fn steady_state_waiting() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
     setup_backups(&client, &server).await;
@@ -607,7 +607,7 @@ async fn incremental_upload_of_keys() -> Result<()> {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
     let backups = client.encryption().backups();
@@ -788,7 +788,7 @@ async fn steady_state_waiting_errors() {
         meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
     let result = client.encryption().backups().wait_for_steady_state().await;

--- a/crates/matrix-sdk/tests/integration/encryption/backups.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/backups.rs
@@ -24,6 +24,7 @@ use matrix_sdk::{
         BackupDownloadStrategy, EncryptionSettings,
     },
     matrix_auth::{MatrixSession, MatrixSessionTokens},
+    test_utils::{no_retry_test_client_with_server, test_client_builder_with_server},
     Client,
 };
 use matrix_sdk_base::SessionMeta;
@@ -42,10 +43,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{
-    encryption::mock_secret_store_with_backup_key, mock_sync, no_retry_test_client_with_server,
-    test_client_builder_with_server,
-};
+use crate::{encryption::mock_secret_store_with_backup_key, mock_sync};
 
 const ROOM_KEY: &[u8] = b"\
         -----BEGIN MEGOLM SESSION DATA-----\n\

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -38,7 +38,7 @@ use wiremock::{
 
 use crate::{
     encryption::mock_secret_store_with_backup_key, logged_in_client, no_retry_test_client,
-    test_client_builder,
+    test_client_builder_with_server,
 };
 
 async fn test_client(user_id: &UserId) -> (Client, wiremock::MockServer) {
@@ -47,7 +47,7 @@ async fn test_client(user_id: &UserId) -> (Client, wiremock::MockServer) {
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
 
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .with_encryption_settings(matrix_sdk::encryption::EncryptionSettings {

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -37,7 +37,7 @@ use wiremock::{
 };
 
 use crate::{
-    encryption::mock_secret_store_with_backup_key, logged_in_client,
+    encryption::mock_secret_store_with_backup_key, logged_in_client_with_server,
     no_retry_test_client_with_server, test_client_builder_with_server,
 };
 
@@ -157,7 +157,7 @@ async fn mock_put_new_default_secret_storage_key(user_id: &UserId, server: &wire
 
 #[async_test]
 async fn recovery_status_server_unavailable() {
-    let (client, _) = logged_in_client().await;
+    let (client, _) = logged_in_client_with_server().await;
     client.encryption().wait_for_e2ee_initialization_tasks().await;
     assert_eq!(client.encryption().recovery().state(), RecoveryState::Unknown);
 }

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -37,8 +37,8 @@ use wiremock::{
 };
 
 use crate::{
-    encryption::mock_secret_store_with_backup_key, logged_in_client, no_retry_test_client,
-    test_client_builder_with_server,
+    encryption::mock_secret_store_with_backup_key, logged_in_client,
+    no_retry_test_client_with_server, test_client_builder_with_server,
 };
 
 async fn test_client(user_id: &UserId) -> (Client, wiremock::MockServer) {
@@ -172,7 +172,7 @@ async fn recovery_status_secret_storage_set_up() {
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
 
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
 
@@ -193,7 +193,7 @@ async fn recovery_status_secret_storage_not_set_up() {
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
 
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("GET"))
         .and(path(format!(
@@ -707,7 +707,7 @@ async fn recover_and_reset() {
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
 
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     mock_secret_store_with_backup_key(user_id, KEY_ID, &server).await;
 

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -23,6 +23,7 @@ use matrix_sdk::{
         BackupDownloadStrategy,
     },
     matrix_auth::{MatrixSession, MatrixSessionTokens},
+    test_utils::{no_retry_test_client_with_server, test_client_builder_with_server},
     Client,
 };
 use matrix_sdk_base::SessionMeta;
@@ -36,10 +37,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{
-    encryption::mock_secret_store_with_backup_key, logged_in_client_with_server,
-    no_retry_test_client_with_server, test_client_builder_with_server,
-};
+use crate::{encryption::mock_secret_store_with_backup_key, logged_in_client_with_server};
 
 async fn test_client(user_id: &UserId) -> (Client, wiremock::MockServer) {
     let session = MatrixSession {

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -23,7 +23,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use crate::{logged_in_client, no_retry_test_client_with_server};
+use crate::{logged_in_client_with_server, no_retry_test_client_with_server};
 
 const SECRET_STORE_KEY: &str = "EsTj 3yST y93F SLpB jJsz eAXc 2XzA ygD3 w69H fGaN TKBj jXEd";
 
@@ -65,7 +65,7 @@ async fn mock_secret_store_key(
 
 #[async_test]
 async fn secret_store_create_default_key() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let user_id = client.user_id().expect("We should know our user ID by now");
 
@@ -140,7 +140,7 @@ async fn secret_store_create_default_key() {
 
 #[async_test]
 async fn secret_store_missing_key_info() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let user_id = client.user_id().expect("We should know our user ID by now");
     let key_id = "bmur2d9ypPUH1msSwCxQOJkuKRmJI55e";
@@ -190,7 +190,7 @@ async fn secret_store_missing_key_info() {
 
 #[async_test]
 async fn secret_store_not_setup() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let user_id = client.user_id().expect("We should know our user ID by now");
 
@@ -221,7 +221,7 @@ async fn secret_store_not_setup() {
 
 #[async_test]
 async fn secret_store_opening() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_secret_store_key(
         &server,
@@ -269,7 +269,7 @@ async fn secret_store_opening() {
 
 #[async_test]
 async fn set_in_secret_store() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_secret_store_key(
         &server,

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -23,7 +23,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use crate::{logged_in_client, no_retry_test_client};
+use crate::{logged_in_client, no_retry_test_client_with_server};
 
 const SECRET_STORE_KEY: &str = "EsTj 3yST y93F SLpB jJsz eAXc 2XzA ygD3 w69H fGaN TKBj jXEd";
 
@@ -375,7 +375,7 @@ async fn restore_cross_signing_from_secret_store() {
         },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
     mock_secret_store_key(
@@ -576,7 +576,7 @@ async fn is_secret_storage_enabled() {
         },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
     {

--- a/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/secret_storage.rs
@@ -4,6 +4,7 @@ use assert_matches::assert_matches;
 use matrix_sdk::{
     encryption::secret_storage::SecretStorageError,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
+    test_utils::no_retry_test_client_with_server,
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::async_test;
@@ -23,7 +24,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, no_retry_test_client_with_server};
+use crate::logged_in_client_with_server;
 
 const SECRET_STORE_KEY: &str = "EsTj 3yST y93F SLpB jJsz eAXc 2XzA ygD3 w69H fGaN TKBj jXEd";
 

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -2,9 +2,9 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use matrix_sdk::{
-    config::{RequestConfig, SyncSettings},
+    config::SyncSettings,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
-    test_utils::test_client_builder,
+    test_utils::{no_retry_test_client, test_client_builder},
     Client, ClientBuilder,
 };
 use matrix_sdk_base::SessionMeta;
@@ -34,10 +34,9 @@ async fn test_client_builder_with_server() -> (ClientBuilder, MockServer) {
     (builder, server)
 }
 
-async fn no_retry_test_client() -> (Client, MockServer) {
-    let (builder, server) = test_client_builder_with_server().await;
-    let client =
-        builder.request_config(RequestConfig::new().disable_retry()).build().await.unwrap();
+async fn no_retry_test_client_with_server() -> (Client, MockServer) {
+    let server = MockServer::start().await;
+    let client = no_retry_test_client(Some(server.uri().to_string())).await;
     (client, server)
 }
 
@@ -49,7 +48,7 @@ async fn logged_in_client() -> (Client, MockServer) {
         },
         tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
     };
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     client.restore_session(session).await.unwrap();
 
     (client, server)

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -3,13 +3,10 @@
 
 use matrix_sdk::{
     config::SyncSettings,
-    matrix_auth::{MatrixSession, MatrixSessionTokens},
-    test_utils::{no_retry_test_client, test_client_builder},
+    test_utils::{self, no_retry_test_client, test_client_builder},
     Client, ClientBuilder,
 };
-use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::test_json;
-use ruma::{device_id, user_id};
 use serde::Serialize;
 use wiremock::{
     matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
@@ -41,16 +38,8 @@ async fn no_retry_test_client_with_server() -> (Client, MockServer) {
 }
 
 async fn logged_in_client() -> (Client, MockServer) {
-    let session = MatrixSession {
-        meta: SessionMeta {
-            user_id: user_id!("@example:localhost").to_owned(),
-            device_id: device_id!("DEVICEID").to_owned(),
-        },
-        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
-    };
-    let (client, server) = no_retry_test_client_with_server().await;
-    client.restore_session(session).await.unwrap();
-
+    let server = MockServer::start().await;
+    let client = test_utils::logged_in_client(Some(server.uri().to_string())).await;
     (client, server)
 }
 

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -4,11 +4,12 @@
 use matrix_sdk::{
     config::{RequestConfig, SyncSettings},
     matrix_auth::{MatrixSession, MatrixSessionTokens},
+    test_utils::test_client_builder,
     Client, ClientBuilder,
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::test_json;
-use ruma::{api::MatrixVersion, device_id, user_id};
+use ruma::{device_id, user_id};
 use serde::Serialize;
 use wiremock::{
     matchers::{header, method, path, path_regex, query_param, query_param_is_missing},
@@ -27,15 +28,14 @@ mod widget;
 
 matrix_sdk_test::init_tracing_for_tests!();
 
-async fn test_client_builder() -> (ClientBuilder, MockServer) {
+async fn test_client_builder_with_server() -> (ClientBuilder, MockServer) {
     let server = MockServer::start().await;
-    let builder =
-        Client::builder().homeserver_url(server.uri()).server_versions([MatrixVersion::V1_0]);
+    let builder = test_client_builder(Some(server.uri().to_string()));
     (builder, server)
 }
 
 async fn no_retry_test_client() -> (Client, MockServer) {
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client =
         builder.request_config(RequestConfig::new().disable_retry()).build().await.unwrap();
     (client, server)

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -1,11 +1,7 @@
 // The http mocking library is not supported for wasm32
 #![cfg(not(target_arch = "wasm32"))]
 
-use matrix_sdk::{
-    config::SyncSettings,
-    test_utils::{logged_in_client, no_retry_test_client, test_client_builder},
-    Client, ClientBuilder,
-};
+use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server, Client};
 use matrix_sdk_test::test_json;
 use serde::Serialize;
 use wiremock::{
@@ -24,24 +20,6 @@ mod room;
 mod widget;
 
 matrix_sdk_test::init_tracing_for_tests!();
-
-async fn test_client_builder_with_server() -> (ClientBuilder, MockServer) {
-    let server = MockServer::start().await;
-    let builder = test_client_builder(Some(server.uri().to_string()));
-    (builder, server)
-}
-
-async fn no_retry_test_client_with_server() -> (Client, MockServer) {
-    let server = MockServer::start().await;
-    let client = no_retry_test_client(Some(server.uri().to_string())).await;
-    (client, server)
-}
-
-async fn logged_in_client_with_server() -> (Client, MockServer) {
-    let server = MockServer::start().await;
-    let client = logged_in_client(Some(server.uri().to_string())).await;
-    (client, server)
-}
 
 async fn synced_client() -> (Client, MockServer) {
     let (client, server) = logged_in_client_with_server().await;

--- a/crates/matrix-sdk/tests/integration/main.rs
+++ b/crates/matrix-sdk/tests/integration/main.rs
@@ -3,7 +3,7 @@
 
 use matrix_sdk::{
     config::SyncSettings,
-    test_utils::{self, no_retry_test_client, test_client_builder},
+    test_utils::{logged_in_client, no_retry_test_client, test_client_builder},
     Client, ClientBuilder,
 };
 use matrix_sdk_test::test_json;
@@ -37,14 +37,14 @@ async fn no_retry_test_client_with_server() -> (Client, MockServer) {
     (client, server)
 }
 
-async fn logged_in_client() -> (Client, MockServer) {
+async fn logged_in_client_with_server() -> (Client, MockServer) {
     let server = MockServer::start().await;
-    let client = test_utils::logged_in_client(Some(server.uri().to_string())).await;
+    let client = logged_in_client(Some(server.uri().to_string())).await;
     (client, server)
 }
 
 async fn synced_client() -> (Client, MockServer) {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     mock_sync(&server, &*test_json::SYNC, None).await;
 
     let sync_settings = SyncSettings::new();

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -31,7 +31,7 @@ use wiremock::{
     Mock, MockServer, Request, ResponseTemplate,
 };
 
-use crate::{logged_in_client, no_retry_test_client, test_client_builder};
+use crate::{logged_in_client, no_retry_test_client, test_client_builder_with_server};
 
 #[async_test]
 async fn test_restore_session() {
@@ -595,7 +595,7 @@ async fn test_login_doesnt_fail_if_cross_signing_bootstrapping_failed() {
 async fn test_login_with_cross_signing_bootstrapping_already_bootstrapped() {
     // Even if we enabled cross-signing bootstrap for another device, it won't
     // restart the procedure.
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -31,11 +31,13 @@ use wiremock::{
     Mock, MockServer, Request, ResponseTemplate,
 };
 
-use crate::{logged_in_client, no_retry_test_client_with_server, test_client_builder_with_server};
+use crate::{
+    logged_in_client_with_server, no_retry_test_client_with_server, test_client_builder_with_server,
+};
 
 #[async_test]
 async fn test_restore_session() {
-    let (client, _) = logged_in_client().await;
+    let (client, _) = logged_in_client_with_server().await;
     let auth = client.matrix_auth();
 
     assert!(auth.logged_in(), "Client should be logged in with the MatrixAuth API");

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -31,7 +31,7 @@ use wiremock::{
     Mock, MockServer, Request, ResponseTemplate,
 };
 
-use crate::{logged_in_client, no_retry_test_client, test_client_builder_with_server};
+use crate::{logged_in_client, no_retry_test_client_with_server, test_client_builder_with_server};
 
 #[async_test]
 async fn test_restore_session() {
@@ -46,7 +46,7 @@ async fn test_restore_session() {
 
 #[async_test]
 async fn test_login() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
     let homeserver = Url::parse(&server.uri()).unwrap();
 
     Mock::given(method("GET"))
@@ -85,7 +85,7 @@ async fn test_login() {
 
 #[async_test]
 async fn test_login_with_discovery() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
@@ -103,7 +103,7 @@ async fn test_login_with_discovery() {
 
 #[async_test]
 async fn test_login_no_discovery() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
@@ -122,7 +122,7 @@ async fn test_login_no_discovery() {
 #[async_test]
 #[cfg(feature = "sso-login")]
 async fn test_login_with_sso() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
@@ -159,7 +159,7 @@ async fn test_login_with_sso() {
 
 #[async_test]
 async fn test_login_with_sso_token() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("GET"))
         .and(path("/_matrix/client/r0/login"))
@@ -194,7 +194,7 @@ async fn test_login_with_sso_token() {
 
 #[async_test]
 async fn test_login_error() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
@@ -225,7 +225,7 @@ async fn test_login_error() {
 
 #[async_test]
 async fn test_register_error() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/register"))

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -4,6 +4,7 @@ use assert_matches::assert_matches;
 use matrix_sdk::{
     config::RequestConfig,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
+    test_utils::{logged_in_client_with_server, no_retry_test_client_with_server},
     AuthApi, AuthSession, Client, RumaApiError,
 };
 use matrix_sdk_base::SessionMeta;
@@ -29,10 +30,6 @@ use url::Url;
 use wiremock::{
     matchers::{method, path},
     Mock, MockServer, Request, ResponseTemplate,
-};
-
-use crate::{
-    logged_in_client_with_server, no_retry_test_client_with_server, test_client_builder_with_server,
 };
 
 #[async_test]
@@ -597,7 +594,7 @@ async fn test_login_doesnt_fail_if_cross_signing_bootstrapping_failed() {
 async fn test_login_with_cross_signing_bootstrapping_already_bootstrapped() {
     // Even if we enabled cross-signing bootstrap for another device, it won't
     // restart the procedure.
-    let (builder, server) = test_client_builder_with_server().await;
+    let (builder, server) = matrix_sdk::test_utils::test_client_builder_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))

--- a/crates/matrix-sdk/tests/integration/notification.rs
+++ b/crates/matrix-sdk/tests/integration/notification.rs
@@ -15,11 +15,11 @@ use stream_assert::{assert_pending, assert_ready};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
 async fn notifications_joined() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let room_id = room_id!("!joined_room:localhost");
     let user_id = client.user_id().unwrap();
 
@@ -103,7 +103,7 @@ async fn notifications_joined() {
 
 #[async_test]
 async fn notifications_invite() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let room_id = room_id!("!invited_room:localhost");
     let user_id = client.user_id().unwrap();
 

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -28,7 +28,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, no_retry_test_client, test_client_builder};
+use crate::{logged_in_client, no_retry_test_client, test_client_builder_with_server};
 
 fn session() -> MatrixSession {
     MatrixSession {
@@ -163,7 +163,7 @@ async fn no_refresh_token() {
 
 #[async_test]
 async fn test_refresh_token() {
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .server_versions([MatrixVersion::V1_3])
@@ -240,7 +240,7 @@ async fn test_refresh_token() {
 
 #[async_test]
 async fn refresh_token_not_handled() {
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .server_versions([MatrixVersion::V1_3])
@@ -274,7 +274,7 @@ async fn refresh_token_not_handled() {
 
 #[async_test]
 async fn refresh_token_handled_success() {
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .server_versions([MatrixVersion::V1_3])
@@ -334,7 +334,7 @@ async fn refresh_token_handled_success() {
 
 #[async_test]
 async fn refresh_token_handled_failure() {
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .server_versions([MatrixVersion::V1_3])
@@ -384,7 +384,7 @@ async fn refresh_token_handled_failure() {
 
 #[async_test]
 async fn refresh_token_handled_multi_success() {
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .server_versions([MatrixVersion::V1_3])
@@ -457,7 +457,7 @@ async fn refresh_token_handled_multi_success() {
 
 #[async_test]
 async fn refresh_token_handled_multi_failure() {
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .server_versions([MatrixVersion::V1_3])
@@ -530,7 +530,7 @@ async fn refresh_token_handled_multi_failure() {
 
 #[async_test]
 async fn refresh_token_handled_other_error() {
-    let (builder, server) = test_client_builder().await;
+    let (builder, server) = test_client_builder_with_server().await;
     let client = builder
         .request_config(RequestConfig::new().disable_retry())
         .server_versions([MatrixVersion::V1_3])

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -28,7 +28,9 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, no_retry_test_client_with_server, test_client_builder_with_server};
+use crate::{
+    logged_in_client_with_server, no_retry_test_client_with_server, test_client_builder_with_server,
+};
 
 fn session() -> MatrixSession {
     MatrixSession {
@@ -147,7 +149,7 @@ async fn register_refresh_token() {
 
 #[async_test]
 async fn no_refresh_token() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     // Refresh token doesn't change.
     Mock::given(method("POST"))

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -10,6 +10,10 @@ use matrix_sdk::{
     config::RequestConfig,
     executor::spawn,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
+    test_utils::{
+        logged_in_client_with_server, no_retry_test_client_with_server,
+        test_client_builder_with_server,
+    },
     HttpError, RefreshTokenError, SessionChange,
 };
 use matrix_sdk_base::SessionMeta;
@@ -26,10 +30,6 @@ use tokio::sync::{broadcast::error::TryRecvError, mpsc};
 use wiremock::{
     matchers::{body_partial_json, header, method, path},
     Mock, ResponseTemplate,
-};
-
-use crate::{
-    logged_in_client_with_server, no_retry_test_client_with_server, test_client_builder_with_server,
 };
 
 fn session() -> MatrixSession {

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -28,7 +28,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, no_retry_test_client, test_client_builder_with_server};
+use crate::{logged_in_client, no_retry_test_client_with_server, test_client_builder_with_server};
 
 fn session() -> MatrixSession {
     MatrixSession {
@@ -45,7 +45,7 @@ fn session() -> MatrixSession {
 
 #[async_test]
 async fn test_login_username_refresh_token() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
@@ -74,7 +74,7 @@ async fn test_login_username_refresh_token() {
 #[async_test]
 #[cfg(feature = "sso-login")]
 async fn login_sso_refresh_token() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/login"))
@@ -118,7 +118,7 @@ async fn login_sso_refresh_token() {
 
 #[async_test]
 async fn register_refresh_token() {
-    let (client, server) = no_retry_test_client().await;
+    let (client, server) = no_retry_test_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path("/_matrix/client/r0/register"))

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -20,11 +20,11 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
 async fn user_presence() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
 
@@ -48,7 +48,7 @@ async fn user_presence() {
 
 #[async_test]
 async fn calculate_room_names_from_summary() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::DEFAULT_SYNC_SUMMARY, None).await;
 
@@ -61,7 +61,7 @@ async fn calculate_room_names_from_summary() {
 
 #[async_test]
 async fn room_names() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
 
@@ -89,7 +89,7 @@ async fn room_names() {
 
 #[async_test]
 async fn test_state_event_getting() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let sync = json!({
         "next_batch": "1234",
@@ -177,7 +177,7 @@ async fn test_state_event_getting() {
 
 #[async_test]
 async fn room_route() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let mut ev_builder = SyncResponseBuilder::new();
     let room_id = &*DEFAULT_TEST_ROOM_ID;
 
@@ -349,7 +349,7 @@ async fn room_route() {
 
 #[async_test]
 async fn room_permalink() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let mut ev_builder = SyncResponseBuilder::new();
     let room_id = room_id!("!test_room:127.0.0.1");
 
@@ -438,7 +438,7 @@ async fn room_permalink() {
 
 #[async_test]
 async fn room_event_permalink() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let mut ev_builder = SyncResponseBuilder::new();
     let room_id = room_id!("!test_room:127.0.0.1");
     let event_id = event_id!("$15139375512JaHAW");
@@ -503,7 +503,7 @@ async fn room_event_permalink() {
 async fn event() {
     let event_id = event_id!("$foun39djjod0f");
 
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut ev_builder = SyncResponseBuilder::new();

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -29,11 +29,11 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_encryption_state, mock_sync, synced_client};
+use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync, synced_client};
 
 #[async_test]
 async fn invite_user_by_id() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/invite$"))
@@ -56,7 +56,7 @@ async fn invite_user_by_id() {
 
 #[async_test]
 async fn invite_user_by_3pid() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/invite$"))
@@ -88,7 +88,7 @@ async fn invite_user_by_3pid() {
 
 #[async_test]
 async fn leave_room() -> Result<(), anyhow::Error> {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/leave$"))
@@ -114,7 +114,7 @@ async fn leave_room() -> Result<(), anyhow::Error> {
 
 #[async_test]
 async fn ban_user() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/ban$"))
@@ -137,7 +137,7 @@ async fn ban_user() {
 
 #[async_test]
 async fn unban_user() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/unban$"))
@@ -160,7 +160,7 @@ async fn unban_user() {
 
 #[async_test]
 async fn test_mark_as_unread() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(
@@ -186,7 +186,7 @@ async fn test_mark_as_unread() {
 
 #[async_test]
 async fn kick_user() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/kick$"))
@@ -209,7 +209,7 @@ async fn kick_user() {
 
 #[async_test]
 async fn send_single_receipt() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/receipt"))
@@ -232,7 +232,7 @@ async fn send_single_receipt() {
 
 #[async_test]
 async fn send_multiple_receipts() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/read_markers$"))
@@ -256,7 +256,7 @@ async fn send_multiple_receipts() {
 
 #[async_test]
 async fn typing_notice() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/typing"))
@@ -280,7 +280,7 @@ async fn typing_notice() {
 async fn room_state_event_send() {
     use ruma::events::room::member::{MembershipState, RoomMemberEventContent};
 
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/.*"))
@@ -308,7 +308,7 @@ async fn room_state_event_send() {
 
 #[async_test]
 async fn room_message_send() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
@@ -335,7 +335,7 @@ async fn room_message_send() {
 
 #[async_test]
 async fn room_attachment_send() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
@@ -383,7 +383,7 @@ async fn room_attachment_send() {
 
 #[async_test]
 async fn room_attachment_send_info() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
@@ -435,7 +435,7 @@ async fn room_attachment_send_info() {
 
 #[async_test]
 async fn room_attachment_send_wrong_info() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
@@ -486,7 +486,7 @@ async fn room_attachment_send_wrong_info() {
 
 #[async_test]
 async fn room_attachment_send_info_thumbnail() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
@@ -644,7 +644,7 @@ async fn set_name() {
 
 #[async_test]
 async fn report_content() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let reason = "I am offended";
     let score = int!(-80);
@@ -677,7 +677,7 @@ async fn report_content() {
 
 #[async_test]
 async fn subscribe_to_typing_notifications() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     let typing_sequences: Arc<Mutex<Vec<Vec<OwnedUserId>>>> = Arc::new(Mutex::new(Vec::new()));
     // The expected typing sequences that we will receive, note that the current
     // user_id is filtered out.

--- a/crates/matrix-sdk/tests/integration/room/left.rs
+++ b/crates/matrix-sdk/tests/integration/room/left.rs
@@ -9,11 +9,11 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
 async fn forget_room() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/forget$"))
@@ -35,7 +35,7 @@ async fn forget_room() {
 
 #[async_test]
 async fn rejoin_room() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/join"))

--- a/crates/matrix-sdk/tests/integration/room/notification_mode.rs
+++ b/crates/matrix-sdk/tests/integration/room/notification_mode.rs
@@ -14,13 +14,13 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
 async fn get_notification_mode() {
     let room_no_rules_id = room_id!("!jEsUZKDJdhlrceRyVU:localhost");
     let room_not_joined_id = room_id!("!aBfUOMDJhmtucfVzGa:localhost");
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 

--- a/crates/matrix-sdk/tests/integration/room/spaces.rs
+++ b/crates/matrix-sdk/tests/integration/room/spaces.rs
@@ -12,7 +12,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync, MockServer};
+use crate::{logged_in_client_with_server, mock_sync, MockServer};
 
 pub static DEFAULT_TEST_SPACE_ID: Lazy<&RoomId> =
     Lazy::new(|| room_id!("!hIMjEx205EXNyjVPCV:localhost"));
@@ -153,7 +153,7 @@ async fn sync_space(
 
 #[async_test]
 async fn no_parent_space() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
 
@@ -170,7 +170,7 @@ async fn no_parent_space() {
 
 #[async_test]
 async fn parent_space_undeserializable() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let mut sync = PARENT_SPACE_SYNC.clone();
     sync["rooms"]["join"][DEFAULT_TEST_ROOM_ID.as_str()]["timeline"]["events"][0]["content"]
@@ -186,7 +186,7 @@ async fn parent_space_undeserializable() {
 
 #[async_test]
 async fn parent_space_redacted() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let mut sync = PARENT_SPACE_SYNC.clone();
     let timeline = &mut sync["rooms"]["join"][DEFAULT_TEST_ROOM_ID.as_str()]["timeline"]["events"];
@@ -215,7 +215,7 @@ async fn parent_space_redacted() {
 
 #[async_test]
 async fn parent_space_unverifiable() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     initial_sync_with_m_space_parent(&client, &server, &PARENT_SPACE_SYNC).await;
 
@@ -230,7 +230,7 @@ async fn parent_space_unverifiable() {
 
 #[async_test]
 async fn parent_space_illegitimate() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_members(&server).await;
 
@@ -249,7 +249,7 @@ async fn parent_space_illegitimate() {
 
 #[async_test]
 async fn parent_space_reciprocal() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let sync_token = initial_sync_with_m_space_parent(&client, &server, &PARENT_SPACE_SYNC).await;
 
@@ -286,7 +286,7 @@ async fn parent_space_reciprocal() {
 
 #[async_test]
 async fn parent_space_redacted_reciprocal() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     mock_members(&server).await;
 
@@ -374,7 +374,7 @@ async fn setup_parent_member(
 
 #[async_test]
 async fn parent_space_powerlevel() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let sync_token = initial_sync_with_m_space_parent(&client, &server, &PARENT_SPACE_SYNC).await;
 
@@ -391,7 +391,7 @@ async fn parent_space_powerlevel() {
 
 #[async_test]
 async fn parent_space_powerlevel_too_low() {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
 
     let sync_token = initial_sync_with_m_space_parent(&client, &server, &PARENT_SPACE_SYNC).await;
 

--- a/crates/matrix-sdk/tests/integration/room/tags.rs
+++ b/crates/matrix-sdk/tests/integration/room/tags.rs
@@ -14,7 +14,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_sync};
+use crate::{logged_in_client_with_server, mock_sync};
 
 enum TagOperation {
     Set,
@@ -70,7 +70,7 @@ async fn synced_client_with_room(
     ev_builder: &mut SyncResponseBuilder,
     room_id: &RoomId,
 ) -> (Client, Room, MockServer) {
-    let (client, server) = logged_in_client().await;
+    let (client, server) = logged_in_client_with_server().await;
     ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
     mock_sync(&server, ev_builder.build_json_sync_response(), None).await;

--- a/crates/matrix-sdk/tests/integration/widget.rs
+++ b/crates/matrix-sdk/tests/integration/widget.rs
@@ -48,7 +48,7 @@ use wiremock::{
     Mock, MockServer, ResponseTemplate,
 };
 
-use crate::{logged_in_client, mock_encryption_state, mock_sync};
+use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync};
 
 /// Create a JSON string from a [`json!`][serde_json::json] "literal".
 #[macro_export]
@@ -70,7 +70,7 @@ async fn run_test_driver(init_on_content_load: bool) -> (Client, MockServer, Wid
         }
     }
 
-    let (client, mock_server) = logged_in_client().await;
+    let (client, mock_server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     let mut sync_builder = SyncResponseBuilder::new();


### PR DESCRIPTION
I wanted to add tests to the event cache, but then I saw that we had 7 (!) copies of the `logged_in_client` method, so not sure which to choose. Instead of choosing, I've refactored a bit the testing utilities to merge / rename them.

This is only a change in test functionality, no features has been changed. The only meaningful impact is that the `matrix-sdk` crate now has an optional dependency on `wiremock` (enabled when `testing`), instead of a `dev-dependency`. Potato, potato, if you ask me.