### PR TITLE
ui: Make Timeline::edit take a RoomMessageEventContentWithoutRelation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4861,9 +4861,9 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8904dcb0cc45d1d2f85e1a392047511ad8633983fd9f52db9d7943730b68d9c"
+checksum = "3a555b3e7ca84892ef6e81eadb42c783b76ffb939d6ad9781a9da7023a501521"
 dependencies = [
  "assign",
  "js_int",
@@ -4935,9 +4935,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ae020edde67e865afa9fcc21bf3fe8ac63e346f218a57ed094f7cc17766596"
+checksum = "fddef15eca0faee500016850a8473fb8c07b17b056b2ae5352ef67cf917102e3"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ http = "1.1.0"
 imbl = "2.0.0"
 itertools = "0.12.0"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { version = "0.10.0", features = [
+ruma = { version = "0.10.1", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -444,7 +444,7 @@ impl Timeline {
         edit_item: Arc<EventTimelineItem>,
     ) -> Result<(), ClientError> {
         self.inner
-            .edit((*new_content).clone().with_relation(None), &edit_item.0)
+            .edit((*new_content).clone(), &edit_item.0)
             .await
             .map_err(|err| anyhow::anyhow!(err))?;
         Ok(())

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -1,0 +1,9 @@
+# unreleased
+
+Breaking changes:
+
+- `Timeline::edit` now takes a `RoomMessageEventContentWithoutRelation`.
+
+# 0.7.0
+
+Initial release

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -46,7 +46,7 @@ use ruma::{
         room::{
             message::{
                 AddMentions, ForwardThread, OriginalRoomMessageEvent, ReplacementMetadata,
-                RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
+                RoomMessageEventContentWithoutRelation,
             },
             redaction::RoomRedactionEventContent,
         },
@@ -386,7 +386,7 @@ impl Timeline {
     #[instrument(skip(self, new_content))]
     pub async fn edit(
         &self,
-        new_content: RoomMessageEventContent,
+        new_content: RoomMessageEventContentWithoutRelation,
         edit_item: &EventTimelineItem,
     ) -> Result<(), UnsupportedEditItem> {
         // Early returns here must be in sync with

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -33,7 +33,7 @@ use ruma::{
         relation::InReplyTo,
         room::message::{
             MessageType, Relation, ReplacementMetadata, RoomMessageEventContent,
-            TextMessageEventContent,
+            RoomMessageEventContentWithoutRelation, TextMessageEventContent,
         },
     },
     room_id, user_id,
@@ -202,7 +202,7 @@ async fn test_send_edit() {
         .await;
 
     timeline
-        .edit(RoomMessageEventContent::text_plain("Hello, Room!"), &hello_world_item)
+        .edit(RoomMessageEventContentWithoutRelation::text_plain("Hello, Room!"), &hello_world_item)
         .await
         .unwrap();
 
@@ -288,7 +288,10 @@ async fn test_send_reply_edit() {
         .mount(&server)
         .await;
 
-    timeline.edit(RoomMessageEventContent::text_plain("Hello, Room!"), &reply_item).await.unwrap();
+    timeline
+        .edit(RoomMessageEventContentWithoutRelation::text_plain("Hello, Room!"), &reply_item)
+        .await
+        .unwrap();
 
     let edit_item =
         assert_next_matches!(timeline_stream, VectorDiff::Set { index: 1, value } => value);

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -531,7 +531,7 @@ async fn test_room_notification_count() -> Result<()> {
     bob_room
         .send(
             RoomMessageEventContent::text_plain("Hello my dear friend Alice!")
-                .set_mentions(Mentions::with_user_ids([alice.user_id().unwrap().to_owned()])),
+                .add_mentions(Mentions::with_user_ids([alice.user_id().unwrap().to_owned()])),
         )
         .await?;
 
@@ -658,7 +658,7 @@ async fn test_room_notification_count() -> Result<()> {
     bob_room
         .send(
             RoomMessageEventContent::text_plain("Why, hello there Alice!")
-                .set_mentions(Mentions::with_user_ids([alice.user_id().unwrap().to_owned()])),
+                .add_mentions(Mentions::with_user_ids([alice.user_id().unwrap().to_owned()])),
         )
         .await?;
 


### PR DESCRIPTION
That way the API is closer to that of `send_reply`.

- [x] Public API changes documented in changelogs (optional)
