### PR TITLE
crypto: Apple Crypto Bindings | Fix crypto xcframework script

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -140,7 +140,7 @@ jobs:
           rustup target add aarch64-apple-ios
           rustup target add aarch64-apple-darwin
           rustup target add x86_64-apple-darwin
-          rustup target add iaarch64-apple-ios-sim
+          rustup target add aarch64-apple-ios-sim
           rustup target add x86_64-apple-ios
 
       # Cargo config can screw with caching and is only used for alias config

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -154,7 +154,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run the Build Framework script
-        run: ./bindings/apple/build_crypto_xcframework.sh
+        run: ./bindings/apple/build_crypto_xcframework.sh -i
 
       - name: Is XCFramework generated?
         if: ${{ hashFiles('generated/MatrixSDKCryptoFFI.zip') != '' }}

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -138,10 +138,6 @@ jobs:
       - name: Add rust targets
         run: |
           rustup target add aarch64-apple-ios
-          rustup target add aarch64-apple-darwin
-          rustup target add x86_64-apple-darwin
-          rustup target add aarch64-apple-ios-sim
-          rustup target add x86_64-apple-ios
 
       # Cargo config can screw with caching and is only used for alias config
       # and extra lints, which we don't care about here

--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -116,3 +116,46 @@ jobs:
     with:
         use_rust_sdk: "." # use local checkout
         use_complement_crypto: "MATCHING_BRANCH"
+
+  test-crypto-apple-framework-generation:
+    name: Generate Crypto FFI Apple XCFramework
+    runs-on: macos-12
+    if: github.event_name == 'push' || !github.event.pull_request.draft
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # install protoc in case we end up rebuilding opentelemetry-proto
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@3.20.3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add rust targets
+        run: |
+          rustup target add aarch64-apple-ios
+          rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
+          rustup target add iaarch64-apple-ios-sim
+          rustup target add x86_64-apple-ios
+
+      # Cargo config can screw with caching and is only used for alias config
+      # and extra lints, which we don't care about here
+      - name: Delete cargo config
+        run: rm .cargo/config.toml
+
+      - name: Load cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run the Build Framework script
+        run: ./bindings/apple/build_crypto_xcframework.sh
+
+      - name: Is XCFramework generated?
+        if: ${{ hashFiles('generated/MatrixSDKCryptoFFI.zip') != '' }}
+        run: echo "XCFramework exists"

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -54,20 +54,19 @@ lipo -create \
   -output "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a"
 
 # Generate uniffi files
-cargo uniffi-bindgen generate \
+cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
   --language swift \
-  --lib-file "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-  --config "${SRC_ROOT}/bindings/${TARGET_CRATE}/uniffi.toml" \
+  --library "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
   --out-dir ${GENERATED_DIR} \
