### PR TITLE
Don't return a Results if some functions can't fail

### DIFF
--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1361,7 +1361,7 @@ impl Encryption {
     /// proposal (MSC3967) to remove this requirement, which would allow for
     /// the initial upload of cross-signing keys without authentication,
     /// rendering this parameter obsolete.
-    pub(crate) async fn run_initialization_tasks(&self, auth_data: Option<AuthData>) -> Result<()> {
+    pub(crate) async fn run_initialization_tasks(&self, auth_data: Option<AuthData>) {
         let mut tasks = self.client.inner.e2ee.tasks.lock().unwrap();
 
         let this = self.clone();
@@ -1381,8 +1381,6 @@ impl Encryption {
 
             this.update_verification_state().await;
         }));
-
-        Ok(())
     }
 
     /// Waits for end-to-end encryption initialization tasks to finish, if any

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -878,7 +878,7 @@ impl MatrixAuth {
                 _ => None,
             };
 
-            self.client.encryption().run_initialization_tasks(auth_data).await?;
+            self.client.encryption().run_initialization_tasks(auth_data).await;
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -751,7 +751,7 @@ impl Oidc {
         }
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks(None).await?;
+        self.client.encryption().run_initialization_tasks(None).await;
 
         Ok(())
     }
@@ -940,7 +940,7 @@ impl Oidc {
         }
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks(None).await?;
+        self.client.encryption().run_initialization_tasks(None).await;
 
         Ok(())
     }


### PR DESCRIPTION
The function to run the E2EE initialization tasks and to enable the cross-process lock in a deferred manner can't actually fail, they still return a `Result` type.

This PR makes removes the `Result` from those functions. I also refactored the enabling of the cross-process lock into a separate method.

No functional changes due to these patches.