### PR TITLE
chore(crypto): Refactor the cross-signing key wrappers

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -785,7 +785,7 @@ impl Account {
     /// Sign the given Master Key
     pub fn sign_master_key(
         &self,
-        master_key: MasterPubkey,
+        master_key: &MasterPubkey,
     ) -> Result<SignatureUploadRequest, SignatureError> {
         let public_key =
             master_key.get_first_key().ok_or(SignatureError::MissingSigningKey)?.to_base64().into();

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -662,6 +662,8 @@ impl PrivateCrossSigningIdentity {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use matrix_sdk_test::async_test;
     use ruma::{device_id, user_id, CanonicalJsonValue, DeviceKeyAlgorithm, DeviceKeyId, UserId};
     use serde_json::json;
@@ -810,7 +812,7 @@ mod tests {
             "We're only uploading our own signature"
         );
 
-        bob_public.master_key = master.try_into().unwrap();
+        bob_public.master_key = Arc::new(master.try_into().unwrap());
 
         user_signing.public_key.verify_master_key(bob_public.master_key()).unwrap();
     }

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/master.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/master.rs
@@ -144,7 +144,7 @@ impl TryFrom<CrossSigningKey> for MasterPubkey {
 
     fn try_from(key: CrossSigningKey) -> Result<Self, Self::Error> {
         if key.usage.contains(&KeyUsage::Master) && key.usage.len() == 1 {
-            Ok(Self(key.into()))
+            Ok(Self(key))
         } else {
             Err(serde::de::Error::custom(format!(
                 "Expected cross signing key usage {} was not found",

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/master.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/master.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::btree_map::Iter, sync::Arc};
+use std::collections::btree_map::Iter;
 
 use ruma::{encryption::KeyUsage, DeviceKeyId, OwnedDeviceKeyId, UserId};
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,7 @@ use crate::{
 /// user signing keys of an user will be signed by their master key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "CrossSigningKey")]
-pub struct MasterPubkey(pub(super) Arc<CrossSigningKey>);
+pub struct MasterPubkey(pub(super) CrossSigningKey);
 
 impl MasterPubkey {
     /// Get the user id of the master key's owner.
@@ -130,6 +130,12 @@ impl<'a> IntoIterator for &'a MasterPubkey {
 impl AsRef<CrossSigningKey> for MasterPubkey {
     fn as_ref(&self) -> &CrossSigningKey {
         &self.0
+    }
+}
+
+impl AsMut<CrossSigningKey> for MasterPubkey {
+    fn as_mut(&mut self) -> &mut CrossSigningKey {
+        &mut self.0
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/self_signing.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/self_signing.rs
@@ -70,7 +70,7 @@ impl TryFrom<CrossSigningKey> for SelfSigningPubkey {
 
     fn try_from(key: CrossSigningKey) -> Result<Self, Self::Error> {
         if key.usage.contains(&KeyUsage::SelfSigning) && key.usage.len() == 1 {
-            Ok(Self(key.into()))
+            Ok(Self(key))
         } else {
             Err(serde::de::Error::custom(format!(
                 "Expected cross signing key usage {} was not found",

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/self_signing.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/self_signing.rs
@@ -1,4 +1,4 @@
-use std::{collections::btree_map::Iter, sync::Arc};
+use std::collections::btree_map::Iter;
 
 use ruma::{encryption::KeyUsage, OwnedDeviceKeyId, UserId};
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,7 @@ use crate::{
 /// Self signing keys are used to sign the user's own devices.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "CrossSigningKey")]
-pub struct SelfSigningPubkey(pub(super) Arc<CrossSigningKey>);
+pub struct SelfSigningPubkey(pub(super) CrossSigningKey);
 
 impl SelfSigningPubkey {
     /// Get the user id of the self signing key's owner.
@@ -83,5 +83,11 @@ impl TryFrom<CrossSigningKey> for SelfSigningPubkey {
 impl AsRef<CrossSigningKey> for SelfSigningPubkey {
     fn as_ref(&self) -> &CrossSigningKey {
         &self.0
+    }
+}
+
+impl AsMut<CrossSigningKey> for SelfSigningPubkey {
+    fn as_mut(&mut self) -> &mut CrossSigningKey {
+        &mut self.0
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/user_signing.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/user_signing.rs
@@ -1,4 +1,4 @@
-use std::{collections::btree_map::Iter, sync::Arc};
+use std::collections::btree_map::Iter;
 
 use ruma::{encryption::KeyUsage, OwnedDeviceKeyId, UserId};
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use crate::{olm::VerifyJson, types::SigningKeys, SignatureError};
 /// User signing keys are used to sign the master keys of other users.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "CrossSigningKey")]
-pub struct UserSigningPubkey(pub(super) Arc<CrossSigningKey>);
+pub struct UserSigningPubkey(pub(super) CrossSigningKey);
 
 impl UserSigningPubkey {
     /// Get the user id of the user signing key's owner.
@@ -73,8 +73,15 @@ impl TryFrom<CrossSigningKey> for UserSigningPubkey {
         }
     }
 }
+
 impl AsRef<CrossSigningKey> for UserSigningPubkey {
     fn as_ref(&self) -> &CrossSigningKey {
         &self.0
+    }
+}
+
+impl AsMut<CrossSigningKey> for UserSigningPubkey {
+    fn as_mut(&mut self) -> &mut CrossSigningKey {
+        &mut self.0
     }
 }

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/user_signing.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/user_signing.rs
@@ -64,7 +64,7 @@ impl TryFrom<CrossSigningKey> for UserSigningPubkey {
 
     fn try_from(key: CrossSigningKey) -> Result<Self, Self::Error> {
         if key.usage.contains(&KeyUsage::UserSigning) && key.usage.len() == 1 {
-            Ok(Self(key.into()))
+            Ok(Self(key))
         } else {
             Err(serde::de::Error::custom(format!(
                 "Expected cross signing key usage {} was not found",


### PR DESCRIPTION
Since the master/self-signing/user-signing public key types are used for public user identities as well as for the private key type we have, and we'd like to sign the public key types it makes sense that the types itself aren't using an Arc.

Let's instead put the Arc inside the user identity structs.

This will allow us later on to more easily sign the public key types.