### PR TITLE
fix(store-encryption): Remove the `displaydoc` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,17 +1440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3524,7 +3513,6 @@ dependencies = [
  "base64 0.22.0",
  "blake3",
  "chacha20poly1305",
- "displaydoc",
  "getrandom",
  "hmac",
  "pbkdf2",

--- a/crates/matrix-sdk-store-encryption/Cargo.toml
+++ b/crates/matrix-sdk-store-encryption/Cargo.toml
@@ -17,7 +17,6 @@ js = ["dep:getrandom", "getrandom?/js"]
 base64 = { workspace = true }
 blake3 = "1.5.0"
 chacha20poly1305 = { version = "0.10.1", features = ["std"] }
-displaydoc = "0.2.4"
 getrandom = { version = "0.2.10", optional = true }
 hmac = "0.12.1"
 pbkdf2 = "0.12.2"

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -28,7 +28,6 @@ use chacha20poly1305::{
     aead::{Aead, Error as EncryptionError},
     Key as ChachaKey, KeyInit, XChaCha20Poly1305, XNonce,
 };
-use displaydoc::Display;
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
 use rand::{thread_rng, Error as RandomError, Fill};
@@ -46,26 +45,39 @@ const BASE64: GeneralPurpose = GeneralPurpose::new(&alphabet::STANDARD, general_
 type MacKeySeed = [u8; 32];
 
 /// Error type for the `StoreCipher` operations.
-#[derive(Debug, Display, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Failed to serialize a value {0}
+    /// Failed to serialize a value.
+    #[error("Failed to serialize a value: `{0}`")]
     Serialization(#[from] rmp_serde::encode::Error),
-    /// Failed to deserialize a value {0}
+
+    /// Failed to deserialize a value.
+    #[error("Failed to deserialize a value: `{0}`")]
     Deserialization(#[from] rmp_serde::decode::Error),
-    /// Failed to deserialize or serialize a JSON value {0}
+
+    /// Failed to deserialize or serialize a JSON value.
+    #[error("Failed to deserialize or serialize a JSON value: `{0}`")]
     Json(#[from] serde_json::Error),
-    /// Error encrypting or decrypting a value {0}
+
+    /// Error encrypting or decrypting a value.
+    #[error("Error encrypting or decrypting a value: `{0}`")]
     Encryption(#[from] EncryptionError),
-    /// Couldn't generate enough randomness for a cryptographic operation: {0}
+
+    /// Could not generate enough randomness for a cryptographic operation: {0}
+    #[error("Could not generate enough randomness for a cryptographic operation: `{0}`")]
     Random(#[from] RandomError),
-    /// Unsupported ciphertext version, expected {0}, got {1}
+
+    /// Unsupported ciphertext version.
+    #[error("Unsupported ciphertext version, expected `{0}`, got `{1}`")]
     Version(u8, u8),
-    /// The ciphertext had an invalid length, expected {0}, got {1}
+
+    /// The ciphertext had an invalid length.
+    #[error("The ciphertext had an invalid length, expected `{0}`, got `{1}`")]
     Length(usize, usize),
-    /**
-     * Failed to import a store cipher, the export used a passphrase while
-     * we're trying to import it using a key or vice-versa.
-     */
+
+    /// Failed to import a store cipher, the export used a passphrase while
+    /// we are trying to import it using a key or vice-versa.
+    #[error("Failed to import a store cipher, the export used a passphrase while we are trying to import it using a key or vice-versa")]
     KdfMismatch,
 }
 


### PR DESCRIPTION
This patch removes the `displaydoc` dependency. Why?

1. It creates a warning in rustc nightly:

```
warning: non-local `impl` definition, they should be avoided as they go against expectation
  --> crates/matrix-sdk-store-encryption/src/lib.rs:49:17
   |
49 | #[derive(Debug, Display, thiserror::Error)]
   |                 ^^^^^^^
   |
   = help: move this `impl` block outside the of the current constant `_DERIVE_Display_FOR_Error`
   = note: an `impl` definition is non-local if it is nested inside an item and may impact type checking outside of that item. This can be the case if neither the trait or the self type are at the same nesting level as the `impl`
   = note: one exception to the rule are anon-const (`const _: () = { ... }`) at top-level module and anon-const at the same nesting as the trait or type
   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
   = note: the derive macro `Display` may come from an old version of the `displaydoc` crate, try updating your dependency with `cargo update -p displaydoc`
   = note: `#[warn(non_local_definitions)]` on by default
   = note: this warning originates in the derive macro `Display` (in Nightly builds, run with -Z macro-backtrace for more info)
```

2. `thiserror` is already used, which seems to provide a similar issue.
3. That's less dependency, and less proc-macro, which will improve the compilation time in general.