### PR TITLE
crypto: MemoryStore uses backup versions to track which sessions are backed up

### DIFF
--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -630,6 +630,8 @@ mod tests {
         OlmMachine,
     };
 
+    use super::BackupMachine;
+
     fn room_key() -> BackedUpRoomKey {
         let json = json!({
             "algorithm": "m.megolm.v1.aes-sha2",
@@ -664,11 +666,10 @@ mod tests {
 
     async fn backup_flow(machine: OlmMachine) -> Result<(), OlmError> {
         let backup_machine = machine.backup_machine();
-        let backup_version =
-            backup_machine.backup_key.read().await.as_ref().and_then(|k| k.backup_version());
-        let backup_version = backup_version.as_deref();
+        let backup_version = current_backup_version(&backup_machine).await;
 
-        let counts = backup_machine.store.inbound_group_session_counts(backup_version).await?;
+        let counts =
+            backup_machine.store.inbound_group_session_counts(backup_version.as_deref()).await?;
 
         assert_eq!(counts.total, 0, "Initially no keys exist");
         assert_eq!(counts.backed_up, 0, "Initially no backed up keys exist");
@@ -676,7 +677,8 @@ mod tests {
         machine.create_outbound_group_session_with_defaults_test_helper(room_id()).await?;
         machine.create_outbound_group_session_with_defaults_test_helper(room_id2()).await?;
 
-        let counts = backup_machine.store.inbound_group_session_counts(backup_version).await?;
+        let counts =
+            backup_machine.store.inbound_group_session_counts(backup_version.as_deref()).await?;
         assert_eq!(counts.total, 2, "Two room keys need to exist in the store");
         assert_eq!(counts.backed_up, 0, "No room keys have been backed up yet");
 
@@ -695,8 +697,10 @@ mod tests {
         );
 
         backup_machine.mark_request_as_sent(&request_id).await?;
+        let backup_version = current_backup_version(backup_machine).await;
 
-        let counts = backup_machine.store.inbound_group_session_counts(backup_version).await?;
+        let counts =
+            backup_machine.store.inbound_group_session_counts(backup_version.as_deref()).await?;
         assert_eq!(counts.total, 2);
         assert_eq!(counts.backed_up, 2, "All room keys have been backed up");
 
@@ -706,8 +710,10 @@ mod tests {
         );
 
         backup_machine.disable_backup().await?;
+        let backup_version = current_backup_version(backup_machine).await;
 
-        let counts = backup_machine.store.inbound_group_session_counts(backup_version).await?;
+        let counts =
+            backup_machine.store.inbound_group_session_counts(backup_version.as_deref()).await?;
         assert_eq!(counts.total, 2);
         assert_eq!(
             counts.backed_up, 0,
@@ -715,6 +721,10 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    async fn current_backup_version(backup_machine: &BackupMachine) -> Option<String> {
+        backup_machine.backup_key.read().await.as_ref().and_then(|k| k.backup_version())
     }
 
     #[async_test]

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -446,7 +446,7 @@ macro_rules! cryptostore_integration_tests {
                 loaded_session.export().await;
 
                 assert_eq!(store.get_inbound_group_sessions().await.unwrap().len(), 1);
-                assert_eq!(store.inbound_group_session_counts(Some("bkpver1")).await.unwrap().total, 1);
+                assert_eq!(store.inbound_group_session_counts(None).await.unwrap().total, 1);
             }
 
             #[async_test]

--- a/crates/matrix-sdk-crypto/src/store/memorystore.rs
+++ b/crates/matrix-sdk-crypto/src/store/memorystore.rs
@@ -69,6 +69,10 @@ pub struct MemoryStore {
     backup_keys: RwLock<BackupKeys>,
     next_batch_token: RwLock<Option<String>>,
     room_settings: StdRwLock<HashMap<OwnedRoomId, RoomSettings>>,
+
+    /// Mapping from the backup version as supplied by the server to an order
+    /// number, so we know which backup is the latest.
+    backup_versions: StdRwLock<HashMap<String, u64>>,
 }
 
 impl Default for MemoryStore {
@@ -92,6 +96,7 @@ impl Default for MemoryStore {
             secret_inbox: Default::default(),
             next_batch_token: Default::default(),
             room_settings: Default::default(),
+            backup_versions: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/element-hq/crypto-internal/issues/208

Validate the algorithm described in https://github.com/element-hq/element-web/issues/26892 by implementing it in in the `MemoryStore`.

Main outstanding question: `InboundGroupSession` (in `crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs`) has a `backed_up` field. Should this be changed (e.g. to `backup_up_to`) or removed? How is it used?