### PR TITLE
crypto: emit no `identities_stream` items on no-op changes

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -4,7 +4,11 @@ Security fixes:
 
 - Don't log the private part of the backup key, introduced in [#71136e4](https://github.com/matrix-org/matrix-rust-sdk/commit/71136e44c03c79f80d6d1a2446673bc4d53a2067).
 
-Changed:
+Changes:
+
+- Avoid emitting entries from `identities_stream_raw` and `devices_stream` when
+  we receive a `/keys/query` response which shows that no devices changed.
+  ([#3442](https://github.com/matrix-org/matrix-rust-sdk/pull/3442))
 
 - Fallback keys are rotated in a time-based manner, instead of waiting for the
   server to tell us that a fallback key got used.

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -848,7 +848,12 @@ impl ReadOnlyDevice {
     }
 
     /// Update a device with a new device keys struct.
-    pub(crate) fn update_device(&mut self, device_keys: &DeviceKeys) -> Result<(), SignatureError> {
+    ///
+    /// Returns `true` if any changes were made to the data.
+    pub(crate) fn update_device(
+        &mut self,
+        device_keys: &DeviceKeys,
+    ) -> Result<bool, SignatureError> {
         self.verify_device_keys(device_keys)?;
 
         if self.user_id() != device_keys.user_id || self.device_id() != device_keys.device_id {
@@ -858,10 +863,13 @@ impl ReadOnlyDevice {
                 self.ed25519_key().map(Box::new),
                 device_keys.ed25519_key().map(Box::new),
             ))
-        } else {
+        } else if self.inner.as_ref() != device_keys {
             self.inner = device_keys.clone().into();
 
-            Ok(())
+            Ok(true)
+        } else {
+            // no changes needed
+            Ok(false)
         }
     }
 
@@ -1066,9 +1074,11 @@ pub(crate) mod tests {
 
         let mut device_keys = device_keys();
         device_keys.unsigned.device_display_name = Some(display_name.clone());
-        device.update_device(&device_keys).unwrap();
-
+        assert!(device.update_device(&device_keys).unwrap());
         assert_eq!(&display_name, device.display_name().as_ref().unwrap());
+
+        // A second call to `update_device` with the same data should return `false`.
+        assert!(!device.update_device(&device_keys).unwrap());
     }
 
     #[test]

--- a/crates/matrix-sdk-crypto/src/types/device_keys.rs
+++ b/crates/matrix-sdk-crypto/src/types/device_keys.rs
@@ -39,7 +39,7 @@ use super::{EventEncryptionAlgorithm, Signatures};
 /// identity keys.
 ///
 /// [device_keys_spec]: https://spec.matrix.org/v1.10/client-server-api/#_matrixclientv3keysupload_devicekeys
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(try_from = "DeviceKeyHelper", into = "DeviceKeyHelper")]
 pub struct DeviceKeys {
     /// The ID of the user the device belongs to.
@@ -130,7 +130,7 @@ impl DeviceKeys {
 }
 
 /// Additional data added to device key information by intermediate servers.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
 pub struct UnsignedDeviceInfo {
     /// The display name which the user set on the device.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Fixes: https://github.com/element-hq/element-web/issues/27165.

Currently, whenever we receive a `/keys/query` response, we emit items from `identities_stream_raw` and `devices_stream` for any users listed in the response, even if there was no actual change to the devices. This PR changes behaviour so that items are only emitted if there are actual changes.

<!-- description of the changes in this PR -->

- [X] Public API changes documented in changelogs (optional)