### PR TITLE
ffi: bump the UniFFi referenced commit again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6068,7 +6068,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 [[package]]
 name = "uniffi"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "anyhow",
  "camino",
@@ -6089,7 +6089,7 @@ dependencies = [
 [[package]]
 name = "uniffi_bindgen"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "anyhow",
  "askama",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "anyhow",
  "camino",
@@ -6123,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "uniffi_core"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -6148,7 +6148,7 @@ dependencies = [
 [[package]]
 name = "uniffi_macros"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "bincode",
  "camino",
@@ -6166,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6177,7 +6177,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "anyhow",
  "camino",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "uniffi_udl"
 version = "0.26.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -6494,7 +6494,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "weedle2"
 version = "5.0.0"
-source = "git+https://github.com/mozilla/uniffi-rs?rev=2e4e2ae53e83c832cdff80cb4c8779038789f7aa#2e4e2ae53e83c832cdff80cb4c8779038789f7aa"
+source = "git+https://github.com/mozilla/uniffi-rs?rev=0a5e2eb5760b4ce5549021ec91de546716de8db1#0a5e2eb5760b4ce5549021ec91de546716de8db1"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ tokio = { version = "1.30.0", default-features = false, features = ["sync"] }
 tokio-stream = "0.1.14"
 tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-core = "0.1.32"
-uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "2e4e2ae53e83c832cdff80cb4c8779038789f7aa" }
-uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "2e4e2ae53e83c832cdff80cb4c8779038789f7aa" }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "0a5e2eb5760b4ce5549021ec91de546716de8db1" }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "0a5e2eb5760b4ce5549021ec91de546716de8db1" }
 vodozemac = "0.5.1"
 zeroize = "1.6.0"
 


### PR DESCRIPTION
At the moment, the SDK can't be built for Android after https://github.com/matrix-org/matrix-rust-sdk/pull/3174 because of these 2 issues:

- https://github.com/mozilla/uniffi-rs/issues/1996
- https://github.com/mozilla/uniffi-rs/issues/1995

Those have been fixed in the new commit.

@stefanceriu: next time we decide to bump to a non-stable version please ask us to test it in every platform. Otherwise we can end up in a similar situation.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
