### PR TITLE
Enable debuginfo for tarpaulin builds.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -105,7 +105,7 @@ jobs:
             --features experimental-widgets,testing
         env:
           CARGO_PROFILE_COV_INHERITS: 'dev'
-          CARGO_PROFILE_COV_DEBUG: 'false'
+          CARGO_PROFILE_COV_DEBUG: 1
           HOMESERVER_URL: "http://localhost:8008"
           HOMESERVER_DOMAIN: "synapse"
           SLIDING_SYNC_PROXY_URL: "http://localhost:8118"


### PR DESCRIPTION
It appears that tarpaulin complains if the symbol information is stripped from the binary, and [as of Rust 1.77](https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#enable-strip-in-release-profiles-by-default), `debug=0` causes Cargo to strip all debug info, leading to errors like:

```
2024-03-21T15:30:52.521627Z ERROR cargo_tarpaulin::test_loader: Error parsing debug information from binary: An I/O error occurred while reading.
2024-03-21T15:30:52.521653Z  WARN cargo_tarpaulin::test_loader: Stripping symbol information can prevent tarpaulin from working. If you want to do this pass `--engine=llvm`
2024-03-21T15:30:52.524745Z ERROR cargo_tarpaulin: Error while parsing binary or DWARF info.
2024-03-21T15:30:52.534462Z  INFO cargo_tarpaulin::process_handling::linux: Launching test
2024-03-21T15:30:52.534498Z  INFO cargo_tarpaulin::process_handling: running /home/runner/work/matrix-rust-sdk/matrix-rust-sdk/target/cov/deps/matrix_sdk_sqlite-0cbb5c9ae8bde620
Error: "Error while parsing binary or DWARF info."
```

To fix this, set `debug=1`.