### PR TITLE
room list service: always request the room name event

### DIFF
--- a/bindings/matrix-sdk-ffi/src/notification.rs
+++ b/bindings/matrix-sdk-ffi/src/notification.rs
@@ -63,7 +63,7 @@ impl NotificationItem {
                 is_name_ambiguous: item.is_sender_name_ambiguous,
             },
             room_info: NotificationRoomInfo {
-                display_name: item.room_display_name,
+                display_name: item.room_computed_display_name,
                 avatar_url: item.room_avatar_url,
                 canonical_alias: item.room_canonical_alias,
                 joined_members_count: item.joined_members_count,

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -40,7 +40,6 @@ use ruma::{
             history_visibility::HistoryVisibility,
             join_rules::JoinRule,
             member::{MembershipState, RoomMemberEventContent},
-            name::RoomNameEventContent,
             redaction::SyncRoomRedactionEvent,
             tombstone::RoomTombstoneEventContent,
         },
@@ -1050,14 +1049,6 @@ impl RoomInfo {
         }
 
         self.base_info.handle_redaction(redacts);
-    }
-
-    /// Update the room name.
-    pub fn update_name(&mut self, name: String) {
-        self.base_info.name = Some(MinimalStateEvent::Original(OriginalMinimalStateEvent {
-            content: RoomNameEventContent::new(name),
-            event_id: None,
-        }));
     }
 
     /// Returns the current room avatar.
