### PR TITLE
FFI Bindings: Expose CryptoStore clear caches

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1537,11 +1537,11 @@ impl OlmMachine {
 
     /// Clear any in-memory caches because they may be out of sync with the
     /// underlying data store.
-    /// 
+    ///
     /// The crypto store layer is caching olm sessions for a given device.
     /// When used in a multi-process context this cache will get outdated.
-    /// If the machine is used by another process, the cache must be invalidating when the
-    /// main process is resumed.
+    /// If the machine is used by another process, the cache must be
+    /// invalidating when the main process is resumed.
     pub async fn clear_crypto_cache(&self) {
         self.inner.clear_crypto_cache().await
     }

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1543,7 +1543,7 @@ impl OlmMachine {
     /// If the machine is used by another process, the cache must be invalidating when the
     /// main process is resumed.
     pub async fn clear_crypto_cache(&self) {
-        self.runtime.block_on(self.inner.clear_crypto_cache())
+        self.inner.clear_crypto_cache().await
     }
 }
 

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1534,6 +1534,12 @@ impl OlmMachine {
         }
         .into()
     }
+
+    /// Clear any in-memory caches because they may be out of sync with the
+    /// underlying data store.
+    pub async fn clear_crypto_cache(&self) {
+        self.runtime.block_on(self.inner.clear_crypto_cache())
+    }
 }
 
 impl OlmMachine {

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1537,6 +1537,11 @@ impl OlmMachine {
 
     /// Clear any in-memory caches because they may be out of sync with the
     /// underlying data store.
+    /// 
+    /// The crypto store layer is caching olm sessions for a given device.
+    /// When used in a multi-process context this cache will get outdated.
+    /// If the machine is used by another process, the cache must be invalidating when the
+    /// main process is resumed.
     pub async fn clear_crypto_cache(&self) {
         self.runtime.block_on(self.inner.clear_crypto_cache())
     }

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -54,6 +54,10 @@ Deprecations:
 
 Additions:
 
+
+- Expose new method `OlmMachine::clear_crypto_cache()`, with FFI bindings
+  ([#3462](https://github.com/matrix-org/matrix-rust-sdk/pull/3462))
+
 - Expose new method `OlmMachine::upload_device_keys()`.
   ([#3457](https://github.com/matrix-org/matrix-rust-sdk/pull/3457))
 

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2150,6 +2150,13 @@ impl OlmMachine {
         let account = cache.account().await?;
         Ok(account.uploaded_key_count())
     }
+
+    /// Clear any in-memory caches because they may be out of sync with the
+    /// underlying data store.
+    pub async fn clear_crypto_cache(&self) {
+        let crypto_store = self.store().crypto_store();
+        crypto_store.as_ref().clear_caches().await;
+    }
 }
 
 /// A set of requests to be executed when bootstrapping cross-signing using


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Exposes the crypto store `clear_caches` method on the OlmMachine to be used by EI to invalidate cache when multiprocess is involed. (see EXI equivalent https://github.com/matrix-org/matrix-rust-sdk/pull/3338)


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
