### PR TITLE
crypto: Add `OlmMachine::device_creation_time`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -19,6 +19,9 @@ Breaking changes:
 
 Additions:
 
+- Expose new method `OlmMachine::device_creation_time`.
+  ([#3275](https://github.com/matrix-org/matrix-rust-sdk/pull/3275))
+
 - Log more details about the Olm session after encryption and decryption.
   ([#3242](https://github.com/matrix-org/matrix-rust-sdk/pull/3242))
 


### PR DESCRIPTION
Turns out this is useful for https://github.com/element-hq/element-meta/issues/2313.