### PR TITLE
ffi: Added dehydrated flag to Device

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/device.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/device.rs
@@ -28,6 +28,8 @@ pub struct Device {
     /// The first time this device was seen in local timestamp, milliseconds
     /// since epoch.
     pub first_time_seen_ts: u64,
+    /// Whether or not the device is a dehydrated device.
+    pub dehydrated: bool,
 }
 
 impl From<InnerDevice> for Device {
@@ -42,6 +44,7 @@ impl From<InnerDevice> for Device {
             locally_trusted: d.is_locally_trusted(),
             cross_signing_trusted: d.is_cross_signing_trusted(),
             first_time_seen_ts: d.first_time_seen_ts().0.into(),
+            dehydrated: d.is_dehydrated(),
         }
     }
 }


### PR DESCRIPTION
Wanted to use dehydrated devices in our application and noticed the `dehydrated` flag is not exposed in the FFI bindings for use.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
