### PR TITLE
timeline: include the remote event's origin in the timeline position/end

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -17,7 +17,7 @@ use std::{fmt, ops::ControlFlow, sync::Arc, time::Duration};
 use matrix_sdk::event_cache::{self, BackPaginationOutcome};
 use tracing::{instrument, trace, warn};
 
-use crate::timeline::inner::TimelineEnd;
+use crate::timeline::{event_item::RemoteEventOrigin, inner::TimelineEnd};
 
 impl super::Timeline {
     /// Add more events to the start of the timeline.
@@ -53,8 +53,14 @@ impl super::Timeline {
                         let num_events = events.len();
                         trace!("Back-pagination succeeded with {num_events} events");
 
-                        let handle_many_res =
-                            self.inner.add_events_at(events, TimelineEnd::Front).await;
+                        let handle_many_res = self
+                            .inner
+                            .add_events_at(
+                                events,
+                                TimelineEnd::Front,
+                                RemoteEventOrigin::Pagination,
+                            )
+                            .await;
 
                         if reached_start {
                             self.back_pagination_status

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -37,7 +37,7 @@ use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
 use crate::timeline::{
-    event_item::AnyOtherFullStateEventContent,
+    event_item::{AnyOtherFullStateEventContent, RemoteEventOrigin},
     inner::{TimelineEnd, TimelineInnerSettings},
     tests::{ReadReceiptMap, TestRoomDataProvider},
     MembershipChange, TimelineDetails, TimelineItemContent, TimelineItemKind, VirtualTimelineItem,
@@ -63,7 +63,8 @@ async fn test_initial_events() {
                         .make_sync_message_event(*BOB, RoomMessageEventContent::text_plain("B")),
                 ),
             ],
-            TimelineEnd::Back { from_cache: false },
+            TimelineEnd::Back,
+            RemoteEventOrigin::Sync,
         )
         .await;
 
@@ -102,7 +103,7 @@ async fn test_replace_with_initial_events_and_read_marker() {
     let factory = EventFactory::new();
     let ev = factory.text_msg("hey").sender(*ALICE).into_sync();
 
-    timeline.inner.add_events_at(vec![ev], TimelineEnd::Back { from_cache: false }).await;
+    timeline.inner.add_events_at(vec![ev], TimelineEnd::Back, RemoteEventOrigin::Sync).await;
 
     let items = timeline.inner.items().await;
     assert_eq!(items.len(), 2);
@@ -286,7 +287,8 @@ async fn test_dedup_initial() {
                 // … and a new event also came in
                 event_c,
             ],
-            TimelineEnd::Back { from_cache: false },
+            TimelineEnd::Back,
+            RemoteEventOrigin::Sync,
         )
         .await;
 
@@ -322,7 +324,7 @@ async fn test_internal_id_prefix() {
 
     timeline
         .inner
-        .add_events_at(vec![ev_a, ev_b, ev_c], TimelineEnd::Back { from_cache: false })
+        .add_events_at(vec![ev_a, ev_b, ev_c], TimelineEnd::Back, RemoteEventOrigin::Sync)
         .await;
 
     let timeline_items = timeline.inner.items().await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -48,6 +48,7 @@ use ruma::{
 
 use super::{
     event_handler::TimelineEventKind,
+    event_item::RemoteEventOrigin,
     inner::{ReactionAction, TimelineEnd, TimelineInnerSettings},
     reactions::ReactionToggleResult,
     traits::RoomDataProvider,
@@ -255,7 +256,9 @@ impl TestTimeline {
 
     async fn handle_back_paginated_custom_event(&self, event: Raw<AnyTimelineEvent>) {
         let timeline_event = TimelineEvent::new(event.cast());
-        self.inner.add_events_at(vec![timeline_event], TimelineEnd::Front).await;
+        self.inner
+            .add_events_at(vec![timeline_event], TimelineEnd::Front, RemoteEventOrigin::Pagination)
+            .await;
     }
 
     async fn handle_read_receipts(

--- a/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reactions.rs
@@ -27,7 +27,8 @@ use ruma::{
 use stream_assert::assert_next_matches;
 
 use crate::timeline::{
-    inner::ReactionAction,
+    event_item::RemoteEventOrigin,
+    inner::{ReactionAction, TimelineEnd},
     reactions::ReactionToggleResult,
     tests::{assert_event_is_updated, assert_no_more_updates, TestTimeline},
     TimelineItem,
@@ -256,7 +257,8 @@ async fn test_initial_reaction_timestamp_is_stored() {
                     RoomMessageEventContent::text_plain("A"),
                 )),
             ],
-            crate::timeline::inner::TimelineEnd::Back { from_cache: false },
+            TimelineEnd::Back,
+            RemoteEventOrigin::Sync,
         )
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -35,7 +35,10 @@ use ruma::{
 use stream_assert::assert_next_matches;
 
 use super::TestTimeline;
-use crate::timeline::{AnyOtherFullStateEventContent, TimelineDetails, TimelineItemContent};
+use crate::timeline::{
+    event_item::RemoteEventOrigin, inner::TimelineEnd, AnyOtherFullStateEventContent,
+    TimelineDetails, TimelineItemContent,
+};
 
 #[async_test]
 async fn test_redact_state_event() {
@@ -152,7 +155,8 @@ async fn test_reaction_redaction_timeline_filter() {
                     .event_builder
                     .make_sync_redacted_message_event(*ALICE, RedactedReactionEventContent::new()),
             )],
-            crate::timeline::inner::TimelineEnd::Back { from_cache: false },
+            TimelineEnd::Back,
+            RemoteEventOrigin::Sync,
         )
         .await;
     // Timeline items are actually empty.


### PR DESCRIPTION
And don't assume inserting to the end means it's coming from sync — as it won't be true for forward pagination anymore.

Supports https://github.com/matrix-org/matrix-rust-sdk/issues/3234, extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3329.