### PR TITLE
ci: Fix coverage uploads in separate workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -131,6 +131,7 @@ jobs:
             cobertura.xml
             pr_number.txt
             commit_sha.txt
+          if-no-files-found: error
 
       - run: |
           echo 'The coverage report was stored in Github artifacts.'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -145,5 +145,5 @@ jobs:
           path: codecov_report.json
 
       - run: |
-          echo "The coverage report was stored in Github artifacts."
-          echo "It will be uploaded to Codecov using `upload_coverage.yml` workflow shortly."
+          echo 'The coverage report was stored in Github artifacts.'
+          echo 'It will be uploaded to Codecov using `upload_coverage.yml` workflow shortly.'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           name: codecov_report
           path: |
-            codecov_report.json
+            cobertura.xml
             pr_number.txt
             commit_sha.txt
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -120,29 +120,17 @@ jobs:
           echo "Storing commit SHA ${{ github.event.pull_request.head.sha }}"
           echo "${{ github.event.pull_request.head.sha }}" > commit_sha.txt
 
-      # Workaround for https://github.com/orgs/community/discussions/25220
-      # Triggered sub-workflow is not able to detect the original commit/PR which is available
-      # in this workflow.
-      - name: Store PR number in artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: pr_number
-          path: pr_number.txt
-
-      - name: Store commit SHA in artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: commit_sha
-          path: commit_sha.txt
-
-      # This stores the coverage report in artifacts. The actual upload to Codecov
-      # is executed by a different workflow `upload_coverage.yml`. The reason for this
-      # split is because `on.pull_request` workflows don't have access to secrets.
+      # This stores the coverage report and metadata in artifacts.
+      # The actual upload to Codecov is executed by a different workflow `upload_coverage.yml`.
+      # The reason for this split is because `on.pull_request` workflows don't have access to secrets.
       - name: Store coverage report in artifacts
         uses: actions/upload-artifact@v4
         with:
           name: codecov_report
-          path: codecov_report.json
+          path: |
+            codecov_report.json
+            pr_number.txt
+            commit_sha.txt
 
       - run: |
           echo 'The coverage report was stored in Github artifacts.'

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -25,9 +25,9 @@ jobs:
 
             // List artifacts of the workflow run that triggered this workflow
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
             });
 
             let codecovReport = artifacts.data.artifacts.filter((artifact) => {
@@ -39,10 +39,10 @@ jobs:
             }
 
             var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: codecovReport[0].id,
-               archive_format: 'zip',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: codecovReport[0].id,
+              archive_format: 'zip',
             });
             fs.writeFileSync('codecov_report.zip', Buffer.from(download.data));
 
@@ -55,10 +55,10 @@ jobs:
             }
 
             var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: prNumber[0].id,
-               archive_format: 'zip',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: prNumber[0].id,
+              archive_format: 'zip',
             });
             fs.writeFileSync('pr_number.zip', Buffer.from(download.data));
 
@@ -71,10 +71,10 @@ jobs:
             }
 
             var download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: commitSha[0].id,
-               archive_format: 'zip',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: commitSha[0].id,
+              archive_format: 'zip',
             });
             fs.writeFileSync('commit_sha.zip', Buffer.from(download.data));
 

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -46,43 +46,9 @@ jobs:
             });
             fs.writeFileSync('codecov_report.zip', Buffer.from(download.data));
 
-            let prNumber = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "pr_number";
-            });
-
-            if (prNumber.length != 1) {
-              throw new Error("Unexpected number of {pr_number} artifacts: " + prNumber.length);
-            }
-
-            var download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: prNumber[0].id,
-              archive_format: 'zip',
-            });
-            fs.writeFileSync('pr_number.zip', Buffer.from(download.data));
-
-            let commitSha = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "commit_sha";
-            });
-
-            if (commitSha.length != 1) {
-              throw new Error("Unexpected number of {commit_sha} artifacts: " + commitSha.length);
-            }
-
-            var download = await github.rest.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: commitSha[0].id,
-              archive_format: 'zip',
-            });
-            fs.writeFileSync('commit_sha.zip', Buffer.from(download.data));
-
       - id: parse_previous_artifacts
         run: |
           unzip codecov_report.zip
-          unzip pr_number.zip
-          unzip commit_sha.zip
 
           echo "Detected PR is: $(<pr_number.txt)"
           echo "Detected commit_sha is: $(<commit_sha.txt)"

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -67,7 +67,6 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
-          files: ${{ github.workspace }}/codecov_report.json
           fail_ci_if_error: true
           # Manual overrides for these parameters are needed because automatic detection
           # in codecov-action does not work for non-`pull_request` workflows.

--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -14,6 +14,7 @@ jobs:
   coverage:
     name: Upload coverage report
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: 'Fetch coverage report from artifacts'
         id: prepare_report


### PR DESCRIPTION
Should start working after this merges. Second-to-last commit is the main fix, everything else is related refactorings.