### PR TITLE
event cache: handle blocking correctly

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -245,21 +245,6 @@ impl TimelineBuilder {
             .instrument(span)
         });
 
-        let mut ignore_user_list_stream = client.subscribe_to_ignore_user_list_changes();
-        let ignore_user_list_update_join_handle = spawn({
-            let inner = inner.clone();
-
-            let span = info_span!(parent: Span::none(), "ignore_user_list_update_handler", room_id = ?room.room_id());
-            span.follows_from(Span::current());
-
-            async move {
-                while ignore_user_list_stream.next().await.is_some() {
-                    inner.clear().await;
-                }
-            }
-            .instrument(span)
-        });
-
         // Not using room.add_event_handler here because RoomKey events are
         // to-device events that are not received in the context of a room.
 
@@ -321,7 +306,6 @@ impl TimelineBuilder {
                 client,
                 event_handler_handles: handles,
                 room_update_join_handle,
-                ignore_user_list_update_join_handle,
                 room_key_from_backups_join_handle,
                 _event_cache_drop_handle: event_cache_drop,
             }),

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -820,7 +820,6 @@ struct TimelineDropHandle {
     client: Client,
     event_handler_handles: Vec<EventHandlerHandle>,
     room_update_join_handle: JoinHandle<()>,
-    ignore_user_list_update_join_handle: JoinHandle<()>,
     room_key_from_backups_join_handle: JoinHandle<()>,
     _event_cache_drop_handle: Arc<EventCacheDropHandles>,
 }
@@ -831,7 +830,6 @@ impl Drop for TimelineDropHandle {
             self.client.remove_event_handler(handle);
         }
         self.room_update_join_handle.abort();
