### PR TITLE
feat(base+ffi+ui): `SlidingSync` and `RoomList` support heroes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,8 +4897,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a555b3e7ca84892ef6e81eadb42c783b76ffb939d6ad9781a9da7023a501521"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "assign",
  "js_int",
@@ -4915,8 +4914,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7ec9d6b5fe002fc018b1daa36f888e80a670ffa7f7778d025e90478c0838ad"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "as_variant",
  "assign",
@@ -4932,14 +4930,14 @@ dependencies = [
  "serde_html_form",
  "serde_json",
  "thiserror",
+ "url",
  "web-time",
 ]
 
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ba97203cc4cab8dc10e62fe8156ae5c61d2553f37c3037759fbae601982fb7b"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -4971,8 +4969,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddef15eca0faee500016850a8473fb8c07b17b056b2ae5352ef67cf917102e3"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -4996,8 +4993,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea43deab72b76655e36305127894249e33f48696a5af3c8aa048dc42d772af45"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -5009,8 +5005,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6d948779da5fb4d1fc2d4c7a3f0cab21453dd14765a72fbee38ef758613d7f"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5022,8 +5017,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa38974f5901ed4e00e10aec57b9ad3b4d6d6c1a1ae683c51b88700b9f4ffba"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5032,8 +5026,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36857a3350ea611ecc9968dcc4f3d5a03227a6c3fcbb446e8530e3be8852282"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -5048,8 +5041,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42ef562eddab426c4402d004ea577f9034c74cd1714e087e9e0d47e88662ec2"
+source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,7 +4897,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "assign",
  "js_int",
@@ -4914,7 +4914,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "as_variant",
  "assign",
