### PR TITLE
feat(base): Update Ruma to get `RoomSummary::heroes` as `Vec<OwnedUserId>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5001,7 +5001,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "assign",
  "js_int",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "as_variant",
  "assign",
@@ -5041,7 +5041,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5073,7 +5073,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -5097,7 +5097,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -5109,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5121,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5130,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma/?rev=ee5e6b8c9e9489c88a1ba7411541201b6790d2d2#ee5e6b8c9e9489c88a1ba7411541201b6790d2d2"
+source = "git+https://github.com/ruma/ruma?rev=75e8829bec0b7bc5332860e1fb2df658d5c71d66#75e8829bec0b7bc5332860e1fb2df658d5c71d66"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "6cd3af9b865f338f7c4be3666e62b67951f948ce", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "75e8829bec0b7bc5332860e1fb2df658d5c71d66", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -54,7 +54,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "6cd3af9b865f338f7c4be3666e
     "unstable-msc3266",
     "unstable-msc4075"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "6cd3af9b865f338f7c4be3666e62b67951f948ce" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "75e8829bec0b7bc5332860e1fb2df658d5c71d66" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -1098,19 +1098,7 @@ impl RoomInfo {
 
         if !summary.is_empty() {
             if !summary.heroes.is_empty() {
-                // Parse the user IDs from Ruma.
-                self.summary.heroes_user_ids = summary
-                    .heroes
-                    .iter()
-                    .filter_map(|hero| match UserId::parse(hero.as_str()) {
-                        Ok(user_id) => Some(user_id),
-                        Err(err) => {
-                            warn!("error when parsing user id from hero '{hero}': {err}");
-                            None
-                        }
-                    })
-                    .collect();
-
+                self.summary.heroes_user_ids = summary.heroes.clone();
                 changed = true;
             }
 
@@ -1908,7 +1896,7 @@ mod tests {
         let me = user_id!("@me:example.org");
         let mut changes = StateChanges::new("".to_owned());
         let summary = assign!(RumaSummary::new(), {
-            heroes: vec![me.to_string(), matthew.to_string()],
+            heroes: vec![me.to_owned(), matthew.to_owned()],
         });
 
         changes.add_stripped_member(
@@ -1957,7 +1945,7 @@ mod tests {
         let mut changes = StateChanges::new("".to_owned());
         let summary = assign!(RumaSummary::new(), {
             joined_member_count: Some(2u32.into()),
-            heroes: vec![me.to_string(), matthew.to_string()],
+            heroes: vec![me.to_owned(), matthew.to_owned()],
         });
 
         let members = changes
@@ -2048,7 +2036,7 @@ mod tests {
 
         let summary = assign!(RumaSummary::new(), {
             joined_member_count: Some(7u32.into()),
-            heroes: vec![denis.to_string(), carol.to_string(), bob.to_string(), erica.to_string()],
+            heroes: vec![denis.to_owned(), carol.to_owned(), bob.to_owned(), erica.to_owned()],
         });
         room.inner.update_if(|info| info.update_from_ruma_summary(&summary));
 
@@ -2116,7 +2104,7 @@ mod tests {
         let mut changes = StateChanges::new("".to_owned());
         let summary = assign!(RumaSummary::new(), {
             joined_member_count: Some(1u32.into()),
-            heroes: vec![me.to_string(), matthew.to_string()],
+            heroes: vec![me.to_owned(), matthew.to_owned()],
         });
 
         let members = changes


### PR DESCRIPTION
This patch updates Ruma to [`75e8829`](https://github.com/ruma/ruma/commit/75e8829bec0b7bc5332860e1fb2df658d5c71d66) so that `RoomSummary::heroes` is now a `Vec<OwnedUserId>` instead of a `Vec<String>`. This patch updates our code accordingly by removing the parsing of heroes as `OwnedUserId`.

---

- [ ] Public API changes documented in changelogs (optional)