### PR TITLE
ci: Add a workflow to verify the minimum supported Rust version (without Cargo.lock changes)

### DIFF
--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -1,0 +1,21 @@
+name: Rust version
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: taiki-e/install-action@cargo-hack
+    - run: cargo hack check --rust-version --workspace --all-targets --ignore-private

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -163,6 +163,7 @@ wasm-bindgen-test = "0.3.33"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+wiremock = { version = "0.5.13" }
 
 [[test]]
 name = "integration"


### PR DESCRIPTION
I managed to not include the `Cargo.lock` changes from #3228, and it seems to run fine on my machine and not cause any change to the `Cargo.lock` file, so just wanted to double-check if those changes were actually needed or not...

Note: don't review, don't merge.