### PR TITLE
room: cache the return of a previous call to `computed_display_name`  and use that in search filters

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/fuzzy_match_room_name.rs
@@ -51,11 +51,11 @@ pub fn new_filter(client: &Client, pattern: &str) -> impl Filter {
     let client = client.clone();
 
     move |room_list_entry| -> bool {
-        let Some(room_id) = room_list_entry.as_room_id() else { return false };
-        let Some(room) = client.get_room(room_id) else { return false };
-        let Some(room_name) = room.name() else { return false };
-
-        searcher.matches(&room_name)
+        room_list_entry
+            .as_room_id()
+            .and_then(|room_id| client.get_room(room_id))
+            .and_then(|room| room.cached_computed_display_name())
+            .map_or(false, |room_name| searcher.matches(&room_name.to_string()))
     }
 }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/filters/normalized_match_room_name.rs
@@ -51,11 +51,11 @@ pub fn new_filter(client: &Client, pattern: &str) -> impl Filter {
     let client = client.clone();
 
     move |room_list_entry| -> bool {
-        let Some(room_id) = room_list_entry.as_room_id() else { return false };
-        let Some(room) = client.get_room(room_id) else { return false };
-        let Some(room_name) = room.name() else { return false };
-
-        searcher.matches(&room_name)
+        room_list_entry
+            .as_room_id()
+            .and_then(|room_id| client.get_room(room_id))
+            .and_then(|room| room.cached_computed_display_name())
+            .map_or(false, |room_name| searcher.matches(&room_name.to_string()))
     }
 }
 


### PR DESCRIPTION
It's not possible to use async code from a search filter, so we can't just plain call `Room::computed_display_name`. Also, it would be too expensive to recompute it every single time we call that function, hence the idea of caching the result.

Ideally, we'd have something like a "get_cached_or_recompute()` method, but it would need to be async as well in the case we have to actually compute the underlying `computed_display_name`. Instead, this commit proposes a stopgap that will store the outcome of
`computed_display_name` in a local internal cache, and make it available in a sync method, so that the search filters may use it.

In theory, the computed display name could then be empty, but! the Room list service that offers the filters is powered by a sliding sync that publishes `RoomInfo` updates for rooms, and `RoomInfo` will internally call `computed_display_name` too.

All in all, it'd be better if there was a better proper caching, but this can act as a stopgap solution in the meanwhile.