### PR TITLE
event cache: rename `backpaginate_with_token` to `backpaginate`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -48,7 +48,7 @@ impl super::Timeline {
 
         while let Some(batch_size) = options.next_event_limit(outcome) {
             loop {
-                match self.event_cache.backpaginate_with_token(batch_size, token).await? {
+                match self.event_cache.backpaginate(batch_size, token).await? {
                     BackPaginationOutcome::Success { events, reached_start } => {
                         let num_events = events.len();
                         trace!("Back-pagination succeeded with {num_events} events");

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -433,12 +433,12 @@ impl RoomEventCache {
     /// If a token has been provided, but it was unknown to the event cache
     /// (i.e. it's not associated to any gap in the timeline stored by the
     /// event cache), then an error result will be returned.
-    pub async fn backpaginate_with_token(
+    pub async fn backpaginate(
         &self,
         batch_size: u16,
         token: Option<PaginationToken>,
     ) -> Result<BackPaginationOutcome> {
-        self.inner.backpaginate_with_token(batch_size, token).await
+        self.inner.backpaginate(batch_size, token).await
     }
 }
 
@@ -602,7 +602,7 @@ impl RoomEventCacheInner {
     ///
     /// Returns the number of messages received in this chunk.
     #[instrument(skip(self))]
-    async fn backpaginate_with_token(
+    async fn backpaginate(
         &self,
         batch_size: u16,
         token: Option<PaginationToken>,
@@ -799,7 +799,7 @@ mod tests {
         let token = PaginationToken("old".to_owned());
 
         // Then I run into an error.
-        let res = room_event_cache.backpaginate_with_token(20, Some(token)).await;
+        let res = room_event_cache.backpaginate(20, Some(token)).await;
         assert_matches!(res.unwrap_err(), EventCacheError::UnknownBackpaginationToken);
     }
 

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -283,7 +283,7 @@ async fn test_backpaginate_once() {
             .unwrap();
         assert!(token.is_some());
 
-        room_event_cache.backpaginate_with_token(20, token).await.unwrap()
+        room_event_cache.backpaginate(20, token).await.unwrap()
     };
 
     // I'll get all the previous events, in "reverse" order (same as the response).
@@ -371,7 +371,7 @@ async fn test_backpaginate_multiple_iterations() {
     while let Some(token) =
         room_event_cache.oldest_backpagination_token(Some(Duration::from_secs(1))).await.unwrap()
     {
-        match room_event_cache.backpaginate_with_token(20, Some(token)).await.unwrap() {
+        match room_event_cache.backpaginate(20, Some(token)).await.unwrap() {
             BackPaginationOutcome::Success { reached_start, events } => {
                 if !global_reached_start {
                     global_reached_start = reached_start;
@@ -506,8 +506,7 @@ async fn test_reset_while_backpaginating() {
 
     let rec = room_event_cache.clone();
     let first_token_clone = first_token.clone();
-    let backpagination =
-        spawn(async move { rec.backpaginate_with_token(20, first_token_clone).await });
+    let backpagination = spawn(async move { rec.backpaginate(20, first_token_clone).await });
 
     // Receive the sync response (which clears the timeline).
     mock_sync(&server, sync_response_body, None).await;
@@ -576,7 +575,7 @@ async fn test_backpaginating_without_token() {
 
     // If we try to back-paginate with a token, it will hit the end of the timeline
     // and give us the resulting event.
-    let outcome = room_event_cache.backpaginate_with_token(20, token).await.unwrap();
+    let outcome = room_event_cache.backpaginate(20, token).await.unwrap();
     assert_let!(BackPaginationOutcome::Success { events, reached_start } = outcome);
 
     assert!(reached_start);


### PR DESCRIPTION
@Hywan gently had me notice that the pagination token is optional. This is a remnant from a previous version of the patch, where the token was mandatory.