### PR TITLE
doc(crypto-ffi): `Device::first_time_seen_ts` has an incorrect unit

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/device.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/device.rs
@@ -25,8 +25,8 @@ pub struct Device {
     /// Is our cross signing identity trusted and does the identity trust the
     /// device.
     pub cross_signing_trusted: bool,
-    /// The first time this device was seen in local timestamp, seconds since
-    /// epoch.
+    /// The first time this device was seen in local timestamp, milliseconds
+    /// since epoch.
     pub first_time_seen_ts: u64,
 }
 


### PR DESCRIPTION
This patch changes seconds to milliseconds for the description of `Device::first_time_seen_ts`.

---

* Close https://github.com/matrix-org/matrix-rust-sdk/issues/3213