### PR TITLE
FFI: Update the power levels of multiple users at once.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -585,17 +585,17 @@ impl Room {
         &self,
         updates: Vec<UserPowerLevelUpdate>,
     ) -> Result<(), ClientError> {
-        let parse_result: Result<Vec<(&UserId, Int)>> = updates
+        let updates = updates
             .iter()
-            .map(|upl| -> Result<(&UserId, Int)> {
-                let user_id: &UserId = <&UserId>::try_from(upl.user_id.as_str())?;
-                let pl = Int::new(upl.power_level).context("Invalid power level")?;
-                Ok((user_id, pl))
+            .map(|update| {
+                let user_id: &UserId = update.user_id.as_str().try_into()?;
+                let power_level = Int::new(update.power_level).context("Invalid power level")?;
+                Ok((user_id, power_level))
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         self.inner
-            .update_power_levels(parse_result?)
+            .update_power_levels(updates)
             .await
             .map_err(|e| ClientError::Generic { msg: e.to_string() })?;
         Ok(())


### PR DESCRIPTION
Having noticed that we were about to queue up calls for multiple members in EX it seemed worth passing in an array. I'm honestly not sure why I didn't originally expose this method in line with the SDK method it calls, but it's fixed now!