### PR TITLE
fix(ruma): Add the `compat-tag-info` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures-util = { version = "0.3.26", default-features = false, features = ["allo
 http = "0.2.6"
 imbl = "2.0.0"
 itertools = "0.12.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "b2542df2bbbdf09af0612c9f28bcfa5620e1911c", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "unstable-msc3401"] }
+ruma = { git = "https://github.com/ruma/ruma", rev = "b2542df2bbbdf09af0612c9f28bcfa5620e1911c", features = ["client-api-c", "compat-upload-signatures", "compat-user-id", "compat-arbitrary-length-ids", "compat-tag-info", "unstable-msc3401"] }
 ruma-common = { git = "https://github.com/ruma/ruma", rev = "b2542df2bbbdf09af0612c9f28bcfa5620e1911c" }
 once_cell = "1.16.0"
 rand = "0.8.5"


### PR DESCRIPTION
This patch enables the `compat-tag-info` feature on Ruma, so that `TagInfo::order` can be deserialized from both a `f64` or a `string` representing a `f64`[^1].

[^1]: https://github.com/ruma/ruma/blob/f24cae17f50d140a0ff112cb3dc74a2053aa1df4/crates/ruma-events/src/tag.rs#L180-L185