### PR TITLE
chore: Bump the vodozemac version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6529,13 +6529,13 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vodozemac"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9858e8b8ff262b4eb95854af3810283f563c9149682b9a2cf85dd003ff912b5c"
+source = "git+https://github.com/matrix-org/vodozemac/?rev=826d0aa22a9b5405535927c7691492db4b92a43b#826d0aa22a9b5405535927c7691492db4b92a43b"
 dependencies = [
  "aes",
  "arrayvec",
  "base64 0.22.1",
  "cbc",
+ "chacha20poly1305",
  "curve25519-dalek",
  "ed25519-dalek",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ tracing-core = "0.1.32"
 uniffi = { version = "0.27.1" }
 uniffi_bindgen = { version = "0.27.1" }
 url = "2.5.0"
-vodozemac = { version = "0.6.0" }
+vodozemac = { git = "https://github.com/matrix-org/vodozemac/", rev = "826d0aa22a9b5405535927c7691492db4b92a43b" }
 wiremock = "0.6.0"
 zeroize = "1.6.0"
 


### PR DESCRIPTION
This gives us the necessary primitives for the QR code login feature. This is being merged sooner because we have all the necessary bits for the WASM bindings EW needs.