### PR TITLE
ui/timeline: allow subscribing to UTDs and late-decrypt events

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -22,7 +22,7 @@ use matrix_sdk_ui::{
         BoxedFilterFn,
     },
     timeline::default_event_filter,
-    unable_to_decrypt_hook::{SmartUtdHook, UnableToDecryptHook},
+    unable_to_decrypt_hook::{UnableToDecryptHook, UtdHookManager},
 };
 use tokio::sync::RwLock;
 
@@ -552,8 +552,8 @@ impl RoomListItem {
         }
 
         if let Some(utd_hook) = self.utd_hook.clone() {
-            timeline_builder =
-                timeline_builder.with_unable_to_decrypt_hook(Arc::new(SmartUtdHook::new(utd_hook)));
+            timeline_builder = timeline_builder
+                .with_unable_to_decrypt_hook(Arc::new(UtdHookManager::new(utd_hook)));
         }
 
         self.inner.init_timeline_with_builder(timeline_builder).map_err(RoomListError::from).await

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -22,7 +22,7 @@ use matrix_sdk_ui::{
         BoxedFilterFn,
     },
     timeline::default_event_filter,
-    unable_to_decrypt_hook::{UnableToDecryptHook, UtdHookManager},
+    unable_to_decrypt_hook::UtdHookManager,
 };
 use tokio::sync::RwLock;
 
