### PR TITLE
ffi: aggregate `RoomMember` fields early instead of requiring calling getters

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -22,7 +22,7 @@ use crate::{
     error::{ClientError, MediaInfoError, RoomError},
     event::{MessageLikeEventType, StateEventType},
     room_info::RoomInfo,
-    room_member::{MembershipState, MessageLikeEventType, RoomMember, StateEventType},
+    room_member::{ExportedRoomMember, RoomMember},
     ruma::ImageInfo,
     timeline::{EventTimelineItem, ReceiptType, Timeline},
     utils::u64_to_uint,
@@ -606,18 +606,6 @@ pub trait TypingNotificationsListener: Sync + Send {
     fn call(&self, typing_user_ids: Vec<String>);
 }
 
-#[derive(uniffi::Record)]
-pub struct ExportedRoomMember {
-    user_id: String,
-    display_name: Option<String>,
-    avatar_url: Option<String>,
-    membership: MembershipState,
-    is_name_ambiguous: bool,
-    power_level: i64,
-    normalized_power_level: i64,
-    is_ignored: bool,
-}
-
 #[derive(uniffi::Object)]
 pub struct RoomMembersIterator {
     chunk_iterator: ChunkIterator<matrix_sdk::room::RoomMember>,
@@ -648,6 +636,7 @@ impl RoomMembersIterator {
                     power_level: m.power_level(),
                     normalized_power_level: m.normalized_power_level(),
                     is_ignored: m.is_ignored(),
+                    suggested_role_for_power_level: m.suggested_role_for_power_level(),
                 })
                 .collect()
         })

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -22,7 +22,7 @@ use crate::{
     error::{ClientError, MediaInfoError, RoomError},
     event::{MessageLikeEventType, StateEventType},
     room_info::RoomInfo,
-    room_member::ExportedRoomMember,
+    room_member::RoomMember,
     ruma::ImageInfo,
     timeline::{EventTimelineItem, ReceiptType, Timeline},
     utils::u64_to_uint,
@@ -128,7 +128,7 @@ impl Room {
         self.inner.active_room_call_participants().iter().map(|u| u.to_string()).collect()
     }
 
-    pub fn inviter(&self) -> Option<ExportedRoomMember> {
+    pub fn inviter(&self) -> Option<RoomMember> {
         if self.inner.state() == RoomState::Invited {
             RUNTIME.block_on(async move {
                 self.inner.invite_details().await.ok().and_then(|a| a.inviter).map(|m| m.into())
@@ -184,7 +184,7 @@ impl Room {
         )))
     }
 
-    pub async fn member(&self, user_id: String) -> Result<ExportedRoomMember, ClientError> {
+    pub async fn member(&self, user_id: String) -> Result<RoomMember, ClientError> {
         let user_id = UserId::parse(&*user_id).context("Invalid user id.")?;
         let member = self.inner.get_member(&user_id).await?.context("No user found")?;
         Ok(member.into())
@@ -618,7 +618,7 @@ impl RoomMembersIterator {
         self.chunk_iterator.len()
     }
 
-    fn next_chunk(&self, chunk_size: u32) -> Option<Vec<ExportedRoomMember>> {
+    fn next_chunk(&self, chunk_size: u32) -> Option<Vec<RoomMember>> {
         self.chunk_iterator
             .next(chunk_size)
             .map(|members| members.into_iter().map(|m| m.into()).collect())

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -4,7 +4,7 @@ use matrix_sdk::RoomState;
 use ruma::OwnedMxcUri;
 
 use crate::{
-    notification_settings::RoomNotificationMode, room::Membership, room_member::ExportedRoomMember,
+    notification_settings::RoomNotificationMode, room::Membership, room_member::RoomMember,
     timeline::EventTimelineItem,
 };
 
@@ -23,7 +23,7 @@ pub struct RoomInfo {
     alternative_aliases: Vec<String>,
     membership: Membership,
     latest_event: Option<Arc<EventTimelineItem>>,
-    inviter: Option<ExportedRoomMember>,
+    inviter: Option<RoomMember>,
     active_members_count: u64,
     invited_members_count: u64,
     joined_members_count: u64,

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -4,7 +4,7 @@ use matrix_sdk::RoomState;
 use ruma::OwnedMxcUri;
 
 use crate::{
-    notification_settings::RoomNotificationMode, room::Membership, room_member::RoomMember,
+    notification_settings::RoomNotificationMode, room::Membership, room_member::ExportedRoomMember,
     timeline::EventTimelineItem,
 };
 
@@ -23,7 +23,7 @@ pub struct RoomInfo {
     alternative_aliases: Vec<String>,
     membership: Membership,
     latest_event: Option<Arc<EventTimelineItem>>,
-    inviter: Option<Arc<RoomMember>>,
+    inviter: Option<ExportedRoomMember>,
     active_members_count: u64,
     invited_members_count: u64,
     joined_members_count: u64,
@@ -68,9 +68,7 @@ impl RoomInfo {
             membership: room.state().into(),
             latest_event,
             inviter: match room.state() {
-                RoomState::Invited => {
-                    room.invite_details().await?.inviter.map(|inner| Arc::new(RoomMember { inner }))
-                }
+                RoomState::Invited => room.invite_details().await?.inviter.map(|m| m.into()),
                 _ => None,
             },
             active_members_count: room.active_members_count(),

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -154,3 +154,16 @@ pub fn suggested_role_for_power_level(power_level: i64) -> RoomMemberRole {
     // It's not possible to expose the constructor on the Enum through Uniffi ☹️
     RoomMemberRole::suggested_role_for_power_level(power_level)
 }
+
+#[derive(uniffi::Record)]
+pub struct ExportedRoomMember {
+    pub user_id: String,
+    pub display_name: Option<String>,
+    pub avatar_url: Option<String>,
+    pub membership: MembershipState,
+    pub is_name_ambiguous: bool,
+    pub power_level: i64,
+    pub normalized_power_level: i64,
+    pub is_ignored: bool,
+    pub suggested_role_for_power_level: RoomMemberRole,
+}

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -1,11 +1,5 @@
 use matrix_sdk::room::{RoomMember as SdkRoomMember, RoomMemberRole};
 
-use super::RUNTIME;
-use crate::{
-    event::{MessageLikeEventType, StateEventType},
-    ClientError,
-};
-
 #[derive(Clone, uniffi::Enum)]
 pub enum MembershipState {
     /// The user is banned.
@@ -45,110 +39,6 @@ impl From<matrix_sdk::ruma::events::room::member::MembershipState> for Membershi
     }
 }
 
-#[derive(uniffi::Object)]
-pub struct RoomMember {
-    pub(crate) inner: SdkRoomMember,
-}
-
-#[uniffi::export]
-impl RoomMember {
-    pub fn user_id(&self) -> String {
-        self.inner.user_id().to_string()
-    }
-
-    pub fn display_name(&self) -> Option<String> {
-        self.inner.display_name().map(|d| d.to_owned())
-    }
-
-    pub fn avatar_url(&self) -> Option<String> {
-        self.inner.avatar_url().map(ToString::to_string)
-    }
-
-    pub fn membership(&self) -> MembershipState {
-        self.inner.membership().to_owned().into()
-    }
-
-    pub fn is_name_ambiguous(&self) -> bool {
-        self.inner.name_ambiguous()
-    }
-
-    pub fn power_level(&self) -> i64 {
-        self.inner.power_level()
-    }
-
-    pub fn suggested_role_for_power_level(&self) -> RoomMemberRole {
-        self.inner.suggested_role_for_power_level()
-    }
-
-    pub fn normalized_power_level(&self) -> i64 {
-        self.inner.normalized_power_level()
-    }
-
-    pub fn is_ignored(&self) -> bool {
-        self.inner.is_ignored()
-    }
-
-    pub fn is_account_user(&self) -> bool {
-        self.inner.is_account_user()
-    }
-
-    /// Adds the room member to the current account data's ignore list
-    /// which will ignore the user across all rooms.
-    pub fn ignore(&self) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move {
-            self.inner.ignore().await?;
-            Ok(())
-        })
-    }
-
-    /// Removes the room member from the current account data's ignore list
-    /// which will unignore the user across all rooms.
-    pub fn unignore(&self) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move {
-            self.inner.unignore().await?;
-            Ok(())
-        })
-    }
-
-    pub fn can_ban(&self) -> bool {
-        self.inner.can_ban()
-    }
-
-    pub fn can_invite(&self) -> bool {
-        self.inner.can_invite()
-    }
-
-    pub fn can_kick(&self) -> bool {
-        self.inner.can_kick()
-    }
-
-    pub fn can_redact_own(&self) -> bool {
-        self.inner.can_redact_own()
-    }
-
-    pub fn can_redact_other(&self) -> bool {
-        self.inner.can_redact_other()
-    }
-
-    pub fn can_send_state(&self, state_event: StateEventType) -> bool {
-        self.inner.can_send_state(state_event.into())
-    }
-
-    pub fn can_send_message(&self, event: MessageLikeEventType) -> bool {
-        self.inner.can_send_message(event.into())
-    }
-
-    pub fn can_trigger_room_notification(&self) -> bool {
-        self.inner.can_trigger_room_notification()
-    }
-}
-
-impl RoomMember {
-    pub fn new(room_member: SdkRoomMember) -> Self {
-        RoomMember { inner: room_member }
-    }
-}
-
 #[uniffi::export]
 pub fn suggested_role_for_power_level(power_level: i64) -> RoomMemberRole {
     // It's not possible to expose the constructor on the Enum through Uniffi ☹️
@@ -166,4 +56,20 @@ pub struct ExportedRoomMember {
     pub normalized_power_level: i64,
     pub is_ignored: bool,
     pub suggested_role_for_power_level: RoomMemberRole,
+}
+
+impl From<SdkRoomMember> for ExportedRoomMember {
+    fn from(m: SdkRoomMember) -> Self {
+        ExportedRoomMember {
+            user_id: m.user_id().to_string(),
+            display_name: m.display_name().map(|s| s.to_owned()),
+            avatar_url: m.avatar_url().map(|a| a.to_string()),
+            membership: m.membership().clone().into(),
+            is_name_ambiguous: m.name_ambiguous(),
+            power_level: m.power_level(),
+            normalized_power_level: m.normalized_power_level(),
+            is_ignored: m.is_ignored(),
+            suggested_role_for_power_level: m.suggested_role_for_power_level(),
+        }
+    }
 }

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -46,7 +46,7 @@ pub fn suggested_role_for_power_level(power_level: i64) -> RoomMemberRole {
 }
 
 #[derive(uniffi::Record)]
-pub struct ExportedRoomMember {
+pub struct RoomMember {
     pub user_id: String,
     pub display_name: Option<String>,
     pub avatar_url: Option<String>,
@@ -58,9 +58,9 @@ pub struct ExportedRoomMember {
     pub suggested_role_for_power_level: RoomMemberRole,
 }
 
-impl From<SdkRoomMember> for ExportedRoomMember {
+impl From<SdkRoomMember> for RoomMember {
     fn from(m: SdkRoomMember) -> Self {
-        ExportedRoomMember {
+        RoomMember {
             user_id: m.user_id().to_string(),
             display_name: m.display_name().map(|s| s.to_owned()),
             avatar_url: m.avatar_url().map(|a| a.to_string()),

--- a/crates/matrix-sdk-base/src/rooms/members.rs
+++ b/crates/matrix-sdk-base/src/rooms/members.rs
@@ -122,7 +122,8 @@ impl RoomMember {
     /// Get the normalized power level of this member.
     ///
     /// The normalized power level depends on the maximum power level that can
-    /// be found in a certain room, positive values are always in the range of 0-100.
+    /// be found in a certain room, positive values are always in the range of
+    /// 0-100.
     pub fn normalized_power_level(&self) -> i64 {
         if self.max_power_level > 0 {
             (self.power_level() * 100) / self.max_power_level

--- a/crates/matrix-sdk-base/src/rooms/members.rs
+++ b/crates/matrix-sdk-base/src/rooms/members.rs
@@ -122,7 +122,7 @@ impl RoomMember {
     /// Get the normalized power level of this member.
     ///
     /// The normalized power level depends on the maximum power level that can
-    /// be found in a certain room, it's always in the range of 0-100.
+    /// be found in a certain room, positive values are always in the range of 0-100.
     pub fn normalized_power_level(&self) -> i64 {
         if self.max_power_level > 0 {
             (self.power_level() * 100) / self.max_power_level

--- a/crates/matrix-sdk/src/config/request.rs
+++ b/crates/matrix-sdk/src/config/request.rs
@@ -98,7 +98,7 @@ impl RequestConfig {
         self
     }
 
-    /// The number of times a request should be retried. The default is no limit
+    /// The number of times a request should be retried. The default is 0 to disable retries.
     #[must_use]
     pub fn retry_limit(mut self, retry_limit: u64) -> Self {
         self.retry_limit = Some(retry_limit);

--- a/crates/matrix-sdk/src/config/request.rs
+++ b/crates/matrix-sdk/src/config/request.rs
@@ -98,7 +98,8 @@ impl RequestConfig {
         self
     }
 
-    /// The number of times a request should be retried. The default is 0 to disable retries.
+    /// The number of times a request should be retried. The default is no
+    /// limit.
     #[must_use]
     pub fn retry_limit(mut self, retry_limit: u64) -> Self {
         self.retry_limit = Some(retry_limit);

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -77,6 +77,7 @@ use tracing::{debug, info, instrument, warn};
 use self::futures::{SendAttachment, SendMessageLikeEvent, SendRawMessageLikeEvent};
 use crate::{
     attachment::AttachmentConfig,
+    config::RequestConfig,
     error::WrongRoomState,
     event_handler::{EventHandler, EventHandlerDropGuard, EventHandlerHandle, SyncEvent},
     media::{MediaFormat, MediaRequest},
@@ -411,7 +412,13 @@ impl Room {
             .members_request_deduplicated_handler
             .run(self.room_id().to_owned(), async move {
                 let request = get_member_events::v3::Request::new(self.inner.room_id().to_owned());
-                let response = self.client.send(request, None).await?;
+                let response = self
+                    .client
+                    .send(
+                        request,
+                        Some(RequestConfig::new().timeout(Duration::from_secs(60)).retry_limit(3)),
+                    )
+                    .await?;
 
                 // That's a large `Future`. Let's `Box::pin` to reduce its size on the stack.
                 Box::pin(self.client.base_client().receive_members(self.room_id(), &response))

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -416,6 +416,8 @@ impl Room {
                     .client
                     .send(
                         request,
+                        // In some cases it can take longer than 30s to load:
+                        // https://github.com/element-hq/synapse/issues/16872
                         Some(RequestConfig::new().timeout(Duration::from_secs(60)).retry_limit(3)),
                     )
                     .await?;


### PR DESCRIPTION
See https://github.com/matrix-org/matrix-rust-sdk/pull/3074 and https://github.com/matrix-org/matrix-rust-sdk/pull/3101 for previous versions. This PR is based on !3074 with minor cleanup.
The corresponding element android PR is here: https://github.com/element-hq/element-x-android/pull/2322

- [ ] Public API changes documented in changelogs (optional)

