### PR TITLE
sliding sync: don't exclude room membership events sent by other users

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -528,7 +528,7 @@ impl BaseClient {
             if let AnySyncStateEvent::RoomMember(member) = &event {
                 // If this event updates the current user's membership, record that in the
                 // room_info.
-                if member.sender() == meta.user_id && member.state_key() == meta.user_id.as_str() {
+                if member.state_key() == meta.user_id.as_str() {
                     room_info.set_state(member.membership().into());
                     break;
                 }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -784,14 +784,14 @@ mod tests {
     }
 
     #[async_test]
-    async fn can_process_empty_sliding_sync_response() {
+    async fn test_can_process_empty_sliding_sync_response() {
         let client = logged_in_base_client(None).await;
         let empty_response = v4::Response::new("5".to_owned());
         client.process_sliding_sync(&empty_response, &()).await.expect("Failed to process sync");
     }
 
     #[async_test]
-    async fn room_with_unspecified_state_is_added_to_client_and_joined_list() {
+    async fn test_room_with_unspecified_state_is_added_to_client_and_joined_list() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -817,7 +817,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn room_name_is_found_when_processing_sliding_sync_response() {
+    async fn test_room_name_is_found_when_processing_sliding_sync_response() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -841,7 +841,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn invited_room_name_is_found_when_processing_sliding_sync_response() {
+    async fn test_invited_room_name_is_found_when_processing_sliding_sync_response() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -867,7 +867,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn left_a_room_from_required_state_event() {
+    async fn test_left_a_room_from_required_state_event() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -897,7 +897,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn left_a_room_from_timeline_state_event() {
+    async fn test_left_a_room_from_timeline_state_event() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -921,7 +921,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn can_be_reinvited_to_a_left_room() {
+    async fn test_can_be_reinvited_to_a_left_room() {
         // See https://github.com/matrix-org/matrix-rust-sdk/issues/1834
 
         // Given a logged-in client
@@ -956,7 +956,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn other_person_leaving_a_dm_is_reflected_in_their_membership_and_direct_targets() {
+    async fn test_other_person_leaving_a_dm_is_reflected_in_their_membership_and_direct_targets() {
         let room_id = room_id!("!r:e.uk");
         let user_a_id = user_id!("@a:e.uk");
         let user_b_id = user_id!("@b:e.uk");
@@ -980,7 +980,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn other_person_refusing_invite_to_a_dm_is_reflected_in_their_membership_and_direct_targets(
+    async fn test_other_person_refusing_invite_to_a_dm_is_reflected_in_their_membership_and_direct_targets(
     ) {
         let room_id = room_id!("!r:e.uk");
         let user_a_id = user_id!("@a:e.uk");
@@ -1005,7 +1005,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn members_count_in_a_dm_where_other_person_has_joined() {
+    async fn test_members_count_in_a_dm_where_other_person_has_joined() {
         let room_id = room_id!("!r:bar.org");
         let user_a_id = user_id!("@a:bar.org");
         let user_b_id = user_id!("@b:bar.org");
@@ -1029,7 +1029,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn members_count_in_a_dm_where_other_person_is_invited() {
+    async fn test_members_count_in_a_dm_where_other_person_is_invited() {
         let room_id = room_id!("!r:bar.org");
         let user_a_id = user_id!("@a:bar.org");
         let user_b_id = user_id!("@b:bar.org");
@@ -1053,7 +1053,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn avatar_is_found_when_processing_sliding_sync_response() {
+    async fn test_avatar_is_found_when_processing_sliding_sync_response() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1077,7 +1077,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn avatar_can_be_unset_when_processing_sliding_sync_response() {
+    async fn test_avatar_can_be_unset_when_processing_sliding_sync_response() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1133,7 +1133,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn avatar_is_found_from_required_state_when_processing_sliding_sync_response() {
+    async fn test_avatar_is_found_from_required_state_when_processing_sliding_sync_response() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1153,7 +1153,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn invitation_room_is_added_to_client_and_invite_list() {
+    async fn test_invitation_room_is_added_to_client_and_invite_list() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1177,7 +1177,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn avatar_is_found_in_invitation_room_when_processing_sliding_sync_response() {
+    async fn test_avatar_is_found_in_invitation_room_when_processing_sliding_sync_response() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1198,7 +1198,8 @@ mod tests {
     }
 
     #[async_test]
-    async fn canonical_alias_is_found_in_invitation_room_when_processing_sliding_sync_response() {
+    async fn test_canonical_alias_is_found_in_invitation_room_when_processing_sliding_sync_response(
+    ) {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1217,7 +1218,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn display_name_from_sliding_sync_overrides_alias() {
+    async fn test_display_name_from_sliding_sync_overrides_alias() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1240,7 +1241,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn last_event_from_sliding_sync_is_cached() {
+    async fn test_last_event_from_sliding_sync_is_cached() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1274,7 +1275,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn cached_latest_event_can_be_redacted() {
+    async fn test_cached_latest_event_can_be_redacted() {
         // Given a logged-in client
         let client = logged_in_base_client(None).await;
         let room_id = room_id!("!r:e.uk");
@@ -1327,14 +1328,14 @@ mod tests {
     }
 
     #[async_test]
-    async fn when_no_events_we_dont_cache_any() {
+    async fn test_when_no_events_we_dont_cache_any() {
         let events = &[];
         let chosen = choose_event_to_cache(events).await;
         assert!(chosen.is_none());
     }
 
     #[async_test]
-    async fn when_only_one_event_we_cache_it() {
+    async fn test_when_only_one_event_we_cache_it() {
         let event1 = make_event("m.room.message", "$1");
         let events = &[event1.clone()];
         let chosen = choose_event_to_cache(events).await;
@@ -1342,7 +1343,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn with_multiple_events_we_cache_the_last_one() {
+    async fn test_with_multiple_events_we_cache_the_last_one() {
         let event1 = make_event("m.room.message", "$1");
         let event2 = make_event("m.room.message", "$2");
         let events = &[event1, event2.clone()];
@@ -1351,7 +1352,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn cache_the_latest_relevant_event_and_ignore_irrelevant_ones_even_if_later() {
+    async fn test_cache_the_latest_relevant_event_and_ignore_irrelevant_ones_even_if_later() {
         let event1 = make_event("m.room.message", "$1");
         let event2 = make_event("m.room.message", "$2");
         let event3 = make_event("m.room.powerlevels", "$3");
@@ -1362,7 +1363,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn prefer_to_cache_nothing_rather_than_irrelevant_events() {
+    async fn test_prefer_to_cache_nothing_rather_than_irrelevant_events() {
         let event1 = make_event("m.room.power_levels", "$1");
         let events = &[event1];
         let chosen = choose_event_to_cache(events).await;
@@ -1370,7 +1371,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn cache_encrypted_events_that_are_after_latest_message() {
+    async fn test_cache_encrypted_events_that_are_after_latest_message() {
         // Given two message events followed by two encrypted
         let event1 = make_event("m.room.message", "$1");
         let event2 = make_event("m.room.message", "$2");
@@ -1400,7 +1401,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn dont_cache_encrypted_events_that_are_before_latest_message() {
+    async fn test_dont_cache_encrypted_events_that_are_before_latest_message() {
         // Given an encrypted event before and after the message
         let event1 = make_encrypted_event("$1");
         let event2 = make_event("m.room.message", "$2");
@@ -1424,7 +1425,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn skip_irrelevant_events_eg_receipts_even_if_after_message() {
+    async fn test_skip_irrelevant_events_eg_receipts_even_if_after_message() {
         // Given two message events followed by two encrypted, with a receipt in the
         // middle
         let event1 = make_event("m.room.message", "$1");
@@ -1451,7 +1452,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn only_store_the_max_number_of_encrypted_events() {
+    async fn test_only_store_the_max_number_of_encrypted_events() {
         // Given two message events followed by lots of encrypted and other irrelevant
         // events
         let evente = make_event("m.room.message", "$e");
@@ -1509,7 +1510,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn dont_overflow_capacity_if_previous_encrypted_events_exist() {
+    async fn test_dont_overflow_capacity_if_previous_encrypted_events_exist() {
         // Given a RoomInfo with lots of encrypted events already inside it
         let room = make_room();
         let mut room_info = room.clone_info();
@@ -1551,7 +1552,7 @@ mod tests {
     }
 
     #[async_test]
-    async fn existing_encrypted_events_are_deleted_if_we_receive_unencrypted() {
+    async fn test_existing_encrypted_events_are_deleted_if_we_receive_unencrypted() {
         // Given a RoomInfo with some encrypted events already inside it
         let room = make_room();
         let mut room_info = room.clone_info();


### PR DESCRIPTION
A kick/ban event has the sender key and the state key defined to different values. The banner/kicker is the actual sender. Sliding sync considered they had to be the same for the event to be legit, but it's not the case. Thanks @ganfra for showing me actual events sent from the sliding sync proxy, which made the bug in the SDK obvious.

Contains a regression test.

Fixes #3315.