### PR TITLE
crypto: Store TrackedUsers in MemoryStore

### DIFF
--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -526,7 +526,7 @@ pub struct Changes {
 }
 
 /// A user for which we are tracking the list of devices.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TrackedUser {
     /// The user ID of the user.
     pub user_id: OwnedUserId,


### PR DESCRIPTION
Because I am trying to get `MemoryStore` to pass the `cryptostore_integration_tests`, I need this store to hold on to the tracked users, when previously it didn't both.

Applies on top of https://github.com/matrix-org/matrix-rust-sdk/pull/3220

Part of my work on https://github.com/element-hq/element-web/issues/26892