### PR TITLE
sdk: Use the `GET /auth_issuer` endpoint for OIDC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -2851,8 +2851,8 @@ dependencies = [
 
 [[package]]
 name = "mas-http"
-version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=099eabd1371d2840a2f025a6372d6428039eb511#099eabd1371d2840a2f025a6372d6428039eb511"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=d3d11594f3d00dd1f0dace17538883e93e1bc50f#d3d11594f3d00dd1f0dace17538883e93e1bc50f"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2861,6 +2861,7 @@ dependencies = [
  "http-body",
  "hyper",
  "opentelemetry",
+ "opentelemetry-semantic-conventions",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2873,8 +2874,8 @@ dependencies = [
 
 [[package]]
 name = "mas-iana"
-version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=099eabd1371d2840a2f025a6372d6428039eb511#099eabd1371d2840a2f025a6372d6428039eb511"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=d3d11594f3d00dd1f0dace17538883e93e1bc50f#d3d11594f3d00dd1f0dace17538883e93e1bc50f"
 dependencies = [
  "schemars",
  "serde",
@@ -2882,8 +2883,8 @@ dependencies = [
 
 [[package]]
 name = "mas-jose"
-version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=099eabd1371d2840a2f025a6372d6428039eb511#099eabd1371d2840a2f025a6372d6428039eb511"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=d3d11594f3d00dd1f0dace17538883e93e1bc50f#d3d11594f3d00dd1f0dace17538883e93e1bc50f"
 dependencies = [
  "base64ct",
  "chrono",
@@ -2912,8 +2913,8 @@ dependencies = [
 
 [[package]]
 name = "mas-oidc-client"
-version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=099eabd1371d2840a2f025a6372d6428039eb511#099eabd1371d2840a2f025a6372d6428039eb511"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=d3d11594f3d00dd1f0dace17538883e93e1bc50f#d3d11594f3d00dd1f0dace17538883e93e1bc50f"
 dependencies = [
  "base64ct",
  "bytes",
@@ -3650,8 +3651,8 @@ dependencies = [
 
 [[package]]
 name = "oauth2-types"
-version = "0.8.0"
-source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=099eabd1371d2840a2f025a6372d6428039eb511#099eabd1371d2840a2f025a6372d6428039eb511"
+version = "0.9.0-rc.1"
+source = "git+https://github.com/matrix-org/matrix-authentication-service?rev=d3d11594f3d00dd1f0dace17538883e93e1bc50f#d3d11594f3d00dd1f0dace17538883e93e1bc50f"
 dependencies = [
  "chrono",
  "data-encoding",
@@ -3659,7 +3660,6 @@ dependencies = [
  "language-tags",
  "mas-iana",
  "mas-jose",
- "parse-display",
  "serde",
  "serde_json",
  "serde_with",
@@ -3949,31 +3949,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "parse-display"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06af5f9333eb47bd9ba8462d612e37a8328a5cb80b13f0af4de4c3b89f52dee5"
-dependencies = [
- "parse-display-derive",
- "regex",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9252f259500ee570c75adcc4e317fa6f57a1e47747d622e0bf838002a7b790"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "regex-syntax 0.8.2",
- "structmeta",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -5479,29 +5454,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structmeta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
 
 [[package]]
 name = "strum"

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -16,13 +16,11 @@ use matrix_sdk::{
         },
         AuthorizationResponse, Oidc, OidcError,
     },
+    reqwest::StatusCode,
     AuthSession, ClientBuildError as MatrixClientBuildError, HttpError, RumaApiError,
 };
 use ruma::{
-    api::{
-        client::discovery::discover_homeserver::AuthenticationServerInfo,
-        error::{DeserializationError, FromHttpResponseError},
-    },
+    api::error::{DeserializationError, FromHttpResponseError},
     OwnedUserId,
 };
 use tokio::sync::RwLock as AsyncRwLock;
@@ -319,8 +317,20 @@ impl AuthenticationService {
             return Err(AuthenticationError::ClientMissing);
         };
 
-        let Some(authentication_server) = client.discovered_authentication_server() else {
-            return Err(AuthenticationError::OidcNotSupported);
+        let oidc = client.inner.oidc();
+
+        let issuer = match oidc.fetch_authentication_issuer().await {
+            Ok(issuer) => issuer,
+            Err(error) => {
+                if error
+                    .as_client_api_error()
+                    .is_some_and(|err| err.status_code == StatusCode::NOT_FOUND)
+                {
+                    return Err(AuthenticationError::OidcNotSupported);
+                } else {
+                    return Err(AuthenticationError::ServerUnreachable(error));
+                }
+            }
         };
 
         let Some(oidc_configuration) = &self.oidc_configuration else {
@@ -330,9 +340,7 @@ impl AuthenticationService {
         let redirect_url = Url::parse(&oidc_configuration.redirect_uri)
             .map_err(|_e| AuthenticationError::OidcMetadataInvalid)?;
 
-        let oidc = client.inner.oidc();
-
-        self.configure_oidc(&oidc, authentication_server, oidc_configuration).await?;
+        self.configure_oidc(&oidc, issuer, oidc_configuration).await?;
 
         let mut data_builder = oidc.login(redirect_url, None)?;
         // TODO: Add a check for the Consent prompt when MAS is updated.
@@ -417,7 +425,7 @@ impl AuthenticationService {
         &self,
         client: &Client,
     ) -> Result<HomeserverLoginDetails, AuthenticationError> {
-        let supports_oidc_login = client.discovered_authentication_server().is_some();
+        let supports_oidc_login = client.inner.oidc().fetch_authentication_issuer().await.is_ok();
         let supports_password_login = client.supports_password_login().await.ok().unwrap_or(false);
         let sliding_sync_proxy = client.sliding_sync_proxy().map(|proxy_url| proxy_url.to_string());
         let url = client.homeserver();
@@ -437,7 +445,7 @@ impl AuthenticationService {
     async fn configure_oidc(
         &self,
         oidc: &Oidc,
-        authentication_server: AuthenticationServerInfo,
+        issuer: String,
         configuration: &OidcConfiguration,
     ) -> Result<(), AuthenticationError> {
         if oidc.client_credentials().is_some() {
@@ -447,22 +455,20 @@ impl AuthenticationService {
 
         let oidc_metadata = self.oidc_metadata(configuration)?;
 
-        if self.load_client_registration(oidc, &authentication_server, oidc_metadata.clone()).await
-        {
+        if self.load_client_registration(oidc, issuer.clone(), oidc_metadata.clone()).await {
             tracing::info!("OIDC configuration loaded from disk.");
             return Ok(());
         }
 
         tracing::info!("Registering this client for OIDC.");
-        let registration_response = oidc
-            .register_client(&authentication_server.issuer, oidc_metadata.clone(), None)
-            .await?;
+        let registration_response =
+            oidc.register_client(&issuer, oidc_metadata.clone(), None).await?;
 
         // The format of the credentials changes according to the client metadata that
         // was sent. Public clients only get a client ID.
         let credentials =
             ClientCredentials::None { client_id: registration_response.client_id.clone() };
-        oidc.restore_registered_client(authentication_server, oidc_metadata, credentials);
+        oidc.restore_registered_client(issuer, oidc_metadata, credentials);
 
         tracing::info!("Persisting OIDC registration data.");
         self.store_client_registration(oidc).await?;
@@ -504,11 +510,11 @@ impl AuthenticationService {
     async fn load_client_registration(
         &self,
         oidc: &Oidc,
-        authentication_server: &AuthenticationServerInfo,
+        issuer: String,
         oidc_metadata: VerifiedClientMetadata,
     ) -> bool {
-        let Ok(issuer) = Url::parse(&authentication_server.issuer) else {
-            tracing::error!("Failed to parse {:?}", authentication_server.issuer);
+        let Ok(issuer_url) = Url::parse(&issuer) else {
+            tracing::error!("Failed to parse {issuer:?}");
             return false;
         };
         let Some(registrations) = OidcRegistrations::new(
@@ -519,12 +525,12 @@ impl AuthenticationService {
         .ok() else {
             return false;
         };
-        let Some(client_id) = registrations.client_id(&issuer) else {
+        let Some(client_id) = registrations.client_id(&issuer_url) else {
             return false;
         };
 
         oidc.restore_registered_client(
-            authentication_server.clone(),
+            issuer,
             oidc_metadata,
             ClientCredentials::None { client_id: client_id.0 },
         );

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -8,13 +8,14 @@ use anyhow::{anyhow, Context as _};
 use matrix_sdk::{
     media::{MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSize},
     oidc::{
+        requests::account_management::AccountManagementActionFull,
         types::{
             client_credentials::ClientCredentials,
             registration::{
                 ClientMetadata, ClientMetadataVerificationError, VerifiedClientMetadata,
             },
         },
-        OidcAccountManagementAction, OidcSession,
+        OidcSession,
     },
     ruma::{
         api::client::{
@@ -317,16 +318,6 @@ impl Client {
         })
     }
 
-    /// The homeserver's trusted OIDC Provider that was discovered in the
-    /// well-known.
-    ///
-    /// This will only be set if the homeserver supports authenticating via
-    /// OpenID Connect and this `Client` was constructed using auto-discovery by
-    /// setting the homeserver with [`ClientBuilder::server_name()`].
-    pub(crate) fn discovered_authentication_server(&self) -> Option<AuthenticationServerInfo> {
-        self.inner.oidc().authentication_server_info().cloned()
-    }
-
     /// The sliding sync proxy of the homeserver. It is either set automatically
     /// during discovery or manually via `set_sliding_sync_proxy` or `None`
     /// when not configured.
@@ -381,11 +372,11 @@ impl Client {
         RUNTIME.block_on(async move { Self::session_inner((*self.inner).clone()).await })
     }
 
-    pub fn account_url(
+    pub async fn account_url(
         &self,
         action: Option<AccountManagementAction>,
     ) -> Result<Option<String>, ClientError> {
-        match self.inner.oidc().account_management_url(action.map(Into::into)) {
+        match self.inner.oidc().account_management_url(action.map(Into::into)).await {
             Ok(url) => Ok(url.map(|u| u.to_string())),
             Err(e) => {
                 tracing::error!("Failed retrieving account management URL: {e}");
@@ -1126,7 +1117,7 @@ impl Session {
                             refresh_token,
                             latest_id_token,
                         },
-                    issuer_info,
+                    issuer,
                 } = api.user_session().context("Missing session")?;
                 let client_id = api
                     .client_credentials()
@@ -1139,7 +1130,7 @@ impl Session {
                     client_id,
                     client_metadata,
                     latest_id_token: latest_id_token.map(|t| t.to_string()),
-                    issuer_info,
+                    issuer,
                 };
 
                 let oidc_data = serde_json::to_string(&oidc_data).ok();
@@ -1192,7 +1183,7 @@ impl TryFrom<Session> for AuthSession {
                     refresh_token,
                     latest_id_token,
                 },
-                issuer_info: oidc_data.issuer_info,
+                issuer: oidc_data.issuer,
             };
 
             let session = OidcSession {
@@ -1227,17 +1218,18 @@ pub(crate) struct OidcSessionData {
     client_id: String,
     client_metadata: VerifiedClientMetadata,
     latest_id_token: Option<String>,
-    issuer_info: AuthenticationServerInfo,
+    issuer: String,
 }
 
 /// Represents an unverified client registration against an OpenID Connect
 /// authentication issuer. Call `validate` on this to use it for restoration.
 #[derive(Deserialize)]
+#[serde(try_from = "OidcUnvalidatedSessionDataDeHelper")]
 pub(crate) struct OidcUnvalidatedSessionData {
     client_id: String,
     client_metadata: ClientMetadata,
     latest_id_token: Option<String>,
-    issuer_info: AuthenticationServerInfo,
+    issuer: String,
 }
 
 impl OidcUnvalidatedSessionData {
@@ -1247,8 +1239,37 @@ impl OidcUnvalidatedSessionData {
             client_id: self.client_id,
             client_metadata: self.client_metadata.validate()?,
             latest_id_token: self.latest_id_token,
-            issuer_info: self.issuer_info,
+            issuer: self.issuer,
         })
+    }
+}
+
+#[derive(Deserialize)]
+struct OidcUnvalidatedSessionDataDeHelper {
+    client_id: String,
+    client_metadata: ClientMetadata,
+    latest_id_token: Option<String>,
+    issuer_info: Option<AuthenticationServerInfo>,
+    issuer: Option<String>,
+}
+
+impl TryFrom<OidcUnvalidatedSessionDataDeHelper> for OidcUnvalidatedSessionData {
+    type Error = String;
+
+    fn try_from(value: OidcUnvalidatedSessionDataDeHelper) -> Result<Self, Self::Error> {
+        let OidcUnvalidatedSessionDataDeHelper {
+            client_id,
+            client_metadata,
+            latest_id_token,
+            issuer_info,
+            issuer,
+        } = value;
+
+        let issuer = issuer
+            .or(issuer_info.map(|info| info.issuer))
+            .ok_or_else(|| "missing field `issuer`".to_owned())?;
+
+        Ok(Self { client_id, client_metadata, latest_id_token, issuer })
     }
 }
 
@@ -1258,19 +1279,19 @@ pub enum AccountManagementAction {
     SessionsList,
     SessionView { device_id: String },
     SessionEnd { device_id: String },
+    AccountDeactivate,
+    CrossSigningReset,
 }
 
-impl From<AccountManagementAction> for OidcAccountManagementAction {
+impl From<AccountManagementAction> for AccountManagementActionFull {
     fn from(value: AccountManagementAction) -> Self {
         match value {
             AccountManagementAction::Profile => Self::Profile,
             AccountManagementAction::SessionsList => Self::SessionsList,
-            AccountManagementAction::SessionView { device_id } => {
-                Self::SessionView { device_id: device_id.into() }
-            }
-            AccountManagementAction::SessionEnd { device_id } => {
-                Self::SessionEnd { device_id: device_id.into() }
-            }
+            AccountManagementAction::SessionView { device_id } => Self::SessionView { device_id },
+            AccountManagementAction::SessionEnd { device_id } => Self::SessionEnd { device_id },
+            AccountManagementAction::AccountDeactivate => Self::AccountDeactivate,
+            AccountManagementAction::CrossSigningReset => Self::CrossSigningReset,
         }
     }
 }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -86,7 +86,7 @@ imbl = { workspace = true, features = ["serde"] }
 indexmap = "2.0.2"
 js_int = "0.2.2"
 language-tags = { version = "0.3.2", optional = true }
-mas-oidc-client = { git = "https://github.com/matrix-org/matrix-authentication-service", rev = "099eabd1371d2840a2f025a6372d6428039eb511", default-features = false, optional = true }
+mas-oidc-client = { git = "https://github.com/matrix-org/matrix-authentication-service", rev = "d3d11594f3d00dd1f0dace17538883e93e1bc50f", default-features = false, optional = true }
 matrix-sdk-base = { workspace = true }
 matrix-sdk-common = { workspace = true }
 matrix-sdk-indexeddb = { workspace = true, optional = true }

--- a/crates/matrix-sdk/src/oidc/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/oidc/auth_code_builder.rs
@@ -150,7 +150,7 @@ impl OidcAuthCodeUrlBuilder {
 
         let data = oidc.data().ok_or(OidcError::NotAuthenticated)?;
         info!(
-            issuer = data.issuer_info.issuer,
+            issuer = data.issuer,
             %scope, "Authorizing scope via the OpenID Connect Authorization Code flow"
         );
 

--- a/crates/matrix-sdk/src/oidc/cross_process.rs
+++ b/crates/matrix-sdk/src/oidc/cross_process.rs
@@ -256,10 +256,7 @@ mod tests {
     use futures_util::future::join_all;
     use matrix_sdk_base::SessionMeta;
     use matrix_sdk_test::async_test;
-    use ruma::{
-        api::client::discovery::discover_homeserver::AuthenticationServerInfo, owned_device_id,
-        owned_user_id,
-    };
+    use ruma::{owned_device_id, owned_user_id};
     use wiremock::{
         matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
@@ -349,9 +346,8 @@ mod tests {
         let oidc = Oidc { client: client.clone(), backend: Arc::new(MockImpl::new()) };
 
         // Restore registered client.
-        let issuer_info = AuthenticationServerInfo::new(ISSUER_URL.to_owned(), None);
         let (client_credentials, client_metadata) = mock_registered_client_data();
-        oidc.restore_registered_client(issuer_info, client_metadata, client_credentials);
+        oidc.restore_registered_client(ISSUER_URL.to_owned(), client_metadata, client_credentials);
 
         // Enable cross-process lock.
         oidc.enable_cross_process_refresh_lock("lock".to_owned()).await?;

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -27,6 +27,7 @@ use hyper::{server::conn::AddrIncoming, service::service_fn, Body, Server};
 use matrix_sdk::{
     config::SyncSettings,
     oidc::{
+        requests::account_management::AccountManagementActionFull,
         types::{
             client_credentials::ClientCredentials,
             iana::oauth::OAuthClientAuthenticationMethod,
@@ -35,15 +36,11 @@ use matrix_sdk::{
             requests::GrantType,
             scope::{Scope, ScopeToken},
         },
-        AuthorizationCode, AuthorizationResponse, OidcAccountManagementAction,
-        OidcAuthorizationData, OidcSession, UserSession,
+        AuthorizationCode, AuthorizationResponse, OidcAuthorizationData, OidcSession, UserSession,
     },
     room::Room,
-    ruma::{
-        api::client::discovery::discover_homeserver::AuthenticationServerInfo,
-        events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
-    },
-    Client, ClientBuildError, Result, RoomState, ServerName,
+    ruma::events::room::message::{MessageType, OriginalSyncRoomMessageEvent},
+    Client, ClientBuildError, Result, RoomState,
 };
 use matrix_sdk_ui::sync_service::SyncService;
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
@@ -57,7 +54,7 @@ use url::Url;
 /// flow.
 ///
 /// You can test this against one of the servers from the OIDC playground:
-/// <https://github.com/vector-im/oidc-playground>.
+/// <https://github.com/element-hq/oidc-playground>.
 ///
 /// To use this, just run `cargo run -p example-oidc-cli`, and everything
 /// is interactive after that. You might want to set the `RUST_LOG` environment
@@ -151,10 +148,10 @@ impl OidcCli {
     async fn new(data_dir: &Path, session_file: PathBuf) -> anyhow::Result<Self> {
         println!("No previous session found, logging in…");
 
-        let (client, client_session, issuer_info) = build_client(data_dir).await?;
+        let (client, client_session, issuer) = build_client(data_dir).await?;
         let cli = Self { client, restored: false, session_file };
 
-        let client_id = cli.register_client(issuer_info).await?;
+        let client_id = cli.register_client(issuer).await?;
         cli.login().await?;
 
         // Persist the session to reuse it later.
@@ -188,13 +185,10 @@ impl OidcCli {
     /// Register the OIDC client with the provider.
     ///
     /// Returns the ID of the client returned by the provider.
-    async fn register_client(
-        &self,
-        issuer_info: AuthenticationServerInfo,
-    ) -> anyhow::Result<String> {
+    async fn register_client(&self, issuer: String) -> anyhow::Result<String> {
         let oidc = self.client.oidc();
 
-        let provider_metadata = oidc.given_provider_metadata(&issuer_info.issuer).await?;
+        let provider_metadata = oidc.given_provider_metadata(&issuer).await?;
 
         if provider_metadata.registration_endpoint.is_none() {
             // This would require to register with the provider manually, which
@@ -212,10 +206,10 @@ impl OidcCli {
         // to update the metadata later without changing the client ID, but requires to
         // have a way to serve public keys online to validate the signature of
         // the JWT.
-        let res = oidc.register_client(&issuer_info.issuer, metadata.clone(), None).await?;
+        let res = oidc.register_client(&issuer, metadata.clone(), None).await?;
 
         oidc.restore_registered_client(
-            issuer_info,
+            issuer,
             metadata,
             ClientCredentials::None { client_id: res.client_id.clone() },
         );
@@ -281,34 +275,9 @@ impl OidcCli {
         let StoredSession { client_session, user_session, client_credentials } =
             serde_json::from_str(&serialized_session)?;
 
-        // We're using autodiscovery here too because we need to properly discover the
-        // OIDC endpoints to properly support refreshing tokens in the watch
-        // command.
-        let (homeserver, insecure) =
-            if let Some(base) = client_session.homeserver.strip_prefix("http://") {
-                (base, true)
-            } else {
-                (
-                    client_session
-                        .homeserver
-                        .strip_prefix("https://")
-                        .unwrap_or(&client_session.homeserver),
-                    false,
-                )
-            };
-        let homeserver = homeserver.strip_suffix('/').unwrap_or(homeserver);
-        let server_name = ServerName::parse(homeserver)?;
-
         // Build the client with the previous settings from the session.
-        let mut client = Client::builder();
-
-        if insecure {
-            client = client.insecure_server_name_no_tls(&server_name);
-        } else {
-            client = client.server_name(&server_name);
-        }
-
-        let client = client
+        let client = Client::builder()
+            .homeserver_url(client_session.homeserver)
             .handle_refresh_tokens()
             .sqlite_store(client_session.db_path, Some(&client_session.passphrase))
             .build()
@@ -351,13 +320,13 @@ impl OidcCli {
                     self.whoami();
                 }
                 Some("account") => {
-                    self.account(None);
+                    self.account(None).await;
                 }
                 Some("profile") => {
-                    self.account(Some(OidcAccountManagementAction::Profile));
+                    self.account(Some(AccountManagementActionFull::Profile)).await;
                 }
                 Some("sessions") => {
-                    self.account(Some(OidcAccountManagementAction::SessionsList));
+                    self.account(Some(AccountManagementActionFull::SessionsList)).await;
                 }
                 Some("watch") => match args.next() {
                     Some(sub) => {
@@ -421,8 +390,8 @@ impl OidcCli {
     }
 
     /// Get the account management URL.
-    fn account(&self, action: Option<OidcAccountManagementAction>) {
-        match self.client.oidc().account_management_url(action) {
+    async fn account(&self, action: Option<AccountManagementActionFull>) {
+        match self.client.oidc().account_management_url(action).await {
             Ok(Some(url)) => {
                 println!("\nTo manage your account, visit: {url}");
             }
@@ -662,9 +631,7 @@ impl OidcCli {
 ///
 /// Returns the client, the data required to restore the client, and the OIDC
 /// issuer advertised by the homeserver.
-async fn build_client(
-    data_dir: &Path,
-) -> anyhow::Result<(Client, ClientSession, AuthenticationServerInfo)> {
+async fn build_client(data_dir: &Path) -> anyhow::Result<(Client, ClientSession, String)> {
     let db_path = data_dir.join("db");
 
     // Generate a random passphrase.
@@ -681,33 +648,12 @@ async fn build_client(
         io::stdin().read_line(&mut homeserver).expect("Unable to read user input");
 
         let homeserver = homeserver.trim();
-        let (homeserver, insecure) = if let Some(base) = homeserver.strip_prefix("http://") {
-            (base, true)
-        } else {
-            (homeserver, false)
-        };
-
-        let server_name = match ServerName::parse(homeserver.trim()) {
-            Ok(s) => s,
-            Err(error) => {
-                println!("Error: not a valid server name: {error}");
-                continue;
-            }
-        };
 
         println!("\nChecking homeserver…");
 
-        let mut client = Client::builder();
-
-        // We need to use server autodiscovery to get the authentication issuer
-        // advertised by the homeserver.
-        if insecure {
-            client = client.insecure_server_name_no_tls(&server_name);
-        } else {
-            client = client.server_name(&server_name);
-        }
-
-        match client
+        match Client::builder()
+            // Try autodiscovery or test the URL.
+            .server_name_or_homeserver_url(homeserver)
             // Make sure to automatically refresh tokens if needs be.
             .handle_refresh_tokens()
             // We use the sqlite store, which is available by default. This is the crucial part to
@@ -718,21 +664,33 @@ async fn build_client(
             .await
         {
             Ok(client) => {
-                // Check if the homeserver advertises an OIDC Provider with auto-discovery.
+                // Check if the homeserver advertises an OIDC Provider.
                 // This can be bypassed by providing the issuer manually, but it should be the
                 // most common case for public homeservers.
-                if let Some(issuer_info) = client.oidc().authentication_server_info().cloned() {
-                    println!("Found issuer: {}", issuer_info.issuer);
+                match client.oidc().fetch_authentication_issuer().await {
+                    Ok(issuer) => {
+                        println!("Found issuer: {issuer}");
 
-                    let homeserver = client.homeserver().to_string();
-                    return Ok((
-                        client,
-                        ClientSession { homeserver, db_path, passphrase },
-                        issuer_info,
-                    ));
+                        let homeserver = client.homeserver().to_string();
+                        return Ok((
+                            client,
+                            ClientSession { homeserver, db_path, passphrase },
+                            issuer,
+                        ));
+                    }
+                    Err(error) => {
+                        if error
+                            .as_client_api_error()
+                            .is_some_and(|err| err.status_code == StatusCode::NOT_FOUND)
+                        {
+                            println!("This homeserver doesn't advertise an authentication issuer.");
+                        } else {
+                            println!("Error fetching the authentication issuer: {error:?}");
+                        }
+                        // The client already initialized the store so we need to remove it.
+                        fs::remove_dir_all(data_dir).await?;
+                    }
                 }
-                println!("This homeserver doesn't advertise an authentication issuer.");
-                println!("Please try again\n");
             }
             Err(error) => match &error {
                 ClientBuildError::AutoDiscovery(_)
@@ -742,6 +700,10 @@ async fn build_client(
                     println!("Please try again\n");
                     // The client already initialized the store so we need to remove it.
                     fs::remove_dir_all(data_dir).await?;
+                }
+                ClientBuildError::InvalidServerName => {
+                    println!("Error: not a valid server name");
+                    println!("Please try again\n");
                 }
                 _ => {
                     // Forward other errors, it's unlikely we can retry with a different outcome.


### PR DESCRIPTION
The well-known method is deprecated.

This removes some tests on methods that were previously only getters but now make a request to the auth issuer.

Tested the example CLI to work with the OIDC playground. Element X should probably be tested with other deployments to confirm this. There should be no code changes needed with the FFI bindings.