### PR TITLE
room: warn at most once per room if the room version is missing

### DIFF
--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -17,7 +17,7 @@ use std::sync::RwLock as SyncRwLock;
 use std::{
     collections::{BTreeMap, HashSet},
     mem,
-    sync::Arc,
+    sync::{atomic::AtomicBool, Arc},
 };
 
 use bitflags::bitflags;
@@ -835,6 +835,12 @@ pub struct RoomInfo {
     /// Base room info which holds some basic event contents important for the
     /// room state.
     pub(crate) base_info: Box<BaseRoomInfo>,
+
+    /// Did we already warn about an unknown room version in
+    /// [`RoomInfo::room_version_or_default`]? This is done to avoid
+    /// spamming about unknown room versions in the log for the same room.
+    #[serde(skip)]
+    pub(crate) warned_about_unknown_room_version: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -870,6 +876,7 @@ impl RoomInfo {
             latest_event: None,
             read_receipts: Default::default(),
             base_info: Box::new(BaseRoomInfo::new()),
+            warned_about_unknown_room_version: Arc::new(false.into()),
         }
     }
 
@@ -1093,6 +1100,26 @@ impl RoomInfo {
     /// Get the room version of this room.
     pub fn room_version(&self) -> Option<&RoomVersionId> {
         self.base_info.room_version()
+    }
+
+    /// Get the room version of this room, or a sensible default.
+    ///
+    /// Will warn (at most once) if the room creation event is missing from this
+    /// [`RoomInfo`].
+    pub fn room_version_or_default(&self) -> RoomVersionId {
+        use std::sync::atomic::Ordering;
+
+        self.base_info.room_version().cloned().unwrap_or_else(|| {
+            if self
+                .warned_about_unknown_room_version
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                warn!("Unknown room version, falling back to v10");
+            }
+
+            RoomVersionId::V10
+        })
     }
 
     /// Get the room type of this room.
@@ -1368,6 +1395,7 @@ mod tests {
             ))),
             base_info: Box::new(BaseRoomInfo::new()),
             read_receipts: Default::default(),
+            warned_about_unknown_room_version: Arc::new(false.into()),
         };
 
         let info_json = json!({

--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -14,7 +14,10 @@
 
 //! Data migration helpers for StateStore implementations.
 
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 #[cfg(feature = "experimental-sliding-sync")]
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
@@ -120,6 +123,7 @@ impl RoomInfoV1 {
             latest_event: latest_event.map(|ev| Box::new(LatestEvent::new(ev))),
             read_receipts: Default::default(),
             base_info: base_info.migrate(create),
+            warned_about_unknown_room_version: Arc::new(false.into()),
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/timeline/traits.rs
+++ b/crates/matrix-sdk-ui/src/timeline/traits.rs
@@ -25,7 +25,7 @@ use ruma::{
 };
 #[cfg(feature = "e2e-encryption")]
 use ruma::{events::AnySyncTimelineEvent, serde::Raw};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 use super::{Profile, TimelineBuilder};
 use crate::timeline::Timeline;
@@ -91,10 +91,7 @@ impl RoomDataProvider for Room {
     }
 
     fn room_version(&self) -> RoomVersionId {
-        (**self).clone_info().room_version().cloned().unwrap_or_else(|| {
-            warn!("Unknown room version, falling back to v10");
-            RoomVersionId::V10
-        })
+        (**self).clone_info().room_version_or_default()
     }
 
     async fn profile_from_user_id(&self, user_id: &UserId) -> Option<Profile> {


### PR DESCRIPTION
This should avoid spamming the logs about missing room versions, like in https://github.com/element-hq/element-x-ios-rageshakes/issues/1656 where the log line is repeated around 100 times over 1000 lines.

Note this isn't super precise: if the same room info is deserialized multiple times, then this will at most warn once per deserialized `RoomInfo`.

Question for reviewers: two other callers of `room_version()` assume it's v1, because the room version is used during redaction of events (>= v11 events may have a different field indicating where the field is redacted). Should this also make use of V10 as a sensible default?