### PR TITLE
day dividers: record the insertion index for operations based on the previous item

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
@@ -40,7 +40,10 @@ pub(super) struct DayDividerAdjuster {
 
 impl Drop for DayDividerAdjuster {
     fn drop(&mut self) {
-        assert!(self.consumed, "the DayDividerAdjuster must be consumed with run()");
+        // Only run the assert if we're not currently panicking.
+        if !std::thread::panicking() {
+            assert!(self.consumed, "the DayDividerAdjuster must be consumed with run()");
+        }
     }
 }
 


### PR DESCRIPTION
See individual commit messages.