### PR TITLE
uniffi: wrap TaskHandle up in an Arc<>

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_directory_search.rs
+++ b/bindings/matrix-sdk-ffi/src/room_directory_search.rs
@@ -106,10 +106,10 @@ impl RoomDirectorySearch {
     pub async fn results(
         &self,
         listener: Box<dyn RoomDirectorySearchEntriesListener>,
-    ) -> TaskHandle {
+    ) -> Arc<TaskHandle> {
         let (initial_values, mut stream) = self.inner.read().await.results();
 
-        TaskHandle::new(RUNTIME.spawn(async move {
+        Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
             listener.on_update(vec![RoomDirectorySearchEntryUpdate::Reset {
                 values: initial_values.into_iter().map(Into::into).collect(),
             }]);
@@ -117,7 +117,7 @@ impl RoomDirectorySearch {
             while let Some(diffs) = stream.next().await {
                 listener.on_update(diffs.into_iter().map(|diff| diff.into()).collect());
             }
-        }))
+        })))
     }
 }
 


### PR DESCRIPTION
Up until uniffi 0.26 it was not possible to send objects across the boundary unless they were wrapped in an `Arc<>`, see https://github.com/mozilla/uniffi-rs/pull/1672

The bindings generator used in complement-crypto only supports up to uniffi 0.25, meaning having a function which returns objects ends up erroring with:
```
error[E0277]: the trait bound `TaskHandle: LowerReturn<UniFfiTag>` is not satisfied
   --> bindings/matrix-sdk-ffi/src/room_directory_search.rs:109:10
    |
109 |     ) -> TaskHandle {
    |          ^^^^^^^^^^ the trait `LowerReturn<UniFfiTag>` is not implemented for `TaskHandle`
    |
    = help: the following other types implement trait `LowerReturn<UT>`:
              <bool as LowerReturn<UT>>
              <i8 as LowerReturn<UT>>
              <i16 as LowerReturn<UT>>
              <i32 as LowerReturn<UT>>
              <i64 as LowerReturn<UT>>
              <u8 as LowerReturn<UT>>
              <u16 as LowerReturn<UT>>
              <u32 as LowerReturn<UT>>
            and 133 others

error[E0277]: the trait bound `TaskHandle: LowerReturn<_>` is not satisfied
   --> bindings/matrix-sdk-ffi/src/room_directory_search.rs:82:1
    |
82  | #[uniffi::export(async_runtime = "tokio")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `LowerReturn<_>` is not implemented for `TaskHandle`
    |
    = help: the following other types implement trait `LowerReturn<UT>`:
              <bool as LowerReturn<UT>>
              <i8 as LowerReturn<UT>>
              <i16 as LowerReturn<UT>>
              <i32 as LowerReturn<UT>>
              <i64 as LowerReturn<UT>>
              <u8 as LowerReturn<UT>>
              <u16 as LowerReturn<UT>>
              <u32 as LowerReturn<UT>>
            and 133 others
```

This PR wraps the offending function in an `Arc<>` to make it uniffi 0.25 compatible, which unbreaks complement crypto.


Going forwards, I want to get complement-crypto into rust SDK CI so this could have been caught earlier. Longer term, I'm slowly learning how to maintain the Go bindings and will bring it up to 0.26.