### PR TITLE
ci: use the latest synapse-service image with msc3266

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
       # tests need a synapse: this is a service and not michaelkaye/setup-matrix-synapse@main as the
       # latter does not provide networking for services to communicate with it.
       synapse:
-        image: ghcr.io/matrix-org/synapse-service:v1.94.0 # keep in sync with ./coverage.yml
+        image: ghcr.io/matrix-org/synapse-service:5b6a75935e560945f69af72e9768bbaac10c9b4f # keep in sync with ./coverage.yml
         env:
             SYNAPSE_COMPLEMENT_DATABASE: sqlite
             SERVER_NAME: synapse

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,7 +62,7 @@ jobs:
       # tests need a synapse: this is a service and not michaelkaye/setup-matrix-synapse@main as the
       # latter does not provide networking for services to communicate with it.
       synapse:
-        image: ghcr.io/matrix-org/synapse-service:v1.94.0 # keep in sync with ./ci.yml
+        image: ghcr.io/matrix-org/synapse-service:5b6a75935e560945f69af72e9768bbaac10c9b4f # keep in sync with ./ci.yml
         env:
             SYNAPSE_COMPLEMENT_DATABASE: sqlite
             SERVER_NAME: synapse

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -1169,18 +1169,7 @@ async fn get_room_preview_with_room_summary(
     public_no_history_room_id: &RoomId,
 ) {
     // Alice has joined the room, so they get the full details.
-    let preview = match RoomPreview::from_room_summary(alice, room_id).await {
-        Ok(r) => r,
-        Err(err) => {
-            if let Some(client_api_error) = err.as_client_api_error() {
-                if client_api_error.status_code == 404 {
-                    warn!("Skipping the room summary test, because the server may not support it.");
-                    return;
-                }
-            }
-            panic!("{err}");
-        }
-    };
+    let preview = RoomPreview::from_room_summary(alice, room_id).await.unwrap();
 
     assert_room_preview(&preview, room_alias);
     assert_eq!(preview.state, Some(RoomState::Joined));


### PR DESCRIPTION
And re-enable the room preview test in integration testing.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3340 (although it doesn't use a standard synapse image, it makes it so that we don't need such a thing).