### PR TITLE
ffi: Expose encryption settings via FFI

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use matrix_sdk::{
+    encryption::BackupDownloadStrategy,
     oidc::{
         registrations::{ClientId, OidcRegistrations, OidcRegistrationsError},
         types::{
@@ -621,12 +622,9 @@ impl AuthenticationService {
             .passphrase(self.passphrase.clone())
             .homeserver_url(homeserver_url)
             .sliding_sync_proxy(sliding_sync_proxy)
-            .with_encryption_settings(matrix_sdk::encryption::EncryptionSettings {
-                auto_enable_cross_signing: true,
-                backup_download_strategy:
-                    matrix_sdk::encryption::BackupDownloadStrategy::AfterDecryptionFailure,
-                auto_enable_backups: true,
-            })
+            .auto_enable_cross_signing(true)
+            .backup_download_strategy(BackupDownloadStrategy::AfterDecryptionFailure)
+            .auto_enable_backups(true)
             .username(user_id.to_string());
 
         if let Some(proxy) = &self.proxy {

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -161,6 +161,7 @@ pub struct EncryptionSettings {
 
 /// Settings for end-to-end encryption features.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum BackupDownloadStrategy {
     /// Automatically download all room keys from the backup when the backup
     /// recovery key has been received. The backup recovery key can be received


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3130

This allows providing encryption settings while constructing a client via FFI, instead of hard-coding specific values.

We do it by holding on to an `EncryptionSettings` inside `ClientBuilder` and updating it when certain methods on the builder are called. During `build_inner()` we provide those `EncryptionSettings` by calling `with_encryption_settings` on `inner_builder`.

I added an enum `BackupDownloadStrategy` to be passed as an argument to `backup_download_strategy`. Let me know if there's a better way.