### PR TITLE
paginator: reset the paginator's state if the task is cancelled

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,7 +38,6 @@ rustflags = [
     "-Wclippy::nonstandard_macro_braces",
     "-Wclippy::str_to_string",
     "-Wclippy::todo",
-    "-Aclippy::box_default"
 ]
 
 [target.'cfg(target_arch = "wasm32")']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,3 +111,4 @@ const_panic = { git = "https://github.com/jplatte/const_panic", rev = "9024a4cb3
 
 [workspace.lints.clippy]
 assigning_clones = "allow"
+box_default = "allow"

--- a/crates/matrix-sdk/src/room/messages.rs
+++ b/crates/matrix-sdk/src/room/messages.rs
@@ -145,7 +145,7 @@ pub struct Messages {
 /// This is a wrapper around
 /// [`ruma::api::client::context::get_context::v3::Response`], with events
 /// decrypted if needs be.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct EventWithContextResponse {
     /// The event targeted by the /context query.
     pub event: Option<TimelineEvent>,


### PR DESCRIPTION
This makes all the requests (/context and /messages) cancellation-safe by making two changes:

- first, use sync locks instead of async locks for the prev/next batch tokens. This ensures that we can't get cancelled after receiving a response and managing internal state, i.e. we keep run-to-completion semantics until the end of the function, once we got a response.
- second, introduce a RAII guard that will reset the state to a given value when dropped. Then use this to reset the state to Initial (resp. Idle) in /context (resp. /messages) when the async call is aborted. We use `mem::forget` once the response has been returned, so as to not call the `Drop` implementation of the guard later on.

A regression test has also been introduced.

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3355.