### PR TITLE
timeline: pin all the local echoes to the bottom

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -951,15 +951,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     .iter()
                     .enumerate()
                     .rev()
-                    .filter_map(|(idx, item)| Some((idx, item.as_event()?)))
-                    .find(|(_, item)| {
-                        !matches!(
-                            item.send_state(),
-                            Some(EventSendState::NotSentYet | EventSendState::Sent { .. })
-                        )
-                    })
-                    .unzip()
-                    .0;
+                    .find_map(|(idx, item)| (!item.as_event()?.is_local_echo()).then_some(idx));
 
                 // Insert the next item after the latest event item that's not a
                 // pending local echo, or at the start if there is no such item.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -273,10 +273,10 @@ async fn test_clear_with_echoes() {
     let event_items: Vec<_> = timeline_items.iter().filter_map(|item| item.as_event()).collect();
 
     assert_eq!(event_items.len(), 3);
-    // The message that failed to send.
-    assert_matches!(event_items[0].send_state(), Some(EventSendState::SendingFailed { .. }));
     // The message that came in from sync.
-    assert_matches!(event_items[1].origin(), Some(EventItemOrigin::Sync));
+    assert_matches!(event_items[0].origin(), Some(EventItemOrigin::Sync));
+    // The message that failed to send.
+    assert_matches!(event_items[1].send_state(), Some(EventSendState::SendingFailed { .. }));
     // The message that is still pending.
     assert_matches!(event_items[2].send_state(), Some(EventSendState::NotSentYet));
 


### PR DESCRIPTION
Before this patch, only local echoes that were messages not sent or messages succesfully sent (but not ack'd yet by sync) would be pinned to the bottom.

This fixes it by also pinning events that failed to send.

Fixes #3287.

@bmarty Can you try this out and confirm it fixes the bug please?