### PR TITLE
Add tests for unknown properties in device keys

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1789,4 +1789,49 @@ pub(crate) mod tests {
 
         manager.take();
     }
+
+    #[async_test]
+    async fn test_key_query_with_unknown_properties() {
+        let manager = manager_test_helper(user_id(), device_id()).await;
+        let other_user = user_id!("@example:localhost");
+        let devices = manager.store.get_user_devices(other_user).await.unwrap();
+        assert_eq!(devices.devices().count(), 0);
+
+        let response = json!({
+            "device_keys": {
+                "@example:localhost": {
+                    "OBEBOSKTBE": {
+                        "algorithms": ["m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2"],
+                        "user_id": "@example:localhost",
+                        "device_id": "OBEBOSKTBE",
+                        "extra_property": "somevalue",
+                        "keys": {
+                            "curve25519:OBEBOSKTBE": "ECrdZebl0DskwbkxoztsiKPb6ivu7M2qQ70BFWwre3w",
+                            "ed25519:OBEBOSKTBE": "hFWo+pG6TVWNzq/ZubUQVL5Ardu9rqHxpKkCbf1/KiA"
+                        },
+                        "signatures": {
+                            "@example:localhost": {
+                                "ed25519:OBEBOSKTBE": "6vyYUgX+IoT1x6Mvf0g/GEPVb2UI3brfL7WZ75WZ81sH4FBFgAzkkuGpw9suGLKXnlEdLH0suBzaT4esVhFDCw",
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        let response = KeysQueryResponse::try_from_http_response(response_from_file(&response))
+            .expect("Can't parse the `/keys/query` response");
+
+        manager.receive_keys_query_response(&TransactionId::new(), &response).await.unwrap();
+
+        let devices = manager.store.get_user_devices(other_user).await.unwrap();
+        assert_eq!(devices.devices().count(), 1);
+
+        manager
+            .store
+            .get_readonly_device(other_user, device_id!("OBEBOSKTBE"))
+            .await
+            .unwrap()
+            .unwrap();
+    }
 }

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -13,6 +13,7 @@ macro_rules! cryptostore_integration_tests {
                 to_device::DeviceIdOrAllDevices, user_id, DeviceId, RoomId, TransactionId, UserId,
             };
             use serde_json::value::to_raw_value;
+            use serde_json::json;
             use $crate::{
                 olm::{
                     Account, Curve25519PublicKey, InboundGroupSession, OlmMessageHash,
@@ -35,9 +36,10 @@ macro_rules! cryptostore_integration_tests {
                         secret_send::SecretSendContent,
                         ToDeviceEvent,
                     },
+                    DeviceKeys,
                     EventEncryptionAlgorithm,
                 },
-                GossippedSecret, ReadOnlyDevice, SecretInfo, ToDeviceRequest, TrackedUser,
+                GossippedSecret, LocalTrust, ReadOnlyDevice, SecretInfo, ToDeviceRequest, TrackedUser,
             };
 
             use super::get_store;
@@ -501,9 +503,28 @@ macro_rules! cryptostore_integration_tests {
                     "SECONDDEVICE".into(),
                 ));
 
+                let json = json!({
+                    "algorithms": ["m.olm.v1.curve25519-aes-sha2", "m.megolm.v1.aes-sha2"],
+                    "user_id": "@bob:localhost",
+                    "device_id": "BOBDEVICE",
+                    "extra_property": "somevalue",
+                    "keys": {
+                        "curve25519:BOBDEVICE": "n0zs7qnaPLLf/OTL+dDLcI5kaPexbUeQ8jLQ2q6sO0E",
+                        "ed25519:BOBDEVICE": "RrKiu4+5EHRBWY6Qj6OtQGC0txpmEeanOz2irEZ/IN4",
+                    },
+                    "signatures": {
+                        "@bob:localhost": {
+                            "ed25519:BOBDEVICE": "9NjPewVHfB7Ah32mJ+CBx64mVoiQ8gbh+/2pc9WfAgut/H0Kqd/bbpgJq9Pn518szaXcGqEq0DxDP6CABBX8CQ",
+                        },
+                    },
+                });
+
+                let bob_device_1_keys: DeviceKeys = serde_json::from_value(json).unwrap();
+                let bob_device_1 = ReadOnlyDevice::new(bob_device_1_keys, LocalTrust::Unset);
+
                 let changes = Changes {
                     devices: DeviceChanges {
-                        new: vec![alice_device_1.clone(), alice_device_2.clone()],
+                        new: vec![alice_device_1.clone(), alice_device_2.clone(), bob_device_1.clone()],
                         ..Default::default()
                     },
                     ..Default::default()
@@ -533,6 +554,14 @@ macro_rules! cryptostore_integration_tests {
 
                 let user_devices = store.get_user_devices(alice_device_1.user_id()).await.unwrap();
                 assert_eq!(user_devices.len(), 2);
+
+                let bob_device = store
+                    .get_device(bob_device_1.user_id(), bob_device_1.device_id())
+                    .await
+                    .unwrap();
+
+                let bob_device_json = serde_json::to_value(bob_device).unwrap();
+                assert_eq!(bob_device_json["inner"]["extra_property"], json!("somevalue"));
             }
 
             #[async_test]


### PR DESCRIPTION
Add tests to ensure that unknown properties in device keys are handled correctly.

One test was previously discussed at https://github.com/matrix-org/matrix-rust-sdk/issues/3132#issuecomment-2002060930  The other test ensures that the /keys/query response handler doesn't freak out about unknown properties.