### PR TITLE
timeline: Use day divider when updating send state

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -410,7 +410,7 @@ impl TimelineInnerState {
         txn.commit();
     }
 
-    fn transaction(&mut self) -> TimelineInnerStateTransaction<'_> {
+    pub(super) fn transaction(&mut self) -> TimelineInnerStateTransaction<'_> {
         let items = self.items.transaction();
         let meta = self.meta.clone();
         TimelineInnerStateTransaction { items, previous_meta: &mut self.meta, meta }
@@ -645,7 +645,7 @@ impl TimelineInnerStateTransaction<'_> {
         self.meta.update_read_marker(&mut self.items);
     }
 
-    fn commit(self) {
+    pub(super) fn commit(self) {
         let Self { items, previous_meta, meta } = self;
 
         // Replace the pointer to the previous meta with the new one.

--- a/crates/matrix-sdk-ui/src/timeline/item.rs
+++ b/crates/matrix-sdk-ui/src/timeline/item.rs
@@ -89,6 +89,10 @@ impl TimelineItem {
         matches!(&self.kind, TimelineItemKind::Event(ev) if ev.is_remote_event())
     }
 
+    pub(crate) fn is_event(&self) -> bool {
+        matches!(&self.kind, TimelineItemKind::Event(_))
+    }
+
     /// Check whether this item is a day divider.
     #[must_use]
     pub fn is_day_divider(&self) -> bool {


### PR DESCRIPTION
When updating the send state of a message, we manually got rid of a day divider, before this patch. Now we let the algorithm run, as we do everywhere else. Also fixes an issue in the algorithm where the final item could be a day divider, and we'd never remove it (since we remove them only when we notice they're a spurious *previous* day divider) — maybe the algorithm could be changed to just do some linear logic with an iterator, but who cares, it's still O(n) with n = number of timeline items.