### PR TITLE
day dividers: don't assume a previous item is at the immediate previous position

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
@@ -19,7 +19,7 @@ use std::{fmt::Display, sync::Arc};
 
 use eyeball_im::ObservableVectorTransaction;
 use ruma::MilliSecondsSinceUnixEpoch;
-use tracing::{event_enabled, instrument, trace, warn, Level};
+use tracing::{error, event_enabled, instrument, trace, warn, Level};
 
 use super::{
     inner::TimelineInnerMetadata, util::timestamp_to_date, TimelineItem, TimelineItemKind,
@@ -271,7 +271,9 @@ impl DayDividerAdjuster {
                     let at = at as usize;
 
                     let replaced = &items[at];
-                    assert!(replaced.is_day_divider(), "we replaced a non day-divider");
+                    if !replaced.is_day_divider() {
+                        error!("we replaced a non day-divider @ {i}: {:?}", replaced.kind());
+                    }
 
                     let unique_id = replaced.unique_id();
                     let item = TimelineItem::new(VirtualTimelineItem::DayDivider(ts), unique_id);
@@ -287,7 +289,9 @@ impl DayDividerAdjuster {
                     assert!(at >= 0);
 
                     let removed = items.remove(at as usize);
-                    assert!(removed.is_day_divider(), "we removed a non day-divider");
+                    if !removed.is_day_divider() {
+                        error!("we removed a non day-divider @ {i}: {:?}", removed.kind());
+                    }
 
                     offset -= 1;
                     max_i = i;

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -749,7 +749,7 @@ pub(in crate::timeline) struct TimelineInnerMetadata {
 }
 
 impl TimelineInnerMetadata {
-    fn new(
+    pub(crate) fn new(
         room_version: RoomVersionId,
         unable_to_decrypt_hook: Option<Arc<UtdHookManager>>,
     ) -> Self {


### PR DESCRIPTION
When removing or replacing a previous item that was a day divider, we assumed it was always at the immediate previous position (i - 1 in the loop). That's not correct, because there could be other items unrelated to the day divider algorithm in between (like a read marker), so it would fail the previous assertion.

The regression test (that fails on current main) shows the required setup:

0. event @ ts X
1. day divider @ ts X+1day
2. read marker
3. event @ ts X

When seeing the event, we decided to remove the "previous" day divider that was spurious, and assumed it was at position 2, while it was at position 1. The solution is to keep track of the actual index of the previous item, in addition to the previous item itself.

Also, I've lowered the severity of the check, from an assertion to an `tracing::error!` statement, so that we can still see it in logs, but it's not preventing the timeline to update. It was a bit harsh to do so.