### PR TITLE
sync service: show the termination report debug info in the error logs

### DIFF
--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -161,7 +161,7 @@ impl SyncService {
 
             if stop_room_list {
                 if let Err(err) = room_list_service.stop_sync() {
-                    error!("unable to stop room list service: {err:#}");
+                    warn!(?report, "unable to stop room list service: {err:#}");
                 }
             }
 
@@ -176,7 +176,7 @@ impl SyncService {
 
             if stop_encryption {
                 if let Err(err) = encryption_sync.stop_sync() {
-                    warn!("unable to stop encryption sync: {err:#}");
+                    warn!(?report, "unable to stop encryption sync: {err:#}");
                 }
             }
 
@@ -406,12 +406,14 @@ impl SyncService {
     }
 }
 
+#[derive(Debug)]
 enum TerminationOrigin {
     EncryptionSync,
     RoomList,
     Scheduler,
 }
 
+#[derive(Debug)]
 struct TerminationReport {
     is_error: bool,
     has_expired: bool,

--- a/crates/matrix-sdk-ui/src/sync_service.rs
+++ b/crates/matrix-sdk-ui/src/sync_service.rs
@@ -233,7 +233,9 @@ impl SyncService {
                     } else {
                         false
                     };
-                    error!("Error while processing encryption in sync service: {err:#}");
+                    if !has_expired {
+                        error!("Error while processing encryption in sync service: {err:#}");
+                    }
                     break (true, has_expired);
                 }
                 None => {
@@ -277,7 +279,9 @@ impl SyncService {
                     } else {
                         false
                     };
-                    error!("Error while processing room list in sync service: {err:#}");
+                    if !has_expired {
+                        error!("Error while processing room list in sync service: {err:#}");
+                    }
                     break (true, has_expired);
                 }
                 None => {


### PR DESCRIPTION
We do see lots of "broken channel" log lines for these two log statements, and since I'm unclear why they happened, I'd like to add a bit more logging to those.

Also makes the log level consistent, both are set to "warn" instead of one warn and one error. Usually it's not a big deal because the only error that may happen is that the channel is broken, indicating the task died before, so there's no need to stop it manually.