### PR TITLE
ffi: expose methods for creating user permalinks and parsing Matrix URIs

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -1,4 +1,7 @@
 use matrix_sdk::room::{RoomMember as SdkRoomMember, RoomMemberRole};
+use ruma::UserId;
+
+use crate::error::ClientError;
 
 #[derive(Clone, uniffi::Enum)]
 pub enum MembershipState {
@@ -49,6 +52,13 @@ pub fn suggested_role_for_power_level(power_level: i64) -> RoomMemberRole {
 pub fn suggested_power_level_for_role(role: RoomMemberRole) -> i64 {
     // It's not possible to expose methods on an Enum through Uniffi ☹️
     role.suggested_power_level()
+}
+
+/// Generates a `matrix.to` permalink from to the given userID.
+#[uniffi::export]
+pub fn matrix_to_user_permalink(user_id: String) -> Result<String, ClientError> {
+    let user_id = UserId::parse(user_id)?;
+    Ok(user_id.matrix_to_uri().to_string())
 }
 
 #[derive(uniffi::Record)]

--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -44,8 +44,9 @@ use ruma::{
             ImageInfo as RumaImageInfo, MediaSource, ThumbnailInfo as RumaThumbnailInfo,
         },
     },
+    matrix_uri::MatrixId as RumaMatrixId,
     serde::JsonObject,
-    OwnedUserId, UInt, UserId,
+    MatrixToUri, MatrixUri as RumaMatrixUri, OwnedUserId, UInt, UserId,
 };
 use tracing::info;
 
@@ -54,6 +55,72 @@ use crate::{
     helpers::unwrap_or_clone_arc,
     utils::u64_to_uint,
 };
+
+/// Parse a matrix entity from a given URI, be it either
+/// a `matrix.to` link or a `matrix:` URI
+#[uniffi::export]
+pub fn parse_matrix_entity_from(uri: String) -> Option<MatrixEntity> {
+    if let Ok(matrix_uri) = RumaMatrixUri::parse(&uri) {
+        return Some(MatrixEntity {
+            id: matrix_uri.id().into(),
+            via: matrix_uri.via().iter().map(|via| via.to_string()).collect(),
+        });
+    }
+
+    if let Ok(matrix_to_uri) = MatrixToUri::parse(&uri) {
+        return Some(MatrixEntity {
+            id: matrix_to_uri.id().into(),
+            via: matrix_to_uri.via().iter().map(|via| via.to_string()).collect(),
+        });
+    }
+
+    None
+}
+
+/// A Matrix entity that can be a room, room alias, user, or event, and a list
+/// of via servers.
+#[derive(uniffi::Record)]
+pub struct MatrixEntity {
+    id: MatrixId,
+    via: Vec<String>,
+}
+
+/// A Matrix ID that can be a room, room alias, user, or event.
+#[derive(Clone, uniffi::Enum)]
+pub enum MatrixId {
+    Room { id: String },
+    RoomAlias { alias: String },
+    User { id: String },
+    EventOnRoomId { room_id: String, event_id: String },
+    EventOnRoomAlias { alias: String, event_id: String },
+}
+
+impl From<&RumaMatrixId> for MatrixId {
+    fn from(value: &RumaMatrixId) -> Self {
+        match value {
+            RumaMatrixId::User(id) => MatrixId::User { id: id.to_string() },
+            RumaMatrixId::Room(id) => MatrixId::Room { id: id.to_string() },
+            RumaMatrixId::RoomAlias(id) => MatrixId::RoomAlias { alias: id.to_string() },
+
+            RumaMatrixId::Event(room_id_or_alias, event_id) => {
+                if room_id_or_alias.is_room_id() {
+                    MatrixId::EventOnRoomId {
+                        room_id: room_id_or_alias.to_string(),
+                        event_id: event_id.to_string(),
+                    }
+                } else if room_id_or_alias.is_room_alias_id() {
+                    MatrixId::EventOnRoomAlias {
+                        alias: room_id_or_alias.to_string(),
+                        event_id: event_id.to_string(),
+                    }
+                } else {
+                    panic!("Unexpected MatrixId type: {:?}", room_id_or_alias)
+                }
+            }
+            _ => panic!("Unexpected MatrixId type: {:?}", value),
+        }
+    }
+}
 
 #[uniffi::export]
 pub fn media_source_from_url(url: String) -> Arc<MediaSource> {


### PR DESCRIPTION
- expose method for generating user `matrix.to` permalinks
- expose method for parsing Matrix URIs and converting them into actual Matrix entities (for both `matrix.to` links as well as actual URIs)