### PR TITLE
timeline: reset pagination status if a live back-pagination is aborted

### DIFF
--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -144,7 +144,7 @@ struct ResetStateGuard {
 
 impl ResetStateGuard {
     /// Create a new reset state guard.
-    fn new(target: PaginatorState, state: SharedObservable<PaginatorState>) -> Self {
+    fn new(state: SharedObservable<PaginatorState>, target: PaginatorState) -> Self {
         Self { target: Some(target), state }
     }
 
@@ -210,7 +210,7 @@ impl Paginator {
             });
         }
 
-        let reset_state_guard = ResetStateGuard::new(PaginatorState::Initial, self.state.clone());
+        let reset_state_guard = ResetStateGuard::new(self.state.clone(), PaginatorState::Initial);
 
         // TODO: do we want to lazy load members?
         let lazy_load_members = true;
@@ -307,7 +307,7 @@ impl Paginator {
             });
         }
 
-        let reset_state_guard = ResetStateGuard::new(PaginatorState::Idle, self.state.clone());
+        let reset_state_guard = ResetStateGuard::new(self.state.clone(), PaginatorState::Idle);
 
         let mut options = MessagesOptions::new(dir).from(token.as_deref());
         options.limit = num_events;


### PR DESCRIPTION
Repetition of https://github.com/matrix-org/matrix-rust-sdk/pull/3359 but at a different layer: the timeline has its own observable state for a back-pagination status, and we should *also* reset it when using back-pagination on a live timeline.

Instead of doing this, we should probably have the status + the pagination being handled in the event cache, using the new Paginator API, but that's a bigger change that I'm working on, and it changes many many public APIs related to the event cache, so I'm slightly postponing that and instead I propose to get this simpler fix merged.

Part of #3355.