### PR TITLE
room list service: always include the `m.room.create` state event in a room subscription

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2411,6 +2411,7 @@ async fn test_room_subscription() -> Result<(), Error> {
                         ["m.room.topic", ""],
                         ["m.room.avatar", ""],
                         ["m.room.canonical_alias", ""],
+                        ["m.room.create", ""], // Added even when it's not specified
                     ],
                     "timeline_limit": 30,
                 },


### PR DESCRIPTION
This way, we're sure that a (UI) timeline will always have access to the `m.room.create` event, and thus get the proper room version, resulting in more correct room redactions (IIUC). It will also avoid causing all the WARN logs in rageshakes, as mitigated by #3299 (which is a nice improvement in separation IMO).

Alternative implementations:

- require the caller to `matrix_ui::...::Room::subscribe()` to pass the proper creation event: this is a bit cumbersome (would require one PR against both EX apps, for my use case), but overall I find this API cumbersome because it shouldn't be the caller's responsibility to specify which events are *required*. The room list service code is opinionated, and it should be fine that the SDK requires some events that are mandatory for it to work well, and then the caller could specify additional state events that aren't mandatory.
- add the `m.room.create` event to the list of required state events in one of the sliding sync list subscriptions. As far as I understand, it's not really required to have it that early (it would be if we wanted to distinguish spaces from non-spaces, for instance), so as to not grow the size of the initial responses, I've kept it in the specific room subscription query.