### PR TITLE
timeline: prevent deadlock in `replace_with_initial_events`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -281,11 +281,17 @@ type ReadReceiptMap =
 #[derive(Clone, Default)]
 struct TestRoomDataProvider {
     initial_user_receipts: ReadReceiptMap,
+    fully_read_marker: Option<OwnedEventId>,
 }
 
 impl TestRoomDataProvider {
-    fn with_initial_user_receipts(initial_user_receipts: ReadReceiptMap) -> Self {
-        Self { initial_user_receipts }
+    fn with_initial_user_receipts(mut self, initial_user_receipts: ReadReceiptMap) -> Self {
+        self.initial_user_receipts = initial_user_receipts;
+        self
+    }
+    fn with_fully_read_marker(mut self, event_id: OwnedEventId) -> Self {
+        self.fully_read_marker = Some(event_id);
+        self
     }
 }
 
@@ -344,6 +350,10 @@ impl RoomDataProvider for TestRoomDataProvider {
         };
 
         Some((push_rules, push_context))
+    }
+
+    async fn load_fully_read_marker(&self) -> Option<OwnedEventId> {
+        self.fully_read_marker.clone()
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -490,7 +490,7 @@ async fn test_initial_public_unthreaded_receipt() {
         );
 
     let timeline = TestTimeline::with_room_data_provider(
-        TestRoomDataProvider::with_initial_user_receipts(initial_user_receipts),
+        TestRoomDataProvider::default().with_initial_user_receipts(initial_user_receipts),
     )
     .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
 
@@ -515,7 +515,7 @@ async fn test_initial_public_main_thread_receipt() {
         );
 
     let timeline = TestTimeline::with_room_data_provider(
-        TestRoomDataProvider::with_initial_user_receipts(initial_user_receipts),
+        TestRoomDataProvider::default().with_initial_user_receipts(initial_user_receipts),
     )
     .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
 
@@ -540,7 +540,7 @@ async fn test_initial_private_unthreaded_receipt() {
         );
 
     let timeline = TestTimeline::with_room_data_provider(
-        TestRoomDataProvider::with_initial_user_receipts(initial_user_receipts),
+        TestRoomDataProvider::default().with_initial_user_receipts(initial_user_receipts),
     )
     .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
 
@@ -565,7 +565,7 @@ async fn test_initial_private_main_thread_receipt() {
         );
 
     let timeline = TestTimeline::with_room_data_provider(
-        TestRoomDataProvider::with_initial_user_receipts(initial_user_receipts),
+        TestRoomDataProvider::default().with_initial_user_receipts(initial_user_receipts),
     )
     .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
 


### PR DESCRIPTION
:warning: This is preventing timelines to be built with read marker support, if there was a fully read marker event stored in the database.

The `state` lock was taken at the top level of this function, and indirectly implicitly in the `set_fully_read_event` function. This fixes it, and adds a regression test.