### PR TITLE
feat(ui,ffi): Add a new `experimental-room-list-with-unified-invites` feature

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -29,7 +29,7 @@ eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }
 futures-util = { workspace = true }
-matrix-sdk-ui = { workspace = true, features = ["e2e-encryption", "uniffi"] }
+matrix-sdk-ui = { workspace = true, features = ["e2e-encryption", "uniffi", "experimental-room-list-with-unified-invites"] }
 mime = "0.3.16"
 once_cell = { workspace = true }
 opentelemetry = "0.21.0"

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use matrix_sdk::{
-    self, encryption::CryptoStoreError, event_cache::EventCacheError, oidc::OidcError, HttpError,
+    encryption::CryptoStoreError, event_cache::EventCacheError, oidc::OidcError, HttpError,
     IdParseError, NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
 use matrix_sdk_ui::{encryption_sync_service, notification_client, sync_service, timeline};

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use matrix_sdk::{

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -95,6 +95,15 @@ impl SyncServiceBuilder {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl SyncServiceBuilder {
+    pub fn with_unified_invites_in_room_list(
+        self: Arc<Self>,
+        with_unified_invites: bool,
+    ) -> Arc<Self> {
+        let this = unwrap_or_clone_arc(self);
+        let builder = this.builder.with_unified_invites_in_room_list(with_unified_invites);
+        Arc::new(Self { builder })
+    }
+
     pub fn with_cross_process_lock(self: Arc<Self>, app_identifier: Option<String>) -> Arc<Self> {
         let this = unwrap_or_clone_arc(self);
         let builder = this.builder.with_cross_process_lock(app_identifier);

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -12,6 +12,9 @@ default = ["e2e-encryption", "native-tls"]
 
 e2e-encryption = ["matrix-sdk/e2e-encryption"]
 
+# This feature will unify the `invites` list with the `all_rooms` list.
+experimental-room-list-with-unified-invites = []
+
 native-tls = ["matrix-sdk/native-tls"]
 rustls-tls = ["matrix-sdk/rustls-tls"]
 

--- a/crates/matrix-sdk-ui/src/room_list_service/state.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/state.rs
@@ -120,6 +120,8 @@ impl Action for AddVisibleRooms {
                         (StateEventType::RoomEncryption, "".to_owned()),
                         (StateEventType::RoomMember, "$LAZY".to_owned()),
                     ]),
+                #[cfg(feature = "experimental-room-list-with-unified-invites")]
+                false,
             ))
             .await
             .map_err(Error::SlidingSync)?;


### PR DESCRIPTION
The idea of this patch is to explore the possibility to unify the `all_rooms` list with the `invites` list in `RoomListService`. Since this is entirely experimental, it's behind a new feature flag. The feature itself can be configured at runtime by using the new `SyncServiceBuilder::with_unified_invites_in_room_list` builder method, or directly with `RoomListService::new_with_unified_invites` constructor.

