### PR TITLE
crypto: Run the crypto integration tests against MemoryStore

### DIFF
--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -33,7 +33,7 @@ pub mod types;
 mod utilities;
 mod verification;
 
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 /// Testing facilities and helpers for crypto tests
 pub mod testing {
     pub use crate::identities::{


### PR DESCRIPTION
Make a simple wrapper for `MemoryStore` so that we can run the crypto store integration tests against it.

Also requires a little build fix to make sure the `testing` module is available when we are running in `test` mode but have not enabled the `testing` feature.

Also, now that the `cryptostore_integration_tests` and `cryptostore_integration_tests_time` macros are used in the default build, we can rustfmt them and see any warnings \o/

Part of https://github.com/element-hq/element-web/issues/26892