### PR TITLE
clippy: disallow useless `async`s

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -38,6 +38,7 @@ rustflags = [
     "-Wclippy::nonstandard_macro_braces",
     "-Wclippy::str_to_string",
     "-Wclippy::todo",
+    "-Wclippy::unused_async",
 ]
 
 [target.'cfg(target_arch = "wasm32")']

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1158,8 +1158,7 @@ impl OlmMachine {
         let methods = methods.into_iter().map(VerificationMethod::from).collect();
 
         Ok(if let Some(identity) = identity.and_then(|i| i.other()) {
-            let content =
-                self.runtime.block_on(identity.verification_request_content(Some(methods)));
+            let content = identity.verification_request_content(Some(methods));
             Some(serde_json::to_string(&content)?)
         } else {
             None

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -1201,11 +1201,7 @@ impl OlmMachine {
         let methods = methods.into_iter().map(VerificationMethod::from).collect();
 
         Ok(if let Some(identity) = identity.and_then(|i| i.other()) {
-            let request = self.runtime.block_on(identity.request_verification(
-                &room_id,
-                &event_id,
-                Some(methods),
-            ));
+            let request = identity.request_verification(&room_id, &event_id, Some(methods));
 
             Some(
                 VerificationRequest { inner: request, runtime: self.runtime.handle().to_owned() }
@@ -1242,8 +1238,7 @@ impl OlmMachine {
             if let Some(device) =
                 self.runtime.block_on(self.inner.get_device(&user_id, device_id, None))?
             {
-                let (verification, request) =
-                    self.runtime.block_on(device.request_verification_with_methods(methods));
+                let (verification, request) = device.request_verification_with_methods(methods);
 
                 Some(RequestVerificationResult {
                     verification: VerificationRequest {

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -456,7 +456,7 @@ impl AuthenticationService {
 
         let oidc_metadata: VerifiedClientMetadata = configuration.try_into()?;
 
-        if self.load_client_registration(oidc, issuer.clone(), oidc_metadata.clone()).await {
+        if self.load_client_registration(oidc, issuer.clone(), oidc_metadata.clone()) {
             tracing::info!("OIDC configuration loaded from disk.");
             return Ok(());
         }
@@ -472,14 +472,14 @@ impl AuthenticationService {
         oidc.restore_registered_client(issuer, oidc_metadata, credentials);
 
         tracing::info!("Persisting OIDC registration data.");
-        self.store_client_registration(oidc).await?;
+        self.store_client_registration(oidc)?;
 
         Ok(())
     }
 
     /// Stores the current OIDC dynamic client registration so it can be re-used
     /// if we ever log in via the same issuer again.
-    async fn store_client_registration(&self, oidc: &Oidc) -> Result<(), AuthenticationError> {
+    fn store_client_registration(&self, oidc: &Oidc) -> Result<(), AuthenticationError> {
         let issuer = Url::parse(oidc.issuer().ok_or(AuthenticationError::OidcNotSupported)?)
             .map_err(|_| AuthenticationError::OidcError {
                 message: String::from("Failed to parse issuer URL."),
@@ -508,7 +508,7 @@ impl AuthenticationService {
 
     /// Attempts to load an existing OIDC dynamic client registration for the
     /// currently configured issuer.
-    async fn load_client_registration(
+    fn load_client_registration(
         &self,
         oidc: &Oidc,
         issuer: String,

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -242,9 +242,7 @@ impl Client {
                     let session_delegate = session_delegate.clone();
                     Box::new(move |client| {
                         let session_delegate = session_delegate.clone();
-                        Box::pin(
-                            async move { Ok(Self::save_session(session_delegate, client).await?) },
-                        )
+                        Ok(Self::save_session(session_delegate, client)?)
                     })
                 },
             )?;
@@ -415,8 +413,8 @@ impl Client {
         })
     }
 
-    pub async fn session(&self) -> Result<Session, ClientError> {
-        Self::session_inner((*self.inner).clone()).await
+    pub fn session(&self) -> Result<Session, ClientError> {
+        Self::session_inner((*self.inner).clone())
     }
 
     pub async fn account_url(
@@ -968,7 +966,7 @@ impl Client {
         }
     }
 
-    async fn session_inner(client: matrix_sdk::Client) -> Result<Session, ClientError> {
+    fn session_inner(client: matrix_sdk::Client) -> Result<Session, ClientError> {
         let auth_api = client.auth_api().context("Missing authentication API")?;
 
         let homeserver_url = client.homeserver().into();
@@ -977,11 +975,11 @@ impl Client {
         Session::new(auth_api, homeserver_url, sliding_sync_proxy)
     }
 
-    async fn save_session(
+    fn save_session(
         session_delegate: Arc<dyn ClientSessionDelegate>,
         client: matrix_sdk::Client,
     ) -> anyhow::Result<()> {
-        let session = Self::session_inner(client).await?;
+        let session = Self::session_inner(client)?;
         session_delegate.save_session_in_keychain(session);
         Ok(())
     }

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -510,9 +510,10 @@ impl RoomListItem {
         Ok(RoomInfo::new(self.inner.inner_room(), latest_event).await?)
     }
 
-    /// Building a `Room`. If its internal timeline hasn't been initialized
-    /// it'll fail.
-    async fn full_room(&self) -> Result<Arc<Room>, RoomListError> {
+    /// Build a full `Room` FFI object, filling its associated timeline.
+    ///
+    /// If its internal timeline hasn't been initialized, it'll fail.
+    fn full_room(&self) -> Result<Arc<Room>, RoomListError> {
         if let Some(timeline) = self.inner.timeline() {
             Ok(Arc::new(Room::with_timeline(
                 self.inner.inner_room().clone(),

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -418,7 +418,6 @@ impl BaseClient {
                             room_info,
                             changes,
                         )
-                        .await;
                     } else {
                         push_context = self.get_push_room_context(room, room_info, changes).await?;
                     }
@@ -1409,7 +1408,7 @@ impl BaseClient {
     /// Update the push context for the given room.
     ///
     /// Updates the context data from `changes` or `room_info`.
-    pub async fn update_push_room_context(
+    pub fn update_push_room_context(
         &self,
         push_rules: &mut PushConditionRoomCtx,
         user_id: &UserId,

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -800,7 +800,7 @@ mod tests {
         // in joined_count)
         let mut room = v4::SlidingSyncRoom::new();
         room.joined_count = Some(uint!(41));
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         let sync_resp =
             client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
@@ -825,7 +825,7 @@ mod tests {
         // When I send sliding sync response containing a room with a name
         let mut room = v4::SlidingSyncRoom::new();
         room.name = Some("little room".to_owned());
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         let sync_resp =
             client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
@@ -853,7 +853,7 @@ mod tests {
         let mut room = v4::SlidingSyncRoom::new();
         set_room_invited(&mut room, inviter, user_id);
         room.name = Some("name from sliding sync response".to_owned());
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         let sync_resp =
             client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
@@ -883,14 +883,14 @@ mod tests {
         // When I join…
         let mut room = v4::SlidingSyncRoom::new();
         set_room_joined(&mut room, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
 
         // And then leave with a `required_state` state event…
         let mut room = v4::SlidingSyncRoom::new();
         set_room_left(&mut room, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         let sync_resp =
             client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
@@ -914,7 +914,7 @@ mod tests {
             // When I join…
             let mut room = v4::SlidingSyncRoom::new();
             set_room_joined(&mut room, user_a_id);
-            let response = response_with_room(room_id, room).await;
+            let response = response_with_room(room_id, room);
             client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
             assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
 
@@ -926,7 +926,7 @@ mod tests {
                 RoomMemberEventContent::new(membership),
                 None,
             ));
-            let response = response_with_room(room_id, room).await;
+            let response = response_with_room(room_id, room);
             let sync_resp =
                 client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
@@ -950,14 +950,14 @@ mod tests {
         // When I join…
         let mut room = v4::SlidingSyncRoom::new();
         set_room_joined(&mut room, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
 
         // And then leave with a `timeline` state event…
         let mut room = v4::SlidingSyncRoom::new();
         set_room_left_as_timeline_event(&mut room, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // The room is left.
@@ -976,7 +976,7 @@ mod tests {
         // When I join...
         let mut room = v4::SlidingSyncRoom::new();
         set_room_joined(&mut room, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
         // (sanity: state is join)
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Joined);
@@ -984,7 +984,7 @@ mod tests {
         // And then leave...
         let mut room = v4::SlidingSyncRoom::new();
         set_room_left(&mut room, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
         // (sanity: state is left)
         assert_eq!(client.get_room(room_id).unwrap().state(), RoomState::Left);
@@ -992,7 +992,7 @@ mod tests {
         // And then get invited back
         let mut room = v4::SlidingSyncRoom::new();
         set_room_invited(&mut room, user_id, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room is in the invite state
@@ -1109,7 +1109,7 @@ mod tests {
 
             room
         };
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room in the client has the avatar
@@ -1135,7 +1135,7 @@ mod tests {
 
             room
         };
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room in the client has the avatar
@@ -1149,7 +1149,7 @@ mod tests {
 
         // When I send sliding sync response containing no avatar.
         let room = v4::SlidingSyncRoom::new();
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room in the client still has the avatar
@@ -1168,7 +1168,7 @@ mod tests {
 
             room
         };
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room in the client has no more avatar
@@ -1185,7 +1185,7 @@ mod tests {
 
         // When I send sliding sync response containing a room with an avatar
         let room = room_with_avatar(mxc_uri!("mxc://e.uk/med1"), user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room in the client has the avatar
@@ -1206,7 +1206,7 @@ mod tests {
         // When I send sliding sync response containing an invited room
         let mut room = v4::SlidingSyncRoom::new();
         set_room_invited(&mut room, user_id, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         let sync_resp =
             client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
@@ -1230,7 +1230,7 @@ mod tests {
         // When I send sliding sync response containing an invited room with an avatar
         let mut room = room_with_avatar(mxc_uri!("mxc://e.uk/med1"), user_id);
         set_room_invited(&mut room, user_id, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room in the client has the avatar
@@ -1253,7 +1253,7 @@ mod tests {
         // When I send sliding sync response containing an invited room with an avatar
         let mut room = room_with_canonical_alias(room_alias_id, user_id);
         set_room_invited(&mut room, user_id, user_id);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room in the client has the avatar
@@ -1273,7 +1273,7 @@ mod tests {
         // alias
         let mut room = room_with_canonical_alias(room_alias_id, user_id);
         room.name = Some("This came from the server".to_owned());
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room's name is NOT overridden by the server-computed display name.
@@ -1303,7 +1303,7 @@ mod tests {
                 name: Some("Alice".to_owned()),
             }),
         ]);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         let _sync_resp =
             client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
@@ -1342,7 +1342,7 @@ mod tests {
         // When the sliding sync response contains a timeline
         let events = &[event_a, event_b.clone()];
         let room = room_with_timeline(events);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room holds the latest event
@@ -1368,7 +1368,7 @@ mod tests {
 
         // When the sliding sync response contains a timeline
         let room = room_with_timeline(&[event_a]);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room holds the latest event
@@ -1389,7 +1389,7 @@ mod tests {
 
         // When a redaction for that event is received
         let room = room_with_timeline(&[redaction]);
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
         // Then the room still holds the latest event
@@ -1778,7 +1778,7 @@ mod tests {
 
         room.required_state.push(make_membership_event(their_id, other_state));
 
-        let mut response = response_with_room(room_id, room).await;
+        let mut response = response_with_room(room_id, room);
         set_direct_with(&mut response, their_id.to_owned(), vec![room_id.to_owned()]);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
     }
@@ -1792,7 +1792,7 @@ mod tests {
     ) {
         let mut room = v4::SlidingSyncRoom::new();
         room.required_state.push(make_membership_event(user_id, new_state));
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
     }
 
@@ -1810,7 +1810,7 @@ mod tests {
             .push(make_global_account_data_event(DirectEventContent(direct_content)));
     }
 
-    async fn response_with_room(room_id: &RoomId, room: v4::SlidingSyncRoom) -> v4::Response {
+    fn response_with_room(room_id: &RoomId, room: v4::SlidingSyncRoom) -> v4::Response {
         let mut response = v4::Response::new("5".to_owned());
         response.rooms.insert(room_id.to_owned(), room);
         response

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -145,7 +145,7 @@ impl BackupMachine {
     }
 
     /// Check if our own device has signed the given signed JSON payload.
-    async fn check_own_device_signature(
+    fn check_own_device_signature(
         &self,
         signatures: &Signatures,
         auth_data: &str,
@@ -285,7 +285,7 @@ impl BackupMachine {
 
         // Check if there's a signature from our own device.
         let device_signature =
-            self.check_own_device_signature(&auth_data.signatures, &serialized_auth_data).await;
+            self.check_own_device_signature(&auth_data.signatures, &serialized_auth_data);
         // Check if there's a signature from our own user identity.
         let user_identity_signature =
             self.check_own_identity_signature(&auth_data.signatures, &serialized_auth_data).await?;

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -301,8 +301,8 @@ impl Device {
     ///
     /// Returns a `VerificationRequest` object and a to-device request that
     /// needs to be sent out.
-    pub async fn request_verification(&self) -> (VerificationRequest, OutgoingVerificationRequest) {
-        self.request_verification_helper(None).await
+    pub fn request_verification(&self) -> (VerificationRequest, OutgoingVerificationRequest) {
+        self.request_verification_helper(None)
     }
 
     /// Request an interactive verification with this `Device`.
@@ -313,24 +313,22 @@ impl Device {
     /// # Arguments
     ///
     /// * `methods` - The verification methods that we want to support.
-    pub async fn request_verification_with_methods(
+    pub fn request_verification_with_methods(
         &self,
         methods: Vec<VerificationMethod>,
     ) -> (VerificationRequest, OutgoingVerificationRequest) {
-        self.request_verification_helper(Some(methods)).await
+        self.request_verification_helper(Some(methods))
     }
 
-    async fn request_verification_helper(
+    fn request_verification_helper(
         &self,
         methods: Option<Vec<VerificationMethod>>,
     ) -> (VerificationRequest, OutgoingVerificationRequest) {
-        self.verification_machine
-            .request_to_device_verification(
-                self.user_id(),
-                vec![self.device_id().to_owned()],
-                methods,
-            )
-            .await
+        self.verification_machine.request_to_device_verification(
+            self.user_id(),
+            vec![self.device_id().to_owned()],
+            methods,
+        )
     }
 
     /// Get the Olm sessions that belong to this device.

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -276,7 +276,7 @@ impl UserIdentity {
     /// started with the [`request_verification()`] method.
     ///
     /// [`request_verification()`]: #method.request_verification
-    pub async fn verification_request_content(
+    pub fn verification_request_content(
         &self,
         methods: Option<Vec<VerificationMethod>>,
     ) -> KeyVerificationRequestEventContent {

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -193,10 +193,11 @@ impl OwnUserIdentity {
             .inner
             .filter_devices_to_request(all_devices, self.verification_machine.own_device_id());
 
-        Ok(self
-            .verification_machine
-            .request_to_device_verification(self.user_id(), devices, methods)
-            .await)
+        Ok(self.verification_machine.request_to_device_verification(
+            self.user_id(),
+            devices,
+            methods,
+        ))
     }
 }
 
@@ -256,15 +257,18 @@ impl UserIdentity {
 
     /// Create a `VerificationRequest` object after the verification request
     /// content has been sent out.
-    pub async fn request_verification(
+    pub fn request_verification(
         &self,
         room_id: &RoomId,
         request_event_id: &EventId,
         methods: Option<Vec<VerificationMethod>>,
     ) -> VerificationRequest {
-        self.verification_machine
-            .request_verification(&self.inner, room_id, request_event_id, methods)
-            .await
+        self.verification_machine.request_verification(
+            &self.inner,
+            room_id,
+            request_event_id,
+            methods,
+        )
     }
 
     /// Send a verification request to the given user.

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -166,8 +166,7 @@ impl OlmMachine {
         device_id: &DeviceId,
         device_data: Raw<DehydratedDeviceData>,
     ) -> Result<OlmMachine, DehydrationError> {
-        let account =
-            Account::rehydrate(pickle_key, self.user_id(), device_id, device_data).await?;
+        let account = Account::rehydrate(pickle_key, self.user_id(), device_id, device_data)?;
         let static_account = account.static_data().clone();
 
         let store = Arc::new(CryptoStoreWrapper::new(self.user_id(), MemoryStore::new()));

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -864,7 +864,7 @@ impl OlmMachine {
         }
     }
 
-    async fn add_withheld_info(&self, changes: &mut Changes, event: &RoomKeyWithheldEvent) {
+    fn add_withheld_info(&self, changes: &mut Changes, event: &RoomKeyWithheldEvent) {
         if let RoomKeyWithheldContent::MegolmV1AesSha2(
             MegolmV1AesSha2WithheldContent::BlackListed(c)
             | MegolmV1AesSha2WithheldContent::Unverified(c),
@@ -1128,7 +1128,7 @@ impl OlmMachine {
         match event {
             RoomKeyRequest(e) => self.inner.key_request_machine.receive_incoming_key_request(e),
             SecretRequest(e) => self.inner.key_request_machine.receive_incoming_secret_request(e),
-            RoomKeyWithheld(e) => self.add_withheld_info(changes, e).await,
+            RoomKeyWithheld(e) => self.add_withheld_info(changes, e),
             KeyVerificationAccept(..)
             | KeyVerificationCancel(..)
             | KeyVerificationKey(..)

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -3756,7 +3756,7 @@ pub(crate) mod tests {
 
         // Alice sends a verification request with her desired methods to Bob
         let (alice_ver_req, request) =
-            bob_device.request_verification_with_methods(vec![VerificationMethod::SasV1]).await;
+            bob_device.request_verification_with_methods(vec![VerificationMethod::SasV1]);
 
         // ----------------------------------------------------------------------------
         // On Bobs's device:

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -693,7 +693,7 @@ impl Account {
         Raw::from_json(to_raw_value(&data).expect("Couldn't serialize our dehydrated device data"))
     }
 
-    pub(crate) async fn rehydrate(
+    pub(crate) fn rehydrate(
         pickle_key: &[u8; 32],
         user_id: &UserId,
         device_id: &DeviceId,

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -104,6 +104,7 @@ impl Session {
     }
 
     /// Get the [`EventEncryptionAlgorithm`] of this [`Session`].
+    #[allow(clippy::unused_async)] // The experimental-algorithms feature uses async code.
     pub async fn algorithm(&self) -> EventEncryptionAlgorithm {
         #[cfg(feature = "experimental-algorithms")]
         if self.session_config().await.version() == 2 {

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -600,7 +600,7 @@ impl PrivateCrossSigningIdentity {
     /// # Panic
     ///
     /// Panics if the pickle_key isn't 32 bytes long.
-    pub async fn from_pickle(pickle: PickledCrossSigningIdentity) -> Result<Self, SigningError> {
+    pub fn from_pickle(pickle: PickledCrossSigningIdentity) -> Result<Self, SigningError> {
         let keys = pickle.keys;
 
         let master = keys.master_key.map(MasterSigning::from_pickle).transpose()?;
@@ -709,7 +709,7 @@ mod tests {
 
         let pickled = identity.pickle().await;
 
-        let unpickled = PrivateCrossSigningIdentity::from_pickle(pickled).await.unwrap();
+        let unpickled = PrivateCrossSigningIdentity::from_pickle(pickled).unwrap();
 
         assert_eq!(identity.user_id, unpickled.user_id);
         assert_eq!(&*identity.master_key.lock().await, &*unpickled.master_key.lock().await);

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -614,7 +614,7 @@ impl GroupSessionManager {
         }
     }
 
-    async fn handle_withheld_devices(
+    fn handle_withheld_devices(
         &self,
         group_session: &OutboundGroupSession,
         withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)>,
@@ -815,7 +815,7 @@ impl GroupSessionManager {
 
         // Now handle and add the withheld recipients to the resulting requests to the
         // `OutboundGroupSession`.
-        self.handle_withheld_devices(&outbound, withheld_devices).await?;
+        self.handle_withheld_devices(&outbound, withheld_devices)?;
 
         // The to-device requests get added to the outbound group session, this
         // way we're making sure that they are persisted and scoped to the

--- a/crates/matrix-sdk-crypto/src/verification/machine.rs
+++ b/crates/matrix-sdk-crypto/src/verification/machine.rs
@@ -72,7 +72,7 @@ impl VerificationMachine {
         &self.store.account.device_id
     }
 
-    pub(crate) async fn request_to_device_verification(
+    pub(crate) fn request_to_device_verification(
         &self,
         user_id: &UserId,
         recipient_devices: Vec<OwnedDeviceId>,
@@ -96,7 +96,7 @@ impl VerificationMachine {
         (verification, request.into())
     }
 
-    pub async fn request_verification(
+    pub fn request_verification(
         &self,
         identity: &ReadOnlyUserIdentity,
         room_id: &RoomId,

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -1548,7 +1548,7 @@ mod tests {
         device_id!("BOBDEVICE")
     }
 
-    async fn get_sas_pair(
+    fn get_sas_pair(
         mac_method: Option<SupportedMacMethod>,
     ) -> (SasState<Created>, SasState<WeAccepted>) {
         let alice = Account::with_device_id(alice_id(), alice_device_id());
@@ -1632,23 +1632,23 @@ mod tests {
             .expect_err("We don't support the old Curve25519 key agreement protocol");
     }
 
-    #[async_test]
-    async fn create_sas() {
-        let (_, _) = get_sas_pair(None).await;
+    #[test]
+    fn test_create_sas() {
+        let (_, _) = get_sas_pair(None);
     }
 
-    #[async_test]
-    async fn sas_accept() {
-        let (alice, bob) = get_sas_pair(None).await;
+    #[test]
+    fn test_sas_accept() {
+        let (alice, bob) = get_sas_pair(None);
         let content = bob.as_content();
         let content = AcceptContent::from(&content);
 
         alice.into_accepted(bob.user_id(), &content).unwrap();
     }
 
-    #[async_test]
-    async fn sas_key_share() {
-        let (alice, bob) = get_sas_pair(None).await;
+    #[test]
+    fn test_sas_key_share() {
+        let (alice, bob) = get_sas_pair(None);
 
         let content = bob.as_content();
         let content = AcceptContent::from(&content);
@@ -1673,8 +1673,8 @@ mod tests {
         assert_eq!(alice.get_emoji(), bob.get_emoji());
     }
 
-    async fn full_flow_helper(mac_method: SupportedMacMethod) {
-        let (alice, bob) = get_sas_pair(Some(mac_method)).await;
+    fn full_flow_helper(mac_method: SupportedMacMethod) {
+        let (alice, bob) = get_sas_pair(Some(mac_method));
 
         let content = bob.as_content();
         let content = AcceptContent::from(&content);
@@ -1728,24 +1728,24 @@ mod tests {
         assert!(alice.verified_devices().contains(&alice.other_device()));
     }
 
-    #[async_test]
-    async fn full_flow() {
-        full_flow_helper(SupportedMacMethod::HkdfHmacSha256).await
+    #[test]
+    fn test_full_flow() {
+        full_flow_helper(SupportedMacMethod::HkdfHmacSha256);
     }
 
-    #[async_test]
-    async fn full_flow_hkdf_hmac_sha_v2() {
-        full_flow_helper(SupportedMacMethod::HkdfHmacSha256V2).await
+    #[test]
+    fn test_full_flow_hkdf_hmac_sha_v2() {
+        full_flow_helper(SupportedMacMethod::HkdfHmacSha256V2);
     }
 
-    #[async_test]
-    async fn full_flow_hkdf_msc3783() {
-        full_flow_helper(SupportedMacMethod::Msc3783HkdfHmacSha256V2).await
+    #[test]
+    fn test_full_flow_hkdf_msc3783() {
+        full_flow_helper(SupportedMacMethod::Msc3783HkdfHmacSha256V2);
     }
 
-    #[async_test]
-    async fn sas_invalid_commitment() {
-        let (alice, bob) = get_sas_pair(None).await;
+    #[test]
+    fn test_sas_invalid_commitment() {
+        let (alice, bob) = get_sas_pair(None);
 
         let mut content = bob.as_content();
         let mut method = content.method_mut();
@@ -1772,9 +1772,9 @@ mod tests {
             .expect_err("Didn't cancel on invalid commitment");
     }
 
-    #[async_test]
-    async fn sas_invalid_sender() {
-        let (alice, bob) = get_sas_pair(None).await;
+    #[test]
+    fn test_sas_invalid_sender() {
+        let (alice, bob) = get_sas_pair(None);
 
         let content = bob.as_content();
         let content = AcceptContent::from(&content);
@@ -1782,9 +1782,9 @@ mod tests {
         alice.into_accepted(sender, &content).expect_err("Didn't cancel on a invalid sender");
     }
 
-    #[async_test]
-    async fn sas_unknown_sas_method() {
-        let (alice, bob) = get_sas_pair(None).await;
+    #[test]
+    fn test_sas_unknown_sas_method() {
+        let (alice, bob) = get_sas_pair(None);
 
         let mut content = bob.as_content();
         let mut method = content.method_mut();
@@ -1803,9 +1803,9 @@ mod tests {
             .expect_err("Didn't cancel on an invalid SAS method");
     }
 
-    #[async_test]
-    async fn test_sas_unknown_method() {
-        let (alice, bob) = get_sas_pair(None).await;
+    #[test]
+    fn test_sas_unknown_method() {
+        let (alice, bob) = get_sas_pair(None);
 
         let content = json!({
             "method": "m.sas.custom",

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -1134,6 +1134,7 @@ impl_crypto_store! {
             }).collect()
     }
 
+    #[allow(clippy::unused_async)] // Mandated by trait on wasm.
     async fn delete_secrets_from_inbox(
         &self,
         secret_name: &SecretName,
@@ -1270,6 +1271,7 @@ impl_crypto_store! {
             .transpose()?)
     }
 
+    #[allow(clippy::unused_async)] // Mandated by trait on wasm.
     async fn set_custom_value(&self, key: &str, value: Vec<u8>) -> Result<()> {
         self
             .inner
@@ -1279,6 +1281,7 @@ impl_crypto_store! {
         Ok(())
     }
 
+    #[allow(clippy::unused_async)] // Mandated by trait on wasm.
     async fn remove_custom_value(&self, key: &str) -> Result<()> {
         self
             .inner
@@ -1329,6 +1332,7 @@ impl_crypto_store! {
         }
     }
 
+    #[allow(clippy::unused_async)] // Mandated by trait on wasm.
     async fn clear_caches(&self) {
         self.session_cache.clear()
         // We don't need to clear `static_account` as it only contains immutable data

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -852,7 +852,6 @@ impl_crypto_store! {
 
             Ok(Some(
                 PrivateCrossSigningIdentity::from_pickle(pickle)
-                    .await
                     .map_err(|_| CryptoStoreError::UnpicklingError)?,
             ))
         } else {

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -708,11 +708,7 @@ impl CryptoStore for SqliteCryptoStore {
         let conn = self.acquire().await?;
         if let Some(i) = conn.get_kv("identity").await? {
             let pickle = self.deserialize_value(&i)?;
-            Ok(Some(
-                PrivateCrossSigningIdentity::from_pickle(pickle)
-                    .await
-                    .map_err(|_| Error::Unpickle)?,
-            ))
+            Ok(Some(PrivateCrossSigningIdentity::from_pickle(pickle).map_err(|_| Error::Unpickle)?))
         } else {
             Ok(None)
         }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -571,7 +571,7 @@ mod tests {
         room.timeline.push(member_event(room_id, user_id, "Alice Margatroid", "mxc://e.org/SEs"));
 
         // And the room is stored in the client so it can be extracted when needed
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync_test_helper(&response).await.unwrap();
 
         // When we construct a timeline event from it
@@ -615,7 +615,7 @@ mod tests {
         // `StateChanges`.
 
         // And the room is stored in the client so it can be extracted when needed
-        let response = response_with_room(room_id, room).await;
+        let response = response_with_room(room_id, room);
         client.process_sliding_sync_test_helper(&response).await.unwrap();
 
         // When we construct a timeline event from it
@@ -665,7 +665,7 @@ mod tests {
         })
     }
 
-    async fn response_with_room(room_id: &RoomId, room: v4::SlidingSyncRoom) -> v4::Response {
+    fn response_with_room(room_id: &RoomId, room: v4::SlidingSyncRoom) -> v4::Response {
         let mut response = v4::Response::new("6".to_owned());
         response.rooms.insert(room_id.to_owned(), room);
         response

--- a/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
+++ b/crates/matrix-sdk-ui/src/timeline/sliding_sync_ext.rs
@@ -103,7 +103,10 @@ mod tests {
     ) {
         let mut room = v4::SlidingSyncRoom::new();
         room.timeline.push(event.event);
-        let response = response_with_room(room_id, room).await;
+
+        let mut response = v4::Response::new("6".to_owned());
+        response.rooms.insert(room_id.to_owned(), room);
+
         client.process_sliding_sync_test_helper(&response).await.unwrap();
     }
 
@@ -133,11 +136,5 @@ mod tests {
             )
             .unwrap(),
         )
-    }
-
-    async fn response_with_room(room_id: &RoomId, room: v4::SlidingSyncRoom) -> v4::Response {
-        let mut response = v4::Response::new("6".to_owned());
-        response.rooms.insert(room_id.to_owned(), room);
-        response
     }
 }

--- a/crates/matrix-sdk/src/authentication/mod.rs
+++ b/crates/matrix-sdk/src/authentication/mod.rs
@@ -17,10 +17,7 @@
 // TODO:(pixlwave) Move AuthenticationService from the FFI into this module.
 // TODO:(poljar) Move the oidc and matrix_auth modules under this module.
 
-use std::pin::Pin;
-
 use as_variant::as_variant;
-use futures_core::Future;
 use matrix_sdk_base::SessionMeta;
 use tokio::sync::{broadcast, Mutex, OnceCell};
 
@@ -45,9 +42,8 @@ pub enum SessionTokens {
 }
 
 pub(crate) type SessionCallbackError = Box<dyn std::error::Error + Send + Sync>;
-pub(crate) type SaveSessionCallback = dyn Fn(Client) -> Pin<Box<dyn Send + Sync + Future<Output = Result<(), SessionCallbackError>>>>
-    + Send
-    + Sync;
+pub(crate) type SaveSessionCallback =
+    dyn Fn(Client) -> Result<(), SessionCallbackError> + Send + Sync;
 pub(crate) type ReloadSessionCallback =
     dyn Fn(Client) -> Result<SessionTokens, SessionCallbackError> + Send + Sync;
 

--- a/crates/matrix-sdk/src/authentication/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/qrcode/login.rs
@@ -252,7 +252,7 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
             // ourselves see us as verified and the recovery/backup states will
             // be known. If we did receive all the secrets in the secrets
             // bundle, then backups will be enabled after this step as well.
-            self.client.encryption().run_initialization_tasks(None).await;
+            self.client.encryption().run_initialization_tasks(None);
             self.client.encryption().wait_for_e2ee_initialization_tasks().await;
 
             trace!("successfully logged in and enabled E2EE.");

--- a/crates/matrix-sdk/src/authentication/qrcode/login.rs
+++ b/crates/matrix-sdk/src/authentication/qrcode/login.rs
@@ -252,7 +252,7 @@ impl<'a> IntoFuture for LoginWithQrCode<'a> {
             // ourselves see us as verified and the recovery/backup states will
             // be known. If we did receive all the secrets in the secrets
             // bundle, then backups will be enabled after this step as well.
-            self.client.encryption().run_initialization_tasks(None);
+            self.client.encryption().spawn_initialization_task(None);
             self.client.encryption().wait_for_e2ee_initialization_tasks().await;
 
             trace!("successfully logged in and enabled E2EE.");

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -589,6 +589,7 @@ async fn check_is_homeserver(homeserver_url: &Url, http_client: &HttpClient) -> 
     }
 }
 
+#[allow(clippy::unused_async)] // False positive when building with !sqlite & !indexeddb
 async fn build_store_config(
     builder_config: BuilderStoreConfig,
 ) -> Result<StoreConfig, ClientBuildError> {

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -878,6 +878,7 @@ impl Backups {
         }
     }
 
+    #[allow(clippy::unused_async)] // Because it's used as an event handler, which must be async.
     pub(crate) async fn utd_event_handler(
         event: SyncRoomEncryptedEvent,
         room: Room,

--- a/crates/matrix-sdk/src/encryption/identities/devices.rs
+++ b/crates/matrix-sdk/src/encryption/identities/devices.rs
@@ -140,7 +140,7 @@ impl Device {
     /// [`request_verification_with_methods()`]:
     /// #method.request_verification_with_methods
     pub async fn request_verification(&self) -> Result<VerificationRequest> {
-        let (verification, request) = self.inner.request_verification().await;
+        let (verification, request) = self.inner.request_verification();
         self.client.send_verification_request(request).await?;
 
         Ok(VerificationRequest { inner: verification, client: self.client.clone() })
@@ -194,7 +194,7 @@ impl Device {
     ) -> Result<VerificationRequest> {
         assert!(!methods.is_empty(), "The list of verification methods can't be non-empty");
 
-        let (verification, request) = self.inner.request_verification_with_methods(methods).await;
+        let (verification, request) = self.inner.request_verification_with_methods(methods);
         self.client.send_verification_request(request).await?;
 
         Ok(VerificationRequest { inner: verification, client: self.client.clone() })

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -454,7 +454,7 @@ impl UserIdentities {
                     .await?;
 
                 let verification =
-                    i.request_verification(room.room_id(), &response.event_id, methods).await;
+                    i.request_verification(room.room_id(), &response.event_id, methods);
 
                 Ok(VerificationRequest { inner: verification, client: self.client.clone() })
             }

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -432,7 +432,7 @@ impl UserIdentities {
                 Ok(VerificationRequest { inner: verification, client: self.client.clone() })
             }
             CryptoUserIdentities::Other(i) => {
-                let content = i.verification_request_content(methods.clone()).await;
+                let content = i.verification_request_content(methods.clone());
 
                 let room = if let Some(room) = self.client.get_dm_room(i.user_id()) {
                     // Make sure that the user, to be verified, is still in the room

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1422,7 +1422,7 @@ impl Encryption {
     /// proposal (MSC3967) to remove this requirement, which would allow for
     /// the initial upload of cross-signing keys without authentication,
     /// rendering this parameter obsolete.
-    pub(crate) fn run_initialization_tasks(&self, auth_data: Option<AuthData>) {
+    pub(crate) fn spawn_initialization_task(&self, auth_data: Option<AuthData>) {
         let mut tasks = self.client.inner.e2ee.tasks.lock().unwrap();
 
         let this = self.clone();

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1422,7 +1422,7 @@ impl Encryption {
     /// proposal (MSC3967) to remove this requirement, which would allow for
     /// the initial upload of cross-signing keys without authentication,
     /// rendering this parameter obsolete.
-    pub(crate) async fn run_initialization_tasks(&self, auth_data: Option<AuthData>) {
+    pub(crate) fn run_initialization_tasks(&self, auth_data: Option<AuthData>) {
         let mut tasks = self.client.inner.e2ee.tasks.lock().unwrap();
 
         let this = self.clone();

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -660,7 +660,7 @@ impl RoomEventCacheInner {
                 room_events.push_gap(Gap { prev_token: prev_token.clone() });
             }
 
-            room_events.push_events(sync_timeline_events.clone().into_iter());
+            room_events.push_events(sync_timeline_events.clone());
         }
 
         // Now that all events have been added, we can trigger the

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -612,7 +612,6 @@ impl RoomEventCacheInner {
             ephemeral_events,
             ambiguity_changes,
         )
-        .await
     }
 
     /// Append a set of events to the room cache and storage, notifying
@@ -631,7 +630,6 @@ impl RoomEventCacheInner {
             ephemeral_events,
             ambiguity_changes,
         )
-        .await
     }
 
     /// Append a set of events, with an attached lock.
@@ -639,7 +637,7 @@ impl RoomEventCacheInner {
     /// If the lock `room_events` is `None`, one will be created.
     ///
     /// This is a private implementation. It must not be exposed publicly.
-    async fn append_events_locked_impl(
+    fn append_events_locked_impl(
         &self,
         mut room_events: RwLockWriteGuard<'_, RoomEvents>,
         sync_timeline_events: Vec<SyncTimelineEvent>,

--- a/crates/matrix-sdk/src/event_cache/pagination.rs
+++ b/crates/matrix-sdk/src/event_cache/pagination.rs
@@ -138,7 +138,7 @@ impl RoomPagination {
 
         let paginator = &self.inner.pagination.paginator;
 
-        paginator.set_idle_state(prev_token.clone(), None).await?;
+        paginator.set_idle_state(prev_token.clone(), None)?;
 
         // Run the actual pagination.
         let PaginationResult { events, hit_end_of_timeline: reached_start } =

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -217,7 +217,7 @@ impl Paginator {
     ///
     /// Will return an `InvalidPreviousState` error if the paginator is busy
     /// (running /context or /messages).
-    pub(super) async fn set_idle_state(
+    pub(super) fn set_idle_state(
         &self,
         prev_batch_token: Option<String>,
         next_batch_token: Option<String>,
@@ -1144,10 +1144,7 @@ mod tests {
 
             // Assuming a paginator ready to back- or forward- paginate,
             let paginator = Paginator::new(room.clone());
-            paginator
-                .set_idle_state(Some("prev".to_owned()), Some("next".to_owned()))
-                .await
-                .unwrap();
+            paginator.set_idle_state(Some("prev".to_owned()), Some("next".to_owned())).unwrap();
 
             let paginator = Arc::new(paginator);
 

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -884,7 +884,7 @@ impl MatrixAuth {
                 _ => None,
             };
 
-            self.client.encryption().run_initialization_tasks(auth_data).await;
+            self.client.encryption().run_initialization_tasks(auth_data);
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -884,7 +884,7 @@ impl MatrixAuth {
                 _ => None,
             };
 
-            self.client.encryption().run_initialization_tasks(auth_data);
+            self.client.encryption().spawn_initialization_task(auth_data);
         }
 
         Ok(())

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -486,7 +486,7 @@ impl MatrixAuth {
                 if let Some(save_session_callback) =
                     self.client.inner.auth_ctx.save_session_callback.get()
                 {
-                    if let Err(err) = save_session_callback(self.client.clone()).await {
+                    if let Err(err) = save_session_callback(self.client.clone()) {
                         error!("when saving session after refresh: {err}");
                     }
                 }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -840,7 +840,7 @@ impl Oidc {
         }
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks(None);
+        self.client.encryption().spawn_initialization_task(None);
 
         Ok(())
     }
@@ -1012,7 +1012,7 @@ impl Oidc {
         self.enable_cross_process_lock().await.map_err(OidcError::from)?;
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks(None);
+        self.client.encryption().spawn_initialization_task(None);
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -1193,7 +1193,7 @@ impl Oidc {
                     {
                         // Satisfies the save_session_callback invariant: set_session_tokens has
                         // been called just above.
-                        if let Err(err) = save_session_callback(this.client.clone()).await {
+                        if let Err(err) = save_session_callback(this.client.clone()) {
                             error!("when saving session after refresh: {err}");
                         }
                     }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -840,7 +840,7 @@ impl Oidc {
         }
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks(None).await;
+        self.client.encryption().run_initialization_tasks(None);
 
         Ok(())
     }
@@ -1012,7 +1012,7 @@ impl Oidc {
         self.enable_cross_process_lock().await.map_err(OidcError::from)?;
 
         #[cfg(feature = "e2e-encryption")]
-        self.client.encryption().run_initialization_tasks(None).await;
+        self.client.encryption().run_initialization_tasks(None);
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/sliding_sync/cache.rs
+++ b/crates/matrix-sdk/src/sliding_sync/cache.rs
@@ -88,7 +88,7 @@ pub(super) async fn store_sliding_sync_state(
     storage
         .set_custom_value(
             instance_storage_key.as_bytes(),
-            serde_json::to_vec(&FrozenSlidingSync::new(position).await)?,
+            serde_json::to_vec(&FrozenSlidingSync::new(position))?,
         )
         .await?;
 

--- a/crates/matrix-sdk/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk/src/sliding_sync/mod.rs
@@ -910,7 +910,7 @@ struct FrozenSlidingSync {
 }
 
 impl FrozenSlidingSync {
-    async fn new(position: &SlidingSyncPositionMarkers) -> Self {
+    fn new(position: &SlidingSyncPositionMarkers) -> Self {
         // The to-device token must be saved in the `FrozenCryptoSlidingSync` now.
         Self { delta_token: position.delta_token.clone(), to_device_since: None }
     }
@@ -1233,7 +1233,7 @@ mod tests {
         // FrozenSlidingSync doesn't contain the to_device_token anymore, as it's saved
         // in the crypto store since PR #2323.
         let position_guard = sliding_sync.inner.position.lock().await;
-        let frozen = FrozenSlidingSync::new(&position_guard).await;
+        let frozen = FrozenSlidingSync::new(&position_guard);
         assert!(frozen.to_device_since.is_none());
 
         Ok(())

--- a/crates/matrix-sdk/tests/integration/refresh_token.rs
+++ b/crates/matrix-sdk/tests/integration/refresh_token.rs
@@ -179,11 +179,8 @@ async fn test_refresh_token() {
         .set_session_callbacks(Box::new(|_| panic!("reload session never called")), {
             let num_save_session_callback_calls = num_save_session_callback_calls.clone();
             Box::new(move |_client| {
-                let num_save_session_callback_calls = num_save_session_callback_calls.clone();
-                Box::pin(async move {
-                    *num_save_session_callback_calls.lock().unwrap() += 1;
-                    Ok(())
-                })
+                *num_save_session_callback_calls.lock().unwrap() += 1;
+                Ok(())
             })
         })
         .unwrap();

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -351,7 +351,7 @@ impl App {
 
     /// Run a small back-pagination (expect a batch of 20 events, continue until
     /// we get 10 timeline items or hit the timeline start).
-    async fn back_paginate(&mut self) {
+    fn back_paginate(&mut self) {
         let Some(sdk_timeline) = self.get_selected_room_id(None).and_then(|room_id| {
             self.timelines.lock().unwrap().get(&room_id).map(|timeline| timeline.timeline.clone())
         }) else {
@@ -483,7 +483,7 @@ impl App {
                             Char('t') => self.details_mode = DetailsMode::TimelineItems,
 
                             Char('b') if self.details_mode == DetailsMode::TimelineItems => {
-                                self.back_paginate().await;
+                                self.back_paginate();
                             }
 
                             Char('m') if self.details_mode == DetailsMode::ReadReceipts => {


### PR DESCRIPTION
Using async when not required will increase compile times, and propagate async-ness to the callers, transitively.

See also the [lint description](https://rust-lang.github.io/rust-clippy/master/#/unused_async).

Since we only had a few false positives, I've enabled it by default. This PR is supposed to be squashed-and-merged, there's no point in keeping the individual commits, but these should help with the review.

(Note there's a renaming in the middle too.)