### PR TITLE
feat: add support for storing breadcrumbs in the state store

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -758,6 +758,15 @@ impl Client {
         let room = self.inner.join_room_by_id(room_id.as_ref()).await?;
         Ok(Arc::new(Room::new(room)))
     }
+
+    pub async fn get_recently_visited_rooms(&self) -> Result<Vec<String>, ClientError> {
+        Ok(self.inner.account().get_recently_visited_rooms().await?)
+    }
+
+    pub async fn track_recently_visited_room(&self, room: String) -> Result<(), ClientError> {
+        self.inner.account().track_recently_visited_room(room).await?;
+        Ok(())
+    }
 }
 
 #[uniffi::export(callback_interface)]

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -48,6 +48,7 @@ use crate::{
 #[allow(clippy::type_complexity)]
 #[derive(Debug)]
 pub struct MemoryStore {
+    recently_visited_rooms: StdRwLock<HashMap<String, Vec<String>>>,
     user_avatar_url: StdRwLock<HashMap<String, String>>,
     sync_token: StdRwLock<Option<String>>,
     filters: StdRwLock<HashMap<String, String>>,
@@ -89,6 +90,7 @@ const NUMBER_OF_MEDIAS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(20) 
 impl Default for MemoryStore {
     fn default() -> Self {
         Self {
+            recently_visited_rooms: Default::default(),
             user_avatar_url: Default::default(),
             sync_token: Default::default(),
             filters: Default::default(),
@@ -177,6 +179,13 @@ impl StateStore for MemoryStore {
                 .get(user_id.as_str())
                 .cloned()
                 .map(StateStoreDataValue::UserAvatarUrl),
+            StateStoreDataKey::RecentlyVisitedRooms(user_id) => self
+                .recently_visited_rooms
+                .read()
+                .unwrap()
+                .get(user_id.as_str())
+                .cloned()
+                .map(StateStoreDataValue::RecentlyVisitedRooms),
         })
     }
 
@@ -202,6 +211,14 @@ impl StateStore for MemoryStore {
                     value.into_user_avatar_url().expect("Session data not a user avatar url"),
                 );
             }
+            StateStoreDataKey::RecentlyVisitedRooms(user_id) => {
+                self.recently_visited_rooms.write().unwrap().insert(
+                    user_id.to_string(),
+                    value
+                        .into_recently_visited_rooms()
+                        .expect("Session data not a list of recently visited rooms"),
+                );
+            }
         }
 
         Ok(())
@@ -215,6 +232,9 @@ impl StateStore for MemoryStore {
             }
             StateStoreDataKey::UserAvatarUrl(user_id) => {
                 self.filters.write().unwrap().remove(user_id.as_str());
+            }
+            StateStoreDataKey::RecentlyVisitedRooms(user_id) => {
+                self.recently_visited_rooms.write().unwrap().remove(user_id.as_str());
             }
         }
         Ok(())

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -805,6 +805,9 @@ pub enum StateStoreDataValue {
 
     /// The user avatar url
     UserAvatarUrl(String),
+
+    /// A list of recently visited room identifiers for the current user
+    RecentlyVisitedRooms(Vec<String>),
 }
 
 impl StateStoreDataValue {
@@ -822,6 +825,11 @@ impl StateStoreDataValue {
     pub fn into_user_avatar_url(self) -> Option<String> {
         as_variant!(self, Self::UserAvatarUrl)
     }
+
+    /// Get this value if it is a list of recently visited rooms.
+    pub fn into_recently_visited_rooms(self) -> Option<Vec<String>> {
+        as_variant!(self, Self::RecentlyVisitedRooms)
+    }
 }
 
 /// A key for key-value data.
@@ -835,6 +843,9 @@ pub enum StateStoreDataKey<'a> {
 
     /// Avatar URL
     UserAvatarUrl(&'a UserId),
+
+    /// Recently visited room identifiers
+    RecentlyVisitedRooms(&'a UserId),
 }
 
 impl StateStoreDataKey<'_> {
@@ -845,4 +856,8 @@ impl StateStoreDataKey<'_> {
     /// Key prefix to use for the [`UserAvatarUrl`][Self::UserAvatarUrl]
     /// variant.
     pub const USER_AVATAR_URL: &'static str = "user_avatar_url";
+
+    /// Key prefix to use for the
+    /// [`RecentlyVisitedRooms`][Self::RecentlyVisitedRooms] variant.
+    pub const RECENTLY_VISITED_ROOMS: &'static str = "recently_visited_rooms";
 }

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -275,6 +275,9 @@ impl SqliteStateStore {
             StateStoreDataKey::UserAvatarUrl(u) => {
                 Cow::Owned(format!("{}:{u}", StateStoreDataKey::USER_AVATAR_URL))
             }
+            StateStoreDataKey::RecentlyVisitedRooms(b) => {
+                Cow::Owned(format!("{}:{b}", StateStoreDataKey::RECENTLY_VISITED_ROOMS))
+            }
         };
 
         self.encode_key(keys::KV_BLOB, &*key_s)
@@ -873,12 +876,18 @@ impl StateStore for SqliteStateStore {
             .get_kv_blob(self.encode_state_store_data_key(key))
             .await?
             .map(|data| {
-                let string = self.deserialize_value(&data)?;
                 Ok(match key {
-                    StateStoreDataKey::SyncToken => StateStoreDataValue::SyncToken(string),
-                    StateStoreDataKey::Filter(_) => StateStoreDataValue::Filter(string),
+                    StateStoreDataKey::SyncToken => {
+                        StateStoreDataValue::SyncToken(self.deserialize_value(&data)?)
+                    }
+                    StateStoreDataKey::Filter(_) => {
+                        StateStoreDataValue::Filter(self.deserialize_value(&data)?)
+                    }
                     StateStoreDataKey::UserAvatarUrl(_) => {
-                        StateStoreDataValue::UserAvatarUrl(string)
+                        StateStoreDataValue::UserAvatarUrl(self.deserialize_value(&data)?)
+                    }
+                    StateStoreDataKey::RecentlyVisitedRooms(_) => {
+                        StateStoreDataValue::RecentlyVisitedRooms(self.deserialize_value(&data)?)
                     }
                 })
             })
@@ -890,19 +899,24 @@ impl StateStore for SqliteStateStore {
         key: StateStoreDataKey<'_>,
         value: StateStoreDataValue,
     ) -> Result<()> {
-        let value = match key {
-            StateStoreDataKey::SyncToken => {
-                value.into_sync_token().expect("Session data not a sync token")
+        let serialized_value = match key {
+            StateStoreDataKey::SyncToken => self.serialize_value(
+                &value.into_sync_token().expect("Session data not a sync token"),
+            )?,
+            StateStoreDataKey::Filter(_) => {
+                self.serialize_value(&value.into_filter().expect("Session data not a filter"))?
             }
-            StateStoreDataKey::Filter(_) => value.into_filter().expect("Session data not a filter"),
-            StateStoreDataKey::UserAvatarUrl(_) => {
-                value.into_user_avatar_url().expect("Session data not an user avatar url")
-            }
+            StateStoreDataKey::UserAvatarUrl(_) => self.serialize_value(
+                &value.into_user_avatar_url().expect("Session data not an user avatar url"),
+            )?,
+            StateStoreDataKey::RecentlyVisitedRooms(_) => self.serialize_value(
+                &value.into_recently_visited_rooms().expect("Session data not breadcrumbs"),
+            )?,
         };
 
         self.acquire()
             .await?
-            .set_kv_blob(self.encode_state_store_data_key(key), self.serialize_value(&value)?)
+            .set_kv_blob(self.encode_state_store_data_key(key), serialized_value)
             .await
     }
 

--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -20,6 +20,7 @@ Additions:
 - Add new method `discard_room_key` on `Room` that allows to discard the current
   outbound session for that room. Can be used by clients as a dev tool like the `/discardsession` command.
 - Add a new `LinkedChunk` data structure to represents all events per room ([#3166](https://github.com/matrix-org/matrix-rust-sdk/pull/3166)).
+- Add new methods for tracking (on device only) the user's recently visited rooms called `Account::track_recently_visited_room(roomId)` and `Account::get_recently_visited_rooms()`
 
 # 0.7.0
 

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -61,6 +61,10 @@ pub struct Account {
 }
 
 impl Account {
+    /// The maximum number of visited room identifiers to keep in the state
+    /// store.
+    const VISITED_ROOMS_LIMIT: usize = 20;
+
     pub(crate) fn new(client: Client) -> Self {
         Self { client }
     }
@@ -920,6 +924,52 @@ impl Account {
                     self.client.user_id().expect("The client should be logged in"),
                 )
             }))
+    }
+
+    /// Retrieves the user's recently visited room list
+    pub async fn get_recently_visited_rooms(&self) -> Result<Vec<String>> {
+        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
+        let data = self
+            .client
+            .store()
+            .get_kv_data(StateStoreDataKey::RecentlyVisitedRooms(user_id))
+            .await?;
+
+        Ok(data
+            .map(|v| {
+                v.into_recently_visited_rooms()
+                    .expect("Session data is not a list of recently visited rooms")
+            })
+            .unwrap_or_default())
+    }
+
+    /// Moves/inserts the given room to the front of the recently visited list
+    pub async fn track_recently_visited_room(&self, room_id: String) -> Result<(), Error> {
+        let user_id = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
+
+        if let Err(error) = RoomId::parse(&room_id) {
+            error!("Invalid room id: {}", error);
+            return Err(Error::Identifier(error));
+        }
+
+        // Get the previously stored recently visited rooms
+        let mut recently_visited_rooms = self.get_recently_visited_rooms().await?;
+
+        // Remove all other occurrences of the new room_id
+        recently_visited_rooms.retain(|r| r != &room_id);
+
+        // And insert it as the most recent
+        recently_visited_rooms.insert(0, room_id);
+
+        // Cap the whole list to the VISITED_ROOMS_LIMIT
+        recently_visited_rooms.truncate(Self::VISITED_ROOMS_LIMIT);
+
+        let data = StateStoreDataValue::RecentlyVisitedRooms(recently_visited_rooms);
+        self.client
+            .store()
+            .set_kv_data(StateStoreDataKey::RecentlyVisitedRooms(user_id), data)
+            .await?;
+        Ok(())
     }
 }
 

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2100,6 +2100,7 @@ impl Client {
 pub(crate) mod tests {
     use std::time::Duration;
 
+    use assert_matches::assert_matches;
     use matrix_sdk_base::RoomState;
     use matrix_sdk_test::{
         async_test, test_json, JoinedRoomBuilder, StateTestEvent, SyncResponseBuilder,
@@ -2119,6 +2120,7 @@ pub(crate) mod tests {
     use crate::{
         config::{RequestConfig, SyncSettings},
         test_utils::{logged_in_client, no_retry_test_client, test_client_builder},
+        Error,
     };
 
     #[async_test]
@@ -2363,5 +2365,75 @@ pub(crate) mod tests {
 
         let msc4028_enabled = client.can_homeserver_push_encrypted_event_to_device().await.unwrap();
         assert!(msc4028_enabled);
+    }
+
+    #[async_test]
+    async fn test_recently_visited_rooms() {
+        // Tracking recently visited rooms requires authentication
+        let client = no_retry_test_client(Some("http://localhost".to_owned())).await;
+        assert_matches!(
+            client.account().track_recently_visited_room("!alpha:localhost".to_owned()).await,
+            Err(Error::AuthenticationRequired)
+        );
+
+        let client = logged_in_client(None).await;
+        let account = client.account();
+
+        // We should start off with an empty list
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 0);
+
+        // Tracking a valid room id should add it to the list
+        account.track_recently_visited_room("!alpha:localhost".to_owned()).await.unwrap();
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 1);
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap(), ["!alpha:localhost"]);
+
+        // Trying to track an invalid room id should return an error
+        assert_matches!(
+            account.track_recently_visited_room("this_is_not_a_valid_room_id".to_owned()).await,
+            Err(Error::Identifier { .. })
+        );
+
+        // And the existing list shouldn't be changed
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 1);
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap(), ["!alpha:localhost"]);
+
+        // Tracking the same room again shouldn't change the list
+        account.track_recently_visited_room("!alpha:localhost".to_owned()).await.unwrap();
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 1);
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap(), ["!alpha:localhost"]);
+
+        // Tracking a second room should add it to the front of the list
+        account.track_recently_visited_room("!beta:localhost".to_owned()).await.unwrap();
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 2);
+        assert_eq!(
+            account.get_recently_visited_rooms().await.unwrap(),
+            ["!beta:localhost", "!alpha:localhost"]
+        );
+
+        // Tracking the first room yet again should move it to the front of the list
+        account.track_recently_visited_room("!alpha:localhost".to_owned()).await.unwrap();
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 2);
+        assert_eq!(
+            account.get_recently_visited_rooms().await.unwrap(),
+            ["!alpha:localhost", "!beta:localhost"]
+        );
+
+        // Tracking should be capped at 20
+        for n in 0..20 {
+            account
+                .track_recently_visited_room(format!("!{n}:localhost").to_owned())
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 20);
+
+        // And the initial rooms should've been pushed out
+        let rooms = account.get_recently_visited_rooms().await.unwrap();
+        assert!(!rooms.contains(&"!alpha:localhost".to_owned()));
+        assert!(!rooms.contains(&"!beta:localhost".to_owned()));
+
+        // And the last tracked room should be the first
+        assert_eq!(rooms.first().unwrap(), "!19:localhost");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3290

This PR add support for tracking the users recently accessed rooms on device, within the state store (potentially encrypted). It does so by exposing 2 new methods on the client/account:
* `track_recently_visited_room` which takes a roomId, validates that it's a valid one, and then updates the ordered (by recency) **set** of stored rooms, capping it at a predefined **20** (inspired by element web's `im.vector.setting.breadcrumbs` which seems to work great in practice)
* `get_recently_visited_rooms` which will just return an array of room identifiers as strings

There's also a test that should properly check this whole behavior.

You can see it all in action within Element X here https://github.com/element-hq/element-x-ios/pull/2628