### PR TITLE
ffi: enable panic logging for all supported platforms not only android

### DIFF
--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -27,6 +27,7 @@ async-compat = "0.2.1"
 eyeball-im = { workspace = true }
 extension-trait = "1.0.1"
 futures-util = { workspace = true }
+log-panics = { version = "2", features = ["with-backtrace"] }
 matrix-sdk-ui = { workspace = true, features = ["e2e-encryption", "uniffi"] }
 mime = "0.3.16"
 once_cell = { workspace = true }
@@ -48,7 +49,6 @@ uuid = { version = "1.4.1", features = ["v4"] }
 language-tags = "0.3.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
-log-panics = { version = "2", features = ["with-backtrace"] }
 paranoid-android = "0.2.1"
 
 [target.'cfg(target_os = "android")'.dependencies.matrix-sdk]

--- a/bindings/matrix-sdk-ffi/src/platform.rs
+++ b/bindings/matrix-sdk-ffi/src/platform.rs
@@ -8,7 +8,6 @@ use tracing_subscriber::{
     EnvFilter, Layer,
 };
 
-#[cfg(target_os = "android")]
 pub fn log_panics() {
     std::env::set_var("RUST_BACKTRACE", "1");
     log_panics::init();
@@ -184,7 +183,6 @@ pub struct TracingConfiguration {
 
 #[uniffi::export]
 pub fn setup_tracing(config: TracingConfiguration) {
-    #[cfg(target_os = "android")]
     log_panics();
 
     tracing_subscriber::registry()


### PR DESCRIPTION
Simple as that, everything just works.

Test rageshake here https://rageshakes.element.io/api/listing/2024-05-31/064228-6IZED7GI/console.2024-05-31-06.log.gz, search for `Burn, baby! Burn! 🔥`