### PR TITLE
sdk: make content of RawEvent public

### DIFF
--- a/crates/matrix-sdk/src/event_handler/context.rs
+++ b/crates/matrix-sdk/src/event_handler/context.rs
@@ -60,7 +60,7 @@ impl EventHandlerContext for Room {
 /// Used as a context argument for event handlers (see
 /// [`Client::add_event_handler`]).
 #[derive(Clone, Debug)]
-pub struct RawEvent(Box<RawJsonValue>);
+pub struct RawEvent(pub Box<RawJsonValue>);
 
 impl Deref for RawEvent {
     type Target = RawJsonValue;


### PR DESCRIPTION
so it can be moved out and converted to other types like ruma::Serde::Raw.

closes #3237.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: `lilydjwg <lilydjwg@gmail.com>`