### PR TITLE
Add more logging for crypto store generation counter

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1927,6 +1927,8 @@ impl OlmMachine {
             None => 0,
         };
 
+        tracing::debug!("Initialising crypto store generation at {}", gen);
+
         self.inner
             .store
             .set_custom_value(Self::CURRENT_GENERATION_STORE_KEY, gen.to_le_bytes().to_vec())

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1939,19 +1939,32 @@ impl OlmMachine {
 
     /// If needs be, update the local and on-disk crypto store generation.
     ///
-    /// Returns true whether another user has modified the internal generation
-    /// counter, and as such we've incremented and updated it in the
-    /// database.
-    ///
     /// ## Requirements
     ///
     /// - This assumes that `initialize_crypto_store_generation` has been called
     /// beforehand.
     /// - This requires that the crypto store lock has been acquired.
-    pub async fn maintain_crypto_store_generation(
-        &self,
+    ///
+    /// # Arguments
+    ///
+    /// * `generation` - The in-memory generation counter (or rather, the
+    ///   `Mutex` wrapping it). This defines the "expected" generation on entry,
+    ///   and, if we determine an update is needed, is updated to hold the "new"
+    ///   generation.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing:
+    ///
+    /// * A `bool`, set to `true` if another process has updated the generation
+    ///   number in the `Store` since our expected value, and as such we've
+    ///   incremented and updated it in the database. Otherwise, `false`.
+    ///
+    /// * The (possibly updated) generation counter.
+    pub async fn maintain_crypto_store_generation<'a>(
+        &'a self,
         generation: &Mutex<Option<u64>>,
-    ) -> StoreResult<bool> {
+    ) -> StoreResult<(bool, u64)> {
         let mut gen_guard = generation.lock().await;
 
         // The database value must be there:
@@ -1973,10 +1986,10 @@ impl OlmMachine {
                 CryptoStoreError::InvalidLockGeneration("invalid format".to_owned())
             })?);
 
