### PR TITLE
ci: Fix flakey integration test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ emsdk-*
 .build
 .swiftpm
 /Package.swift
+# code coverage report
+cobertura.xml
 
 ## User settings
 xcuserdata/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,6 +2633,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-structural-diff"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25c7940d3c84d2079306c176c7b2b37622b6bc5e43fbd1541b1e4a4e1fd02045"
+dependencies = [
+ "difflib",
+ "regex",
+ "serde_json",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,11 +3266,13 @@ dependencies = [
  "assert_matches",
  "assert_matches2",
  "assign",
+ "eyeball",
  "eyeball-im",
  "futures",
  "futures-core",
  "futures-util",
  "http",
+ "json-structural-diff",
  "matrix-sdk",
  "matrix-sdk-test",
  "matrix-sdk-ui",

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1211,6 +1211,12 @@ impl RoomInfo {
     pub fn active_room_call_participants(&self) -> Vec<OwnedUserId> {
         self.active_room_call_memberships().iter().map(|(user_id, _)| user_id.clone()).collect()
     }
+
+    /// Returns the latest (decrypted) event recorded for this room.
+    #[cfg(feature = "experimental-sliding-sync")]
+    pub fn latest_event(&self) -> Option<&LatestEvent> {
+        self.latest_event.as_deref()
+    }
 }
 
 #[cfg(feature = "experimental-sliding-sync")]

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -10,6 +10,7 @@ assert_matches = { workspace = true }
 assert_matches2 = { workspace = true }
 anyhow = { workspace = true }
 assign = "1"
+eyeball = { workspace = true }
 eyeball-im = { workspace = true }
 futures = { version = "0.3.29", features = ["executor"] }
 futures-core = { workspace = true }
@@ -27,3 +28,4 @@ tempfile = "3.3.0"
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing = { workspace = true }
 wiremock = { workspace = true }
+json-structural-diff = "0.1.0"


### PR DESCRIPTION
This PR adds logs to `test_toggling_reactions`, which fails and we don't really understand why (although we suspect some low-level tokio issue — which might just be a fallout from a timeout).

Also, this makes the `test_room_notification_count` test much more robust: instead of just waiting for `RoomInfo` updates, it now contains some assertions related to those updates. During debugging, I've used a cute hack to see how the `RoomInfo` updates were evolving over time: every time we'd receive an update, we'd store it, so the next time we can compute a (JSON) diff of the two updates. This helped understanding why sometimes an assertion was failing, or in a few places, it showed me that I thought something was happening but it was completely unrelated, and the update was about something entirely different.

It also showed me that, despite sending a new message event in a sync response, synapse would sometimes not maintain the `unread_notifications_count` up to date *in the same sync response*. The next sync response would contain this update, though. Because of this, we sometimes have to wait for extra sync responses in this test, which is bleh, but oh well.