### PR TITLE
ffi: Expose discovered sliding sync proxy URL

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -187,6 +187,7 @@ impl OidcAuthenticationData {
 #[derive(uniffi::Object)]
 pub struct HomeserverLoginDetails {
     url: String,
+    sliding_sync_proxy: Option<String>,
     supports_oidc_login: bool,
     supports_password_login: bool,
 }
@@ -196,6 +197,11 @@ impl HomeserverLoginDetails {
     /// The URL of the currently configured homeserver.
     pub fn url(&self) -> String {
         self.url.clone()
+    }
+
+    /// The URL of the discovered sliding sync proxy, if any
+    pub fn sliding_sync_proxy(&self) -> Option<String> {
+        self.sliding_sync_proxy.clone()
     }
 
     /// Whether the current homeserver supports login using OIDC.
@@ -261,7 +267,7 @@ impl AuthenticationService {
 
         // Make sure there's a sliding sync proxy available.
         if self.custom_sliding_sync_proxy.read().unwrap().is_none()
-            && client.discovered_sliding_sync_proxy().is_none()
+            && details.sliding_sync_proxy().is_none()
         {
             return Err(AuthenticationError::SlidingSyncNotAvailable);
         }
@@ -411,9 +417,15 @@ impl AuthenticationService {
     ) -> Result<HomeserverLoginDetails, AuthenticationError> {
         let supports_oidc_login = client.discovered_authentication_server().is_some();
         let supports_password_login = client.supports_password_login().await.ok().unwrap_or(false);
+        let sliding_sync_proxy = client.sliding_sync_proxy().map(|proxy_url| proxy_url.to_string());
         let url = client.homeserver();
 
-        Ok(HomeserverLoginDetails { url, supports_oidc_login, supports_password_login })
+        Ok(HomeserverLoginDetails {
+            url,
+            sliding_sync_proxy,
+            supports_oidc_login,
+            supports_password_login,
+        })
     }
 
     /// Handle any necessary configuration in order for login via OIDC to
@@ -591,7 +603,7 @@ impl AuthenticationService {
             .read()
             .unwrap()
             .clone()
-            .or_else(|| client.discovered_sliding_sync_proxy().map(|url| url.to_string()));
+            .or_else(|| client.sliding_sync_proxy().map(|url| url.to_string()));
 
         // Wait for the parent client to finish running its initialization tasks.
         RUNTIME.block_on(client.inner.encryption().wait_for_e2ee_initialization_tasks());

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -199,7 +199,8 @@ impl HomeserverLoginDetails {
         self.url.clone()
     }
 
-    /// The URL of the discovered sliding sync proxy, if any
+    /// The URL of the discovered or manually set sliding sync proxy,
+    /// if any.
     pub fn sliding_sync_proxy(&self) -> Option<String> {
         self.sliding_sync_proxy.clone()
     }

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -329,9 +329,10 @@ impl Client {
         self.inner.oidc().authentication_server_info().cloned()
     }
 
-    /// The sliding sync proxy that is trusted by the homeserver. `None` when
-    /// not configured.
-    pub fn discovered_sliding_sync_proxy(&self) -> Option<Url> {
+    /// The sliding sync proxy of the homeserver. It is either set automatically
+    /// during discovery or manually via `set_sliding_sync_proxy` or `None`
+    /// when not configured.
+    pub fn sliding_sync_proxy(&self) -> Option<Url> {
         self.inner.sliding_sync_proxy()
     }
 


### PR DESCRIPTION
Closes #3265.

There is currently no way to get the URL of a homeserver's sliding sync proxy before logging in on the homeserver.

I suggest exposing the URL via the `HomeserverLoginDetail` struct after configuring the homeserver (through `configure_homeserver`).

Since the homeserver may not declare a corresponding sliding sync proxy, this value is an `Optional`. It is used later in `configure_homeserver` to check if a sliding sync proxy exists and throws an error otherwise. Previously, this check was done against the client's `discovered_sliding_sync_proxy` function.

- [ ] Public API changes documented in changelogs (optional)

---
Signed-off-by: Thomas Völkl <thomas@vollkorntomate.de>