### PR TITLE
sdk: move `get_profile` from `Client` to `Account`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -662,7 +662,7 @@ impl Client {
     pub fn get_profile(&self, user_id: String) -> Result<UserProfile, ClientError> {
         RUNTIME.block_on(async move {
             let owned_user_id = UserId::parse(user_id.clone())?;
-            let response = self.inner.get_profile(&owned_user_id).await?;
+            let response = self.inner.account().get_profile(&owned_user_id).await?;
 
             let user_profile = UserProfile {
                 user_id,

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -662,7 +662,7 @@ impl Client {
     pub fn get_profile(&self, user_id: String) -> Result<UserProfile, ClientError> {
         RUNTIME.block_on(async move {
             let owned_user_id = UserId::parse(user_id.clone())?;
-            let response = self.inner.account().get_profile(&owned_user_id).await?;
+            let response = self.inner.account().fetch_user_profile_of(&owned_user_id).await?;
 
             let user_profile = UserProfile {
                 user_id,

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 - Replace `impl MediaEventContent` with `&impl MediaEventContent` in
   `Media::get_file`/`Media::remove_file`/`Media::get_thumbnail`/`Media::remove_thumbnail`
 - A custom sliding sync proxy set with `ClientBuilder::sliding_sync_proxy` now takes precedence over a discovered proxy.
+- `Client::get_profile` was moved to `Account` and renamed to `Account::fetch_user_profile_of`. `Account::get_profile` was renamed to `Account::fetch_user_profile`.
 
 Additions:
 

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -261,16 +261,16 @@ impl Account {
     /// # async {
     /// # let homeserver = Url::parse("http://localhost:8080")?;
     /// # let client = Client::new(homeserver).await?;
-    /// let profile = client.account().get_current_user_profile().await?;
+    /// let profile = client.account().fetch_user_profile().await?;
     /// println!(
     ///     "You are '{:?}' with avatar '{:?}'",
     ///     profile.displayname, profile.avatar_url
     /// );
     /// # anyhow::Ok(()) };
     /// ```
-    pub async fn get_current_user_profile(&self) -> Result<get_profile::v3::Response> {
+    pub async fn fetch_user_profile(&self) -> Result<get_profile::v3::Response> {
         let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
-        self.get_profile(user_id).await
+        self.fetch_user_profile_of(user_id).await
     }
 
     /// Get the profile for a given user id
@@ -278,7 +278,10 @@ impl Account {
     /// # Arguments
     ///
     /// * `user_id` the matrix id this function downloads the profile for
-    pub async fn get_profile(&self, user_id: &UserId) -> Result<get_profile::v3::Response> {
+    pub async fn fetch_user_profile_of(
+        &self,
+        user_id: &UserId,
+    ) -> Result<get_profile::v3::Response> {
         let request = get_profile::v3::Request::new(user_id.to_owned());
         Ok(self.client.send(request, Some(RequestConfig::short_retry().force_auth())).await?)
     }

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -261,18 +261,26 @@ impl Account {
     /// # async {
     /// # let homeserver = Url::parse("http://localhost:8080")?;
     /// # let client = Client::new(homeserver).await?;
-    /// let profile = client.account().get_profile().await?;
+    /// let profile = client.account().get_current_user_profile().await?;
     /// println!(
     ///     "You are '{:?}' with avatar '{:?}'",
     ///     profile.displayname, profile.avatar_url
     /// );
     /// # anyhow::Ok(()) };
     /// ```
-    pub async fn get_profile(&self) -> Result<get_profile::v3::Response> {
+    pub async fn get_current_user_profile(&self) -> Result<get_profile::v3::Response> {
         let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
+        self.get_profile(user_id).await
+    }
+
+    /// Get the profile for a given user id
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` the matrix id this function downloads the profile for
+    pub async fn get_profile(&self, user_id: &UserId) -> Result<get_profile::v3::Response> {
         let request = get_profile::v3::Request::new(user_id.to_owned());
-        let request_config = self.client.request_config().force_auth();
-        Ok(self.client.send(request, Some(request_config)).await?)
+        Ok(self.client.send(request, Some(RequestConfig::short_retry().force_auth())).await?)
     }
 
     /// Change the password of the account.

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -48,7 +48,6 @@ use ruma::{
             },
             filter::{create_filter::v3::Request as FilterUploadRequest, FilterDefinition},
             membership::{join_room_by_id, join_room_by_id_or_alias},
-            profile::get_profile,
             push::{set_pusher, Pusher},
             room::create_room,
             session::login::v3::DiscoveryInfo,
@@ -2046,16 +2045,6 @@ impl Client {
     pub async fn set_pusher(&self, pusher: Pusher) -> HttpResult<set_pusher::v3::Response> {
         let request = set_pusher::v3::Request::post(pusher);
         self.send(request, None).await
-    }
-
-    /// Get the profile for a given user id
-    ///
-    /// # Arguments
-    ///
-    /// * `user_id` the matrix id this function downloads the profile for
-    pub async fn get_profile(&self, user_id: &UserId) -> Result<get_profile::v3::Response> {
-        let request = get_profile::v3::Request::new(user_id.to_owned());
-        Ok(self.send(request, Some(RequestConfig::short_retry())).await?)
     }
 
     /// Get the notification settings of the current owner of the client.

--- a/crates/matrix-sdk/src/widget/settings/mod.rs
+++ b/crates/matrix-sdk/src/widget/settings/mod.rs
@@ -91,7 +91,7 @@ impl WidgetSettings {
         props: ClientProperties,
     ) -> Result<Url, url::ParseError> {
         self._generate_webview_url(
-            room.client().account().get_profile().await.unwrap_or_default(),
+            room.client().account().get_current_user_profile().await.unwrap_or_default(),
             room.own_user_id(),
             room.room_id(),
             room.client().device_id().unwrap_or("UNKNOWN".into()),

--- a/crates/matrix-sdk/src/widget/settings/mod.rs
+++ b/crates/matrix-sdk/src/widget/settings/mod.rs
@@ -91,7 +91,7 @@ impl WidgetSettings {
         props: ClientProperties,
     ) -> Result<Url, url::ParseError> {
         self._generate_webview_url(
-            room.client().account().get_current_user_profile().await.unwrap_or_default(),
+            room.client().account().fetch_user_profile().await.unwrap_or_default(),
             room.own_user_id(),
             room.room_id(),
             room.client().device_id().unwrap_or("UNKNOWN".into()),


### PR DESCRIPTION
Also rename existing `Account::get_profile` to `Account::get_current_user_profile` and reuse the new function.<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
