### PR TITLE
crypto: Decrypt events bundled in unsigned object of another event

### DIFF
--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -772,6 +772,7 @@ mod tests {
                 }),
                 encryption_info: None,
                 push_actions,
+                unsigned_encryption_info: None,
             }
         }
 
@@ -857,6 +858,7 @@ mod tests {
                 }),
                 encryption_info: None,
                 push_actions: Vec::new(),
+                unsigned_encryption_info: None,
             }
         }
 

--- a/crates/matrix-sdk-common/src/lib.rs
+++ b/crates/matrix-sdk-common/src/lib.rs
@@ -15,6 +15,9 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_debug_implementations)]
 
+use std::pin::Pin;
+
+use futures_core::Future;
 #[doc(no_inline)]
 pub use instant;
 #[doc(no_inline)]
@@ -88,3 +91,9 @@ macro_rules! boxed_into_future {
         >>;
     };
 }
+
+/// A `Box::pin` future that is `Send` on non-wasm, and without `Send` on wasm.
+#[cfg(target_arch = "wasm32")]
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+#[cfg(not(target_arch = "wasm32"))]
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -51,7 +51,7 @@ pub(crate) mod tests {
         serde::Raw,
         user_id, DeviceId, UserId,
     };
-    use serde_json::{json, Value};
+    use serde_json::{from_value, json, Value};
     use vodozemac::{
         olm::{OlmMessage, SessionConfig},
         Curve25519PublicKey, Ed25519PublicKey,
@@ -250,7 +250,7 @@ pub(crate) mod tests {
 
         if let AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
             MessageLikeEvent::Original(e),
-        )) = decrypted.deserialize().unwrap()
+        )) = from_value(decrypted.into()).unwrap()
         {
             assert_matches!(e.content.relates_to, Some(Relation::Replacement(_)));
         } else {

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -229,7 +229,7 @@ impl TestTimeline {
     }
 
     async fn handle_live_event(&self, event: Raw<AnySyncTimelineEvent>) {
-        let event = SyncTimelineEvent { event, encryption_info: None, push_actions: vec![] };
+        let event = SyncTimelineEvent::new(event);
         self.inner.handle_live_event(event).await
     }
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -377,9 +377,10 @@ impl Room {
             }
         }
 
-        let push_actions = self.event_push_actions(&event).await?;
+        let mut event = TimelineEvent::new(event);
+        event.push_actions = self.event_push_actions(&event.event).await?;
 
-        Ok(TimelineEvent { event, encryption_info: None, push_actions })
+        Ok(event)
     }
 
     /// Fetch the event with the given `EventId` in this room.


### PR DESCRIPTION
Allows to potentially have a fully decrypted event.

Fixes #2976.