### PR TITLE
fix(wasm): avoid std::time and tokio::time

### DIFF
--- a/crates/matrix-sdk-common/src/tracing_timer.rs
+++ b/crates/matrix-sdk-common/src/tracing_timer.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Instant;
+use crate::instant::Instant;
 
 use tracing::{callsite::DefaultCallsite, Callsite as _};
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -71,6 +71,7 @@ use std::{future::ready, num::NonZeroUsize, sync::Arc, time::Duration};
 use async_stream::stream;
 use eyeball::{SharedObservable, Subscriber};
 use futures_util::{pin_mut, Stream, StreamExt};
+use matrix_sdk::timeout::timeout;
 pub use matrix_sdk::RoomListEntry;
 use matrix_sdk::{
     event_cache::EventCacheError, sliding_sync::Ranges, Client, Error as SlidingSyncError,
@@ -90,10 +91,7 @@ use ruma::{
 };
 pub use state::*;
 use thiserror::Error;
-use tokio::{
-    sync::{Mutex, RwLock},
-    time::timeout,
-};
+use tokio::sync::{Mutex, RwLock};
 
 /// The [`RoomListService`] type. See the module's documentation to learn more.
 #[derive(Debug)]
@@ -391,7 +389,7 @@ impl RoomListService {
                 };
 
                 // `state.next().await` has a maximum of `yield_delay` time to execute…
-                let next_state = match timeout(yield_delay, state.next()).await {
+                let next_state = match timeout(state.next(), yield_delay).await {
                     // A new state has been received before `yield_delay` time. The new
                     // `sync_indicator` value won't be yielded.
                     Ok(next_state) => next_state,

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -53,18 +53,16 @@ use matrix_sdk_base::{
     sync::{JoinedRoomUpdate, LeftRoomUpdate, RoomUpdates, Timeline},
 };
 use matrix_sdk_common::executor::{spawn, JoinHandle};
+use matrix_sdk_common::timeout::timeout;
 use ruma::{
     assign,
     events::{AnyRoomAccountDataEvent, AnySyncEphemeralRoomEvent},
     serde::Raw,
     OwnedEventId, OwnedRoomId, RoomId,
 };
-use tokio::{
-    sync::{
-        broadcast::{error::RecvError, Receiver, Sender},
-        Mutex, Notify, RwLock, RwLockReadGuard, RwLockWriteGuard,
-    },
-    time::timeout,
+use tokio::sync::{
+    broadcast::{error::RecvError, Receiver, Sender},
+    Mutex, Notify, RwLock, RwLockReadGuard, RwLockWriteGuard,
 };
 use tracing::{error, instrument, trace, warn};
 
@@ -817,7 +815,7 @@ impl RoomEventCacheInner {
 
         // Otherwise wait for a notification that we received a token.
         // Timeouts are fine, per this function's contract.
-        let _ = timeout(max_wait, self.pagination_token_notifier.notified()).await;
+        let _ = timeout(self.pagination_token_notifier.notified(), max_wait).await;
 
         Ok(get_oldest(self.events.read().await))
     }


### PR DESCRIPTION
Signed-off-by: Manmeet Singh <manmeetmann2003@gmail.com>
