### PR TITLE
sdk/ffi: ability to delete a pusher

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -627,13 +627,13 @@ impl Client {
             profile_tag,
             lang,
         };
-        self.inner.set_pusher(pusher_init.into()).await?;
+        self.inner.pusher().set(pusher_init.into()).await?;
         Ok(())
     }
 
     /// Deletes a pusher of given pusher ids
     pub async fn delete_pusher(&self, identifiers: PusherIdentifiers) -> Result<(), ClientError> {
-        self.inner.delete_pusher(identifiers.into()).await?;
+        self.inner.pusher().delete(identifiers.into()).await?;
         Ok(())
     }
 

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -608,7 +608,7 @@ impl Client {
     }
 
     /// Registers a pusher with given parameters
-    pub fn set_pusher(
+    pub async fn set_pusher(
         &self,
         identifiers: PusherIdentifiers,
         kind: PusherKind,
@@ -617,29 +617,24 @@ impl Client {
         profile_tag: Option<String>,
         lang: String,
     ) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move {
-            let ids = identifiers.into();
+        let ids = identifiers.into();
 
-            let pusher_init = PusherInit {
-                ids,
-                kind: kind.try_into()?,
-                app_display_name,
-                device_display_name,
-                profile_tag,
-                lang,
-            };
-            self.inner.set_pusher(pusher_init.into()).await?;
-            Ok(())
-        })
+        let pusher_init = PusherInit {
+            ids,
+            kind: kind.try_into()?,
+            app_display_name,
+            device_display_name,
+            profile_tag,
+            lang,
+        };
+        self.inner.set_pusher(pusher_init.into()).await?;
+        Ok(())
     }
 
     /// Deletes a pusher of given pusher ids
-    pub fn delete_pusher(&self, identifiers: PusherIdentifiers) -> Result<(), ClientError> {
-        RUNTIME.block_on(async move {
-            let ids = identifiers.into();
-            self.inner.delete_pusher(ids).await?;
-            Ok(())
-        })
+    pub async fn delete_pusher(&self, identifiers: PusherIdentifiers) -> Result<(), ClientError> {
+        self.inner.delete_pusher(identifiers.into()).await?;
+        Ok(())
     }
 
     /// The homeserver this client is configured to use.

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -633,6 +633,15 @@ impl Client {
         })
     }
 
