### PR TITLE
tests: rename ev_builder to sync_builder + add test_ prefix to test functions

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -1515,9 +1515,9 @@ mod tests {
 
         let client = logged_in_base_client(Some(user_id)).await;
 
-        let mut ev_builder = SyncResponseBuilder::new();
+        let mut sync_builder = SyncResponseBuilder::new();
 
-        let response = ev_builder
+        let response = sync_builder
             .add_left_room(LeftRoomBuilder::new(room_id).add_timeline_event(sync_timeline_event!({
                 "content": {
                     "displayname": "Alice",
@@ -1533,7 +1533,7 @@ mod tests {
         client.receive_sync_response(response).await.unwrap();
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Left);
 
-        let response = ev_builder
+        let response = sync_builder
             .add_invited_room(InvitedRoomBuilder::new(room_id).add_state_event(
                 StrippedStateTestEvent::Custom(json!({
                     "content": {
@@ -1675,8 +1675,8 @@ mod tests {
         event_id: &str,
         user_id: &UserId,
     ) -> crate::Room {
-        let mut ev_builder = SyncResponseBuilder::new();
-        let response = ev_builder
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
             .add_joined_room(matrix_sdk_test::JoinedRoomBuilder::new(room_id).add_timeline_event(
                 sync_timeline_event!({
                     "content": {
@@ -1802,8 +1802,8 @@ mod tests {
             .unwrap();
 
         // Preamble: let the SDK know about the room.
-        let mut ev_builder = SyncResponseBuilder::new();
-        let response = ev_builder
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
             .add_joined_room(matrix_sdk_test::JoinedRoomBuilder::new(room_id))
             .build_sync_response();
         client.receive_sync_response(response).await.unwrap();
@@ -1861,8 +1861,8 @@ mod tests {
             .unwrap();
 
         // Preamble: let the SDK know about the room, and that the invited user left it.
-        let mut ev_builder = SyncResponseBuilder::new();
-        let response = ev_builder
+        let mut sync_builder = SyncResponseBuilder::new();
+        let response = sync_builder
             .add_joined_room(matrix_sdk_test::JoinedRoomBuilder::new(room_id).add_state_event(
                 StateTestEvent::Custom(json!({
                     "content": {

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -45,13 +45,13 @@ async fn test_notification_client_with_context() {
         "type": "m.room.message",
     });
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id).add_timeline_event(sync_timeline_event!(event_json)),
     );
 
     // First, mock a sync that contains a text message.
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -44,10 +44,10 @@ async fn test_echo() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -95,7 +95,7 @@ async fn test_echo() {
     let item = sent_confirmation.as_event().unwrap();
     assert_matches!(item.send_state(), Some(EventSendState::Sent { .. }));
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {
                 "body": "Hello, World!",
@@ -109,7 +109,7 @@ async fn test_echo() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -132,10 +132,10 @@ async fn test_retry_failed() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -188,10 +188,10 @@ async fn test_dedup_by_event_id_late() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -226,7 +226,7 @@ async fn test_dedup_by_event_id_late() {
         assert_next_matches!( timeline_stream, VectorDiff::PushFront { value } => value);
     assert!(day_divider.is_day_divider());
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {
                 "body": "Hello, World!",
@@ -240,7 +240,7 @@ async fn test_dedup_by_event_id_late() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
     let remote_echo =
@@ -263,10 +263,10 @@ async fn test_cancel_failed() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -55,10 +55,10 @@ async fn test_edit() {
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -67,7 +67,7 @@ async fn test_edit() {
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let event_id = event_id!("$msda7m:localhost");
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         event_builder.make_sync_message_event_with_id(
             &ALICE,
             event_id,
@@ -75,7 +75,7 @@ async fn test_edit() {
         ),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -90,7 +90,7 @@ async fn test_edit() {
     assert_let!(Some(VectorDiff::PushFront { value: day_divider }) = timeline_stream.next().await);
     assert!(day_divider.is_day_divider());
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(event_builder.make_sync_message_event(
                 &BOB,
@@ -107,7 +107,7 @@ async fn test_edit() {
             ),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -46,10 +46,10 @@ async fn test_reaction() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -57,7 +57,7 @@ async fn test_reaction() {
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -84,7 +84,7 @@ async fn test_reaction() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -125,7 +125,7 @@ async fn test_reaction() {
 
     // TODO: After adding raw timeline items, check for one here
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {},
             "redacts": "$031IXQRi27504",
@@ -136,7 +136,7 @@ async fn test_reaction() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -155,10 +155,10 @@ async fn test_redacted_message() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -166,7 +166,7 @@ async fn test_redacted_message() {
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {},
@@ -195,7 +195,7 @@ async fn test_redacted_message() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -214,10 +214,10 @@ async fn test_read_marker() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -225,7 +225,7 @@ async fn test_read_marker() {
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {
                 "body": "hello",
@@ -238,7 +238,7 @@ async fn test_read_marker() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -248,17 +248,17 @@ async fn test_read_marker() {
     assert_let!(Some(VectorDiff::PushFront { value: day_divider }) = timeline_stream.next().await);
     assert!(day_divider.is_day_divider());
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id).add_account_data(RoomAccountDataTestEvent::FullyRead),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
     // Nothing should happen, the marker cannot be added at the end.
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {
                 "body": "hello to you!",
@@ -271,7 +271,7 @@ async fn test_read_marker() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -290,8 +290,8 @@ async fn test_sync_highlighted() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder
         // We need the member event and power levels locally so the push rules processor works.
         .add_joined_room(
             JoinedRoomBuilder::new(room_id)
@@ -299,7 +299,7 @@ async fn test_sync_highlighted() {
                 .add_state_event(StateTestEvent::PowerLevels),
         );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -307,7 +307,7 @@ async fn test_sync_highlighted() {
     let timeline = room.timeline().await.unwrap();
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {
                 "body": "hello",
@@ -320,7 +320,7 @@ async fn test_sync_highlighted() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -332,7 +332,7 @@ async fn test_sync_highlighted() {
     assert_let!(Some(VectorDiff::PushFront { value: day_divider }) = timeline_stream.next().await);
     assert!(day_divider.is_day_divider());
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {
                 "body": "This room has been replaced",
@@ -346,7 +346,7 @@ async fn test_sync_highlighted() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/read_receipts.rs
@@ -64,10 +64,10 @@ async fn test_read_receipts_updates() {
     let second_event_id = event_id!("$e32037280er453l:localhost");
     let third_event_id = event_id!("$Sg2037280074GZr34:localhost");
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -84,7 +84,7 @@ async fn test_read_receipts_updates() {
     let bob_receipt = timeline.latest_user_read_receipt(bob).await;
     assert_matches!(bob_receipt, None);
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -123,7 +123,7 @@ async fn test_read_receipts_updates() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -158,7 +158,7 @@ async fn test_read_receipts_updates() {
     assert!(day_divider.is_day_divider());
 
     // Read receipt on unknown event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 "$unknowneventid": {
@@ -173,7 +173,7 @@ async fn test_read_receipts_updates() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -181,7 +181,7 @@ async fn test_read_receipts_updates() {
     assert_eq!(alice_receipt_event_id, third_event.event_id().unwrap());
 
     // Read receipt on older event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 second_event_id: {
@@ -200,7 +200,7 @@ async fn test_read_receipts_updates() {
     assert_eq!(alice_receipt_event_id, third_event_id);
 
     // Read receipt on same event is ignored.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 third_event_id: {
@@ -219,7 +219,7 @@ async fn test_read_receipts_updates() {
     assert_eq!(alice_receipt_event_id, third_event_id);
 
     // New user with explicit threaded and unthreaded read receipts.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 second_event_id: {
@@ -242,7 +242,7 @@ async fn test_read_receipts_updates() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -256,7 +256,7 @@ async fn test_read_receipts_updates() {
     assert_eq!(bob_receipt_event_id, third_event_id);
 
     // Private read receipt is updated.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 second_event_id: {
@@ -271,7 +271,7 @@ async fn test_read_receipts_updates() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -292,10 +292,10 @@ async fn test_read_receipts_updates_on_filtered_events() {
     let event_b_id = event_id!("$e32037280er453l:localhost");
     let event_c_id = event_id!("$Sg2037280074GZr34:localhost");
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -321,7 +321,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
         timeline.latest_user_read_receipt_timeline_event_id(*BOB).await;
     assert_matches!(bob_receipt_timeline_event, None);
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             // Event A
             .add_timeline_event(sync_timeline_event!({
@@ -358,7 +358,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -401,7 +401,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
     assert!(day_divider.is_day_divider());
 
     // Read receipt on filtered event.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 event_b_id: {
@@ -416,7 +416,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -429,7 +429,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
     assert_eq!(own_receipt_timeline_event, event_a.event_id().unwrap());
 
     // Update with explicit read receipt.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 event_c_id: {
@@ -444,7 +444,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -464,7 +464,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
     assert_eq!(bob_receipt_timeline_event, event_c_id);
 
     // Private read receipt is updated.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 event_c_id: {
@@ -479,7 +479,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -500,10 +500,10 @@ async fn test_send_single_receipt() {
 
     let own_user_id = client.user_id().unwrap();
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -565,7 +565,7 @@ async fn test_send_single_receipt() {
     server.reset().await;
 
     // Unchanged receipts are not sent.
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
                 "content": {
@@ -592,7 +592,7 @@ async fn test_send_single_receipt() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -679,7 +679,7 @@ async fn test_send_single_receipt() {
     // Newer receipts in the timeline are sent.
     let third_receipts_event_id = event_id!("$third_receipts_event_id");
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -726,7 +726,7 @@ async fn test_send_single_receipt() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -782,7 +782,7 @@ async fn test_send_single_receipt() {
     server.reset().await;
 
     // Older receipts in the timeline are not sent.
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
                 "content": {
@@ -809,7 +809,7 @@ async fn test_send_single_receipt() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -847,10 +847,10 @@ async fn test_mark_as_read() {
 
     let own_user_id = client.user_id().unwrap();
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -861,7 +861,7 @@ async fn test_mark_as_read() {
     let reaction_event_id = event_id!("$reaction_event_id");
 
     // When I receive an event with a reaction on it,
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -900,7 +900,7 @@ async fn test_mark_as_read() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -950,10 +950,10 @@ async fn test_send_multiple_receipts() {
 
     let own_user_id = client.user_id().unwrap();
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -984,7 +984,7 @@ async fn test_send_multiple_receipts() {
     server.reset().await;
 
     // Unchanged receipts are not sent.
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
                 "content": {
@@ -1011,7 +1011,7 @@ async fn test_send_multiple_receipts() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -1048,7 +1048,7 @@ async fn test_send_multiple_receipts() {
         .public_read_receipt(Some(third_receipts_event_id.to_owned()))
         .private_read_receipt(Some(third_receipts_event_id.to_owned()));
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -1095,7 +1095,7 @@ async fn test_send_multiple_receipts() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -1116,7 +1116,7 @@ async fn test_send_multiple_receipts() {
     server.reset().await;
 
     // Older receipts in the timeline are not sent.
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_ephemeral_event(EphemeralTestEvent::Custom(json!({
                 "content": {
@@ -1143,7 +1143,7 @@ async fn test_send_multiple_receipts() {
             }))),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -1164,10 +1164,10 @@ async fn test_latest_user_read_receipt() {
     let event_d_id = event_id!("$event_d");
     let event_e_id = event_id!("$event_e");
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -1181,7 +1181,7 @@ async fn test_latest_user_read_receipt() {
     assert_matches!(user_receipt, None);
 
     // Only private receipt.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 event_a_id: {
@@ -1194,7 +1194,7 @@ async fn test_latest_user_read_receipt() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -1203,7 +1203,7 @@ async fn test_latest_user_read_receipt() {
 
     // Private and public receipts without timestamp should return private
     // receipt.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 event_b_id: {
@@ -1216,7 +1216,7 @@ async fn test_latest_user_read_receipt() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -1224,7 +1224,7 @@ async fn test_latest_user_read_receipt() {
     assert_eq!(user_receipt_id, event_a_id);
 
     // Public receipt with bigger timestamp.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 event_c_id: {
@@ -1246,7 +1246,7 @@ async fn test_latest_user_read_receipt() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -1254,7 +1254,7 @@ async fn test_latest_user_read_receipt() {
     assert_eq!(user_receipt_id, event_d_id);
 
     // Private receipt with bigger timestamp.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 event_e_id: {
@@ -1269,7 +1269,7 @@ async fn test_latest_user_read_receipt() {
         })),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -179,10 +179,10 @@ async fn test_transfer_in_reply_to_details_to_re_received_item() {
     let event_builder = EventBuilder::new();
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -199,10 +199,10 @@ async fn test_transfer_in_reply_to_details_to_re_received_item() {
             }),
         }),
     );
-    ev_builder
+    sync_builder
         .add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(reply_event.clone()));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -240,9 +240,9 @@ async fn test_transfer_in_reply_to_details_to_re_received_item() {
     assert_matches!(in_reply_to.event, TimelineDetails::Ready(_));
 
     // ... and then we re-receive the reply event
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(reply_event));
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(reply_event));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
     // ... the replied-to event details should remain from when we fetched them

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -92,10 +92,10 @@ async fn test_event_filter() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -104,7 +104,7 @@ async fn test_event_filter() {
     let (_, mut timeline_stream) = timeline.subscribe().await;
 
     let first_event_id = event_id!("$YTQwYl2ply");
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {
                 "body": "hello",
@@ -117,7 +117,7 @@ async fn test_event_filter() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -134,7 +134,7 @@ async fn test_event_filter() {
 
     let second_event_id = event_id!("$Ga6Y2l0gKY");
     let edit_event_id = event_id!("$7i9In0gEmB");
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -168,7 +168,7 @@ async fn test_event_filter() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -198,10 +198,10 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -217,7 +217,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let second_event_id = event_id!("$YTQwYl2pl2");
     let third_event_id = event_id!("$YTQwYl2pl3");
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -251,7 +251,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -275,7 +275,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let fourth_event_id = event_id!("$YTQwYl2pl4");
     let fiveth_event_id = event_id!("$YTQwYl2pl5");
 
-    ev_builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
+    sync_builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
         "content": {
             "ignored_users": {
                 bob: {}
@@ -284,7 +284,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
         "type": "m.ignored_user_list",
     })));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -292,7 +292,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
     assert_pending!(timeline_stream);
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -316,7 +316,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -342,10 +342,10 @@ async fn test_profile_updates() {
     let (client, server) = logged_in_client_with_server().await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -361,7 +361,7 @@ async fn test_profile_updates() {
     let event_1_id = event_id!("$YTQwYl2pl1");
     let event_2_id = event_id!("$YTQwYl2pl2");
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -385,7 +385,7 @@ async fn test_profile_updates() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -410,7 +410,7 @@ async fn test_profile_updates() {
     let event_4_id = event_id!("$YTQwYl2pl4");
     let event_5_id = event_id!("$YTQwYl2pl5");
 
-    ev_builder.add_joined_room(
+    sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
             .add_timeline_event(sync_timeline_event!({
                 "content": {
@@ -446,7 +446,7 @@ async fn test_profile_updates() {
             })),
     );
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -514,7 +514,7 @@ async fn test_profile_updates() {
     // Change name to be ambiguous.
     let event_6_id = event_id!("$YTQwYl2pl6");
 
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_event(
         sync_timeline_event!({
             "content": {
                 "displayname": "Member",
@@ -528,7 +528,7 @@ async fn test_profile_updates() {
         }),
     ));
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -32,7 +32,7 @@ use wiremock::{
 use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync, synced_client};
 
 #[async_test]
-async fn invite_user_by_id() {
+async fn test_invite_user_by_id() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -55,7 +55,7 @@ async fn invite_user_by_id() {
 }
 
 #[async_test]
-async fn invite_user_by_3pid() {
+async fn test_invite_user_by_3pid() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -87,7 +87,7 @@ async fn invite_user_by_3pid() {
 }
 
 #[async_test]
-async fn leave_room() -> Result<(), anyhow::Error> {
+async fn test_leave_room() -> Result<(), anyhow::Error> {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -113,7 +113,7 @@ async fn leave_room() -> Result<(), anyhow::Error> {
 }
 
 #[async_test]
-async fn ban_user() {
+async fn test_ban_user() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -136,7 +136,7 @@ async fn ban_user() {
 }
 
 #[async_test]
-async fn unban_user() {
+async fn test_unban_user() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -185,7 +185,7 @@ async fn test_mark_as_unread() {
 }
 
 #[async_test]
-async fn kick_user() {
+async fn test_kick_user() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -208,7 +208,7 @@ async fn kick_user() {
 }
 
 #[async_test]
-async fn send_single_receipt() {
+async fn test_send_single_receipt() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -231,7 +231,7 @@ async fn send_single_receipt() {
 }
 
 #[async_test]
-async fn send_multiple_receipts() {
+async fn test_send_multiple_receipts() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("POST"))
@@ -255,7 +255,7 @@ async fn send_multiple_receipts() {
 }
 
 #[async_test]
-async fn typing_notice() {
+async fn test_typing_notice() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
@@ -277,7 +277,7 @@ async fn typing_notice() {
 }
 
 #[async_test]
-async fn room_state_event_send() {
+async fn test_room_state_event_send() {
     use ruma::events::room::member::{MembershipState, RoomMemberEventContent};
 
     let (client, server) = logged_in_client_with_server().await;
@@ -307,7 +307,7 @@ async fn room_state_event_send() {
 }
 
 #[async_test]
-async fn room_message_send() {
+async fn test_room_message_send() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
@@ -334,7 +334,7 @@ async fn room_message_send() {
 }
 
 #[async_test]
-async fn room_attachment_send() {
+async fn test_room_attachment_send() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
@@ -382,7 +382,7 @@ async fn room_attachment_send() {
 }
 
 #[async_test]
-async fn room_attachment_send_info() {
+async fn test_room_attachment_send_info() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
@@ -436,7 +436,7 @@ async fn room_attachment_send_info() {
 }
 
 #[async_test]
-async fn room_attachment_send_wrong_info() {
+async fn test_room_attachment_send_wrong_info() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
@@ -489,7 +489,7 @@ async fn room_attachment_send_wrong_info() {
 }
 
 #[async_test]
-async fn room_attachment_send_info_thumbnail() {
+async fn test_room_attachment_send_info_thumbnail() {
     let (client, server) = logged_in_client_with_server().await;
 
     Mock::given(method("PUT"))
@@ -558,7 +558,7 @@ async fn room_attachment_send_info_thumbnail() {
 }
 
 #[async_test]
-async fn room_redact() {
+async fn test_room_redact() {
     let (client, server) = synced_client().await;
 
     Mock::given(method("PUT"))
@@ -581,7 +581,7 @@ async fn room_redact() {
 
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn fetch_members_deduplication() {
+async fn test_fetch_members_deduplication() {
     let (client, server) = synced_client().await;
 
     // We don't need any members, we're just checking if we're correctly
@@ -622,7 +622,7 @@ async fn fetch_members_deduplication() {
 }
 
 #[async_test]
-async fn set_name() {
+async fn test_set_name() {
     let (client, server) = synced_client().await;
 
     mock_sync(&server, &*test_json::SYNC, None).await;
@@ -647,7 +647,7 @@ async fn set_name() {
 }
 
 #[async_test]
-async fn report_content() {
+async fn test_report_content() {
     let (client, server) = logged_in_client_with_server().await;
 
     let reason = "I am offended";
@@ -680,7 +680,7 @@ async fn report_content() {
 }
 
 #[async_test]
-async fn subscribe_to_typing_notifications() {
+async fn test_subscribe_to_typing_notifications() {
     let (client, server) = logged_in_client_with_server().await;
     let typing_sequences: Arc<Mutex<Vec<Vec<OwnedUserId>>>> = Arc::new(Mutex::new(Vec::new()));
     // The expected typing sequences that we will receive, note that the current
@@ -688,11 +688,11 @@ async fn subscribe_to_typing_notifications() {
     let asserted_typing_sequences =
         vec![vec![user_id!("@alice:matrix.org"), user_id!("@bob:example.com")], vec![]];
     let room_id = room_id!("!test:example.org");
-    let mut ev_builder = SyncResponseBuilder::new();
+    let mut sync_builder = SyncResponseBuilder::new();
 
     // Initial sync with our test room.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
@@ -718,7 +718,7 @@ async fn subscribe_to_typing_notifications() {
 
     // Then send a typing notification with 3 users typing, including the current
     // user.
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 "user_ids": [
@@ -731,12 +731,12 @@ async fn subscribe_to_typing_notifications() {
             "type": "m.typing"
         })),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
     // Then send a typing notification with no user typing
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_ephemeral_event(
         EphemeralTestEvent::Custom(json!({
             "content": {
                 "user_ids": []
@@ -745,7 +745,7 @@ async fn subscribe_to_typing_notifications() {
             "type": "m.typing"
         })),
     ));
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 
@@ -754,7 +754,7 @@ async fn subscribe_to_typing_notifications() {
 }
 
 #[async_test]
-async fn get_suggested_user_role() {
+async fn test_get_suggested_user_role() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::DEFAULT_SYNC_SUMMARY, None).await;
@@ -773,7 +773,7 @@ async fn get_suggested_user_role() {
 }
 
 #[async_test]
-async fn get_power_level_for_user() {
+async fn test_get_power_level_for_user() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::DEFAULT_SYNC_SUMMARY, None).await;
@@ -793,7 +793,7 @@ async fn get_power_level_for_user() {
 }
 
 #[async_test]
-async fn get_users_with_power_levels() {
+async fn test_get_users_with_power_levels() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::sync::SYNC_ADMIN_AND_MOD, None).await;
@@ -809,7 +809,7 @@ async fn get_users_with_power_levels() {
 }
 
 #[async_test]
-async fn get_users_with_power_levels_is_empty_if_power_level_info_is_not_available() {
+async fn test_get_users_with_power_levels_is_empty_if_power_level_info_is_not_available() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*test_json::INVITE_SYNC, None).await;
@@ -823,7 +823,7 @@ async fn get_users_with_power_levels_is_empty_if_power_level_info_is_not_availab
 }
 
 #[async_test]
-async fn reset_power_levels() {
+async fn test_reset_power_levels() {
     let (client, server) = logged_in_client_with_server().await;
 
     mock_sync(&server, &*CUSTOM_ROOM_POWER_LEVELS, None).await;

--- a/crates/matrix-sdk/tests/integration/room/notification_mode.rs
+++ b/crates/matrix-sdk/tests/integration/room/notification_mode.rs
@@ -17,7 +17,7 @@ use wiremock::{
 use crate::{logged_in_client_with_server, mock_sync};
 
 #[async_test]
-async fn get_notification_mode() {
+async fn test_get_notification_mode() {
     let room_no_rules_id = room_id!("!jEsUZKDJdhlrceRyVU:localhost");
     let room_not_joined_id = room_id!("!aBfUOMDJhmtucfVzGa:localhost");
     let (client, server) = logged_in_client_with_server().await;
@@ -25,13 +25,13 @@ async fn get_notification_mode() {
     let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
 
     // Add the rooms for the tests
-    let mut ev_builder = SyncResponseBuilder::new();
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID));
-    ev_builder.add_joined_room(JoinedRoomBuilder::new(room_no_rules_id));
-    ev_builder.add_invited_room(InvitedRoomBuilder::new(room_not_joined_id));
-    ev_builder.add_global_account_data_event(GlobalAccountDataTestEvent::PushRules);
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(&DEFAULT_TEST_ROOM_ID));
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_no_rules_id));
+    sync_builder.add_invited_room(InvitedRoomBuilder::new(room_not_joined_id));
+    sync_builder.add_global_account_data_event(GlobalAccountDataTestEvent::PushRules);
 
-    mock_sync(&server, ev_builder.build_json_sync_response(), None).await;
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
     server.reset().await;
 


### PR DESCRIPTION
I am in `--pedantic` mode today.