### PR TITLE
feat(sdk): `EventCache` fully uses `RoomEvents`/`LinkedChunk`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -517,8 +517,8 @@ impl RoomEventCacheInner {
         Ok(())
     }
 
-    // Remove existing events, and append a set of events to the room cache and
-    // storage, notifying observers.
+    /// Remove existing events, and append a set of events to the room cache and
+    /// storage, notifying observers.
     async fn replace_all_events_by(
         &self,
         events: Vec<SyncTimelineEvent>,

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -391,12 +391,10 @@ impl RoomEventCache {
     pub async fn subscribe(
         &self,
     ) -> Result<(Vec<SyncTimelineEvent>, Receiver<RoomEventCacheUpdate>)> {
-        /*
-        let store = self.inner.store.lock().await;
+        let events =
+            self.inner.events.read().await.events().map(|(_position, item)| item.clone()).collect();
 
-        Ok((store.room_events(self.inner.room.room_id()).await?, self.inner.sender.subscribe()))
-        */
-        todo!()
+        Ok((events, self.inner.sender.subscribe()))
     }
 
     /// Returns the oldest back-pagination token, that is, the one closest to

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -573,7 +573,9 @@ impl RoomEventCacheInner {
         // Make sure there's at most one back-pagination request.
         let _guard = self.pagination_lock.lock().await;
 
-        // Make sure the `RoomEvents` isn't updated while we are back-paginating.
+        // Make sure the `RoomEvents` isn't updated while we are back-paginating. This
+        // is really important, for example if a sync is happening while we are
+        // back-paginating.
         let mut room_events = self.events.write().await;
 
         // Check that the `token` exists if any.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -685,7 +685,7 @@ impl RoomEventCacheInner {
             // (backward). The `RoomEvents` API expects the first event to be the oldest.
             .rev()
             .cloned()
-            .map(|timeline_event| SyncTimelineEvent::from(timeline_event));
+            .map(SyncTimelineEvent::from);
 
         // There is a `token`/gap, let's replace it by new events!
         if let Some(gap_identifier) = gap_identifier {
@@ -755,7 +755,7 @@ impl RoomEventCacheInner {
         max_wait: Option<Duration>,
     ) -> Result<Option<PaginationToken>> {
         // Optimistically try to return the backpagination token immediately.
-        fn get_oldest(room_events: RwLockReadGuard<RoomEvents>) -> Option<PaginationToken> {
+        fn get_oldest(room_events: RwLockReadGuard<'_, RoomEvents>) -> Option<PaginationToken> {
             room_events.chunks().find_map(|chunk| match chunk.content() {
                 ChunkContent::Gap(gap) => Some(gap.prev_token.clone()),
                 ChunkContent::Items(..) => None,

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -270,6 +270,12 @@ struct EventCacheInner {
     /// on the owning client.
     client: Weak<ClientInner>,
 
+    /// A lock used when many rooms must be updated at once.
+    ///
+    /// [`Mutex`] is “fair”, as it is implemented as a FIFO. It is important to
+    /// ensure that multiple updates will be applied in the correct order, which
+    /// is enforced by taking this lock when handling an update.
+    // TODO: that's the place to add a cross-process lock!
     multiple_room_updates_lock: Mutex<()>,
 
     /// Lazily-filled cache of live [`RoomEventCache`], once per room.
@@ -277,7 +283,6 @@ struct EventCacheInner {
 
     /// Handles to keep alive the task listening to updates.
     drop_handles: OnceLock<Arc<EventCacheDropHandles>>,
-    // TODO: that's the place to add a cross-process lock!
 }
 
 impl EventCacheInner {

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -70,7 +70,7 @@ use tracing::{error, instrument, trace, warn};
 
 use self::{
     linked_chunk::ChunkContent,
-    store::{EventCacheStore, Gap, MemoryStore, PaginationToken, RoomEvents, TimelineEntry},
+    store::{Gap, PaginationToken, RoomEvents},
 };
 use crate::{client::ClientInner, room::MessagesOptions, Client, Room};
 
@@ -767,7 +767,7 @@ mod tests {
     use matrix_sdk_test::{async_test, sync_timeline_event};
     use ruma::room_id;
 
-    use super::{store::TimelineEntry, EventCacheError};
+    use super::EventCacheError;
     use crate::{event_cache::store::PaginationToken, test_utils::logged_in_client};
 
     #[async_test]

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -205,17 +205,7 @@ impl EventCache {
                     // Forget everything we know; we could have missed events, and we have
                     // no way to reconcile at the moment!
                     // TODO: implement Smart Matching™,
-                    todo!();
-                    /*
-                    let store = inner.store.lock().await;
-                    let mut by_room = inner.by_room.write().await;
-                    for room_id in by_room.keys() {
-                        if let Err(err) = store.clear_room(room_id).await {
-                            error!("unable to clear room after room updates lag: {err}");
-                        }
-                    }
-                    by_room.clear();
-                    */
+                    inner.by_room.write().await.clear();
                 }
 
                 Err(RecvError::Closed) => {

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -259,12 +259,8 @@ impl EventCache {
         // We could have received events during a previous sync; remove them all, since
         // we can't know where to insert the "initial events" with respect to
         // them.
-        todo!();
-        /*
-        let store = self.inner.store.lock().await;
+        room_cache.inner.events.write().await.reset();
 
-        store.clear_room(room_id).await?;
-        */
         let _ = room_cache.inner.sender.send(RoomEventCacheUpdate::Clear);
 
         room_cache

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -249,10 +249,6 @@ impl EventCache {
         // We could have received events during a previous sync; remove them all, since
         // we can't know where to insert the "initial events" with respect to
         // them.
-        // let mut room_events = room_cache.inner.events.write().await;
-        // room_events.reset();
-
-        // let _ = room_cache.inner.sender.send(RoomEventCacheUpdate::Clear);
 
         room_cache
             .inner

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -230,6 +230,11 @@ impl RoomEvents {
         Self { chunks: LinkedChunk::new() }
     }
 
+    /// Clear all events.
+    pub fn reset(&mut self) {
+        self.chunks = LinkedChunk::new();
+    }
+
     /// Return the number of events.
     pub fn len(&self) -> usize {
         self.chunks.len()
@@ -249,6 +254,11 @@ impl RoomEvents {
         I::IntoIter: ExactSizeIterator,
     {
         self.chunks.push_items_back(events)
+    }
+
+    /// Push a gap after existing events.
+    pub fn push_gap(&mut self, gap: Gap) {
+        self.chunks.push_gap_back(gap)
     }
 
     /// Insert events at a specified position.
@@ -271,6 +281,22 @@ impl RoomEvents {
         position: Position,
     ) -> StdResult<(), LinkedChunkError> {
         self.chunks.insert_gap_at(gap, position)
+    }
+
+    /// Replace the gap identified by `gap_identifier`, by events.
+    ///
+    /// Because the `gap_identifier` can represent non-gap chunk, this method
+    /// returns a `Result`.
+    pub fn replace_gap_at<I>(
+        &mut self,
+        items: I,
+        gap_identifier: ChunkIdentifier,
+    ) -> StdResult<(), LinkedChunkError>
+    where
+        I: IntoIterator<Item = SyncTimelineEvent>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.chunks.replace_gap_at(items, gap_identifier)
     }
 
     /// Search for a chunk, and return its identifier.
@@ -326,6 +352,13 @@ impl RoomEvents {
     /// The most recent event comes first.
     pub fn revents(&self) -> impl Iterator<Item = (Position, &SyncTimelineEvent)> {
         self.chunks.ritems()
+    }
+
+    /// Iterate over the events, forward.
+    ///
+    /// The oldest event comes first.
+    pub fn events(&self) -> impl Iterator<Item = (ItemPosition, &SyncTimelineEvent)> {
+        self.chunks.items()
     }
 
     /// Iterate over the events, starting from `position`, backward.

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -65,7 +65,7 @@ impl RoomEvents {
         self.push_events(once(event))
     }
 
-    /// Push events after existing events.
+    /// Push events after all events or gaps.
     ///
     /// The last event in `events` is the most recent one.
     pub fn push_events<I>(&mut self, events: I)
@@ -76,7 +76,7 @@ impl RoomEvents {
         self.chunks.push_items_back(events)
     }
 
-    /// Push a gap after existing events.
+    /// Push a gap after all events or gaps.
     pub fn push_gap(&mut self, gap: Gap) {
         self.chunks.push_gap_back(gap)
     }

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -12,198 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, fmt, iter::once, result::Result as StdResult};
+use std::{fmt, iter::once, result::Result};
 
-use async_trait::async_trait;
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
-use ruma::{OwnedRoomId, RoomId};
-use tokio::sync::RwLock;
 
-use super::{
-    linked_chunk::{
-        Chunk, ChunkIdentifier, LinkedChunk, LinkedChunkError, LinkedChunkIter,
-        LinkedChunkIterBackward, Position,
-    },
-    Result,
+use super::linked_chunk::{
+    Chunk, ChunkIdentifier, LinkedChunk, LinkedChunkError, LinkedChunkIter,
+    LinkedChunkIterBackward, Position,
 };
-
-/// A store that can be remember information about the event cache.
-///
-/// It really acts as a cache, in the sense that clearing the backing data
-/// should not have any irremediable effect, other than providing a lesser user
-/// experience.
-#[async_trait]
-pub trait EventCacheStore: Send + Sync {
-    /// Returns all the known events for the given room.
-    async fn room_events(&self, room: &RoomId) -> Result<Vec<SyncTimelineEvent>>;
-
-    /// Adds all the entries to the given room's timeline.
-    async fn append_room_entries(&self, room: &RoomId, entries: Vec<TimelineEntry>) -> Result<()>;
-
-    /// Returns whether the store knows about the given pagination token.
-    async fn contains_gap(&self, room: &RoomId, pagination_token: &PaginationToken)
-        -> Result<bool>;
-
-    /// Replaces a given gap (identified by its pagination token) with the given
-    /// entries.
-    ///
-    /// Note: if the gap hasn't been found, then nothing happens, and the events
-    /// are lost.
-    ///
-    /// Returns whether the gap was found.
-    async fn replace_gap(
-        &self,
-        room: &RoomId,
-        gap_id: Option<&PaginationToken>,
-        entries: Vec<TimelineEntry>,
-    ) -> Result<bool>;
-
-    /// Retrieve the oldest backpagination token for the given room.
-    async fn oldest_backpagination_token(&self, room: &RoomId) -> Result<Option<PaginationToken>>;
-
-    /// Clear all the information tied to a given room.
-    ///
-    /// This forgets the following:
-    /// - events in the room
-    /// - pagination tokens
-    async fn clear_room(&self, room: &RoomId) -> Result<()>;
-}
 
 /// A newtype wrapper for a pagination token returned by a /messages response.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PaginationToken(pub String);
-
-#[derive(Clone)]
-pub enum TimelineEntry {
-    Event(SyncTimelineEvent),
-
-    Gap {
-        /// The token to use in the query, extracted from a previous "from" /
-        /// "end" field of a `/messages` response.
-        prev_token: PaginationToken,
-    },
-}
-
-/// All the information related to a room and stored in the event cache.
-#[derive(Default)]
-struct RoomInfo {
-    /// All the timeline entries per room, in sync order.
-    entries: Vec<TimelineEntry>,
-}
-
-impl RoomInfo {
-    fn clear(&mut self) {
-        self.entries.clear();
-    }
-}
-
-/// An [`EventCacheStore`] implementation that keeps all the information in
-/// memory.
-#[derive(Default)]
-pub(crate) struct MemoryStore {
-    by_room: RwLock<BTreeMap<OwnedRoomId, RoomInfo>>,
-}
-
-impl MemoryStore {
-    /// Create a new empty [`MemoryStore`].
-    pub fn new() -> Self {
-        Default::default()
-    }
-}
-
-#[async_trait]
-impl EventCacheStore for MemoryStore {
-    async fn room_events(&self, room: &RoomId) -> Result<Vec<SyncTimelineEvent>> {
-        Ok(self
-            .by_room
-            .read()
-            .await
-            .get(room)
-            .map(|room_info| {
-                room_info
-                    .entries
-                    .iter()
-                    .filter_map(
-                        |entry| if let TimelineEntry::Event(ev) = entry { Some(ev) } else { None },
-                    )
-                    .cloned()
-                    .collect()
-            })
-            .unwrap_or_default())
-    }
-
-    async fn append_room_entries(&self, room: &RoomId, entries: Vec<TimelineEntry>) -> Result<()> {
-        self.by_room.write().await.entry(room.to_owned()).or_default().entries.extend(entries);
-        Ok(())
-    }
-
-    async fn clear_room(&self, room: &RoomId) -> Result<()> {
-        // Clear the room, so as to avoid reallocations if the room is being reused.
-        // XXX: do we also want an actual way to *remove* a room? (for left rooms)
-        if let Some(room) = self.by_room.write().await.get_mut(room) {
-            room.clear();
-        }
-
-        Ok(())
-    }
-
-    async fn oldest_backpagination_token(&self, room: &RoomId) -> Result<Option<PaginationToken>> {
-        Ok(self.by_room.read().await.get(room).and_then(|room| {
-            room.entries.iter().find_map(|entry| {
-                if let TimelineEntry::Gap { prev_token: backpagination_token } = entry {
-                    Some(backpagination_token.clone())
-                } else {
-                    None
-                }
-            })
-        }))
-    }
-
-    async fn contains_gap(&self, room: &RoomId, needle: &PaginationToken) -> Result<bool> {
-        let mut by_room_guard = self.by_room.write().await;
-        let room = by_room_guard.entry(room.to_owned()).or_default();
-
-        Ok(room.entries.iter().any(|entry| {
-            if let TimelineEntry::Gap { prev_token: existing } = entry {
-                existing == needle
-            } else {
-                false
-            }
-        }))
-    }
-
-    async fn replace_gap(
-        &self,
-        room: &RoomId,
-        token: Option<&PaginationToken>,
-        entries: Vec<TimelineEntry>,
-    ) -> Result<bool> {
-        let mut by_room_guard = self.by_room.write().await;
-        let room = by_room_guard.entry(room.to_owned()).or_default();
-
-        if let Some(token) = token {
-            let gap_pos = room.entries.iter().enumerate().find_map(|(i, t)| {
-                if let TimelineEntry::Gap { prev_token: existing } = t {
-                    if existing == token {
-                        return Some(i);
-                    }
-                }
-                None
-            });
-
-            if let Some(pos) = gap_pos {
-                room.entries.splice(pos..pos + 1, entries);
-                Ok(true)
-            } else {
-                Ok(false)
-            }
-        } else {
-            // We had no previous token: assume we can prepend the events.
-            room.entries.splice(0..0, entries);
-            Ok(true)
-        }
-    }
-}
 
 #[derive(Debug)]
 pub struct Gap {
@@ -266,7 +86,7 @@ impl RoomEvents {
         &mut self,
         events: I,
         position: Position,
-    ) -> StdResult<(), LinkedChunkError>
+    ) -> Result<(), LinkedChunkError>
     where
         I: IntoIterator<Item = SyncTimelineEvent>,
         I::IntoIter: ExactSizeIterator,
@@ -275,11 +95,7 @@ impl RoomEvents {
     }
 
     /// Insert a gap at a specified position.
-    pub fn insert_gap_at(
-        &mut self,
-        gap: Gap,
-        position: Position,
-    ) -> StdResult<(), LinkedChunkError> {
+    pub fn insert_gap_at(&mut self, gap: Gap, position: Position) -> Result<(), LinkedChunkError> {
         self.chunks.insert_gap_at(gap, position)
     }
 
@@ -291,7 +107,7 @@ impl RoomEvents {
         &mut self,
         items: I,
         gap_identifier: ChunkIdentifier,
-    ) -> StdResult<(), LinkedChunkError>
+    ) -> Result<(), LinkedChunkError>
     where
         I: IntoIterator<Item = SyncTimelineEvent>,
         I::IntoIter: ExactSizeIterator,
@@ -335,7 +151,7 @@ impl RoomEvents {
     pub fn rchunks_from(
         &self,
         identifier: ChunkIdentifier,
-    ) -> StdResult<
+    ) -> Result<
         LinkedChunkIterBackward<'_, SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>,
         LinkedChunkError,
     > {
@@ -347,10 +163,8 @@ impl RoomEvents {
     pub fn chunks_from(
         &self,
         identifier: ChunkIdentifier,
-    ) -> StdResult<
-        LinkedChunkIter<'_, SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>,
-        LinkedChunkError,
-    > {
+    ) -> Result<LinkedChunkIter<'_, SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>, LinkedChunkError>
+    {
         self.chunks.chunks_from(identifier)
     }
 
@@ -364,7 +178,7 @@ impl RoomEvents {
     /// Iterate over the events, forward.
     ///
     /// The oldest event comes first.
-    pub fn events(&self) -> impl Iterator<Item = (ItemPosition, &SyncTimelineEvent)> {
+    pub fn events(&self) -> impl Iterator<Item = (Position, &SyncTimelineEvent)> {
         self.chunks.items()
     }
 
@@ -372,7 +186,7 @@ impl RoomEvents {
     pub fn revents_from(
         &self,
         position: Position,
-    ) -> StdResult<impl Iterator<Item = (Position, &SyncTimelineEvent)>, LinkedChunkError> {
+    ) -> Result<impl Iterator<Item = (Position, &SyncTimelineEvent)>, LinkedChunkError> {
         self.chunks.ritems_from(position)
     }
 
@@ -381,13 +195,13 @@ impl RoomEvents {
     pub fn events_from(
         &self,
         position: Position,
-    ) -> StdResult<impl Iterator<Item = (Position, &SyncTimelineEvent)>, LinkedChunkError> {
+    ) -> Result<impl Iterator<Item = (Position, &SyncTimelineEvent)>, LinkedChunkError> {
         self.chunks.items_from(position)
     }
 }
 
 impl fmt::Debug for RoomEvents {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> StdResult<(), fmt::Error> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         formatter.debug_struct("RoomEvents").field("chunk", &self.chunks).finish()
     }
 }

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fmt, iter::once, result::Result};
+use std::{fmt, iter::once};
 
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 
@@ -103,16 +103,19 @@ impl RoomEvents {
     ///
     /// Because the `gap_identifier` can represent non-gap chunk, this method
     /// returns a `Result`.
+    ///
+    /// The returned `Chunk` represents the newly created `Chunk` that contains
+    /// the first events.
     pub fn replace_gap_at<I>(
         &mut self,
-        items: I,
+        events: I,
         gap_identifier: ChunkIdentifier,
-    ) -> Result<(), LinkedChunkError>
+    ) -> Result<&Chunk<SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>, LinkedChunkError>
     where
         I: IntoIterator<Item = SyncTimelineEvent>,
         I::IntoIter: ExactSizeIterator,
     {
-        self.chunks.replace_gap_at(items, gap_identifier)
+        self.chunks.replace_gap_at(events, gap_identifier)
     }
 
     /// Search for a chunk, and return its identifier.

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -324,6 +324,13 @@ impl RoomEvents {
         self.chunks.rchunks()
     }
 
+    /// Iterate over the chunks, forward.
+    ///
+    /// The oldest chunk comes first.
+    pub fn chunks(&self) -> LinkedChunkIter<'_, SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY> {
+        self.chunks.chunks()
+    }
+
     /// Iterate over the chunks, starting from `identifier`, backward.
     pub fn rchunks_from(
         &self,

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -104,8 +104,8 @@ impl RoomEvents {
     /// Because the `gap_identifier` can represent non-gap chunk, this method
     /// returns a `Result`.
     ///
-    /// The returned `Chunk` represents the newly created `Chunk` that contains
-    /// the first events.
+    /// This method returns a reference to the (first if many) newly created
+    /// `Chunk` that contains the `items`.
     pub fn replace_gap_at<I>(
         &mut self,
         events: I,

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -428,12 +428,11 @@ async fn test_reset_while_backpaginating() {
             JoinedRoomBuilder::new(room_id)
                 // Note to self: a timeline must have at least single event to be properly
                 // serialized.
-                .add_timeline_event(event_builder.make_sync_message_event_with_id(
+                .add_timeline_event(event_builder.make_sync_message_event(
                     user_id!("@a:b.c"),
-                    event_id!("$from_first_sync"),
                     RoomMessageEventContent::text_plain("heyo"),
                 ))
-                .set_timeline_prev_batch("first_prev_batch_token".to_owned()),
+                .set_timeline_prev_batch("first_backpagination".to_owned()),
         );
         let response_body = sync_builder.build_json_sync_response();
 
@@ -472,27 +471,25 @@ async fn test_reset_while_backpaginating() {
         JoinedRoomBuilder::new(room_id)
             // Note to self: a timeline must have at least single event to be properly
             // serialized.
-            .add_timeline_event(event_builder.make_sync_message_event_with_id(
+            .add_timeline_event(event_builder.make_sync_message_event(
                 user_id!("@a:b.c"),
-                event_id!("$from_second_sync"),
                 RoomMessageEventContent::text_plain("heyo"),
             ))
-            .set_timeline_prev_batch("second_prev_batch_token_from_sync".to_owned())
+            .set_timeline_prev_batch("second_backpagination".to_owned())
             .set_timeline_limited(),
     );
     let sync_response_body = sync_builder.build_json_sync_response();
 
     // First back-pagination request:
-    let chunk = non_sync_events!(event_builder, [ (room_id, "$from_backpagination": "lalala") ]);
+    let chunk = non_sync_events!(event_builder, [ (room_id, "$2": "lalala") ]);
     let response_json = json!({
         "chunk": chunk,
         "start": "t392-516_47314_0_7_1_1_1_11444_1",
-        "end": "second_prev_batch_token_from_backpagination"
     });
     Mock::given(method("GET"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
         .and(header("authorization", "Bearer 1234"))
-        .and(query_param("from", "first_prev_batch_token"))
+        .and(query_param("from", "first_backpagination"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_json(response_json.clone())
@@ -515,17 +512,16 @@ async fn test_reset_while_backpaginating() {
     mock_sync(&server, sync_response_body, None).await;
     client.sync_once(Default::default()).await.unwrap();
 
-    let outcome = backpagination.await.expect("join failed");
+    let outcome = backpagination.await.expect("join failed").unwrap();
 
     // Backpagination should be confused, and the operation should result in an
     // unknown token.
-    assert_matches!(outcome, Ok(BackPaginationOutcome::UnknownBackpaginationToken));
+    assert_matches!(outcome, BackPaginationOutcome::UnknownBackpaginationToken);
 
     // Now if we retrieve the earliest token, it's not the one we had before.
-    // Even better, it's the one from the sync, NOT from the backpagination!
     let second_token = room_event_cache.oldest_backpagination_token(None).await.unwrap().unwrap();
     assert!(first_token.unwrap() != second_token);
-    assert_eq!(second_token.0, "second_prev_batch_token_from_sync");
+    assert_eq!(second_token.0, "second_backpagination");
 }
 
 #[async_test]

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -509,11 +509,7 @@ async fn test_reset_while_backpaginating() {
 
     let rec = room_event_cache.clone();
     let first_token_clone = first_token.clone();
-    let backpagination = spawn(async move {
-        let ret = rec.backpaginate(20, first_token_clone).await;
-
-        ret
-    });
+    let backpagination = spawn(async move { rec.backpaginate(20, first_token_clone).await });
 
     // Receive the sync response (which clears the timeline).
     mock_sync(&server, sync_response_body, None).await;


### PR DESCRIPTION
`EventCache` uses a custom `EventCacheStore` trait to store all events for all rooms.

The idea of this PR is to use the newly introduced `LinkedChunk` in https://github.com/matrix-org/matrix-rust-sdk/pull/3166. Instead of having one store for all events for all rooms, now there is one `LinkedChunk`/store per room.

Of course, @bnjbvr and I are discussing a lot, which explains why the actual `EventCacheStore` was already adopting some patterns from `LinkedChunk`. The migration was easier.

Several PR were necessary to make this work possible:

* [x] Build on top of https://github.com/matrix-org/matrix-rust-sdk/pull/3227
* [x] Extracted commits about `LinkedChunk` in https://github.com/matrix-org/matrix-rust-sdk/pull/3236
* [x] Other extracted commits about `LinkedChunk` in https://github.com/matrix-org/matrix-rust-sdk/pull/3251

Briefly, this PR removes the `EventCacheStore` and the `MemoryStore`, and replace them by `LinkedChunk`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3058