@@ -2081,24 +2072,6 @@ mod tests {
         assert_eq!(
             room.computed_display_name().await.unwrap(),
             DisplayName::EmptyWas("Matthew".to_owned())
-        );
-    }
-
-    #[test]
-    fn test_setting_the_name_on_room_info_creates_a_fake_event() {
-        // Given a room
-        let mut room_info = RoomInfo::new(room_id!("!r:e.uk"), RoomState::Joined);
-
-        // When I update its name
-        room_info.update_name("new name".to_owned());
-
-        // Then it reports the name I provided
-        assert_eq!(room_info.name(), Some("new name"));
-
-        // And that is implemented by making a fake event
-        assert_eq!(
-            room_info.base_info.name.as_ref().unwrap().as_original().unwrap().content.name,
-            "new name"
         );
     }
 

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -577,8 +577,8 @@ pub struct NotificationItem {
     /// Is the sender's name ambiguous?
     pub is_sender_name_ambiguous: bool,
 
-    /// Room display name.
-    pub room_display_name: String,
+    /// Room computed display name.
+    pub room_computed_display_name: String,
     /// Room avatar URL.
     pub room_avatar_url: Option<String>,
     /// Room canonical alias.
@@ -669,7 +669,7 @@ impl NotificationItem {
             sender_display_name,
             sender_avatar_url,
             is_sender_name_ambiguous,
-            room_display_name: room.computed_display_name().await?.to_string(),
+            room_computed_display_name: room.computed_display_name().await?.to_string(),
             room_avatar_url: room.avatar_url().map(|s| s.to_string()),
             room_canonical_alias: room.canonical_alias().map(|c| c.to_string()),
             is_direct_message_room: room.is_direct().await?,

--- a/crates/matrix-sdk-ui/src/notification_client.rs
+++ b/crates/matrix-sdk-ui/src/notification_client.rs
@@ -346,7 +346,6 @@ impl NotificationClient {
 
         // Room power levels are necessary to build the push context.
         let required_state = vec![
-            (StateEventType::RoomAvatar, "".to_owned()),
             (StateEventType::RoomEncryption, "".to_owned()),
             (StateEventType::RoomMember, "$LAZY".to_owned()),
             (StateEventType::RoomMember, "$ME".to_owned()),

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -181,7 +181,6 @@ impl RoomListService {
                     )
                     .timeline_limit(1)
                     .required_state(vec![
-                        (StateEventType::RoomAvatar, "".to_owned()),
                         (StateEventType::RoomEncryption, "".to_owned()),
                         (StateEventType::RoomMember, "$LAZY".to_owned()),
                         (StateEventType::RoomMember, "$ME".to_owned()),

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -185,6 +185,7 @@ impl RoomListService {
                         (StateEventType::RoomEncryption, "".to_owned()),
                         (StateEventType::RoomMember, "$LAZY".to_owned()),
                         (StateEventType::RoomMember, "$ME".to_owned()),
+                        (StateEventType::RoomName, "".to_owned()),
                         (StateEventType::RoomPowerLevels, "".to_owned()),
                     ]),
             ))

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -255,7 +255,6 @@ async fn test_notification_client_sliding_sync() {
                         [0, 16]
                     ],
                     "required_state": [
-                        ["m.room.avatar", ""],
                         ["m.room.encryption", ""],
                         ["m.room.member", "$LAZY"],
                         ["m.room.member", "$ME"],
@@ -275,7 +274,6 @@ async fn test_notification_client_sliding_sync() {
             "room_subscriptions": {
                 "!a98sd12bjh:example.org": {
                     "required_state": [
-                        ["m.room.avatar", ""],
                         ["m.room.encryption", ""],
                         ["m.room.member", "$LAZY"],
                         ["m.room.member", "$ME"],

--- a/crates/matrix-sdk-ui/tests/integration/notification_client.rs
+++ b/crates/matrix-sdk-ui/tests/integration/notification_client.rs
@@ -304,6 +304,6 @@ async fn test_notification_client_sliding_sync() {
     });
     assert_eq!(item.sender_display_name.as_deref(), Some(sender_display_name));
     assert_eq!(item.sender_avatar_url.as_deref(), Some(sender_avatar_url));
-    assert_eq!(item.room_display_name, room_name);
+    assert_eq!(item.room_computed_display_name, sender_display_name);
     assert_eq!(item.is_noisy, Some(false));
 }

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -269,7 +269,6 @@ async fn test_sync_all_states() -> Result<(), Error> {
                 ALL_ROOMS: {
                     "ranges": [[0, 19]],
                     "required_state": [
-                        ["m.room.avatar", ""],
                         ["m.room.encryption", ""],
                         ["m.room.member", "$LAZY"],
                         ["m.room.member", "$ME"],
@@ -1815,7 +1814,6 @@ async fn test_dynamic_entries_stream_manual_update() -> Result<(), Error> {
             "lists": {
                 ALL_ROOMS: {
                     "required_state": [
-                        ["m.room.avatar", ""],
                         ["m.room.encryption", ""],
                         ["m.room.member", "$LAZY"],
                         ["m.room.member", "$ME"],

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -273,6 +273,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.encryption", ""],
                         ["m.room.member", "$LAZY"],
                         ["m.room.member", "$ME"],
+                        ["m.room.name", ""],
                         ["m.room.power_levels", ""],
                     ],
                     "filters": {
@@ -1449,9 +1450,21 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             },
             "rooms": {
                 "!r0:bar.org": {
-                    "name": "Matrix Foobar",
+                    "name": "This is ignored",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Matrix Foobar"
+                            },
+                            "event_id": "$1",
+                            "origin_server_ts": 42,
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name"
+                        },
+                    ],
                 },
             },
         },
@@ -1510,24 +1523,72 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
             },
             "rooms": {
                 "!r1:bar.org": {
-                    "name": "Matrix Bar",
+                    "name": "Yop yop",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Matrix Foobar"
+                            },
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name",
+                            "event_id": "$2",
+                            "origin_server_ts": 42,
+                        },
+                    ],
                 },
                 "!r2:bar.org": {
                     "name": "Hello",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Hello"
+                            },
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name",
+                            "event_id": "$3",
+                            "origin_server_ts": 42,
+                        },
+                    ],
                 },
                 "!r3:bar.org": {
                     "name": "Helios live",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Helios live"
+                            },
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name",
+                            "event_id": "$4",
+                            "origin_server_ts": 42,
+                        },
+                    ],
                 },
                 "!r4:bar.org": {
                     "name": "Matrix Baz",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Matrix Baz"
+                            },
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name",
+                            "event_id": "$5",
+                            "origin_server_ts": 42,
+                        },
+                    ],
                 },
             },
         },
@@ -1581,16 +1642,52 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
                     "name": "Matrix Barracuda Room",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Matrix Barracuda Room"
+                            },
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name",
+                            "event_id": "$6",
+                            "origin_server_ts": 42,
+                        },
+                    ],
                 },
                 "!r6:bar.org": {
                     "name": "Matrix is real as hell",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Matrix is real as hell"
+                            },
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name",
+                            "event_id": "$7",
+                            "origin_server_ts": 42,
+                        },
+                    ],
                 },
                 "!r7:bar.org": {
                     "name": "Matrix Baraka",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Matrix Baraka"
+                            },
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name",
+                            "event_id": "$8",
+                            "origin_server_ts": 42,
+                        },
+                    ],
                 },
             },
         },
