### PR TITLE
Expose new sticker source field (and drop url field)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,17 +43,18 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma/", rev = "ee5e6b8c9e9489c88a1ba7411541201b6790d2d2", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "6cd3af9b865f338f7c4be3666e62b67951f948ce", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
     "compat-arbitrary-length-ids",
     "compat-tag-info",
+    "compat-encrypted-stickers",
     "unstable-msc3401",
     "unstable-msc3266",
     "unstable-msc4075"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "ee5e6b8c9e9489c88a1ba7411541201b6790d2d2" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "6cd3af9b865f338f7c4be3666e62b67951f948ce" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -16,7 +16,10 @@ use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{crypto::types::events::UtdCause, room::power_levels::power_level_user_changes};
 use matrix_sdk_ui::timeline::{PollResult, TimelineDetails};
-use ruma::events::{room::message::RoomMessageEventContentWithoutRelation, FullStateEventContent};
+use ruma::events::{
+    room::{message::RoomMessageEventContentWithoutRelation, MediaSource},
+    FullStateEventContent,
+};
 use tracing::warn;
 
 use super::ProfileDetails;
@@ -38,7 +41,7 @@ impl TimelineItemContent {
                 TimelineItemContentKind::Sticker {
                     body: content.body.clone(),
                     info: (&content.info).into(),
-                    url: content.url.to_string(),
+                    source: Arc::new(MediaSource::from(content.source.clone())),
                 }
             }
             Content::Poll(poll_state) => TimelineItemContentKind::from(poll_state.results()),
@@ -112,7 +115,7 @@ pub enum TimelineItemContentKind {
     Sticker {
         body: String,
         info: ImageInfo,
-        url: String,
+        source: Arc<MediaSource>,
     },
     Poll {
         question: String,

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -114,7 +114,7 @@ pub trait MediaEventContent {
 
 impl MediaEventContent for StickerEventContent {
     fn source(&self) -> Option<MediaSource> {
-        Some(MediaSource::Plain(self.url.clone()))
+        Some(MediaSource::from(self.source.clone()))
     }
 
     fn thumbnail_source(&self) -> Option<MediaSource> {


### PR DESCRIPTION
<!-- description of the changes in this PR -->
Depends on https://github.com/ruma/ruma/pull/1820

The StickerEventContent struct changed (url is gone, source was added), this change exposes the new field.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Marco Alvarez <surakin@gmail.com>
