### PR TITLE
crypto: Remove the KeysBackup variant of the OutgoingRequest enum

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/responses.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/responses.rs
@@ -164,7 +164,6 @@ impl From<OutgoingRequest> for Request {
             },
             RoomMessage(r) => Request::from(r),
             KeysClaim(c) => (r.request_id().to_owned(), c.clone()).into(),
-            KeysBackup(b) => (r.request_id().to_owned(), b.clone()).into(),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -39,8 +39,7 @@ use crate::{
     olm::{BackedUpRoomKey, ExportedRoomKey, InboundGroupSession, SignedJsonObject},
     store::{BackupDecryptionKey, BackupKeys, Changes, RoomKeyCounts, Store},
     types::{MegolmV1AuthData, RoomKeyBackupInfo, Signatures},
-    CryptoStoreError, Device, KeysBackupRequest, OutgoingRequest, RoomKeyImportResult,
-    SignatureError,
+    CryptoStoreError, Device, KeysBackupRequest, RoomKeyImportResult, SignatureError,
 };
 
 mod keys;
@@ -68,12 +67,6 @@ struct PendingBackup {
     request_id: OwnedTransactionId,
     request: KeysBackupRequest,
     sessions: BTreeMap<OwnedRoomId, BTreeMap<SenderKey, BTreeSet<SessionId>>>,
-}
-
-impl From<PendingBackup> for OutgoingRequest {
-    fn from(b: PendingBackup) -> Self {
-        OutgoingRequest { request_id: b.request_id, request: Arc::new(b.request.into()) }
-    }
 }
 
 /// The result of a signature verification of a signed JSON object.

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -218,8 +218,6 @@ pub enum OutgoingRequests {
     /// A room message request, usually for sending in-room interactive
     /// verification events.
     RoomMessage(RoomMessageRequest),
-    /// A request that will back up a batch of room keys to the server.
-    KeysBackup(KeysBackupRequest),
 }
 
 #[cfg(test)]
@@ -232,12 +230,6 @@ impl OutgoingRequests {
 impl From<KeysQueryRequest> for OutgoingRequests {
     fn from(request: KeysQueryRequest) -> Self {
         Self::KeysQuery(request)
-    }
-}
-
-impl From<KeysBackupRequest> for OutgoingRequests {
-    fn from(r: KeysBackupRequest) -> Self {
-        Self::KeysBackup(r)
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -771,7 +771,6 @@ impl TryFrom<OutgoingRequest> for OutgoingContent {
         match value.request() {
             crate::OutgoingRequests::KeysUpload(_)
             | crate::OutgoingRequests::KeysQuery(_)
-            | crate::OutgoingRequests::KeysBackup(_)
             | crate::OutgoingRequests::SignatureUpload(_)
             | crate::OutgoingRequests::KeysClaim(_) => Err("Invalid request type".to_owned()),
             crate::OutgoingRequests::ToDeviceRequest(r) => Self::try_from(r.clone()),

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -36,7 +36,6 @@ use matrix_sdk_base::crypto::{
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     api::client::{
-        backup::add_backup_keys::v3::Response as KeysBackupResponse,
         keys::{
             get_keys, upload_keys, upload_signing_keys::v3::Request as UploadSigningKeysRequest,
         },
@@ -541,25 +540,9 @@ impl Client {
                 let response = self.send(request.clone(), None).await?;
                 self.mark_request_as_sent(r.request_id(), &response).await?;
             }
-            OutgoingRequests::KeysBackup(request) => {
-                let response = self.send_backup_request(request).await?;
-                self.mark_request_as_sent(r.request_id(), &response).await?;
-            }
         }
 
         Ok(())
-    }
-
-    async fn send_backup_request(
-        &self,
-        request: &matrix_sdk_base::crypto::KeysBackupRequest,
-    ) -> Result<KeysBackupResponse> {
-        let request = ruma::api::client::backup::add_backup_keys::v3::Request::new(
-            request.version.clone(),
-            request.rooms.clone(),
-        );
-
-        Ok(self.send(request, None).await?)
     }
 
     pub(crate) async fn send_outgoing_requests(&self) -> Result<()> {


### PR DESCRIPTION
Backing up room keys isn't part of the outgoing requests processing loop, instead the user is supposed to have a separate loop calling `BackupMachine::backup()`.

This closes #3244.

- [ ] Public API changes documented in changelogs (optional)
