### PR TITLE
timeline: indicate if we've hit the start of the timeline in the live back-pagination status

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -18,14 +18,13 @@ use anyhow::{Context, Result};
 use as_variant::as_variant;
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt as _};
-use matrix_sdk::{
-    attachment::{
-        AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
-        BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
-    },
-    event_cache::paginator::PaginatorState,
+use matrix_sdk::attachment::{
+    AttachmentConfig, AttachmentInfo, BaseAudioInfo, BaseFileInfo, BaseImageInfo,
+    BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
 };
-use matrix_sdk_ui::timeline::{EventItemOrigin, Profile, TimelineDetails};
+use matrix_sdk_ui::timeline::{
+    EventItemOrigin, LiveBackPaginationStatus, Profile, TimelineDetails,
+};
 use mime::Mime;
 use ruma::{
     events::{
@@ -591,7 +590,7 @@ pub trait TimelineListener: Sync + Send {
 
 #[uniffi::export(callback_interface)]
 pub trait PaginationStatusListener: Sync + Send {
-    fn on_update(&self, status: PaginatorState);
+    fn on_update(&self, status: LiveBackPaginationStatus);
 }
 
 #[derive(Clone, uniffi::Object)]

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -162,11 +162,15 @@ impl Timeline {
         self.inner.fetch_members().await
     }
 
-    pub fn subscribe_to_back_pagination_status(
+    pub async fn subscribe_to_back_pagination_status(
         &self,
         listener: Box<dyn PaginationStatusListener>,
     ) -> Result<Arc<TaskHandle>, ClientError> {
-        let (initial, mut subscriber) = self.inner.back_pagination_status();
+        let (initial, mut subscriber) = self
+            .inner
+            .live_back_pagination_status()
+            .await
+            .context("can't subscribe to the back-pagination status on a focused timeline")?;
 
         Ok(Arc::new(TaskHandle::new(RUNTIME.spawn(async move {
             // Send the current state even if it hasn't changed right away.

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -95,6 +95,7 @@ pub use self::{
     event_type_filter::TimelineEventTypeFilter,
     inner::default_event_filter,
     item::{TimelineItem, TimelineItemKind},
+    pagination::LiveBackPaginationStatus,
     polls::PollResult,
     reactions::ReactionSenderData,
     sliding_sync_ext::SlidingSyncRoomExt,

--- a/crates/matrix-sdk-ui/src/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/src/timeline/pagination.rs
@@ -112,15 +112,19 @@ impl super::Timeline {
         Ok(false)
     }
 
-    /// Subscribe to the back-pagination status of the timeline.
+    /// Subscribe to the back-pagination status of a live timeline.
+    ///
+    /// This will return `None` if the timeline is in the focused mode.
     ///
     /// Note: this may send multiple Paginating/Idle sequences during a single
     /// call to [`Self::paginate_backwards()`].
-    // TODO: rename to live_back_pagination_status and add check that the timeline
-    // is live.
-    pub fn back_pagination_status(
+    pub async fn live_back_pagination_status(
         &self,
-    ) -> (LiveBackPaginationStatus, impl Stream<Item = LiveBackPaginationStatus>) {
+    ) -> Option<(LiveBackPaginationStatus, impl Stream<Item = LiveBackPaginationStatus>)> {
+        if !self.inner.is_live().await {
+            return None;
+        }
+
         let pagination = self.event_cache.pagination();
 
         let mut status = pagination.status();
@@ -138,7 +142,7 @@ impl super::Timeline {
             }
         });
 
-        (current_value, stream)
+        Some((current_value, stream))
     }
 }
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -78,6 +78,11 @@ async fn test_new_focused() {
         .await
         .unwrap();
 
+    assert!(
+        timeline.live_back_pagination_status().await.is_none(),
+        "there should be no live back-pagination status for a focused timeline"
+    );
+
     server.reset().await;
 
     let (items, mut timeline_stream) = timeline.subscribe().await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/pagination.rs
@@ -64,7 +64,7 @@ async fn test_back_pagination() {
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
-    let (_, mut back_pagination_status) = timeline.back_pagination_status();
+    let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     Mock::given(method("GET"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
@@ -248,7 +248,7 @@ async fn test_wait_for_token() {
     let timeline = Arc::new(room.timeline().await.unwrap());
 
     let from = "t392-516_47314_0_7_1_1_1_11444_1";
-    let (_, mut back_pagination_status) = timeline.back_pagination_status();
+    let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     Mock::given(method("GET"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
@@ -427,7 +427,7 @@ async fn test_timeline_reset_while_paginating() {
         .mount(&server)
         .await;
 
-    let (_, mut back_pagination_status) = timeline.back_pagination_status();
+    let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     let paginate = async { timeline.live_paginate_backwards(10).await.unwrap() };
 
@@ -451,7 +451,7 @@ async fn test_timeline_reset_while_paginating() {
 
         assert!(seen_paginating);
 
-        let (status, _) = timeline.back_pagination_status();
+        let (status, _) = timeline.live_back_pagination_status().await.unwrap();
 
         // Timeline start reached because second pagination response contains no end
         // field.
@@ -564,7 +564,7 @@ async fn test_empty_chunk() {
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
-    let (_, mut back_pagination_status) = timeline.back_pagination_status();
+    let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     // It should try to do another request after the empty chunk.
     Mock::given(method("GET"))
@@ -654,7 +654,7 @@ async fn test_until_num_items_with_empty_chunk() {
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
     let (_, mut timeline_stream) = timeline.subscribe().await;
-    let (_, mut back_pagination_status) = timeline.back_pagination_status();
+    let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     Mock::given(method("GET"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/messages$"))
@@ -768,7 +768,7 @@ async fn test_back_pagination_aborted() {
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
-    let (_, mut back_pagination_status) = timeline.back_pagination_status();
+    let (_, mut back_pagination_status) = timeline.live_back_pagination_status().await.unwrap();
 
     // Delay the server response, so we have time to abort the request.
     Mock::given(method("GET"))

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -241,6 +241,22 @@ impl RoomPagination {
     pub fn status(&self) -> Subscriber<PaginatorState> {
         self.inner.pagination.paginator.state()
     }
+
+    /// Returns whether we've hit the start of the timeline.
+    ///
+    /// This is true if, and only if, we didn't have a previous-batch token and
+    /// running backwards pagination would be useless.
+    pub fn hit_timeline_start(&self) -> bool {
+        self.inner.pagination.paginator.hit_timeline_start()
+    }
+
+    /// Returns whether we've hit the end of the timeline.
+    ///
+    /// This is true if, and only if, we didn't have a next-batch token and
+    /// running forwards pagination would be useless.
+    pub fn hit_timeline_end(&self) -> bool {
+        self.inner.pagination.paginator.hit_timeline_end()
+    }
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -137,7 +137,7 @@ pub struct PaginationResult {
     /// topological order.
     pub events: Vec<TimelineEvent>,
 
-    /// Did we hit an end of the timeline?
+    /// Did we hit *an* end of the timeline?
     ///
     /// If this is the result of a backward pagination, this means we hit the
     /// *start* of the timeline.
@@ -332,6 +332,22 @@ impl Paginator {
         num_events: UInt,
     ) -> Result<PaginationResult, PaginatorError> {
         self.paginate(Direction::Backward, num_events, &self.prev_batch_token).await
+    }
+
+    /// Returns whether we've hit the start of the timeline.
+    ///
+    /// This is true if, and only if, we didn't have a previous-batch token and
+    /// running backwards pagination would be useless.
+    pub fn hit_timeline_start(&self) -> bool {
+        matches!(*self.prev_batch_token.lock().unwrap(), PaginationToken::HitEnd)
+    }
+
+    /// Returns whether we've hit the end of the timeline.
+    ///
+    /// This is true if, and only if, we didn't have a next-batch token and
+    /// running forwards pagination would be useless.
+    pub fn hit_timeline_end(&self) -> bool {
+        matches!(*self.next_batch_token.lock().unwrap(), PaginationToken::HitEnd)
     }
 
     /// Runs a forward pagination (requesting `num_events` to the server), from
@@ -746,6 +762,13 @@ mod tests {
 
         // When I call `Paginator::start_from`, it works,
         let paginator = Arc::new(Paginator::new(room.clone()));
+
+        assert!(!paginator.hit_timeline_start(), "we must have a prev-batch token");
+        assert!(
+            !paginator.hit_timeline_end(),
+            "we don't know about the status of the next-batch token"
+        );
+
         let context =
             paginator.start_from(event_id, uint!(100)).await.expect("start_from should work");
 
@@ -754,9 +777,12 @@ mod tests {
         assert_event_matches_msg(&context.events[0], "initial");
         assert_eq!(context.events[0].event.deserialize().unwrap().event_id(), event_id);
 
-        // There's a previous batch.
+        // There's a previous batch, but no next batch.
         assert!(context.has_prev);
         assert!(!context.has_next);
+
+        assert!(!paginator.hit_timeline_start());
+        assert!(paginator.hit_timeline_end());
 
         // Preparing data for the next back-pagination.
         *room.prev_events.lock().await = vec![event_factory.text_msg("previous").into_timeline()];
@@ -766,6 +792,7 @@ mod tests {
         let prev =
             paginator.paginate_backward(uint!(100)).await.expect("paginate backward should work");
         assert!(!prev.hit_end_of_timeline);
+        assert!(!paginator.hit_timeline_start());
         assert_eq!(prev.events.len(), 1);
         assert_event_matches_msg(&prev.events[0], "previous");
 
@@ -779,6 +806,7 @@ mod tests {
             .await
             .expect("paginate backward the second time should work");
         assert!(prev.hit_end_of_timeline);
+        assert!(paginator.hit_timeline_start());
         assert_eq!(prev.events.len(), 1);
         assert_event_matches_msg(&prev.events[0], "oldest");
 
@@ -789,6 +817,7 @@ mod tests {
             .await
             .expect("paginate backward the third time should work");
         assert!(prev.hit_end_of_timeline);
+        assert!(paginator.hit_timeline_start());
         assert!(prev.events.is_empty());
     }
 
@@ -849,6 +878,12 @@ mod tests {
 
         // When I call `Paginator::start_from`, it works,
         let paginator = Arc::new(Paginator::new(room.clone()));
+        assert!(!paginator.hit_timeline_end(), "we must have a next-batch token");
+        assert!(
+            !paginator.hit_timeline_start(),
+            "we don't know about the status of the prev-batch token"
+        );
+
         let context =
             paginator.start_from(event_id, uint!(100)).await.expect("start_from should work");
 
@@ -857,9 +892,13 @@ mod tests {
         assert_event_matches_msg(&context.events[0], "initial");
         assert_eq!(context.events[0].event.deserialize().unwrap().event_id(), event_id);
 
-        // There's a next batch.
+        // There's a next batch, but no previous batch (i.e. we've hit the start of the
+        // timeline).
         assert!(!context.has_prev);
         assert!(context.has_next);
+
+        assert!(paginator.hit_timeline_start());
+        assert!(!paginator.hit_timeline_end());
 
         // Preparing data for the next forward-pagination.
         *room.next_events.lock().await = vec![event_factory.text_msg("next").into_timeline()];
@@ -871,6 +910,7 @@ mod tests {
         assert!(!next.hit_end_of_timeline);
         assert_eq!(next.events.len(), 1);
         assert_event_matches_msg(&next.events[0], "next");
+        assert!(!paginator.hit_timeline_end());
 
         // And I can forward-paginate again, because there's a prev batch token
         // still.
@@ -884,6 +924,7 @@ mod tests {
         assert!(next.hit_end_of_timeline);
         assert_eq!(next.events.len(), 1);
         assert_event_matches_msg(&next.events[0], "latest");
+        assert!(paginator.hit_timeline_end());
 
         // I've hit the start of the timeline, but back-paginating again will
         // return immediately.
@@ -893,6 +934,7 @@ mod tests {
             .expect("paginate forward the third time should work");
         assert!(next.hit_end_of_timeline);
         assert!(next.events.is_empty());
+        assert!(paginator.hit_timeline_end());
     }
 
     #[async_test]


### PR DESCRIPTION
This should help with the integration of the back-pagination status, when we have automatic back-pagination in the background.