### PR TITLE
day divider: don't assume events have event id

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -708,7 +708,7 @@ impl TimelineInnerStateTransaction<'_> {
     }
 
     fn adjust_day_dividers(&mut self, mut adjuster: DayDividerAdjuster) {
-        adjuster.maybe_adjust_day_dividers(&mut self.items, &mut self.meta);
+        adjuster.run(&mut self.items, &mut self.meta);
     }
 }
 


### PR DESCRIPTION
Local echoes (which haven't received a remote echo yet) can have no event id, so when computing the report, don't unwrap the event id but use a sensible default instead.

Also tweaks comments from a previous version of another PR. And rename `DayDividerAdjuster::maybe_adjust_day_dividers` to `run`.