### PR TITLE
ffi: add `previous` power levels to `OtherState::RoomPowerLevels`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -353,30 +353,20 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherFullStateEventContent> for OtherStat
                 Self::RoomName { name }
             }
             Content::RoomPinnedEvents(_) => Self::RoomPinnedEvents,
-            Content::RoomPowerLevels(c) => {
-                let previous: Option<HashMap<String, i64>> = match c {
-                    FullContent::Original { prev_content, .. } => {
-                        prev_content.as_ref().map(|prev_content| {
-                            prev_content
-                                .users
-                                .iter()
-                                .map(|(k, &v)| (k.to_string(), v.into()))
-                                .collect()
-                        })
-                    }
-                    FullContent::Redacted(_) => None,
-                };
-                let users: HashMap<String, i64> = match c {
-                    FullContent::Original { content, prev_content } => {
-                        power_level_user_changes(content, prev_content)
-                            .iter()
-                            .map(|(k, v)| (k.to_string(), *v))
-                            .collect()
-                    }
-                    FullContent::Redacted(_) => Default::default(),
-                };
-                Self::RoomPowerLevels { users, previous }
-            }
+            Content::RoomPowerLevels(c) => match c {
+                FullContent::Original { content, prev_content } => Self::RoomPowerLevels {
+                    users: power_level_user_changes(content, prev_content)
+                        .iter()
+                        .map(|(k, v)| (k.to_string(), *v))
+                        .collect(),
+                    previous: prev_content.as_ref().map(|prev_content| {
+                        prev_content.users.iter().map(|(k, &v)| (k.to_string(), v.into())).collect()
+                    }),
+                },
+                FullContent::Redacted(_) => {
+                    Self::RoomPowerLevels { users: Default::default(), previous: None }
+                }
+            },
             Content::RoomServerAcl(_) => Self::RoomServerAcl,
             Content::RoomThirdPartyInvite(c) => {
                 let display_name = match c {

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -358,17 +358,13 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherFullStateEventContent> for OtherStat
                 let users: HashMap<String, i64>;
                 match c {
                     FullContent::Original { content, prev_content } => {
-                        previous = if let Some(prev_content) = prev_content {
-                            Some(
-                                prev_content
-                                    .users
-                                    .iter()
-                                    .map(|(k, &v)| (k.to_string(), v.into()))
-                                    .collect(),
-                            )
-                        } else {
-                            None
-                        };
+                        previous = prev_content.as_ref().map(|prev_content| {
+                            prev_content
+                                .users
+                                .iter()
+                                .map(|(k, &v)| (k.to_string(), v.into()))
+                                .collect()
+                        });
                         users = power_level_user_changes(content, prev_content)
                             .iter()
                             .map(|(k, v)| (k.to_string(), *v))

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -354,26 +354,26 @@ impl From<&matrix_sdk_ui::timeline::AnyOtherFullStateEventContent> for OtherStat
             }
             Content::RoomPinnedEvents(_) => Self::RoomPinnedEvents,
             Content::RoomPowerLevels(c) => {
-                let previous: Option<HashMap<String, i64>>;
-                let users: HashMap<String, i64>;
-                match c {
-                    FullContent::Original { content, prev_content } => {
-                        previous = prev_content.as_ref().map(|prev_content| {
+                let previous: Option<HashMap<String, i64>> = match c {
+                    FullContent::Original { prev_content, .. } => {
+                        prev_content.as_ref().map(|prev_content| {
                             prev_content
                                 .users
                                 .iter()
                                 .map(|(k, &v)| (k.to_string(), v.into()))
                                 .collect()
-                        });
-                        users = power_level_user_changes(content, prev_content)
+                        })
+                    }
+                    FullContent::Redacted(_) => None,
+                };
+                let users: HashMap<String, i64> = match c {
+                    FullContent::Original { content, prev_content } => {
+                        power_level_user_changes(content, prev_content)
                             .iter()
                             .map(|(k, v)| (k.to_string(), *v))
                             .collect()
                     }
-                    FullContent::Redacted(_) => {
-                        previous = None;
-                        users = Default::default();
-                    }
+                    FullContent::Redacted(_) => Default::default(),
                 };
                 Self::RoomPowerLevels { users, previous }
             }


### PR DESCRIPTION
This is needed to be able to diff between increases and decreases of power levels ("user Alice was promoted Admin", etc.).

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
