### PR TITLE
room preview: allow passing through a list of servers to discover a room with MSC3266

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_preview.rs
+++ b/bindings/matrix-sdk-ffi/src/room_preview.rs
@@ -1,5 +1,5 @@
 use matrix_sdk::{room_preview::RoomPreview as SdkRoomPreview, RoomState};
-use ruma::{space::SpaceRoomJoinRule, OwnedRoomId};
+use ruma::space::SpaceRoomJoinRule;
 
 /// The preview of a room, be it invited/joined/left, or not.
 #[derive(uniffi::Record)]
@@ -31,9 +31,9 @@ pub struct RoomPreview {
 }
 
 impl RoomPreview {
-    pub(crate) fn from_sdk(room_id: OwnedRoomId, preview: SdkRoomPreview) -> Self {
+    pub(crate) fn from_sdk(preview: SdkRoomPreview) -> Self {
         Self {
-            room_id: room_id.to_string(),
+            room_id: preview.room_id.to_string(),
             canonical_alias: preview.canonical_alias.map(|alias| alias.to_string()),
             name: preview.name,
             topic: preview.topic,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -946,13 +946,19 @@ impl Client {
     /// they've joined/left/been invited to it) or not.
     pub async fn get_room_preview(
         &self,
-        room_id: &RoomId,
+        room_or_alias_id: &RoomOrAliasId,
         via: Vec<OwnedServerName>,
     ) -> Result<RoomPreview> {
-        if let Some(room) = self.get_room(room_id) {
+        let room_id = match <&RoomId>::try_from(room_or_alias_id) {
+            Ok(room_id) => room_id.to_owned(),
+            Err(alias) => self.resolve_room_alias(alias).await?.room_id,
+        };
+
+        if let Some(room) = self.get_room(&room_id) {
             return Ok(RoomPreview::from_known(&room));
         }
-        RoomPreview::from_unknown(self, room_id, via).await
+
+        RoomPreview::from_unknown(self, room_id, room_or_alias_id, via).await
     }
 
     /// Resolve a room alias to a room id and a list of servers which know

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -944,11 +944,15 @@ impl Client {
 
     /// Gets the preview of a room, whether the current user knows it (because
     /// they've joined/left/been invited to it) or not.
-    pub async fn get_room_preview(&self, room_id: &RoomId) -> Result<RoomPreview> {
+    pub async fn get_room_preview(
+        &self,
+        room_id: &RoomId,
+        via: Vec<OwnedServerName>,
+    ) -> Result<RoomPreview> {
         if let Some(room) = self.get_room(room_id) {
             return Ok(RoomPreview::from_known(&room));
         }
-        RoomPreview::from_unknown(self, room_id).await
+        RoomPreview::from_unknown(self, room_id, via).await
     }
 
     /// Resolve a room alias to a room id and a list of servers which know

--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -24,7 +24,7 @@ use ruma::{
     events::room::{history_visibility::HistoryVisibility, join_rules::JoinRule},
     room::RoomType,
     space::SpaceRoomJoinRule,
-    OwnedMxcUri, OwnedRoomAliasId, OwnedServerName, RoomId,
+    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedServerName, RoomId, RoomOrAliasId,
 };
 use tokio::try_join;
 use tracing::{instrument, warn};
@@ -34,6 +34,12 @@ use crate::{Client, Room};
 /// The preview of a room, be it invited/joined/left, or not.
 #[derive(Debug)]
 pub struct RoomPreview {
+    /// The actual room id for this room.
+    ///
+    /// Remember the room preview can be fetched from a room alias id, so we
+    /// might not know ahead of time what the room id is.
+    pub room_id: OwnedRoomId,
+
     /// The canonical alias for the room.
     pub canonical_alias: Option<OwnedRoomAliasId>,
 
@@ -76,6 +82,7 @@ impl RoomPreview {
         state: Option<RoomState>,
     ) -> Self {
         RoomPreview {
+            room_id: room_info.room_id().to_owned(),
             canonical_alias: room_info.canonical_alias().map(ToOwned::to_owned),
             name: room_info.name().map(ToOwned::to_owned),
             topic: room_info.topic().map(ToOwned::to_owned),
@@ -110,12 +117,13 @@ impl RoomPreview {
     #[instrument(skip(client))]
     pub(crate) async fn from_unknown(
         client: &Client,
-        room_id: &RoomId,
+        room_id: OwnedRoomId,
+        room_or_alias_id: &RoomOrAliasId,
         via: Vec<OwnedServerName>,
     ) -> crate::Result<Self> {
         // Use the room summary endpoint, if available, as described in
         // https://github.com/deepbluev7/matrix-doc/blob/room-summaries/proposals/3266-room-summary.md
-        match Self::from_room_summary(client, room_id, via).await {
+        match Self::from_room_summary(client, room_id.clone(), room_or_alias_id, via).await {
             Ok(res) => return Ok(res),
             Err(err) => {
                 warn!("error when previewing room from the room summary endpoint: {err}");
@@ -127,7 +135,7 @@ impl RoomPreview {
         // - then use a public room filter set to this room id
 
         // Resort to using the room state endpoint, as well as the joined members one.
-        Self::from_state_events(client, room_id).await
+        Self::from_state_events(client, &room_id).await
     }
 
     /// Get a [`RoomPreview`] using MSC3266, if available on the remote server.
@@ -138,11 +146,12 @@ impl RoomPreview {
     /// `Client::get_room_preview` in general over this.
     pub async fn from_room_summary(
         client: &Client,
-        room_id: &RoomId,
+        room_id: OwnedRoomId,
+        room_or_alias_id: &RoomOrAliasId,
         via: Vec<OwnedServerName>,
     ) -> crate::Result<Self> {
         let request = ruma::api::client::room::get_summary::msc3266::Request::new(
-            room_id.to_owned().into(),
+            room_or_alias_id.to_owned(),
             via,
         );
 
@@ -151,13 +160,14 @@ impl RoomPreview {
         // The server returns a `Left` room state for rooms the user has not joined. Be
         // more precise than that, and set it to `None` if we haven't joined
         // that room.
-        let state = if client.get_room(room_id).is_none() {
+        let state = if client.get_room(&room_id).is_none() {
             None
         } else {
             response.membership.map(|membership| RoomState::from(&membership))
         };
 
         Ok(RoomPreview {
+            room_id,
             canonical_alias: response.canonical_alias,
             name: response.name,
             topic: response.topic,

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -1118,7 +1118,7 @@ async fn test_room_preview() -> Result<()> {
     {
         // Dummy test for `Client::get_room_preview` which may call one or the other
         // methods.
-        let preview = alice.get_room_preview(room_id).await.unwrap();
+        let preview = alice.get_room_preview(room_id, Vec::new()).await.unwrap();
         assert_room_preview(&preview, &room_alias);
         assert_eq!(preview.state, Some(RoomState::Joined));
     }
@@ -1169,20 +1169,21 @@ async fn get_room_preview_with_room_summary(
     public_no_history_room_id: &RoomId,
 ) {
     // Alice has joined the room, so they get the full details.
-    let preview = RoomPreview::from_room_summary(alice, room_id).await.unwrap();
+    let preview = RoomPreview::from_room_summary(alice, room_id, Vec::new()).await.unwrap();
 
     assert_room_preview(&preview, room_alias);
     assert_eq!(preview.state, Some(RoomState::Joined));
 
     // Bob definitely doesn't know about the room, but they can get a preview of the
     // room too.
-    let preview = RoomPreview::from_room_summary(bob, room_id).await.unwrap();
+    let preview = RoomPreview::from_room_summary(bob, room_id, Vec::new()).await.unwrap();
     assert_room_preview(&preview, room_alias);
     assert!(preview.state.is_none());
 
     // Bob can preview the second room with the room summary (because its join rule
     // is set to public, or because Alice is a member of that room).
-    let preview = RoomPreview::from_room_summary(bob, public_no_history_room_id).await.unwrap();
+    let preview =
+        RoomPreview::from_room_summary(bob, public_no_history_room_id, Vec::new()).await.unwrap();
     assert_eq!(preview.name.unwrap(), "Alice's Room 2");
     assert!(preview.state.is_none());
 }


### PR DESCRIPTION
Fixes #3395.