### PR TITLE
ffi: fix multiple issues with the `AuthenticationService` and `deadpool`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -666,8 +666,8 @@ impl Client {
         Arc::new(NotificationSettings::new((*self.inner).clone(), inner))
     }
 
-    pub fn encryption(&self) -> Arc<Encryption> {
-        Arc::new(self.inner.encryption().into())
+    pub fn encryption(self: Arc<Self>) -> Arc<Encryption> {
+        Arc::new(Encryption { inner: self.inner.encryption(), _client: self.clone() })
     }
 
     // Ignored users

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -9,17 +9,18 @@ use thiserror::Error;
 use zeroize::Zeroize;
 
 use super::RUNTIME;
-use crate::{error::ClientError, task_handle::TaskHandle};
+use crate::{client::Client, error::ClientError, task_handle::TaskHandle};
 
 #[derive(uniffi::Object)]
 pub struct Encryption {
-    inner: matrix_sdk::encryption::Encryption,
-}
+    pub(crate) inner: matrix_sdk::encryption::Encryption,
 
-impl From<matrix_sdk::encryption::Encryption> for Encryption {
-    fn from(value: matrix_sdk::encryption::Encryption) -> Self {
-        Self { inner: value }
-    }
+    /// A reference to the FFI client.
+    ///
+    /// Note: we do this to make it so that the FFI `NotificationClient` keeps
+    /// the FFI `Client` and thus the SDK `Client` alive. Otherwise, we
+    /// would need to repeat the hack done in the FFI `Client::drop` method.
+    pub(crate) _client: Arc<Client>,
 }
 
 #[uniffi::export(callback_interface)]


### PR DESCRIPTION
- Fixes a regression in the `AuthenticationService` introduced in https://github.com/matrix-org/matrix-rust-sdk/pull/3473. See the commit message.
- FFI objects that contain (directly or transitively) a reference to a SDK `Client` may drop before the FFI `Client` has dropped. As a matter of fact, they should *also* hold a reference to the FFI `Client`, otherwise we may need to replicate the `ManuallyDrop` hack introduced for the FFI `Client` in all those structures. There's a precedent for keeping a link to the FFI `Client`, in `NotificationClient`, so I copied it in a few places.