### PR TITLE
ci: Bump version of rust nightly

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-02-06
+        toolchain: nightly-2024-05-09
         components: rustfmt
 
     - name: Run Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,7 +278,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-06
+          toolchain: nightly-2024-05-09
           components: rustfmt
 
       - name: Cargo fmt
@@ -315,7 +315,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-06
+          toolchain: nightly-2024-05-09
           components: clippy
 
       - name: Load cache

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-06
+          toolchain: nightly-2024-05-09
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -49,7 +49,7 @@ features = ["crypto-store"]
 
 [dependencies.tokio]
 version = "1.33.0"
-default_features = false
+default-features = false
 features = ["rt-multi-thread"]
 
 [build-dependencies]

--- a/crates/matrix-sdk-base/build.rs
+++ b/crates/matrix-sdk-base/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Prevent unnecessary rerunning of this build script
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Prevent nightly CI from erroring on tarpaulin_include attribute
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin_include)");
+}

--- a/crates/matrix-sdk-common/build.rs
+++ b/crates/matrix-sdk-common/build.rs
@@ -1,6 +1,12 @@
 use std::{env, process};
 
 fn main() {
+    // Prevent unnecessary rerunning of this build script
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Prevent nightly CI from erroring on tarpaulin_include attribute
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin_include)");
+
     let is_wasm = env::var_os("CARGO_CFG_TARGET_ARCH").is_some_and(|arch| arch == "wasm32");
     if is_wasm && env::var_os("CARGO_FEATURE_JS").is_none() {
         eprintln!(

--- a/crates/matrix-sdk-crypto/build.rs
+++ b/crates/matrix-sdk-crypto/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Prevent unnecessary rerunning of this build script
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Prevent nightly CI from erroring on tarpaulin_include attribute
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin_include)");
+}

--- a/crates/matrix-sdk-indexeddb/build.rs
+++ b/crates/matrix-sdk-indexeddb/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Prevent unnecessary rerunning of this build script
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Prevent nightly CI from erroring on tarpaulin_include attribute
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin_include)");
+}

--- a/crates/matrix-sdk-sqlite/build.rs
+++ b/crates/matrix-sdk-sqlite/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Prevent unnecessary rerunning of this build script
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Prevent nightly CI from erroring on tarpaulin_include attribute
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin_include)");
+}

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -20,6 +20,9 @@ rustls-tls = ["matrix-sdk/rustls-tls"]
 
 uniffi = ["dep:uniffi", "matrix-sdk/uniffi", "matrix-sdk-base/uniffi"]
 
+# Add support for encrypted extensible events.
+unstable-msc3956 = ["ruma/unstable-msc3956"]
+
 [dependencies]
 as_variant = { workspace = true }
 async_cell = "0.2.2"

--- a/crates/matrix-sdk-ui/build.rs
+++ b/crates/matrix-sdk-ui/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Prevent unnecessary rerunning of this build script
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Prevent nightly CI from erroring on tarpaulin_include attribute
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin_include)");
+}

--- a/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
@@ -133,9 +133,9 @@ impl DayDividerAdjuster {
         // Then check invariants.
         if let Some(report) = self.check_invariants(items, initial_state) {
             warn!("Errors encountered when checking invariants.");
-            #[cfg(any(debug, test))]
+            #[cfg(any(debug_assertions, test))]
             panic!("{report}");
-            #[cfg(not(any(debug, test)))]
+            #[cfg(not(any(debug_assertions, test)))]
             warn!("{report}");
         }
 

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -844,7 +844,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         }
     }
 
-    #[cfg(any(test, feature = "testing"))]
+    #[cfg(test)]
     pub(super) async fn set_fully_read_event(&self, fully_read_event_id: OwnedEventId) {
         self.state.write().await.set_fully_read_event(fully_read_event_id);
     }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -122,14 +122,14 @@ optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.3.0", features = ["futures"] }
-reqwest = { version = "0.12.4", default_features = false }
+reqwest = { version = "0.12.4", default-features = false }
 tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 backoff = { version = "0.4.0", features = ["tokio"] }
 # only activate reqwest's stream feature on non-wasm, the wasm part seems to not
 # support *sending* streams, which makes it useless for us.
-reqwest = { version = "0.12.4", default_features = false, features = ["stream"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["stream"] }
 tokio = { workspace = true, features = ["fs", "rt", "macros"] }
 tokio-util = "0.7.9"
 wiremock = { workspace = true, optional = true }

--- a/crates/matrix-sdk/build.rs
+++ b/crates/matrix-sdk/build.rs
@@ -19,6 +19,12 @@ fn ensure(cond: bool, err: &str) {
 }
 
 fn main() {
+    // Prevent unnecessary rerunning of this build script
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Prevent nightly CI from erroring on tarpaulin_include attribute
+    println!("cargo:rustc-check-cfg=cfg(tarpaulin_include)");
+
     let native_tls_set = env_is_set("CARGO_FEATURE_NATIVE_TLS");
     let rustls_tls_set = env_is_set("CARGO_FEATURE_RUSTLS_TLS");
     ensure(

--- a/crates/matrix-sdk/src/sliding_sync/README.md
+++ b/crates/matrix-sdk/src/sliding_sync/README.md
@@ -131,13 +131,13 @@ in two additional full-sync-modes, which require additional configuration:
 ## Rooms
 
 Next to the room list, the details for rooms are the next important aspect.
-Each [list](#lists) only references the [`OwnedRoomId`][ruma::OwnedRoomId]
-of the room at the given position. The details (`required_state`s and
-timeline items) requested by all lists are bundled, together with the common
-details (e.g. whether it is a `dm` or its calculated name) and made
-available on the Sliding Sync session struct as a [reactive](#reactive-api)
-through [`.get_all_rooms`](SlidingSync::get_all_rooms), [`get_room`](SlidingSync::get_room)
-and [`get_rooms`](SlidingSync::get_rooms) APIs.
+Each [list](#lists) only references the [`OwnedRoomId`] of the room at the given
+position. The details (`required_state`s and timeline items) requested by all
+lists are bundled, together with the common details (e.g. whether it is a `dm`
+or its calculated name) and made available on the Sliding Sync session struct as
+a [reactive](#reactive-api) through [`.get_all_rooms`](SlidingSync::get_all_rooms),
+[`get_room`](SlidingSync::get_room) and [`get_rooms`](SlidingSync::get_rooms)
+APIs.
 
 Notably, this map only knows about the rooms that have come down [Sliding
 Sync protocol][MSC] and if the given room isn't in any active list range, it

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,7 +11,7 @@ use kotlin::KotlinArgs;
 use swift::SwiftArgs;
 use xshell::cmd;
 
-const NIGHTLY: &str = "nightly-2024-02-06";
+const NIGHTLY: &str = "nightly-2024-05-09";
 
 type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 


### PR DESCRIPTION
Includes fixes for:

- Warnings when using `default_features` instead of `default-features` in `Cargo.toml`: Cargo says that it will not be supported anymore in the upcoming 2024 edition
- Errors with `cfg` options: Cargo now [checks cfgs at compile-time](https://blog.rust-lang.org/2024/05/06/check-cfg.html), which means that custom options need to be declared in build scripts. It also detects cargo features used in code that do not exist in the manifest.