### PR TITLE
sdk(base): misc refactorings + a test for #3277

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1482,9 +1482,11 @@ mod tests {
     };
     use ruma::{
         api::{client as api, IncomingResponse},
-        room_id, user_id, UserId,
+        room_id,
+        serde::Raw,
+        user_id, UserId,
     };
-    use serde_json::json;
+    use serde_json::{json, value::to_raw_value};
 
     use super::BaseClient;
     use crate::{
@@ -1738,5 +1740,64 @@ mod tests {
             .expect("State event not found")
             .deserialize()
             .expect("Failed to deserialize state event");
+    }
+
+    #[async_test]
+    async fn test_invited_members_arent_ignored() {
+        let user_id = user_id!("@alice:example.org");
+        let inviter_user_id = user_id!("@bob:example.org");
+        let room_id = room_id!("!ithpyNKDtmhneaTQja:example.org");
+
+        let client = BaseClient::new();
+        client
+            .set_session_meta(SessionMeta {
+                user_id: user_id.to_owned(),
+                device_id: "FOOBAR".into(),
+            })
+            .await
+            .unwrap();
+
+        // Preamble: let the SDK know about the room.
+        let mut ev_builder = SyncResponseBuilder::new();
+        let response = ev_builder
+            .add_joined_room(matrix_sdk_test::JoinedRoomBuilder::new(room_id))
+            .build_sync_response();
+        client.receive_sync_response(response).await.unwrap();
+
+        // When I process the result of a /members request that only contains an invited
+        // member,
+        let request = api::membership::get_member_events::v3::Request::new(room_id.to_owned());
+
+        let raw_member_event = json!({
+            "content": {
+                "avatar_url": "mxc://localhost/fewjilfewjil42",
+                "displayname": "Invited Alice",
+                "membership": "invite"
+            },
+            "event_id": "$151800140517rfvjc:localhost",
+            "origin_server_ts": 151800140,
+            "room_id": room_id,
+            "sender": inviter_user_id,
+            "state_key": user_id,
+            "type": "m.room.member",
+            "unsigned": {
+                "age": 13374242,
+            }
+        });
+        let response = api::membership::get_member_events::v3::Response::new(vec![Raw::from_json(
+            to_raw_value(&raw_member_event).unwrap(),
+        )]);
+
+        // It's correctly processed,
+        client.receive_all_members(room_id, &request, &response).await.unwrap();
+
+        let room = client.get_room(room_id).unwrap();
+
+        // And I can get the invited member display name and avatar.
+        let member = room.get_member(user_id).await.expect("ok").expect("exists");
+
+        assert_eq!(member.user_id(), user_id);
+        assert_eq!(member.display_name().unwrap(), "Invited Alice");
+        assert_eq!(member.avatar_url().unwrap().to_string(), "mxc://localhost/fewjilfewjil42");
     }
 }

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -290,7 +290,7 @@ mod tests {
     use crate::latest_event::{is_suitable_for_latest_event, LatestEvent, PossibleLatestEvent};
 
     #[test]
-    fn room_messages_are_suitable() {
+    fn test_room_messages_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
             SyncRoomMessageEvent::Original(OriginalSyncMessageLikeEvent {
                 content: RoomMessageEventContent::new(MessageType::Image(
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn polls_are_suitable() {
+    fn test_polls_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::UnstablePollStart(
             SyncUnstablePollStartEvent::Original(OriginalSyncMessageLikeEvent {
                 content: NewUnstablePollStartEventContent::new(UnstablePollStartContentBlock::new(
@@ -337,7 +337,7 @@ mod tests {
     }
 
     #[test]
-    fn call_invites_are_suitable() {
+    fn test_call_invites_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::CallInvite(
             SyncCallInviteEvent::Original(OriginalSyncMessageLikeEvent {
                 content: CallInviteEventContent::new(
@@ -359,7 +359,7 @@ mod tests {
     }
 
     #[test]
-    fn different_types_of_messagelike_are_unsuitable() {
+    fn test_different_types_of_messagelike_are_unsuitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::Sticker(
             SyncStickerEvent::Original(OriginalSyncMessageLikeEvent {
                 content: StickerEventContent::new(
@@ -381,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn redacted_messages_are_suitable() {
+    fn test_redacted_messages_are_suitable() {
         // Ruma does not allow constructing UnsignedRoomRedactionEvent instances.
         let room_redaction_event: UnsignedRoomRedactionEvent = serde_json::from_value(json!({
             "content": {},
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_messages_are_unsuitable() {
+    fn test_encrypted_messages_are_unsuitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomEncrypted(
             SyncRoomEncryptedEvent::Original(OriginalSyncMessageLikeEvent {
                 content: RoomEncryptedEventContent::new(
@@ -429,7 +429,7 @@ mod tests {
     }
 
     #[test]
-    fn state_events_are_unsuitable() {
+    fn test_state_events_are_unsuitable() {
         let event = AnySyncTimelineEvent::State(AnySyncStateEvent::RoomTopic(
             SyncRoomTopicEvent::Original(OriginalSyncStateEvent {
                 content: RoomTopicEventContent::new("".to_owned()),
@@ -448,7 +448,7 @@ mod tests {
     }
 
     #[test]
-    fn replacement_events_are_unsuitable() {
+    fn test_replacement_events_are_unsuitable() {
         let mut event_content = RoomMessageEventContent::text_plain("Bye bye, world!");
         event_content.relates_to = Some(Relation::Replacement(Replacement::new(
             owned_event_id!("$1"),
@@ -472,7 +472,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_latest_event() {
+    fn test_deserialize_latest_event() {
         #[derive(Debug, serde::Serialize, serde::Deserialize)]
         struct TestStruct {
             latest_event: LatestEvent,

--- a/crates/matrix-sdk-base/src/rooms/members.rs
+++ b/crates/matrix-sdk-base/src/rooms/members.rs
@@ -235,7 +235,7 @@ impl RoomMember {
     }
 }
 
-// Information about a the room a member is in.
+// Information about the room a member is in.
 pub(crate) struct MemberRoomInfo<'a> {
     pub(crate) power_levels: Arc<Option<SyncOrStrippedState<RoomPowerLevelsEventContent>>>,
     pub(crate) max_power_level: i64,

--- a/crates/matrix-sdk-base/src/rooms/members.rs
+++ b/crates/matrix-sdk-base/src/rooms/members.rs
@@ -52,8 +52,12 @@ pub struct RoomMember {
 }
 
 impl RoomMember {
-    pub(crate) fn from_parts(member_info: MemberInfo, room_info: &MemberRoomInfo<'_>) -> Self {
-        let MemberInfo { event, profile, presence } = member_info;
+    pub(crate) fn from_parts(
+        event: MemberEvent,
+        profile: Option<MinimalRoomMemberEvent>,
+        presence: Option<PresenceEvent>,
+        room_info: &MemberRoomInfo<'_>,
+    ) -> Self {
         let MemberRoomInfo {
             power_levels,
             max_power_level,
@@ -229,13 +233,6 @@ impl RoomMember {
     pub fn is_ignored(&self) -> bool {
         self.is_ignored
     }
-}
-
-// Information about a room member.
-pub(crate) struct MemberInfo {
-    pub event: MemberEvent,
-    pub(crate) profile: Option<MinimalRoomMemberEvent>,
-    pub(crate) presence: Option<PresenceEvent>,
 }
 
 // Information about a the room a member is in.

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -58,8 +58,8 @@ use tokio::sync::broadcast;
 use tracing::{debug, field::debug, info, instrument, warn};
 
 use super::{
-    members::{MemberInfo, MemberRoomInfo},
-    BaseRoomInfo, DisplayName, RoomCreateWithCreatorEventContent, RoomMember, RoomNotableTags,
+    members::MemberRoomInfo, BaseRoomInfo, DisplayName, RoomCreateWithCreatorEventContent,
+    RoomMember, RoomNotableTags,
 };
 #[cfg(feature = "experimental-sliding-sync")]
 use crate::latest_event::LatestEvent;
@@ -547,10 +547,7 @@ impl Room {
         for event in member_events {
             let profile = profiles.remove(event.user_id());
             let presence = presences.remove(event.user_id());
-
-            let member_info = MemberInfo { event, profile, presence };
-
-            members.push(RoomMember::from_parts(member_info, &room_info))
+            members.push(RoomMember::from_parts(event, profile, presence, &room_info))
         }
 
         Ok(members)
@@ -697,8 +694,7 @@ impl Room {
         let display_names = [event.display_name().to_owned()];
         let room_info = self.member_room_info(&display_names).await?;
 
-        let member_info = MemberInfo { event, profile, presence };
-        Ok(Some(RoomMember::from_parts(member_info, &room_info)))
+        Ok(Some(RoomMember::from_parts(event, profile, presence, &room_info)))
     }
 
     /// The current `MemberRoomInfo` for this room.

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1353,7 +1353,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "experimental-sliding-sync")]
-    fn room_info_serialization() {
+    fn test_room_info_serialization() {
         // This test exists to make sure we don't accidentally change the
         // serialized format for `RoomInfo`.
 
@@ -1436,7 +1436,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "experimental-sliding-sync")]
-    fn room_info_deserialization_without_optional_items() {
+    fn test_room_info_deserialization_without_optional_items() {
         // Ensure we can still deserialize RoomInfos before we added things to its
         // schema
 
@@ -1680,13 +1680,13 @@ mod tests {
     }
 
     #[async_test]
-    async fn display_name_for_joined_room_is_empty_if_no_info() {
+    async fn test_display_name_for_joined_room_is_empty_if_no_info() {
         let (_, room) = make_room(RoomState::Joined);
         assert_eq!(room.display_name().await.unwrap(), DisplayName::Empty);
     }
 
     #[async_test]
-    async fn display_name_for_joined_room_uses_canonical_alias_if_available() {
+    async fn test_display_name_for_joined_room_uses_canonical_alias_if_available() {
         let (_, room) = make_room(RoomState::Joined);
         room.inner
             .update(|info| info.base_info.canonical_alias = Some(make_canonical_alias_event()));
@@ -1694,7 +1694,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn display_name_for_joined_room_prefers_name_over_alias() {
+    async fn test_display_name_for_joined_room_prefers_name_over_alias() {
         let (_, room) = make_room(RoomState::Joined);
         room.inner
             .update(|info| info.base_info.canonical_alias = Some(make_canonical_alias_event()));
@@ -1705,13 +1705,13 @@ mod tests {
     }
 
     #[async_test]
-    async fn display_name_for_invited_room_is_empty_if_no_info() {
+    async fn test_display_name_for_invited_room_is_empty_if_no_info() {
         let (_, room) = make_room(RoomState::Invited);
         assert_eq!(room.display_name().await.unwrap(), DisplayName::Empty);
     }
 
     #[async_test]
-    async fn display_name_for_invited_room_is_empty_if_room_name_empty() {
+    async fn test_display_name_for_invited_room_is_empty_if_room_name_empty() {
         let (_, room) = make_room(RoomState::Invited);
 
         let room_name = MinimalStateEvent::Original(OriginalMinimalStateEvent {
@@ -1724,7 +1724,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn display_name_for_invited_room_uses_canonical_alias_if_available() {
+    async fn test_display_name_for_invited_room_uses_canonical_alias_if_available() {
         let (_, room) = make_room(RoomState::Invited);
         room.inner
             .update(|info| info.base_info.canonical_alias = Some(make_canonical_alias_event()));
@@ -1732,7 +1732,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn display_name_for_invited_room_prefers_name_over_alias() {
+    async fn test_display_name_for_invited_room_prefers_name_over_alias() {
         let (_, room) = make_room(RoomState::Invited);
         room.inner
             .update(|info| info.base_info.canonical_alias = Some(make_canonical_alias_event()));
@@ -1889,7 +1889,7 @@ mod tests {
     }
 
     #[test]
-    fn setting_the_name_on_room_info_creates_a_fake_event() {
+    fn test_setting_the_name_on_room_info_creates_a_fake_event() {
         // Given a room
         let mut room_info = RoomInfo::new(room_id!("!r:e.uk"), RoomState::Joined);
 
@@ -1952,7 +1952,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "experimental-sliding-sync")]
-    fn when_we_provide_a_newly_decrypted_event_it_replaces_latest_event() {
+    fn test_when_we_provide_a_newly_decrypted_event_it_replaces_latest_event() {
         // Given a room with an encrypted event
         let (_store, room) = make_room(RoomState::Joined);
         add_encrypted_event(&room, "$A");
@@ -1971,7 +1971,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "experimental-sliding-sync")]
-    fn when_a_newly_decrypted_event_appears_we_delete_all_older_encrypted_events() {
+    fn test_when_a_newly_decrypted_event_appears_we_delete_all_older_encrypted_events() {
         // Given a room with some encrypted events and a latest event
         let (_store, room) = make_room(RoomState::Joined);
         room.inner.update(|info| info.latest_event = Some(make_latest_event("$A")));
@@ -1999,7 +1999,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "experimental-sliding-sync")]
-    fn replacing_the_newest_event_leaves_none_left() {
+    fn test_replacing_the_newest_event_leaves_none_left() {
         // Given a room with some encrypted events
         let (_store, room) = make_room(RoomState::Joined);
         add_encrypted_event(&room, "$0");
@@ -2121,7 +2121,7 @@ mod tests {
     }
 
     #[test]
-    fn show_correct_active_call_state() {
+    fn test_show_correct_active_call_state() {
         let room = create_call_with_member_events_for_user(&ALICE, &BOB, &CAROL);
 
         // This check also tests the ordering.
@@ -2135,7 +2135,7 @@ mod tests {
     }
 
     #[test]
-    fn active_call_is_false_when_everyone_left() {
+    fn test_active_call_is_false_when_everyone_left() {
         let room = create_call_with_member_events_for_user(&ALICE, &BOB, &CAROL);
 
         let b_empty_membership = call_member_state_event(Vec::new(), "$1234_1", &BOB);


### PR DESCRIPTION
@stefanceriu This adds a test for #3277, but it passes even if I revert your commit, so I'm not too sure what your PR fixes; would you be interested in adding commits to this PR until the test is a regression test (aka it fails before your patch, it passes after your patch)? (also we should consider reverting #3277, because it's likely wrong — see last comment I've posted there)

Anyhow, this PR contains a few cleanups that I've made while digging into code related to all of this. `MemberRoomInfo` seems super shady in terms of performance: it's computed in `member_room_info()`, which takes twice the same RW lock and does 3 DB requests; this method is called once per `get_member`; and `get_member` is sometimes called in loops. Oh well, fun for another day.