### PR TITLE
chore: Avoid importing types redundantly

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -14,7 +14,6 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    convert::{TryFrom, TryInto},
     ops::Deref,
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/crates/matrix-sdk-crypto/src/verification/event_enums.rs
+++ b/crates/matrix-sdk-crypto/src/verification/event_enums.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::BTreeMap,
-    convert::{TryFrom, TryInto},
-};
+use std::collections::BTreeMap;
 
 use as_variant::as_variant;
 use ruma::{

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -14,7 +14,6 @@
 
 use std::{
     collections::HashMap,
-    convert::{TryFrom, TryInto},
     sync::{Arc, RwLock as StdRwLock},
 };
 


### PR DESCRIPTION
`TryFrom` and `TryInto` are imported redundantly. They are already defined in `core::prelude::rust_2021` which is automatically imported. This is generating warnings on my side. This patch fixes that.