### PR TITLE
ffi: Fix `get_element_call_required_permissions`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -260,11 +260,12 @@ pub fn new_virtual_element_call_widget(
 /// but should only be done as temporal workarounds until this function is
 /// adjusted
 #[uniffi::export]
-pub fn get_element_call_required_permissions() -> WidgetCapabilities {
+pub fn get_element_call_required_permissions(own_user_id: String) -> WidgetCapabilities {
     use ruma::events::StateEventType;
 
     WidgetCapabilities {
         read: vec![
+            WidgetEventFilter::StateWithType { event_type: "org.matrix.msc3401.call".to_owned() },
             WidgetEventFilter::StateWithType { event_type: StateEventType::CallMember.to_string() },
             WidgetEventFilter::StateWithType { event_type: StateEventType::RoomMember.to_string() },
             WidgetEventFilter::MessageLikeWithType {
@@ -275,11 +276,14 @@ pub fn get_element_call_required_permissions() -> WidgetCapabilities {
             },
         ],
         send: vec![
-            WidgetEventFilter::StateWithType { event_type: StateEventType::CallMember.to_string() },
-            WidgetEventFilter::StateWithType {
+            WidgetEventFilter::StateWithTypeAndStateKey {
+                event_type: StateEventType::CallMember.to_string(),
+                state_key: own_user_id.clone(),
+            },
+            WidgetEventFilter::MessageLikeWithType {
                 event_type: "org.matrix.rageshake_request".to_owned(),
             },
-            WidgetEventFilter::StateWithType {
+            WidgetEventFilter::MessageLikeWithType {
                 event_type: "io.element.call.encryption_keys".to_owned(),
             },
         ],


### PR DESCRIPTION
-fix what permissions `get_element_call_required_permissions` returns and have them match what Element Call actually expects
- this got implemented in https://github.com/matrix-org/matrix-rust-sdk/pull/2825 but never actually worked in the app, resulting in ElementCall getting stuck on a `Loading` screen
- tweaked the permissions list by running ElementCall and comparing it to the capabilities returned in `acquireCapabilities(capabilities:)`
- check all of this with @toger5, which also tells me that `org.matrix.msc3401.call` is deprecated and should not be required although ElementCall doesn't work without it.  He will clean up the web side and then come back to remove this as well in a later PR.
