### PR TITLE
UTD hook: stop re-reporting of UTDs on app relaunch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,6 +2143,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "growable-bloom-filter"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c669fa03050eb3445343f215d62fc1ab831e8098bc9a55f26e9724faff11075c"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,6 +3581,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "fuzzy-matcher",
+ "growable-bloom-filter",
  "imbl",
  "indexmap 2.2.6",
  "itertools 0.12.1",
@@ -4565,7 +4578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.63",
@@ -7155,6 +7168,12 @@ dependencies = [
  "uniffi_bindgen",
  "xshell",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3591,6 +3591,7 @@ dependencies = [
  "mime",
  "once_cell",
  "pin-project-lite",
+ "rmp-serde",
  "ruma",
  "serde",
  "serde_json",

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -4,7 +4,9 @@ use matrix_sdk::{
     encryption::CryptoStoreError, event_cache::EventCacheError, oidc::OidcError, HttpError,
     IdParseError, NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
-use matrix_sdk_ui::{encryption_sync_service, notification_client, sync_service, timeline};
+use matrix_sdk_ui::{
+    encryption_sync_service, notification_client, sync_service, timeline, unable_to_decrypt_hook,
+};
 use uniffi::UnexpectedUniFFICallbackError;
 
 #[derive(Debug, thiserror::Error)]
@@ -81,6 +83,12 @@ impl From<mime::FromStrError> for ClientError {
 
 impl From<encryption_sync_service::Error> for ClientError {
     fn from(e: encryption_sync_service::Error) -> Self {
+        Self::new(e)
+    }
+}
+
+impl From<unable_to_decrypt_hook::Error> for ClientError {
+    fn from(e: unable_to_decrypt_hook::Error) -> Self {
         Self::new(e)
     }
 }

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -62,6 +62,8 @@ pub trait StateStoreIntegrationTests {
     async fn test_user_avatar_url_saving(&self);
     /// Test sync token saving.
     async fn test_sync_token_saving(&self);
+    /// Test UtdHookManagerData saving.
+    async fn test_utd_hook_manager_data_saving(&self);
     /// Test stripped room member saving.
     async fn test_stripped_member_saving(&self);
     /// Test room power levels saving.
@@ -592,6 +594,37 @@ impl StateStoreIntegrationTests for DynStateStore {
 
         self.remove_kv_data(StateStoreDataKey::SyncToken).await.unwrap();
         assert_matches!(self.get_kv_data(StateStoreDataKey::SyncToken).await, Ok(None));
+    }
+
+    async fn test_utd_hook_manager_data_saving(&self) {
+        // Before any data is written, the getter should return None.
+        assert!(
+            self.get_kv_data(StateStoreDataKey::UtdHookManagerData)
+                .await
+                .expect("Could not read data")
+                .is_none(),
+            "Store was not empty at start"
+        );
+
+        // Put some data in the store...
+        let data = "some data".as_bytes().to_vec();
+        self.set_kv_data(
+            StateStoreDataKey::UtdHookManagerData,
+            StateStoreDataValue::UtdHookManagerData(data.clone()),
+        )
+        .await
+        .expect("Could not save data");
+
+        // ... and check it comes back.
+        let read_data = self
+            .get_kv_data(StateStoreDataKey::UtdHookManagerData)
+            .await
+            .expect("Could not read data")
+            .expect("no data found")
+            .into_utd_hook_manager_data()
+            .expect("not UtdHookManagerData");
+
+        assert_eq!(read_data, data);
     }
 
     async fn test_stripped_member_saving(&self) {
@@ -1349,6 +1382,12 @@ macro_rules! statestore_integration_tests {
         async fn test_sync_token_saving() {
             let store = get_store().await.unwrap().into_state_store();
             store.test_sync_token_saving().await
+        }
+
+        #[async_test]
+        async fn test_utd_hook_manager_data_saving() {
+             let store = get_store().await.expect("creating store failed").into_state_store();
+             store.test_utd_hook_manager_data_saving().await;
         }
 
         #[async_test]

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -808,6 +808,10 @@ pub enum StateStoreDataValue {
 
     /// A list of recently visited room identifiers for the current user
     RecentlyVisitedRooms(Vec<String>),
+
+    /// Persistent data for
+    /// `matrix_sdk_ui::unable_to_decrypt_hook::UtdHookManager`.
+    UtdHookManagerData(Vec<u8>),
 }
 
 impl StateStoreDataValue {
@@ -830,6 +834,11 @@ impl StateStoreDataValue {
     pub fn into_recently_visited_rooms(self) -> Option<Vec<String>> {
         as_variant!(self, Self::RecentlyVisitedRooms)
     }
+
+    /// Get this value if it is the data for the `UtdHookManager`.
+    pub fn into_utd_hook_manager_data(self) -> Option<Vec<u8>> {
+        as_variant!(self, Self::UtdHookManagerData)
+    }
 }
 
 /// A key for key-value data.
@@ -846,6 +855,10 @@ pub enum StateStoreDataKey<'a> {
 
     /// Recently visited room identifiers
     RecentlyVisitedRooms(&'a UserId),
+
+    /// Persistent data for
+    /// `matrix_sdk_ui::unable_to_decrypt_hook::UtdHookManager`.
+    UtdHookManagerData,
 }
 
 impl StateStoreDataKey<'_> {
@@ -860,4 +873,8 @@ impl StateStoreDataKey<'_> {
     /// Key prefix to use for the
     /// [`RecentlyVisitedRooms`][Self::RecentlyVisitedRooms] variant.
     pub const RECENTLY_VISITED_ROOMS: &'static str = "recently_visited_rooms";
+
+    /// Key to use for the [`UtdHookManagerData`][Self::UtdHookManagerData]
+    /// variant.
+    pub const UTD_HOOK_MANAGER_DATA: &'static str = "utd_hook_manager_data";
 }

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -388,6 +388,9 @@ impl IndexeddbStateStore {
             StateStoreDataKey::RecentlyVisitedRooms(user_id) => {
                 self.encode_key(keys::KV, (StateStoreDataKey::RECENTLY_VISITED_ROOMS, user_id))
             }
+            StateStoreDataKey::UtdHookManagerData => {
+                self.encode_key(keys::KV, StateStoreDataKey::UTD_HOOK_MANAGER_DATA)
+            }
         }
     }
 }
@@ -449,6 +452,10 @@ impl_state_store!({
                 .map(|f| self.deserialize_event::<Vec<String>>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::RecentlyVisitedRooms),
+            StateStoreDataKey::UtdHookManagerData => value
+                .map(|f| self.deserialize_event::<Vec<u8>>(&f))
+                .transpose()?
+                .map(StateStoreDataValue::UtdHookManagerData),
         };
 
         Ok(value)
@@ -474,6 +481,9 @@ impl_state_store!({
                 &value
                     .into_recently_visited_rooms()
                     .expect("Session data not a recently visited room list"),
+            ),
+            StateStoreDataKey::UtdHookManagerData => self.serialize_event(
+                &value.into_utd_hook_manager_data().expect("Session data not UtdHookManagerData"),
             ),
         };
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -278,6 +278,9 @@ impl SqliteStateStore {
             StateStoreDataKey::RecentlyVisitedRooms(b) => {
                 Cow::Owned(format!("{}:{b}", StateStoreDataKey::RECENTLY_VISITED_ROOMS))
             }
+            StateStoreDataKey::UtdHookManagerData => {
+                Cow::Borrowed(StateStoreDataKey::UTD_HOOK_MANAGER_DATA)
+            }
         };
 
         self.encode_key(keys::KV_BLOB, &*key_s)
@@ -896,6 +899,9 @@ impl StateStore for SqliteStateStore {
                     StateStoreDataKey::RecentlyVisitedRooms(_) => {
                         StateStoreDataValue::RecentlyVisitedRooms(self.deserialize_value(&data)?)
                     }
+                    StateStoreDataKey::UtdHookManagerData => {
+                        StateStoreDataValue::UtdHookManagerData(self.deserialize_value(&data)?)
+                    }
                 })
             })
             .transpose()
@@ -918,6 +924,9 @@ impl StateStore for SqliteStateStore {
             )?,
             StateStoreDataKey::RecentlyVisitedRooms(_) => self.serialize_value(
                 &value.into_recently_visited_rooms().expect("Session data not breadcrumbs"),
+            )?,
+            StateStoreDataKey::UtdHookManagerData => self.serialize_value(
+                &value.into_utd_hook_manager_data().expect("Session data not UtdHookManagerData"),
             )?,
         };
 

--- a/crates/matrix-sdk-ui/CHANGELOG.md
+++ b/crates/matrix-sdk-ui/CHANGELOG.md
@@ -11,6 +11,13 @@ Bug fixes:
 - `UtdHookManager` no longer re-reports UTD events as late decryptions.
   ([#3840](https://github.com/matrix-org/matrix-rust-sdk/pull/3840))
 
+Other changes:
+
+- `UtdHookManager` no longer reports UTD events that were already reported in a
+  previous session.
+  ([#3490](https://github.com/matrix-org/matrix-rust-sdk/pull/3490))
+
+
 # 0.7.0
 
 Initial release

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -34,6 +34,7 @@ eyeball-im-util = { workspace = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
 fuzzy-matcher = "0.3.7"
+growable-bloom-filter = "2.1.0"
 imbl = { workspace = true, features = ["serde"] }
 indexmap = "2.0.0"
 itertools = { workspace = true }

--- a/crates/matrix-sdk-ui/Cargo.toml
+++ b/crates/matrix-sdk-ui/Cargo.toml
@@ -43,6 +43,7 @@ matrix-sdk-base = { workspace = true }
 mime = "0.3.16"
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
+rmp-serde = "1.3.0"
 ruma = { workspace = true, features = ["html", "unstable-msc3381"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -23,7 +23,10 @@ use std::{
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
-use matrix_sdk::crypto::{decrypt_room_key_export, types::events::UtdCause, OlmMachine};
+use matrix_sdk::{
+    crypto::{decrypt_room_key_export, types::events::UtdCause, OlmMachine},
+    test_utils::test_client_builder,
+};
 use matrix_sdk_test::{async_test, BOB};
 use ruma::{
     assign,
@@ -76,7 +79,8 @@ async fn test_retry_message_decryption() {
     }
 
     let hook = Arc::new(DummyUtdHook::default());
-    let utd_hook = Arc::new(UtdHookManager::new(hook.clone()));
+    let client = test_client_builder(None).build().await.unwrap();
+    let utd_hook = Arc::new(UtdHookManager::new(hook.clone(), client));
 
     let timeline = TestTimeline::with_unable_to_decrypt_hook(utd_hook.clone());
     let mut stream = timeline.subscribe().await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/encryption.rs
@@ -80,7 +80,7 @@ async fn test_retry_message_decryption() {
 
     let hook = Arc::new(DummyUtdHook::default());
     let client = test_client_builder(None).build().await.unwrap();
-    let utd_hook = Arc::new(UtdHookManager::new(hook.clone(), client));
+    let utd_hook = Arc::new(UtdHookManager::new(hook.clone(), client).await.unwrap());
 
     let timeline = TestTimeline::with_unable_to_decrypt_hook(utd_hook.clone());
     let mut stream = timeline.subscribe().await;


### PR DESCRIPTION
This is a fix to #3374. The principle is that we use a Bloom filter to keep track of which events we have already reported to the parent UTD hook. This data is loaded from database on startup, and flushed out shortly after update.