### PR TITLE
Fix trigger condition for new upload_coverage workflow

### DIFF
--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -6,7 +6,7 @@ on:
   # This workflow is triggered after every successfull execution
   # of `coverage` workflow.
   workflow_run:
-    workflows: ["coverage"]
+    workflows: ["Code Coverage"]
     types:
       - completed
 


### PR DESCRIPTION
Because GitHub actions has no IDs for workflows, you refer to them by name. What could possibly go wrong?