### PR TITLE
feat: add support for `m.call.invite` events in the timeline and as a last room message

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -41,6 +41,7 @@ impl TimelineItemContent {
                 }
             }
             Content::Poll(poll_state) => TimelineItemContentKind::from(poll_state.results()),
+            Content::CallInvite => TimelineItemContentKind::CallInvite,
             Content::UnableToDecrypt(msg) => {
                 TimelineItemContentKind::UnableToDecrypt { msg: EncryptedMessage::new(msg) }
             }
@@ -113,6 +114,7 @@ pub enum TimelineItemContentKind {
         end_time: Option<u64>,
         has_been_edited: bool,
     },
+    CallInvite,
     UnableToDecrypt {
         msg: EncryptedMessage,
     },

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -720,11 +720,14 @@ impl BaseClient {
                 // We found an event we can decrypt
                 if let Ok(any_sync_event) = decrypted.event.deserialize() {
                     // We can deserialize it to find its type
-                    if let PossibleLatestEvent::YesRoomMessage(_) =
-                        is_suitable_for_latest_event(&any_sync_event)
-                    {
-                        // The event is the right type for us to use as latest_event
-                        return Some((Box::new(LatestEvent::new(decrypted)), i));
+                    match is_suitable_for_latest_event(&any_sync_event) {
+                        PossibleLatestEvent::YesRoomMessage(_)
+                        | PossibleLatestEvent::YesPoll(_)
+                        | PossibleLatestEvent::YesCallInvite(_) => {
+                            // The event is the right type for us to use as latest_event
+                            return Some((Box::new(LatestEvent::new(decrypted)), i));
+                        }
+                        _ => (),
                     }
                 }
             }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -585,8 +585,10 @@ async fn cache_latest_events(
     for event in events.iter().rev() {
         if let Ok(timeline_event) = event.event.deserialize() {
             match is_suitable_for_latest_event(&timeline_event) {
-                PossibleLatestEvent::YesRoomMessage(_) | PossibleLatestEvent::YesPoll(_) => {
-                    // m.room.message or m.poll.start - we found one! Store it.
+                PossibleLatestEvent::YesRoomMessage(_)
+                | PossibleLatestEvent::YesPoll(_)
+                | PossibleLatestEvent::YesCallInvite(_) => {
+                    // We found a suitable latest event. Store it.
 
                     // In order to make the latest event fast to read, we want to keep the
                     // associated sender in cache. This is a best-effort to gather enough

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -309,6 +309,10 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 ) => self.handle_poll_start(c, should_add),
                 AnyMessageLikeEventContent::UnstablePollResponse(c) => self.handle_poll_response(c),
                 AnyMessageLikeEventContent::UnstablePollEnd(c) => self.handle_poll_end(c),
+                AnyMessageLikeEventContent::CallInvite(_) => {
+                    self.add(should_add, TimelineItemContent::CallInvite);
+                }
+
                 // TODO
                 _ => {
                     debug!(

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -193,6 +193,7 @@ pub fn default_event_filter(event: &AnySyncTimelineEvent, room_version: &RoomVer
                         | AnyMessageLikeEventContent::UnstablePollStart(
                             UnstablePollStartEventContent::New(_),
                         )
+                        | AnyMessageLikeEventContent::CallInvite(_)
                         | AnyMessageLikeEventContent::RoomEncrypted(_) => true,
 
                         _ => false,

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -598,6 +598,9 @@ impl Timeline {
             TimelineItemContent::Poll(poll_state) => AnyMessageLikeEventContent::UnstablePollStart(
                 UnstablePollStartEventContent::New(poll_state.into()),
             ),
+            TimelineItemContent::CallInvite => {
+                error_return!("Retrying call events is not currently supported");
+            }
         };
 
         debug!("Retrying failed local echo");


### PR DESCRIPTION
 Prompted by https://github.com/element-hq/element-x-ios/issues/1837

This PR exposes `m.call.invite` events on the Timeline and as a latest Room message. It will allow the client to render them and inform the user accordingly.