### PR TITLE
Remove `OlmError::Decryption`

### DIFF
--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -38,10 +38,6 @@ pub enum OlmError {
     #[error(transparent)]
     JsonError(#[from] SerdeError),
 
-    /// The event could not have been decrypted.
-    #[error(transparent)]
-    Decryption(#[from] vodozemac::olm::DecryptionError),
-
     /// The received room key couldn't be converted into a valid Megolm session.
     #[error(transparent)]
     SessionCreation(#[from] SessionCreationError),


### PR DESCRIPTION
Putting this up for discussion and CI checks:

As far as I can tell, whenever Vodozemac returns a `DecryptionError`, matrix-sdk-crypto then wraps it as a `SessionWedged`, so the presence of `DecryptionError` here is redundant and misleading.