### PR TITLE
Update minimum supported Rust version to 1.76

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default-members = ["benchmarks", "crates/*", "labs/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.70"
+rust-version = "1.76"
 
 [workspace.dependencies]
 anyhow = "1.0.68"


### PR DESCRIPTION
This reflects the reality of the situation at the moment: we need 1.76. to compile, and Ruma requires 1.75.