### PR TITLE
utd hook: fix re-reporting of late-decrypted events

### DIFF
--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -6,6 +6,11 @@ Breaking changes:
 - `Timeline::send_attachment` now takes an `impl Into<PathBuf>` for the path of
   the file to send.
 
+Bug fixes:
+
+- `UtdHookManager` no longer re-reports UTD events as late decryptions.
+  ([#3840](https://github.com/matrix-org/matrix-rust-sdk/pull/3840))
+
 # 0.7.0
 
 Initial release

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -157,6 +157,10 @@ async fn test_retry_message_decryption() {
     {
         let utds = hook.utds.lock().unwrap();
         assert_eq!(utds.len(), 1);
+
+        // The previous UTD report is still there.
+        assert_eq!(utds[0].event_id, event.event_id().unwrap());
+        assert!(utds[0].time_to_decrypt.is_none());
     }
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -153,17 +153,10 @@ async fn test_retry_message_decryption() {
     assert_eq!(message.body(), "It's a secret to everybody");
     assert!(!event.is_highlighted());
 
+    // The message should not be re-reported as a late decryption.
     {
         let utds = hook.utds.lock().unwrap();
-        assert_eq!(utds.len(), 2);
-
-        // The previous UTD report is still there.
-        assert_eq!(utds[0].event_id, event.event_id().unwrap());
-        assert!(utds[0].time_to_decrypt.is_none());
-
-        // The UTD is now *also* reported as a late-decryption event.
-        assert_eq!(utds[1].event_id, event.event_id().unwrap());
-        assert!(utds[1].time_to_decrypt.is_some());
+        assert_eq!(utds.len(), 1);
     }
 }
 

--- a/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
+++ b/crates/matrix-sdk-ui/src/unable_to_decrypt_hook.rs
@@ -314,6 +314,10 @@ mod tests {
         {
             let utds = hook.utds.lock().unwrap();
             assert_eq!(utds.len(), 1);
+
+            // The previous report is still there. (There was no grace period.)
+            assert_eq!(utds[0].event_id, event_id!("$1"));
+            assert!(utds[0].time_to_decrypt.is_none());
         }
     }
 


### PR DESCRIPTION
If an event cannot be decrypted after a grace period, it is reported to the application (and thence Posthog) as a UTD event. Currently, if it is then successfully decrypted, the event is then re-reported as a "late decryption".

This does not match the expected behaviour in Posthog - an event is *either* a UTD, or a late decryption; it makes no sense for it to be both. This PR fixes the problem.

I've attempted to make the commits sensible, but I'm not entirely sure I've succeeded. The tests do pass after each commit, though. The interesting change itself is somewhere in the middle; there is non-functional groundwork before and cleanup afterwards.

<!-- description of the changes in this PR -->

- [x] Public API changes documented in changelogs (optional)