+    /// Deletes a pusher of given pusher ids
+    pub fn delete_pusher(&self, identifiers: PusherIdentifiers) -> Result<(), ClientError> {
+        RUNTIME.block_on(async move {
+            let ids = identifiers.into();
+            self.inner.delete_pusher(ids).await?;
+            Ok(())
+        })
+    }
+
     /// The homeserver this client is configured to use.
     pub fn homeserver(&self) -> String {
         self.inner.homeserver().to_string()

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -48,7 +48,7 @@ use ruma::{
             },
             filter::{create_filter::v3::Request as FilterUploadRequest, FilterDefinition},
             membership::{join_room_by_id, join_room_by_id_or_alias},
-            push::{set_pusher, Pusher},
+            push::{set_pusher, Pusher, PusherIds},
             room::create_room,
             session::login::v3::DiscoveryInfo,
             sync::sync_events,
@@ -2047,6 +2047,15 @@ impl Client {
         self.send(request, None).await
     }
 
+    /// Deletes a pusher by its ids
+    pub async fn delete_pusher(
+        &self,
+        pusher_ids: PusherIds,
+    ) -> HttpResult<set_pusher::v3::Response> {
+        let request = set_pusher::v3::Request::delete(pusher_ids);
+        self.send(request, None).await
+    }
+
     /// Get the notification settings of the current owner of the client.
     pub async fn notification_settings(&self) -> NotificationSettings {
         let ruleset = self.account().push_rules().await.unwrap_or_else(|_| Ruleset::new());
@@ -2110,7 +2119,11 @@ pub(crate) mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-    use ruma::{events::ignored_user_list::IgnoredUserListEventContent, UserId};
+    use ruma::{
+        api::client::push::PusherIds, events::ignored_user_list::IgnoredUserListEventContent,
+        UserId,
+    };
+    use serde_json::json;
     use url::Url;
     use wiremock::{
         matchers::{body_json, header, method, path},
@@ -2365,5 +2378,22 @@ pub(crate) mod tests {
 
         let msc4028_enabled = client.can_homeserver_push_encrypted_event_to_device().await.unwrap();
         assert!(msc4028_enabled);
+    }
+
+    #[async_test]
+    async fn test_delete_pusher() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+
+        Mock::given(method("POST"))
+            .and(path("_matrix/client/r0/pushers/set"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+            .mount(&server)
+            .await;
+
+        let pusher_ids = PusherIds::new("pushKey".to_owned(), "app_id".to_owned());
+        let response = client.delete_pusher(pusher_ids).await;
+
+        assert!(response.is_ok());
     }
 }

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -47,6 +47,7 @@ pub mod media;
 pub mod notification_settings;
 #[cfg(feature = "experimental-oidc")]
 pub mod oidc;
+pub mod pusher;
 pub mod room;
 pub mod room_directory_search;
 pub mod utils;
@@ -78,6 +79,7 @@ pub use matrix_sdk_sqlite::SqliteCryptoStore;
 #[cfg(feature = "sqlite")]
 pub use matrix_sdk_sqlite::SqliteStateStore;
 pub use media::Media;
+pub use pusher::Pusher;
 pub use room::Room;
 pub use ruma::{IdParseError, OwnedServerName, ServerName};
 #[cfg(feature = "experimental-sliding-sync")]

--- a/crates/matrix-sdk/src/pusher.rs
+++ b/crates/matrix-sdk/src/pusher.rs
@@ -1,4 +1,5 @@
-// Copyright 2024 FIXME help with copyright wording
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+// Copyright 2024 Hanadi Tamimi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/crates/matrix-sdk/src/pusher.rs
+++ b/crates/matrix-sdk/src/pusher.rs
@@ -1,0 +1,107 @@
+// Copyright 2024 FIXME help with copyright wording
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! High-level pusher API.
+
+use ruma::api::client::push::{set_pusher, PusherIds};
+
+use crate::{Client, Result};
+
+/// A high-level API to interact with the pusher API.
+///
+/// All the methods in this struct send a request to the homeserver.
+#[derive(Debug, Clone)]
+pub struct Pusher {
+    /// The underlying HTTP client.
+    client: Client,
+}
+
+impl Pusher {
+    pub(crate) fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Sets a given pusher
+    pub async fn set(&self, pusher: ruma::api::client::push::Pusher) -> Result<()> {
+        let request = set_pusher::v3::Request::post(pusher);
+        self.client.send(request, None).await?;
+        Ok(())
+    }
+
+    /// Deletes a pusher by its ids
+    pub async fn delete(&self, pusher_ids: PusherIds) -> Result<()> {
+        let request = set_pusher::v3::Request::delete(pusher_ids);
+        self.client.send(request, None).await?;
+        Ok(())
+    }
+}
+
+// The http mocking library is not supported for wasm32
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use matrix_sdk_test::{async_test, test_json};
+    use ruma::{
+        api::client::push::{PusherIds, PusherInit, PusherKind},
+        push::HttpPusherData,
+    };
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    use crate::test_utils::logged_in_client;
+
+    async fn mock_api(server: MockServer) {
+        Mock::given(method("POST"))
+            .and(path("_matrix/client/r0/pushers/set"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&*test_json::EMPTY))
+            .mount(&server)
+            .await;
+    }
+
+    #[async_test]
+    async fn test_set_pusher() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        mock_api(server).await;
+
+        // prepare dummy pusher
+        let pusher = PusherInit {
+            ids: PusherIds::new("pushKey".to_owned(), "app_id".to_owned()),
+            app_display_name: "name".to_owned(),
+            kind: PusherKind::Http(HttpPusherData::new("dummy".to_owned())),
+            lang: "EN".to_owned(),
+            device_display_name: "name".to_owned(),
+            profile_tag: None,
+        };
+
+        let response = client.pusher().set(pusher.into()).await;
+
+        assert!(response.is_ok());
+    }
+
+    #[async_test]
+    async fn test_delete_pusher() {
+        let server = MockServer::start().await;
+        let client = logged_in_client(Some(server.uri())).await;
+        mock_api(server).await;
+
+        // prepare pusher ids
+        let pusher_ids = PusherIds::new("pushKey".to_owned(), "app_id".to_owned());
+
+        let response = client.pusher().delete(pusher_ids).await;
+
+        assert!(response.is_ok());
+    }
+}


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3096

I chose to create a new method for delete pusher because Ruma defines a delete action itself.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: @hanadi92