### PR TITLE
ui: Expose message mentions

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -477,6 +477,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 in_reply_to: msg.in_reply_to.clone(),
                 thread_root: msg.thread_root.clone(),
                 edited: true,
+                mentions: replacement.new_content.mentions,
             });
 
             let edit_json = match &this.ctx.flow {

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -27,7 +27,7 @@ use ruma::{
             SyncRoomMessageEvent,
         },
         AnyMessageLikeEventContent, AnySyncMessageLikeEvent, AnyTimelineEvent,
-        BundledMessageLikeRelations,
+        BundledMessageLikeRelations, Mentions,
     },
     html::RemoveReplyFallback,
     OwnedEventId, OwnedUserId, RoomVersionId, UserId,
@@ -52,6 +52,7 @@ pub struct Message {
     /// Event ID of the thread root, if this is a threaded message.
     pub(in crate::timeline) thread_root: Option<OwnedEventId>,
     pub(in crate::timeline) edited: bool,
+    pub(in crate::timeline) mentions: Option<Mentions>,
 }
 
 impl Message {
@@ -94,11 +95,11 @@ impl Message {
             _ => None,
         });
 
-        let msgtype = match edit {
+        let (msgtype, mentions) = match edit {
             Some(mut e) => {
                 // Edit's content is never supposed to contain the reply fallback.
                 e.new_content.msgtype.sanitize(DEFAULT_SANITIZER_MODE, RemoveReplyFallback::No);
-                e.new_content.msgtype
+                (e.new_content.msgtype, e.new_content.mentions)
             }
             None => {
                 let remove_reply_fallback = if in_reply_to.is_some() {
@@ -109,11 +110,11 @@ impl Message {
 
                 let mut msgtype = c.msgtype;
                 msgtype.sanitize(DEFAULT_SANITIZER_MODE, remove_reply_fallback);
-                msgtype
+                (msgtype, c.mentions)
             }
         };
 
-        Self { msgtype, in_reply_to, thread_root, edited }
+        Self { msgtype, in_reply_to, thread_root, edited, mentions }
     }
 
     /// Get the `msgtype`-specific data of this message.
@@ -142,6 +143,11 @@ impl Message {
     /// `false`).
     pub fn is_edited(&self) -> bool {
         self.edited
+    }
+
+    /// Get the mentions of this message.
+    pub fn mentions(&self) -> Option<&Mentions> {
+        self.mentions.as_ref()
     }
 
     pub(in crate::timeline) fn to_content(&self) -> RoomMessageEventContent {
@@ -192,7 +198,7 @@ fn make_relates_to(
 #[cfg(not(tarpaulin_include))]
 impl fmt::Debug for Message {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { msgtype: _, in_reply_to, thread_root, edited } = self;
+        let Self { msgtype: _, in_reply_to, thread_root, edited, mentions: _ } = self;
         // since timeline items are logged, don't include all fields here so
         // people don't leak personal data in bug reports
         f.debug_struct("Message")

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -419,7 +419,7 @@ impl Timeline {
             });
 
         let content = new_content.make_replacement(
-            ReplacementMetadata::new(event_id.to_owned(), None),
+            ReplacementMetadata::new(event_id.to_owned(), original_content.mentions.clone()),
             replied_to_message.as_ref(),
         );
 


### PR DESCRIPTION
Our main use case for this in Fractal is to check if there is a intentional room mention in the message to see if we need to try to look for `@room` in the text to replace it with a visual aid.

This has another benefit for edits: the users that were mentioned in the original event are not supposed to be mentioned again when sending an edit. Ruma takes care of that, but only if the original mentions are provided, which is now the case.

I didn't add the mentions in `Message::to_content()` because in both cases where it the method is called it would be unused.