### PR TITLE
clippy: disable the box_default lint

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,6 +38,7 @@ rustflags = [
     "-Wclippy::nonstandard_macro_braces",
     "-Wclippy::str_to_string",
     "-Wclippy::todo",
+    "-Aclippy::box_default"
 ]
 
 [target.'cfg(target_arch = "wasm32")']


### PR DESCRIPTION
The clippy website explains that `Box::new(Default::default())` can be shortened to `Box::default()` and that it's more readable. That's true… when you don't have a generic parameter in the mix (which may be required if rustc can't infer the type of the boxee), in which case it just looks bad, e.g. `Box::<MyType>::default()` instead of `Box::new(MyType::default())`.

I do strongly prefer the latter, and propose to get rid of the lint, as a result.