@@ -107,7 +107,7 @@ impl From<RoomListInput> for matrix_sdk_ui::room_list_service::Input {
 #[derive(uniffi::Object)]
 pub struct RoomListService {
     pub(crate) inner: Arc<matrix_sdk_ui::RoomListService>,
-    pub(crate) utd_hook: Option<Arc<dyn UnableToDecryptHook>>,
+    pub(crate) utd_hook: Option<Arc<UtdHookManager>>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -478,7 +478,7 @@ impl FilterWrapper {
 #[derive(uniffi::Object)]
 pub struct RoomListItem {
     inner: Arc<matrix_sdk_ui::room_list_service::Room>,
-    utd_hook: Option<Arc<dyn UnableToDecryptHook>>,
+    utd_hook: Option<Arc<UtdHookManager>>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -552,8 +552,7 @@ impl RoomListItem {
         }
 
         if let Some(utd_hook) = self.utd_hook.clone() {
-            timeline_builder = timeline_builder
-                .with_unable_to_decrypt_hook(Arc::new(UtdHookManager::new(utd_hook)));
+            timeline_builder = timeline_builder.with_unable_to_decrypt_hook(utd_hook);
         }
 
         self.inner.init_timeline_with_builder(timeline_builder).map_err(RoomListError::from).await

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -22,7 +22,7 @@ use matrix_sdk_ui::{
         BoxedFilterFn,
     },
     timeline::default_event_filter,
-    unable_to_decrypt_hook::UnableToDecryptHook,
+    unable_to_decrypt_hook::{SmartUtdHook, UnableToDecryptHook},
 };
 use tokio::sync::RwLock;
 
@@ -552,7 +552,8 @@ impl RoomListItem {
         }
 
         if let Some(utd_hook) = self.utd_hook.clone() {
-            timeline_builder = timeline_builder.with_unable_to_decrypt_hook(utd_hook);
+            timeline_builder =
+                timeline_builder.with_unable_to_decrypt_hook(Arc::new(SmartUtdHook::new(utd_hook)));
         }
 
         self.inner.init_timeline_with_builder(timeline_builder).map_err(RoomListError::from).await

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -128,7 +128,8 @@ impl SyncServiceBuilder {
 
         let this = unwrap_or_clone_arc(self);
         let utd_hook = Some(Arc::new(
-            UtdHookManager::new(Arc::new(UtdHook { delegate })).with_delay(UTD_HOOK_GRACE_PERIOD),
+            UtdHookManager::new(Arc::new(UtdHook { delegate }))
+                .with_max_delay(UTD_HOOK_GRACE_PERIOD),
         ));
         Arc::new(Self { builder: this.builder, utd_hook })
     }

--- a/bindings/matrix-sdk-ffi/src/sync_service.rs
+++ b/bindings/matrix-sdk-ffi/src/sync_service.rs
@@ -137,8 +137,6 @@ impl SyncServiceBuilder {
 #[uniffi::export(callback_interface)]
 pub trait UnableToDecryptDelegate: Sync + Send {
     fn on_utd(&self, info: Arc<UnableToDecryptInfo>);
-
-    fn on_late_decrypt(&self, info: Arc<UnableToDecryptInfo>);
 }
 
 struct UtdHook {
@@ -154,9 +152,5 @@ impl std::fmt::Debug for UtdHook {
 impl UnableToDecryptHook for UtdHook {
     fn on_utd(&self, info: UnableToDecryptInfo) {
         self.delegate.on_utd(Arc::new(info));
-    }
-
-    fn on_late_decrypt(&self, info: UnableToDecryptInfo) {
-        self.delegate.on_late_decrypt(Arc::new(info));
     }
 }

--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -21,6 +21,7 @@ pub mod notification_client;
 pub mod room_list_service;
 pub mod sync_service;
 pub mod timeline;
+pub mod unable_to_decrypt_hook;
 
 pub use self::{room_list_service::RoomListService, timeline::Timeline};
 

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -62,7 +62,8 @@ impl TimelineBuilder {
         }
     }
 
-    /// Sets up an [`UnableToDecryptHook`] for the timeline we're building.
+    /// Sets up a hook to catch unable-to-decrypt (UTD) events for the timeline
+    /// we're building.
     ///
     /// If it was previously set before, will overwrite the previous one.
     pub fn with_unable_to_decrypt_hook(mut self, hook: Arc<UtdHookManager>) -> Self {

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -36,7 +36,7 @@ use super::{
     queue::send_queued_messages,
     BackPaginationStatus, Timeline, TimelineDropHandle,
 };
-use crate::unable_to_decrypt_hook::UnableToDecryptHook;
+use crate::unable_to_decrypt_hook::SmartUtdHook;
 
 /// Builder that allows creating and configuring various parts of a
 /// [`Timeline`].
@@ -49,7 +49,7 @@ pub struct TimelineBuilder {
 
     /// An optional hook to call whenever we run into an unable-to-decrypt or a
     /// late-decryption event.
-    unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
+    unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>,
 }
 
 impl TimelineBuilder {
@@ -65,7 +65,7 @@ impl TimelineBuilder {
     /// Sets up an [`UnableToDecryptHook`] for the timeline we're building.
     ///
     /// If it was previously set before, will overwrite the previous one.
-    pub fn with_unable_to_decrypt_hook(mut self, hook: Arc<dyn UnableToDecryptHook>) -> Self {
+    pub fn with_unable_to_decrypt_hook(mut self, hook: Arc<SmartUtdHook>) -> Self {
         self.unable_to_decrypt_hook = Some(hook);
         self
     }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -36,7 +36,7 @@ use super::{
     queue::send_queued_messages,
     BackPaginationStatus, Timeline, TimelineDropHandle,
 };
-use crate::unable_to_decrypt_hook::SmartUtdHook;
+use crate::unable_to_decrypt_hook::UtdHookManager;
 
 /// Builder that allows creating and configuring various parts of a
 /// [`Timeline`].
@@ -49,7 +49,7 @@ pub struct TimelineBuilder {
 
     /// An optional hook to call whenever we run into an unable-to-decrypt or a
     /// late-decryption event.
-    unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>,
+    unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
 }
 
 impl TimelineBuilder {
@@ -65,7 +65,7 @@ impl TimelineBuilder {
     /// Sets up an [`UnableToDecryptHook`] for the timeline we're building.
     ///
     /// If it was previously set before, will overwrite the previous one.
-    pub fn with_unable_to_decrypt_hook(mut self, hook: Arc<SmartUtdHook>) -> Self {
+    pub fn with_unable_to_decrypt_hook(mut self, hook: Arc<UtdHookManager>) -> Self {
         self.unable_to_decrypt_hook = Some(hook);
         self
     }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -36,6 +36,7 @@ use super::{
     queue::send_queued_messages,
     BackPaginationStatus, Timeline, TimelineDropHandle,
 };
+use crate::unable_to_decrypt_hook::UnableToDecryptHook;
 
 /// Builder that allows creating and configuring various parts of a
 /// [`Timeline`].
@@ -45,11 +46,28 @@ pub struct TimelineBuilder {
     room: Room,
     prev_token: Option<String>,
     settings: TimelineInnerSettings,
+
+    /// An optional hook to call whenever we run into an unable-to-decrypt or a
+    /// late-decryption event.
+    unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
 }
 
 impl TimelineBuilder {
     pub(super) fn new(room: &Room) -> Self {
-        Self { room: room.clone(), prev_token: None, settings: TimelineInnerSettings::default() }
+        Self {
+            room: room.clone(),
+            prev_token: None,
+            settings: TimelineInnerSettings::default(),
+            unable_to_decrypt_hook: None,
+        }
+    }
+
+    /// Sets up an [`UnableToDecryptHook`] for the timeline we're building.
+    ///
+    /// If it was previously set before, will overwrite the previous one.
+    pub fn with_unable_to_decrypt_hook(mut self, hook: Arc<dyn UnableToDecryptHook>) -> Self {
+        self.unable_to_decrypt_hook = Some(hook);
+        self
     }
 
     /// Add initial events to the timeline.
@@ -119,7 +137,7 @@ impl TimelineBuilder {
         )
     )]
     pub async fn build(self) -> event_cache::Result<Timeline> {
-        let Self { room, prev_token, settings } = self;
+        let Self { room, prev_token, settings, unable_to_decrypt_hook } = self;
 
         let client = room.client();
         let event_cache = client.event_cache();
@@ -133,7 +151,7 @@ impl TimelineBuilder {
         let has_events = !events.is_empty();
         let track_read_marker_and_receipts = settings.track_read_receipts;
 
-        let mut inner = TimelineInner::new(room).with_settings(settings);
+        let mut inner = TimelineInner::new(room, unable_to_decrypt_hook).with_settings(settings);
 
         if track_read_marker_and_receipts {
             inner.populate_initial_user_receipt(ReceiptType::Read).await;

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -59,10 +59,7 @@ use super::{
     EventTimelineItem, InReplyToDetails, Message, OtherState, ReactionGroup, ReactionSenderData,
     Sticker, TimelineDetails, TimelineItem, TimelineItemContent, VirtualTimelineItem,
 };
-use crate::{
-    events::SyncTimelineEventWithoutContent, unable_to_decrypt_hook::UnableToDecryptInfo,
-    DEFAULT_SANITIZER_MODE,
-};
+use crate::{events::SyncTimelineEventWithoutContent, DEFAULT_SANITIZER_MODE};
 
 #[derive(Clone)]
 pub(super) enum Flow {
@@ -305,7 +302,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     // timeline.
                     if let Some(hook) = self.meta.unable_to_decrypt_hook.as_ref() {
                         if let Flow::Remote { event_id, .. } = &self.ctx.flow {
-                            hook.on_utd(UnableToDecryptInfo { event_id: event_id.to_owned() });
+                            hook.on_utd(event_id);
                         }
                     }
                 }

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -66,7 +66,7 @@ use super::{
     AnnotationKey, EventSendState, EventTimelineItem, InReplyToDetails, Message, Profile,
     RepliedToEvent, TimelineDetails, TimelineItem, TimelineItemContent, TimelineItemKind,
 };
-use crate::{timeline::TimelineEventFilterFn, unable_to_decrypt_hook::UnableToDecryptHook};
+use crate::{timeline::TimelineEventFilterFn, unable_to_decrypt_hook::SmartUtdHook};
 
 mod state;
 
@@ -212,7 +212,7 @@ pub fn default_event_filter(event: &AnySyncTimelineEvent, room_version: &RoomVer
 impl<P: RoomDataProvider> TimelineInner<P> {
     pub(super) fn new(
         room_data_provider: P,
-        unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
+        unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>,
     ) -> Self {
         let state =
             TimelineInnerState::new(room_data_provider.room_version(), unable_to_decrypt_hook);
@@ -754,7 +754,6 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         session_ids: Option<BTreeSet<String>>,
     ) {
         use super::EncryptedMessage;
-        use crate::unable_to_decrypt_hook::UnableToDecryptInfo;
 
         let mut state = self.state.clone().write_owned().await;
 
@@ -834,9 +833,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
                             // Notify observers that we managed to eventually decrypt an event.
                             if let Some(hook) = unable_to_decrypt_hook {
-                                hook.on_late_decrypt(UnableToDecryptInfo {
-                                    event_id: remote_event.event_id.clone(),
-                                })
+                                hook.on_late_decrypt(&remote_event.event_id);
                             }
 
                             Some(event)

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -66,7 +66,7 @@ use super::{
     AnnotationKey, EventSendState, EventTimelineItem, InReplyToDetails, Message, Profile,
     RepliedToEvent, TimelineDetails, TimelineItem, TimelineItemContent, TimelineItemKind,
 };
-use crate::{timeline::TimelineEventFilterFn, unable_to_decrypt_hook::SmartUtdHook};
+use crate::{timeline::TimelineEventFilterFn, unable_to_decrypt_hook::UtdHookManager};
 
 mod state;
 
@@ -212,7 +212,7 @@ pub fn default_event_filter(event: &AnySyncTimelineEvent, room_version: &RoomVer
 impl<P: RoomDataProvider> TimelineInner<P> {
     pub(super) fn new(
         room_data_provider: P,
-        unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>,
+        unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
     ) -> Self {
         let state =
             TimelineInnerState::new(room_data_provider.room_version(), unable_to_decrypt_hook);

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -54,6 +54,7 @@ use crate::{
         AnnotationKey, Error as TimelineError, Profile, ReactionSenderData, TimelineItem,
         TimelineItemKind, VirtualTimelineItem,
     },
+    unable_to_decrypt_hook::UnableToDecryptHook,
 };
 
 #[derive(Debug)]
@@ -63,13 +64,16 @@ pub(in crate::timeline) struct TimelineInnerState {
 }
 
 impl TimelineInnerState {
-    pub(super) fn new(room_version: RoomVersionId) -> Self {
+    pub(super) fn new(
+        room_version: RoomVersionId,
+        unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
+    ) -> Self {
         Self {
             // Upstream default capacity is currently 16, which is making
             // sliding-sync tests with 20 events lag. This should still be
             // small enough.
             items: ObservableVector::with_capacity(32),
-            meta: TimelineInnerMetadata::new(room_version),
+            meta: TimelineInnerMetadata::new(room_version, unable_to_decrypt_hook),
         }
     }
 
@@ -806,10 +810,16 @@ pub(in crate::timeline) struct TimelineInnerMetadata {
     ///
     /// Private because it's not needed by `TimelineEventHandler`.
     back_pagination_tokens: VecDeque<(OwnedEventId, String)>,
+
+    /// The hook to call whenever we run into a unable-to-decrypt event.
+    pub(crate) unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
 }
 
 impl TimelineInnerMetadata {
-    fn new(room_version: RoomVersionId) -> TimelineInnerMetadata {
+    fn new(
+        room_version: RoomVersionId,
+        unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
+    ) -> TimelineInnerMetadata {
         Self {
             all_events: Default::default(),
             next_internal_id: Default::default(),
@@ -824,6 +834,7 @@ impl TimelineInnerMetadata {
             in_flight_reaction: Default::default(),
             room_version,
             back_pagination_tokens: VecDeque::new(),
+            unable_to_decrypt_hook,
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -54,7 +54,7 @@ use crate::{
         AnnotationKey, Error as TimelineError, Profile, ReactionSenderData, TimelineItem,
         TimelineItemKind, VirtualTimelineItem,
     },
-    unable_to_decrypt_hook::UnableToDecryptHook,
+    unable_to_decrypt_hook::SmartUtdHook,
 };
 
 #[derive(Debug)]
@@ -66,7 +66,7 @@ pub(in crate::timeline) struct TimelineInnerState {
 impl TimelineInnerState {
     pub(super) fn new(
         room_version: RoomVersionId,
-        unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
+        unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>,
     ) -> Self {
         Self {
             // Upstream default capacity is currently 16, which is making
@@ -812,14 +812,11 @@ pub(in crate::timeline) struct TimelineInnerMetadata {
     back_pagination_tokens: VecDeque<(OwnedEventId, String)>,
 
     /// The hook to call whenever we run into a unable-to-decrypt event.
-    pub(crate) unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
+    pub(crate) unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>,
 }
 
 impl TimelineInnerMetadata {
-    fn new(
-        room_version: RoomVersionId,
-        unable_to_decrypt_hook: Option<Arc<dyn UnableToDecryptHook>>,
-    ) -> TimelineInnerMetadata {
+    fn new(room_version: RoomVersionId, unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>) -> Self {
         Self {
             all_events: Default::default(),
             next_internal_id: Default::default(),

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -54,7 +54,7 @@ use crate::{
         AnnotationKey, Error as TimelineError, Profile, ReactionSenderData, TimelineItem,
         TimelineItemKind, VirtualTimelineItem,
     },
-    unable_to_decrypt_hook::SmartUtdHook,
+    unable_to_decrypt_hook::UtdHookManager,
 };
 
 #[derive(Debug)]
@@ -66,7 +66,7 @@ pub(in crate::timeline) struct TimelineInnerState {
 impl TimelineInnerState {
     pub(super) fn new(
         room_version: RoomVersionId,
-        unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>,
+        unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
     ) -> Self {
         Self {
             // Upstream default capacity is currently 16, which is making
@@ -812,11 +812,14 @@ pub(in crate::timeline) struct TimelineInnerMetadata {
     back_pagination_tokens: VecDeque<(OwnedEventId, String)>,
 
     /// The hook to call whenever we run into a unable-to-decrypt event.
-    pub(crate) unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>,
+    pub(crate) unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
 }
 
 impl TimelineInnerMetadata {
-    fn new(room_version: RoomVersionId, unable_to_decrypt_hook: Option<Arc<SmartUtdHook>>) -> Self {
+    fn new(
+        room_version: RoomVersionId,
+        unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
+    ) -> Self {
         Self {
             all_events: Default::default(),
             next_internal_id: Default::default(),

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 #[async_test]
-async fn retry_message_decryption() {
+async fn test_retry_message_decryption() {
     const SESSION_ID: &str = "gM8i47Xhu0q52xLfgUXzanCMpLinoyVyH7R58cBuVBU";
     const SESSION_KEY: &[u8] = b"\
         -----BEGIN MEGOLM SESSION DATA-----\n\
@@ -161,7 +161,7 @@ async fn retry_message_decryption() {
 }
 
 #[async_test]
-async fn retry_edit_decryption() {
+async fn test_retry_edit_decryption() {
     const SESSION1_KEY: &[u8] = b"\
         -----BEGIN MEGOLM SESSION DATA-----\n\
         AXou7bY+PWm0GrxTioyoKTkxAgfrQ5lGIla62WoBMrqWAAAACgXidLIt0gaK5NT3mGigzFAPjh/M0ibXjSvo\
@@ -267,7 +267,7 @@ async fn retry_edit_decryption() {
 }
 
 #[async_test]
-async fn retry_edit_and_more() {
+async fn test_retry_edit_and_more() {
     const DEVICE_ID: &str = "MTEGRRVPEN";
     const SENDER_KEY: &str = "NFPM2+ucU3n3sEdbDdwwv48Bsj4AiQ185lGuRFjy+gs";
     const SESSION_ID: &str = "SMNh04luorH5E8J3b4XYuOBFp8dldO5njacq0OFO70o";
@@ -372,7 +372,7 @@ async fn retry_edit_and_more() {
 }
 
 #[async_test]
-async fn retry_message_decryption_highlighted() {
+async fn test_retry_message_decryption_highlighted() {
     const SESSION_ID: &str = "C25PoE+4MlNidQD0YU5ibZqHawV0zZ/up7R8vYJBYTY";
     const SESSION_KEY: &[u8] = b"\
         -----BEGIN MEGOLM SESSION DATA-----\n\

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -38,7 +38,7 @@ use stream_assert::assert_next_matches;
 use super::TestTimeline;
 use crate::{
     timeline::{EncryptedMessage, TimelineItemContent},
-    unable_to_decrypt_hook::{SmartUtdHook, UnableToDecryptHook, UnableToDecryptInfo},
+    unable_to_decrypt_hook::{UnableToDecryptHook, UnableToDecryptInfo, UtdHookManager},
 };
 
 #[async_test]
@@ -70,7 +70,7 @@ async fn test_retry_message_decryption() {
     }
 
     let hook = Arc::new(DummyUtdHook::default());
-    let utd_hook = Arc::new(SmartUtdHook::new(hook.clone()));
+    let utd_hook = Arc::new(UtdHookManager::new(hook.clone()));
 
     let timeline = TestTimeline::with_unable_to_decrypt_hook(utd_hook.clone());
     let mut stream = timeline.subscribe().await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -54,7 +54,7 @@ use super::{
     traits::RoomDataProvider,
     EventTimelineItem, Profile, TimelineInner, TimelineItem,
 };
-use crate::unable_to_decrypt_hook::UnableToDecryptHook;
+use crate::unable_to_decrypt_hook::SmartUtdHook;
 
 mod basic;
 mod echo;
@@ -88,7 +88,7 @@ impl TestTimeline {
         }
     }
 
-    fn with_unable_to_decrypt_hook(hook: Arc<dyn UnableToDecryptHook>) -> Self {
+    fn with_unable_to_decrypt_hook(hook: Arc<SmartUtdHook>) -> Self {
         Self {
             inner: TimelineInner::new(TestRoomDataProvider::default(), Some(hook)),
             event_builder: EventBuilder::new(),

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -54,7 +54,7 @@ use super::{
     traits::RoomDataProvider,
     EventTimelineItem, Profile, TimelineInner, TimelineItem,
 };
-use crate::unable_to_decrypt_hook::SmartUtdHook;
+use crate::unable_to_decrypt_hook::UtdHookManager;
 
 mod basic;
 mod echo;
@@ -88,7 +88,7 @@ impl TestTimeline {
         }
     }
 
-    fn with_unable_to_decrypt_hook(hook: Arc<SmartUtdHook>) -> Self {
+    fn with_unable_to_decrypt_hook(hook: Arc<UtdHookManager>) -> Self {
         Self {
             inner: TimelineInner::new(TestRoomDataProvider::default(), Some(hook)),
             event_builder: EventBuilder::new(),

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -54,6 +54,7 @@ use super::{
     traits::RoomDataProvider,
     EventTimelineItem, Profile, TimelineInner, TimelineItem,
 };
+use crate::unable_to_decrypt_hook::UnableToDecryptHook;
 
 mod basic;
 mod echo;
@@ -81,7 +82,17 @@ impl TestTimeline {
     }
 
     fn with_room_data_provider(room_data_provider: TestRoomDataProvider) -> Self {
-        Self { inner: TimelineInner::new(room_data_provider), event_builder: EventBuilder::new() }
+        Self {
+            inner: TimelineInner::new(room_data_provider, None),
+            event_builder: EventBuilder::new(),
+        }
+    }
+
+    fn with_unable_to_decrypt_hook(hook: Arc<dyn UnableToDecryptHook>) -> Self {
+        Self {
+            inner: TimelineInner::new(TestRoomDataProvider::default(), Some(hook)),
+            event_builder: EventBuilder::new(),
+        }
     }
 
     fn with_settings(mut self, settings: TimelineInnerSettings) -> Self {

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -21,9 +21,11 @@
 use std::{
     collections::HashSet,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use ruma::OwnedEventId;
+use tokio::{spawn, task::JoinHandle, time::sleep};
 
 /// A generic interface which methods get called whenever we observe a
 /// unable-to-decrypt (UTD) event.
@@ -44,7 +46,7 @@ pub trait UnableToDecryptHook: std::fmt::Debug + Send + Sync {
 }
 
 /// Information about an event we couldn't decrypt.
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UnableToDecryptInfo {
     /// The identifier of the event that couldn't get decrypted.
     pub event_id: OwnedEventId,
@@ -52,37 +54,105 @@ pub struct UnableToDecryptInfo {
 
 /// A decorator over an existing [`UnableToDecryptHook`] that deduplicates UTDs
 /// on similar events, and adds basic consistency checks.
+///
+/// It can also implement a grace period before reporting an event as a UTD, if
+/// configured with [`Self::with_delay`]. Instead of immediately reporting the
+/// UTD, the reporting will be delayed by the grace period; the reporting of the
+/// late decryption via [`UnableToDecryptHook::on_late_decrypt`] still happens
+/// in all the cases, though.
 #[derive(Debug)]
 pub struct SmartUtdHook {
     /// The parent hook we'll call, when we have found a unique UTD.
     parent: Arc<dyn UnableToDecryptHook>,
 
     /// The set of events we've already marked as UTDs before.
+    ///
+    /// Note: this is unbounded, because we have absolutely no idea how long it
+    /// will take for a UTD to resolve, or if it will even resolve at any
+    /// point.
     known_utds: Arc<Mutex<HashSet<OwnedEventId>>>,
+
+    /// An optional delay before marking the event as UTD.
+    delay: Option<Duration>,
+
+    /// The set of outstanding tasks to report deferred UTDs.
+    pending_delayed: Arc<Mutex<Vec<(OwnedEventId, JoinHandle<()>)>>>,
 }
 
 impl SmartUtdHook {
     /// Create a new [`SmartUtdHook`] for the given hook.
     pub fn new(parent: Arc<dyn UnableToDecryptHook>) -> Self {
-        Self { parent, known_utds: Default::default() }
+        Self {
+            parent,
+            known_utds: Default::default(),
+            delay: None,
+            pending_delayed: Default::default(),
+        }
+    }
+
+    /// Reports UTDs with the given delay.
+    ///
+    /// Note: late decryptions are always reported, even if there was a grace
+    /// period set for the reporting of the UTD.
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = Some(delay);
+        self
+    }
+}
+
+impl Drop for SmartUtdHook {
+    fn drop(&mut self) {
+        // Cancel all the outstanding delayed tasks to report UTDs.
+        let mut pending_delayed = self.pending_delayed.lock().unwrap();
+        for (_, task) in pending_delayed.drain(..) {
+            task.abort();
+        }
     }
 }
 
 impl UnableToDecryptHook for SmartUtdHook {
     fn on_utd(&self, info: UnableToDecryptInfo) {
-        let mut set = self.known_utds.lock().unwrap();
-
         // Only let the parent hook know if the event wasn't already handled.
-        if set.insert(info.event_id.to_owned()) {
-            self.parent.on_utd(info);
+        if !self.known_utds.lock().unwrap().insert(info.event_id.to_owned()) {
+            return;
         }
+
+        let Some(delay) = self.delay.clone() else {
+            // No delay: immediately report the event to the parent hook.
+            self.parent.on_utd(info);
+            return;
+        };
+
+        let event_id = info.event_id.clone();
+
+        // Clone Arc'd pointers shared with the task below.
+        let known_utds = self.known_utds.clone();
+        let pending_delayed = self.pending_delayed.clone();
+        let parent = self.parent.clone();
+
+        // Spawn a task that will wait for the given delay, and maybe call the parent
+        // hook then.
+        let handle = spawn(async move {
+            // Wait for the given delay.
+            sleep(delay.clone()).await;
+
+            // In any case, remove the task from the outstanding set.
+            pending_delayed.lock().unwrap().retain(|(event_id, _)| *event_id != info.event_id);
+
+            // Check if the event is still in the set: if not, it's been decrypted since
+            // then!
+            if known_utds.lock().unwrap().contains(&info.event_id) {
+                parent.on_utd(info);
+            }
+        });
+
+        // Add the task to the set of pending tasks.
+        self.pending_delayed.lock().unwrap().push((event_id, handle));
     }
 
     fn on_late_decrypt(&self, info: UnableToDecryptInfo) {
-        let mut set = self.known_utds.lock().unwrap();
-
         // Only let the parent hook know if the event was known to be a UTDs.
-        if set.remove(&info.event_id) {
+        if self.known_utds.lock().unwrap().remove(&info.event_id) {
             self.parent.on_late_decrypt(info);
         }
     }
@@ -90,6 +160,7 @@ impl UnableToDecryptHook for SmartUtdHook {
 
 #[cfg(test)]
 mod tests {
+    use matrix_sdk_test::async_test;
     use ruma::{event_id, owned_event_id};
 
     use super::*;
@@ -191,5 +262,84 @@ mod tests {
             assert_eq!(utds.len(), 1);
             assert_eq!(utds[0].event_id, event_id!("$1"));
         }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))] // wasm32 has no time for that
+    #[async_test]
+    async fn test_delayed_reporting() {
+        // If I create a dummy hook,
+        let hook = Arc::new(Dummy::default());
+
+        // And I wrap with the SmartUtdHook decorator, configured to delay reporting
+        // after 2 seconds.
+        let wrapper = SmartUtdHook::new(hook.clone()).with_delay(Duration::from_secs(2));
+
+        // And I call the `on_utd` method for an event,
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+
+        // Then the UTD has not been notified quite yet.
+        assert!(hook.utds.lock().unwrap().is_empty());
+        assert!(hook.late_decrypted.lock().unwrap().is_empty());
+
+        // If I wait for 1 second, then it's still not been notified yet.
+        sleep(Duration::from_secs(1)).await;
+
+        assert!(hook.utds.lock().unwrap().is_empty());
+        assert!(hook.late_decrypted.lock().unwrap().is_empty());
+
+        // But if I wait just a bit more, then it's been notified \o/
+        sleep(Duration::from_millis(1500)).await;
+
+        {
+            let utds = hook.utds.lock().unwrap();
+            assert_eq!(utds.len(), 1);
+            assert_eq!(utds[0].event_id, event_id!("$1"));
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))] // wasm32 has no time for that
+    #[async_test]
+    async fn test_delayed_not_reporting() {
+        // If I create a dummy hook,
+        let hook = Arc::new(Dummy::default());
+
+        // And I wrap with the SmartUtdHook decorator, configured to delay reporting
+        // after 2 seconds.
+        let wrapper = SmartUtdHook::new(hook.clone()).with_delay(Duration::from_secs(2));
+
+        // And I call the `on_utd` method for an event,
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+
+        // Then the UTD has not been notified quite yet.
+        assert!(hook.utds.lock().unwrap().is_empty());
+        assert!(hook.late_decrypted.lock().unwrap().is_empty());
+        assert_eq!(wrapper.pending_delayed.lock().unwrap().len(), 1);
+
+        // If I wait for 1 second, and mark the event as late-decrypted,
+        sleep(Duration::from_secs(1)).await;
+
+        wrapper.on_late_decrypt(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+
+        // Then it's still not reported as a UTD (but it's reported as a late-decrypted
+        // event).
+        assert!(hook.utds.lock().unwrap().is_empty());
+        {
+            let late = hook.late_decrypted.lock().unwrap();
+            assert_eq!(late.len(), 1);
+            assert_eq!(late[0].event_id, event_id!("$1"));
+        }
+
+        // And I get the same result after the grace period ended for sure.
+        sleep(Duration::from_millis(1500)).await;
+
+        assert!(hook.utds.lock().unwrap().is_empty());
+        {
+            let late = hook.late_decrypted.lock().unwrap();
+            assert_eq!(late.len(), 1);
+            assert_eq!(late[0].event_id, event_id!("$1"));
+        }
+
+        // And there aren't any pending delayed reports anymore.
+        assert!(wrapper.pending_delayed.lock().unwrap().is_empty());
     }
 }

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -47,6 +47,7 @@ pub trait UnableToDecryptHook: std::fmt::Debug + Send + Sync {
 
 /// Information about an event we couldn't decrypt.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct UnableToDecryptInfo {
     /// The identifier of the event that couldn't get decrypted.
     pub event_id: OwnedEventId,

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -41,7 +41,6 @@ pub trait UnableToDecryptHook: std::fmt::Debug + Send + Sync {
 
 /// Information about an event we were unable to decrypt (UTD).
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct UnableToDecryptInfo {
     /// The identifier of the event that couldn't get decrypted.
     pub event_id: OwnedEventId,

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -52,6 +52,8 @@ pub struct UnableToDecryptInfo {
     pub time_to_decrypt: Option<Duration>,
 }
 
+type PendingUtdReports = Vec<(OwnedEventId, JoinHandle<()>)>;
+
 /// A manager over an existing [`UnableToDecryptHook`] that deduplicates UTDs
 /// on similar events, and adds basic consistency checks.
 ///
@@ -78,9 +80,7 @@ pub struct UtdHookManager {
 
     /// The set of outstanding tasks to report deferred UTDs, including the
     /// event relating to the task.
-    #[allow(clippy::type_complexity)]
-    // No clippy, adding a type alias is just cognitive overhead here.
-    pending_delayed: Arc<Mutex<Vec<(OwnedEventId, JoinHandle<()>)>>>,
+    pending_delayed: Arc<Mutex<PendingUtdReports>>,
 }
 
 impl UtdHookManager {

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -27,7 +27,7 @@ use ruma::OwnedEventId;
 
 /// A generic interface which methods get called whenever we observe a
 /// unable-to-decrypt (UTD) event.
-pub trait UnableToDecryptHook {
+pub trait UnableToDecryptHook: std::fmt::Debug + Send + Sync {
     /// Called every time the hook observes an encrypted event that couldn't be
     /// decrypted.
     fn on_utd(&self, info: UnableToDecryptInfo);
@@ -94,7 +94,7 @@ mod tests {
 
     use super::*;
 
-    #[derive(Default)]
+    #[derive(Debug, Default)]
     struct Dummy {
         utds: Mutex<Vec<UnableToDecryptInfo>>,
         late_decrypted: Mutex<Vec<UnableToDecryptInfo>>,

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -1,0 +1,195 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module provides a generic interface to subscribe to unable-to-decrypt
+//! events, and notable updates to such events.
+//!
+//! This provides a general trait that a consumer may implement, as well as
+//! utilities to simplify usage of this trait.
+
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+use ruma::OwnedEventId;
+
+/// A generic interface which methods get called whenever we observe a
+/// unable-to-decrypt (UTD) event.
+pub trait UnableToDecryptHook {
+    /// Called every time the hook observes an encrypted event that couldn't be
+    /// decrypted.
+    fn on_utd(&self, info: UnableToDecryptInfo);
+
+    /// Called every time we successfully decrypted an event that before,
+    /// couldn't be decrypted initially.
+    ///
+    /// This happens whenever the key to decrypt an event comes in after we saw
+    /// the encrypted event. The cause might be that the network sent the
+    /// key slower than the event itself, or that there was any failure in
+    /// the decryption process, or that the key to decrypt was received late
+    /// (e.g. from a backup, etc.).
+    fn on_late_decrypt(&self, info: UnableToDecryptInfo);
+}
+
+/// Information about an event we couldn't decrypt.
+#[derive(Clone, Debug, Hash, PartialEq)]
+pub struct UnableToDecryptInfo {
+    /// The identifier of the event that couldn't get decrypted.
+    pub event_id: OwnedEventId,
+}
+
+/// A decorator over an existing [`UnableToDecryptHook`] that deduplicates UTDs
+/// on similar events, and adds basic consistency checks.
+#[derive(Debug)]
+pub struct SmartUtdHook {
+    /// The parent hook we'll call, when we have found a unique UTD.
+    parent: Arc<dyn UnableToDecryptHook>,
+
+    /// The set of events we've already marked as UTDs before.
+    known_utds: Arc<Mutex<HashSet<OwnedEventId>>>,
+}
+
+impl SmartUtdHook {
+    /// Create a new [`SmartUtdHook`] for the given hook.
+    pub fn new(parent: Arc<dyn UnableToDecryptHook>) -> Self {
+        Self { parent, known_utds: Default::default() }
+    }
+}
+
+impl UnableToDecryptHook for SmartUtdHook {
+    fn on_utd(&self, info: UnableToDecryptInfo) {
+        let mut set = self.known_utds.lock().unwrap();
+
+        // Only let the parent hook know if the event wasn't already handled.
+        if set.insert(info.event_id.to_owned()) {
+            self.parent.on_utd(info);
+        }
+    }
+
+    fn on_late_decrypt(&self, info: UnableToDecryptInfo) {
+        let mut set = self.known_utds.lock().unwrap();
+
+        // Only let the parent hook know if the event was known to be a UTDs.
+        if set.remove(&info.event_id) {
+            self.parent.on_late_decrypt(info);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma::{event_id, owned_event_id};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct Dummy {
+        utds: Mutex<Vec<UnableToDecryptInfo>>,
+        late_decrypted: Mutex<Vec<UnableToDecryptInfo>>,
+    }
+
+    impl UnableToDecryptHook for Dummy {
+        fn on_utd(&self, info: UnableToDecryptInfo) {
+            self.utds.lock().unwrap().push(info);
+        }
+        fn on_late_decrypt(&self, info: UnableToDecryptInfo) {
+            self.late_decrypted.lock().unwrap().push(info);
+        }
+    }
+
+    #[test]
+    fn test_deduplicates_utds() {
+        // If I create a dummy hook,
+        let hook = Arc::new(Dummy::default());
+
+        // And I wrap with the SmartUtdHook decorator,
+        let wrapper = SmartUtdHook::new(hook.clone());
+
+        // And I call the `on_utd` method multiple times, sometimes on the same event,
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$2") });
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$2") });
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$3") });
+
+        // Then the event ids have been deduplicated,
+        {
+            let utds = hook.utds.lock().unwrap();
+            assert_eq!(utds.len(), 3);
+            assert_eq!(utds[0].event_id, event_id!("$1"));
+            assert_eq!(utds[1].event_id, event_id!("$2"));
+            assert_eq!(utds[2].event_id, event_id!("$3"));
+        }
+
+        // And no late decryption has been reported.
+        assert!(hook.late_decrypted.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_on_late_decrypted_no_effect() {
+        // If I create a dummy hook,
+        let hook = Arc::new(Dummy::default());
+
+        // And I wrap with the SmartUtdHook decorator,
+        let wrapper = SmartUtdHook::new(hook.clone());
+
+        // And I call the `on_late_decrypt` method before the event had been marked as
+        // utd,
+        wrapper.on_late_decrypt(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+
+        // Then nothing is registered in the parent hook.
+        assert!(hook.utds.lock().unwrap().is_empty());
+        assert!(hook.late_decrypted.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_on_late_decrypted_after_utd() {
+        // If I create a dummy hook,
+        let hook = Arc::new(Dummy::default());
+
+        // And I wrap with the SmartUtdHook decorator,
+        let wrapper = SmartUtdHook::new(hook.clone());
+
+        // And I call the `on_utd` method for an event,
+        wrapper.on_utd(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+
+        // Then the UTD has been notified, but not as late-decrypted event.
+        {
+            let utds = hook.utds.lock().unwrap();
+            assert_eq!(utds.len(), 1);
+            assert_eq!(utds[0].event_id, event_id!("$1"));
+        }
+        assert!(hook.late_decrypted.lock().unwrap().is_empty());
+
+        // And when I call the `on_late_decrypt` method before the event had been marked
+        // as utd,
+        wrapper.on_late_decrypt(UnableToDecryptInfo { event_id: owned_event_id!("$1") });
+
+        // Then the event is now known as a late-decrypted event too.
+        {
+            let late_decrypted = hook.late_decrypted.lock().unwrap();
+            assert_eq!(late_decrypted.len(), 1);
+            assert_eq!(late_decrypted[0].event_id, event_id!("$1"));
+        }
+
+        // (Sanity check: The reported UTD hasn't been touched.)
+        {
+            let utds = hook.utds.lock().unwrap();
+            assert_eq!(utds.len(), 1);
+            assert_eq!(utds[0].event_id, event_id!("$1"));
+        }
+    }
+}


### PR DESCRIPTION
This adds a new mechanism in the UI crate (since re-attempts to decrypt happen in the timeline, as of today — later that'll happen in the event cache) to notify whenever we run into a UTD (an event couldn't be decrypted) or a late-decryption event (after some time, a UTD could be decrypted).

This new hook will deduplicate pings for the same event (identifying events on their event id), and also implements an optional grace period. If an event was a UTD:

- if it's still a UTD after the grace period, then it's reported with a `None` `time_to_decrypt`,
- if it's not a UTD anymore (i.e. it's been decrypted in the meanwhile), then it's reported with a `time_to_decrypt` set to the time it took to decrypt the event (approximate, since it starts counting from the time the timeline receives it, not the time the SDK fails to decrypt it at first).

It's configurable as an optional hook on timeline builders. For the FFI, it's configurable at the sync service's level with a "delegate", and then the sync service will forward the hook to the timelines it creates, and the hook will forward the UTD info to the delegate.

Part of https://github.com/element-hq/element-meta/issues/2300.