### PR TITLE
timeline: keep in sync with the event cache after a `clear()`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -404,9 +404,23 @@ impl TimelineInnerState {
         txn.commit();
     }
 
-    pub(super) fn clear(&mut self) {
+    pub(super) async fn clear_and_replace_with<P: RoomDataProvider>(
+        &mut self,
+        events: Vec<SyncTimelineEvent>,
+        room_data_provider: &P,
+        settings: &TimelineInnerSettings,
+    ) {
         let mut txn = self.transaction();
+
         txn.clear();
+        txn.add_events_at(
+            events,
+            TimelineEnd::Back { from_cache: false },
+            room_data_provider,
+            settings,
+        )
+        .await;
+
         txn.commit();
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -161,7 +161,7 @@ impl Timeline {
 
     /// Clear all timeline items.
     pub async fn clear(&self) {
-        self.inner.clear().await;
+        self.inner.clear_and_replace(Some(&self.event_cache)).await;
     }
 
     /// Subscribe to the back-pagination status of the timeline.

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -594,7 +594,7 @@ async fn test_clear_read_receipts() {
     assert!(event_a.read_receipts().get(*BOB).is_some());
 
     // We received a limited timeline.
-    timeline.inner.clear().await;
+    timeline.inner.clear_and_replace(None).await;
 
     // New message via sync.
     timeline

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -283,13 +283,15 @@ async fn test_clear_with_echoes() {
     // When we clear the timeline now,
     timeline.clear().await;
 
-    // … the two local messages should remain.
+    // … the two local messages should remain, after the original event from the
+    // cache.
     let timeline_items = timeline.items().await;
     let event_items: Vec<_> = timeline_items.iter().filter_map(|item| item.as_event()).collect();
 
-    assert_eq!(event_items.len(), 2);
-    assert_matches!(event_items[0].send_state(), Some(EventSendState::SendingFailed { .. }));
-    assert_matches!(event_items[1].send_state(), Some(EventSendState::NotSentYet));
+    assert_eq!(event_items.len(), 3);
+    assert_matches!(event_items[0].origin(), Some(EventItemOrigin::Sync));
+    assert_matches!(event_items[1].send_state(), Some(EventSendState::SendingFailed { .. }));
+    assert_matches!(event_items[2].send_state(), Some(EventSendState::NotSentYet));
 }
 
 #[async_test]


### PR DESCRIPTION
See #3311 for a stream of consciousness explaining why this is needed.