### PR TITLE
ffi: don't abort RoomInfo creation if the room member invite event is missing

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -134,11 +134,11 @@ impl Room {
         self.inner.active_room_call_participants().iter().map(|u| u.to_string()).collect()
     }
 
-    pub fn inviter(&self) -> Option<RoomMember> {
+    /// For rooms one is invited to, retrieves the room member information for
+    /// the user who invited the logged-in user to a room.
+    pub async fn inviter(&self) -> Option<RoomMember> {
         if self.inner.state() == RoomState::Invited {
-            RUNTIME.block_on(async move {
-                self.inner.invite_details().await.ok().and_then(|a| a.inviter).map(|m| m.into())
-            })
+            self.inner.invite_details().await.ok().and_then(|a| a.inviter).map(|m| m.into())
         } else {
             None
         }


### PR DESCRIPTION
`Room::invite_details()` can return an error if the room member event (the invite) is missing from the store. Usually that would be a sign that the state is semi-broken, since there should always be such an event for an invited room. But if it's missing, it shouldn't break the creation of a `RoomInfo`, and just be missing from the struct.

Also, setting the `inviter` field to `None` when `Room::invite_details()` returned an error is consistent with the FFI `Room::inviter()` function which also returns `None` in that case.