### PR TITLE
indexeddb: expose new method `IndexeddbCryptoStore::open_with_key`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,6 +3381,7 @@ dependencies = [
  "base64 0.22.1",
  "getrandom",
  "gloo-utils",
+ "hkdf",
  "indexed_db_futures",
  "js-sys",
  "matrix-sdk-base",
@@ -3393,6 +3394,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "tracing",
@@ -3401,6 +3403,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3388,6 +3388,7 @@ dependencies = [
  "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
  "matrix-sdk-test",
+ "rand",
  "ruma",
  "serde",
  "serde-wasm-bindgen",

--- a/crates/matrix-sdk-indexeddb/CHANGELOG.md
+++ b/crates/matrix-sdk-indexeddb/CHANGELOG.md
@@ -1,4 +1,6 @@
-# unreleased
+# UNRELEASED
+
+- Add new method `IndexeddbCryptoStore::open_with_key`. ([#3423](https://github.com/matrix-org/matrix-rust-sdk/pull/3423))
 
 - `save_change` performance improvement, all encryption and serialization
   is done now outside of the db transaction.

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -50,6 +50,7 @@ matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-common = { workspace = true, features = ["js"] }
 matrix-sdk-crypto = { workspace = true, features = ["js", "testing"] }
 matrix-sdk-test = { workspace = true }
+rand = { workspace = true }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["registry", "tracing-log"] }
 uuid = "1.3.0"
 wasm-bindgen-test = "0.3.33"

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -38,6 +38,9 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 wasm-bindgen = "0.2.83"
 web-sys = { version = "0.3.57", features = ["IdbKeyRange"] }
+hkdf = "0.12.4"
+zeroize.workspace = true
+sha2.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # for wasm32 we need to activate this

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -39,8 +39,8 @@ tracing = { workspace = true }
 wasm-bindgen = "0.2.83"
 web-sys = { version = "0.3.57", features = ["IdbKeyRange"] }
 hkdf = "0.12.4"
-zeroize.workspace = true
-sha2.workspace = true
+zeroize = { workspace = true }
+sha2 = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # for wasm32 we need to activate this

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -272,7 +272,22 @@ impl IndexeddbCryptoStore {
         IndexeddbCryptoStore::open_with_store_cipher("crypto", None).await
     }
 
-    /// Open a new `IndexeddbCryptoStore` with given name and passphrase
+    /// Open an `IndexeddbCryptoStore` with given name and passphrase.
+    ///
+    /// If the store previously existed, the encryption cipher is initialised
+    /// using the given passphrase and the details from the meta store. If the
+    /// store did not previously exist, a new encryption cipher is derived
+    /// from the passphrase, and the details are stored to the metastore.
+    ///
+    /// The store is then opened, or a new one created, using the encryption
+    /// cipher.
+    ///
+    /// # Arguments
+    ///
+    /// * `prefix` - Common prefix for the names of the two IndexedDB stores.
+    /// * `passphrase` - Passphrase which is used to derive a key to encrypt the
+    ///   key which is used to encrypt the store. Must be the same each time the
+    ///   store is opened.
     pub async fn open_with_passphrase(prefix: &str, passphrase: &str) -> Result<Self> {
         let db = open_meta_db(prefix).await?;
         let store_cipher = load_store_cipher(&db).await?;

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -336,7 +336,7 @@ impl IndexeddbCryptoStore {
     /// # Arguments
     ///
     /// * `prefix` - Common prefix for the names of the two IndexedDB stores.
-    /// * `key` - key with which to encrypt the key which is used to encrypt the
+    /// * `key` - Key with which to encrypt the key which is used to encrypt the
     ///   store. Must be the same each time the store is opened.
     pub async fn open_with_key(prefix: &str, key: &[u8; 32]) -> Result<Self> {
         // The application might also use the provided key for something else, so to


### PR DESCRIPTION
Part of a resolution to https://github.com/element-hq/element-web/issues/26821: allow applications to skip the PBKDF2 operation if they already have a cryptographically secure key.

In order to maintain compatibility for existing element-web sessions, if we discover that we have an existing store that was encrypted with a key derived from PBKDF2, then we reconstruct what element-web used to do: specifically, we base64-encode the key to obtain the "passphrase" that was previously passed in. If that matches, we know we've got the right key, and can update the meta store accordingly.