### PR TITLE
event cache: don't cause a reference cycle with `Client` because of pagination

### DIFF
--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -68,7 +68,7 @@ use self::{
 };
 use crate::{
     attachment::{AttachmentConfig, Thumbnail},
-    client::ClientInner,
+    client::{ClientInner, WeakClient},
     encryption::{
         identities::{Device, UserDevices},
         verification::{SasVerification, Verification, VerificationRequest},
@@ -126,7 +126,7 @@ impl EncryptionData {
     }
 
     pub fn initialize_room_key_tasks(&self, client: &Arc<ClientInner>) {
-        let weak_client = Arc::downgrade(client);
+        let weak_client = WeakClient::from_inner(client);
 
         let mut tasks = self.tasks.lock().unwrap();
         tasks.upload_room_keys = Some(BackupUploadingTask::new(weak_client.clone()));

--- a/crates/matrix-sdk/src/room/messages.rs
+++ b/crates/matrix-sdk/src/room/messages.rs
@@ -125,7 +125,7 @@ impl fmt::Debug for MessagesOptions {
 ///
 /// In short, this is a possibly decrypted version of the response of a
 /// `room/messages` api call.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Messages {
     /// The token the pagination starts from.
     pub start: String,

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -92,6 +92,7 @@ pub use self::{
 use crate::event_cache::EventCache;
 use crate::{
     attachment::AttachmentConfig,
+    client::WeakClient,
     config::RequestConfig,
     error::WrongRoomState,
     event_cache::{self, EventCacheDropHandles, RoomEventCache},
@@ -2626,6 +2627,25 @@ impl Room {
             // from a `Room`.
             (maybe_room.unwrap(), drop_handles)
         })
+    }
+}
+
+/// A wrapper for a weak client and a room id that allows to lazily retrieve a
+/// room, only when needed.
+pub(crate) struct WeakRoom {
+    client: WeakClient,
+    room_id: OwnedRoomId,
+}
+
+impl WeakRoom {
+    /// Create a new `WeakRoom` given its weak components.
+    pub fn new(client: WeakClient, room_id: OwnedRoomId) -> Self {
+        Self { client, room_id }
+    }
+
+    /// Attempts to reconstruct the room.
+    pub fn get(&self) -> Option<Room> {
+        self.client.get().and_then(|client| client.get_room(&self.room_id))
     }
 }
 


### PR DESCRIPTION
See individual commit messages.