### PR TITLE
feat(sdk): Improve `RoomEventCacheUpdate`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -220,13 +220,15 @@ impl TimelineBuilder {
                             inner.clear().await;
                         }
 
-                        RoomEventCacheUpdate::Append { events, ephemeral, ambiguity_changes } => {
+                        RoomEventCacheUpdate::Append { events, ephemeral } => {
                             trace!("Received new events from sync.");
 
                             // TODO: (bnjbvr) ephemeral should be handled by the event cache, and
                             // we should replace this with a simple `add_events_at`.
                             inner.handle_sync_events(events, ephemeral).await;
+                        }
 
+                        RoomEventCacheUpdate::Members { ambiguity_changes } => {
                             if !ambiguity_changes.is_empty() {
                                 let member_ambiguity_changes = ambiguity_changes
                                     .values()

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -228,7 +228,7 @@ impl TimelineBuilder {
                         }
 
                         RoomEventCacheUpdate::AddTimelineEvents { events, origin } => {
-                            trace!("Received new timeline events from sync.");
+                            trace!("Received new timeline events.");
 
                             inner.add_events_at(
                                 events,

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -203,7 +203,7 @@ impl TimelineBuilder {
                     };
 
                     match update {
-                        RoomEventCacheUpdate::ReadMarker { event_id } => {
+                        RoomEventCacheUpdate::ReadMarker { move_to: event_id } => {
                             trace!(target = %event_id, "Handling fully read marker.");
                             inner.handle_fully_read_marker(event_id).await;
                         }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -203,7 +203,7 @@ impl TimelineBuilder {
                     };
 
                     match update {
-                        RoomEventCacheUpdate::UpdateReadMarker { event_id } => {
+                        RoomEventCacheUpdate::ReadMarker { event_id } => {
                             trace!(target = %event_id, "Handling fully read marker.");
                             inner.handle_fully_read_marker(event_id).await;
                         }

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -220,12 +220,12 @@ impl TimelineBuilder {
                             inner.clear().await;
                         }
 
-                        RoomEventCacheUpdate::Append { events, ephemeral } => {
+                        RoomEventCacheUpdate::SyncEvents { timeline, ephemeral } => {
                             trace!("Received new events from sync.");
 
                             // TODO: (bnjbvr) ephemeral should be handled by the event cache, and
                             // we should replace this with a simple `add_events_at`.
-                            inner.handle_sync_events(events, ephemeral).await;
+                            inner.handle_sync_events(timeline, ephemeral).await;
                         }
 
                         RoomEventCacheUpdate::Members { ambiguity_changes } => {

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -203,7 +203,7 @@ impl TimelineBuilder {
                     };
 
                     match update {
-                        RoomEventCacheUpdate::ReadMarker { move_to: event_id } => {
+                        RoomEventCacheUpdate::MoveReadMarkerTo { event_id } => {
                             trace!(target = %event_id, "Handling fully read marker.");
                             inner.handle_fully_read_marker(event_id).await;
                         }
@@ -228,7 +228,7 @@ impl TimelineBuilder {
                             inner.handle_sync_events(timeline, ephemeral).await;
                         }
 
-                        RoomEventCacheUpdate::Members { ambiguity_changes } => {
+                        RoomEventCacheUpdate::UpdateMembers { ambiguity_changes } => {
                             if !ambiguity_changes.is_empty() {
                                 let member_ambiguity_changes = ambiguity_changes
                                     .values()

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -606,13 +606,12 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         self.state.write().await.handle_fully_read_marker(fully_read_event_id);
     }
 
-    pub(super) async fn handle_sync_events(
+    pub(super) async fn handle_ephemeral_events(
         &self,
-        events: Vec<SyncTimelineEvent>,
-        ephemeral: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
     ) {
         let mut state = self.state.write().await;
-        state.handle_sync_events(events, ephemeral, &self.room_data_provider, &self.settings).await;
+        state.handle_ephemeral_events(events, &self.room_data_provider).await;
     }
 
     #[cfg(test)]

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -681,9 +681,9 @@ impl RoomEventCacheInner {
             }
 
             if !ephemeral_events.is_empty() {
-                let _ = self.sender.send(RoomEventCacheUpdate::AddEphemeralEvents {
-                    events: ephemeral_events,
-                });
+                let _ = self
+                    .sender
+                    .send(RoomEventCacheUpdate::AddEphemeralEvents { events: ephemeral_events });
             }
 
             if !ambiguity_changes.is_empty() {

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -517,7 +517,7 @@ impl RoomEventCacheInner {
                     // Propagate to observers. (We ignore the error if there aren't any.)
                     let _ = self
                         .sender
-                        .send(RoomEventCacheUpdate::ReadMarker { event_id: ev.content.event_id });
+                        .send(RoomEventCacheUpdate::ReadMarker { move_to: ev.content.event_id });
                 }
 
                 Ok(_) => {
@@ -704,7 +704,7 @@ pub enum RoomEventCacheUpdate {
     /// The fully read marker has moved to a different event.
     ReadMarker {
         /// Event at which the read marker is now pointing.
-        event_id: OwnedEventId,
+        move_to: OwnedEventId,
     },
 
     /// The room has new events.

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -515,9 +515,9 @@ impl RoomEventCacheInner {
                     handled_read_marker = true;
 
                     // Propagate to observers. (We ignore the error if there aren't any.)
-                    let _ = self.sender.send(RoomEventCacheUpdate::UpdateReadMarker {
-                        event_id: ev.content.event_id,
-                    });
+                    let _ = self
+                        .sender
+                        .send(RoomEventCacheUpdate::ReadMarker { event_id: ev.content.event_id });
                 }
 
                 Ok(_) => {
@@ -702,7 +702,7 @@ pub enum RoomEventCacheUpdate {
     Clear,
 
     /// The fully read marker has moved to a different event.
-    UpdateReadMarker {
+    ReadMarker {
         /// Event at which the read marker is now pointing.
         event_id: OwnedEventId,
     },
@@ -788,10 +788,7 @@ mod tests {
             .unwrap();
 
         // … there's only one read marker update.
-        assert_matches!(
-            stream.recv().await.unwrap(),
-            RoomEventCacheUpdate::UpdateReadMarker { .. }
-        );
+        assert_matches!(stream.recv().await.unwrap(), RoomEventCacheUpdate::ReadMarker { .. });
 
         assert!(stream.recv().now_or_never().is_none());
     }

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -592,7 +592,7 @@ impl RoomEventCacheInner {
         &self,
         sync_timeline_events: Vec<SyncTimelineEvent>,
         prev_batch: Option<String>,
-        sync_ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
     ) -> Result<()> {
         // Acquire the lock.
@@ -609,7 +609,7 @@ impl RoomEventCacheInner {
             room_events,
             sync_timeline_events,
             prev_batch,
-            sync_ephemeral_events,
+            ephemeral_events,
             ambiguity_changes,
         )
         .await
@@ -621,14 +621,14 @@ impl RoomEventCacheInner {
         &self,
         sync_timeline_events: Vec<SyncTimelineEvent>,
         prev_batch: Option<String>,
-        sync_ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
     ) -> Result<()> {
         self.append_events_locked_impl(
             self.events.write().await,
             sync_timeline_events,
             prev_batch,
-            sync_ephemeral_events,
+            ephemeral_events,
             ambiguity_changes,
         )
         .await
@@ -644,12 +644,12 @@ impl RoomEventCacheInner {
         mut room_events: RwLockWriteGuard<'_, RoomEvents>,
         sync_timeline_events: Vec<SyncTimelineEvent>,
         prev_batch: Option<String>,
-        sync_ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
+        ephemeral_events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
         ambiguity_changes: BTreeMap<OwnedEventId, AmbiguityChange>,
     ) -> Result<()> {
         if sync_timeline_events.is_empty()
             && prev_batch.is_none()
-            && sync_ephemeral_events.is_empty()
+            && ephemeral_events.is_empty()
             && ambiguity_changes.is_empty()
         {
             return Ok(());
@@ -680,9 +680,9 @@ impl RoomEventCacheInner {
                 });
             }
 
-            if !sync_ephemeral_events.is_empty() {
+            if !ephemeral_events.is_empty() {
                 let _ = self.sender.send(RoomEventCacheUpdate::AddEphemeralEvents {
-                    events: sync_ephemeral_events,
+                    events: ephemeral_events,
                 });
             }
 

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -104,9 +104,9 @@ async fn test_add_initial_events() {
         .expect("should've received a room event cache update");
 
     // Which contains the event that was sent beforehand.
-    assert_let!(RoomEventCacheUpdate::Append { events, .. } = update);
-    assert_eq!(events.len(), 1);
-    assert_event_matches_msg(&events[0], "bonjour monde");
+    assert_let!(RoomEventCacheUpdate::SyncEvents { timeline: timeline_events, .. } = update);
+    assert_eq!(timeline_events.len(), 1);
+    assert_event_matches_msg(&timeline_events[0], "bonjour monde");
 
     // And when I later add initial events to this room,
 
@@ -130,9 +130,9 @@ async fn test_add_initial_events() {
         .await
         .expect("timeout after receiving a sync update")
         .expect("should've received a room event cache update");
-    assert_let!(RoomEventCacheUpdate::Append { events, .. } = update);
-    assert_eq!(events.len(), 1);
-    assert_event_matches_msg(&events[0], "new choice!");
+    assert_let!(RoomEventCacheUpdate::SyncEvents { timeline: timeline_events, .. } = update);
+    assert_eq!(timeline_events.len(), 1);
+    assert_event_matches_msg(&timeline_events[0], "new choice!");
 
     // That's all, folks!
     assert!(subscriber.is_empty());
@@ -233,9 +233,9 @@ async fn test_ignored_unignored() {
         .expect("timeout after receiving a sync update")
         .expect("should've received a room event cache update");
 
-    assert_let!(RoomEventCacheUpdate::Append { events, .. } = update);
-    assert_eq!(events.len(), 1);
-    assert_event_matches_msg(&events[0], "i don't like this dexter");
+    assert_let!(RoomEventCacheUpdate::SyncEvents { timeline: timeline_events, .. } = update);
+    assert_eq!(timeline_events.len(), 1);
+    assert_event_matches_msg(&timeline_events[0], "i don't like this dexter");
 
     // The other room has been cleared too.
     {

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -104,9 +104,9 @@ async fn test_add_initial_events() {
         .expect("should've received a room event cache update");
 
     // Which contains the event that was sent beforehand.
-    assert_let!(RoomEventCacheUpdate::SyncEvents { timeline: timeline_events, .. } = update);
-    assert_eq!(timeline_events.len(), 1);
-    assert_event_matches_msg(&timeline_events[0], "bonjour monde");
+    assert_let!(RoomEventCacheUpdate::AddTimelineEvents { events, .. } = update);
+    assert_eq!(events.len(), 1);
+    assert_event_matches_msg(&events[0], "bonjour monde");
 
     // And when I later add initial events to this room,
 
@@ -130,9 +130,9 @@ async fn test_add_initial_events() {
         .await
         .expect("timeout after receiving a sync update")
         .expect("should've received a room event cache update");
-    assert_let!(RoomEventCacheUpdate::SyncEvents { timeline: timeline_events, .. } = update);
-    assert_eq!(timeline_events.len(), 1);
-    assert_event_matches_msg(&timeline_events[0], "new choice!");
+    assert_let!(RoomEventCacheUpdate::AddTimelineEvents { events, .. } = update);
+    assert_eq!(events.len(), 1);
+    assert_event_matches_msg(&events[0], "new choice!");
 
     // That's all, folks!
     assert!(subscriber.is_empty());
@@ -233,9 +233,9 @@ async fn test_ignored_unignored() {
         .expect("timeout after receiving a sync update")
         .expect("should've received a room event cache update");
 
-    assert_let!(RoomEventCacheUpdate::SyncEvents { timeline: timeline_events, .. } = update);
-    assert_eq!(timeline_events.len(), 1);
-    assert_event_matches_msg(&timeline_events[0], "i don't like this dexter");
+    assert_let!(RoomEventCacheUpdate::AddTimelineEvents { events, .. } = update);
+    assert_eq!(events.len(), 1);
+    assert_event_matches_msg(&events[0], "i don't like this dexter");
 
     // The other room has been cleared too.
     {


### PR DESCRIPTION
This patch improves/refactors `RoomEventCacheUpdate` a little bit. That's preliminary work to support `VectorDiff` from the `EventCache` into the `Timeline`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280