### PR TITLE
ffi: bump uniffi to latest to generate open swift classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6067,9 +6067,8 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "uniffi"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "anyhow",
  "camino",
@@ -6089,9 +6088,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "anyhow",
  "askama",
@@ -6114,9 +6112,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "anyhow",
  "camino",
@@ -6125,9 +6122,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -6135,9 +6131,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -6152,9 +6147,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "bincode",
  "camino",
@@ -6171,9 +6165,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6183,9 +6176,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "anyhow",
  "camino",
@@ -6196,9 +6188,8 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
+version = "0.26.0"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -6503,8 +6494,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures-util = { version = "0.3.26", default-features = false, features = ["allo
 http = "0.2.6"
 itertools = "0.12.0"
 ruma = { git = "https://github.com/ruma/ruma", rev = "68c9bb0930f2195fa8672fbef9633ef62737df5d", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "68c9bb0930f2195fa8672fbef9633ef62737df5d"}
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "68c9bb0930f2195fa8672fbef9633ef62737df5d" }
 once_cell = "1.16.0"
 rand = "0.8.5"
 serde = "1.0.151"
@@ -50,8 +50,8 @@ tokio = { version = "1.30.0", default-features = false, features = ["sync"] }
 tokio-stream = "0.1.14"
 tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-core = "0.1.32"
-uniffi = "0.26.1"
-uniffi_bindgen = "0.26.1"
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "2e4e2ae53e83c832cdff80cb4c8779038789f7aa" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "2e4e2ae53e83c832cdff80cb4c8779038789f7aa" }
 vodozemac = "0.5.1"
 zeroize = "1.6.0"
 


### PR DESCRIPTION
This will pull in https://github.com/mozilla/uniffi-rs/pull/1975 and hopefuly not cause any breaking changes.