### PR TITLE
day divider: make it impossible to handle an event without adjusting day dividers

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -48,7 +48,7 @@ use ruma::{
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 use super::{
-    day_dividers::DayDividerToken,
+    day_dividers::DayDividerAdjuster,
     event_item::{
         AnyOtherFullStateEventContent, BundledReactions, EventItemIdentifier, EventSendState,
         EventTimelineItemKind, LocalEventTimelineItem, Profile, RemoteEventOrigin,
@@ -272,17 +272,16 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
     /// Handle an event.
     ///
-    /// The [`DayDividerToken`] is unused, but it statically ensures that
-    /// callers make sure to adjust day dividers once this has been called.
-    ///
     /// Returns the number of timeline updates that were made.
     #[instrument(skip_all, fields(txn_id, event_id, position))]
     pub(super) fn handle_event(
         mut self,
-        _day_divider_token: &DayDividerToken,
+        day_divider_adjuster: &mut DayDividerAdjuster,
         event_kind: TimelineEventKind,
     ) -> HandleEventResult {
         let span = tracing::Span::current();
+
+        day_divider_adjuster.mark_used();
 
         let should_add = match &self.ctx.flow {
             Flow::Local { txn_id, .. } => {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -48,6 +48,7 @@ use ruma::{
 use tracing::{debug, error, field::debug, info, instrument, trace, warn};
 
 use super::{
+    day_dividers::DayDividerToken,
     event_item::{
         AnyOtherFullStateEventContent, BundledReactions, EventItemIdentifier, EventSendState,
         EventTimelineItemKind, LocalEventTimelineItem, Profile, RemoteEventOrigin,
@@ -271,9 +272,16 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
     /// Handle an event.
     ///
+    /// The [`DayDividerToken`] is unused, but it statically ensures that
+    /// callers make sure to adjust day dividers once this has been called.
+    ///
     /// Returns the number of timeline updates that were made.
     #[instrument(skip_all, fields(txn_id, event_id, position))]
-    pub(super) fn handle_event(mut self, event_kind: TimelineEventKind) -> HandleEventResult {
+    pub(super) fn handle_event(
+        mut self,
+        _day_divider_token: &DayDividerToken,
+        event_kind: TimelineEventKind,
+    ) -> HandleEventResult {
         let span = tracing::Span::current();
 
         let should_add = match &self.ctx.flow {


### PR DESCRIPTION
The previous API relied on the callers not forgetting about adjusting day dividers after handling an event.

This makes it statically impossible, by requiring that `TimelineEventHandler` takes an unused `&DayDividerToken` when operating. The only way to get a `DayDividerToken` is by creating a `DayDividerAdjuster`, so that we know there's one in scope that will be used later.

Additional checks are added to the `DayDividerAdjuster`, to make sure the adjuster is effectively called when needed.