-        let expected_gen = match gen_guard.as_ref() {
+        let new_gen = match gen_guard.as_ref() {
             Some(expected_gen) => {
                 if actual_gen == *expected_gen {
-                    return Ok(false);
+                    return Ok((false, actual_gen));
                 }
                 // Increment the biggest, and store it everywhere.
                 actual_gen.max(*expected_gen).wrapping_add(1)
@@ -1992,22 +2005,19 @@ impl OlmMachine {
             "Crypto store generation mismatch: previously known was {:?}, actual is {:?}, next is {}",
             *gen_guard,
             actual_gen,
-            expected_gen
+            new_gen
         );
 
         // Update known value.
-        *gen_guard = Some(expected_gen);
+        *gen_guard = Some(new_gen);
 
         // Update value in database.
         self.inner
             .store
-            .set_custom_value(
-                Self::CURRENT_GENERATION_STORE_KEY,
-                expected_gen.to_le_bytes().to_vec(),
-            )
+            .set_custom_value(Self::CURRENT_GENERATION_STORE_KEY, new_gen.to_le_bytes().to_vec())
             .await?;
 
-        Ok(true)
+        Ok((true, new_gen))
     }
 
     /// Manage dehydrated devices.

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -202,8 +202,9 @@ pub enum VerificationState {
 }
 
 /// Wraps together a `CrossProcessLockStoreGuard` and a generation number.
+#[derive(Debug)]
 pub struct CrossProcessLockStoreGuardWithGeneration {
-    guard: CrossProcessStoreLockGuard,
+    _guard: CrossProcessStoreLockGuard,
     generation: u64,
 }
 
@@ -1298,7 +1299,7 @@ impl Encryption {
 
             let generation = self.on_lock_newly_acquired().await?;
 
-            Ok(Some(CrossProcessLockStoreGuardWithGeneration { guard, generation }))
+            Ok(Some(CrossProcessLockStoreGuardWithGeneration { _guard: guard, generation }))
         } else {
             Ok(None)
         }
@@ -1320,7 +1321,7 @@ impl Encryption {
 
             let generation = self.on_lock_newly_acquired().await?;
 
-            Ok(Some(CrossProcessLockStoreGuardWithGeneration { guard, generation }))
+            Ok(Some(CrossProcessLockStoreGuardWithGeneration { _guard: guard, generation }))
         } else {
             Ok(None)
         }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1279,8 +1279,10 @@ impl Encryption {
             Ok(generation_number)
         } else {
             // XXX: not sure this is reachable. Seems like the OlmMachine should always have
-            // been initialised by the time we get here. We'll just return the
-            // magic number 0.
+            // been initialised by the time we get here. Ideally we'd panic, or return an
+            // error, but for now I'm just adding some logging to check if it
+            // happens, and returning the magic number 0.
+            warn!("Encryption::on_lock_newly_acquired: called before OlmMachine initialised");
             Ok(0)
         }
     }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -78,7 +78,7 @@ use ruma::{
 use serde::de::DeserializeOwned;
 use thiserror::Error;
 use tokio::sync::broadcast;
-use tracing::{debug, info, instrument, warn};
+use tracing::{debug, info, instrument, warn, Span};
 
 use self::futures::{SendAttachment, SendMessageLikeEvent, SendRawMessageLikeEvent};
 pub use self::{
@@ -1448,12 +1448,13 @@ impl Room {
     // TODO: expose this publicly so people can pre-share a group session if
     // e.g. a user starts to type a message for a room.
     #[cfg(feature = "e2e-encryption")]
-    #[instrument(skip_all, fields(room_id = ?self.room_id()))]
+    #[instrument(skip_all, fields(room_id = ?self.room_id(), store_generation))]
     async fn preshare_room_key(&self) -> Result<()> {
         self.ensure_room_joined()?;
 
         // Take and release the lock on the store, if needs be.
-        let _guard = self.client.encryption().spin_lock_store(Some(60000)).await?;
+        let guard = self.client.encryption().spin_lock_store(Some(60000)).await?;
+        Span::current().record("store_generation", guard.map(|guard| guard.generation()));
 
         self.client
             .locks()

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -78,7 +78,7 @@ use ruma::{
 use serde::de::DeserializeOwned;
 use thiserror::Error;
 use tokio::sync::broadcast;
-use tracing::{debug, info, instrument, warn, Span};
+use tracing::{debug, info, instrument, warn};
 
 use self::futures::{SendAttachment, SendMessageLikeEvent, SendRawMessageLikeEvent};
 pub use self::{
@@ -1454,7 +1454,7 @@ impl Room {
 
         // Take and release the lock on the store, if needs be.
         let guard = self.client.encryption().spin_lock_store(Some(60000)).await?;
-        Span::current().record("store_generation", guard.map(|guard| guard.generation()));
+        tracing::Span::current().record("store_generation", guard.map(|guard| guard.generation()));
 
         self.client
             .locks()

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -722,14 +722,11 @@ impl SlidingSync {
     pub fn sync(&self) -> impl Stream<Item = Result<UpdateSummary, crate::Error>> + '_ {
         debug!("Starting sync stream");
 
-        let sync_span = Span::current();
         let mut internal_channel_receiver = self.inner.internal_channel.subscribe();
 
         stream! {
             loop {
-                sync_span.in_scope(|| {
-                    debug!("Sync stream is running");
-                });
+                debug!("Sync stream is running");
 
                 select! {
                     biased;
@@ -737,9 +734,7 @@ impl SlidingSync {
                     internal_message = internal_channel_receiver.recv() => {
                         use SlidingSyncInternalMessage::*;
 
-                        sync_span.in_scope(|| {
-                            debug!(?internal_message, "Sync stream has received an internal message");
-                        });
+                        debug!(?internal_message, "Sync stream has received an internal message");
 
                         match internal_message {
                             Err(_) | Ok(SyncLoopStop) => {
@@ -752,7 +747,7 @@ impl SlidingSync {
                         }
                     }
 
-                    update_summary = self.sync_once().instrument(sync_span.clone()) => {
+                    update_summary = self.sync_once() => {
                         match update_summary {
                             Ok(updates) => {
                                 yield Ok(updates);
@@ -767,9 +762,7 @@ impl SlidingSync {
                             Err(error) => {
                                 if error.client_api_error_kind() == Some(&ErrorKind::UnknownPos) {
                                     // The Sliding Sync session has expired. Let's reset `pos` and sticky parameters.
-                                    sync_span.in_scope(|| async {
-                                        self.expire_session().await;
-                                    }).await;
+                                    self.expire_session().await;
                                 }
 
                                 yield Err(error);


### PR DESCRIPTION
It's a bit unclear whether the crypto-store generation counter is doing the right thing in terms of causing us to reload the OlmMachine. There is a suspicion that things might be keeping hold of references to the old OlmMachine.

This PR attempts to add the generation number to the logging for any operations that hold the cross-process lock. It's obviously not bulletproof: for example, it is possible for the `OlmMachine` to be replaced without holding the lock; but hopefully this will at least help us understand what's going on.