### PR TITLE
crypto: Add a backup_version argument to group session backup methods

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -17,6 +17,10 @@ Breaking changes:
 - Add new `dehydrated` property to `olm::account::PickledAccount`.
   ([#3164](https://github.com/matrix-org/matrix-rust-sdk/pull/3164))
 
+- Add a `backup_version` argument to `CryptoStore`'s
+  `inbound_group_sessions_for_backup` and
+  `mark_inbound_group_sessions_as_backed_up` methods.
+
 Additions:
 
 - Expose new method `OlmMachine::device_creation_time`.

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -8,6 +8,12 @@ Changed:
 
 Breaking changes:
 
+- Add a `backup_version` argument to `CryptoStore`'s
+  `inbound_group_sessions_for_backup`,
+  `mark_inbound_group_sessions_as_backed_up` and
+  `inbound_group_session_counts` methods.
+  ([#3253](https://github.com/matrix-org/matrix-rust-sdk/pull/3253))
+
 - Rename the `OlmMachine::invalidate_group_session` method to
   `OlmMachine::discard_room_key`
 
@@ -16,10 +22,6 @@ Breaking changes:
 
 - Add new `dehydrated` property to `olm::account::PickledAccount`.
   ([#3164](https://github.com/matrix-org/matrix-rust-sdk/pull/3164))
-
-- Add a `backup_version` argument to `CryptoStore`'s
-  `inbound_group_sessions_for_backup` and
-  `mark_inbound_group_sessions_as_backed_up` methods.
 
 Additions:
 

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -476,7 +476,12 @@ impl BackupMachine {
 
                 trace!(request_id = ?r.request_id, keys = ?r.sessions, "Marking room keys as backed up");
 
-                self.store.mark_inbound_group_sessions_as_backed_up(&room_and_session_ids).await?;
+                self.store
+                    .mark_inbound_group_sessions_as_backed_up(
+                        &r.request.version,
+                        &room_and_session_ids,
+                    )
+                    .await?;
 
                 trace!(
                     request_id = ?r.request_id,
@@ -514,7 +519,7 @@ impl BackupMachine {
         };
 
         let sessions =
-            self.store.inbound_group_sessions_for_backup(Self::BACKUP_BATCH_SIZE).await?;
+            self.store.inbound_group_sessions_for_backup(&version, Self::BACKUP_BATCH_SIZE).await?;
 
         if sessions.is_empty() {
             trace!(?backup_key, "No room keys need to be backed up");

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -442,7 +442,7 @@ macro_rules! cryptostore_integration_tests {
                 loaded_session.export().await;
 
                 assert_eq!(store.get_inbound_group_sessions().await.unwrap().len(), 1);
-                assert_eq!(store.inbound_group_session_counts(Some("bkpver1")).await.unwrap().total, 1);
+                assert_eq!(store.inbound_group_session_counts(None).await.unwrap().total, 1);
             }
 
             #[async_test]

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -323,8 +323,8 @@ macro_rules! cryptostore_integration_tests {
                     .unwrap();
                 assert_eq!(session, loaded_session);
                 assert_eq!(store.get_inbound_group_sessions().await.unwrap().len(), 1);
-                assert_eq!(store.inbound_group_session_counts().await.unwrap().total, 1);
-                assert_eq!(store.inbound_group_session_counts().await.unwrap().backed_up, 0);
+                assert_eq!(store.inbound_group_session_counts(None).await.unwrap().total, 1);
+                assert_eq!(store.inbound_group_session_counts(None).await.unwrap().backed_up, 0);
 
                 let to_back_up = store.inbound_group_sessions_for_backup("bkpver", 1).await.unwrap();
                 assert_eq!(to_back_up, vec![session])
@@ -377,7 +377,7 @@ macro_rules! cryptostore_integration_tests {
             async fn reset_inbound_group_session_for_backup() {
                 let (account, store) =
                     get_loaded_store("reset_inbound_group_session_for_backup").await;
-                assert_eq!(store.inbound_group_session_counts().await.unwrap().total, 0);
+                assert_eq!(store.inbound_group_session_counts(None).await.unwrap().total, 0);
 
                 let room_id = &room_id!("!test:localhost");
                 let (_, session) = account.create_group_session_pair_with_defaults(room_id).await;
@@ -393,8 +393,8 @@ macro_rules! cryptostore_integration_tests {
                     .await
                     .expect("Failed to mark_inbound_group_sessions_as_backed_up.");
 
-                assert_eq!(store.inbound_group_session_counts().await.unwrap().total, 1);
-                assert_eq!(store.inbound_group_session_counts().await.unwrap().backed_up, 1);
+                assert_eq!(store.inbound_group_session_counts(Some("bkpver1")).await.unwrap().total, 1);
+                assert_eq!(store.inbound_group_session_counts(Some("bkpver1")).await.unwrap().backed_up, 1);
 
                 // Sanity: before resetting, we have nothing to back up
                 let to_back_up = store.inbound_group_sessions_for_backup("bkpver1", 1).await.unwrap();
@@ -442,7 +442,7 @@ macro_rules! cryptostore_integration_tests {
                 loaded_session.export().await;
 
                 assert_eq!(store.get_inbound_group_sessions().await.unwrap().len(), 1);
-                assert_eq!(store.inbound_group_session_counts().await.unwrap().total, 1);
+                assert_eq!(store.inbound_group_session_counts(Some("bkpver1")).await.unwrap().total, 1);
             }
 
             #[async_test]

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -279,6 +279,7 @@ impl CryptoStore for MemoryStore {
 
     async fn inbound_group_sessions_for_backup(
         &self,
+        _backup_version: &str,
         limit: usize,
     ) -> Result<Vec<InboundGroupSession>> {
         Ok(self
@@ -292,6 +293,7 @@ impl CryptoStore for MemoryStore {
 
     async fn mark_inbound_group_sessions_as_backed_up(
         &self,
+        _backup_version: &str,
         room_and_session_ids: &[(&RoomId, &str)],
     ) -> Result<()> {
         for (room_id, session_id) in room_and_session_ids {
@@ -764,16 +766,20 @@ mod integration_tests {
 
         async fn inbound_group_sessions_for_backup(
             &self,
+            backup_version: &str,
             limit: usize,
         ) -> Result<Vec<InboundGroupSession>, Self::Error> {
-            self.0.inbound_group_sessions_for_backup(limit).await
+            self.0.inbound_group_sessions_for_backup(backup_version, limit).await
         }
 
         async fn mark_inbound_group_sessions_as_backed_up(
             &self,
+            backup_version: &str,
             room_and_session_ids: &[(&RoomId, &str)],
         ) -> Result<(), Self::Error> {
-            self.0.mark_inbound_group_sessions_as_backed_up(room_and_session_ids).await
+            self.0
+                .mark_inbound_group_sessions_as_backed_up(backup_version, room_and_session_ids)
+                .await
         }
 
         async fn reset_backup_state(&self) -> Result<(), Self::Error> {

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -270,7 +270,10 @@ impl CryptoStore for MemoryStore {
         Ok(self.inbound_group_sessions.get_all())
     }
 
-    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
+    async fn inbound_group_session_counts(
+        &self,
+        _backup_version: Option<&str>,
+    ) -> Result<RoomKeyCounts> {
         let backed_up =
             self.get_inbound_group_sessions().await?.into_iter().filter(|s| s.backed_up()).count();
 
@@ -760,8 +763,11 @@ mod integration_tests {
             self.0.get_inbound_group_sessions().await
         }
 
-        async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts, Self::Error> {
-            self.0.inbound_group_session_counts().await
+        async fn inbound_group_session_counts(
+            &self,
+            backup_version: Option<&str>,
+        ) -> Result<RoomKeyCounts, Self::Error> {
+            self.0.inbound_group_session_counts(backup_version).await
         }
 
         async fn inbound_group_sessions_for_backup(

--- a/crates/matrix-sdk-crypto/src/store/traits.rs
+++ b/crates/matrix-sdk-crypto/src/store/traits.rs
@@ -105,7 +105,10 @@ pub trait CryptoStore: AsyncTraitDeps {
 
     /// Get the number inbound group sessions we have and how many of them are
     /// backed up.
-    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts, Self::Error>;
+    async fn inbound_group_session_counts(
+        &self,
+        backup_version: Option<&str>,
+    ) -> Result<RoomKeyCounts, Self::Error>;
 
     /// Return a batch of ['InboundGroupSession'] ("room keys") that have not
     /// yet been backed up in the supplied backup version.
@@ -349,8 +352,11 @@ impl<T: CryptoStore> CryptoStore for EraseCryptoStoreError<T> {
         self.0.get_inbound_group_sessions().await.map_err(Into::into)
     }
 
-    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
-        self.0.inbound_group_session_counts().await.map_err(Into::into)
+    async fn inbound_group_session_counts(
+        &self,
+        backup_version: Option<&str>,
+    ) -> Result<RoomKeyCounts> {
+        self.0.inbound_group_session_counts(backup_version).await.map_err(Into::into)
     }
     async fn inbound_group_sessions_for_backup(
         &self,

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -889,6 +889,7 @@ impl_crypto_store! {
 
     async fn inbound_group_sessions_for_backup(
         &self,
+        _backup_version: &str,
         limit: usize,
     ) -> Result<Vec<InboundGroupSession>> {
         let tx = self
@@ -933,7 +934,10 @@ impl_crypto_store! {
         Ok(result)
     }
 
-    async fn mark_inbound_group_sessions_as_backed_up(&self, room_and_session_ids: &[(&RoomId, &str)]) -> Result<()> {
+    async fn mark_inbound_group_sessions_as_backed_up(&self,
+        _backup_version: &str,
+        room_and_session_ids: &[(&RoomId, &str)]
+    ) -> Result<()> {
         let tx = self
             .inner
             .transaction_on_one_with_mode(

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -873,7 +873,7 @@ impl_crypto_store! {
         ).await
     }
 
-    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
+    async fn inbound_group_session_counts(&self, _backup_version: Option<&str>) -> Result<RoomKeyCounts> {
         let tx = self
             .inner
             .transaction_on_one_with_mode(

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -946,6 +946,7 @@ impl CryptoStore for SqliteCryptoStore {
 
     async fn inbound_group_sessions_for_backup(
         &self,
+        _backup_version: &str,
         limit: usize,
     ) -> Result<Vec<InboundGroupSession>> {
         self.acquire()
@@ -962,6 +963,7 @@ impl CryptoStore for SqliteCryptoStore {
 
     async fn mark_inbound_group_sessions_as_backed_up(
         &self,
+        _backup_version: &str,
         session_ids: &[(&RoomId, &str)],
     ) -> Result<()> {
         Ok(self

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -477,7 +477,10 @@ trait SqliteObjectCryptoStoreExt: SqliteObjectExt {
             .await?)
     }
 
-    async fn get_inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
+    async fn get_inbound_group_session_counts(
+        &self,
+        _backup_version: Option<&str>,
+    ) -> Result<RoomKeyCounts> {
         let total = self
             .query_row("SELECT count(*) FROM inbound_group_session", (), |row| row.get(0))
             .await?;
@@ -940,8 +943,11 @@ impl CryptoStore for SqliteCryptoStore {
             .collect()
     }
 
-    async fn inbound_group_session_counts(&self) -> Result<RoomKeyCounts> {
-        Ok(self.acquire().await?.get_inbound_group_session_counts().await?)
+    async fn inbound_group_session_counts(
+        &self,
+        backup_version: Option<&str>,
+    ) -> Result<RoomKeyCounts> {
+        Ok(self.acquire().await?.get_inbound_group_session_counts(backup_version).await?)
     }
 
     async fn inbound_group_sessions_for_backup(


### PR DESCRIPTION
As outlined in https://github.com/element-hq/element-web/issues/26892#issuecomment-1961271348 , pass in the backup version we mean when we call `inbound_group_sessions_for_backup` and `mark_inbound_group_sessions_as_backed_up`. This will allow us to switch smoothly to a new backup version when the user asks to reset it, instead of modifying lots of records in our DB when this happens.

Fixes https://github.com/element-hq/crypto-internal/issues/206