### PR TITLE
ffi: Add the user's display name to `RoomMembership` timeline content

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -16,6 +16,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{crypto::types::events::UtdCause, room::power_levels::power_level_user_changes};
 use matrix_sdk_ui::timeline::{PollResult, TimelineDetails};
+use ruma::events::FullStateEventContent;
 use tracing::warn;
 
 use super::ProfileDetails;
@@ -47,6 +48,13 @@ impl TimelineItemContent {
             }
             Content::MembershipChange(membership) => TimelineItemContentKind::RoomMembership {
                 user_id: membership.user_id().to_string(),
+                user_display_name: if let FullStateEventContent::Original { content, .. } =
+                    membership.content()
+                {
+                    content.displayname.clone()
+                } else {
+                    None
+                },
                 change: membership.change().map(Into::into),
             },
             Content::ProfileChange(profile) => {
@@ -120,6 +128,7 @@ pub enum TimelineItemContentKind {
     },
     RoomMembership {
         user_id: String,
+        user_display_name: Option<String>,
         change: Option<MembershipChange>,
     },
     ProfileChange {


### PR DESCRIPTION
This is useful to properly format membership state events.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
