### PR TITLE
timeline: a few drive-by refactorings

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -196,7 +196,7 @@ impl TimelineBuilder {
                             // TODO: (bnjbvr) account_data and ephemeral should be handled by the
                             // event cache, and we should replace this with a simple
                             // `handle_add_events`.
-                            inner.handle_joined_room_update(events, account_data, ephemeral).await;
+                            inner.handle_sync_events(events, account_data, ephemeral).await;
 
                             let member_ambiguity_changes = ambiguity_changes
                                 .values()

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -188,7 +188,6 @@ impl TimelineBuilder {
 
                         RoomEventCacheUpdate::Append {
                             events,
-                            prev_batch,
                             account_data,
                             ephemeral,
                             ambiguity_changes,
@@ -201,7 +200,7 @@ impl TimelineBuilder {
                             // `handle_add_events`.
                             let timeline = matrix_sdk_base::sync::Timeline {
                                 limited: false,
-                                prev_batch,
+                                prev_batch: None,
                                 events,
                             };
                             let update = JoinedRoomUpdate {

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -36,7 +36,7 @@ use super::{
     queue::send_queued_messages,
     BackPaginationStatus, Timeline, TimelineDropHandle,
 };
-use crate::unable_to_decrypt_hook::UtdHookManager;
+use crate::{timeline::inner::TimelineEnd, unable_to_decrypt_hook::UtdHookManager};
 
 /// Builder that allows creating and configuring various parts of a
 /// [`Timeline`].
@@ -148,7 +148,7 @@ impl TimelineBuilder {
         }
 
         if has_events {
-            inner.add_initial_events(events).await;
+            inner.add_events_at(events, TimelineEnd::Back { from_cache: true }).await;
         }
         if track_read_marker_and_receipts {
             inner.load_fully_read_event().await;

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -21,7 +21,6 @@ use matrix_sdk::{
     executor::spawn,
     Room,
 };
-use matrix_sdk_base::sync::JoinedRoomUpdate;
 use ruma::{
     events::{receipt::ReceiptType, AnySyncTimelineEvent},
     RoomVersionId,
@@ -194,24 +193,10 @@ impl TimelineBuilder {
                         } => {
                             trace!("Received new events");
 
-                            // XXX this timeline and the joined room updates are synthetic, until
-                            // we get rid of `handle_joined_room_update` by adding all functionality
-                            // back in the event cache, and replacing it with a simple
+                            // TODO: (bnjbvr) account_data and ephemeral should be handled by the
+                            // event cache, and we should replace this with a simple
                             // `handle_add_events`.
-                            let timeline = matrix_sdk_base::sync::Timeline {
-                                limited: false,
-                                prev_batch: None,
-                                events,
-                            };
-                            let update = JoinedRoomUpdate {
-                                unread_notifications: Default::default(),
-                                timeline,
-                                state: Default::default(),
-                                account_data,
-                                ephemeral,
-                                ambiguity_changes: Default::default(),
-                            };
-                            inner.handle_joined_room_update(update).await;
+                            inner.handle_joined_room_update(events, account_data, ephemeral).await;
 
                             let member_ambiguity_changes = ambiguity_changes
                                 .values()

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -249,7 +249,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         state: &'a mut TimelineInnerStateTransaction<'o>,
         ctx: TimelineEventContext,
     ) -> Self {
-        let TimelineInnerStateTransaction { items, meta } = state;
+        let TimelineInnerStateTransaction { items, meta, .. } = state;
         Self { items, meta, ctx, result: HandleEventResult::default() }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -425,7 +425,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         self.state.write().await.clear();
     }
 
-    pub(super) async fn handle_joined_room_update(
+    pub(super) async fn handle_sync_events(
         &self,
         events: Vec<SyncTimelineEvent>,
         account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
@@ -433,7 +433,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
     ) {
         let mut state = self.state.write().await;
         state
-            .handle_joined_room_update(
+            .handle_sync_events(
                 events,
                 account_data,
                 ephemeral,

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -667,22 +667,12 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
     /// Handle a list of back-paginated events.
     ///
-    /// Returns the number of timeline updates that were made. Short-circuits
-    /// and returns `None` if the number of items added or updated exceeds
-    /// `u16::MAX`, which should practically never happen.
-    ///
-    /// # Arguments
-    ///
-    /// * `events` - The events from back-pagination
-    ///
-    /// * `back_pagination_token` - The back-pagination token for loading
-    ///   further events
+    /// Returns the number of timeline updates that were made.
     pub(super) async fn handle_back_paginated_events(
         &self,
         events: Vec<TimelineEvent>,
-    ) -> Option<HandleManyEventsResult> {
+    ) -> HandleManyEventsResult {
         let mut state = self.state.write().await;
-
         state.handle_back_paginated_events(events, &self.room_data_provider, &self.settings).await
     }
 
@@ -1130,8 +1120,14 @@ impl TimelineInner {
 
 #[derive(Debug, Default)]
 pub(super) struct HandleManyEventsResult {
-    pub items_added: u16,
-    pub items_updated: u16,
+    /// The number of items that were added to the timeline.
+    ///
+    /// Note one can't assume anything about the position at which those were
+    /// added.
+    pub items_added: u64,
+
+    /// The number of items that were updated in the timeline.
+    pub items_updated: u64,
 }
 
 async fn fetch_replied_to_event(

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -115,7 +115,7 @@ impl TimelineInnerState {
     }
 
     #[instrument(skip_all)]
-    pub(super) async fn handle_joined_room_update<P: RoomDataProvider>(
+    pub(super) async fn handle_sync_events<P: RoomDataProvider>(
         &mut self,
         events: Vec<SyncTimelineEvent>,
         account_data: Vec<Raw<AnyRoomAccountDataEvent>>,

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -184,7 +184,13 @@ impl TimelineInnerState {
         settings: &TimelineInnerSettings,
     ) {
         let mut txn = self.transaction();
-        txn.handle_live_event(event, room_data_provider, settings).await;
+        txn.handle_remote_event(
+            event,
+            TimelineItemPosition::End { from_cache: false },
+            room_data_provider,
+            settings,
+        )
+        .await;
         txn.commit();
     }
 
@@ -464,27 +470,14 @@ impl TimelineInnerStateTransaction<'_> {
         let num_events = timeline.events.len();
         for (i, event) in timeline.events.into_iter().enumerate() {
             trace!("Handling event {} out of {num_events}", i + 1);
-            self.handle_live_event(event, room_data_provider, settings).await;
+            self.handle_remote_event(
+                event,
+                TimelineItemPosition::End { from_cache: false },
+                room_data_provider,
+                settings,
+            )
+            .await;
         }
-    }
-
-    /// Handle a live remote event.
-    ///
-    /// Shorthand for `handle_remote_event` with a `position` of
-    /// `TimelineItemPosition::End { from_cache: false }`.
-    async fn handle_live_event<P: RoomDataProvider>(
-        &mut self,
-        event: SyncTimelineEvent,
-        room_data_provider: &P,
-        settings: &TimelineInnerSettings,
-    ) -> (Option<OwnedEventId>, HandleEventResult) {
-        self.handle_remote_event(
-            event,
-            TimelineItemPosition::End { from_cache: false },
-            room_data_provider,
-            settings,
-        )
-        .await
     }
 
     /// Handle a remote event.

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -16,7 +16,6 @@ use std::{
     collections::VecDeque,
     future::Future,
     mem::{self, ManuallyDrop},
-    ops::{Deref, DerefMut},
     sync::Arc,
 };
 
@@ -407,20 +406,6 @@ impl TimelineInnerState {
         let items = ManuallyDrop::new(self.items.transaction());
         let meta = ManuallyDrop::new(self.meta.clone());
         TimelineInnerStateTransaction { items, previous_meta: &mut self.meta, meta }
-    }
-}
-
-impl Deref for TimelineInnerState {
-    type Target = TimelineInnerMetadata;
-
-    fn deref(&self) -> &Self::Target {
-        &self.meta
-    }
-}
-
-impl DerefMut for TimelineInnerState {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.meta
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -17,6 +17,8 @@ use std::{fmt, ops::ControlFlow, sync::Arc, time::Duration};
 use matrix_sdk::event_cache::{self, BackPaginationOutcome};
 use tracing::{debug, instrument, trace, warn};
 
+use crate::timeline::inner::TimelineEnd;
+
 impl super::Timeline {
     /// Add more events to the start of the timeline.
     #[instrument(skip_all, fields(room_id = ?self.room().room_id(), ?options))]
@@ -52,7 +54,7 @@ impl super::Timeline {
                         trace!("Back-pagination succeeded with {num_events} events");
 
                         let handle_many_events_result =
-                            self.inner.handle_back_paginated_events(events).await;
+                            self.inner.add_events_at(events, TimelineEnd::Front).await;
 
                         if reached_start {
                             self.back_pagination_status

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -53,7 +53,7 @@ impl super::Timeline {
                         let num_events = events.len();
                         trace!("Back-pagination succeeded with {num_events} events");
 
-                        let handle_many_events_result =
+                        let handle_many_res =
                             self.inner.add_events_at(events, TimelineEnd::Front).await;
 
                         if reached_start {
@@ -68,8 +68,8 @@ impl super::Timeline {
                                 .total_events_received
                                 .checked_add(outcome.events_received)?;
 
-                            outcome.items_added = handle_many_events_result.items_added;
-                            outcome.items_updated = handle_many_events_result.items_updated;
+                            outcome.items_added = handle_many_res.items_added;
+                            outcome.items_updated = handle_many_res.items_updated;
                             outcome.total_items_added += outcome.items_added;
                             outcome.total_items_updated += outcome.items_updated;
 

--- a/crates/matrix-sdk-ui/src/timeline/polls.rs
+++ b/crates/matrix-sdk-ui/src/timeline/polls.rs
@@ -141,7 +141,7 @@ impl From<PollState> for NewUnstablePollStartEventContent {
 
 /// Acts as a cache for poll response and poll end events handled before their
 /// start event has been handled.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(super) struct PollPendingEvents {
     pub(super) pending_poll_responses: HashMap<OwnedEventId, Vec<ResponseData>>,
     pub(super) pending_poll_ends: HashMap<OwnedEventId, MilliSecondsSinceUnixEpoch>,

--- a/crates/matrix-sdk-ui/src/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/reactions.rs
@@ -33,7 +33,7 @@ pub struct ReactionSenderData {
     pub timestamp: MilliSecondsSinceUnixEpoch,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(super) struct Reactions {
     /// Reaction event / txn ID => sender and reaction data.
     pub(super) map: HashMap<EventItemIdentifier, (ReactionSenderData, Annotation)>,

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -370,11 +370,10 @@ impl TimelineInnerStateTransaction<'_> {
                         receipt: &receipt,
                     };
 
-                    let meta = &mut *self.meta;
-                    meta.read_receipts.maybe_update_read_receipt(
+                    self.meta.read_receipts.maybe_update_read_receipt(
                         full_receipt,
                         is_own_user_id,
-                        &meta.all_events,
+                        &self.meta.all_events,
                         &mut self.items,
                     );
                 }
@@ -406,11 +405,10 @@ impl TimelineInnerStateTransaction<'_> {
                 receipt: &receipt,
             };
 
-            let meta = &mut *self.meta;
-            meta.read_receipts.maybe_update_read_receipt(
+            self.meta.read_receipts.maybe_update_read_receipt(
                 full_receipt,
                 user_id == own_user_id,
-                &meta.all_events,
+                &self.meta.all_events,
                 &mut self.items,
             );
         }
@@ -436,11 +434,10 @@ impl TimelineInnerStateTransaction<'_> {
         let full_receipt =
             FullReceipt { event_id, user_id, receipt_type: ReceiptType::Read, receipt: &receipt };
 
-        let meta = &mut *self.meta;
-        meta.read_receipts.maybe_update_read_receipt(
+        self.meta.read_receipts.maybe_update_read_receipt(
             full_receipt,
             is_own_event,
-            &meta.all_events,
+            &self.meta.all_events,
             &mut self.items,
         );
     }

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -446,6 +446,7 @@ impl TimelineInnerStateTransaction<'_> {
     pub(super) fn maybe_update_read_receipts_of_prev_event(&mut self, event_id: &EventId) {
         // Find the previous visible event, if there is one.
         let Some(prev_event_meta) = self
+            .meta
             .all_events
             .iter()
             .rev()
@@ -474,9 +475,9 @@ impl TimelineInnerStateTransaction<'_> {
             return;
         };
 
-        let read_receipts = self.read_receipts.compute_event_receipts(
+        let read_receipts = self.meta.read_receipts.compute_event_receipts(
             &remote_prev_event_item.event_id,
-            &self.all_events,
+            &self.meta.all_events,
             false,
         );
 

--- a/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/read_receipts.rs
@@ -370,10 +370,11 @@ impl TimelineInnerStateTransaction<'_> {
                         receipt: &receipt,
                     };
 
-                    self.meta.read_receipts.maybe_update_read_receipt(
+                    let meta = &mut *self.meta;
+                    meta.read_receipts.maybe_update_read_receipt(
                         full_receipt,
                         is_own_user_id,
-                        &self.meta.all_events,
+                        &meta.all_events,
                         &mut self.items,
                     );
                 }
@@ -404,10 +405,12 @@ impl TimelineInnerStateTransaction<'_> {
                 receipt_type: ReceiptType::Read,
                 receipt: &receipt,
             };
-            self.meta.read_receipts.maybe_update_read_receipt(
+
+            let meta = &mut *self.meta;
+            meta.read_receipts.maybe_update_read_receipt(
                 full_receipt,
                 user_id == own_user_id,
-                &self.meta.all_events,
+                &meta.all_events,
                 &mut self.items,
             );
         }
@@ -433,10 +436,11 @@ impl TimelineInnerStateTransaction<'_> {
         let full_receipt =
             FullReceipt { event_id, user_id, receipt_type: ReceiptType::Read, receipt: &receipt };
 
-        self.meta.read_receipts.maybe_update_read_receipt(
+        let meta = &mut *self.meta;
+        meta.read_receipts.maybe_update_read_receipt(
             full_receipt,
             is_own_event,
-            &self.meta.all_events,
+            &meta.all_events,
             &mut self.items,
         );
     }

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -39,7 +39,7 @@ use crate::timeline::{
 };
 
 #[async_test]
-async fn initial_events() {
+async fn test_initial_events() {
     let mut timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
@@ -68,7 +68,7 @@ async fn initial_events() {
 }
 
 #[async_test]
-async fn sticker() {
+async fn test_sticker() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
@@ -96,7 +96,7 @@ async fn sticker() {
 }
 
 #[async_test]
-async fn room_member() {
+async fn test_room_member() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
@@ -164,7 +164,7 @@ async fn room_member() {
 }
 
 #[async_test]
-async fn other_state() {
+async fn test_other_state() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
@@ -190,7 +190,7 @@ async fn other_state() {
 }
 
 #[async_test]
-async fn dedup_pagination() {
+async fn test_dedup_pagination() {
     let timeline = TestTimeline::new();
 
     let event = timeline
@@ -213,7 +213,7 @@ async fn dedup_pagination() {
 }
 
 #[async_test]
-async fn dedup_initial() {
+async fn test_dedup_initial() {
     let mut timeline = TestTimeline::new();
 
     let event_a = SyncTimelineEvent::new(
@@ -266,7 +266,7 @@ async fn dedup_initial() {
 }
 
 #[async_test]
-async fn sanitized() {
+async fn test_sanitized() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
@@ -307,7 +307,7 @@ async fn sanitized() {
 }
 
 #[async_test]
-async fn reply() {
+async fn test_reply() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
@@ -363,7 +363,7 @@ async fn reply() {
 }
 
 #[async_test]
-async fn thread() {
+async fn test_thread() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/edit.rs
@@ -31,7 +31,7 @@ use super::TestTimeline;
 use crate::timeline::TimelineItemContent;
 
 #[async_test]
-async fn live_redacted() {
+async fn test_live_redacted() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
@@ -55,7 +55,7 @@ async fn live_redacted() {
 }
 
 #[async_test]
-async fn live_sanitized() {
+async fn test_live_sanitized() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 
@@ -105,7 +105,7 @@ async fn live_sanitized() {
 }
 
 #[async_test]
-async fn aggregated_sanitized() {
+async fn test_aggregated_sanitized() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -49,7 +49,7 @@ use ruma::{
 
 use super::{
     event_item::EventItemIdentifier,
-    inner::{ReactionAction, TimelineInnerSettings},
+    inner::{ReactionAction, TimelineEnd, TimelineInnerSettings},
     reactions::ReactionToggleResult,
     traits::RoomDataProvider,
     EventTimelineItem, Profile, TimelineInner, TimelineItem,
@@ -243,7 +243,7 @@ impl TestTimeline {
 
     async fn handle_back_paginated_custom_event(&self, event: Raw<AnyTimelineEvent>) {
         let timeline_event = TimelineEvent::new(event.cast());
-        self.inner.handle_back_paginated_events(vec![timeline_event]).await;
+        self.inner.add_events_at(vec![timeline_event], TimelineEnd::Front).await;
     }
 
     async fn handle_read_receipts(

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -243,7 +243,7 @@ impl TestTimeline {
 
     async fn handle_back_paginated_custom_event(&self, event: Raw<AnyTimelineEvent>) {
         let timeline_event = TimelineEvent::new(event.cast());
-        self.inner.handle_back_paginated_events(vec![timeline_event]).await.unwrap();
+        self.inner.handle_back_paginated_events(vec![timeline_event]).await;
     }
 
     async fn handle_read_receipts(

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -37,7 +37,7 @@ use crate::timeline::{
 const REACTION_KEY: &str = "👍";
 
 #[async_test]
-async fn add_reaction_failed() {
+async fn test_add_reaction_failed() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
@@ -57,7 +57,7 @@ async fn add_reaction_failed() {
 }
 
 #[async_test]
-async fn add_reaction_on_non_existent_event() {
+async fn test_add_reaction_on_non_existent_event() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
     let msg_id = EventId::new(server_name!("example.org")); // non existent event
@@ -69,7 +69,7 @@ async fn add_reaction_on_non_existent_event() {
 }
 
 #[async_test]
-async fn add_reaction_success() {
+async fn test_add_reaction_success() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
@@ -93,7 +93,7 @@ async fn add_reaction_success() {
 }
 
 #[async_test]
-async fn redact_reaction_success() {
+async fn test_redact_reaction_success() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
@@ -115,7 +115,7 @@ async fn redact_reaction_success() {
 }
 
 #[async_test]
-async fn redact_reaction_failure() {
+async fn test_redact_reaction_failure() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
@@ -141,7 +141,7 @@ async fn redact_reaction_failure() {
 }
 
 #[async_test]
-async fn redact_reaction_from_non_existent_event() {
+async fn test_redact_reaction_from_non_existent_event() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
     let reaction_id = EventId::new(server_name!("example.org")); // non existent event
@@ -154,7 +154,7 @@ async fn redact_reaction_from_non_existent_event() {
 }
 
 #[async_test]
-async fn toggle_during_request_resolves_new_action() {
+async fn test_toggle_during_request_resolves_new_action() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
@@ -205,7 +205,7 @@ async fn toggle_during_request_resolves_new_action() {
 }
 
 #[async_test]
-async fn reactions_store_timestamp() {
+async fn test_reactions_store_timestamp() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe().await;
     let (msg_id, msg_pos) = send_first_message(&timeline, &mut stream).await;
@@ -238,7 +238,7 @@ async fn reactions_store_timestamp() {
 }
 
 #[async_test]
-async fn initial_reaction_timestamp_is_stored() {
+async fn test_initial_reaction_timestamp_is_stored() {
     let mut timeline = TestTimeline::new();
 
     let message_event_id = EventId::new(server_name!("dummy.server"));

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -239,25 +239,28 @@ async fn test_reactions_store_timestamp() {
 
 #[async_test]
 async fn test_initial_reaction_timestamp_is_stored() {
-    let mut timeline = TestTimeline::new();
+    let timeline = TestTimeline::new();
 
     let message_event_id = EventId::new(server_name!("dummy.server"));
     let reaction_timestamp = MilliSecondsSinceUnixEpoch(uint!(39845));
 
     timeline
         .inner
-        .add_initial_events(vec![
-            SyncTimelineEvent::new(timeline.event_builder.make_sync_reaction(
-                *ALICE,
-                &Annotation::new(message_event_id.clone(), REACTION_KEY.to_owned()),
-                reaction_timestamp,
-            )),
-            SyncTimelineEvent::new(timeline.event_builder.make_sync_message_event_with_id(
-                *ALICE,
-                &message_event_id,
-                RoomMessageEventContent::text_plain("A"),
-            )),
-        ])
+        .add_events_at(
+            vec![
+                SyncTimelineEvent::new(timeline.event_builder.make_sync_reaction(
+                    *ALICE,
+                    &Annotation::new(message_event_id.clone(), REACTION_KEY.to_owned()),
+                    reaction_timestamp,
+                )),
+                SyncTimelineEvent::new(timeline.event_builder.make_sync_message_event_with_id(
+                    *ALICE,
+                    &message_event_id,
+                    RoomMessageEventContent::text_plain("A"),
+                )),
+            ],
+            crate::timeline::inner::TimelineEnd::Back { from_cache: false },
+        )
         .await;
 
     let items = timeline.inner.items().await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -100,7 +100,7 @@ async fn test_read_receipts_updates_on_live_events() {
 }
 
 #[async_test]
-async fn read_receipts_updates_on_back_paginated_events() {
+async fn test_read_receipts_updates_on_back_paginated_events() {
     let timeline = TestTimeline::new()
         .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
     let room_id = room_id!("!room:localhost");
@@ -223,7 +223,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
 }
 
 #[async_test]
-async fn read_receipts_updates_on_filtered_events_with_stored() {
+async fn test_read_receipts_updates_on_filtered_events_with_stored() {
     let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
         track_read_receipts: true,
         event_filter: Arc::new(filter_notice),
@@ -276,7 +276,7 @@ async fn read_receipts_updates_on_filtered_events_with_stored() {
 }
 
 #[async_test]
-async fn read_receipts_updates_on_back_paginated_filtered_events() {
+async fn test_read_receipts_updates_on_back_paginated_filtered_events() {
     let timeline = TestTimeline::new().with_settings(TimelineInnerSettings {
         track_read_receipts: true,
         event_filter: Arc::new(filter_notice),
@@ -331,7 +331,7 @@ async fn read_receipts_updates_on_back_paginated_filtered_events() {
 
 #[cfg(feature = "e2e-encryption")]
 #[async_test]
-async fn read_receipts_updates_on_message_decryption() {
+async fn test_read_receipts_updates_on_message_decryption() {
     use std::{io::Cursor, iter};
 
     use assert_matches::assert_matches;
@@ -466,7 +466,7 @@ async fn read_receipts_updates_on_message_decryption() {
 }
 
 #[async_test]
-async fn initial_public_unthreaded_receipt() {
+async fn test_initial_public_unthreaded_receipt() {
     let event_id = owned_event_id!("$event_with_receipt");
 
     // Add initial unthreaded public receipt.
@@ -491,7 +491,7 @@ async fn initial_public_unthreaded_receipt() {
 }
 
 #[async_test]
-async fn initial_public_main_thread_receipt() {
+async fn test_initial_public_main_thread_receipt() {
     let event_id = owned_event_id!("$event_with_receipt");
 
     // Add initial public receipt on the main thread.
@@ -516,7 +516,7 @@ async fn initial_public_main_thread_receipt() {
 }
 
 #[async_test]
-async fn initial_private_unthreaded_receipt() {
+async fn test_initial_private_unthreaded_receipt() {
     let event_id = owned_event_id!("$event_with_receipt");
 
     // Add initial unthreaded private receipt.
@@ -541,7 +541,7 @@ async fn initial_private_unthreaded_receipt() {
 }
 
 #[async_test]
-async fn initial_private_main_thread_receipt() {
+async fn test_initial_private_main_thread_receipt() {
     let event_id = owned_event_id!("$event_with_receipt");
 
     // Add initial private receipt on the main thread.
@@ -566,7 +566,7 @@ async fn initial_private_main_thread_receipt() {
 }
 
 #[async_test]
-async fn clear_read_receipts() {
+async fn test_clear_read_receipts() {
     let room_id = room_id!("!room:localhost");
     let event_a_id = event_id!("$event_a");
     let event_b_id = event_id!("$event_b");

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -140,17 +140,20 @@ async fn test_reaction_redaction() {
 
 #[async_test]
 async fn test_reaction_redaction_timeline_filter() {
-    let mut timeline = TestTimeline::new();
+    let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
     // Initialise a timeline with a redacted reaction.
     timeline
         .inner
-        .add_initial_events(vec![SyncTimelineEvent::new(
-            timeline
-                .event_builder
-                .make_sync_redacted_message_event(*ALICE, RedactedReactionEventContent::new()),
-        )])
+        .add_events_at(
+            vec![SyncTimelineEvent::new(
+                timeline
+                    .event_builder
+                    .make_sync_redacted_message_event(*ALICE, RedactedReactionEventContent::new()),
+            )],
+            crate::timeline::inner::TimelineEnd::Back { from_cache: false },
+        )
         .await;
     // Timeline items are actually empty.
     assert_eq!(timeline.inner.items().await.len(), 0);

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -38,7 +38,7 @@ use super::TestTimeline;
 use crate::timeline::{AnyOtherFullStateEventContent, TimelineDetails, TimelineItemContent};
 
 #[async_test]
-async fn redact_state_event() {
+async fn test_redact_state_event() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
@@ -68,7 +68,7 @@ async fn redact_state_event() {
 }
 
 #[async_test]
-async fn redact_replied_to_event() {
+async fn test_redact_replied_to_event() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
@@ -114,7 +114,7 @@ async fn redact_replied_to_event() {
 }
 
 #[async_test]
-async fn reaction_redaction() {
+async fn test_reaction_redaction() {
     let timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
@@ -139,7 +139,7 @@ async fn reaction_redaction() {
 }
 
 #[async_test]
-async fn reaction_redaction_timeline_filter() {
+async fn test_reaction_redaction_timeline_filter() {
     let mut timeline = TestTimeline::new();
     let mut stream = timeline.subscribe_events().await;
 
@@ -180,7 +180,7 @@ async fn reaction_redaction_timeline_filter() {
 }
 
 #[async_test]
-async fn receive_unredacted() {
+async fn test_receive_unredacted() {
     let timeline = TestTimeline::new();
 
     // send two events, second one redacted

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -586,7 +586,6 @@ impl RoomEventCacheInner {
 
         let _ = self.sender.send(RoomEventCacheUpdate::Append {
             events,
-            prev_batch,
             account_data,
             ephemeral,
             ambiguity_changes,
@@ -742,8 +741,6 @@ pub enum RoomEventCacheUpdate {
     Append {
         /// All the new events that have been added to the room's timeline.
         events: Vec<SyncTimelineEvent>,
-        /// XXX: this is temporary, until prev_batch lives in the event cache
-        prev_batch: Option<String>,
         /// XXX: this is temporary, until account data lives in the event cache
         /// — or will it live there?
         account_data: Vec<Raw<AnyRoomAccountDataEvent>>,

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -31,8 +31,9 @@
 //! - [ ] expose that information with a new data structure similar to the
 //!   `RoomInfo`, and that may update a `RoomListService`.
 //! - [ ] provide read receipts for each message.
-//! - [ ] backwards and forward pagination, and reconcile results with cached
-//!   timelines.
+//! - [x] backwards pagination
+//! - [ ] forward pagination
+//! - [ ] reconcile results with cached timelines.
 //! - [ ] retry decryption upon receiving new keys (from an encryption sync
 //!   service or from a key backup).
 //! - [ ] expose the latest event for a given room.


### PR DESCRIPTION
This introduces a few refactorings to mostly the timeline. Commits can be reviewed in isolation.

Notable changes:

- by raising the size of the type holding the number of events touched in `HandleManyEventsResult`, I got rid of most overflow checks, with the reasoning that u64 should be enough for everyone, aka: we shouldn't get `u64::max_value()` events while back-paginating (even if we do it multiple times), nor should we get that many events in a single sync response. I think this heuristic is fine, and that gets rid of one fallible path. (I slightly wonder if we could even get rid of the transaction mechanism, but it seems some functions use it with early returns, so it's still used at least.)
- I got rid of a few `Deref` implementations that were surprising to me. I don't like surprising; I like explicit and boring code :smiling_face_with_tear:.
- I fixed a potential soundness issue in the `TimelineInnerStateTransaction` data structure: the `items` were modified and committed only at the end, but the `meta` was a mutable reference to the actual metadata, and it could be modified while the transaction would be aborted. Instead, I clone it in the ctor, and replace it in the `commit()` method.