### PR TITLE
fix(sdk): Various tiny improvements for `LinkedChunk`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -415,7 +415,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
     /// Iterate over the items, forward.
     ///
     /// It iterates from the first to the last item.
-    pub fn items(&self) -> impl Iterator<Item = (ItemPosition, &T)> {
+    pub fn items(&self) -> impl Iterator<Item = (ItemPosition, &Item)> {
         let first_chunk = self.first_chunk();
         let ChunkContent::Items(items) = first_chunk.content() else {
             unreachable!("The first chunk is necessarily an `Items`");
@@ -467,7 +467,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
     }
 
     /// Get the first chunk, as an immutable reference.
-    fn first_chunk(&self) -> &Chunk<T, U, C> {
+    fn first_chunk(&self) -> &Chunk<Item, Gap, CAP> {
         unsafe { self.first.as_ref() }
     }
 
@@ -748,7 +748,7 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
     }
 
     /// Get the content of the chunk.
-    pub fn content(&self) -> &ChunkContent<T, U> {
+    pub fn content(&self) -> &ChunkContent<Item, Gap> {
         &self.content
     }
 

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -402,7 +402,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
     ///
     /// It iterates from the last to the first item.
     pub fn ritems(&self) -> impl Iterator<Item = (ItemPosition, &Item)> {
-        self.ritems_from(ItemPosition(self.latest_chunk().identifier(), 0))
+        self.ritems_from(self.latest_chunk().identifier().to_last_item_position())
             .expect("`iter_items_from` cannot fail because at least one empty chunk must exist")
     }
 
@@ -552,6 +552,14 @@ impl ChunkIdentifierGenerator {
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(transparent)]
 pub struct ChunkIdentifier(u64);
+
+impl ChunkIdentifier {
+    /// Transform the `ChunkIdentifier` into an `ItemPosition` representing the
+    /// last item position.
+    fn to_last_item_position(self) -> ItemPosition {
+        ItemPosition(self, 0)
+    }
+}
 
 /// The position of an item in a [`LinkedChunk`].
 ///

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -598,6 +598,12 @@ impl ItemPosition {
     }
 }
 
+impl From<ChunkIdentifier> for ItemPosition {
+    fn from(chunk_identifier: ChunkIdentifier) -> Self {
+        Self(chunk_identifier, 0)
+    }
+}
+
 /// An iterator over a [`LinkedChunk`] that traverses the chunk in backward
 /// direction (i.e. it calls `previous` on each chunk to make progress).
 pub struct LinkedChunkIterBackward<'a, Item, Gap, const CAP: usize> {

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -583,7 +583,7 @@ impl ChunkIdentifier {
 ///
 /// It's a pair of a chunk position and an item index. `(…, 0)` represents
 /// the last item in the chunk.
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ItemPosition(ChunkIdentifier, usize);
 
 impl ItemPosition {

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -98,7 +98,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
         if last_chunk.is_first_chunk().not() {
             // Maybe `last_chunk` is the same as the previous `self.last` chunk, but it's
             // OK.
-            self.last = Some(NonNull::from(last_chunk));
+            self.last = Some(last_chunk.as_ptr());
         }
 
         self.length += number_of_items;
@@ -176,7 +176,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
         if chunk.is_first_chunk().not() && chunk.is_last_chunk() {
             // Maybe `chunk` is the same as the previous `self.last` chunk, but it's
             // OK.
-            self.last = Some(NonNull::from(chunk));
+            self.last = Some(chunk.as_ptr());
         }
 
         self.length += number_of_items;
@@ -241,7 +241,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
         if chunk.is_first_chunk().not() && chunk.is_last_chunk() {
             // Maybe `chunk` is the same as the previous `self.last` chunk, but it's
             // OK.
-            self.last = Some(NonNull::from(chunk));
+            self.last = Some(chunk.as_ptr());
         }
 
         Ok(())
@@ -719,6 +719,11 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
         NonNull::from(Box::leak(chunk_box))
     }
 
+    /// Get the pointer to `Self`.
+    pub fn as_ptr(&self) -> NonNull<Self> {
+        NonNull::from(self)
+    }
+
     /// Check whether this current chunk is a gap chunk.
     pub fn is_gap(&self) -> bool {
         matches!(self.content, ChunkContent::Gap(..))
@@ -848,7 +853,7 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
         // Link to the new chunk.
         self.next = Some(new_chunk_ptr);
         // Link the new chunk to this one.
-        new_chunk.previous = Some(NonNull::from(self));
+        new_chunk.previous = Some(self.as_ptr());
 
         new_chunk
     }

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -736,6 +736,11 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
         self.identifier
     }
 
+    /// Get the content of the chunk.
+    pub fn content(&self) -> &ChunkContent<T, U> {
+        &self.content
+    }
+
     /// The length of the chunk, i.e. how many items are in it.
     ///
     /// It will always return 0 if it's a gap chunk.

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -720,12 +720,12 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
     }
 
     /// Check whether this current chunk is a gap chunk.
-    fn is_gap(&self) -> bool {
+    pub fn is_gap(&self) -> bool {
         matches!(self.content, ChunkContent::Gap(..))
     }
 
     /// Check whether this current chunk is an items  chunk.
-    fn is_items(&self) -> bool {
+    pub fn is_items(&self) -> bool {
         !self.is_gap()
     }
 

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -21,8 +21,8 @@ use tokio::sync::RwLock;
 
 use super::{
     linked_chunk::{
-        Chunk, ChunkIdentifier, ItemPosition, LinkedChunk, LinkedChunkError, LinkedChunkIter,
-        LinkedChunkIterBackward,
+        Chunk, ChunkIdentifier, LinkedChunk, LinkedChunkError, LinkedChunkIter,
+        LinkedChunkIterBackward, Position,
     },
     Result,
 };
@@ -255,7 +255,7 @@ impl RoomEvents {
     pub fn insert_events_at<I>(
         &mut self,
         events: I,
-        position: ItemPosition,
+        position: Position,
     ) -> StdResult<(), LinkedChunkError>
     where
         I: IntoIterator<Item = SyncTimelineEvent>,
@@ -267,10 +267,10 @@ impl RoomEvents {
     /// Insert a gap at a specified position.
     pub fn insert_gap_at(
         &mut self,
-        position: ItemPosition,
         gap: Gap,
+        position: Position,
     ) -> StdResult<(), LinkedChunkError> {
-        self.chunks.insert_gap_at(position, gap)
+        self.chunks.insert_gap_at(gap, position)
     }
 
     /// Search for a chunk, and return its identifier.
@@ -282,7 +282,7 @@ impl RoomEvents {
     }
 
     /// Search for an item, and return its position.
-    pub fn event_position<'a, P>(&'a self, predicate: P) -> Option<ItemPosition>
+    pub fn event_position<'a, P>(&'a self, predicate: P) -> Option<Position>
     where
         P: FnMut(&'a SyncTimelineEvent) -> bool,
     {
@@ -324,15 +324,15 @@ impl RoomEvents {
     /// Iterate over the events, backward.
     ///
     /// The most recent event comes first.
-    pub fn revents(&self) -> impl Iterator<Item = (ItemPosition, &SyncTimelineEvent)> {
+    pub fn revents(&self) -> impl Iterator<Item = (Position, &SyncTimelineEvent)> {
         self.chunks.ritems()
     }
 
     /// Iterate over the events, starting from `position`, backward.
     pub fn revents_from(
         &self,
-        position: ItemPosition,
-    ) -> StdResult<impl Iterator<Item = (ItemPosition, &SyncTimelineEvent)>, LinkedChunkError> {
+        position: Position,
+    ) -> StdResult<impl Iterator<Item = (Position, &SyncTimelineEvent)>, LinkedChunkError> {
         self.chunks.ritems_from(position)
     }
 
@@ -340,8 +340,8 @@ impl RoomEvents {
     /// to the latest event.
     pub fn events_from(
         &self,
-        position: ItemPosition,
-    ) -> StdResult<impl Iterator<Item = (ItemPosition, &SyncTimelineEvent)>, LinkedChunkError> {
+        position: Position,
+    ) -> StdResult<impl Iterator<Item = (Position, &SyncTimelineEvent)>, LinkedChunkError> {
         self.chunks.items_from(position)
     }
 }


### PR DESCRIPTION
Those patches have been cherry-picked from https://github.com/matrix-org/matrix-rust-sdk/pull/3230. It's a collection of tiny improvements or bug fixes for `LinkedChunk`. More have been added after that. It's best to review them one by one.