### PR TITLE
xtask: Allow passing multiple targets to Swift's build-framework.

### DIFF
--- a/.github/workflows/bindings_ci.yml
+++ b/.github/workflows/bindings_ci.yml
@@ -108,4 +108,4 @@ jobs:
         run: swift test
 
       - name: Build Framework
-        run: target/debug/xtask swift build-framework --only-target=aarch64-apple-ios
+        run: target/debug/xtask swift build-framework --target=aarch64-apple-ios


### PR DESCRIPTION
Currently `cargo xtask swift build-framework` lets us either build a single target, or all supported targets. This PR allows to pass `--target triple-1 --target triple2` to build a subset of the supported targets.