### PR TITLE
sdk & ffi: add user power levels to `RoomInfo` and a fn to get the user's role given a user id

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -2,7 +2,7 @@ use std::{convert::TryFrom, sync::Arc};
 
 use anyhow::{Context, Result};
 use matrix_sdk::{
-    room::{power_levels::RoomPowerLevelChanges, Room as SdkRoom},
+    room::{power_levels::RoomPowerLevelChanges, Room as SdkRoom, RoomMemberRole},
     RoomMemberships, RoomState,
 };
 use matrix_sdk_ui::timeline::RoomExt;
@@ -593,6 +593,17 @@ impl Room {
             .await
             .map_err(|e| ClientError::Generic { msg: e.to_string() })?;
         Ok(())
+    }
+
+    pub async fn suggested_role_for_user(
+        &self,
+        user_id: String,
+    ) -> Result<RoomMemberRole, ClientError> {
+        let user_id = UserId::parse(&user_id)?;
+        self.inner
+            .get_suggested_user_role(user_id)
+            .await
+            .map_err(|e| ClientError::Generic { msg: e.to_string() })
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::RoomState;
 use ruma::OwnedMxcUri;
@@ -27,6 +27,7 @@ pub struct RoomInfo {
     active_members_count: u64,
     invited_members_count: u64,
     joined_members_count: u64,
+    user_power_levels: HashMap<String, i64>,
     highlight_count: u64,
     notification_count: u64,
     user_defined_notification_mode: Option<RoomNotificationMode>,
@@ -53,6 +54,12 @@ impl RoomInfo {
     ) -> matrix_sdk::Result<Self> {
         let unread_notification_counts = room.unread_notification_counts();
 
+        let power_levels = room.room_power_levels().await?;
+        let mut user_power_levels = HashMap::<String, i64>::new();
+        for (id, level) in power_levels.users.iter() {
+            user_power_levels.insert(id.to_string(), (*level).into());
+        }
+
         Ok(Self {
             id: room.room_id().to_string(),
             name: room.name(),
@@ -76,6 +83,7 @@ impl RoomInfo {
             active_members_count: room.active_members_count(),
             invited_members_count: room.invited_members_count(),
             joined_members_count: room.joined_members_count(),
+            user_power_levels,
             highlight_count: unread_notification_counts.highlight_count,
             notification_count: unread_notification_counts.notification_count,
             user_defined_notification_mode: room

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -15,6 +15,7 @@ Additions:
 
 - Add the `ClientBuilder::add_root_certificates()` method which re-exposes the
   `reqwest::ClientBuilder::add_root_certificate()` functionality.
+- Add `Room::get_user_power_level(user_id)` and `Room::get_suggested_user_role(user_id)` to be able to fetch power level info about an user without loading the room member list.
 
 Additions:
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -75,6 +75,10 @@ use tokio::sync::broadcast;
 use tracing::{debug, info, instrument, warn};
 
 use self::futures::{SendAttachment, SendMessageLikeEvent, SendRawMessageLikeEvent};
+pub use self::{
+    member::{RoomMember, RoomMemberRole},
+    messages::{Messages, MessagesOptions},
+};
 use crate::{
     attachment::AttachmentConfig,
     error::WrongRoomState,
@@ -91,11 +95,6 @@ pub mod futures;
 mod member;
 mod messages;
 pub mod power_levels;
-
-pub use self::{
-    member::{RoomMember, RoomMemberRole},
-    messages::{Messages, MessagesOptions},
-};
 
 /// A struct containing methods that are common for Joined, Invited and Left
 /// Rooms
@@ -1843,6 +1842,22 @@ impl Room {
             .ok_or(Error::InsufficientData)?
             .deserialize()?
             .power_levels())
+    }
+
+    /// Gets the suggested role for the user with the provided `user_id`.
+    /// This method checks the `RoomPowerLevels` events instead of loading the
+    /// member list and looking for the member.
+    pub async fn get_suggested_user_role(&self, user_id: OwnedUserId) -> Result<RoomMemberRole> {
+        let power_level = self.get_user_power_level(user_id).await?;
+        Ok(RoomMemberRole::suggested_role_for_power_level(power_level))
+    }
+
+    /// Gets the power level the user with the provided `user_id`.
+    /// This method checks the `RoomPowerLevels` events instead of loading the
+    /// member list and looking for the member.
+    async fn get_user_power_level(&self, user_id: OwnedUserId) -> Result<i64> {
+        let event = self.room_power_levels().await?;
+        Ok(event.for_user(&user_id).into())
     }
 
     /// Sets the name of this room.


### PR DESCRIPTION
Changes:
- sdk: Add `get_user_power_level` and `get_suggested_user_role` functions so we don't need to load the whole room member list to know if a user has some power level/role.
- ffi: add an FFI fn for `get_suggested_user_role`.
- ffi: add `user_power_levels` to `RoomInfo`.

The goal of this PR is being able to fetch a user's power level or role almost immediately and avoid having to load and find the user in the room member list, which can be very slow to load (especially in EX Android).

- [ ] Public API changes documented in changelogs (optional)
