### PR TITLE
Crypto: Expose the _disable-minimum-rotation-period-ms flag via main crates

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [features]
 default = ["bundled-sqlite"]
 bundled-sqlite = ["matrix-sdk-sqlite/bundled"]
+_disable-minimum-rotation-period-ms = ["matrix-sdk-crypto/_disable-minimum-rotation-period-ms"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [features]
 default = ["bundled-sqlite"]
 bundled-sqlite = ["matrix-sdk/bundled-sqlite"]
+_disable-minimum-rotation-period-ms = ["matrix-sdk/_disable-minimum-rotation-period-ms"]
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/crates/matrix-sdk-base/Cargo.toml
+++ b/crates/matrix-sdk-base/Cargo.toml
@@ -34,6 +34,8 @@ testing = [
     "matrix-sdk-crypto?/testing",
 ]
 
+_disable-minimum-rotation-period-ms = ["matrix-sdk-crypto?/_disable-minimum-rotation-period-ms"]
+
 [dependencies]
 as_variant = { workspace = true }
 assert_matches = { workspace = true, optional = true }

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -18,6 +18,7 @@ default = ["e2e-encryption", "state-store"]
 state-store = ["dep:matrix-sdk-base"]
 e2e-encryption = ["dep:matrix-sdk-crypto"]
 testing = ["matrix-sdk-crypto?/testing"]
+_disable-minimum-rotation-period-ms = ["matrix-sdk-crypto?/_disable-minimum-rotation-period-ms"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = { workspace = true }
 [features]
 default = ["state-store"]
 testing = ["matrix-sdk-crypto?/testing"]
+_disable-minimum-rotation-period-ms = ["matrix-sdk-crypto?/_disable-minimum-rotation-period-ms"]
 
 bundled = ["rusqlite/bundled"]
 crypto-store = ["dep:matrix-sdk-crypto"]

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -61,6 +61,12 @@ experimental-widgets = ["dep:language-tags", "dep:uuid"]
 
 docsrs = ["e2e-encryption", "sqlite", "indexeddb", "sso-login", "qrcode", "image-proc"]
 
+_disable-minimum-rotation-period-ms = [
+    "matrix-sdk-base/_disable-minimum-rotation-period-ms",
+    "matrix-sdk-sqlite?/_disable-minimum-rotation-period-ms",
+    "matrix-sdk-indexeddb?/_disable-minimum-rotation-period-ms",
+]
+
 [dependencies]
 anyhow = { workspace = true, optional = true }
 anymap2 = "0.13.0"


### PR DESCRIPTION
In order to be able to use the `_disable-minimum-rotation-period-ms` feature flag in the complement-crypto build, we need to expose it via the top-level crates.

Follows on from https://github.com/matrix-org/matrix-rust-sdk/pull/3200

(See https://github.com/matrix-org/complement-crypto/issues/17 )