### PR TITLE
sdk: Add an info log with the `event_id` when a room event is succesfully sent

### DIFF
--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -32,7 +32,7 @@ use ruma::{
     serde::Raw,
     OwnedTransactionId, TransactionId,
 };
-use tracing::{debug, info, Instrument, Span};
+use tracing::{debug, Instrument, Span};
 
 use super::Room;
 use crate::{
@@ -202,10 +202,8 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
 
             let response = room.client.send(request, None).await?;
 
-            info!(
-                event_id = ?response.event_id,
-                "Sent event in room",
-            );
+            tracing::Span::current().record("event_id", tracing::field::debug(&response.event_id));
+            debug!("Sent event in room");
 
             Ok(response)
         };

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -32,7 +32,7 @@ use ruma::{
     serde::Raw,
     OwnedTransactionId, TransactionId,
 };
-use tracing::{debug, Instrument, Span};
+use tracing::{debug, info, Instrument, Span};
 
 use super::Room;
 use crate::{
@@ -201,6 +201,12 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
             );
 
             let response = room.client.send(request, None).await?;
+
+            info!(
+                event_id = ?response.event_id,
+                "Sent event in room",
+            );
+
             Ok(response)
         };
 

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -32,7 +32,7 @@ use ruma::{
     serde::Raw,
     OwnedTransactionId, TransactionId,
 };
-use tracing::{debug, Instrument, Span};
+use tracing::{debug, info, Instrument, Span};
 
 use super::Room;
 use crate::{
@@ -203,7 +203,7 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
             let response = room.client.send(request, None).await?;
 
             tracing::Span::current().record("event_id", tracing::field::debug(&response.event_id));
-            debug!("Sent event in room");
+            info!("Sent event in room");
 
             Ok(response)
         };

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1652,7 +1652,7 @@ impl Room {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    #[instrument(skip_all, fields(event_type, room_id = ?self.room_id(), transaction_id, encrypted))]
+    #[instrument(skip_all, fields(event_type, room_id = ?self.room_id(), transaction_id, encrypted, event_id))]
     pub fn send_raw<'a>(
         &'a self,
         event_type: &'a str,


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Fixes https://github.com/element-hq/element-x-ios/issues/2216

We were not logging the id of events we send. Make it hards to debug UISI when we want to ensure that the device was the sender.

~~I did put it as `info` level, let me know if you think it should be `debug`. I'll then have to update the filter so that it appears correctly in the app logs.~~

~~Logs will look like that~~
~~> 2024-02-23T15:29:21.915148Z  INFO matrix_sdk::room::futures: Sent event in room event_id="$sUpMhXe18_hrac6MNNZQEQllk7d_jAlpLN2FxJdjqmU" | crates/matrix-sdk/src/room/futures.rs:205 | spans: root > send_raw{room_id="!NCkAdxsQkjlTESyKQC:matrix.org" transaction_id="cee10b9ac7db429291005852e5e31e1f" encrypted=true}~~

**Edit**

As per suggestion the`event_id` is now added to the current span

Logs looks like that now:
> 2024-02-26T09:01:05.050013Z DEBUG matrix_sdk::room::futures: Sent event in room | crates/matrix-sdk/src/room/futures.rs:206 | spans: root > send_raw{room_id="!NCkAdxsQkjlTESyKQC:matrix.org" transaction_id="75f1cc491666405bb679a05f9a15cea5" encrypted=true event_id="$osiV8sQu2nQGPkUth7smOQBu0Fg5KAe1Hosq0dtrD8Y"}

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
