### PR TITLE
event cache: internalize handling of the account data

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -185,18 +185,17 @@ impl TimelineBuilder {
                             inner.clear().await;
                         }
 
-                        RoomEventCacheUpdate::Append {
-                            events,
-                            account_data,
-                            ephemeral,
-                            ambiguity_changes,
-                        } => {
+                        RoomEventCacheUpdate::UpdateReadMarker { event_id } => {
+                            trace!(target = %event_id, "Handling fully read marker.");
+                            inner.handle_fully_read_marker(event_id).await;
+                        }
+
+                        RoomEventCacheUpdate::Append { events, ephemeral, ambiguity_changes } => {
                             trace!("Received new events");
 
-                            // TODO: (bnjbvr) account_data and ephemeral should be handled by the
-                            // event cache, and we should replace this with a simple
-                            // `handle_add_events`.
-                            inner.handle_sync_events(events, account_data, ephemeral).await;
+                            // TODO: (bnjbvr) ephemeral should be handled by the event cache, and
+                            // we should replace this with a simple `add_events_at`.
+                            inner.handle_sync_events(events, ephemeral).await;
 
                             let member_ambiguity_changes = ambiguity_changes
                                 .values()

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -41,8 +41,8 @@ use ruma::{
             message::{MessageType, Relation},
             redaction::RoomRedactionEventContent,
         },
-        AnyMessageLikeEventContent, AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent,
-        AnySyncMessageLikeEvent, AnySyncTimelineEvent, MessageLikeEventType,
+        AnyMessageLikeEventContent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
+        AnySyncTimelineEvent, MessageLikeEventType,
     },
     serde::Raw,
     EventId, OwnedEventId, OwnedTransactionId, RoomVersionId, TransactionId, UserId,
@@ -426,22 +426,17 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         self.state.write().await.clear();
     }
 
+    pub(super) async fn handle_fully_read_marker(&self, fully_read_event_id: OwnedEventId) {
+        self.state.write().await.handle_fully_read_marker(fully_read_event_id);
+    }
+
     pub(super) async fn handle_sync_events(
         &self,
         events: Vec<SyncTimelineEvent>,
-        account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
         ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
     ) {
         let mut state = self.state.write().await;
-        state
-            .handle_sync_events(
-                events,
-                account_data,
-                ephemeral,
-                &self.room_data_provider,
-                &self.settings,
-            )
-            .await;
+        state.handle_sync_events(events, ephemeral, &self.room_data_provider, &self.settings).await;
     }
 
     #[cfg(test)]


### PR DESCRIPTION
This is a relatively simple change: this moves handling the fully read marker for a given room into the event cache, so listeners can react to a specific event for that, instead of handling themselves all the account data changes.

Not sure if that's a better API than just returning all the account data changes, so I would love feedback on this. At least it's sufficient for the UI timeline use case, and so it seems sufficient right now (and we could make it different later).

Part of #3058.