### PR TITLE
room preview: use the room summary MSC3266 endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
+name = "date_header"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c03c416ed1a30fbb027ef484ba6ab6f80e1eada675e1a2b92fd673c045a1f1d"
+
+[[package]]
 name = "deadpool"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,16 +2298,16 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
 dependencies = [
  "log",
  "mac",
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2970,12 +2976,12 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+checksum = "c7940b09815a02810a42b9e1bc41c069880a87de68e9b1dcbe754a3ba3b47c20"
 dependencies = [
  "log",
- "phf 0.10.1",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -4192,15 +4198,6 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
@@ -4211,12 +4208,12 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -5017,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.9.4"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "assign",
  "js_int",
@@ -5028,16 +5025,18 @@ dependencies = [
  "ruma-federation-api",
  "ruma-html",
  "ruma-push-gateway-api",
+ "web-time",
 ]
 
 [[package]]
 name = "ruma-client-api"
 version = "0.17.4"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "as_variant",
  "assign",
  "bytes",
+ "date_header",
  "http",
  "js_int",
  "js_option",
@@ -5047,12 +5046,14 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
+ "thiserror",
+ "web-time",
 ]
 
 [[package]]
 name = "ruma-common"
 version = "0.12.1"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "as_variant",
  "base64 0.21.7",
@@ -5084,7 +5085,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.27.11"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "as_variant",
  "indexmap 2.2.2",
@@ -5108,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -5120,11 +5121,11 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.1.0"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "as_variant",
  "html5ever",
- "phf 0.11.2",
+ "phf",
  "tracing",
  "wildmatch",
 ]
@@ -5132,7 +5133,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.3"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5141,7 +5142,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.12.0"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "once_cell",
  "proc-macro-crate 2.0.2",
@@ -5156,7 +5157,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=4c00bd010dbdca6005bd599b52e90a0b7015d056#4c00bd010dbdca6005bd599b52e90a0b7015d056"
+source = "git+https://github.com/ruma/ruma?rev=21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa#21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,15 +39,16 @@ futures-util = { version = "0.3.26", default-features = false, features = [
 http = "0.2.6"
 imbl = "2.0.0"
 itertools = "0.12.0"
-ruma = { git = "https://github.com/ruma/ruma", rev = "4c00bd010dbdca6005bd599b52e90a0b7015d056", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
     "compat-arbitrary-length-ids",
     "compat-tag-info",
     "unstable-msc3401",
+    "unstable-msc3266",
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "4c00bd010dbdca6005bd599b52e90a0b7015d056" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "21b644ac6ae1c7d4a4f7e98a6481a3318f2deeaa" }
 once_cell = "1.16.0"
 rand = "0.8.5"
 serde = "1.0.151"

--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -1,8 +1,5 @@
 use matrix_sdk::{room_preview::RoomPreview as SdkRoomPreview, RoomState};
-use ruma::{
-    events::room::{history_visibility::HistoryVisibility, join_rules::JoinRule},
-    OwnedRoomId,
-};
+use ruma::{space::SpaceRoomJoinRule, OwnedRoomId};
 
 /// The preview of a room, be it invited/joined/left, or not.
 #[derive(uniffi::Record)]
@@ -43,12 +40,14 @@ impl RoomPreview {
             avatar_url: preview.avatar_url.map(|url| url.to_string()),
             num_joined_members: preview.num_joined_members,
             room_type: preview.room_type.map(|room_type| room_type.to_string()),
-            is_history_world_readable: preview.history_visibility
-                == HistoryVisibility::WorldReadable,
+            is_history_world_readable: preview.is_world_readable,
             is_joined: preview.state.map_or(false, |state| state == RoomState::Joined),
             is_invited: preview.state.map_or(false, |state| state == RoomState::Invited),
-            is_public: preview.join_rule == JoinRule::Public,
-            can_knock: matches!(preview.join_rule, JoinRule::KnockRestricted(_) | JoinRule::Knock),
+            is_public: preview.join_rule == SpaceRoomJoinRule::Public,
+            can_knock: matches!(
+                preview.join_rule,
+                SpaceRoomJoinRule::KnockRestricted | SpaceRoomJoinRule::Knock
+            ),
         }
     }
 }

