### PR TITLE
event cache: increase the buffer's size for listeners to `RoomEventCache`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -197,11 +197,13 @@ impl TimelineBuilder {
                             // we should replace this with a simple `add_events_at`.
                             inner.handle_sync_events(events, ephemeral).await;
 
-                            let member_ambiguity_changes = ambiguity_changes
-                                .values()
-                                .flat_map(|change| change.user_ids())
-                                .collect::<BTreeSet<_>>();
-                            inner.force_update_sender_profiles(&member_ambiguity_changes).await;
+                            if !ambiguity_changes.is_empty() {
+                                let member_ambiguity_changes = ambiguity_changes
+                                    .values()
+                                    .flat_map(|change| change.user_ids())
+                                    .collect::<BTreeSet<_>>();
+                                inner.force_update_sender_profiles(&member_ambiguity_changes).await;
+                            }
                         }
                     }
                 }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -172,8 +172,11 @@ impl TimelineBuilder {
                     let update = match event_subscriber.recv().await {
                         Ok(up) => up,
                         Err(broadcast::error::RecvError::Closed) => break,
-                        Err(broadcast::error::RecvError::Lagged(_)) => {
-                            warn!("Lagged behind sync responses, resetting timeline");
+                        Err(broadcast::error::RecvError::Lagged(num_skipped)) => {
+                            warn!(
+                                num_skipped,
+                                "Lagged behind event cache updates, resetting timeline"
+                            );
                             inner.clear().await;
                             continue;
                         }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -203,11 +203,11 @@ impl EventCache {
                     }
                 }
 
-                Err(RecvError::Lagged(_)) => {
+                Err(RecvError::Lagged(num_skipped)) => {
                     // Forget everything we know; we could have missed events, and we have
                     // no way to reconcile at the moment!
                     // TODO: implement Smart Matching™,
-                    warn!("Lagged behind room updates, clearing all rooms");
+                    warn!(num_skipped, "Lagged behind room updates, clearing all rooms");
 
                     // Note: one must NOT clear the `by_room` map, because if something subscribed
                     // to a room update, they would never get any new update for that room, since
@@ -460,7 +460,7 @@ impl RoomEventCacheInner {
     /// Creates a new cache for a room, and subscribes to room updates, so as
     /// to handle new timeline events.
     fn new(room: Room) -> Self {
-        let sender = Sender::new(32);
+        let sender = Sender::new(128);
 
         Self {
             room,


### PR DESCRIPTION
There were cases in the wild of a (UI) timeline lagging behind updates sent from a `RoomEventCache`. The previous buffer size was 32, which I thought would be sufficient for anyone, but with more `RoomEventCacheUpdate` added recently (notably: the read marker update, or, the timeline update code might have gotten slower recently), it might need to get a bit bigger. Let's see if this helps, as a first measure.

Also add more logs and better handle the event cache lagging behind room updates; this would be catastrophic if it happened, so we need to get some logs, at the very least. See details in commit messages.