### PR TITLE
tests: try bumping the timeout duration in `test_room_notification_count`

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -505,7 +505,7 @@ async fn test_room_notification_count() -> Result<()> {
     assert_eq!(alice_room.num_unread_mentions(), 0);
 
     // Remote echo for our own message.
-    assert!(timeout(Duration::from_secs(3), room_info_updates.next())
+    assert!(timeout(Duration::from_secs(10), room_info_updates.next())
         .await
         .expect("timeout getting room info update #6")
         .is_some());


### PR DESCRIPTION
The test has been failing with a timeout recently, several time. Let's see if it was a fluke caused by the low threshold (because the server might be busy handling other requests from other tests), or an actual issue.

I don't repro the failure locally with my test coverage setup, so let's see if it's just about waiting a bit longer.