### PR TITLE
crypto: Add a feature flag to disable the minimum session rotation time

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -22,6 +22,7 @@ qrcode = ["dep:matrix-sdk-qrcode"]
 message-ids = ["dep:ulid"]
 experimental-algorithms = []
 uniffi = ["dep:uniffi"]
+disable-minimum-rotation-period-ms = []
 
 # Testing helpers for implementations based upon this
 testing = ["dep:http"]

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -22,7 +22,7 @@ qrcode = ["dep:matrix-sdk-qrcode"]
 message-ids = ["dep:ulid"]
 experimental-algorithms = []
 uniffi = ["dep:uniffi"]
-disable-minimum-rotation-period-ms = []
+_disable-minimum-rotation-period-ms = []
 
 # Testing helpers for implementations based upon this
 testing = ["dep:http"]

--- a/crates/matrix-sdk-crypto/README.md
+++ b/crates/matrix-sdk-crypto/README.md
@@ -70,4 +70,6 @@ The following crate feature flags are available:
 
 * `qrcode`: Enbles QRcode generation and reading code
 
-* `testing`: provides facilities and functions for tests, in particular for integration testing store implementations. ATTENTION: do not ever use outside of tests, we do not provide any stability warantees on these, these are merely helpers. If you find you _need_ any function provided here outside of tests, please open a Github Issue and inform us about your use case for us to consider.
+* `testing`: Provides facilities and functions for tests, in particular for integration testing store implementations. ATTENTION: do not ever use outside of tests, we do not provide any stability warantees on these, these are merely helpers. If you find you _need_ any function provided here outside of tests, please open a Github Issue and inform us about your use case for us to consider.
+
+* `_disable-minimum-rotation-period-ms`: Do not use except for testing. Disables the floor on the rotation period of room keys.

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -59,7 +59,10 @@ use crate::{
     ReadOnlyDevice, ToDeviceRequest,
 };
 
-const ROTATION_PERIOD: Duration = Duration::from_millis(604800000);
+const ONE_HOUR: Duration = Duration::from_secs(60 * 60);
+const ONE_WEEK: Duration = Duration::from_secs(60 * 60 * 24 * 7);
+
+const ROTATION_PERIOD: Duration = ONE_WEEK;
 const ROTATION_MESSAGES: u64 = 100;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -432,7 +435,7 @@ impl OutboundGroupSession {
         if cfg!(feature = "_disable-minimum-rotation-period-ms") {
             self.settings.rotation_period
         } else {
-            max(self.settings.rotation_period, Duration::from_secs(3600))
+            max(self.settings.rotation_period, ONE_HOUR)
         }
     }
 
@@ -788,6 +791,8 @@ mod tests {
 
         use crate::{olm::OutboundGroupSession, Account, EncryptionSettings, MegolmError};
 
+        const TWO_HOURS: Duration = Duration::from_secs(60 * 60 * 2);
+
         #[async_test]
         async fn session_is_not_expired_if_no_messages_sent_and_no_time_passed() {
             // Given a session that expires after one message
@@ -831,7 +836,7 @@ mod tests {
         async fn session_with_rotation_period_is_not_expired_after_no_time() {
             // Given a session with a 2h expiration
             let session = create_session(EncryptionSettings {
-                rotation_period: Duration::from_secs(7200),
+                rotation_period: TWO_HOURS,
                 ..Default::default()
             })
             .await;
@@ -846,7 +851,7 @@ mod tests {
         async fn session_is_expired_after_rotation_period() {
             // Given a session with a 2h expiration
             let mut session = create_session(EncryptionSettings {
-                rotation_period: Duration::from_secs(7200),
+                rotation_period: TWO_HOURS,
                 ..Default::default()
             })
             .await;

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -426,10 +426,10 @@ impl OutboundGroupSession {
     /// This is to prevent a malicious or careless user causing sessions to be
     /// rotated very frequently.
     ///
-    /// The feature flag `disable-minimum-rotation-period-ms` can
+    /// The feature flag `_disable-minimum-rotation-period-ms` can
     /// be used to prevent this behaviour (which can be useful for tests).
     fn safe_rotation_period(&self) -> Duration {
-        if cfg!(feature = "disable-minimum-rotation-period-ms") {
+        if cfg!(feature = "_disable-minimum-rotation-period-ms") {
             self.settings.rotation_period
         } else {
             max(self.settings.rotation_period, Duration::from_secs(3600))
@@ -860,7 +860,7 @@ mod tests {
         }
 
         #[async_test]
-        #[cfg(not(feature = "disable-minimum-rotation-period-ms"))]
+        #[cfg(not(feature = "_disable-minimum-rotation-period-ms"))]
         async fn session_does_not_expire_under_one_hour_even_if_we_ask_for_shorter() {
             // Given a session with a 100ms expiration
             let mut session = create_session(EncryptionSettings {
@@ -884,7 +884,7 @@ mod tests {
         }
 
         #[async_test]
-        #[cfg(feature = "disable-minimum-rotation-period-ms")]
+        #[cfg(feature = "_disable-minimum-rotation-period-ms")]
         async fn with_disable_minrotperiod_feature_sessions_can_expire_quickly() {
             // Given a session with a 100ms expiration
             let mut session = create_session(EncryptionSettings {


### PR DESCRIPTION
Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/3198

I suggest reviewing commit by commit.

As discussed IRL with @poljar, add a feature flag that will allow us to remove the minimum session rotation time, so that we can write complement-crypto tests that use very short expirations.

See https://github.com/matrix-org/complement-crypto/issues/17 for more.