### PR TITLE
feat(sdk): Introduce `LinkedChunkUpdate`

### DIFF
--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -15,6 +15,8 @@
 #![allow(dead_code)]
 
 use std::{
+    convert::Infallible,
+    error::Error,
     fmt,
     marker::PhantomData,
     ops::Not,
@@ -26,11 +28,18 @@ use std::{
 };
 
 /// Errors of [`LinkedChunk`].
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum LinkedChunkError {
+    #[error("The chunk identifier is invalid: `{identifier:?}`")]
     InvalidChunkIdentifier { identifier: ChunkIdentifier },
+
+    #[error("The chunk is a gap: `{identifier:?}`")]
     ChunkIsAGap { identifier: ChunkIdentifier },
+
+    #[error("The chunk is an item: `{identifier:?}`")]
     ChunkIsItems { identifier: ChunkIdentifier },
+
+    #[error("The item index is invalid: `{index}`")]
     InvalidItemIndex { index: usize },
 }
 
@@ -1120,7 +1129,7 @@ impl<Item, Gap> LinkedChunkListener<Item, Gap> for () {
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::Debug;
+    use std::{convert::Infallible, fmt::Debug};
 
     use assert_matches::assert_matches;
 
@@ -1256,7 +1265,7 @@ mod tests {
         Item: Clone + Debug + Send + Sync,
         Gap: Clone + Debug + Send + Sync,
     {
-        type Error = ();
+        type Error = Infallible;
 
         fn new_chunk_items(
             &self,
@@ -1808,7 +1817,7 @@ mod tests {
             let position_after_f =
                 Position(position_of_f.chunk_identifier(), position_of_f.index() + 1);
 
-            linked_chunk.insert_items_at(['p', 'q'], position_after_f).await?;
+            linked_chunk.insert_items_at(['p', 'q'], position_after_f)?;
             assert_items_eq!(
                 linked_chunk,
                 ['l', 'm', 'n'] ['o', 'a', 'b'] ['r', 's', 'c'] ['d', 'w', 'x'] ['y', 'z', 'e'] ['f', 'p', 'q']

--- a/crates/matrix-sdk/src/event_cache/linked_chunk.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk.rs
@@ -975,6 +975,18 @@ mod tests {
         LinkedChunkError, Position,
     };
 
+    /// A macro to test the items and the gap of a `LinkedChunk`.
+    /// A chunk is delimited by `[` and `]`. An item chunk has the form `[a, b,
+    /// c]` where `a`, `b` and `c` are items. A gap chunk has the form `[-]`.
+    ///
+    /// For example, here is an assertion of 7 chunks: 1 items chunk, 1 gap
+    /// chunk, 2 items chunks, 1 gap chunk, 2 items chunk. `a` is the oldest
+    /// item of the oldest chunk (the first chunk), and `i` is the oldest (and
+    /// newest) item of the newest chunk (the last chunk).
+    ///
+    /// ```rust,no_run
+    /// assert_items_eq!(linked_chunk, ['a'] [-] ['b', 'c', 'd'] ['e'] [-] ['f', 'g', 'h'] ['i']);
+    /// ```
     macro_rules! assert_items_eq {
         ( @_ [ $iterator:ident ] { [-] $( $rest:tt )* } { $( $accumulator:tt )* } ) => {
             assert_items_eq!(

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -215,6 +215,7 @@ impl EventCache {
                     // re-creating the `RoomEventCache` would create a new unrelated sender.
 
                     let rooms = inner.by_room.write().await;
+
                     for room in rooms.values() {
                         // Notify all the observers that we've lost track of state. (We ignore the
                         // error if there aren't any.)
@@ -761,19 +762,19 @@ impl RoomEventCacheInner {
             Some(first_event_pos) => {
                 if let Some(prev_token_gap) = prev_token {
                     room_events
-                            .insert_gap_at(prev_token_gap, first_event_pos)
-                            // SAFETY: The `first_event_pos` can only be an `Item` chunk, it's
-                            // an invariant of `LinkedChunk`. Also, it can only represent a valid
-                            // `ChunkIdentifier` as the data structure isn't modified yet.
-                            .expect("`first_event_pos` must point to a valid `Item` chunk when inserting a gap");
+                        .insert_gap_at(prev_token_gap, first_event_pos)
+                        // SAFETY: The `first_event_pos` can only be an `Item` chunk, it's
+                        // an invariant of `LinkedChunk`. Also, it can only represent a valid
+                        // `ChunkIdentifier` as the data structure isn't modified yet.
+                        .expect("`first_event_pos` must point to a valid `Item` chunk when inserting a gap");
                 }
 
                 room_events
-                        .insert_events_at(sync_events, first_event_pos)
-                        // SAFETY: The `first_event_pos` can only be an `Item` chunk, it's
-                        // an invariant of `LinkedChunk`. The chunk it points to has not been
-                        // removed.
-                        .expect("The `first_event_pos` must point to a valid `Item` chunk when inserting events");
+                    .insert_events_at(sync_events, first_event_pos)
+                    // SAFETY: The `first_event_pos` can only be an `Item` chunk, it's
+                    // an invariant of `LinkedChunk`. The chunk it points to has not been
+                    // removed.
+                    .expect("The `first_event_pos` must point to a valid `Item` chunk when inserting events");
             }
 
             // There is no first item. Let's simply push.

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -25,7 +25,7 @@ use super::linked_chunk::{
 #[derive(Clone, Debug, PartialEq)]
 pub struct PaginationToken(pub String);
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Gap {
     /// The token to use in the query, extracted from a previous "from" /
     /// "end" field of a `/messages` response.

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -35,7 +35,7 @@ pub struct Gap {
 const DEFAULT_CHUNK_CAPACITY: usize = 128;
 
 pub struct RoomEvents {
-    chunks: LinkedChunk<SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>,
+    chunks: LinkedChunk<DEFAULT_CHUNK_CAPACITY, SyncTimelineEvent, Gap>,
 }
 
 impl Default for RoomEvents {
@@ -110,7 +110,7 @@ impl RoomEvents {
         &mut self,
         events: I,
         gap_identifier: ChunkIdentifier,
-    ) -> Result<&Chunk<SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>, LinkedChunkError>
+    ) -> Result<&Chunk<DEFAULT_CHUNK_CAPACITY, SyncTimelineEvent, Gap>, LinkedChunkError>
     where
         I: IntoIterator<Item = SyncTimelineEvent>,
         I::IntoIter: ExactSizeIterator,
@@ -121,7 +121,7 @@ impl RoomEvents {
     /// Search for a chunk, and return its identifier.
     pub fn chunk_identifier<'a, P>(&'a self, predicate: P) -> Option<ChunkIdentifier>
     where
-        P: FnMut(&'a Chunk<SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>) -> bool,
+        P: FnMut(&'a Chunk<DEFAULT_CHUNK_CAPACITY, SyncTimelineEvent, Gap>) -> bool,
     {
         self.chunks.chunk_identifier(predicate)
     }
@@ -139,14 +139,14 @@ impl RoomEvents {
     /// The most recent chunk comes first.
     pub fn rchunks(
         &self,
-    ) -> LinkedChunkIterBackward<'_, SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY> {
+    ) -> LinkedChunkIterBackward<'_, DEFAULT_CHUNK_CAPACITY, SyncTimelineEvent, Gap> {
         self.chunks.rchunks()
     }
 
     /// Iterate over the chunks, forward.
     ///
     /// The oldest chunk comes first.
-    pub fn chunks(&self) -> LinkedChunkIter<'_, SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY> {
+    pub fn chunks(&self) -> LinkedChunkIter<'_, DEFAULT_CHUNK_CAPACITY, SyncTimelineEvent, Gap> {
         self.chunks.chunks()
     }
 
@@ -155,7 +155,7 @@ impl RoomEvents {
         &self,
         identifier: ChunkIdentifier,
     ) -> Result<
-        LinkedChunkIterBackward<'_, SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>,
+        LinkedChunkIterBackward<'_, DEFAULT_CHUNK_CAPACITY, SyncTimelineEvent, Gap>,
         LinkedChunkError,
     > {
         self.chunks.rchunks_from(identifier)
@@ -166,7 +166,7 @@ impl RoomEvents {
     pub fn chunks_from(
         &self,
         identifier: ChunkIdentifier,
-    ) -> Result<LinkedChunkIter<'_, SyncTimelineEvent, Gap, DEFAULT_CHUNK_CAPACITY>, LinkedChunkError>
+    ) -> Result<LinkedChunkIter<'_, DEFAULT_CHUNK_CAPACITY, SyncTimelineEvent, Gap>, LinkedChunkError>
     {
         self.chunks.chunks_from(identifier)
     }


### PR DESCRIPTION
This patch introduces `LinkedChunkUpdate` and `LinkedChunk::updates(&mut self) -> &mut Vec<LinkedChunkUpdate>`. It's a new mechanism that is used by `LinkedChunk` in order to get a list of all updates that happened in a `LinkedChunk`. This is the fundamental piece to write a persistent storage for `LinkedChunk`, and thus for `EventCache`, see #3280 to learn more.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280