--- a/crates/matrix-sdk/tests/integration/matrix_auth.rs
+++ b/crates/matrix-sdk/tests/integration/matrix_auth.rs
@@ -206,7 +206,7 @@ async fn test_login_error() {
             assert_eq!(api_err.status_code, http::StatusCode::from_u16(403).unwrap());
 
             if let client_api::error::ErrorBody::Standard { kind, message } = &api_err.body {
-                if *kind != client_api::error::ErrorKind::Forbidden {
+                if !matches!(*kind, client_api::error::ErrorKind::Forbidden { .. }) {
                     panic!("found the wrong `ErrorKind` {kind:?}, expected `Forbidden");
                 }
 
@@ -247,7 +247,7 @@ async fn test_register_error() {
         if let Some(api_err) = err.as_client_api_error() {
             assert_eq!(api_err.status_code, http::StatusCode::from_u16(403).unwrap());
             if let client_api::error::ErrorBody::Standard { kind, message } = &api_err.body {
-                if *kind != client_api::error::ErrorKind::Forbidden {
+                if !matches!(*kind, client_api::error::ErrorKind::Forbidden { .. }) {
                     panic!("found the wrong `ErrorKind` {kind:?}, expected `Forbidden");
                 }
 

--- a/testing/matrix-sdk-integration-testing/assets/ci-start.sh
+++ b/testing/matrix-sdk-integration-testing/assets/ci-start.sh
@@ -56,6 +56,9 @@ rc_invites:
  per_issuer:
   per_second: 1000
   burst_count: 1000
+
+experimental_features:
+ msc3266_enabled: true
 """ >>  /data/homeserver.yaml
 
 echo " ====== Starting server with:  ====== "

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -10,6 +10,7 @@ use futures_util::{pin_mut, FutureExt, StreamExt as _};
 use matrix_sdk::{
     bytes::Bytes,
     config::SyncSettings,
+    room_preview::RoomPreview,
     ruma::{
         api::client::{
             receipt::create_receipt::v3::ReceiptType,
@@ -29,6 +30,8 @@ use matrix_sdk::{
             AnySyncMessageLikeEvent, InitialStateEvent, Mentions, StateEventType,
         },
         mxc_uri,
+        space::SpaceRoomJoinRule,
+        RoomId,
     },
     Client, RoomInfo, RoomListEntry, RoomMemberships, RoomState, SlidingSyncList, SlidingSyncMode,
 };
@@ -1082,14 +1085,24 @@ async fn test_room_preview() -> Result<()> {
                 InitialStateEvent::new(RoomHistoryVisibilityEventContent::new(HistoryVisibility::WorldReadable)).to_raw_any(),
                 InitialStateEvent::new(RoomJoinRulesEventContent::new(JoinRule::Invite)).to_raw_any(),
             ],
-            //TODO: this doesn't allow preview => could be tested!
-            //preset: Some(RoomPreset::PrivateChat),
         }))
         .await?;
 
     room.set_avatar_url(mxc_uri!("mxc://localhost/alice"), None).await?;
 
+    // Alice creates another room, and still doesn't invite Bob.
+    let private_room = alice
+        .create_room(assign!(CreateRoomRequest::new(), {
+            name: Some("Alice's Room 2".to_owned()),
+            initial_state: vec![
+                InitialStateEvent::new(RoomHistoryVisibilityEventContent::new(HistoryVisibility::Shared)).to_raw_any(),
+                InitialStateEvent::new(RoomJoinRulesEventContent::new(JoinRule::Public)).to_raw_any(),
+            ],
+        }))
+        .await?;
+
     let room_id = room.room_id();
+    let private_room_id = private_room.room_id();
 
     // Wait for Alice's stream to stabilize (stop updating when we haven't received
     // successful updates for more than 2 seconds).
@@ -1104,49 +1117,76 @@ async fn test_room_preview() -> Result<()> {
         }
     }
 
-    let preview = alice.get_room_preview(room_id).await?;
-    assert_eq!(preview.canonical_alias.unwrap().alias(), room_alias);
-    assert_eq!(preview.name.unwrap(), "Alice's Room");
-    assert_eq!(preview.topic.unwrap(), "Discussing Alice's Topic");
-    assert_eq!(preview.avatar_url.unwrap(), mxc_uri!("mxc://localhost/alice"));
+    get_room_preview_with_room_state(&alice, &bob, &room_alias, room_id, private_room_id).await;
+    get_room_preview_with_room_summary(&alice, &bob, &room_alias, room_id, private_room_id).await;
+
+    {
+        // Dummy test for `Client::get_room_preview` which may call one or the other
+        // methods.
+        let preview = alice.get_room_preview(room_id).await.unwrap();
+        assert_room_preview(&preview, &room_alias);
+        assert_eq!(preview.state, Some(RoomState::Joined));
+    }
+
+    Ok(())
+}
+
+fn assert_room_preview(preview: &RoomPreview, room_alias: &str) {
+    assert_eq!(preview.canonical_alias.as_ref().unwrap().alias(), room_alias);
+    assert_eq!(preview.name.as_ref().unwrap(), "Alice's Room");
+    assert_eq!(preview.topic.as_ref().unwrap(), "Discussing Alice's Topic");
+    assert_eq!(preview.avatar_url.as_ref().unwrap(), mxc_uri!("mxc://localhost/alice"));
     assert_eq!(preview.num_joined_members, 1);
     assert!(preview.room_type.is_none());
-    // Because of the preset:
-    assert_eq!(preview.join_rule, JoinRule::Invite);
-    assert_eq!(preview.history_visibility, HistoryVisibility::WorldReadable);
+    assert_eq!(preview.join_rule, SpaceRoomJoinRule::Invite);
+    assert!(preview.is_world_readable);
+}
+
+async fn get_room_preview_with_room_state(
+    alice: &Client,
+    bob: &Client,
+    room_alias: &str,
+    room_id: &RoomId,
+    public_no_history_room_id: &RoomId,
+) {
+    // Alice has joined the room, so they get the full details.
+    let preview = RoomPreview::from_state_events(alice, room_id).await.unwrap();
+    assert_room_preview(&preview, room_alias);
     assert_eq!(preview.state, Some(RoomState::Joined));
 
     // Bob definitely doesn't know about the room, but they can get a preview of the
     // room too.
-    let preview = bob.get_room_preview(room_id).await?;
+    let preview = RoomPreview::from_state_events(bob, room_id).await.unwrap();
+    assert_room_preview(&preview, room_alias);
+    assert!(preview.state.is_none());
 
-    assert_eq!(preview.canonical_alias.unwrap().alias(), room_alias);
-    assert_eq!(preview.name.unwrap(), "Alice's Room");
-    assert_eq!(preview.topic.unwrap(), "Discussing Alice's Topic");
-    assert_eq!(preview.avatar_url.unwrap(), mxc_uri!("mxc://localhost/alice"));
-    assert_eq!(preview.num_joined_members, 1);
-    assert!(preview.room_type.is_none());
-    assert_eq!(preview.join_rule, JoinRule::Invite);
-    assert_eq!(preview.history_visibility, HistoryVisibility::WorldReadable);
-
-    // Only difference with Alice's room is here: since Bob hasn't joined the room,
-    // they don't have any associated room state.
-    assert_eq!(preview.state, None);
-
-    // Now Alice creates another room, with a private preset, and still doesn't
-    // invite Bob.
-    let room = alice
-        .create_room(assign!(CreateRoomRequest::new(), {
-            initial_state: vec![
-                InitialStateEvent::new(RoomHistoryVisibilityEventContent::new(HistoryVisibility::Shared)).to_raw_any(),
-                InitialStateEvent::new(RoomJoinRulesEventContent::new(JoinRule::Invite)).to_raw_any(),
-            ],
-        }))
-        .await?;
-
-    // So Bob can't preview it.
-    let preview_result = bob.get_room_preview(room.room_id()).await;
+    // Bob can't preview the second room, because its history visibility is neither
+    // world-readable, nor have they joined the room before.
+    let preview_result = RoomPreview::from_state_events(bob, public_no_history_room_id).await;
     assert_eq!(preview_result.unwrap_err().as_client_api_error().unwrap().status_code, 403);
+}
 
-    Ok(())
+async fn get_room_preview_with_room_summary(
+    alice: &Client,
+    bob: &Client,
+    room_alias: &str,
+    room_id: &RoomId,
+    public_no_history_room_id: &RoomId,
+) {
+    // Alice has joined the room, so they get the full details.
+    let preview = RoomPreview::from_room_summary(alice, room_id).await.unwrap();
+    assert_room_preview(&preview, room_alias);
+    assert_eq!(preview.state, Some(RoomState::Joined));
+
+    // Bob definitely doesn't know about the room, but they can get a preview of the
+    // room too.
+    let preview = RoomPreview::from_room_summary(bob, room_id).await.unwrap();
+    assert_room_preview(&preview, room_alias);
+    assert!(preview.state.is_none());
+
+    // Bob can preview the second room with the room summary (because its join rule
+    // is set to public, or because Alice is a member of that room).
+    let preview = RoomPreview::from_room_summary(bob, public_no_history_room_id).await.unwrap();
+    assert_eq!(preview.name.unwrap(), "Alice's Room 2");
+    assert!(preview.state.is_none());
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -1174,7 +1174,19 @@ async fn get_room_preview_with_room_summary(
     public_no_history_room_id: &RoomId,
 ) {
     // Alice has joined the room, so they get the full details.
-    let preview = RoomPreview::from_room_summary(alice, room_id).await.unwrap();
+    let preview = match RoomPreview::from_room_summary(alice, room_id).await {
+        Ok(r) => r,
+        Err(err) => {
+            if let Some(client_api_error) = err.as_client_api_error() {
+                if client_api_error.status_code == 404 {
+                    warn!("Skipping the room summary test, because the server may not support it.");
+                    return;
+                }
+            }
+            panic!("{err}");
+        }
+    };
+
     assert_room_preview(&preview, room_alias);
     assert_eq!(preview.state, Some(RoomState::Joined));
 


### PR DESCRIPTION
This adds support for MSC3266 when fetching a room preview, for servers that support it. If the server doesn't support it, we resort to using the room state event endpoint.

Pretty sure the integration testing in CI will hate this, since I'm unit-testing the `from_room_summary` method, which requires an experimental feature to be enabled on the synapse service. If that's the case, I'll disable this test.

Using a fork of Ruma to cut corners, since the review of the feature there is getting complicated. Maybe https://github.com/ruma/ruma/pull/1776 will get approved some day soon :smiling_face_with_tear: 