### PR TITLE
ci: update codecov action to v4

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -111,7 +111,7 @@ jobs:
           SLIDING_SYNC_PROXY_URL: "http://localhost:8118"
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           # Work around frequent upload errors, for runs inside the main repo (not PRs from forks).
           # Otherwise not required for public repos.


### PR DESCRIPTION
https://github.com/codecov/codecov-action/tree/v4?tab=readme-ov-file#v4-release

> Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token)

Let's see if it helps with forks. 