### PR TITLE
Add optimization on StateStore to allow setting a custom value without read

### DIFF
--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -302,7 +302,8 @@ pub trait StateStore: AsyncTraitDeps {
     /// * `key` - The key to fetch data for
     async fn get_custom_value(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
-    /// Put arbitrary data into the custom store
+    /// Put arbitrary data into the custom store, return the data previously
+    /// stored
     ///
     /// # Arguments
     ///
@@ -314,6 +315,27 @@ pub trait StateStore: AsyncTraitDeps {
         key: &[u8],
         value: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Put arbitrary data into the custom store, do not attempt to read any
+    /// previous data
+    ///
+    /// Optimization option for set_custom_values for stores that would perform
+    /// better withouts the extra read and the caller not needing that data
+    /// returned. Otherwise this just wraps around `set_custom_data` and
+    /// discards the result.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to insert data into
+    ///
+    /// * `value` - The value to insert
+    async fn set_custom_value_no_read(
+        &self,
+        key: &[u8],
+        value: Vec<u8>,
+    ) -> Result<(), Self::Error> {
+        self.set_custom_value(key, value).await.map(|_| ())
+    }
 
     /// Remove arbitrary data from the custom store and return it if existed
     ///

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1517,6 +1517,13 @@ impl StateStore for SqliteStateStore {
         self.acquire().await?.get_kv_blob(self.encode_custom_key(key)).await
     }
 
+    async fn set_custom_value_no_read(&self, key: &[u8], value: Vec<u8>) -> Result<()> {
+        let conn = self.acquire().await?;
+        let key = self.encode_custom_key(key);
+        conn.set_kv_blob(key, value).await?;
+        Ok(())
+    }
+
     async fn set_custom_value(&self, key: &[u8], value: Vec<u8>) -> Result<Option<Vec<u8>>> {
         let conn = self.acquire().await?;
         let key = self.encode_custom_key(key);


### PR DESCRIPTION
A backwards compatible optimization addition to the `StateStore` allowing to set_custom_value without reading it first.

Background: we use the set_custom_value quite extensively to store our own code. At times this can be a bit larger and it adds quite a bit of delay into the processing to have a get and the corresponding mem-copies happen from the SQlite store all the way to the our App just to have it discarded at the end. 

Thus, this PR adds a `set_custom_value_no_read` which falls back to `set_custom_value` discarding the given value by default - and thus makes it backwards compatible - but allows the store implementation to provide a more efficient set-implementation if useful. This is implemented for the SQlite store implementation in this PR as well.


Signed-off-by: Benjamin Kampmann <ben@acter.global>
