### PR TITLE
ui: Take a `PathBuf` to send an attachment

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -1,0 +1,10 @@
+# unreleased
+
+Breaking changes:
+
+- `Timeline::send_attachment` now takes an `impl Into<PathBuf>` for the path of
+  the file to send.
+
+# 0.7.0
+
+Initial release

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! See [`Timeline`] for details.
 
-use std::{pin::Pin, sync::Arc, task::Poll};
+use std::{path::PathBuf, pin::Pin, sync::Arc, task::Poll};
 
 use eyeball::SharedObservable;
 use eyeball_im::VectorDiff;
@@ -542,7 +542,7 @@ impl Timeline {
     ///
     /// # Arguments
     ///
-    /// * `filename` - The filename of the file to be sent
+    /// * `path` - The path of the file to be sent
     ///
     /// * `mime_type` - The attachment's mime type
     ///
@@ -553,11 +553,11 @@ impl Timeline {
     #[instrument(skip_all)]
     pub fn send_attachment(
         &self,
-        filename: String,
+        path: impl Into<PathBuf>,
         mime_type: Mime,
         config: AttachmentConfig,
     ) -> SendAttachment<'_> {
-        SendAttachment::new(self, filename, mime_type, config)
+        SendAttachment::new(self, path.into(), mime_type, config)
     }
 
     /// Retry sending a message that previously failed to send.


### PR DESCRIPTION
I found the previous API confusing. Firstly, the parameter name was "filename" when we want a file path. Secondly, we take a `String` when we want a `Path` (or `PathBuf` to get an owned value here).

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)
