### PR TITLE
chore(ffi): Remove support for opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,40 +410,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
 dependencies = [
  "async-trait",
- "axum-core 0.4.3",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.1.0",
@@ -468,23 +440,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1675,7 +1630,7 @@ name = "example-oidc-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "axum 0.7.4",
+ "axum",
  "dirs",
  "futures-util",
  "matrix-sdk",
@@ -2432,18 +2387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.28",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,7 +3117,7 @@ dependencies = [
  "async-channel",
  "async-stream",
  "async-trait",
- "axum 0.7.4",
+ "axum",
  "backoff",
  "bytes",
  "bytesize",
@@ -3207,7 +3150,7 @@ dependencies = [
  "mime2ext",
  "once_cell",
  "rand",
- "reqwest 0.12.4",
+ "reqwest",
  "ruma",
  "serde",
  "serde_html_form",
@@ -3376,10 +3319,8 @@ dependencies = [
  "anyhow",
  "as_variant",
  "async-compat",
- "base64 0.22.0",
  "extension-trait",
  "eyeball-im",
- "futures-core",
  "futures-util",
  "language-tags",
  "log-panics",
@@ -3387,9 +3328,6 @@ dependencies = [
  "matrix-sdk-ui",
  "mime",
  "once_cell",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
  "paranoid-android",
  "ruma",
  "sanitize-filename-reader-friendly",
@@ -3401,7 +3339,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-core",
- "tracing-opentelemetry",
  "tracing-subscriber",
  "uniffi",
  "url",
@@ -3462,7 +3399,7 @@ dependencies = [
  "matrix-sdk-ui",
  "once_cell",
  "rand",
- "reqwest 0.12.4",
+ "reqwest",
  "serde_json",
  "stream_assert",
  "tempfile",
@@ -4017,52 +3954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbfa5308166ca861434f0b0913569579b8e587430a3d6bcd7fd671921ec145a"
-dependencies = [
- "async-trait",
- "bytes",
- "http 0.2.12",
- "opentelemetry",
- "reqwest 0.11.20",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
-dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "prost",
- "reqwest 0.11.20",
- "thiserror",
- "tokio",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
-dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
- "prost",
- "tonic",
-]
-
-[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4079,15 +3970,12 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
  "once_cell",
  "opentelemetry",
  "ordered-float",
  "percent-encoding",
  "rand",
  "thiserror",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -4849,40 +4737,6 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
@@ -4929,7 +4783,7 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg 0.52.0",
+ "winreg",
 ]
 
 [[package]]
@@ -6034,16 +5888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6179,33 +6023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.28",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6213,13 +6030,9 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
- "slab",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6331,10 +6144,8 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
- "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -7076,16 +6887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -24,17 +24,12 @@ vergen = { version = "8.1.3", features = ["build", "git", "gitcl"] }
 anyhow = { workspace = true }
 as_variant = { workspace = true }
 async-compat = "0.2.1"
-base64 = "0.22"
 eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
-futures-core = { workspace = true }
 futures-util = { workspace = true }
 matrix-sdk-ui = { workspace = true, features = ["e2e-encryption", "uniffi", "experimental-room-list-with-unified-invites"] }
 mime = "0.3.16"
 once_cell = { workspace = true }
-opentelemetry = "0.22.0"
-opentelemetry_sdk = { version = "0.22.0", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.15.0", features = ["tokio", "reqwest-client", "http-proto"] }
 ruma = { workspace = true, features = ["html", "unstable-unspecified", "unstable-msc3488", "compat-unset-avatar", "unstable-msc3245-v1-compat"] }
 sanitize-filename-reader-friendly = "2.2.1"
 serde = { workspace = true }
@@ -42,7 +37,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }
-tracing-opentelemetry = "0.23.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = { version = "0.2.2" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/bindings/matrix-sdk-ffi/README.md
+++ b/bindings/matrix-sdk-ffi/README.md
@@ -2,14 +2,6 @@
 
 This uses [`uniffi`](https://mozilla.github.io/uniffi-rs/Overview.html) to build the matrix bindings for native support and wasm-bindgen for web-browser assembly support. Please refer to the specific section to figure out how to build and use the bindings for your platform.
 
-# OpenTelemetry support
-
-The bindings have support for OpenTelemetry, allowing for the upload of traces to
-any OpenTelemetry collector. This support is provided through the
-[`opentelemetry`](https://docs.rs/opentelemetry/latest/opentelemetry/)
-crate, which requires the [`protoc`] binary to be installed during the build
-process.
-
 ## Platforms
 
 ### Swift/iOS sync

--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -1,11 +1,3 @@
-use std::{collections::HashMap, fmt::Debug, pin::Pin};
-
-use base64::{engine::general_purpose::STANDARD, Engine};
-use futures_core::future::BoxFuture;
-use opentelemetry::KeyValue;
-use opentelemetry_otlp::{Protocol, WithExportConfig};
-use opentelemetry_sdk::{runtime::RuntimeChannel, trace::Tracer, Resource};
-use tokio::runtime::Handle;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_core::Subscriber;
 use tracing_subscriber::{
@@ -15,78 +7,6 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
     EnvFilter, Layer,
 };
-
-use crate::RUNTIME;
-
-#[derive(Clone, Debug)]
-struct TokioRuntime {
-    runtime: Handle,
-}
-
-impl opentelemetry_sdk::runtime::Runtime for TokioRuntime {
-    type Interval = tokio_stream::wrappers::IntervalStream;
-    type Delay = Pin<Box<tokio::time::Sleep>>;
-
-    fn interval(&self, period: std::time::Duration) -> Self::Interval {
-        let _guard = self.runtime.enter();
-        tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(period))
-    }
-
-    fn spawn(&self, future: BoxFuture<'static, ()>) {
-        #[allow(clippy::let_underscore_future)]
-        let _ = self.runtime.spawn(future);
-    }
-
-    fn delay(&self, duration: std::time::Duration) -> Self::Delay {
-        let _guard = self.runtime.enter();
-        Box::pin(tokio::time::sleep(duration))
-    }
-}
-
-impl RuntimeChannel for TokioRuntime {
-    type Receiver<T: Debug + Send> = tokio_stream::wrappers::ReceiverStream<T>;
-    type Sender<T: Debug + Send> = tokio::sync::mpsc::Sender<T>;
-
-    fn batch_message_channel<T: Debug + Send>(
-        &self,
-        capacity: usize,
-    ) -> (Self::Sender<T>, Self::Receiver<T>) {
-        let (sender, receiver) = tokio::sync::mpsc::channel(capacity);
-        (sender, tokio_stream::wrappers::ReceiverStream::new(receiver))
-    }
-}
-
-pub fn create_otlp_tracer(
-    user: String,
-    password: String,
-    otlp_endpoint: String,
-    client_name: String,
-) -> anyhow::Result<Tracer> {
-    let runtime = RUNTIME.handle().to_owned();
-
-    let auth = STANDARD.encode(format!("{user}:{password}"));
-    let headers = HashMap::from([("Authorization".to_owned(), format!("Basic {auth}"))]);
-
-    let exporter = opentelemetry_otlp::new_exporter()
-        .http()
-        .with_protocol(Protocol::HttpBinary)
-        .with_endpoint(otlp_endpoint)
-        .with_headers(headers);
-
-    let tracer_runtime = TokioRuntime { runtime: runtime.to_owned() };
-
-    let _guard = runtime.enter();
-    let tracer = opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_exporter(exporter)
-        .with_trace_config(
-            opentelemetry_sdk::trace::config()
-                .with_resource(Resource::new(vec![KeyValue::new("service.name", client_name)])),
-        )
-        .install_batch(tracer_runtime)?;
-
-    Ok(tracer)
-}
 
 #[cfg(target_os = "android")]
 pub fn log_panics() {
@@ -270,39 +190,5 @@ pub fn setup_tracing(config: TracingConfiguration) {
     tracing_subscriber::registry()
         .with(EnvFilter::new(&config.filter))
         .with(text_layers(config))
-        .init();
-}
-
-#[derive(uniffi::Record)]
-pub struct OtlpTracingConfiguration {
-    client_name: String,
-    user: String,
-    password: String,
-    otlp_endpoint: String,
-    filter: String,
-    /// Controls whether to print to stdout or, equivalent, the system logs on
-    /// Android.
-    write_to_stdout_or_system: bool,
-    write_to_files: Option<TracingFileConfiguration>,
-}
-
-#[uniffi::export]
-pub fn setup_otlp_tracing(config: OtlpTracingConfiguration) {
-    #[cfg(target_os = "android")]
-    log_panics();
-
-    let otlp_tracer =
-        create_otlp_tracer(config.user, config.password, config.otlp_endpoint, config.client_name)
-            .expect("Couldn't configure the OpenTelemetry tracer");
-    let otlp_layer = tracing_opentelemetry::layer().with_tracer(otlp_tracer);
-
-    tracing_subscriber::registry()
-        .with(EnvFilter::new(&config.filter))
-        .with(text_layers(TracingConfiguration {
-            filter: config.filter,
-            write_to_stdout_or_system: config.write_to_stdout_or_system,
-            write_to_files: config.write_to_files,
-        }))
-        .with(otlp_layer)
         .init();
 }


### PR DESCRIPTION
This patch removes support for OpenTelemetry in `matrix-sdk-ffi` because it's not used anymore by anybody. It also adds multiple duplicated dependencies (like `reqwest`). Anyway. Farewell.

Removing opentelemetry removes axum 0.6.20, hyper-timeout, reqwest 0.11.20, tokio-timeout, tonic and winreg.