### PR TITLE
clippy: fix extra errors and enforce `target-applies-to-host` in xtask

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -425,7 +425,7 @@ impl ClientBuilder {
                     random_dir
                         .to_str()
                         .expect("The base path and the uuid both are valid UTF-8 strings")
-                        .to_string(),
+                        .to_owned(),
                 );
 
                 Some((base_directory, random_dir))

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1296,11 +1296,11 @@ mod tests {
         room.heroes = Some(vec![
             assign!(v4::SlidingSyncRoomHero::default(), {
                 user_id: Some(gordon),
-                name: Some("Gordon".to_string()),
+                name: Some("Gordon".to_owned()),
             }),
             assign!(v4::SlidingSyncRoomHero::default(), {
                 user_id: Some(alice),
-                name: Some("Alice".to_string()),
+                name: Some("Alice".to_owned()),
             }),
         ]);
         let response = response_with_room(room_id, room).await;
@@ -1315,7 +1315,7 @@ mod tests {
         // And heroes are part of the summary.
         assert_eq!(
             client_room.clone_info().summary.heroes(),
-            &["@gordon:e.uk".to_string(), "@alice:e.uk".to_string()]
+            &["@gordon:e.uk".to_owned(), "@alice:e.uk".to_owned()]
         );
     }
 

--- a/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/sliding_sync.rs
@@ -122,7 +122,10 @@ macro_rules! sliding_sync_then_assert_request_and_fake_response {
                         &json!({ $( $request_json )* }),
                         $crate::sliding_sync_then_assert_request_and_fake_response!(@assertion_config $sign)
                     ) {
-                        dbg!(json_value);
+                        #[allow(clippy::dbg_macro)]
+                        {
+                            dbg!(json_value);
+                        }
                         panic!("{error}");
                     }
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -179,7 +179,10 @@ fn check_typos() -> Result<()> {
 
 fn check_clippy() -> Result<()> {
     cmd!("rustup run {NIGHTLY} cargo clippy --all-targets --features testing -- -D warnings")
+        // Work around https://github.com/rust-lang/cargo/issues/10744
+        .env("CARGO_TARGET_APPLIES_TO_HOST", "true")
         .run()?;
+
     cmd!(
         "rustup run {NIGHTLY} cargo clippy --workspace --all-targets
             --exclude matrix-sdk-crypto --exclude xtask
@@ -187,12 +190,16 @@ fn check_clippy() -> Result<()> {
             --features native-tls,experimental-sliding-sync,sso-login,testing
             -- -D warnings"
     )
+    .env("CARGO_TARGET_APPLIES_TO_HOST", "true")
     .run()?;
+
     cmd!(
         "rustup run {NIGHTLY} cargo clippy --all-targets -p matrix-sdk-crypto
             --no-default-features -- -D warnings"
     )
+    .env("CARGO_TARGET_APPLIES_TO_HOST", "true")
     .run()?;
+
     Ok(())
 }
 


### PR DESCRIPTION
This enforces the env variable to set the `--target-applies-to-host` setting when running in xtask. I'm not sure why it's required, but without it, the CI step didn't find all the issues that I could find locally. @jplatte if you have any idea about that, I'd be curious; I've mostly cargo culted the existing workaround used when building the doc. It looks like another instance of https://github.com/rust-lang/cargo/issues/10744 in a slightly different context.

The second commit fixes the issues found by clippy.