### PR TITLE
sdk: add Room::default_power_levels() function

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -642,24 +642,24 @@ pub struct RoomPowerLevels {
 
 impl From<RumaPowerLevels> for RoomPowerLevels {
     fn from(value: RumaPowerLevels) -> Self {
-        let default_state: i64 = value.state_default.into();
-        let room_name =
-            value.events.get(&TimelineEventType::RoomName).map_or(default_state, |l| (*l).into());
-        let room_avatar =
-            value.events.get(&TimelineEventType::RoomAvatar).map_or(default_state, |l| (*l).into());
-        let room_topic =
-            value.events.get(&TimelineEventType::RoomTopic).map_or(default_state, |l| (*l).into());
+        fn state_event_level_for(
+            power_levels: &RumaPowerLevels,
+            event_type: &TimelineEventType,
+        ) -> i64 {
+            let default_state: i64 = power_levels.state_default.into();
+            power_levels.events.get(event_type).map_or(default_state, |&level| level.into())
+        }
         Self {
             ban: value.ban.into(),
             invite: value.invite.into(),
             kick: value.kick.into(),
             redact: value.redact.into(),
             events_default: value.events_default.into(),
-            state_default: default_state,
+            state_default: value.state_default.into(),
             users_default: value.users_default.into(),
-            room_name,
-            room_avatar,
-            room_topic,
+            room_name: state_event_level_for(&value, &TimelineEventType::RoomName),
+            room_avatar: state_event_level_for(&value, &TimelineEventType::RoomAvatar),
+            room_topic: state_event_level_for(&value, &TimelineEventType::RoomTopic),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -567,11 +567,9 @@ impl Room {
         Ok(())
     }
 
-    pub async fn build_power_level_changes_from_current(
-        &self,
-    ) -> Result<RoomPowerLevelChanges, ClientError> {
+    pub async fn get_power_levels(&self) -> Result<RoomPowerLevels, ClientError> {
         let power_levels = self.inner.room_power_levels().await?;
-        Ok(power_levels.into())
+        Ok(RoomPowerLevels::from(power_levels))
     }
 
     pub async fn apply_power_level_changes(
@@ -610,9 +608,8 @@ impl Room {
         Ok(self.inner.get_suggested_user_role(&user_id).await?)
     }
 
-    pub fn default_power_levels(&self) -> RoomPowerLevels {
-        let levels = SdkRoom::default_power_levels();
-        RoomPowerLevels::from(levels)
+    pub async fn reset_power_levels(&self) -> Result<RoomPowerLevels, ClientError> {
+        Ok(RoomPowerLevels::from(self.inner.reset_power_levels().await?))
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
+use std::{convert::TryFrom, sync::Arc};
 
 use anyhow::{Context, Result};
 use matrix_sdk::{
@@ -17,8 +17,7 @@ use ruma::{
         },
         TimelineEventType,
     },
-    power_levels::NotificationPowerLevels,
-    EventId, Int, OwnedUserId, UserId,
+    EventId, Int, UserId,
 };
 use tokio::sync::RwLock;
 use tracing::error;

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1860,6 +1860,13 @@ impl Room {
             .power_levels())
     }
 
+    /// Get the default power levels for any room
+    ///
+    /// [spec] https://spec.matrix.org/v1.9/client-server-api/#mroompower_levels
+    pub fn default_power_levels() -> RoomPowerLevels {
+        RoomPowerLevels::from(RoomPowerLevelsEventContent::new())
+    }
+
     /// Gets the suggested role for the user with the provided `user_id`.
     ///
     /// This method checks the `RoomPowerLevels` events instead of loading the
@@ -2848,7 +2855,7 @@ mod tests {
     use crate::{
         config::RequestConfig,
         matrix_auth::{MatrixSession, MatrixSessionTokens},
-        Client,
+        Client, Room,
     };
 
     #[cfg(all(feature = "sqlite", feature = "e2e-encryption"))]
@@ -2995,5 +3002,20 @@ mod tests {
         assert_eq!(score.value(), -100);
         ReportedContentScore::try_from(int!(10)).unwrap_err();
         ReportedContentScore::try_from(int!(-110)).unwrap_err();
+    }
+
+    #[test]
+    fn default_power_levels() {
+        let default_power_levels = Room::default_power_levels();
+        assert_eq!(default_power_levels.ban, int!(50));
+        assert_eq!(default_power_levels.events_default, int!(0));
+        assert_eq!(default_power_levels.invite, int!(0));
+        assert_eq!(default_power_levels.kick, int!(50));
+        assert_eq!(default_power_levels.redact, int!(50));
+        assert_eq!(default_power_levels.state_default, int!(50));
+        assert_eq!(default_power_levels.users_default, int!(0));
+        assert!(default_power_levels.events.is_empty());
+        assert!(default_power_levels.notifications.is_default());
+        assert!(default_power_levels.users.is_empty());
     }
 }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1862,7 +1862,7 @@ impl Room {
 
     /// Get the default power levels for any room
     ///
-    /// [spec] https://spec.matrix.org/v1.9/client-server-api/#mroompower_levels
+    /// [spec]: https://spec.matrix.org/v1.9/client-server-api/#mroompower_levels
     pub fn default_power_levels() -> RoomPowerLevels {
         RoomPowerLevels::from(RoomPowerLevelsEventContent::new())
     }

--- a/testing/matrix-sdk-test/src/test_json/sync.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync.rs
@@ -1714,3 +1714,144 @@ pub static SYNC_ADMIN_AND_MOD: Lazy<JsonValue> = Lazy::new(|| {
         }
     })
 });
+
+pub static CUSTOM_ROOM_POWER_LEVELS: Lazy<JsonValue> = Lazy::new(|| {
+    json!({
+        "device_one_time_keys_count": {},
+        "next_batch": "s526_47314_0_7_1_1_1_11444_1",
+        "device_lists": {
+            "changed": [
+                "@admin:example.org"
+            ],
+            "left": []
+        },
+        "rooms": {
+            "invite": {},
+            "join": {
+                *DEFAULT_TEST_ROOM_ID: {
+                    "summary": {
+                        "m.heroes": [
+                          "@example2:localhost"
+                        ],
+                        "m.joined_member_count": 1,
+                        "m.invited_member_count": 0
+                      },
+                    "account_data": {
+                        "events": []
+                    },
+                    "ephemeral": {
+                        "events": []
+                    },
+                    "state": {
+                        "events": [
+                            {
+                                "content": {
+                                    "join_rule": "public"
+                                },
+                                "event_id": "$15139375514WsgmR:localhost",
+                                "origin_server_ts": 151393755000000_u64,
+                                "sender": "@admin:localhost",
+                                "state_key": "",
+                                "type": "m.room.join_rules",
+                                "unsigned": {
+                                    "age": 7034220
+                                }
+                            },
+                            {
+                                "content": {
+                                    "avatar_url": null,
+                                    "displayname": "admin",
+                                    "membership": "join"
+                                },
+                                "event_id": "$151800140517rfvjc:localhost",
+                                "membership": "join",
+                                "origin_server_ts": 151800140000000_u64,
+                                "sender": "@admin:localhost",
+                                "state_key": "@admin:localhost",
+                                "type": "m.room.member",
+                                "unsigned": {
+                                    "age": 297036,
+                                    "replaces_state": "$151800111315tsynI:localhost"
+                                }
+                            },
+                            {
+                                "content": {
+                                    "creator": "@example:localhost"
+                                },
+                                "event_id": "$15139375510KUZHi:localhost",
+                                "origin_server_ts": 151393755000000_u64,
+                                "sender": "@admin:localhost",
+                                "state_key": "",
+                                "type": "m.room.create",
+                                "unsigned": {
+                                    "age": 703422
+                                }
+                            },
+                            {
+                                "content": {
+                                    "ban": 100,
+                                    "events": {
+                                        "m.room.avatar": 100,
+                                        "m.room.canonical_alias": 50,
+                                        "m.room.history_visibility": 100,
+                                        "m.room.name": 50,
+                                        "m.room.power_levels": 100
+                                    },
+                                    "events_default": 0,
+                                    "invite": 0,
+                                    "kick": 50,
+                                    "redact": 50,
+                                    "state_default": 50,
+                                    "users": {
+                                        "@admin:localhost": 100
+                                    },
+                                    "users_default": 0
+                                },
+                                "event_id": "$15139375512JaHAW:localhost",
+                                "origin_server_ts": 151393755000000_u64,
+                                "sender": "@admin:localhost",
+                                "state_key": "",
+                                "type": "m.room.power_levels",
+                                "unsigned": {
+                                    "age": 703422
+                                }
+                            }
+                        ]
+                    },
+                    "timeline": {
+                        "events": [
+                            {
+                                "content": {
+                                    "body": "baba",
+                                    "format": "org.matrix.custom.html",
+                                    "formatted_body": "<strong>baba</strong>",
+                                    "msgtype": "m.text"
+                                },
+                                "event_id": "$152037280074GZeOm:localhost",
+                                "origin_server_ts": 152037280000000_u64,
+                                "sender": "@admin:localhost",
+                                "type": "m.room.message",
+                                "unsigned": {
+                                    "age": 598971425
+                                }
+                            }
+                        ],
+                        "limited": true,
+                        "prev_batch": "t392-516_47314_0_7_1_1_1_11444_1"
+                    },
+                    "unread_notifications": {
+                        "highlight_count": 0,
+                        "notification_count": 11
+                    }
+                }
+            },
+            "leave": {}
+        },
+        "to_device": {
+            "events": []
+        },
+        "presence": {
+            "events": []
+        }
+    })
+});


### PR DESCRIPTION
This will return the default power level for several actions based on the Matrix spec.

We can use this info to add a 'reset to defaults' option in the clients.

cc @pixlwave 

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
