### PR TITLE
ci: Split codecov uploads into a separate workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Code coverage
+name: Code Coverage
 
 on:
   push:
@@ -110,12 +110,40 @@ jobs:
           HOMESERVER_DOMAIN: "synapse"
           SLIDING_SYNC_PROXY_URL: "http://localhost:8118"
 
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
+      # Copied with minimal adjustments, source:
+      # https://github.com/google/mdbook-i18n-helpers/blob/2168b9cea1f4f76b55426591a9bcc308a620194f/.github/workflows/test.yml
+      - name: Get PR number and commit SHA
+        run: |
+          echo "Storing PR number ${{ github.event.number }}"
+          echo "${{ github.event.number }}" > pr_number.txt
+
+          echo "Storing commit SHA ${{ github.event.pull_request.head.sha }}"
+          echo "${{ github.event.pull_request.head.sha }}" > commit_sha.txt
+
+      # Workaround for https://github.com/orgs/community/discussions/25220
+      # Triggered sub-workflow is not able to detect the original commit/PR which is available
+      # in this workflow.
+      - name: Store PR number in artifacts
+        uses: actions/upload-artifact@v4
         with:
-          # Work around frequent upload errors, for runs inside the main repo (not PRs from forks).
-          # Otherwise not required for public repos.
-          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
-          # The upload sometimes fails due to https://github.com/codecov/codecov-action/issues/837.
-          # To make sure that the failure gets flagged clearly in the UI, fail the action.
-          fail_ci_if_error: true
+          name: pr_number
+          path: pr_number.txt
+
+      - name: Store commit SHA in artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: commit_sha
+          path: commit_sha.txt
+
+      # This stores the coverage report in artifacts. The actual upload to Codecov
+      # is executed by a different workflow `upload_coverage.yml`. The reason for this
+      # split is because `on.pull_request` workflows don't have access to secrets.
+      - name: Store coverage report in artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: codecov_report
+          path: codecov_report.json
+
+      - run: |
+          echo "The coverage report was stored in Github artifacts."
+          echo "It will be uploaded to Codecov using `upload_coverage.yml` workflow shortly."

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -1,0 +1,113 @@
+# Copied with minimal adjustments, source:
+# https://github.com/google/mdbook-i18n-helpers/blob/2168b9cea1f4f76b55426591a9bcc308a620194f/.github/workflows/coverage-report.yml
+name: Codecov
+
+on:
+  # This workflow is triggered after every successfull execution
+  # of `coverage` workflow.
+  workflow_run:
+    workflows: ["coverage"]
+    types:
+      - completed
+
+jobs:
+  coverage:
+    name: Upload coverage report
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Fetch coverage report from artifacts'
+        id: prepare_report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            var fs = require('fs');
+
+            // List artifacts of the workflow run that triggered this workflow
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+
+            let codecovReport = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "codecov_report";
+            });
+
+            if (codecovReport.length != 1) {
+              throw new Error("Unexpected number of {codecov_report} artifacts: " + codecovReport.length);
+            }
+
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: codecovReport[0].id,
+               archive_format: 'zip',
+            });
+            fs.writeFileSync('codecov_report.zip', Buffer.from(download.data));
+
+            let prNumber = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number";
+            });
+
+            if (prNumber.length != 1) {
+              throw new Error("Unexpected number of {pr_number} artifacts: " + prNumber.length);
+            }
+
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: prNumber[0].id,
+               archive_format: 'zip',
+            });
+            fs.writeFileSync('pr_number.zip', Buffer.from(download.data));
+
+            let commitSha = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "commit_sha";
+            });
+
+            if (commitSha.length != 1) {
+              throw new Error("Unexpected number of {commit_sha} artifacts: " + commitSha.length);
+            }
+
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: commitSha[0].id,
+               archive_format: 'zip',
+            });
+            fs.writeFileSync('commit_sha.zip', Buffer.from(download.data));
+
+      - id: parse_previous_artifacts
+        run: |
+          unzip codecov_report.zip
+          unzip pr_number.zip
+          unzip commit_sha.zip
+
+          echo "Detected PR is: $(<pr_number.txt)"
+          echo "Detected commit_sha is: $(<commit_sha.txt)"
+
+          # Make the params available as step output
+          echo "override_pr=$(<pr_number.txt)" >> "$GITHUB_OUTPUT"
+          echo "override_commit=$(<commit_sha.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.parse_previous_artifacts.outputs.override_commit || '' }}
+          path: repo_root
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
+          files: ${{ github.workspace }}/codecov_report.json
+          fail_ci_if_error: true
+          # Manual overrides for these parameters are needed because automatic detection
+          # in codecov-action does not work for non-`pull_request` workflows.
+          # In `main` branch push, these default to empty strings since we want to run
+          # the analysis on HEAD.
+          override_commit: ${{ steps.parse_previous_artifacts.outputs.override_commit || '' }}
+          override_pr: ${{ steps.parse_previous_artifacts.outputs.override_pr || '' }}
+          working-directory: ${{ github.workspace }}/repo_root
+          # Location where coverage report files are searched for
+          directory: ${{ github.workspace }}


### PR DESCRIPTION
… which runs in the context of the main repo even for PRs from forks, and can be retried individually without rerunning coverage collection.

I saw you're still suffering from codecov's problems, so I decided to take the time required to look up the most recent suggested workaround (most up-to-date upstream issue discussing this stuff is https://github.com/codecov/feedback/issues/301 and contains links to the workflows I copied here).

Hope it works. If not, maybe you can get it to work. Can't promise that I'll put more time into this.