### PR TITLE
event cache: enforce unique access on the `EventCacheStore`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -135,8 +135,7 @@ impl EventCache {
         let inner = Arc::new(EventCacheInner {
             client: Arc::downgrade(client),
             by_room: Default::default(),
-            store,
-            process_lock: Default::default(),
+            store: Arc::new(Mutex::new(store)),
             drop_handles: Default::default(),
         });
 
@@ -188,9 +187,10 @@ impl EventCache {
                     // Forget everything we know; we could have missed events, and we have
                     // no way to reconcile at the moment!
                     // TODO: implement Smart Matching™,
+                    let store = inner.store.lock().await;
                     let mut by_room = inner.by_room.write().await;
                     for room_id in by_room.keys() {
-                        if let Err(err) = inner.store.clear_room_events(room_id).await {
+                        if let Err(err) = store.clear_room_events(room_id).await {
                             error!("unable to clear room after room updates lag: {err}");
                         }
                     }
@@ -233,10 +233,12 @@ impl EventCache {
         // We could have received events during a previous sync; remove them all, since
         // we can't know where to insert the "initial events" with respect to
         // them.
-        self.inner.store.clear_room_events(room_id).await?;
+        let store = self.inner.store.lock().await;
+
+        store.clear_room_events(room_id).await?;
         let _ = room_cache.inner.sender.send(RoomEventCacheUpdate::Clear);
 
-        room_cache.inner.append_events(events).await?;
+        room_cache.inner.append_events(&**store, events).await?;
 
         Ok(())
     }
@@ -251,14 +253,13 @@ struct EventCacheInner {
     by_room: RwLock<BTreeMap<OwnedRoomId, RoomEventCache>>,
 
     /// Backend used for storage.
-    store: Arc<dyn EventCacheStore>,
-
-    /// A lock to make sure that despite multiple updates coming to the
-    /// `EventCache`, it will only handle one at a time.
     ///
     /// [`Mutex`] is “fair”, as it is implemented as a FIFO. It is important to
-    /// ensure that multiple updates will be applied in the correct order.
-    process_lock: Mutex<()>,
+    /// ensure that multiple updates will be applied in the correct order, which
+    /// is enforced by taking the store lock when handling an update.
+    ///
+    /// TODO: replace with a cross-process lock
+    store: Arc<Mutex<Arc<dyn EventCacheStore>>>,
 
     /// Handles to keep alive the task listening to updates.
     drop_handles: OnceLock<Arc<EventCacheDropHandles>>,
@@ -273,13 +274,13 @@ impl EventCacheInner {
     async fn handle_room_updates(&self, updates: RoomUpdates) -> Result<()> {
         // First, take the lock that indicates we're processing updates, to avoid
         // handling multiple updates concurrently.
-        let _process_lock = self.process_lock.lock().await;
+        let store = self.store.lock().await;
 
         // Left rooms.
         for (room_id, left_room_update) in updates.leave {
             let room = self.for_room(&room_id).await?;
 
-            if let Err(err) = room.inner.handle_left_room_update(left_room_update).await {
+            if let Err(err) = room.inner.handle_left_room_update(&**store, left_room_update).await {
                 // Non-fatal error, try to continue to the next room.
                 error!("handling left room update: {err}");
             }
@@ -289,7 +290,9 @@ impl EventCacheInner {
         for (room_id, joined_room_update) in updates.join {
             let room = self.for_room(&room_id).await?;
 
-            if let Err(err) = room.inner.handle_joined_room_update(joined_room_update).await {
+            if let Err(err) =
+                room.inner.handle_joined_room_update(&**store, joined_room_update).await
+            {
                 // Non-fatal error, try to continue to the next room.
                 error!("handling joined room update: {err}");
             }
@@ -354,7 +357,7 @@ impl Debug for RoomEventCache {
 
 impl RoomEventCache {
     /// Create a new [`RoomEventCache`] using the given room and store.
-    fn new(room: Room, store: Arc<dyn EventCacheStore>) -> Self {
+    fn new(room: Room, store: Arc<Mutex<Arc<dyn EventCacheStore>>>) -> Self {
         Self { inner: Arc::new(RoomEventCacheInner::new(room, store)) }
     }
 
@@ -365,10 +368,9 @@ impl RoomEventCache {
     pub async fn subscribe(
         &self,
     ) -> Result<(Vec<SyncTimelineEvent>, Receiver<RoomEventCacheUpdate>)> {
-        Ok((
-            self.inner.store.room_events(self.inner.room.room_id()).await?,
-            self.inner.sender.subscribe(),
-        ))
+        let store = self.inner.store.lock().await;
+
+        Ok((store.room_events(self.inner.room.room_id()).await?, self.inner.sender.subscribe()))
     }
 }
 
@@ -377,8 +379,10 @@ struct RoomEventCacheInner {
     /// Sender part for subscribers to this room.
     sender: Sender<RoomEventCacheUpdate>,
 
-    /// A pointer to the store implementation used for this event cache.
-    store: Arc<dyn EventCacheStore>,
+    /// Backend used for storage, shared with the parent [`EventCacheInner`].
+    ///
+    /// See comment there.
+    store: Arc<Mutex<Arc<dyn EventCacheStore>>>,
 
     /// The Client [`Room`] this event cache pertains to.
     room: Room,
@@ -387,13 +391,18 @@ struct RoomEventCacheInner {
 impl RoomEventCacheInner {
     /// Creates a new cache for a room, and subscribes to room updates, so as
     /// to handle new timeline events.
-    fn new(room: Room, store: Arc<dyn EventCacheStore>) -> Self {
+    fn new(room: Room, store: Arc<Mutex<Arc<dyn EventCacheStore>>>) -> Self {
         let sender = Sender::new(32);
         Self { room, store, sender }
     }
 
-    async fn handle_joined_room_update(&self, updates: JoinedRoomUpdate) -> Result<()> {
+    async fn handle_joined_room_update(
+        &self,
+        store: &dyn EventCacheStore,
+        updates: JoinedRoomUpdate,
+    ) -> Result<()> {
         self.handle_timeline(
+            store,
             updates.timeline,
             updates.ephemeral.clone(),
             updates.account_data,
@@ -405,6 +414,7 @@ impl RoomEventCacheInner {
 
     async fn handle_timeline(
         &self,
+        store: &dyn EventCacheStore,
         timeline: Timeline,
         ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
@@ -415,7 +425,7 @@ impl RoomEventCacheInner {
             // timeline, but we're not there yet. In the meanwhile, clear the
             // items from the room. TODO: implement Smart Matching™.
             trace!("limited timeline, clearing all previous events");
-            self.store.clear_room_events(self.room.room_id()).await?;
+            store.clear_room_events(self.room.room_id()).await?;
             let _ = self.sender.send(RoomEventCacheUpdate::Clear);
         }
 
@@ -427,7 +437,7 @@ impl RoomEventCacheInner {
             || !ambiguity_changes.is_empty()
         {
             trace!("adding new events");
-            self.store.add_room_events(self.room.room_id(), timeline.events.clone()).await?;
+            store.add_room_events(self.room.room_id(), timeline.events.clone()).await?;
 
             // Propagate events to observers.
             let _ = self.sender.send(RoomEventCacheUpdate::Append {
@@ -442,20 +452,34 @@ impl RoomEventCacheInner {
         Ok(())
     }
 
-    async fn handle_left_room_update(&self, updates: LeftRoomUpdate) -> Result<()> {
-        self.handle_timeline(updates.timeline, Vec::new(), Vec::new(), updates.ambiguity_changes)
-            .await?;
+    async fn handle_left_room_update(
+        &self,
+        store: &dyn EventCacheStore,
+        updates: LeftRoomUpdate,
+    ) -> Result<()> {
+        self.handle_timeline(
+            store,
+            updates.timeline,
+            Vec::new(),
+            Vec::new(),
+            updates.ambiguity_changes,
+        )
+        .await?;
         Ok(())
     }
 
     /// Append a set of events to the room cache and storage, notifying
     /// observers.
-    async fn append_events(&self, events: Vec<SyncTimelineEvent>) -> Result<()> {
+    async fn append_events(
+        &self,
+        store: &dyn EventCacheStore,
+        events: Vec<SyncTimelineEvent>,
+    ) -> Result<()> {
         if events.is_empty() {
             return Ok(());
         }
 
-        self.store.add_room_events(self.room.room_id(), events.clone()).await?;
+        store.add_room_events(self.room.room_id(), events.clone()).await?;
 
         let _ = self.sender.send(RoomEventCacheUpdate::Append {
             events,


### PR DESCRIPTION
Before this patch, there could potentially be a race condition between `EventCache::handle_room_updates` and `EventCache::add_initial_events`, for instance like that:

- `add_initial_events` clears events in a room
- `handle_room_updates` adds events received from sync
- `add_initial_events` adds the initial events

And that could lead to duplicate events.

This paves the way for the crypto-store lock by making it so that access to the store is protected behind a lock, so we don't actually need another lock only dedicated to processing.