### PR TITLE
Fix some clippy warnings

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -811,9 +811,9 @@ mod tests {
         assert_eq!(client_room.state(), RoomState::Joined);
 
         // And it is added to the list of joined rooms only.
-        assert!(sync_resp.rooms.join.get(room_id).is_some());
-        assert!(sync_resp.rooms.leave.get(room_id).is_none());
-        assert!(sync_resp.rooms.invite.get(room_id).is_none());
+        assert!(sync_resp.rooms.join.contains_key(room_id));
+        assert!(!sync_resp.rooms.leave.contains_key(room_id));
+        assert!(!sync_resp.rooms.invite.contains_key(room_id));
     }
 
     #[async_test]
@@ -835,9 +835,9 @@ mod tests {
         assert_eq!(client_room.state(), RoomState::Joined);
 
         // And it is added to the list of joined rooms only.
-        assert!(sync_resp.rooms.join.get(room_id).is_some());
-        assert!(sync_resp.rooms.leave.get(room_id).is_none());
-        assert!(sync_resp.rooms.invite.get(room_id).is_none());
+        assert!(sync_resp.rooms.join.contains_key(room_id));
+        assert!(!sync_resp.rooms.leave.contains_key(room_id));
+        assert!(!sync_resp.rooms.invite.contains_key(room_id));
     }
 
     #[async_test]
@@ -861,9 +861,9 @@ mod tests {
         assert_eq!(client_room.state(), RoomState::Invited);
 
         // And it is added to the list of invited rooms only.
-        assert!(sync_resp.rooms.join.get(room_id).is_none());
-        assert!(sync_resp.rooms.leave.get(room_id).is_none());
-        assert!(sync_resp.rooms.invite.get(room_id).is_some());
+        assert!(!sync_resp.rooms.join.contains_key(room_id));
+        assert!(!sync_resp.rooms.leave.contains_key(room_id));
+        assert!(sync_resp.rooms.invite.contains_key(room_id));
     }
 
     #[async_test]
@@ -890,10 +890,10 @@ mod tests {
         // The room is left.
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Left);
 
-        // And it is added to the list of invited rooms only.
-        assert!(sync_resp.rooms.join.get(room_id).is_none());
-        assert!(sync_resp.rooms.leave.get(room_id).is_some());
-        assert!(sync_resp.rooms.invite.get(room_id).is_none());
+        // And it is added to the list of left rooms only.
+        assert!(!sync_resp.rooms.join.contains_key(room_id));
+        assert!(sync_resp.rooms.leave.contains_key(room_id));
+        assert!(!sync_resp.rooms.invite.contains_key(room_id));
     }
 
     #[async_test]
@@ -1173,7 +1173,7 @@ mod tests {
 
         // And it is added to the list of invited rooms, not the joined ones
         assert!(!sync_resp.rooms.invite[room_id].invite_state.is_empty());
-        assert!(sync_resp.rooms.join.get(room_id).is_none());
+        assert!(!sync_resp.rooms.join.contains_key(room_id));
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/verification/requests.rs
+++ b/crates/matrix-sdk-crypto/src/verification/requests.rs
@@ -1621,10 +1621,7 @@ struct Done {}
 #[cfg(test)]
 mod tests {
 
-    use std::{
-        convert::{TryFrom, TryInto},
-        time::Duration,
-    };
+    use std::time::Duration;
 
     use assert_matches::assert_matches;
     use assert_matches2::assert_let;

--- a/crates/matrix-sdk/src/oidc/registrations.rs
+++ b/crates/matrix-sdk/src/oidc/registrations.rs
@@ -202,11 +202,8 @@ impl OidcRegistrations {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, default::Default};
-
-    use mas_oidc_client::types::registration::{ClientMetadata, Localized};
+    use mas_oidc_client::types::registration::Localized;
     use tempfile::tempdir;
-    use wiremock::http::Url;
 
     use super::*;
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -1289,7 +1289,7 @@ mod tests {
 
         assert!(request.txn_id.is_some());
         assert_eq!(request.room_subscriptions.len(), 1);
-        assert!(request.room_subscriptions.get(r0).is_some());
+        assert!(request.room_subscriptions.contains_key(r0));
 
         let tid = request.txn_id.unwrap();
 

--- a/examples/image_bot/src/main.rs
+++ b/examples/image_bot/src/main.rs
@@ -1,7 +1,6 @@
 use std::{env, fs, process::exit};
 
 use matrix_sdk::{
-    self,
     attachment::AttachmentConfig,
     config::SyncSettings,
     ruma::events::room::message::{MessageType, OriginalSyncRoomMessageEvent},

--- a/examples/login/src/main.rs
+++ b/examples/login/src/main.rs
@@ -6,7 +6,6 @@ use std::{
 
 use anyhow::anyhow;
 use matrix_sdk::{
-    self,
     config::SyncSettings,
     ruma::{
         api::client::session::get_login_types::v3::{IdentityProvider, LoginType},

--- a/examples/timeline/src/main.rs
+++ b/examples/timeline/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use futures_util::StreamExt;
-use matrix_sdk::{self, config::SyncSettings, ruma::OwnedRoomId, Client};
+use matrix_sdk::{config::SyncSettings, ruma::OwnedRoomId, Client};
 use matrix_sdk_ui::timeline::RoomExt;
 use url::Url;
 

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -10,7 +10,6 @@ use futures_util::{pin_mut, FutureExt, StreamExt as _};
 use matrix_sdk::{
     bytes::Bytes,
     config::SyncSettings,
-    reqwest,
     ruma::{
         api::client::{
             receipt::create_receipt::v3::ReceiptType,


### PR DESCRIPTION
I am guessing these are new clippy lints in nightly.

I have a bunch of other warnings (27 currently) that I didn't fix because they seem a bit pedantic to me, so I'm not sure if they are wanted (but I would love to see all the warnings go away):
- https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones, in a lot of places, for example at: https://github.com/matrix-org/matrix-rust-sdk/blob/29f7f88a2c527eacae71cfbcfaeacd785a37f3c2/crates/matrix-sdk-base/src/client.rs#L422
- https://rust-lang.github.io/rust-clippy/master/index.html#mixed_attributes_style, for example at: https://github.com/matrix-org/matrix-rust-sdk/blob/29f7f88a2c527eacae71cfbcfaeacd785a37f3c2/crates/matrix-sdk-crypto/src/identities/device.rs#L980-L983
- https://rust-lang.github.io/rust-clippy/master/index.html#multiple_bound_locations, for example at: https://github.com/matrix-org/matrix-rust-sdk/blob/29f7f88a2c527eacae71cfbcfaeacd785a37f3c2/crates/matrix-sdk-crypto/src/types/mod.rs#L249-L252