### PR TITLE
chore(crypto): Fixup version and changelog from patch release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,7 +3256,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-crypto"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -1,9 +1,5 @@
 # UNRELEASED
 
-Security fixes:
-
-- Don't log the private part of the backup key, introduced in [#71136e4](https://github.com/matrix-org/matrix-rust-sdk/commit/71136e44c03c79f80d6d1a2446673bc4d53a2067).
-
 Changes:
 
 - Sign the device keys with the user-identity (i.e. cross-signing keys) if
@@ -99,6 +95,13 @@ Additions:
 
 - Include event timestamps on logs from event decryption.
   ([#3194](https://github.com/matrix-org/matrix-rust-sdk/pull/3194))
+
+
+## 0.7.1 
+
+Security fixes:
+
+- Don't log the private part of the backup key, introduced in [#71136e4](https://github.com/matrix-org/matrix-rust-sdk/commit/71136e44c03c79f80d6d1a2446673bc4d53a2067).
 
 # 0.7.0
 

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-crypto"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
-version = "0.7.0"
+version = "0.7.1"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
<!-- description of the changes in this PR -->

It appears that the patch release 0.7.1 branch has not been merged in main, causing the crypto crate changelog to be outdated, and the toml version also.

Attempt to fix that

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
