### PR TITLE
feat(sdk): Improve `ChunkIdentifierGenerator`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -107,7 +107,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
     /// Push a gap at the end of the [`LinkedChunk`], i.e. after the last
     /// chunk.
     pub fn push_gap_back(&mut self, content: Gap) {
-        let next_identifier = self.chunk_identifier_generator.generate_next().unwrap();
+        let next_identifier = self.chunk_identifier_generator.generate_next();
 
         let last_chunk = self.latest_chunk_mut();
         last_chunk.insert_next(Chunk::new_gap_leaked(next_identifier, content));
@@ -211,7 +211,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
                 .expect("Previous chunk must be present");
 
             previous_chunk.insert_next(Chunk::new_gap_leaked(
-                chunk_identifier_generator.generate_next().unwrap(),
+                chunk_identifier_generator.generate_next(),
                 content,
             ));
 
@@ -238,12 +238,12 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
                 chunk
                     // Insert a new gap chunk.
                     .insert_next(Chunk::new_gap_leaked(
-                        chunk_identifier_generator.generate_next().unwrap(),
+                        chunk_identifier_generator.generate_next(),
                         content,
                     ))
                     // Insert a new items chunk.
                     .insert_next(Chunk::new_items_leaked(
-                        chunk_identifier_generator.generate_next().unwrap(),
+                        chunk_identifier_generator.generate_next(),
                     ))
                     // Finally, push the items that have been detached.
                     .push_items(detached_items.into_iter(), &chunk_identifier_generator)
@@ -296,7 +296,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
                     let last_inserted_chunk = chunk
                         // Insert a new items chunk…
                         .insert_next(Chunk::new_items_leaked(
-                            chunk_identifier_generator.generate_next().unwrap(),
+                            chunk_identifier_generator.generate_next(),
                         )) // … and insert the items.
                         .push_items(items, &chunk_identifier_generator);
 
@@ -590,17 +590,17 @@ impl ChunkIdentifierGenerator {
     /// Generate the next unique identifier.
     ///
     /// Note that it can fail if there is no more unique identifier available.
-    /// In this case, `Result::Err` contains the previous unique identifier.
-    pub fn generate_next(&self) -> Result<ChunkIdentifier, ChunkIdentifier> {
+    /// In this case, this method will panic.
+    pub fn generate_next(&self) -> ChunkIdentifier {
         let previous = self.next.fetch_add(1, Ordering::Relaxed);
 
         // Check for overflows.
         // unlikely — TODO: call `std::intrinsics::unlikely` once it's stable.
         if previous == u64::MAX {
-            return Err(ChunkIdentifier(previous));
+            panic!("No more chunk identifiers available. Congrats, you did it. 2^64 identifiers have been consumed.")
         }
 
-        Ok(ChunkIdentifier(previous.saturating_add(1)))
+        ChunkIdentifier(previous.saturating_add(1))
     }
 }
 
@@ -835,9 +835,7 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
             ChunkContent::Gap(..) => {
                 self
                     // Insert a new items chunk.
-                    .insert_next(Self::new_items_leaked(
-                        chunk_identifier_generator.generate_next().unwrap(),
-                    ))
+                    .insert_next(Self::new_items_leaked(chunk_identifier_generator.generate_next()))
                     // Now push the new items on the next chunk, and return the result of
                     // `push_items`.
                     .push_items(new_items, chunk_identifier_generator)
@@ -862,7 +860,7 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
                     self
                         // Insert a new items chunk.
                         .insert_next(Self::new_items_leaked(
-                            chunk_identifier_generator.generate_next().unwrap(),
+                            chunk_identifier_generator.generate_next(),
                         ))
                         // Now push the rest of the new items on the next chunk, and return the
                         // result of `push_items`.
@@ -1040,18 +1038,18 @@ mod tests {
     fn test_chunk_identifier_generator() {
         let generator = ChunkIdentifierGenerator::new_from_scratch();
 
-        assert_eq!(generator.generate_next(), Ok(ChunkIdentifier(1)));
-        assert_eq!(generator.generate_next(), Ok(ChunkIdentifier(2)));
-        assert_eq!(generator.generate_next(), Ok(ChunkIdentifier(3)));
-        assert_eq!(generator.generate_next(), Ok(ChunkIdentifier(4)));
+        assert_eq!(generator.generate_next(), ChunkIdentifier(1));
+        assert_eq!(generator.generate_next(), ChunkIdentifier(2));
+        assert_eq!(generator.generate_next(), ChunkIdentifier(3));
+        assert_eq!(generator.generate_next(), ChunkIdentifier(4));
 
         let generator =
             ChunkIdentifierGenerator::new_from_previous_chunk_identifier(ChunkIdentifier(42));
 
-        assert_eq!(generator.generate_next(), Ok(ChunkIdentifier(43)));
-        assert_eq!(generator.generate_next(), Ok(ChunkIdentifier(44)));
-        assert_eq!(generator.generate_next(), Ok(ChunkIdentifier(45)));
-        assert_eq!(generator.generate_next(), Ok(ChunkIdentifier(46)));
+        assert_eq!(generator.generate_next(), ChunkIdentifier(43));
+        assert_eq!(generator.generate_next(), ChunkIdentifier(44));
+        assert_eq!(generator.generate_next(), ChunkIdentifier(45));
+        assert_eq!(generator.generate_next(), ChunkIdentifier(46));
     }
 
     #[test]

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -107,7 +107,7 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
     /// Push a gap at the end of the [`LinkedChunk`], i.e. after the last
     /// chunk.
     pub fn push_gap_back(&mut self, content: Gap) {
-        let next_identifier = self.chunk_identifier_generator.generate_next();
+        let next_identifier = self.chunk_identifier_generator.next();
 
         let last_chunk = self.latest_chunk_mut();
         last_chunk.insert_next(Chunk::new_gap_leaked(next_identifier, content));
@@ -210,10 +210,8 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
                 // `chunk.previous.is_some()` in the `if` statement.
                 .expect("Previous chunk must be present");
 
-            previous_chunk.insert_next(Chunk::new_gap_leaked(
-                chunk_identifier_generator.generate_next(),
-                content,
-            ));
+            previous_chunk
+                .insert_next(Chunk::new_gap_leaked(chunk_identifier_generator.next(), content));
 
             // We don't need to update `self.last` because we have inserted a new chunk
             // before `chunk`.
@@ -237,14 +235,9 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
 
                 chunk
                     // Insert a new gap chunk.
-                    .insert_next(Chunk::new_gap_leaked(
-                        chunk_identifier_generator.generate_next(),
-                        content,
-                    ))
+                    .insert_next(Chunk::new_gap_leaked(chunk_identifier_generator.next(), content))
                     // Insert a new items chunk.
-                    .insert_next(Chunk::new_items_leaked(
-                        chunk_identifier_generator.generate_next(),
-                    ))
+                    .insert_next(Chunk::new_items_leaked(chunk_identifier_generator.next()))
                     // Finally, push the items that have been detached.
                     .push_items(detached_items.into_iter(), &chunk_identifier_generator)
             }
@@ -295,9 +288,8 @@ impl<Item, Gap, const CAP: usize> LinkedChunk<Item, Gap, CAP> {
 
                     let last_inserted_chunk = chunk
                         // Insert a new items chunk…
-                        .insert_next(Chunk::new_items_leaked(
-                            chunk_identifier_generator.generate_next(),
-                        )) // … and insert the items.
+                        .insert_next(Chunk::new_items_leaked(chunk_identifier_generator.next()))
+                        // … and insert the items.
                         .push_items(items, &chunk_identifier_generator);
 
                     (
@@ -591,7 +583,7 @@ impl ChunkIdentifierGenerator {
     ///
     /// Note that it can fail if there is no more unique identifier available.
     /// In this case, this method will panic.
-    pub fn generate_next(&self) -> ChunkIdentifier {
+    pub fn next(&self) -> ChunkIdentifier {
         let previous = self.next.fetch_add(1, Ordering::Relaxed);
 
         // Check for overflows.
@@ -600,7 +592,7 @@ impl ChunkIdentifierGenerator {
             panic!("No more chunk identifiers available. Congrats, you did it. 2^64 identifiers have been consumed.")
         }
 
-        ChunkIdentifier(previous.saturating_add(1))
+        ChunkIdentifier(previous + 1)
     }
 }
 
@@ -835,7 +827,7 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
             ChunkContent::Gap(..) => {
                 self
                     // Insert a new items chunk.
-                    .insert_next(Self::new_items_leaked(chunk_identifier_generator.generate_next()))
+                    .insert_next(Self::new_items_leaked(chunk_identifier_generator.next()))
                     // Now push the new items on the next chunk, and return the result of
                     // `push_items`.
                     .push_items(new_items, chunk_identifier_generator)
@@ -859,9 +851,7 @@ impl<Item, Gap, const CAPACITY: usize> Chunk<Item, Gap, CAPACITY> {
 
                     self
                         // Insert a new items chunk.
-                        .insert_next(Self::new_items_leaked(
-                            chunk_identifier_generator.generate_next(),
-                        ))
+                        .insert_next(Self::new_items_leaked(chunk_identifier_generator.next()))
                         // Now push the rest of the new items on the next chunk, and return the
                         // result of `push_items`.
                         .push_items(new_items, chunk_identifier_generator)
@@ -1038,18 +1028,18 @@ mod tests {
     fn test_chunk_identifier_generator() {
         let generator = ChunkIdentifierGenerator::new_from_scratch();
 
-        assert_eq!(generator.generate_next(), ChunkIdentifier(1));
-        assert_eq!(generator.generate_next(), ChunkIdentifier(2));
-        assert_eq!(generator.generate_next(), ChunkIdentifier(3));
-        assert_eq!(generator.generate_next(), ChunkIdentifier(4));
+        assert_eq!(generator.next(), ChunkIdentifier(1));
+        assert_eq!(generator.next(), ChunkIdentifier(2));
+        assert_eq!(generator.next(), ChunkIdentifier(3));
+        assert_eq!(generator.next(), ChunkIdentifier(4));
 
         let generator =
             ChunkIdentifierGenerator::new_from_previous_chunk_identifier(ChunkIdentifier(42));
 
-        assert_eq!(generator.generate_next(), ChunkIdentifier(43));
-        assert_eq!(generator.generate_next(), ChunkIdentifier(44));
-        assert_eq!(generator.generate_next(), ChunkIdentifier(45));
-        assert_eq!(generator.generate_next(), ChunkIdentifier(46));
+        assert_eq!(generator.next(), ChunkIdentifier(43));
+        assert_eq!(generator.next(), ChunkIdentifier(44));
+        assert_eq!(generator.next(), ChunkIdentifier(45));
+        assert_eq!(generator.next(), ChunkIdentifier(46));
     }
 
     #[test]

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -593,15 +593,14 @@ impl ChunkIdentifierGenerator {
     /// In this case, `Result::Err` contains the previous unique identifier.
     pub fn generate_next(&self) -> Result<ChunkIdentifier, ChunkIdentifier> {
         let previous = self.next.fetch_add(1, Ordering::Relaxed);
-        let current = self.next.load(Ordering::Relaxed);
 
         // Check for overflows.
         // unlikely — TODO: call `std::intrinsics::unlikely` once it's stable.
-        if current < previous {
+        if previous == u64::MAX {
             return Err(ChunkIdentifier(previous));
         }
 
-        Ok(ChunkIdentifier(current))
+        Ok(ChunkIdentifier(previous.saturating_add(1)))
     }
 }
 


### PR DESCRIPTION
Follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/3251#discussion_r1532103818.

1. As suggested by @poljar, it is possible that the
value of the atomic changes between the `fetch_add` and the `load` (if
and only if it is used in a concurrency model, which is not the case
right now, but anyway… better being correct now!). The idea is not
`load` but repeat the addition manually to compute the “current” value.
2. Makes `ChunkIdentifierGenerator::generate_next` to panic
if there is no more identifiers available. It was previously returning
a `Result` but we were doing nothing with this `Result` except
`unwrap`ping it. To simplify the API: let's panic.