### PR TITLE
FFI: Allow the creation of a matrix.to link for any room alias.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -18,7 +18,7 @@ use ruma::{
         },
         TimelineEventType,
     },
-    EventId, Int, UserId,
+    EventId, Int, RoomAliasId, UserId,
 };
 use tokio::sync::RwLock;
 use tracing::error;
@@ -665,6 +665,15 @@ impl Room {
         let event_id = EventId::parse(event_id)?;
         Ok(self.inner.matrix_to_event_permalink(event_id).await?.to_string())
     }
+}
+
+/// Generates a `matrix.to` permalink to the given room alias.
+#[uniffi::export]
+pub fn matrix_to_room_alias_permalink(
+    room_alias: String,
+) -> std::result::Result<String, ClientError> {
+    let room_alias = RoomAliasId::parse(room_alias)?;
+    Ok(room_alias.matrix_to_uri().to_string())
 }
 
 #[derive(uniffi::Record)]

--- a/bindings/matrix-sdk-ffi/src/room_member.rs
+++ b/bindings/matrix-sdk-ffi/src/room_member.rs
@@ -54,7 +54,7 @@ pub fn suggested_power_level_for_role(role: RoomMemberRole) -> i64 {
     role.suggested_power_level()
 }
 
-/// Generates a `matrix.to` permalink from to the given userID.
+/// Generates a `matrix.to` permalink to the given userID.
 #[uniffi::export]
 pub fn matrix_to_user_permalink(user_id: String) -> Result<String, ClientError> {
     let user_id = UserId::parse(user_id)?;


### PR DESCRIPTION
Whilst the FFI currently supports creating a matrix.to room alias link directly from a `Room`, there isn't a way to do so when you already have one as a string. This PR fixes that by adding a global `matrix_to_room_alias_permalink` method similar to the existing `matrix_to_user_permalink` method. (This is only useful against an alias, as a plain room ID doesn't provide enough info to construct the URL with the necessary via parameters).