### PR TITLE
WIP: client: Set pool_max_idle_per_host to 0 on hyper::Client

### DIFF
--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -33,7 +33,7 @@ pub mod types;
 mod utilities;
 mod verification;
 
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 /// Testing facilities and helpers for crypto tests
 pub mod testing {
     pub use crate::identities::{

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -153,8 +153,10 @@ impl HttpSettings {
     /// Build a client with the specified configuration.
     pub(crate) fn make_client(&self) -> Result<reqwest::Client, HttpError> {
         let user_agent = self.user_agent.clone().unwrap_or_else(|| "matrix-rust-sdk".to_owned());
-        let mut http_client =
-            reqwest::Client::builder().user_agent(user_agent).timeout(self.timeout);
+        let mut http_client = reqwest::Client::builder()
+            .pool_max_idle_per_host(0)
+            .user_agent(user_agent)
+            .timeout(self.timeout);
 
         if self.disable_ssl_verification {
             warn!("SSL verification disabled in the HTTP client!");


### PR DESCRIPTION
NOT READY FOR REVIEW. Marked as such to encourage GH to run the relevant job.

This is just a test to see whether the errors we were seeing here: https://github.com/matrix-org/matrix-rust-sdk/actions/runs/8388525873/job/22972906570?pr=3252#step:9:1818 are fixed by setting `pool_max_idle_per_host` to 0 on the hyper client.

It's a total guess, but here are the issues I found that suggest it might help:

* https://github.com/Azure/azure-sdk-for-rust/pull/1550
* https://github.com/fussybeaver/bollard/issues/387