### PR TITLE
event cache: add support for running back-pagination

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -168,11 +168,10 @@ impl Room {
             .add_initial_events(
                 self.inner.room.room_id(),
                 self.inner.sliding_sync_room.timeline_queue().iter().cloned().collect(),
+                self.inner.sliding_sync_room.prev_batch(),
             )
             .await?;
 
-        Ok(Timeline::builder(&self.inner.room)
-            .with_pagination_token(self.inner.sliding_sync_room.prev_batch())
-            .track_read_marker_and_receipts())
+        Ok(Timeline::builder(&self.inner.room).track_read_marker_and_receipts())
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/tests/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/pagination.rs
@@ -22,7 +22,7 @@ use super::TestTimeline;
 use crate::timeline::{inner::HandleBackPaginatedEventsError, pagination::PaginationTokens};
 
 #[async_test]
-async fn back_pagination_token_not_updated_with_empty_chunk() {
+async fn test_back_pagination_token_not_updated_with_empty_chunk() {
     let timeline = TestTimeline::new();
 
     timeline
@@ -65,7 +65,7 @@ async fn back_pagination_token_not_updated_with_empty_chunk() {
 }
 
 #[async_test]
-async fn back_pagination_token_not_updated_invalid_event() {
+async fn test_back_pagination_token_not_updated_invalid_event() {
     let timeline = TestTimeline::new();
 
     // Invalid empty event.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -258,14 +258,14 @@ async fn timeline_test_helper(
     // TODO: when the event cache handles its own cache, we can remove this.
     client
         .event_cache()
-        .add_initial_events(room_id, sliding_sync_room.timeline_queue().iter().cloned().collect())
+        .add_initial_events(
+            room_id,
+            sliding_sync_room.timeline_queue().iter().cloned().collect(),
+            sliding_sync_room.prev_batch(),
+        )
         .await?;
 
-    let timeline = Timeline::builder(&sdk_room)
-        .with_pagination_token(sliding_sync_room.prev_batch())
-        .track_read_marker_and_receipts()
-        .build()
-        .await?;
+    let timeline = Timeline::builder(&sdk_room).track_read_marker_and_receipts().build().await?;
 
     Ok(timeline.subscribe().await)
 }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -762,9 +762,10 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use assert_matches2::assert_matches;
+    use matrix_sdk_common::executor::spawn;
     use matrix_sdk_test::{async_test, sync_timeline_event};
     use ruma::room_id;
-    use tokio::{spawn, time::sleep};
+    use tokio::time::sleep;
 
     use super::{store::TimelineEntry, EventCacheError};
     use crate::{event_cache::store::PaginationToken, test_utils::logged_in_client};

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -969,8 +969,8 @@ mod tests {
 
         // then I do get one eventually.
         assert_eq!(found.as_ref(), Some(&expected_token));
-        // and I have waited between ~400 and ~600 milliseconds.
-        assert!(waited.as_millis() < 650);
+        // and I have waited between ~400 and ~1000 milliseconds.
+        assert!(waited.as_secs() < 1);
         assert!(waited.as_millis() >= 400);
 
         // The task succeeded.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -44,26 +44,33 @@ use std::{
     collections::BTreeMap,
     fmt::Debug,
     sync::{Arc, OnceLock, Weak},
+    time::Duration,
 };
 
 use matrix_sdk_base::{
-    deserialized_responses::{AmbiguityChange, SyncTimelineEvent},
+    deserialized_responses::{AmbiguityChange, SyncTimelineEvent, TimelineEvent},
     sync::{JoinedRoomUpdate, LeftRoomUpdate, RoomUpdates, Timeline},
 };
 use matrix_sdk_common::executor::{spawn, JoinHandle};
 use ruma::{
+    assign,
     events::{AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent},
     serde::Raw,
     OwnedEventId, OwnedRoomId, RoomId,
 };
-use tokio::sync::{
-    broadcast::{error::RecvError, Receiver, Sender},
-    Mutex, RwLock,
+use tokio::{
+    sync::{
+        broadcast::{error::RecvError, Receiver, Sender},
+        Mutex, Notify, RwLock,
+    },
+    time::timeout,
 };
 use tracing::{error, instrument, trace, warn};
 
-use self::store::{EventCacheStore, MemoryStore};
-use crate::{client::ClientInner, Client, Room};
+use self::store::{EventCacheStore, MemoryStore, TimelineEntry};
+use crate::{
+    client::ClientInner, event_cache::store::PaginationToken, room::MessagesOptions, Client, Room,
+};
 
 mod store;
 
@@ -77,11 +84,27 @@ pub enum EventCacheError {
     )]
     NotSubscribedYet,
 
+    /// The room hasn't been found in the client.
+    ///
+    /// Technically, it's possible to request a `RoomEventCache` for a room that
+    /// is not known to the client, leading to this error.
+    #[error("Room {0} hasn't been found in the Client.")]
+    RoomNotFound(OwnedRoomId),
+
+    /// The given back-pagination token is unknown to the event cache.
+    #[error("The given back-pagination token is unknown to the event cache.")]
+    UnknownBackpaginationToken,
+
     /// The [`EventCache`] owns a weak reference to the [`Client`] it pertains
     /// to. It's possible this weak reference points to nothing anymore, at
     /// times where we try to use the client.
     #[error("The owning client of the event cache has been dropped.")]
     ClientDropped,
+
+    /// Another error caused by the SDK happened somewhere, and we report it to
+    /// the caller.
+    #[error("SDK error: {0}")]
+    SdkError(#[source] crate::Error),
 }
 
 /// A result using the [`EventCacheError`].
@@ -183,7 +206,7 @@ impl EventCache {
                     let store = inner.store.lock().await;
                     let mut by_room = inner.by_room.write().await;
                     for room_id in by_room.keys() {
-                        if let Err(err) = store.clear_room_events(room_id).await {
+                        if let Err(err) = store.clear_room(room_id).await {
                             error!("unable to clear room after room updates lag: {err}");
                         }
                     }
@@ -221,6 +244,7 @@ impl EventCache {
         &self,
         room_id: &RoomId,
         events: Vec<SyncTimelineEvent>,
+        prev_batch: Option<String>,
     ) -> Result<()> {
         let Some(room_cache) = self.inner.for_room(room_id).await? else {
             warn!("unknown room, skipping");
@@ -232,10 +256,20 @@ impl EventCache {
         // them.
         let store = self.inner.store.lock().await;
 
-        store.clear_room_events(room_id).await?;
+        store.clear_room(room_id).await?;
         let _ = room_cache.inner.sender.send(RoomEventCacheUpdate::Clear);
 
-        room_cache.inner.append_events(&**store, events).await?;
+        room_cache
+            .inner
+            .append_events(
+                &**store,
+                events,
+                prev_batch,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
+            .await?;
 
         Ok(())
     }
@@ -376,6 +410,34 @@ impl RoomEventCache {
 
         Ok((store.room_events(self.inner.room.room_id()).await?, self.inner.sender.subscribe()))
     }
+
+    /// Returns the earliest back-pagination token, that is, the one closest to
+    /// the beginning of the timeline as we know it.
+    ///
+    /// Optionally, wait at most for the given duration for a back-pagination
+    /// token to be returned by a sync.
+    pub async fn earliest_backpagination_token(
+        &self,
+        max_wait: Option<Duration>,
+    ) -> Result<Option<PaginationToken>> {
+        self.inner.earliest_backpagination_token(max_wait).await
+    }
+
+    /// Back-paginate with the given token, if provided.
+    ///
+    /// If no token has been provided, it will back-paginate from the end of the
+    /// room.
+    ///
+    /// If a token has been provided, but it was unknown to the event cache
+    /// (i.e. it's not associated to any gap in the timeline stored by the
+    /// event cache), then an error result will be returned.
+    pub async fn backpaginate_with_token(
+        &self,
+        batch_size: u16,
+        token: Option<PaginationToken>,
+    ) -> Result<BackPaginationOutcome> {
+        self.inner.backpaginate_with_token(batch_size, token).await
+    }
 }
 
 /// The (non-clonable) details of the `RoomEventCache`.
@@ -388,8 +450,15 @@ struct RoomEventCacheInner {
     /// See comment there.
     store: Arc<Mutex<Arc<dyn EventCacheStore>>>,
 
+    /// A notifier that we received a new pagination token.
+    pagination_token_notifier: Notify,
+
     /// The Client [`Room`] this event cache pertains to.
     room: Room,
+
+    /// A lock that ensures we don't run multiple pagination queries at the same
+    /// time.
+    pagination_lock: Mutex<()>,
 }
 
 impl RoomEventCacheInner {
@@ -397,7 +466,13 @@ impl RoomEventCacheInner {
     /// to handle new timeline events.
     fn new(room: Room, store: Arc<Mutex<Arc<dyn EventCacheStore>>>) -> Self {
         let sender = Sender::new(32);
-        Self { room, store, sender }
+        Self {
+            room,
+            store,
+            sender,
+            pagination_lock: Default::default(),
+            pagination_token_notifier: Default::default(),
+        }
     }
 
     async fn handle_joined_room_update(
@@ -429,29 +504,25 @@ impl RoomEventCacheInner {
             // timeline, but we're not there yet. In the meanwhile, clear the
             // items from the room. TODO: implement Smart Matching™.
             trace!("limited timeline, clearing all previous events");
-            store.clear_room_events(self.room.room_id()).await?;
+
+            // Clear internal state (events, pagination tokens, etc.).
+            store.clear_room(self.room.room_id()).await?;
+
+            // Propagate to observers.
             let _ = self.sender.send(RoomEventCacheUpdate::Clear);
         }
 
         // Add all the events to the backend.
-        if !timeline.events.is_empty()
-            || timeline.prev_batch.is_some()
-            || !ephemeral.is_empty()
-            || !account_data.is_empty()
-            || !ambiguity_changes.is_empty()
-        {
-            trace!("adding new events");
-            store.add_room_events(self.room.room_id(), timeline.events.clone()).await?;
-
-            // Propagate events to observers.
-            let _ = self.sender.send(RoomEventCacheUpdate::Append {
-                events: timeline.events,
-                prev_batch: timeline.prev_batch,
-                ephemeral,
-                account_data,
-                ambiguity_changes,
-            });
-        }
+        trace!("adding new events");
+        self.append_events(
+            store,
+            timeline.events,
+            timeline.prev_batch,
+            account_data,
+            ephemeral,
+            ambiguity_changes,
+        )
+        .await?;
 
         Ok(())
     }
@@ -478,23 +549,186 @@ impl RoomEventCacheInner {
         &self,
         store: &dyn EventCacheStore,
         events: Vec<SyncTimelineEvent>,
+        prev_batch: Option<String>,
+        account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
+        ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
     ) -> Result<()> {
-        if events.is_empty() {
+        if events.is_empty()
+            && prev_batch.is_none()
+            && ephemeral.is_empty()
+            && account_data.is_empty()
+            && ambiguity_changes.is_empty()
+        {
             return Ok(());
         }
 
-        store.add_room_events(self.room.room_id(), events.clone()).await?;
+        let room_id = self.room.room_id();
+
+        // Add the previous back-pagination token (if present), followed by the timeline
+        // events themselves.
+        let gap_with_token = prev_batch
+            .clone()
+            .map(|val| TimelineEntry::Gap { prev_token: PaginationToken(val) })
+            .into_iter();
+
+        store
+            .append_room_entries(
+                room_id,
+                gap_with_token.chain(events.iter().cloned().map(TimelineEntry::Event)).collect(),
+            )
+            .await?;
+
+        if prev_batch.is_some() {
+            self.pagination_token_notifier.notify_one();
+        }
 
         let _ = self.sender.send(RoomEventCacheUpdate::Append {
             events,
-            prev_batch: None,
-            account_data: Default::default(),
-            ephemeral: Default::default(),
-            ambiguity_changes: Default::default(),
+            prev_batch,
+            account_data,
+            ephemeral,
+            ambiguity_changes,
         });
 
         Ok(())
     }
+
+    /// Run a single back-pagination `/messages` request.
+    ///
+    /// This will only run one request; since a backpagination may need to
+    /// continue, it's preferable to use [`Self::backpaginate_until`].
+    ///
+    /// Returns the number of messages received in this chunk.
+    #[instrument(skip(self))]
+    async fn backpaginate_with_token(
+        &self,
+        batch_size: u16,
+        token: Option<PaginationToken>,
+    ) -> Result<BackPaginationOutcome> {
+        // Make sure there's at most one back-pagination request.
+        let _guard = self.pagination_lock.lock().await;
+
+        if let Some(token) = token.as_ref() {
+            let store = self.store.lock().await;
+            if !store.contains_gap(self.room.room_id(), token).await? {
+                return Err(EventCacheError::UnknownBackpaginationToken);
+            }
+        }
+
+        let messages = self
+            .room
+            .messages(assign!(MessagesOptions::backward(), {
+                from: token.as_ref().map(|token| token.0.clone()),
+                limit: batch_size.into()
+            }))
+            .await
+            .map_err(EventCacheError::SdkError)?;
+
+        // Would we want to backpaginate again, we'd start from the `end` token as the
+        // next `from` token.
+
+        let prev_token = messages.end;
+
+        // If this token is missing, then we've reached the end of the timeline.
+        let reached_start = prev_token.is_none();
+
+        // Note: The chunk could be empty.
+        //
+        // If there's any event, they are presented in reverse order (i.e. the first one
+        // should be prepended first).
+        let events = messages.chunk;
+
+        // Prepend the previous token (if any) at the beginning of the timeline,
+        // followed by the events received in the response (in reverse order).
+        let new_gap = prev_token
+            .map(|token| TimelineEntry::Gap { prev_token: PaginationToken(token) })
+            .into_iter();
+
+        // For storage, reverse events to store them in the normal (non-reversed order).
+        //
+        // It's fine to convert from `TimelineEvent` (i.e. that has a room id) to
+        // `SyncTimelineEvent` (i.e. that doesn't have it), because those events are
+        // always tied to a room in storage anyways.
+        let new_events = events.iter().rev().map(|ev| TimelineEntry::Event(ev.clone().into()));
+
+        let replaced = self
+            .store
+            .lock()
+            .await
+            .replace_gap(self.room.room_id(), token.as_ref(), new_gap.chain(new_events).collect())
+            .await?;
+
+        if !replaced {
+            // The previous token disappeared!
+            // This can happen if we got a limited timeline and lost track of our pagination
+            // token, because the whole timeline has been reset.
+            //
+            // TODO: With smarter reconciliation, this might get away. In the meanwhile,
+            // early return and forget about all the events.
+            trace!("gap was missing, likely because we observed a gappy sync response");
+            Ok(BackPaginationOutcome::UnknownBackpaginationToken)
+        } else {
+            trace!("replaced gap with new events from backpagination");
+
+            // TODO: implement smarter reconciliation later
+            //let _ = self.sender.send(RoomEventCacheUpdate::Prepend { events });
+
+            Ok(BackPaginationOutcome::Success { events, reached_start })
+        }
+    }
+
+    /// Returns the earliest back-pagination token, that is, the one closest to
+    /// the beginning of the timeline as we know it.
+    ///
+    /// Optionally, wait at most for the given duration for a back-pagination
+    /// token to be returned by a sync.
+    async fn earliest_backpagination_token(
+        &self,
+        max_wait: Option<Duration>,
+    ) -> Result<Option<PaginationToken>> {
+        // Optimistically try to return the backpagination token immediately.
+        if let Some(token) =
+            self.store.lock().await.earliest_backpagination_token(self.room.room_id()).await?
+        {
+            return Ok(Some(token));
+        }
+
+        let Some(max_wait) = max_wait else {
+            // We had no token and no time to wait, so... no tokens.
+            return Ok(None);
+        };
+
+        // Otherwise wait for a notification that we received a token.
+        // Timeouts are fine, per this function's contract.
+        let _ = timeout(max_wait, self.pagination_token_notifier.notified()).await;
+
+        self.store.lock().await.earliest_backpagination_token(self.room.room_id()).await
+    }
+}
+
+/// The result of a single back-pagination request.
+#[derive(Debug)]
+pub enum BackPaginationOutcome {
+    /// The back-pagination succeeded, and new events have been found.
+    Success {
+        /// Did the back-pagination reach the start of the timeline?
+        reached_start: bool,
+
+        /// All the events that have been returned in the back-pagination
+        /// request.
+        ///
+        /// Events are presented in reverse order: event[0], if present, is the
+        /// most "recent" event from the chunk (or technically, the last one in
+        /// the topological ordering).
+        ///
+        /// Note: they're not deduplicated (TODO: smart reconciliation).
+        events: Vec<TimelineEvent>,
+    },
+
+    /// The back-pagination token was unknown to the event cache, and the caller
+    /// must retry after obtaining a new back-pagination token.
+    UnknownBackpaginationToken,
 }
 
 /// An update related to events happened in a room.
@@ -502,12 +736,12 @@ impl RoomEventCacheInner {
 pub enum RoomEventCacheUpdate {
     /// The room has been cleared from events.
     Clear,
+
     /// The room has new events.
     Append {
-        /// All the new events that have been added to the room.
+        /// All the new events that have been added to the room's timeline.
         events: Vec<SyncTimelineEvent>,
-        /// XXX: this is temporary, until backpagination lives in the event
-        /// cache.
+        /// XXX: this is temporary, until prev_batch lives in the event cache
         prev_batch: Option<String>,
         /// XXX: this is temporary, until account data lives in the event cache
         /// — or will it live there?
@@ -521,4 +755,244 @@ pub enum RoomEventCacheUpdate {
         /// details of the ambiguity change.
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use assert_matches2::assert_matches;
+    use matrix_sdk_test::{async_test, sync_timeline_event};
+    use ruma::room_id;
+    use tokio::{spawn, time::sleep};
+
+    use super::{store::TimelineEntry, EventCacheError};
+    use crate::{event_cache::store::PaginationToken, test_utils::logged_in_client};
+
+    #[async_test]
+    async fn test_must_explicitly_subscribe() {
+        let client = logged_in_client(None).await;
+
+        let event_cache = client.event_cache();
+
+        // If I create a room event subscriber for a room before subscribing the event
+        // cache,
+        let room_id = room_id!("!omelette:fromage.fr");
+        let result = event_cache.for_room(room_id).await;
+
+        // Then it fails, because one must explicitly call `.subscribe()` on the event
+        // cache.
+        assert_matches!(result, Err(EventCacheError::NotSubscribedYet));
+    }
+
+    #[async_test]
+    async fn test_wait_no_pagination_token() {
+        let client = logged_in_client(None).await;
+        let room_id = room_id!("!galette:saucisse.bzh");
+        client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
+
+        client.event_cache().subscribe().unwrap();
+
+        // When I only have events in a room,
+        client
+            .event_cache()
+            .inner
+            .store
+            .lock()
+            .await
+            .append_room_entries(
+                room_id,
+                vec![TimelineEntry::Event(
+                    sync_timeline_event!({
+                        "sender": "b@z.h",
+                        "type": "m.room.message",
+                        "event_id": "$ida",
+                        "origin_server_ts": 12344446,
+                        "content": { "body":"yolo", "msgtype": "m.text" },
+                    })
+                    .into(),
+                )],
+            )
+            .await
+            .unwrap();
+
+        let (room_event_cache, _drop_handlers) =
+            client.event_cache().for_room(room_id).await.unwrap();
+        let room_event_cache = room_event_cache.unwrap();
+
+        // If I don't wait for the backpagination token,
+        let found = room_event_cache.earliest_backpagination_token(None).await.unwrap();
+        // Then I don't find it.
+        assert!(found.is_none());
+
+        // If I wait for a back-pagination token for 0 seconds,
+        let before = Instant::now();
+        let found = room_event_cache
+            .earliest_backpagination_token(Some(Duration::default()))
+            .await
+            .unwrap();
+        let waited = before.elapsed();
+        // then I don't get any,
+        assert!(found.is_none());
+        // and I haven't waited long.
+        assert!(waited.as_secs() < 1);
+
+        // If I wait for a back-pagination token for 1 second,
+        let before = Instant::now();
+        let found = room_event_cache
+            .earliest_backpagination_token(Some(Duration::from_secs(1)))
+            .await
+            .unwrap();
+        let waited = before.elapsed();
+        // then I still don't get any.
+        assert!(found.is_none());
+        // and I've waited a bit.
+        assert!(waited.as_secs() < 2);
+        assert!(waited.as_secs() >= 1);
+    }
+
+    #[async_test]
+    async fn test_wait_for_pagination_token_already_present() {
+        let client = logged_in_client(None).await;
+        let room_id = room_id!("!galette:saucisse.bzh");
+        client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
+
+        client.event_cache().subscribe().unwrap();
+
+        let (room_event_cache, _drop_handles) =
+            client.event_cache().for_room(room_id).await.unwrap();
+        let room_event_cache = room_event_cache.unwrap();
+
+        let expected_token = PaginationToken("old".to_owned());
+
+        // When I have events and multiple gaps, in a room,
+        client
+            .event_cache()
+            .inner
+            .store
+            .lock()
+            .await
+            .append_room_entries(
+                room_id,
+                vec![
+                    TimelineEntry::Gap { prev_token: expected_token.clone() },
+                    TimelineEntry::Event(
+                        sync_timeline_event!({
+                            "sender": "b@z.h",
+                            "type": "m.room.message",
+                            "event_id": "$ida",
+                            "origin_server_ts": 12344446,
+                            "content": { "body":"yolo", "msgtype": "m.text" },
+                        })
+                        .into(),
+                    ),
+                ],
+            )
+            .await
+            .unwrap();
+
+        // If I don't wait for a back-pagination token,
+        let found = room_event_cache.earliest_backpagination_token(None).await.unwrap();
+        // Then I get it.
+        assert_eq!(found.as_ref(), Some(&expected_token));
+
+        // If I wait for a back-pagination token for 0 seconds,
+        let before = Instant::now();
+        let found = room_event_cache
+            .earliest_backpagination_token(Some(Duration::default()))
+            .await
+            .unwrap();
+        let waited = before.elapsed();
+        // then I do get one.
+        assert_eq!(found.as_ref(), Some(&expected_token));
+        // and I haven't waited long.
+        assert!(waited.as_millis() < 100);
+
+        // If I wait for a back-pagination token for 1 second,
+        let before = Instant::now();
+        let found = room_event_cache
+            .earliest_backpagination_token(Some(Duration::from_secs(1)))
+            .await
+            .unwrap();
+        let waited = before.elapsed();
+        // then I do get one.
+        assert_eq!(found.as_ref(), Some(&expected_token));
+        // and I haven't waited long.
+        assert!(waited.as_millis() < 100);
+    }
+
+    #[async_test]
+    async fn test_wait_for_late_pagination_token() {
+        let client = logged_in_client(None).await;
+        let room_id = room_id!("!galette:saucisse.bzh");
+        client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
+
+        client.event_cache().subscribe().unwrap();
+
+        let (room_event_cache, _drop_handles) =
+            client.event_cache().for_room(room_id).await.unwrap();
+        let room_event_cache = room_event_cache.unwrap();
+
+        let expected_token = PaginationToken("old".to_owned());
+
+        let before = Instant::now();
+        let cloned_expected_token = expected_token.clone();
+        let insert_token_task = spawn(async move {
+            // If a backpagination token is inserted after 400 milliseconds,
+            sleep(Duration::from_millis(400)).await;
+
+            client
+                .event_cache()
+                .inner
+                .store
+                .lock()
+                .await
+                .append_room_entries(
+                    room_id,
+                    vec![TimelineEntry::Gap { prev_token: cloned_expected_token }],
+                )
+                .await
+                .unwrap();
+        });
+
+        // Then first I don't get it (if I'm not waiting,)
+        let found = room_event_cache.earliest_backpagination_token(None).await.unwrap();
+        assert!(found.is_none());
+
+        // And if I wait for the back-pagination token for 600ms,
+        let found = room_event_cache
+            .earliest_backpagination_token(Some(Duration::from_millis(600)))
+            .await
+            .unwrap();
+        let waited = before.elapsed();
+
+        // then I do get one eventually.
+        assert_eq!(found.as_ref(), Some(&expected_token));
+        // and I have waited between ~400 and ~600 milliseconds.
+        assert!(waited.as_millis() < 650);
+        assert!(waited.as_millis() >= 400);
+
+        // The task succeeded.
+        insert_token_task.await.unwrap();
+    }
+
+    #[async_test]
+    async fn test_unknown_pagination_token() {
+        let client = logged_in_client(None).await;
+        let room_id = room_id!("!galette:saucisse.bzh");
+        client.base_client().get_or_create_room(room_id, matrix_sdk_base::RoomState::Joined);
+
+        client.event_cache().subscribe().unwrap();
+
+        let (room_event_cache, _drop_handles) =
+            client.event_cache().for_room(room_id).await.unwrap();
+        let room_event_cache = room_event_cache.unwrap();
+
+        // If I try to back-paginate with an unknown back-pagination token,
+        let token = PaginationToken("old".to_owned());
+
+        // Then I run into an error.
+        let res = room_event_cache.backpaginate_with_token(20, Some(token)).await;
+        assert_matches!(res.unwrap_err(), EventCacheError::UnknownBackpaginationToken);
+    }
 }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -718,9 +718,9 @@ pub enum BackPaginationOutcome {
         /// All the events that have been returned in the back-pagination
         /// request.
         ///
-        /// Events are presented in reverse order: event[0], if present, is the
-        /// most "recent" event from the chunk (or technically, the last one in
-        /// the topological ordering).
+        /// Events are presented in reverse order: the first element of the vec,
+        /// if present, is the most "recent" event from the chunk (or
+        /// technically, the last one in the topological ordering).
         ///
         /// Note: they're not deduplicated (TODO: smart reconciliation).
         events: Vec<TimelineEvent>,

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
-use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
+use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 use ruma::{OwnedRoomId, RoomId};
 use tokio::sync::RwLock;
 
@@ -31,40 +31,173 @@ pub trait EventCacheStore: Send + Sync {
     /// Returns all the known events for the given room.
     async fn room_events(&self, room: &RoomId) -> Result<Vec<SyncTimelineEvent>>;
 
-    /// Adds all the events to the given room.
-    async fn add_room_events(&self, room: &RoomId, events: Vec<SyncTimelineEvent>) -> Result<()>;
+    /// Adds all the entries to the given room's timeline.
+    async fn append_room_entries(&self, room: &RoomId, entries: Vec<TimelineEntry>) -> Result<()>;
 
-    /// Clear all the events from the given room.
-    async fn clear_room_events(&self, room: &RoomId) -> Result<()>;
+    /// Returns whether the store knows about the given pagination token.
+    async fn contains_gap(&self, room: &RoomId, pagination_token: &PaginationToken)
+        -> Result<bool>;
+
+    /// Replaces a given gap (identified by its pagination token) with the given
+    /// entries.
+    ///
+    /// Note: if the gap hasn't been found, then nothing happens, and the events
+    /// are lost.
+    ///
+    /// Returns whether the gap was found.
+    async fn replace_gap(
+        &self,
+        room: &RoomId,
+        gap_id: Option<&PaginationToken>,
+        entries: Vec<TimelineEntry>,
+    ) -> Result<bool>;
+
+    /// Retrieve the earliest (oldest backpagination token for the given room.)
+    async fn earliest_backpagination_token(&self, room: &RoomId)
+        -> Result<Option<PaginationToken>>;
+
+    /// Clear all the information tied to a given room.
+    ///
+    /// This forgets the following:
+    /// - events in the room
+    /// - pagination tokens
+    async fn clear_room(&self, room: &RoomId) -> Result<()>;
+}
+
+/// A newtype wrapper for a pagination token returned by a /messages response.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PaginationToken(pub String);
+
+#[derive(Clone)]
+pub enum TimelineEntry {
+    Event(SyncTimelineEvent),
+
+    Gap {
+        /// The token to use in the query, extracted from a previous "from" /
+        /// "end" field of a `/messages` response.
+        prev_token: PaginationToken,
+    },
+}
+
+/// All the information related to a room and stored in the event cache.
+#[derive(Default)]
+struct RoomInfo {
+    /// All the timeline entries per room, in sync order.
+    entries: Vec<TimelineEntry>,
+}
+
+impl RoomInfo {
+    fn clear(&mut self) {
+        self.entries.clear();
+    }
 }
 
 /// An [`EventCacheStore`] implementation that keeps all the information in
 /// memory.
+#[derive(Default)]
 pub(crate) struct MemoryStore {
-    /// All the events per room, in sync order.
-    by_room: RwLock<BTreeMap<OwnedRoomId, Vec<SyncTimelineEvent>>>,
+    by_room: RwLock<BTreeMap<OwnedRoomId, RoomInfo>>,
 }
 
 impl MemoryStore {
     /// Create a new empty [`MemoryStore`].
     pub fn new() -> Self {
-        Self { by_room: Default::default() }
+        Default::default()
     }
 }
 
 #[async_trait]
 impl EventCacheStore for MemoryStore {
     async fn room_events(&self, room: &RoomId) -> Result<Vec<SyncTimelineEvent>> {
-        Ok(self.by_room.read().await.get(room).cloned().unwrap_or_default())
+        Ok(self
+            .by_room
+            .read()
+            .await
+            .get(room)
+            .map(|room_info| {
+                room_info
+                    .entries
+                    .iter()
+                    .filter_map(
+                        |entry| if let TimelineEntry::Event(ev) = entry { Some(ev) } else { None },
+                    )
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default())
     }
 
-    async fn add_room_events(&self, room: &RoomId, events: Vec<SyncTimelineEvent>) -> Result<()> {
-        self.by_room.write().await.entry(room.to_owned()).or_default().extend(events);
+    async fn append_room_entries(&self, room: &RoomId, entries: Vec<TimelineEntry>) -> Result<()> {
+        self.by_room.write().await.entry(room.to_owned()).or_default().entries.extend(entries);
         Ok(())
     }
 
-    async fn clear_room_events(&self, room: &RoomId) -> Result<()> {
-        let _ = self.by_room.write().await.remove(room);
+    async fn clear_room(&self, room: &RoomId) -> Result<()> {
+        // Clear the room, so as to avoid reallocations if the room is being reused.
+        // XXX: do we also want an actual way to *remove* a room? (for left rooms)
+        if let Some(room) = self.by_room.write().await.get_mut(room) {
+            room.clear();
+        }
         Ok(())
+    }
+
+    async fn earliest_backpagination_token(
+        &self,
+        room: &RoomId,
+    ) -> Result<Option<PaginationToken>> {
+        Ok(self.by_room.read().await.get(room).and_then(|room| {
+            room.entries.iter().find_map(|entry| {
+                if let TimelineEntry::Gap { prev_token: backpagination_token } = entry {
+                    Some(backpagination_token.clone())
+                } else {
+                    None
+                }
+            })
+        }))
+    }
+
+    async fn contains_gap(&self, room: &RoomId, needle: &PaginationToken) -> Result<bool> {
+        let mut by_room_guard = self.by_room.write().await;
+        let room = by_room_guard.entry(room.to_owned()).or_default();
+
+        Ok(room.entries.iter().any(|entry| {
+            if let TimelineEntry::Gap { prev_token: existing } = entry {
+                existing == needle
+            } else {
+                false
+            }
+        }))
+    }
+
+    async fn replace_gap(
+        &self,
+        room: &RoomId,
+        token: Option<&PaginationToken>,
+        entries: Vec<TimelineEntry>,
+    ) -> Result<bool> {
+        let mut by_room_guard = self.by_room.write().await;
+        let room = by_room_guard.entry(room.to_owned()).or_default();
+
+        if let Some(token) = token {
+            let gap_pos = room.entries.iter().enumerate().find_map(|(i, t)| {
+                if let TimelineEntry::Gap { prev_token: existing } = t {
+                    if existing == token {
+                        return Some(i);
+                    }
+                }
+                None
+            });
+
+            if let Some(pos) = gap_pos {
+                room.entries.splice(pos..pos + 1, entries);
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        } else {
+            // We had no previous token: assume we can prepend the events.
+            room.entries.splice(0..0, entries);
+            Ok(true)
+        }
     }
 }

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -52,9 +52,8 @@ pub trait EventCacheStore: Send + Sync {
         entries: Vec<TimelineEntry>,
     ) -> Result<bool>;
 
-    /// Retrieve the earliest (oldest backpagination token for the given room.)
-    async fn earliest_backpagination_token(&self, room: &RoomId)
-        -> Result<Option<PaginationToken>>;
+    /// Retrieve the oldest backpagination token for the given room.
+    async fn oldest_backpagination_token(&self, room: &RoomId) -> Result<Option<PaginationToken>>;
 
     /// Clear all the information tied to a given room.
     ///
@@ -141,10 +140,7 @@ impl EventCacheStore for MemoryStore {
         Ok(())
     }
 
-    async fn earliest_backpagination_token(
-        &self,
-        room: &RoomId,
-    ) -> Result<Option<PaginationToken>> {
+    async fn oldest_backpagination_token(&self, room: &RoomId) -> Result<Option<PaginationToken>> {
         Ok(self.by_room.read().await.get(room).and_then(|room| {
             room.entries.iter().find_map(|entry| {
                 if let TimelineEntry::Gap { prev_token: backpagination_token } = entry {

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -395,10 +395,10 @@ async fn test_backpaginate_multiple_iterations() {
     // And next time I'll open the room, I'll get the events in the right order.
     let (events, _receiver) = room_event_cache.subscribe().await.unwrap();
 
-    assert_event_matches_msg(&events[0].clone().into(), "oh well");
-    assert_event_matches_msg(&events[1].clone().into(), "hello");
-    assert_event_matches_msg(&events[2].clone().into(), "world");
-    assert_event_matches_msg(&events[3].clone().into(), "heyo");
+    assert_event_matches_msg(&events[0], "oh well");
+    assert_event_matches_msg(&events[1], "hello");
+    assert_event_matches_msg(&events[2], "world");
+    assert_event_matches_msg(&events[3], "heyo");
     assert_eq!(events.len(), 4);
 
     assert!(room_stream.is_empty());

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
-    event_cache::{EventCacheError, RoomEventCacheUpdate},
+    event_cache::{BackPaginationOutcome, EventCacheError, RoomEventCacheUpdate},
     test_utils::logged_in_client_with_server,
 };
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
@@ -10,16 +10,28 @@ use matrix_sdk_test::{
     async_test, sync_timeline_event, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder,
 };
 use ruma::{
+    event_id,
     events::{
         room::message::{MessageType, RoomMessageEventContent},
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent,
+        AnySyncMessageLikeEvent, AnySyncTimelineEvent, AnyTimelineEvent,
     },
-    room_id, user_id,
+    room_id,
+    serde::Raw,
+    user_id,
 };
-use tokio::time::timeout;
+use serde_json::json;
+use tokio::{
+    spawn,
+    time::{sleep, timeout},
+};
+use wiremock::{
+    matchers::{header, method, path_regex, query_param},
+    Mock, MockServer, ResponseTemplate,
+};
 
 use crate::mock_sync;
 
+#[track_caller]
 fn assert_event_matches_msg(event: &SyncTimelineEvent, expected: &str) {
     let event = event.event.deserialize().unwrap();
     assert_let!(
@@ -134,6 +146,7 @@ async fn test_add_initial_events() {
                 "origin_server_ts": 12344446,
                 "content": { "body":"new choice!", "msgtype": "m.text" },
             }))],
+            None,
         )
         .await
         .unwrap();
@@ -156,4 +169,420 @@ async fn test_add_initial_events() {
 
     // That's all, folks!
     assert!(subscriber.is_empty());
+}
+
+macro_rules! non_sync_events {
+    ( @_ $builder:expr, [ ( $room_id:expr , $event_id:literal : $msg:literal ) $(, $( $rest:tt )* )? ] [ $( $accumulator:tt )* ] ) => {
+        non_sync_events!(
+            @_ $builder,
+            [ $( $( $rest )* )? ]
+            [ $( $accumulator )*
+              $builder.make_message_event_with_id(
+                user_id!("@a:b.c"),
+                $room_id,
+                event_id!($event_id),
+                RoomMessageEventContent::text_plain($msg)
+              ),
+            ]
+        )
+    };
+
+    ( @_ $builder:expr, [] [ $( $accumulator:tt )* ] ) => {
+        vec![ $( $accumulator )* ]
+    };
+
+    ( $builder:expr, [ $( $all:tt )* ] ) => {
+        non_sync_events!( @_ $builder, [ $( $all )* ] [] )
+    };
+}
+
+/// Puts a mounting point for /messages for a pagination request, matching
+/// against a precise `from` token given as `expected_from`, and returning the
+/// chunk of events and the next token as `end` (if available).
+async fn mock_messages(
+    server: &MockServer,
+    expected_from: &str,
+    next_token: Option<&str>,
+    chunk: Vec<Raw<AnyTimelineEvent>>,
+) {
+    let response_json = json!({
+        "chunk": chunk,
+        "start": "t392-516_47314_0_7_1_1_1_11444_1",
+        "end": next_token,
+    });
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(query_param("from", expected_from))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response_json))
+        .expect(1)
+        .mount(server)
+        .await;
+}
+
+#[async_test]
+async fn test_backpaginate_once() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    let event_cache = client.event_cache();
+
+    // Immediately subscribe the event cache to sync updates.
+    event_cache.subscribe().unwrap();
+
+    // If I sync and get informed I've joined The Room, and get a previous batch
+    // token,
+    let room_id = room_id!("!omelette:fromage.fr");
+
+    let event_builder = EventBuilder::new();
+    let mut sync_builder = SyncResponseBuilder::new();
+
+    {
+        sync_builder.add_joined_room(
+            JoinedRoomBuilder::new(room_id)
+                // Note to self: a timeline must have at least single event to be properly
+                // serialized.
+                .add_timeline_event(event_builder.make_sync_message_event(
+                    user_id!("@a:b.c"),
+                    RoomMessageEventContent::text_plain("heyo"),
+                ))
+                .set_timeline_prev_batch("prev_batch".to_owned()),
+        );
+        let response_body = sync_builder.build_json_sync_response();
+
+        mock_sync(&server, response_body, None).await;
+        client.sync_once(Default::default()).await.unwrap();
+        server.reset().await;
+    }
+
+    let (room_event_cache, _drop_handles) =
+        client.get_room(room_id).unwrap().event_cache().await.unwrap();
+
+    // Wait for the event cache to process the sync response.
+    sleep(Duration::from_millis(300)).await;
+
+    let (events, room_stream) = room_event_cache.subscribe().await.unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert!(room_stream.is_empty());
+
+    let outcome = {
+        // Note: events must be presented in reversed order, since this is
+        // back-pagination.
+        mock_messages(
+            &server,
+            "prev_batch",
+            None,
+            non_sync_events!(event_builder, [ (room_id, "$2": "world"), (room_id, "$3": "hello") ]),
+        )
+        .await;
+
+        // Then if I backpaginate,
+        let token = room_event_cache
+            .earliest_backpagination_token(Some(Duration::from_secs(1)))
+            .await
+            .unwrap();
+        assert!(token.is_some());
+
+        room_event_cache.backpaginate_with_token(20, token).await.unwrap()
+    };
+
+    // I'll get all the previous events, in "reverse" order (same as the response).
+    assert_let!(BackPaginationOutcome::Success { events, reached_start } = outcome);
+    assert!(reached_start);
+
+    assert_event_matches_msg(&events[0].clone().into(), "world");
+    assert_event_matches_msg(&events[1].clone().into(), "hello");
+    assert_eq!(events.len(), 2);
+
+    assert!(room_stream.is_empty());
+}
+
+#[async_test]
+async fn test_backpaginate_multiple_iterations() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    let event_cache = client.event_cache();
+
+    // Immediately subscribe the event cache to sync updates.
+    event_cache.subscribe().unwrap();
+
+    // If I sync and get informed I've joined The Room, and get a previous batch
+    // token,
+    let room_id = room_id!("!omelette:fromage.fr");
+
+    let event_builder = EventBuilder::new();
+    let mut sync_builder = SyncResponseBuilder::new();
+
+    {
+        sync_builder.add_joined_room(
+            JoinedRoomBuilder::new(room_id)
+                // Note to self: a timeline must have at least single event to be properly
+                // serialized.
+                .add_timeline_event(event_builder.make_sync_message_event(
+                    user_id!("@a:b.c"),
+                    RoomMessageEventContent::text_plain("heyo"),
+                ))
+                .set_timeline_prev_batch("prev_batch".to_owned()),
+        );
+        let response_body = sync_builder.build_json_sync_response();
+
+        mock_sync(&server, response_body, None).await;
+        client.sync_once(Default::default()).await.unwrap();
+        server.reset().await;
+    }
+
+    let (room_event_cache, _drop_handles) =
+        client.get_room(room_id).unwrap().event_cache().await.unwrap();
+
+    // Wait for the event cache to process the sync response.
+    sleep(Duration::from_millis(300)).await;
+
+    let (events, room_stream) = room_event_cache.subscribe().await.unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert!(room_stream.is_empty());
+
+    let mut num_iterations = 0;
+    let mut global_events = Vec::new();
+    let mut global_reached_start = false;
+
+    // The first back-pagination will return these two.
+    mock_messages(
+        &server,
+        "prev_batch",
+        Some("prev_batch2"),
+        non_sync_events!(event_builder, [ (room_id, "$2": "world"), (room_id, "$3": "hello") ]),
+    )
+    .await;
+
+    // The second round of back-pagination will return this one.
+    mock_messages(
+        &server,
+        "prev_batch2",
+        None,
+        non_sync_events!(event_builder, [ (room_id, "$4": "oh well"), ]),
+    )
+    .await;
+
+    // Then if I backpaginate in a loop,
+    while let Some(token) =
+        room_event_cache.earliest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap()
+    {
+        match room_event_cache.backpaginate_with_token(20, Some(token)).await.unwrap() {
+            BackPaginationOutcome::Success { reached_start, events } => {
+                if !global_reached_start {
+                    global_reached_start = reached_start;
+                }
+                global_events.extend(events);
+            }
+            BackPaginationOutcome::UnknownBackpaginationToken => {
+                panic!("shouldn't run into unknown backpagination error")
+            }
+        }
+
+        num_iterations += 1;
+    }
+
+    // I'll get all the previous events,
+    assert_eq!(num_iterations, 2);
+    assert!(global_reached_start);
+
+    assert_event_matches_msg(&global_events[0].clone().into(), "world");
+    assert_event_matches_msg(&global_events[1].clone().into(), "hello");
+    assert_event_matches_msg(&global_events[2].clone().into(), "oh well");
+    assert_eq!(global_events.len(), 3);
+
+    // And next time I'll open the room, I'll get the events in the right order.
+    let (events, _receiver) = room_event_cache.subscribe().await.unwrap();
+
+    assert_event_matches_msg(&events[0].clone().into(), "oh well");
+    assert_event_matches_msg(&events[1].clone().into(), "hello");
+    assert_event_matches_msg(&events[2].clone().into(), "world");
+    assert_event_matches_msg(&events[3].clone().into(), "heyo");
+    assert_eq!(events.len(), 4);
+
+    assert!(room_stream.is_empty());
+}
+
+#[async_test]
+async fn test_reset_while_backpaginating() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    let event_cache = client.event_cache();
+
+    // Immediately subscribe the event cache to sync updates.
+    event_cache.subscribe().unwrap();
+
+    // If I sync and get informed I've joined The Room, and get a previous batch
+    // token,
+    let room_id = room_id!("!omelette:fromage.fr");
+
+    let event_builder = EventBuilder::new();
+    let mut sync_builder = SyncResponseBuilder::new();
+
+    {
+        sync_builder.add_joined_room(
+            JoinedRoomBuilder::new(room_id)
+                // Note to self: a timeline must have at least single event to be properly
+                // serialized.
+                .add_timeline_event(event_builder.make_sync_message_event(
+                    user_id!("@a:b.c"),
+                    RoomMessageEventContent::text_plain("heyo"),
+                ))
+                .set_timeline_prev_batch("first_backpagination".to_owned()),
+        );
+        let response_body = sync_builder.build_json_sync_response();
+
+        mock_sync(&server, response_body, None).await;
+        client.sync_once(Default::default()).await.unwrap();
+        server.reset().await;
+    }
+
+    let (room_event_cache, _drop_handles) =
+        client.get_room(room_id).unwrap().event_cache().await.unwrap();
+
+    // Wait for the event cache to process the sync response.
+    sleep(Duration::from_millis(300)).await;
+
+    let (events, room_stream) = room_event_cache.subscribe().await.unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert!(room_stream.is_empty());
+
+    // We're going to cause a small race:
+    // - a background request to sync will be sent,
+    // - a backpagination will be sent concurrently.
+    //
+    // So events have to happen in this order:
+    // - the backpagination request is sent, with a prev-batch A
+    // - the sync endpoint returns *after* the backpagination started, before the
+    // backpagination ends
+    // - the backpagination ends, with a prev-batch token that's now stale.
+    //
+    // The backpagination should result in an unknown-token-error.
+
+    sync_builder.add_joined_room(
+        JoinedRoomBuilder::new(room_id)
+            // Note to self: a timeline must have at least single event to be properly
+            // serialized.
+            .add_timeline_event(event_builder.make_sync_message_event(
+                user_id!("@a:b.c"),
+                RoomMessageEventContent::text_plain("heyo"),
+            ))
+            .set_timeline_prev_batch("second_backpagination".to_owned())
+            .set_timeline_limited(),
+    );
+    let sync_response_body = sync_builder.build_json_sync_response();
+
+    // First back-pagination request:
+    let chunk = non_sync_events!(event_builder, [ (room_id, "$2": "lalala") ]);
+    let response_json = json!({
+        "chunk": chunk,
+        "start": "t392-516_47314_0_7_1_1_1_11444_1",
+    });
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
+        .and(header("authorization", "Bearer 1234"))
+        .and(query_param("from", "first_backpagination"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(response_json.clone())
+                .set_delay(Duration::from_millis(500)), /* This is why we don't use
+                                                         * `mock_messages`. */
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let first_token =
+        room_event_cache.earliest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap();
+    assert!(first_token.is_some());
+
+    let rec = room_event_cache.clone();
+    let first_token_clone = first_token.clone();
+    let backpagination =
+        spawn(async move { rec.backpaginate_with_token(20, first_token_clone).await });
+
+    // Receive the sync response (which clears the timeline).
+    mock_sync(&server, sync_response_body, None).await;
+    client.sync_once(Default::default()).await.unwrap();
+
+    let outcome = backpagination.await.expect("join failed").unwrap();
+
+    // Backpagination should be confused, and the operation should result in an
+    // unknown token.
+    assert_matches!(outcome, BackPaginationOutcome::UnknownBackpaginationToken);
+
+    // Now if we retrieve the earliest token, it's not the one we had before.
+    let second_token = room_event_cache.earliest_backpagination_token(None).await.unwrap().unwrap();
+    assert!(first_token.unwrap() != second_token);
+    assert_eq!(second_token.0, "second_backpagination");
+}
+
+#[async_test]
+async fn test_backpaginating_without_token() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    let event_cache = client.event_cache();
+
+    // Immediately subscribe the event cache to sync updates.
+    event_cache.subscribe().unwrap();
+
+    // If I sync and get informed I've joined The Room, without a previous batch
+    // token,
+    let room_id = room_id!("!omelette:fromage.fr");
+
+    let event_builder = EventBuilder::new();
+    let mut sync_builder = SyncResponseBuilder::new();
+
+    {
+        sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+        let response_body = sync_builder.build_json_sync_response();
+
+        mock_sync(&server, response_body, None).await;
+        client.sync_once(Default::default()).await.unwrap();
+        server.reset().await;
+    }
+
+    let (room_event_cache, _drop_handles) =
+        client.get_room(room_id).unwrap().event_cache().await.unwrap();
+
+    // Wait for the event cache to process the sync response.
+    // TODO: this is a code smell; should the event cache observers be called in
+    // real-time, instead of receiving an async update?
+    sleep(Duration::from_millis(300)).await;
+
+    let (events, room_stream) = room_event_cache.subscribe().await.unwrap();
+
+    assert!(events.is_empty());
+    assert!(room_stream.is_empty());
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "chunk": non_sync_events!(event_builder, [(room_id, "$2": "hi")]),
+            "start": "t392-516_47314_0_7_1_1_1_11444_1",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // We don't have a token.
+    let token =
+        room_event_cache.earliest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap();
+    assert!(token.is_none());
+
+    // If we try to back-paginate with a token, it will hit the end of the timeline
+    // and give us the resulting event.
+    let outcome = room_event_cache.backpaginate_with_token(20, token).await.unwrap();
+    assert_let!(BackPaginationOutcome::Success { events, reached_start } = outcome);
+
+    assert!(reached_start);
+
+    // And we get notified about the new event.
+    assert_event_matches_msg(&events[0].clone().into(), "hi");
+    assert_eq!(events.len(), 1);
+
+    assert!(room_stream.is_empty());
 }

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -278,7 +278,7 @@ async fn test_backpaginate_once() {
 
         // Then if I backpaginate,
         let token = room_event_cache
-            .earliest_backpagination_token(Some(Duration::from_secs(1)))
+            .oldest_backpagination_token(Some(Duration::from_secs(1)))
             .await
             .unwrap();
         assert!(token.is_some());
@@ -369,7 +369,7 @@ async fn test_backpaginate_multiple_iterations() {
 
     // Then if I backpaginate in a loop,
     while let Some(token) =
-        room_event_cache.earliest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap()
+        room_event_cache.oldest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap()
     {
         match room_event_cache.backpaginate_with_token(20, Some(token)).await.unwrap() {
             BackPaginationOutcome::Success { reached_start, events } => {
@@ -501,7 +501,7 @@ async fn test_reset_while_backpaginating() {
         .await;
 
     let first_token =
-        room_event_cache.earliest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap();
+        room_event_cache.oldest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap();
     assert!(first_token.is_some());
 
     let rec = room_event_cache.clone();
@@ -520,7 +520,7 @@ async fn test_reset_while_backpaginating() {
     assert_matches!(outcome, BackPaginationOutcome::UnknownBackpaginationToken);
 
     // Now if we retrieve the earliest token, it's not the one we had before.
-    let second_token = room_event_cache.earliest_backpagination_token(None).await.unwrap().unwrap();
+    let second_token = room_event_cache.oldest_backpagination_token(None).await.unwrap().unwrap();
     assert!(first_token.unwrap() != second_token);
     assert_eq!(second_token.0, "second_backpagination");
 }
@@ -571,7 +571,7 @@ async fn test_backpaginating_without_token() {
 
     // We don't have a token.
     let token =
-        room_event_cache.earliest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap();
+        room_event_cache.oldest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap();
     assert!(token.is_none());
 
     // If we try to back-paginate with a token, it will hit the end of the timeline


### PR DESCRIPTION
This adds support for back-pagination into the event cache, supporting enough features for integrating with the timeline (which is going to happen in a separate PR).

The idea is to provide two new primitives:

- one to get (or wait, if we don't have any handy) the latest pagination token received by the sync,
- one to run a single back-pagination, given a token (or not — which will backpaginate from the end of the room's timeline)

The timeline code can then use those two primitives in a loop to replicate the current behavior it has (next PR to be open Soon™).

The representation of events in the store is changed, so that a timeline can have *entries*, which are one of two things:

- either an event, as before
- or a gap, identified by a backpagination token (at the moment)

This allows us to avoid a lot of complexity from the back-pagination code in the timeline, where we'd attach the backpagination token to an event that only had an event_id. We don't have to do this here, and I suppose we could even attach the backpagination token to the next event itself.

This doesn't do reconciliation yet; the plan is to add it as a next step.