-        self.ignore_user_list_update_join_handle.abort();
         self.room_key_from_backups_join_handle.abort();
     }
 }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -229,7 +229,7 @@ async fn test_focused_timeline_reacts() {
     // to the $1 event.
     sync_response_builder.add_joined_room(JoinedRoomBuilder::new(room_id).add_timeline_bulk([
         // This event must be ignored.
-        f.text_msg("this is a sync event").sender(*ALICE).into_raw_sync(),
+        f.text_msg("this is a sync event").sender(*ALICE).into(),
         // This event must not be ignored.
         sync_timeline_event!({
             "content": {

--- a/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/subscribe.rs
@@ -18,7 +18,10 @@ use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt};
-use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
+use matrix_sdk::{
+    config::SyncSettings,
+    test_utils::{events::EventFactory, logged_in_client_with_server},
+};
 use matrix_sdk_test::{
     async_test, sync_timeline_event, EventBuilder, GlobalAccountDataTestEvent, JoinedRoomBuilder,
     SyncResponseBuilder, ALICE, BOB,
@@ -30,7 +33,7 @@ use ruma::{
         member::{MembershipState, RoomMemberEventContent},
         message::{MessageType, RoomMessageEventContent},
     },
-    room_id,
+    room_id, user_id,
 };
 use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
@@ -210,45 +213,22 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     let (_, timeline_stream) = timeline.subscribe().await;
     pin_mut!(timeline_stream);
 
-    let alice = "@alice:example.org";
-    let bob = "@bob:example.org";
+    let alice = user_id!("@alice:example.org");
+    let bob = user_id!("@bob:example.org");
 
     let first_event_id = event_id!("$YTQwYl2pl1");
     let second_event_id = event_id!("$YTQwYl2pl2");
     let third_event_id = event_id!("$YTQwYl2pl3");
 
+    let mut ev_factory = EventFactory::new().room(room_id);
+
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(sync_timeline_event!({
-                "content": {
-                    "body": "hello",
-                    "msgtype": "m.text",
-                },
-                "event_id": first_event_id,
-                "origin_server_ts": 152037280,
-                "sender": alice,
-                "type": "m.room.message",
-            }))
-            .add_timeline_event(sync_timeline_event!({
-                "content": {
-                    "body": "hello",
-                    "msgtype": "m.text",
-                },
-                "event_id": second_event_id,
-                "origin_server_ts": 152037281,
-                "sender": bob,
-                "type": "m.room.message",
-            }))
-            .add_timeline_event(sync_timeline_event!({
-                "content": {
-                    "body": "hello",
-                    "msgtype": "m.text",
-                },
-                "event_id": third_event_id,
-                "origin_server_ts": 152037282,
-                "sender": alice,
-                "type": "m.room.message",
-            })),
+            .add_timeline_event(ev_factory.text_msg("hello").sender(alice).event_id(first_event_id))
+            .add_timeline_event(ev_factory.text_msg("hello").sender(bob).event_id(second_event_id))
+            .add_timeline_event(
+                ev_factory.text_msg("hello").sender(alice).event_id(third_event_id),
+            ),
     );
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
@@ -272,9 +252,6 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     });
     assert_pending!(timeline_stream);
 
-    let fourth_event_id = event_id!("$YTQwYl2pl4");
-    let fiveth_event_id = event_id!("$YTQwYl2pl5");
-
     sync_builder.add_global_account_data_event(GlobalAccountDataTestEvent::Custom(json!({
         "content": {
             "ignored_users": {
@@ -292,28 +269,16 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
     assert_next_matches!(timeline_stream, VectorDiff::Clear);
     assert_pending!(timeline_stream);
 
+    let fourth_event_id = event_id!("$YTQwYl2pl4");
+    let fifth_event_id = event_id!("$YTQwYl2pl5");
+
+    // All the next events are sent by Alice now.
+    ev_factory = ev_factory.sender(alice);
+
     sync_builder.add_joined_room(
         JoinedRoomBuilder::new(room_id)
-            .add_timeline_event(sync_timeline_event!({
-                "content": {
-                    "body": "hello",
-                    "msgtype": "m.text",
-                },
-                "event_id": fourth_event_id,
-                "origin_server_ts": 152037283,
-                "sender": alice,
-                "type": "m.room.message",
-            }))
-            .add_timeline_event(sync_timeline_event!({
-                "content": {
-                    "body": "hello",
-                    "msgtype": "m.text",
-                },
-                "event_id": fiveth_event_id,
-                "origin_server_ts": 152037284,
-                "sender": alice,
-                "type": "m.room.message",
-            })),
+            .add_timeline_event(ev_factory.text_msg("hello").event_id(fourth_event_id))
+            .add_timeline_event(ev_factory.text_msg("hello").event_id(fifth_event_id)),
     );
 
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
@@ -328,7 +293,7 @@ async fn test_timeline_is_reset_when_a_user_is_ignored_or_unignored() {
         assert_eq!(value.as_event().unwrap().event_id(), Some(fourth_event_id));
     });
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
-        assert_eq!(value.as_event().unwrap().event_id(), Some(fiveth_event_id));
+        assert_eq!(value.as_event().unwrap().event_id(), Some(fifth_event_id));
     });
     assert_next_matches!(timeline_stream, VectorDiff::PushFront { value } => {
         assert!(value.is_day_divider());

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -48,6 +48,7 @@ use std::{
     time::Duration,
 };
 
+use eyeball::Subscriber;
 use matrix_sdk_base::{
     deserialized_responses::{AmbiguityChange, SyncTimelineEvent, TimelineEvent},
     sync::{JoinedRoomUpdate, LeftRoomUpdate, RoomUpdates, Timeline},
@@ -66,7 +67,7 @@ use tokio::{
     },
     time::timeout,
 };
-use tracing::{error, instrument, trace, warn};
+use tracing::{error, info_span, instrument, trace, warn, Instrument as _, Span};
 
 use self::{
     linked_chunk::ChunkContent,
@@ -118,6 +119,9 @@ pub type Result<T> = std::result::Result<T, EventCacheError>;
 pub struct EventCacheDropHandles {
     /// Task that listens to room updates.
     listen_updates_task: JoinHandle<()>,
+
+    /// Task that listens to updates to the user's ignored list.
+    ignore_user_list_update_task: JoinHandle<()>,
 }
 
 impl Debug for EventCacheDropHandles {
@@ -129,6 +133,7 @@ impl Debug for EventCacheDropHandles {
 impl Drop for EventCacheDropHandles {
     fn drop(&mut self) {
         self.listen_updates_task.abort();
+        self.ignore_user_list_update_task.abort();
     }
 }
 
@@ -172,14 +177,37 @@ impl EventCache {
 
         let _ = self.inner.drop_handles.get_or_init(|| {
             // Spawn the task that will listen to all the room updates at once.
-            let room_updates_feed = client.subscribe_to_all_room_updates();
-            let listen_updates_task =
-                spawn(Self::listen_task(self.inner.clone(), room_updates_feed));
+            let listen_updates_task = spawn(Self::listen_task(
+                self.inner.clone(),
+                client.subscribe_to_all_room_updates(),
+            ));
 
-            Arc::new(EventCacheDropHandles { listen_updates_task })
+            let ignore_user_list_update_task = spawn(Self::ignore_user_list_update_task(
+                self.inner.clone(),
+                client.subscribe_to_ignore_user_list_changes(),
+            ));
+
+            Arc::new(EventCacheDropHandles { listen_updates_task, ignore_user_list_update_task })
         });
 
         Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn ignore_user_list_update_task(
+        inner: Arc<EventCacheInner>,
+        mut ignore_user_list_stream: Subscriber<Vec<String>>,
+    ) {
+        let span = info_span!(parent: Span::none(), "ignore_user_list_update_task");
+        span.follows_from(Span::current());
+
+        async move {
+            while ignore_user_list_stream.next().await.is_some() {
+                inner.clear_all_rooms().await;
+            }
+        }
+        .instrument(span)
+        .await;
     }
 
     #[instrument(skip_all)]
@@ -209,20 +237,7 @@ impl EventCache {
                     // no way to reconcile at the moment!
                     // TODO: implement Smart Matching™,
                     warn!(num_skipped, "Lagged behind room updates, clearing all rooms");
-
-                    // Note: one must NOT clear the `by_room` map, because if something subscribed
-                    // to a room update, they would never get any new update for that room, since
-                    // re-creating the `RoomEventCache` would create a new unrelated sender.
-
-                    let rooms = inner.by_room.write().await;
-
-                    for room in rooms.values() {
-                        // Notify all the observers that we've lost track of state. (We ignore the
-                        // error if there aren't any.)
-                        let _ = room.inner.sender.send(RoomEventCacheUpdate::Clear);
-                        // Clear all the events in memory.
-                        room.inner.events.write().await.reset();
-                    }
+                    inner.clear_all_rooms().await;
                 }
 
                 Err(RecvError::Closed) => {
@@ -299,6 +314,22 @@ struct EventCacheInner {
 impl EventCacheInner {
     fn client(&self) -> Result<Client> {
         Ok(Client { inner: self.client.upgrade().ok_or(EventCacheError::ClientDropped)? })
+    }
+
+    /// Clears all the room's data.
+    async fn clear_all_rooms(&self) {
+        // Note: one must NOT clear the `by_room` map, because if something subscribed
+        // to a room update, they would never get any new update for that room, since
+        // re-creating the `RoomEventCache` would create a new unrelated sender.
+        let rooms = self.by_room.write().await;
+
+        for room in rooms.values() {
+            // Notify all the observers that we've lost track of state. (We ignore the
+            // error if there aren't any.)
+            let _ = room.inner.sender.send(RoomEventCacheUpdate::Clear);
+            // Clear all the events in memory.
+            room.inner.events.write().await.reset();
+        }
     }
 
     /// Handles a single set of room updates at once.

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -96,12 +96,12 @@ where
     }
 }
 
-impl<E: EventContent> Into<Raw<AnySyncTimelineEvent>> for EventBuilder<E>
+impl<E: EventContent> From<EventBuilder<E>> for Raw<AnySyncTimelineEvent>
 where
     E::EventType: Serialize,
 {
-    fn into(self) -> Raw<AnySyncTimelineEvent> {
-        self.into_raw_sync()
+    fn from(val: EventBuilder<E>) -> Self {
+        val.into_raw_sync()
     }
 }
 

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -96,6 +96,15 @@ where
     }
 }
 
+impl<E: EventContent> Into<Raw<AnySyncTimelineEvent>> for EventBuilder<E>
+where
+    E::EventType: Serialize,
+{
+    fn into(self) -> Raw<AnySyncTimelineEvent> {
+        self.into_raw_sync()
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct EventFactory {
     next_ts: AtomicU64,


### PR DESCRIPTION
This should "fix" ignoring/unignoring users, which had regressed likely since the introduction of the event cache.

This is still not perfect: in theory the sliding sync room cache should *also* be emptied every time we get an ignored/unignored change, but better to wait for https://github.com/matrix-org/matrix-rust-sdk/pull/3092 to land, instead of trying to work around it somewhere else.

Part of #3058, should help with https://github.com/element-hq/element-meta/issues/2382 too.