### PR TITLE
crypto: Add `SasState::Created` variant

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -28,8 +28,11 @@ pub trait SasListener: Send {
 /// An Enum describing the state the SAS verification is in.
 #[derive(uniffi::Enum)]
 pub enum SasState {
-    /// The verification has been started, the protocols that should be used
-    /// have been proposed and can be accepted.
+    /// The verification has been created, the protocols that should be used
+    /// have been proposed to the other party.
+    Created,
+    /// The verification has been started, the other party proposed the
+    /// protocols that should be used and that can be accepted.
     Started,
     /// The verification has been accepted and both sides agreed to a set of
     /// protocols that will be used for the verification process.
@@ -58,6 +61,7 @@ pub enum SasState {
 impl From<RustSasState> for SasState {
     fn from(s: RustSasState) -> Self {
         match s {
+            RustSasState::Created { .. } => Self::Created,
             RustSasState::Started { .. } => Self::Started,
             RustSasState::Accepted { .. } => Self::Accepted,
             RustSasState::KeysExchanged { emojis, decimals } => Self::KeysExchanged {

--- a/bindings/matrix-sdk-ffi/src/session_verification.rs
+++ b/bindings/matrix-sdk-ffi/src/session_verification.rs
@@ -246,7 +246,10 @@ impl SessionVerificationController {
                     }
                     break;
                 }
-                SasState::Started { .. } | SasState::Accepted { .. } | SasState::Confirmed => (),
+                SasState::Created { .. }
+                | SasState::Started { .. }
+                | SasState::Accepted { .. }
+                | SasState::Confirmed => (),
             }
         }
     }

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -47,6 +47,9 @@ Breaking changes:
 - Remove deprecated `OlmMachine::import_room_keys`.
   ([#3448](https://github.com/matrix-org/matrix-rust-sdk/pull/3448))
 
+- Add the `SasState::Created` variant to differentiate the state between the
+  party that sent the verification start and the party that received it.
+
 Deprecations:
 
 - Deprecate `BackupMachine::import_backed_up_room_keys`.

--- a/crates/matrix-sdk/src/encryption/verification/sas.rs
+++ b/crates/matrix-sdk/src/encryption/verification/sas.rs
@@ -235,6 +235,10 @@ impl SasVerification {
     ///
     /// ```text
     ///                ┌───────┐
+    ///                │Created│
+    ///                └───┬───┘
+    ///                    │
+    ///                ┌───⌄───┐
     ///                │Started│
     ///                └───┬───┘
     ///                    │
@@ -305,7 +309,8 @@ impl SasVerification {
     ///             );
     ///             break;
     ///         }
-    ///         SasState::Started { .. }
+    ///         SasState::Created { .. }
+    ///         | SasState::Started { .. }
     ///         | SasState::Accepted { .. }
     ///         | SasState::Confirmed => (),
     ///     }

--- a/examples/emoji_verification/src/main.rs
+++ b/examples/emoji_verification/src/main.rs
@@ -91,7 +91,10 @@ async fn sas_verification_handler(client: Client, sas: SasVerification) {
 
                 break;
             }
-            SasState::Started { .. } | SasState::Accepted { .. } | SasState::Confirmed => (),
+            SasState::Created { .. }
+            | SasState::Started { .. }
+            | SasState::Accepted { .. }
+            | SasState::Confirmed => (),
         }
     }
 }

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -188,7 +188,7 @@ async fn test_mutual_sas_verification() -> Result<()> {
 
     let bob_sas = bob_verification.sas().unwrap();
 
-    assert_matches!(alice_sas.state(), SasState::Started { .. });
+    assert_matches!(alice_sas.state(), SasState::Created { .. });
     assert_matches!(bob_sas.state(), SasState::Started { .. });
 
     bob_sas.accept().await?;


### PR DESCRIPTION
To differentiate the SAS state between the party that sent the verification start and the party that received it.

- [x] Public API changes documented in changelogs (optional)

Fixes #2979.
