### PR TITLE
crypto: Add new error messages for verification cancellation

### DIFF
--- a/crates/matrix-sdk-crypto/src/verification/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/mod.rs
@@ -364,6 +364,8 @@ impl Cancelled {
             }
             CancelCode::InvalidMessage => "The received message was invalid.",
             CancelCode::KeyMismatch => "The expected key did not match the verified one",
+            CancelCode::MismatchedCommitment => "The hash commitment did not match.",
+            CancelCode::MismatchedSas => "The SAS did not match.",
             CancelCode::Timeout => "The verification process timed out.",
             CancelCode::UnexpectedMessage => "The device received an unexpected message.",
             CancelCode::UnknownMethod => {


### PR DESCRIPTION
Append error msg for the missed cancel codes.
Sorry, my mistake closed [my previous PR](https://github.com/matrix-org/matrix-rust-sdk/pull/3209).
Will fix [this issue](https://github.com/matrix-org/matrix-rust-sdk/pull/3209#discussion_r1523058621).