### PR TITLE
Revert "fix: Process profiles for all room members not only state event senders (#3278)"

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1171,6 +1171,9 @@ impl BaseClient {
 
             let sync_member: SyncRoomMemberEvent = member.clone().into();
 
+            // Senders can fake the profile easily so we keep track of profiles that the
+            // member set themselves to avoid having confusing profile changes
+            // when a member gets kicked/banned.
             if member.state_key() == member.sender() {
                 changes
                     .profiles

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -69,7 +69,7 @@ use crate::{
         StateChanges, StateStoreDataKey, StateStoreDataValue, StateStoreExt, Store, StoreConfig,
     },
     sync::{JoinedRoomUpdate, LeftRoomUpdate, Notification, RoomUpdates, SyncResponse, Timeline},
-    MinimalRoomMemberEvent, RoomStateFilter, SessionMeta,
+    RoomStateFilter, SessionMeta,
 };
 
 /// A no IO Client implementation.
@@ -1170,13 +1170,14 @@ impl BaseClient {
             }
 
             let sync_member: SyncRoomMemberEvent = member.clone().into();
-            let profile = MinimalRoomMemberEvent::from(sync_member);
 
-            changes
-                .profiles
-                .entry(room_id.to_owned())
-                .or_default()
-                .insert(member.state_key().to_owned(), profile);
+            if member.state_key() == member.sender() {
+                changes
+                    .profiles
+                    .entry(room_id.to_owned())
+                    .or_default()
+                    .insert(member.sender().to_owned(), sync_member.into());
+            }
 
             changes
                 .state


### PR DESCRIPTION
This reverts commit 99e47ed5d7750bb65e271ad2361c9dbbb46d7914, for the following reasons:

- it's easy for a sender to put arbitrary content in the `m.room.member` event content for the person they're inviting, so the previous code, while uncommented, was a measure against abuse. I've added a comment in a separate commit there.
- I've written a test in #3283 for what I thought #3278 was fixing, but it's passing even after reverting #3278, so the test isn't showing what's getting fixed, and it's not clear as a result what the PR was fixing. We should identify that first, before writing a blind fix like this.

cc @stefanceriu 