### PR TITLE
sdk&ffi: server unstable features support for MSC4028

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -319,6 +319,16 @@ impl NotificationSettings {
         }
     }
 
+    /// Check whether [MSC 4028 push rule][rule] is enabled on the homeserver.
+    ///
+    /// [rule]: https://github.com/matrix-org/matrix-spec-proposals/blob/giomfo/push_encrypted_events/proposals/4028-push-all-encrypted-events-except-for-muted-rooms.md
+    pub async fn can_homeserver_push_encrypted_event_to_device(&self) -> bool {
+        match self.sdk_client.unstable_features().await {
+            Ok(unstable_feature) => *unstable_feature.get("org.matrix.msc4028").unwrap_or(&false),
+            Err(_) => false,
+        }
+    }
+
     /// Set whether user mentions are enabled.
     pub async fn set_user_mention_enabled(
         &self,

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -323,10 +323,7 @@ impl NotificationSettings {
     ///
     /// [rule]: https://github.com/matrix-org/matrix-spec-proposals/blob/giomfo/push_encrypted_events/proposals/4028-push-all-encrypted-events-except-for-muted-rooms.md
     pub async fn can_homeserver_push_encrypted_event_to_device(&self) -> bool {
-        match self.sdk_client.unstable_features().await {
-            Ok(unstable_feature) => unstable_feature.get("org.matrix.msc4028").copied().unwrap_or(false),
-            Err(_) => false,
-        }
+        self.sdk_client.can_homeserver_push_encrypted_event_to_device().await.unwrap()
     }
 
     /// Set whether user mentions are enabled.

--- a/bindings/matrix-sdk-ffi/src/notification_settings.rs
+++ b/bindings/matrix-sdk-ffi/src/notification_settings.rs
@@ -324,7 +324,7 @@ impl NotificationSettings {
     /// [rule]: https://github.com/matrix-org/matrix-spec-proposals/blob/giomfo/push_encrypted_events/proposals/4028-push-all-encrypted-events-except-for-muted-rooms.md
     pub async fn can_homeserver_push_encrypted_event_to_device(&self) -> bool {
         match self.sdk_client.unstable_features().await {
-            Ok(unstable_feature) => *unstable_feature.get("org.matrix.msc4028").unwrap_or(&false),
+            Ok(unstable_feature) => unstable_feature.get("org.matrix.msc4028").copied().unwrap_or(false),
             Err(_) => false,
         }
     }

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, fmt, sync::Arc};
+use std::{fmt, sync::Arc};
 
 use matrix_sdk_base::{store::StoreConfig, BaseClient};
 use ruma::{
@@ -90,7 +90,6 @@ pub struct ClientBuilder {
     request_config: RequestConfig,
     respect_login_well_known: bool,
     server_versions: Option<Box<[MatrixVersion]>>,
-    unstable_features: Option<BTreeMap<String, bool>>,
     handle_refresh_tokens: bool,
     base_client: Option<BaseClient>,
     #[cfg(feature = "e2e-encryption")]
@@ -108,7 +107,6 @@ impl ClientBuilder {
             request_config: Default::default(),
             respect_login_well_known: true,
             server_versions: None,
-            unstable_features: None,
             handle_refresh_tokens: false,
             base_client: None,
             #[cfg(feature = "e2e-encryption")]
@@ -510,7 +508,7 @@ impl ClientBuilder {
             http_client,
             base_client,
             self.server_versions,
-            self.unstable_features,
+            None,
             self.respect_login_well_known,
             event_cache,
             #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fmt, sync::Arc};
+use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use matrix_sdk_base::{store::StoreConfig, BaseClient};
 use ruma::{
@@ -90,6 +90,7 @@ pub struct ClientBuilder {
     request_config: RequestConfig,
     respect_login_well_known: bool,
     server_versions: Option<Box<[MatrixVersion]>>,
+    unstable_features: Option<BTreeMap<String, bool>>,
     handle_refresh_tokens: bool,
     base_client: Option<BaseClient>,
     #[cfg(feature = "e2e-encryption")]
@@ -107,6 +108,7 @@ impl ClientBuilder {
             request_config: Default::default(),
             respect_login_well_known: true,
             server_versions: None,
+            unstable_features: None,
             handle_refresh_tokens: false,
             base_client: None,
             #[cfg(feature = "e2e-encryption")]
@@ -508,6 +510,7 @@ impl ClientBuilder {
             http_client,
             base_client,
             self.server_versions,
+            self.unstable_features,
             self.respect_login_well_known,
             event_cache,
             #[cfg(feature = "e2e-encryption")]

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2374,6 +2374,6 @@ pub(crate) mod tests {
             .await;
 
         let msc4028_enabled = client.can_homeserver_push_encrypted_event_to_device().await.unwrap();
-        assert_eq!(msc4028_enabled, true);
+        assert!(msc4028_enabled);
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -235,6 +235,9 @@ pub(crate) struct ClientInner {
     /// The Matrix versions the server supports (well-known ones only)
     server_versions: OnceCell<Box<[MatrixVersion]>>,
 
+    /// The unstable features and their on/off state on the server
+    unstable_features: OnceCell<BTreeMap<String, bool>>,
+
     /// Collection of locks individual client methods might want to use, either
     /// to ensure that only a single call to a method happens at once or to
     /// deduplicate multiple calls to a method.
@@ -292,6 +295,7 @@ impl ClientInner {
         http_client: HttpClient,
         base_client: BaseClient,
         server_versions: Option<Box<[MatrixVersion]>>,
+        unstable_features: Option<BTreeMap<String, bool>>,
         respect_login_well_known: bool,
         event_cache: OnceCell<EventCache>,
         #[cfg(feature = "e2e-encryption")] encryption_settings: EncryptionSettings,
@@ -305,6 +309,7 @@ impl ClientInner {
             base_client,
             locks: Default::default(),
             server_versions: OnceCell::new_with(server_versions),
+            unstable_features: OnceCell::new_with(unstable_features),
             typing_notice_times: Default::default(),
             event_handlers: Default::default(),
             notification_handlers: Default::default(),
@@ -1401,6 +1406,49 @@ impl Client {
         Ok(server_versions)
     }
 
+    /// Fetch unstable_features from homeserver
+    async fn request_unstable_features(&self) -> HttpResult<BTreeMap<String, bool>> {
+        let unstable_features: BTreeMap<String, bool> = self
+            .inner
+            .http_client
+            .send(
+                get_supported_versions::Request::new(),
+                None,
+                self.homeserver().to_string(),
+                None,
+                &[MatrixVersion::V1_0],
+                Default::default(),
+            )
+            .await?
+            .unstable_features;
+
+        Ok(unstable_features)
+    }
+
+    /// Get unstable features from `request_unstable_features` or cache
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use matrix_sdk::{Client, config::SyncSettings};
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://localhost:8080")?;
+    /// # let mut client = Client::new(homeserver).await?;
+    /// let unstable_features = client.unstable_features().await.unwrap();
+    /// let msc_x = unstable_features.get("msc_x").unwrap_or(&false);
+    /// # anyhow::Ok(()) };
+    /// ```
+    pub async fn unstable_features(&self) -> HttpResult<&BTreeMap<String, bool>> {
+        let unstable_features = self
+            .inner
+            .unstable_features
+            .get_or_try_init(|| self.request_unstable_features())
+            .await?;
+
+        Ok(unstable_features)
+    }
+
     /// Get information of all our own devices.
     ///
     /// # Examples
@@ -2006,6 +2054,7 @@ impl Client {
                 self.inner.http_client.clone(),
                 self.inner.base_client.clone_with_in_memory_state_store(),
                 self.inner.server_versions.get().cloned(),
+                self.inner.unstable_features.get().cloned(),
                 self.inner.respect_login_well_known,
                 self.inner.event_cache.clone(),
                 #[cfg(feature = "e2e-encryption")]
@@ -2268,5 +2317,23 @@ pub(crate) mod tests {
         assert_eq!(result.display_name.clone().unwrap(), "Test");
         assert_eq!(result.avatar_url.clone().unwrap().to_string(), "mxc://example.me/someid");
         assert!(!response.limited);
+    }
+
+    #[async_test]
+    async fn test_homeserver_server_versions() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("GET"))
+            .and(path("_matrix/client/versions"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(&*test_json::api_responses::VERSIONS),
+            )
+            .mount(&server)
+            .await;
+        let unstable_features = client.request_unstable_features().await.unwrap();
+
+        assert_eq!(unstable_features.get("org.matrix.e2e_cross_signing"), Some(&true));
+        assert_eq!(unstable_features, client.unstable_features().await.unwrap().clone())
     }
 }

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1435,7 +1435,7 @@ impl Client {
     /// # async {
     /// # let homeserver = Url::parse("http://localhost:8080")?;
     /// # let mut client = Client::new(homeserver).await?;
-    /// let unstable_features = client.unstable_features().await.unwrap();
+    /// let unstable_features = client.unstable_features().await?;
     /// let msc_x = unstable_features.get("msc_x").unwrap_or(&false);
     /// # anyhow::Ok(()) };
     /// ```
@@ -1460,16 +1460,11 @@ impl Client {
     /// # let homeserver = Url::parse("http://localhost:8080")?;
     /// # let mut client = Client::new(homeserver).await?;
     /// let msc4028_enabled =
-    ///     client.can_homeserver_push_encrypted_event_to_device().await.unwrap();
+    ///     client.can_homeserver_push_encrypted_event_to_device().await?;
     /// # anyhow::Ok(()) };
     /// ```
     pub async fn can_homeserver_push_encrypted_event_to_device(&self) -> HttpResult<bool> {
-        match self.unstable_features().await {
-            Ok(unstable_feature) => {
-                Ok(unstable_feature.get("org.matrix.msc4028").copied().unwrap_or(false))
-            }
-            Err(_) => Ok(false),
-        }
+        Ok(self.unstable_features().await?.get("org.matrix.msc4028").copied().unwrap_or(false))
     }
 
     /// Get information of all our own devices.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1449,7 +1449,7 @@ impl Client {
         Ok(unstable_features)
     }
 
-    /// Check whether [MSC 4028 push rule][rule] is enabled on the homeserver.
+    /// Check whether MSC 4028 is enabled on the homeserver.
     ///
     /// # Examples
     ///

--- a/testing/matrix-sdk-test/src/test_json/api_responses.rs
+++ b/testing/matrix-sdk-test/src/test_json/api_responses.rs
@@ -324,7 +324,8 @@ pub static VERSIONS: Lazy<JsonValue> = Lazy::new(|| {
         ],
         "unstable_features": {
             "org.matrix.label_based_filtering":true,
-            "org.matrix.e2e_cross_signing":true
+            "org.matrix.e2e_cross_signing":true,
+            "org.matrix.msc4028":true
         }
     })
 });


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3191

Allows support for fetching the unstable_features from `/_matrix/clients/versions`.
Specifically, to be used for checking the state of org.matrix.msc4028 through ffi to the clients.

P.S. ^ I can split them into two PRs if necessary.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: @hanadi92 
