### PR TITLE
ffi: get rid of `Timeline::get_timeline_event_content_by_event_id`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use matrix_sdk::{crypto::types::events::UtdCause, room::power_levels::power_level_user_changes};
 use matrix_sdk_ui::timeline::{PollResult, TimelineDetails};
-use ruma::events::FullStateEventContent;
+use ruma::events::{room::message::RoomMessageEventContentWithoutRelation, FullStateEventContent};
 use tracing::warn;
 
 use super::ProfileDetails;
@@ -177,6 +177,10 @@ impl Message {
 
     pub fn is_edited(&self) -> bool {
         self.0.is_edited()
+    }
+
+    pub fn content(&self) -> Arc<RoomMessageEventContentWithoutRelation> {
+        Arc::new(RoomMessageEventContentWithoutRelation::new(self.0.msgtype().clone()))
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -540,28 +540,6 @@ impl Timeline {
         Ok(Arc::new(EventTimelineItem(item)))
     }
 
-    pub async fn get_timeline_event_content_by_event_id(
-        &self,
-        event_id: String,
-    ) -> Result<Arc<RoomMessageEventContentWithoutRelation>, ClientError> {
-        let event_id = EventId::parse(event_id)?;
-
-        let item = self
-            .inner
-            .item_by_event_id(&event_id)
-            .await
-            .context("Item with given event ID not found")?;
-
-        let msgtype = item
-            .content()
-            .as_message()
-            .context("Item with given event ID is not a message")?
-            .msgtype()
-            .to_owned();
-
-        Ok(Arc::new(RoomMessageEventContentWithoutRelation::new(msgtype)))
-    }
-
     pub async fn latest_event(&self) -> Option<Arc<EventTimelineItem>> {
         let latest_event = self.inner.latest_event().await;
 


### PR DESCRIPTION
This can be equivalently retrieved using:

`get_timeline_event_by_event_id(event_id).content().as_message()?.content()`

As per the commit date, this is used in one place in both EXA and EXI, so it seems fine to change the caller's call sites.

And this avoids one explicit call site of
`Timeline::item_by_event_id()`.