@@ -1717,6 +1814,14 @@ async fn test_dynamic_entries_stream_manual_update() -> Result<(), Error> {
         assert request >= {
             "lists": {
                 ALL_ROOMS: {
+                    "required_state": [
+                        ["m.room.avatar", ""],
+                        ["m.room.encryption", ""],
+                        ["m.room.member", "$LAZY"],
+                        ["m.room.member", "$ME"],
+                        ["m.room.name", ""],
+                        ["m.room.power_levels", ""],
+                    ],
                     "ranges": [[0, 19]],
                 },
             },
@@ -1739,9 +1844,21 @@ async fn test_dynamic_entries_stream_manual_update() -> Result<(), Error> {
             },
             "rooms": {
                 "!r0:bar.org": {
-                    "name": "Matrix Foobar",
+                    "name": "This is ignored",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Matrix Foobar"
+                            },
+                            "event_id": "$1",
+                            "origin_server_ts": 42,
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name"
+                        },
+                    ],
                 },
             },
         },
@@ -1801,6 +1918,18 @@ async fn test_dynamic_entries_stream_manual_update() -> Result<(), Error> {
                     "name": "Matrix Bar",
                     "initial": true,
                     "timeline": [],
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Matrix Bar"
+                            },
+                            "event_id": "$2",
+                            "origin_server_ts": 42,
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name"
+                        },
+                    ],
                 },
             },
         },
@@ -1920,9 +2049,21 @@ async fn test_room() -> Result<(), Error> {
             },
             "rooms": {
                 room_id_0: {
-                    "name": "Room #0",
+                    "name": "This is ignored",
                     "avatar": "mxc://homeserver/media",
                     "initial": true,
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Room #0"
+                            },
+                            "event_id": "$1",
+                            "origin_server_ts": 42,
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name"
+                        },
+                    ],
                 },
                 room_id_1: {
                     "initial": true,
@@ -1969,8 +2110,19 @@ async fn test_room() -> Result<(), Error> {
             },
             "rooms": {
                 room_id_1: {
-                    "name": "Room #1",
                     "avatar": "mxc://homeserver/other-media",
+                    "required_state": [
+                        {
+                            "content": {
+                                "name": "Room #1"
+                            },
+                            "event_id": "$1",
+                            "origin_server_ts": 42,
+                            "sender": "@example:bar.org",
+                            "state_key": "",
+                            "type": "m.room.name"
+                        },
+                    ],
                 },
             },
         },

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -107,8 +107,8 @@ async fn test_notification() -> Result<()> {
         // In theory, the room name ought to be ROOM_NAME here, but the sliding sync
         // proxy returns the other person's name as the room's name (as of
         // 2023-08-04).
-        assert!(notification.room_display_name != ROOM_NAME);
-        assert_eq!(notification.room_display_name, ALICE_NAME);
+        assert!(notification.room_computed_display_name != ROOM_NAME);
+        assert_eq!(notification.room_computed_display_name, ALICE_NAME);
 
         // Then with /context.
         let notification_client =
@@ -194,7 +194,7 @@ async fn test_notification() -> Result<()> {
         );
 
         assert_eq!(notification.sender_display_name.as_deref(), Some(ALICE_NAME));
-        assert_eq!(notification.room_display_name, ROOM_NAME);
+        assert_eq!(notification.room_computed_display_name, ROOM_NAME);
     };
 
     let notification_client =


### PR DESCRIPTION
And don't rely on the `name` field in the response as provided by the server. The name displayed by the server was before saved as the `m.room.name` event for that room, which is not the right semantics when the name has been computed by the server. The computation of a name should happen client-side, so as to be able to translate it according to the user's language.

Instead, this PR makes it so that we ignore the `name` field from the sliding sync response, and instead request the `m.room.name` event for all the rooms in the room list service.

Conversely, the `m.room.avatar` is always set to the `avatar` field from a room sub-part of a response, and it's likely more precise than the actual content of the `m.room.avatar` (it will user the other user avatar for a DM room). We could also compute that client-side, but since the server does it for us, and its default choice is Good™, we use that instead. As a result, the state event was requested but always unused, so we can stop requesting it explicitly in the room list / notification services.