### PR TITLE
chore: Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,7 +3383,7 @@ dependencies = [
  "anyhow",
  "as_variant",
  "async-compat",
- "base64 0.21.7",
+ "base64 0.22.0",
  "extension-trait",
  "eyeball-im",
  "futures-core",
@@ -3425,7 +3425,7 @@ dependencies = [
  "assert_matches",
  "assert_matches2",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.0",
  "getrandom",
  "gloo-utils",
  "indexed_db_futures",
@@ -3521,7 +3521,7 @@ name = "matrix-sdk-store-encryption"
 version = "0.7.0"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.0",
  "blake3",
  "chacha20poly1305",
  "displaydoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,9 +288,9 @@ checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
 
 [[package]]
 name = "async-channel"
-version = "2.1.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ async-rx = "0.1.3"
 async-stream = "0.3.3"
 async-trait = "0.1.60"
 as_variant = "1.2.0"
-base64 = "0.21.0"
+base64 = "0.22.0"
 byteorder = "1.4.3"
 eyeball = { version = "0.8.7", features = ["tracing"] }
 eyeball-im = { version = "0.4.1", features = ["tracing"] }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,7 +24,7 @@ vergen = { version = "8.1.3", features = ["build", "git", "gitcl"] }
 anyhow = { workspace = true }
 as_variant = { workspace = true }
 async-compat = "0.2.1"
-base64 = "0.21"
+base64 = "0.22"
 eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-core = { workspace = true }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -68,7 +68,7 @@ anymap2 = "0.13.0"
 aquamarine = "0.5.0"
 assert_matches2 = { workspace = true, optional = true }
 as_variant = { workspace = true }
-async-channel = "2.1.0"
+async-channel = "2.2.1"
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 axum = { version = "0.7.4", optional = true }
@@ -76,7 +76,7 @@ bytes = "1.1.0"
 bytesize = "1.1"
 cfg-vis = "0.3.0"
 chrono = { version = "0.4.23", optional = true }
-event-listener = "4.0.0"
+event-listener = "5.3.0"
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }
 eyeball-im-util = { workspace = true, optional = true }


### PR DESCRIPTION
base64 now matches the version used in ruma and vodozemac.

I saw other possible upgrades but they created duplicate entries in `Cargo.lock`, so I tried to be conservative, and ended up only upgrading ~~this one~~ these.

Edit: It turns out I missed the update of async-channel which allows to update event-listener too.