### PR TITLE
FFI: Expose getting a power level from a role.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -154,3 +154,9 @@ pub fn suggested_role_for_power_level(power_level: i64) -> RoomMemberRole {
     // It's not possible to expose the constructor on the Enum through Uniffi ☹️
     RoomMemberRole::suggested_role_for_power_level(power_level)
 }
+
+#[uniffi::export]
+pub fn suggested_power_level_for_role(role: RoomMemberRole) -> i64 {
+    // It's not possible to expose methods on an Enum through Uniffi ☹️
+    role.suggested_power_level()
+}


### PR DESCRIPTION
This PR exposes a method to get the suggested power level from a role. Just like using the role's constructor with a power level, the macros don't allow to `uniffi::export` a method on an enum, so this needs to be done as a global method ☹️