### PR TITLE
ffi: revert some functions back to sync

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -210,8 +210,11 @@ impl Room {
         Ok(Timeline::new(timeline))
     }
 
-    pub async fn display_name(&self) -> Result<String, ClientError> {
-        Ok(self.inner.display_name().await?.to_string())
+    /// Returns the room's name from the state event if available, otherwise
+    /// compute a room name based on the room's nature (DM or not) and number of
+    /// members.
+    pub fn computed_display_name(&self) -> Result<String, ClientError> {
+        Ok(RUNTIME.block_on(self.inner.computed_display_name())?.to_string())
     }
 
     pub async fn is_encrypted(&self) -> Result<bool, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -80,8 +80,13 @@ impl Room {
     /// Returns the room's name from the state event if available, otherwise
     /// compute a room name based on the room's nature (DM or not) and number of
     /// members.
-    pub fn name(&self) -> Result<String, ClientError> {
+    pub fn display_name(&self) -> Result<String, ClientError> {
         Ok(RUNTIME.block_on(self.inner.computed_display_name())?.to_string())
+    }
+
+    /// The raw name as present in the room state event.
+    pub fn raw_name(&self) -> Option<String> {
+        self.inner.name()
     }
 
     pub fn topic(&self) -> Option<String> {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -92,8 +92,8 @@ impl Room {
         self.inner.avatar_url().map(|m| m.to_string())
     }
 
-    pub async fn is_direct(&self) -> bool {
-        self.inner.is_direct().await.unwrap_or(false)
+    pub fn is_direct(&self) -> bool {
+        RUNTIME.block_on(self.inner.is_direct()).unwrap_or(false)
     }
 
     pub fn is_public(&self) -> bool {
@@ -213,8 +213,8 @@ impl Room {
         Ok(Timeline::new(timeline))
     }
 
-    pub async fn is_encrypted(&self) -> Result<bool, ClientError> {
-        Ok(self.inner.is_encrypted().await?)
+    pub fn is_encrypted(&self) -> Result<bool, ClientError> {
+        Ok(RUNTIME.block_on(self.inner.is_encrypted())?)
     }
 
     pub async fn members(&self) -> Result<Arc<RoomMembersIterator>, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -251,8 +251,6 @@ impl Room {
     }
 
     pub async fn room_info(&self) -> Result<RoomInfo, ClientError> {
-        let avatar_url = self.inner.avatar_url();
-
         // Look for a local event in the `Timeline`.
         //
         // First off, let's see if a `Timeline` exists…
@@ -263,7 +261,6 @@ impl Room {
                 if timeline_last_event.is_local_echo() {
                     return Ok(RoomInfo::new(
                         &self.inner,
-                        avatar_url,
                         Some(Arc::new(EventTimelineItem(timeline_last_event))),
                     )
                     .await?);
@@ -285,7 +282,7 @@ impl Room {
             None => None,
         };
 
-        Ok(RoomInfo::new(&self.inner, avatar_url, latest_event).await?)
+        Ok(RoomInfo::new(&self.inner, latest_event).await?)
     }
 
     pub fn subscribe_to_room_info_updates(

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -77,8 +77,11 @@ impl Room {
         self.inner.room_id().to_string()
     }
 
-    pub fn name(&self) -> Option<String> {
-        self.inner.name()
+    /// Returns the room's name from the state event if available, otherwise
+    /// compute a room name based on the room's nature (DM or not) and number of
+    /// members.
+    pub fn name(&self) -> Result<String, ClientError> {
+        Ok(RUNTIME.block_on(self.inner.computed_display_name())?.to_string())
     }
 
     pub fn topic(&self) -> Option<String> {
@@ -208,13 +211,6 @@ impl Room {
         };
 
         Ok(Timeline::new(timeline))
-    }
-
-    /// Returns the room's name from the state event if available, otherwise
-    /// compute a room name based on the room's nature (DM or not) and number of
-    /// members.
-    pub fn computed_display_name(&self) -> Result<String, ClientError> {
-        Ok(RUNTIME.block_on(self.inner.computed_display_name())?.to_string())
     }
 
     pub async fn is_encrypted(&self) -> Result<bool, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -12,7 +12,9 @@ pub struct RoomInfo {
     id: String,
     /// The room's name from the room state event if received from sync, or one
     /// that's been computed otherwise.
-    name: Option<String>,
+    display_name: Option<String>,
+    /// Room name as defined by the room state event only.
+    raw_name: Option<String>,
     topic: Option<String>,
     avatar_url: Option<String>,
     is_direct: bool,
@@ -67,7 +69,8 @@ impl RoomInfo {
 
         Ok(Self {
             id: room.room_id().to_string(),
-            name: room.computed_display_name().await.ok().map(|name| name.to_string()),
+            display_name: room.computed_display_name().await.ok().map(|name| name.to_string()),
+            raw_name: room.name(),
             topic: room.topic(),
             avatar_url: room.avatar_url().map(Into::into),
             is_direct: room.is_direct().await?,

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::RoomState;
-use ruma::OwnedMxcUri;
 
 use crate::{
     notification_settings::RoomNotificationMode, room::Membership, room_member::RoomMember,
@@ -56,7 +55,6 @@ pub struct RoomInfo {
 impl RoomInfo {
     pub(crate) async fn new(
         room: &matrix_sdk::Room,
-        avatar_url: Option<OwnedMxcUri>,
         latest_event: Option<Arc<EventTimelineItem>>,
     ) -> matrix_sdk::Result<Self> {
         let unread_notification_counts = room.unread_notification_counts();
@@ -71,7 +69,7 @@ impl RoomInfo {
             id: room.room_id().to_string(),
             name: room.computed_display_name().await.ok().map(|name| name.to_string()),
             topic: room.topic(),
-            avatar_url: avatar_url.map(Into::into),
+            avatar_url: room.avatar_url().map(Into::into),
             is_direct: room.is_direct().await?,
             is_public: room.is_public(),
             is_space: room.is_space(),

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -11,6 +11,8 @@ use crate::{
 #[derive(uniffi::Record)]
 pub struct RoomInfo {
     id: String,
+    /// The room's name from the room state event if received from sync, or one
+    /// that's been computed otherwise.
     name: Option<String>,
     topic: Option<String>,
     avatar_url: Option<String>,
@@ -67,7 +69,7 @@ impl RoomInfo {
 
         Ok(Self {
             id: room.room_id().to_string(),
-            name: room.name(),
+            name: room.computed_display_name().await.ok().map(|name| name.to_string()),
             topic: room.topic(),
             avatar_url: avatar_url.map(Into::into),
             is_direct: room.is_direct().await?,

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -498,8 +498,8 @@ impl RoomListItem {
         self.inner.avatar_url().map(|uri| uri.to_string())
     }
 
-    async fn is_direct(&self) -> bool {
-        self.inner.inner_room().is_direct().await.unwrap_or(false)
+    fn is_direct(&self) -> bool {
+        RUNTIME.block_on(self.inner.inner_room().is_direct()).unwrap_or(false)
     }
 
     fn canonical_alias(&self) -> Option<String> {

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -493,7 +493,7 @@ impl RoomListItem {
     /// Returns the room's name from the state event if available, otherwise
     /// compute a room name based on the room's nature (DM or not) and number of
     /// members.
-    fn computed_display_name(&self) -> Option<String> {
+    fn name(&self) -> Option<String> {
         RUNTIME.block_on(self.inner.computed_display_name())
     }
 

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -490,8 +490,11 @@ impl RoomListItem {
         self.inner.id().to_string()
     }
 
-    async fn name(&self) -> Option<String> {
-        self.inner.name().await
+    /// Returns the room's name from the state event if available, otherwise
+    /// compute a room name based on the room's nature (DM or not) and number of
+    /// members.
+    fn computed_display_name(&self) -> Option<String> {
+        RUNTIME.block_on(self.inner.computed_display_name())
     }
 
     fn avatar_url(&self) -> Option<String> {

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -493,7 +493,7 @@ impl RoomListItem {
     /// Returns the room's name from the state event if available, otherwise
     /// compute a room name based on the room's nature (DM or not) and number of
     /// members.
-    fn name(&self) -> Option<String> {
+    fn display_name(&self) -> Option<String> {
         RUNTIME.block_on(self.inner.computed_display_name())
     }
 

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -510,9 +510,9 @@ impl RoomListItem {
     }
 
     pub async fn room_info(&self) -> Result<RoomInfo, ClientError> {
-        let avatar_url = self.inner.avatar_url();
         let latest_event = self.inner.latest_event().await.map(EventTimelineItem).map(Arc::new);
-        Ok(RoomInfo::new(self.inner.inner_room(), avatar_url, latest_event).await?)
+
+        Ok(RoomInfo::new(self.inner.inner_room(), latest_event).await?)
     }
 
     /// Building a `Room`. If its internal timeline hasn't been initialized

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1635,7 +1635,7 @@ mod tests {
         let room = client.get_room(room_id).expect("Room not found");
         assert_eq!(room.state(), RoomState::Invited);
         assert_eq!(
-            room.display_name().await.expect("fetching display name failed"),
+            room.computed_display_name().await.expect("fetching display name failed"),
             DisplayName::Calculated("Kyra".to_owned())
         );
     }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -413,7 +413,8 @@ impl Room {
 
     /// Get the `m.room.name` of this room.
     ///
-    /// The returned string is guaranteed not to be empty.
+    /// The returned string may be empty if the event has been redacted, or it's
+    /// missing from storage.
     pub fn name(&self) -> Option<String> {
         self.inner.read().name().map(ToOwned::to_owned)
     }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1272,7 +1272,7 @@ mod tests {
         // Then the room's name is just exactly what the server supplied
         let client_room = client.get_room(room_id).expect("No room found");
         assert_eq!(
-            client_room.display_name().await.unwrap().to_string(),
+            client_room.computed_display_name().await.unwrap().to_string(),
             "This came from the server"
         );
     }

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -715,7 +715,7 @@ impl NotificationItem {
             sender_display_name,
             sender_avatar_url,
             is_sender_name_ambiguous,
-            room_display_name: room.display_name().await?.to_string(),
+            room_display_name: room.computed_display_name().await?.to_string(),
             room_avatar_url: room.avatar_url().map(|s| s.to_string()),
             room_canonical_alias: room.canonical_alias().map(|c| c.to_string()),
             is_direct_message_room: room.is_direct().await?,

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -83,9 +83,9 @@ impl Room {
         self.inner.room.room_id()
     }
 
-    /// Get the name of the room if it exists.
-    pub async fn name(&self) -> Option<String> {
-        Some(self.inner.room.display_name().await.ok()?.to_string())
+    /// Get a computed room name for the room.
+    pub async fn computed_display_name(&self) -> Option<String> {
+        Some(self.inner.room.computed_display_name().await.ok()?.to_string())
     }
 
     /// Get the underlying [`matrix_sdk::Room`].

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2260,7 +2260,7 @@ async fn test_room() -> Result<(), Error> {
     let room0 = room_list.room(room_id_0).await?;
 
     // Room has received a name from sliding sync.
-    assert_eq!(room0.name().await, Some("Room #0".to_owned()));
+    assert_eq!(room0.computed_display_name().await, Some("Room #0".to_owned()));
 
     // Room has received an avatar from sliding sync.
     assert_eq!(room0.avatar_url(), Some(mxc_uri!("mxc://homeserver/media").to_owned()));
@@ -2268,7 +2268,7 @@ async fn test_room() -> Result<(), Error> {
     let room1 = room_list.room(room_id_1).await?;
 
     // Room has not received a name from sliding sync, then it's calculated.
-    assert_eq!(room1.name().await, Some("Empty Room".to_owned()));
+    assert_eq!(room1.computed_display_name().await, Some("Empty Room".to_owned()));
 
     // Room has not received an avatar from sliding sync, then it's calculated, but
     // there is nothing to calculate from, so there is no URL.
@@ -2303,7 +2303,7 @@ async fn test_room() -> Result<(), Error> {
     };
 
     // Room has _now_ received a name from sliding sync!
-    assert_eq!(room1.name().await, Some("Room #1".to_owned()));
+    assert_eq!(room1.computed_display_name().await, Some("Room #1".to_owned()));
 
     // Room has _now_ received an avatar URL from sliding sync!
     assert_eq!(room1.avatar_url(), Some(mxc_uri!("mxc://homeserver/other-media").to_owned()));

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -121,6 +121,10 @@ impl Account {
 
     /// Get the MXC URI of the account's avatar, if set.
     ///
+    /// This always sends a request to the server to retrieve this information.
+    /// If successful, this fills the cache, and makes it so that
+    /// [`Self::get_cached_avatar_url`] will always return something.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -902,7 +906,7 @@ impl Account {
         Ok(ignored_user_list)
     }
 
-    /// Get the current push rules.
+    /// Get the current push rules from storage.
     ///
     /// If no push rules event was found, or it fails to deserialize, a ruleset
     /// with the server-default push rules is returned.

--- a/crates/matrix-sdk/tests/integration/room/common.rs
+++ b/crates/matrix-sdk/tests/integration/room/common.rs
@@ -56,7 +56,10 @@ async fn calculate_room_names_from_summary() {
     let _response = client.sync_once(sync_settings).await.unwrap();
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
 
-    assert_eq!(DisplayName::Calculated("example2".to_owned()), room.display_name().await.unwrap());
+    assert_eq!(
+        DisplayName::Calculated("example2".to_owned()),
+        room.computed_display_name().await.unwrap()
+    );
 }
 
 #[async_test]
@@ -72,7 +75,10 @@ async fn room_names() {
     assert_eq!(client.rooms().len(), 1);
     let room = client.get_room(&DEFAULT_TEST_ROOM_ID).unwrap();
 
-    assert_eq!(DisplayName::Aliased("tutorial".to_owned()), room.display_name().await.unwrap());
+    assert_eq!(
+        DisplayName::Aliased("tutorial".to_owned()),
+        room.computed_display_name().await.unwrap()
+    );
 
     mock_sync(&server, &*test_json::INVITE_SYNC, Some(sync_token.clone())).await;
 
@@ -83,7 +89,7 @@ async fn room_names() {
 
     assert_eq!(
         DisplayName::Named("My Room Name".to_owned()),
-        invited_room.display_name().await.unwrap()
+        invited_room.computed_display_name().await.unwrap()
     );
 }
 

--- a/examples/oidc_cli/src/main.rs
+++ b/examples/oidc_cli/src/main.rs
@@ -880,7 +880,7 @@ async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {
     }
     let MessageType::Text(text_content) = &event.content.msgtype else { return };
 
-    let room_name = match room.display_name().await {
+    let room_name = match room.computed_display_name().await {
         Ok(room_name) => room_name.to_string(),
         Err(error) => {
             println!("Error getting room display name: {error}");

--- a/examples/persist_session/src/main.rs
+++ b/examples/persist_session/src/main.rs
@@ -297,7 +297,7 @@ async fn on_room_message(event: OriginalSyncRoomMessageEvent, room: Room) {
     }
     let MessageType::Text(text_content) = &event.content.msgtype else { return };
 
-    let room_name = match room.display_name().await {
+    let room_name = match room.computed_display_name().await {
         Ok(room_name) => room_name.to_string(),
         Err(error) => {
             println!("Error getting room display name: {error}");


### PR DESCRIPTION
Reverts a few changes of https://github.com/matrix-org/matrix-rust-sdk/pull/3368, and also simplify / add more comments / etc.

One notable change: in `Room`, `RoomInfo` and `RoomListItem`, the `name()` method will now always return the computed display name only, and not alternate between the computed display name and the raw name from the room state event. Let me know if that's something we don't want.