-  "${SRC_ROOT}/bindings/${TARGET_CRATE}/src/olm.udl"
 
 # Move headers to the right place
 HEADERS_DIR=${GENERATED_DIR}/headers
 mkdir -p ${HEADERS_DIR}
 mv ${GENERATED_DIR}/*.h ${HEADERS_DIR}
 
-# Rename and move modulemap to the right place
-mv ${GENERATED_DIR}/*.modulemap ${HEADERS_DIR}/module.modulemap
+# Rename and merge the modulemap files into a single file to the right place
+for f in ${GENERATED_DIR}/*.modulemap; do cat $f; echo; done > ${HEADERS_DIR}/module.modulemap
+rm ${GENERATED_DIR}/*.modulemap
 
 # Move source files to the right place
 SWIFT_DIR="${GENERATED_DIR}/Sources"

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -57,7 +57,7 @@ lipo -create \
 cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
   --language swift \
   --library "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-  --out-dir ${GENERATED_DIR} \
+  --out-dir ${GENERATED_DIR}
 
 # Move headers to the right place
 HEADERS_DIR=${GENERATED_DIR}/headers

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -63,7 +63,7 @@ fi
 echo -e "\nCreating XCFramework"
 # Lipo together the libraries for the same platform
 
-if [ !${only_ios} ]; then
+if ! ${only_ios}; then
   echo "Lipo together the libraries for the same platform"
   # MacOS
   lipo -create \

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -78,19 +78,11 @@ if ! ${only_ios}; then
     -output "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a"
 fi
 
-if ${only_ios}; then
-  # Generate uniffi files
-  cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
-    --language swift \
-    --library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-    --out-dir ${GENERATED_DIR}
-else
-  # Generate uniffi files
-  cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
-    --language swift \
-    --library "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-    --out-dir ${GENERATED_DIR}
-fi
+# Generate uniffi files
+cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
+  --language swift \
+  --library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+  --out-dir ${GENERATED_DIR}
 
 # Move headers to the right place
 HEADERS_DIR=${GENERATED_DIR}/headers

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -eEu
 
+helpFunction() {
+  echo ""
+  echo "Usage: $0 -only_ios"
+  echo -e "\t-i Option to build only for iOS. Default will build for all targets."
+  exit 1
+}
+
+only_ios='false'
+
+while getopts ':i' 'opt'; do
+  case ${opt} in
+  'i') only_ios='true' ;;
+  ?) helpFunction ;;
+  esac
+done
+
 cd "$(dirname "$0")"
 
 # Path to the repo root
@@ -22,42 +38,59 @@ TARGET_CRATE=matrix-sdk-crypto-ffi
 # Required by olm-sys crate
 export IOS_SDK_PATH=`xcrun --show-sdk-path --sdk iphoneos`
 
-# iOS
-echo -e "Building for iOS [1/5]"
-cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios"
+if ${only_ios}; then
+  # iOS
+  echo -e "Building only for iOS"
+  cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios"
+else
+  # iOS
+  echo -e "Building for iOS [1/5]"
+  cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios"
 
-# MacOS
-echo -e "\nBuilding for macOS (Apple Silicon) [2/5]"
-cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-darwin"
-echo -e "\nBuilding for macOS (Intel) [3/5]"
-cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "x86_64-apple-darwin"
+  # MacOS
+  echo -e "\nBuilding for macOS (Apple Silicon) [2/5]"
+  cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-darwin"
+  echo -e "\nBuilding for macOS (Intel) [3/5]"
+  cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "x86_64-apple-darwin"
 
-# iOS Simulator
-echo -e "\nBuilding for iOS Simulator (Apple Silicon) [4/5]"
-cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios-sim"
-echo -e "\nBuilding for iOS Simulator (Intel) [5/5]"
-cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "x86_64-apple-ios"
+  # iOS Simulator
+  echo -e "\nBuilding for iOS Simulator (Apple Silicon) [4/5]"
+  cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "aarch64-apple-ios-sim"
+  echo -e "\nBuilding for iOS Simulator (Intel) [5/5]"
+  cargo build -p ${TARGET_CRATE} ${REL_FLAG} --target "x86_64-apple-ios"
+fi
 
 echo -e "\nCreating XCFramework"
 # Lipo together the libraries for the same platform
 
-# MacOS
-lipo -create \
-  "${TARGET_DIR}/x86_64-apple-darwin/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-  "${TARGET_DIR}/aarch64-apple-darwin/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-  -output "${GENERATED_DIR}/macos/libmatrix_sdk_crypto_ffi.a"
+if [ !${only_ios} ]; then
+  echo "Lipo together the libraries for the same platform"
+  # MacOS
+  lipo -create \
+    "${TARGET_DIR}/x86_64-apple-darwin/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+    "${TARGET_DIR}/aarch64-apple-darwin/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+    -output "${GENERATED_DIR}/macos/libmatrix_sdk_crypto_ffi.a"
 
-# iOS Simulator
-lipo -create \
-  "${TARGET_DIR}/x86_64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-  "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-  -output "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a"
+  # iOS Simulator
+  lipo -create \
+    "${TARGET_DIR}/x86_64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+    "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+    -output "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a"
+fi
 
-# Generate uniffi files
-cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
-  --language swift \
-  --library "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-  --out-dir ${GENERATED_DIR}
+if ${only_ios}; then
+  # Generate uniffi files
+  cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
+    --language swift \
+    --library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+    --out-dir ${GENERATED_DIR}
+else
+  # Generate uniffi files
+  cd ../matrix-sdk-crypto-ffi && cargo run --bin matrix_sdk_crypto_ffi generate \
+    --language swift \
+    --library "${TARGET_DIR}/aarch64-apple-ios-sim/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+    --out-dir ${GENERATED_DIR}
+fi
 
 # Move headers to the right place
 HEADERS_DIR=${GENERATED_DIR}/headers
@@ -76,15 +109,21 @@ mv ${GENERATED_DIR}/*.swift ${SWIFT_DIR}
 # Build the xcframework
 
 if [ -d "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework" ]; then rm -rf "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"; fi
-
-xcodebuild -create-xcframework \
-  -library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
-  -headers ${HEADERS_DIR} \
-  -library "${GENERATED_DIR}/macos/libmatrix_sdk_crypto_ffi.a" \
-  -headers ${HEADERS_DIR} \
-  -library "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a" \
-  -headers ${HEADERS_DIR} \
-  -output "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"
+if ${only_ios}; then
+  xcodebuild -create-xcframework \
+    -library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+    -headers ${HEADERS_DIR} \
+    -output "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"
+else
+  xcodebuild -create-xcframework \
+    -library "${TARGET_DIR}/aarch64-apple-ios/${REL_TYPE_DIR}/libmatrix_sdk_crypto_ffi.a" \
+    -headers ${HEADERS_DIR} \
+    -library "${GENERATED_DIR}/macos/libmatrix_sdk_crypto_ffi.a" \
+    -headers ${HEADERS_DIR} \
+    -library "${GENERATED_DIR}/simulator/libmatrix_sdk_crypto_ffi.a" \
+    -headers ${HEADERS_DIR} \
+    -output "${GENERATED_DIR}/MatrixSDKCryptoFFI.xcframework"
+fi
 
 # Cleanup
 if [ -d "${GENERATED_DIR}/macos" ]; then rm -rf "${GENERATED_DIR}/macos"; fi

--- a/bindings/apple/build_crypto_xcframework.sh
+++ b/bindings/apple/build_crypto_xcframework.sh
@@ -90,7 +90,10 @@ mkdir -p ${HEADERS_DIR}
 mv ${GENERATED_DIR}/*.h ${HEADERS_DIR}
 
 # Rename and merge the modulemap files into a single file to the right place
-for f in ${GENERATED_DIR}/*.modulemap; do cat $f; echo; done > ${HEADERS_DIR}/module.modulemap
+for f in ${GENERATED_DIR}/*.modulemap
+do 
+  cat $f; echo; 
+done > ${HEADERS_DIR}/module.modulemap
 rm ${GENERATED_DIR}/*.modulemap
 
 # Move source files to the right place

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -12,6 +12,10 @@ publish = false
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
+[[bin]]
+name = "matrix_sdk_crypto_ffi"
+path = "uniffi-bindgen.rs"
+
 [features]
 default = ["bundled-sqlite"]
 bundled-sqlite = ["matrix-sdk-sqlite/bundled"]
@@ -31,7 +35,7 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
-uniffi = { workspace = true }
+uniffi = { workspace = true , features = ["cli"]}
 vodozemac = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
@@ -54,6 +58,7 @@ features = ["rt-multi-thread"]
 
 [build-dependencies]
 vergen = { version = "8.2.5", features = ["build", "git", "gitcl"] }
+uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 tempfile = "3.8.0"

--- a/bindings/matrix-sdk-crypto-ffi/uniffi-bindgen.rs
+++ b/bindings/matrix-sdk-crypto-ffi/uniffi-bindgen.rs
@@ -1,0 +1,4 @@
+
+fn main() {
+    uniffi::uniffi_bindgen_main()
+}

--- a/bindings/matrix-sdk-crypto-ffi/uniffi-bindgen.rs
+++ b/bindings/matrix-sdk-crypto-ffi/uniffi-bindgen.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     uniffi::uniffi_bindgen_main()
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3310

The script to build the crypto bindings was not working anymore since the move from UDL to procedural macro.

Modified as per the following recommendations https://mozilla.github.io/uniffi-rs/tutorial/foreign_language_bindings.html#running-uniffi-bindgen-using-a-library-file-recommended

There is some changes in the generated framework, there are now two swift files and two modulemap files that have to be merged together in the final xcframework.

Previous structure was
<img width="268" alt="image" src="https://github.com/matrix-org/matrix-rust-sdk/assets/9841565/2a9a4ce5-c113-4087-96be-eec12630d5be">


The new one is 
<img width="297" alt="image" src="https://github.com/matrix-org/matrix-rust-sdk/assets/9841565/8c273efe-3793-4667-b10a-0790fa382ec6">


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
