### PR TITLE
Revert "feat(sdk): Add `RoomPagination::run_backwards(…, until)`"

### DIFF
--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -76,7 +76,7 @@ mod pagination;
 mod store;
 
 pub mod paginator;
-pub use pagination::{RoomPagination, TimelineHasBeenResetWhilePaginating};
+pub use pagination::RoomPagination;
 
 /// An error observed in the [`EventCache`].
 #[derive(thiserror::Error, Debug)]

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -14,7 +14,7 @@
 
 //! A sub-object for running pagination tasks on a given room.
 
-use std::{future::Future, ops::ControlFlow, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use eyeball::Subscriber;
 use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
@@ -59,75 +59,17 @@ impl RoomPagination {
     /// This automatically takes care of waiting for a pagination token from
     /// sync, if we haven't done that before.
     ///
-    /// The `until` argument is an async closure that returns a [`ControlFlow`]
-    /// to decide whether a new pagination must be run or not. It's helpful when
-    /// the server replies with e.g. a certain set of events, but we would like
-    /// more, or the event we are looking for isn't part of this set: in this
-    /// case, `until` returns [`Control::Continue`], otherwise it returns
-    /// [`ControlFlow::Break`]. `until` receives [`BackPaginationOutcome`] as
-    /// its sole argument.
-    ///
     /// # Errors
     ///
     /// It may return an error if the pagination token used during
     /// back-pagination has disappeared while we started the pagination. In
     /// that case, it's desirable to call the method again.
-    ///
-    /// # Example
-    ///
-    /// To do a single run:
-    ///
-    /// ```rust
-    /// use std::ops::ControlFlow;
-    ///
-    /// use matrix_sdk::event_cache::{
-    ///     BackPaginationOutcome,
-    ///     RoomPagination,
-    ///     TimelineHasBeenResetWhilePaginating
-    /// };
-    ///
-    /// # async fn foo(room_pagination: RoomPagination) {
-    /// let result = room_pagination.run_backwards(
-    ///     42,
-    ///     |BackPaginationOutcome { events, reached_start },
-    ///      _timeline_has_been_reset: TimelineHasBeenResetWhilePaginating| async move {
-    ///         // Do something with `events` and `reached_start` maybe?
-    ///         let _ = events;
-    ///         let _ = reached_start;
-    ///
-    ///         ControlFlow::Break(())
-    ///     }
-    /// ).await;
-    /// # }
-    #[instrument(skip(self, until))]
-    pub async fn run_backwards<Until, Break, UntilFuture>(
-        &self,
-        batch_size: u16,
-        mut until: Until,
-    ) -> Result<Break>
-    where
-        Until: FnMut(BackPaginationOutcome, TimelineHasBeenResetWhilePaginating) -> UntilFuture,
-        UntilFuture: Future<Output = ControlFlow<Break, ()>>,
-    {
-        let mut timeline_has_been_reset = TimelineHasBeenResetWhilePaginating::No;
-
+    #[instrument(skip(self))]
+    pub async fn run_backwards(&self, batch_size: u16) -> Result<BackPaginationOutcome> {
         loop {
-            if let Some(outcome) = self.run_backwards_impl(batch_size).await? {
-                match until(outcome, timeline_has_been_reset).await {
-                    ControlFlow::Continue(()) => {
-                        trace!("back-pagination continues");
-
-                        timeline_has_been_reset = TimelineHasBeenResetWhilePaginating::No;
-
-                        continue;
-                    }
-
-                    ControlFlow::Break(value) => return Ok(value),
-                }
+            if let Some(result) = self.run_backwards_impl(batch_size).await? {
+                return Ok(result);
             }
-
-            timeline_has_been_reset = TimelineHasBeenResetWhilePaginating::Yes;
-
             debug!("back-pagination has been internally restarted because of a timeline reset.");
         }
     }
@@ -315,16 +257,6 @@ impl RoomPagination {
     pub fn hit_timeline_end(&self) -> bool {
         self.inner.pagination.paginator.hit_timeline_end()
     }
-}
-
-/// A type representing whether the timeline has been reset.
-#[derive(Debug)]
-pub enum TimelineHasBeenResetWhilePaginating {
-    /// The timeline has been reset.
-    Yes,
-
-    /// The timeline has not been reset.
-    No,
 }
 
 #[cfg(test)]

--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -1,11 +1,8 @@
-use std::{future::ready, ops::ControlFlow, time::Duration};
+use std::time::Duration;
 
 use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
-    event_cache::{
-        BackPaginationOutcome, EventCacheError, RoomEventCacheUpdate,
-        TimelineHasBeenResetWhilePaginating,
-    },
+    event_cache::{BackPaginationOutcome, EventCacheError, RoomEventCacheUpdate},
     test_utils::{assert_event_matches_msg, events::EventFactory, logged_in_client_with_server},
 };
 use matrix_sdk_test::{
@@ -26,13 +23,6 @@ use wiremock::{
 };
 
 use crate::mock_sync;
-
-async fn once(
-    outcome: BackPaginationOutcome,
-    _timeline_has_been_reset: TimelineHasBeenResetWhilePaginating,
-) -> ControlFlow<BackPaginationOutcome, ()> {
-    ControlFlow::Break(outcome)
-}
 
 #[async_test]
 async fn test_must_explicitly_subscribe() {
@@ -372,7 +362,7 @@ async fn test_backpaginate_once() {
 
         assert!(pagination.get_or_wait_for_token().await.is_some());
 
-        pagination.run_backwards(20, once).await.unwrap()
+        pagination.run_backwards(20).await.unwrap()
     };
 
     // I'll get all the previous events, in "reverse" order (same as the response).
@@ -387,7 +377,7 @@ async fn test_backpaginate_once() {
 }
 
 #[async_test]
-async fn test_backpaginate_many_times_with_many_iterations() {
+async fn test_backpaginate_multiple_iterations() {
     let (client, server) = logged_in_client_with_server().await;
 
     let event_cache = client.event_cache();
@@ -435,7 +425,6 @@ async fn test_backpaginate_many_times_with_many_iterations() {
     }
 
     let mut num_iterations = 0;
-    let mut num_paginations = 0;
     let mut global_events = Vec::new();
     let mut global_reached_start = false;
 
@@ -460,149 +449,19 @@ async fn test_backpaginate_many_times_with_many_iterations() {
     // Then if I backpaginate in a loop,
     let pagination = room_event_cache.pagination();
     while pagination.get_or_wait_for_token().await.is_some() {
-        pagination
-            .run_backwards(20, |outcome, timeline_has_been_reset| {
-                num_paginations += 1;
+        let BackPaginationOutcome { reached_start, events } =
+            pagination.run_backwards(20).await.unwrap();
 
-                assert_matches!(timeline_has_been_reset, TimelineHasBeenResetWhilePaginating::No);
-
-                if !global_reached_start {
-                    global_reached_start = outcome.reached_start;
-                }
-
-                global_events.extend(outcome.events);
-
-                ready(ControlFlow::Break(()))
-            })
-            .await
-            .unwrap();
+        if !global_reached_start {
+            global_reached_start = reached_start;
+        }
+        global_events.extend(events);
 
         num_iterations += 1;
     }
 
     // I'll get all the previous events,
-    assert_eq!(num_iterations, 2); // in two iterations…
-    assert_eq!(num_paginations, 2); // … we get two paginations.
-    assert!(global_reached_start);
-
-    assert_event_matches_msg(&global_events[0], "world");
-    assert_event_matches_msg(&global_events[1], "hello");
-    assert_event_matches_msg(&global_events[2], "oh well");
-    assert_eq!(global_events.len(), 3);
-
-    // And next time I'll open the room, I'll get the events in the right order.
-    let (events, _receiver) = room_event_cache.subscribe().await.unwrap();
-
-    assert_event_matches_msg(&events[0], "oh well");
-    assert_event_matches_msg(&events[1], "hello");
-    assert_event_matches_msg(&events[2], "world");
-    assert_event_matches_msg(&events[3], "heyo");
-    assert_eq!(events.len(), 4);
-
-    assert!(room_stream.is_empty());
-}
-
-#[async_test]
-async fn test_backpaginate_many_times_with_one_iteration() {
-    let (client, server) = logged_in_client_with_server().await;
-
-    let event_cache = client.event_cache();
-
-    // Immediately subscribe the event cache to sync updates.
-    event_cache.subscribe().unwrap();
-
-    // If I sync and get informed I've joined The Room, and get a previous batch
-    // token,
-    let room_id = room_id!("!omelette:fromage.fr");
-
-    let event_builder = EventBuilder::new();
-    let mut sync_builder = SyncResponseBuilder::new();
-
-    {
-        sync_builder.add_joined_room(
-            JoinedRoomBuilder::new(room_id)
-                // Note to self: a timeline must have at least single event to be properly
-                // serialized.
-                .add_timeline_event(event_builder.make_sync_message_event(
-                    user_id!("@a:b.c"),
-                    RoomMessageEventContent::text_plain("heyo"),
-                ))
-                .set_timeline_prev_batch("prev_batch".to_owned()),
-        );
-        let response_body = sync_builder.build_json_sync_response();
-
-        mock_sync(&server, response_body, None).await;
-        client.sync_once(Default::default()).await.unwrap();
-        server.reset().await;
-    }
-
-    let (room_event_cache, _drop_handles) =
-        client.get_room(room_id).unwrap().event_cache().await.unwrap();
-
-    let (events, mut room_stream) = room_event_cache.subscribe().await.unwrap();
-
-    // This is racy: either the initial message has been processed by the event
-    // cache (and no room updates will happen in this case), or it hasn't, and
-    // the stream will return the next message soon.
-    if events.is_empty() {
-        let _ = room_stream.recv().await.expect("read error");
-    } else {
-        assert_eq!(events.len(), 1);
-    }
-
-    let mut num_iterations = 0;
-    let mut num_paginations = 0;
-    let mut global_events = Vec::new();
-    let mut global_reached_start = false;
-
-    // The first back-pagination will return these two.
-    mock_messages(
-        &server,
-        "prev_batch",
-        Some("prev_batch2"),
-        non_sync_events!(event_builder, [ (room_id, "$2": "world"), (room_id, "$3": "hello") ]),
-    )
-    .await;
-
-    // The second round of back-pagination will return this one.
-    mock_messages(
-        &server,
-        "prev_batch2",
-        None,
-        non_sync_events!(event_builder, [ (room_id, "$4": "oh well"), ]),
-    )
-    .await;
-
-    // Then if I backpaginate in a loop,
-    let pagination = room_event_cache.pagination();
-    while pagination.get_or_wait_for_token().await.is_some() {
-        pagination
-            .run_backwards(20, |outcome, timeline_has_been_reset| {
-                num_paginations += 1;
-
-                assert_matches!(timeline_has_been_reset, TimelineHasBeenResetWhilePaginating::No);
-
-                if !global_reached_start {
-                    global_reached_start = outcome.reached_start;
-                }
-
-                global_events.extend(outcome.events);
-
-                ready(if outcome.reached_start {
-                    ControlFlow::Break(())
-                } else {
-                    ControlFlow::Continue(())
-                })
-            })
-            .await
-            .unwrap();
-
-        num_iterations += 1;
-    }
-
-    // I'll get all the previous events,
-    assert_eq!(num_iterations, 1); // in one iteration…
-    assert_eq!(num_paginations, 2); // … we get two paginations!
+    assert_eq!(num_iterations, 2);
     assert!(global_reached_start);
 
     assert_event_matches_msg(&global_events[0], "world");
@@ -727,18 +586,7 @@ async fn test_reset_while_backpaginating() {
 
     let backpagination = spawn({
         let pagination = room_event_cache.pagination();
-        async move {
-            pagination
-                .run_backwards(20, |outcome, timeline_has_been_reset| {
-                    assert_matches!(
-                        timeline_has_been_reset,
-                        TimelineHasBeenResetWhilePaginating::Yes
-                    );
-
-                    ready(ControlFlow::Break(outcome))
-                })
-                .await
-        }
+        async move { pagination.run_backwards(20).await }
     });
 
     // Receive the sync response (which clears the timeline).
@@ -808,7 +656,7 @@ async fn test_backpaginating_without_token() {
     // If we try to back-paginate with a token, it will hit the end of the timeline
     // and give us the resulting event.
     let BackPaginationOutcome { events, reached_start } =
-        pagination.run_backwards(20, once).await.unwrap();
+        pagination.run_backwards(20).await.unwrap();
 
     assert!(reached_start);
 


### PR DESCRIPTION
Reverting changes because the PR didn't pass CI at the time of merging, and it's been force-merged. We can't break `main` like this, especially when the PR author is not around to fix it thereafter.