### PR TITLE
timeline: after an event cache update lag, fetch previous events back from the cache

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -384,7 +384,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 
     /// Populates our own latest read receipt in the in-memory by-user read
     /// receipt cache.
-    pub(super) async fn populate_initial_user_receipt(&mut self, receipt_type: ReceiptType) {
+    pub(super) async fn populate_initial_user_receipt(&self, receipt_type: ReceiptType) {
         let own_user_id = self.room_data_provider.own_user_id().to_owned();
 
         let mut read_receipt = self
@@ -963,6 +963,40 @@ impl<P: RoomDataProvider> TimelineInner<P> {
 impl TimelineInner {
     pub(super) fn room(&self) -> &Room {
         &self.room_data_provider
+    }
+
+    /// Replaces the content of the current timeline with initial events.
+    ///
+    /// Also sets up read receipts and the read marker for a live timeline of a
+    /// room.
+    ///
+    /// This is all done with a single lock guard, since we don't want the state
+    /// to be modified between the clear and re-insertion of new events.
+    pub(super) async fn replace_with_initial_events(&self, events: Vec<SyncTimelineEvent>) {
+        let mut state = self.state.write().await;
+
+        state.clear();
+
+        let track_read_markers = self.settings.track_read_receipts;
+        if track_read_markers {
+            self.populate_initial_user_receipt(ReceiptType::Read).await;
+            self.populate_initial_user_receipt(ReceiptType::ReadPrivate).await;
+        }
+
+        if !events.is_empty() {
+            state
+                .add_events_at(
+                    events,
+                    TimelineEnd::Back { from_cache: true },
+                    &self.room_data_provider,
+                    &self.settings,
+                )
+                .await;
+        }
+
+        if track_read_markers {
+            self.load_fully_read_event().await;
+        }
     }
 
     /// Get the current fully-read event, from storage.


### PR DESCRIPTION
Fixes #3311.

When the timeline is lagging behind the event cache, it should not only clear what it contains (because it may be lagging some information coming from the event cache), it should also retrieve the events the cache knows about, and adds them as if they were "initial" events.

This makes sure that the event cache's events and the timeline's events are always the same, and that, in the case of a lag, there won't be any missing chunks (caused by the event cache back-pagination being further away in the past, than what's displayed in the timeline).

The lag behind a bit too hard to reproduce, I've not included a test here; but I think this should be the right move.