### PR TITLE
Update JS bindings link

### DIFF
--- a/bindings/README.md
+++ b/bindings/README.md
@@ -11,7 +11,7 @@ maintained by the owners of the Matrix Rust SDK project.
 
 There are also external bindings in other repositories:
 
-* [`matrix-sdk-crypto-js`], JavaScript bindings of the
+* [`matrix-sdk-crypto-wasm`], JavaScript / WebAssembly bindings of the
   [`matrix-sdk-crypto`] crate,
 * [`matrix-sdk-crypto-nodejs`], Node.js bindings of the
   [`matrix-sdk-crypto`] crate
@@ -22,7 +22,7 @@ There are also external bindings in other repositories:
 [`matrix-sdk-ffi`]: ./matrix-sdk-ffi
 [`matrix-sdk`]: ../crates/matrix-sdk
 
-[`matrix-sdk-crypto-js`]: https://github.com/matrix-org/matrix-rust-sdk-crypto-web
+[`matrix-sdk-crypto-wasm`]: https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm
 [`matrix-sdk-crypto-nodejs`]: https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs
 
 ## Contributing


### PR DESCRIPTION
It looks like the repo has moved. I also think it's worth calling out that the bindings use Wasm (which means they're not usable in e.g. React Native).

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: Johannes Marbach <n0-0ne+github@mailbox.org>
