### PR TITLE
feat(sdk): Mutation-based testing and property-based testing for `LinkedChunk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3170,6 +3185,7 @@ dependencies = [
  "mime",
  "mime2ext",
  "once_cell",
+ "proptest",
  "rand",
  "reqwest",
  "ruma",
@@ -4448,6 +4464,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
@@ -4455,6 +4473,8 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax 0.8.3",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -4516,6 +4536,12 @@ checksum = "23e719ca51966ff9f5a8436edb00d6115b3c606a0bb27c8f8ca74a38ff2b036d"
 dependencies = [
  "image",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -4653,7 +4679,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -5146,6 +5172,18 @@ name = "rustversion"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092474d1a01ea8278f69e6a358998405fae5b8b963ddaeb2b0b04a128bf1dfb0"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -6557,6 +6595,15 @@ dependencies = [
  "thiserror",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -143,6 +143,7 @@ futures-executor = { workspace = true }
 matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-test = { workspace = true }
 once_cell = { workspace = true }
+proptest = "1.4.0"
 serde_urlencoded = "0.7.1"
 stream_assert = { workspace = true }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -143,7 +143,6 @@ futures-executor = { workspace = true }
 matrix-sdk-base = { workspace = true, features = ["testing"] }
 matrix-sdk-test = { workspace = true }
 once_cell = { workspace = true }
-proptest = "1.4.0"
 serde_urlencoded = "0.7.1"
 stream_assert = { workspace = true }
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
@@ -152,6 +151,7 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 wasm-bindgen-test = "0.3.33"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+proptest = "1.4.0"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 wiremock = { workspace = true }
 

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
@@ -611,6 +611,7 @@ mod tests {
         assert_eq!(diffs.len(), 1);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     mod proptests {
         use proptest::prelude::*;
 

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
@@ -33,6 +33,7 @@ type ChunkLength = usize;
 /// `Vec<VectorDiff<Item>>` (this type). Basically, it helps to consume a
 /// [`LinkedChunk<CAP, Item, Gap>`](super::LinkedChunk) as if it was an
 /// [`eyeball_im::ObservableVector<Item>`].
+#[derive(Debug)]
 pub struct AsVector<Item, Gap> {
     /// Strong reference to [`UpdatesInner`].
     updates: Arc<RwLock<UpdatesInner<Item, Gap>>>,
@@ -82,6 +83,7 @@ impl<Item, Gap> AsVector<Item, Gap> {
 }
 
 /// Internal type that converts [`Update`] into [`VectorDiff`].
+#[derive(Debug)]
 struct UpdateToVectorDiff {
     /// Pairs of all known chunks and their respective length. This is the only
     /// required data for this algorithm.

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
@@ -1248,6 +1248,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Not;
+
     use assert_matches::assert_matches;
 
     use super::{
@@ -2150,5 +2152,24 @@ mod tests {
             assert_eq!(chunk.first_position(), Position(ChunkIdentifier(3), 0));
             assert_eq!(chunk.last_position(), Position(ChunkIdentifier(3), 0));
         }
+    }
+
+    #[test]
+    fn test_is_first_and_last_chunk() {
+        let mut linked_chunk = LinkedChunk::<3, char, ()>::new();
+
+        let mut chunks = linked_chunk.chunks().peekable();
+        assert!(chunks.peek().unwrap().is_first_chunk());
+        assert!(chunks.next().unwrap().is_last_chunk());
+        assert!(chunks.next().is_none());
+
+        linked_chunk.push_items_back(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']);
+
+        let mut chunks = linked_chunk.chunks().peekable();
+        assert!(chunks.next().unwrap().is_first_chunk());
+        assert!(chunks.peek().unwrap().is_first_chunk().not());
+        assert!(chunks.next().unwrap().is_last_chunk().not());
+        assert!(chunks.next().unwrap().is_last_chunk());
+        assert!(chunks.next().is_none());
     }
 }

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
@@ -216,6 +216,12 @@ pub struct LinkedChunk<const CHUNK_CAPACITY: usize, Item, Gap> {
     marker: PhantomData<Box<Chunk<CHUNK_CAPACITY, Item, Gap>>>,
 }
 
+impl<const CAP: usize, Item, Gap> Default for LinkedChunk<CAP, Item, Gap> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
     /// Create a new [`Self`].
     pub fn new() -> Self {
@@ -252,6 +258,7 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
     }
 
     /// Get the number of items in this linked chunk.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.length
     }

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
@@ -865,6 +865,7 @@ impl Position {
 
 /// An iterator over a [`LinkedChunk`] that traverses the chunk in backward
 /// direction (i.e. it calls `previous` on each chunk to make progress).
+#[derive(Debug)]
 pub struct IterBackward<'a, const CAP: usize, Item, Gap> {
     chunk: Option<&'a Chunk<CAP, Item, Gap>>,
 }
@@ -890,6 +891,7 @@ impl<'a, const CAP: usize, Item, Gap> Iterator for IterBackward<'a, CAP, Item, G
 
 /// An iterator over a [`LinkedChunk`] that traverses the chunk in forward
 /// direction (i.e. it calls `next` on each chunk to make progress).
+#[derive(Debug)]
 pub struct Iter<'a, const CAP: usize, Item, Gap> {
     chunk: Option<&'a Chunk<CAP, Item, Gap>>,
 }

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/updates.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/updates.rs
@@ -95,6 +95,7 @@ pub enum Update<Item, Gap> {
 /// A collection of [`Update`]s that can be observed.
 ///
 /// Get a value for this type with [`LinkedChunk::updates`].
+#[derive(Debug)]
 pub struct ObservableUpdates<Item, Gap> {
     pub(super) inner: Arc<RwLock<UpdatesInner<Item, Gap>>>,
 }
@@ -164,6 +165,7 @@ pub(super) type ReaderToken = usize;
 /// for example with [`UpdatesSubscriber`]. Of course, they can be multiple
 /// `UpdatesSubscriber`s at the same time. Hence the need of supporting multiple
 /// readers.
+#[derive(Debug)]
 pub(super) struct UpdatesInner<Item, Gap> {
     /// All the updates that have not been read by all readers.
     updates: Vec<Update<Item, Gap>>,


### PR DESCRIPTION
This patch is the result of:

* Running [`cargo mutants`](https://mutants.rs/) on `matrix_sdk::event_cache::linked_chunk`,
* Having fun with [`cargo fuzz`](https://rust-fuzz.github.io/book/cargo-fuzz.html), then replacing it with [`proptest`](https://proptest-rs.github.io/proptest/proptest/index.html).

Mutation-based testing has revealed that one test was missing, it's been addressed by https://github.com/matrix-org/matrix-rust-sdk/commit/50f9cd6b4536389d65d7b51fb6e5a940c0346eb1.

Property-based testing has revealed nothing except that the test I wrote was raising a bug, addressed by https://github.com/matrix-org/matrix-rust-sdk/pull/3460/commits/ed41d49fe14350edb746278d52a39a884debb29b.

The property-based test is present in this patch too.