@@ -4937,7 +4937,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -4969,7 +4969,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -4993,7 +4993,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -5005,7 +5005,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5026,7 +5026,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=1c1cfe9a7e604f930169cdece597009ecb2a4aaf#1c1cfe9a7e604f930169cdece597009ecb2a4aaf"
+source = "git+https://github.com/Hywan/ruma?branch=feat-sliding-sync-list-include-heroes#8ff12161c2e598f3bfff28e543b304dbdad2af27"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "1c1cfe9a7e604f930169cdece597009ecb2a4aaf", features = [
+ruma = { git = "https://github.com/Hywan/ruma", branch = "feat-sliding-sync-list-include-heroes", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -53,7 +53,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "1c1cfe9a7e604f930169cdece5
     "unstable-msc3266",
     "unstable-msc4075"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "1c1cfe9a7e604f930169cdece597009ecb2a4aaf" }
+ruma-common = { git = "https://github.com/Hywan/ruma", branch = "feat-sliding-sync-list-include-heroes" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { version = "0.10.1", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "1c1cfe9a7e604f930169cdece597009ecb2a4aaf", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -53,7 +53,7 @@ ruma = { version = "0.10.1", features = [
     "unstable-msc3266",
     "unstable-msc4075"
 ] }
-ruma-common = { version = "0.13.0" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "1c1cfe9a7e604f930169cdece597009ecb2a4aaf" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -615,6 +615,7 @@ pub struct RequiredState {
 pub struct RoomSubscription {
     pub required_state: Option<Vec<RequiredState>>,
     pub timeline_limit: Option<u32>,
+    pub include_heroes: Option<bool>,
 }
 
 impl From<RoomSubscription> for RumaRoomSubscription {
@@ -623,7 +624,8 @@ impl From<RoomSubscription> for RumaRoomSubscription {
             required_state: val.required_state.map(|r|
                 r.into_iter().map(|s| (s.key.into(), s.value)).collect()
             ).unwrap_or_default(),
-            timeline_limit: val.timeline_limit.map(|u| u.into())
+            timeline_limit: val.timeline_limit.map(|u| u.into()),
+            include_heroes: val.include_heroes,
         })
     }
 }

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -120,6 +120,13 @@ pub struct RoomSummary {
     invited_member_count: u64,
 }
 
+#[cfg(test)]
+impl RoomSummary {
+    pub(crate) fn heroes(&self) -> &[String] {
+        &self.heroes
+    }
+}
+
 /// Enum keeping track in which state the room is, e.g. if our own user is
 /// joined, invited, or has left the room.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -703,8 +703,12 @@ fn process_room_properties(room_data: &v4::SlidingSyncRoom, room_info: &mut Room
     room_summary.joined_member_count = room_data.joined_count;
 
     if let Some(heroes) = &room_data.heroes {
-        room_summary.heroes =
-            heroes.iter().filter_map(|hero| hero.name.as_ref().cloned()).collect();
+        // It's not clear for Ruma, but the `heroes` field should be a collection of
+        // [`UserId`].
+        room_summary.heroes = heroes
+            .iter()
+            .filter_map(|hero| hero.user_id.as_ref().map(ToString::to_string))
+            .collect();
     }
 
     room_info.update_summary(&room_summary);
@@ -1313,7 +1317,7 @@ mod tests {
         // And heroes are part of the summary.
         assert_eq!(
             client_room.clone_info().summary.heroes(),
-            &["Gordon".to_string(), "Alice".to_string()]
+            &["@gordon:e.uk".to_string(), "@alice:e.uk".to_string()]
         );
     }
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -693,13 +693,20 @@ fn process_room_properties(room_data: &v4::SlidingSyncRoom, room_info: &mut Room
     }
 
     // Sliding sync doesn't have a room summary, nevertheless it contains the joined
-    // and invited member counts. It likely will never have a heroes concept since
-    // it calculates the room display name for us.
+    // and invited member counts, in addition to the heroes if it's been configured
+    // to return them (see the [`v4::RoomSubscription::include_heroes`]).
     //
     // Let's at least fetch the member counts, since they might be useful.
     let mut room_summary = RoomSummary::new();
+
     room_summary.invited_member_count = room_data.invited_count;
     room_summary.joined_member_count = room_data.joined_count;
+
+    if let Some(heroes) = &room_data.heroes {
+        room_summary.heroes =
+            heroes.iter().filter_map(|hero| hero.name.as_ref().cloned()).collect();
+    }
+
     room_info.update_summary(&room_summary);
 
     room_info.set_prev_batch(room_data.prev_batch.as_deref());
@@ -1271,6 +1278,43 @@ mod tests {
         let client_room = client.get_room(room_id).expect("No room found");
         assert_eq!(client_room.computed_display_name().await.unwrap().to_string(), "myroom");
         assert!(client_room.name().is_none());
+    }
+
+    #[async_test]
+    async fn test_compute_heroes_from_sliding_sync() {
+        // Given a logged-in client
+        let client = logged_in_base_client(None).await;
+        let room_id = room_id!("!r:e.uk");
+        let gordon = user_id!("@gordon:e.uk").to_owned();
+        let alice = user_id!("@alice:e.uk").to_owned();
+
+        // When I send sliding sync response containing a room (with identifiable data
+        // in `heroes`)
+        let mut room = v4::SlidingSyncRoom::new();
+        room.heroes = Some(vec![
+            assign!(v4::SlidingSyncRoomHero::default(), {
+                user_id: Some(gordon),
+                name: Some("Gordon".to_string()),
+            }),
+            assign!(v4::SlidingSyncRoomHero::default(), {
+                user_id: Some(alice),
+                name: Some("Alice".to_string()),
+            }),
+        ]);
+        let response = response_with_room(room_id, room).await;
+        let _sync_resp =
+            client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+
+        // Then the room appears in the client.
+        let client_room = client.get_room(room_id).expect("No room found");
+        assert_eq!(client_room.room_id(), room_id);
+        assert_eq!(client_room.state(), RoomState::Joined);
+
+        // And heroes are part of the summary.
+        assert_eq!(
+            client_room.clone_info().summary.heroes(),
+            &["Gordon".to_string(), "Alice".to_string()]
+        );
     }
 
     #[async_test]

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -459,6 +459,7 @@ fn configure_all_or_visible_rooms_list(
 ) -> SlidingSyncListBuilder {
     list_builder
         .sort(vec!["by_recency".to_owned(), "by_name".to_owned()])
+        .include_heroes(Some(true))
         .filters(Some(assign!(SyncRequestListFilters::default(), {
             // As defined in the [SlidingSync MSC](https://github.com/matrix-org/matrix-spec-proposals/blob/9450ced7fb9cf5ea9077d029b3adf36aebfa8709/proposals/3575-sync.md?plain=1#L444)
             // If unset, both invited and joined rooms are returned. If false, no invited rooms are

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -275,6 +275,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.name", ""],
                         ["m.room.power_levels", ""],
                     ],
+                    "include_heroes": true,
                     "filters": {
                         "is_tombstoned": false,
                         "not_room_types": ["m.space"],
@@ -333,6 +334,7 @@ async fn test_sync_all_states() -> Result<(), Error> {
                         ["m.room.encryption", ""],
                         ["m.room.member", "$LAZY"],
                     ],
+                    "include_heroes": true,
                     "filters": {
                         "is_tombstoned": false,
                         "not_room_types": ["m.space"],

--- a/crates/matrix-sdk/src/sliding_sync/list/builder.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/builder.rs
@@ -49,6 +49,7 @@ pub struct SlidingSyncListBuilder {
     sync_mode: SlidingSyncMode,
     sort: Vec<String>,
     required_state: Vec<(StateEventType, String)>,
+    include_heroes: Option<bool>,
     filters: Option<v4::SyncRequestListFilters>,
     timeline_limit: Option<Bound>,
     pub(crate) name: String,
@@ -74,6 +75,7 @@ impl fmt::Debug for SlidingSyncListBuilder {
             .field("sync_mode", &self.sync_mode)
             .field("sort", &self.sort)
             .field("required_state", &self.required_state)
+            .field("include_heroes", &self.include_heroes)
             .field("filters", &self.filters)
             .field("timeline_limit", &self.timeline_limit)
             .field("name", &self.name)
@@ -91,6 +93,7 @@ impl SlidingSyncListBuilder {
                 (StateEventType::RoomEncryption, "".to_owned()),
                 (StateEventType::RoomTombstone, "".to_owned()),
             ],
+            include_heroes: None,
             filters: None,
             timeline_limit: None,
             name: name.into(),
@@ -129,6 +132,12 @@ impl SlidingSyncListBuilder {
     /// Required states to return per room.
     pub fn required_state(mut self, value: Vec<(StateEventType, String)>) -> Self {
         self.required_state = value;
+        self
+    }
+
+    /// Include heroes.
+    pub fn include_heroes(mut self, value: Option<bool>) -> Self {
+        self.include_heroes = value;
         self
     }
 
@@ -207,6 +216,7 @@ impl SlidingSyncListBuilder {
                     SlidingSyncListStickyParameters::new(
                         self.sort,
                         self.required_state,
+                        self.include_heroes,
                         self.filters,
                         self.timeline_limit,
                         self.bump_event_types,

--- a/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
+++ b/crates/matrix-sdk/src/sliding_sync/list/sticky.rs
@@ -16,6 +16,10 @@ pub(super) struct SlidingSyncListStickyParameters {
     /// Required states to return per room.
     required_state: Vec<(StateEventType, String)>,
 
+    /// Return a stripped variant of membership events for the users used to
+    /// calculate the room name.
+    include_heroes: Option<bool>,
+
     /// Any filters to apply to the query.
     filters: Option<v4::SyncRequestListFilters>,
 
@@ -31,13 +35,14 @@ impl SlidingSyncListStickyParameters {
     pub fn new(
         sort: Vec<String>,
         required_state: Vec<(StateEventType, String)>,
+        include_heroes: Option<bool>,
         filters: Option<v4::SyncRequestListFilters>,
         timeline_limit: Option<Bound>,
         bump_event_types: Vec<TimelineEventType>,
     ) -> Self {
         // Consider that each list will have at least one parameter set, so invalidate
         // it by default.
-        Self { sort, required_state, filters, timeline_limit, bump_event_types }
+        Self { sort, required_state, include_heroes, filters, timeline_limit, bump_event_types }
     }
 }
 
@@ -58,6 +63,7 @@ impl StickyData for SlidingSyncListStickyParameters {
         request.sort = self.sort.to_vec();
         request.room_details.required_state = self.required_state.to_vec();
         request.room_details.timeline_limit = self.timeline_limit.map(Into::into);
+        request.include_heroes = self.include_heroes;
         request.filters = self.filters.clone();
         request.bump_event_types = self.bump_event_types.clone();
     }


### PR DESCRIPTION
This patch does the following things:

1. It updates Ruma to the latest revision at the time of writing, it adds `include_heroes` on `RoomSubscription`
2. It updates `matrix-sdk-ffi` to provide the `RoomSubscription::include_heroes` field,
3. It updates `matrix-sdk-base` so that SlidingSync consumes `heroes` from the response and update the `RoomSummary` accordingly.
4. It updates Ruma once again, this time on my own fork (waiting for the PR to be merged), which includes a bug fix (a hero has a `displayname`, not a `name` :-/), and adds `include_heroes` on the `SlidingSyncList`
5. It updates `matrix-sdk` to provide `include_heroes` on `SlidingSyncListBuilder` and inside the sticky parameters of a `SlidingSyncList`
6. It updates `matrix-sdk-ui` to enable `include_heroes` by default for `all_rooms` and `visible_rooms`.

---

* Close https://github.com/matrix-org/matrix-rust-sdk/issues/2702