### PR TITLE
FFI: Expose ed25519/curve25519 keys in bindings

### DIFF
--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -213,20 +213,17 @@ impl From<encryption::VerificationState> for VerificationState {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl Encryption {
-
-
     /// Get the public ed25519 key of our own device. This is usually what is
     /// called the fingerprint of the device.
     pub async fn ed25519_key(&self) -> Option<String> {
         self.inner.ed25519_key().await
     }
 
-    /// Get the public curve25519 key of our own device in base64. This is usually what is
-    /// called the identiy key of the device.
+    /// Get the public curve25519 key of our own device in base64. This is
+    /// usually what is called the identiy key of the device.
     pub async fn curve25519_key(&self) -> Option<String> {
         self.inner.curve25519_key().await
     }
-    
 
     pub fn backup_state_listener(&self, listener: Box<dyn BackupStateListener>) -> Arc<TaskHandle> {
         let mut stream = self.inner.backups().state_stream();

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -220,7 +220,7 @@ impl Encryption {
     }
 
     /// Get the public curve25519 key of our own device in base64. This is
-    /// usually what is called the identiy key of the device.
+    /// usually what is called the identity key of the device.
     pub async fn curve25519_key(&self) -> Option<String> {
         self.inner.curve25519_key().await
     }

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -213,6 +213,21 @@ impl From<encryption::VerificationState> for VerificationState {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl Encryption {
+
+
+    /// Get the public ed25519 key of our own device. This is usually what is
+    /// called the fingerprint of the device.
+    pub async fn ed25519_key(&self) -> Option<String> {
+        self.inner.ed25519_key().await
+    }
+
+    /// Get the public curve25519 key of our own device in base64. This is usually what is
+    /// called the identiy key of the device.
+    pub async fn curve25519_key(&self) -> Option<String> {
+        self.inner.curve25519_key().await
+    }
+    
+
     pub fn backup_state_listener(&self, listener: Box<dyn BackupStateListener>) -> Arc<TaskHandle> {
         let mut stream = self.inner.backups().state_stream();
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -613,8 +613,8 @@ impl Encryption {
         self.client.olm_machine().await.as_ref().map(|o| o.identity_keys().ed25519.to_base64())
     }
 
-    /// Get the public curve25519 key of our own device in base64. This is usually what is
-    /// called the identiy key of the device.
+    /// Get the public curve25519 key of our own device in base64. This is
+    /// usually what is called the identiy key of the device.
     pub async fn curve25519_key(&self) -> Option<String> {
         self.client.olm_machine().await.as_ref().map(|o| o.identity_keys().curve25519.to_base64())
     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -614,7 +614,7 @@ impl Encryption {
     }
 
     /// Get the public curve25519 key of our own device in base64. This is
-    /// usually what is called the identiy key of the device.
+    /// usually what is called the identity key of the device.
     pub async fn curve25519_key(&self) -> Option<String> {
         self.client.olm_machine().await.as_ref().map(|o| o.identity_keys().curve25519.to_base64())
     }

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -613,6 +613,12 @@ impl Encryption {
         self.client.olm_machine().await.as_ref().map(|o| o.identity_keys().ed25519.to_base64())
     }
 
+    /// Get the public curve25519 key of our own device in base64. This is usually what is
+    /// called the identiy key of the device.
+    pub async fn curve25519_key(&self) -> Option<String> {
+        self.client.olm_machine().await.as_ref().map(|o| o.identity_keys().curve25519.to_base64())
+    }
+
     /// Get the status of the private cross signing keys.
     ///
     /// This can be used to check which private cross signing keys we have


### PR DESCRIPTION
<!-- description of the changes in this PR -->

The Element-X rageshakes are lacking device keys info, see https://github.com/element-hq/element-x-ios/issues/2550

This change exposes these so that it can be used by the app.
The `ed25519_key()` was already present in the sdk but not exposed in bindings. I added a second one for `curve25519_key()` in both sdk and bindings.

Can be accessed via `client.encryption().curve25519Key()` in the aps

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
