### PR TITLE
FFI: Replace `base_path + user_id` with a `session_path`.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -38,7 +38,7 @@ use crate::{
 
 #[derive(uniffi::Object)]
 pub struct AuthenticationService {
-    base_path: String,
+    session_path: String,
     passphrase: Option<String>,
     user_agent: Option<String>,
     client: AsyncRwLock<Option<Client>>,
@@ -233,7 +233,7 @@ impl AuthenticationService {
     // this to a builder pattern as well.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        base_path: String,
+        session_path: String,
         passphrase: Option<String>,
         user_agent: Option<String>,
         additional_root_certificates: Vec<Vec<u8>>,
@@ -244,7 +244,7 @@ impl AuthenticationService {
         cross_process_refresh_lock_id: Option<String>,
     ) -> Arc<Self> {
         Arc::new(AuthenticationService {
-            base_path,
+            session_path,
             passphrase,
             user_agent,
             client: AsyncRwLock::new(None),
@@ -427,12 +427,10 @@ impl AuthenticationService {
 }
 
 impl AuthenticationService {
-    /// Create a new client builder pre-configured with the service's HTTP
-    /// configuration if needed.
-    ///
-    /// Note: this client doesn't set the base path by default.
+    /// Create a new client builder pre-configured with the store path and the service's
+    /// HTTP configuration if needed.
     fn new_client_builder(&self) -> Arc<ClientBuilder> {
-        let mut builder = ClientBuilder::new();
+        let mut builder = ClientBuilder::new().session_path(self.session_path.clone());
 
         if let Some(user_agent) = self.user_agent.clone() {
             builder = builder.user_agent(user_agent);

--- a/bindings/matrix-sdk-ffi/src/authentication_service.rs
+++ b/bindings/matrix-sdk-ffi/src/authentication_service.rs
@@ -224,6 +224,35 @@ impl HomeserverLoginDetails {
 #[uniffi::export(async_runtime = "tokio")]
 impl AuthenticationService {
     /// Creates a new service to authenticate a user with.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_path` - A path to the directory where the session data will
+    ///   be stored. A new directory **must** be given for each subsequent
+    ///   session as the database isn't designed to be shared.
+    ///
+    /// * `passphrase` - An optional passphrase to use to encrypt the session
+    ///   data.
+    ///
+    /// * `user_agent` - An optional user agent to use when making requests.
+    ///
+    /// * `additional_root_certificates` - Additional root certificates to trust
+    ///   when making requests when built with rustls.
+    ///
+    /// * `proxy` - An optional HTTP(S) proxy URL to use when making requests.
+    ///
+    /// * `oidc_configuration` - Configuration data about the app to use during
+    ///   OIDC authentication. This is required if OIDC authentication is to be
+    ///   used.
+    ///
+    /// * `custom_sliding_sync_proxy` - An optional sliding sync proxy URL that
+    ///   will override the proxy discovered from the homeserver's well-known.
+    ///
+    /// * `session_delegate` - A delegate that will handle token refresh etc.
+    ///   when the cross-process lock is configured.
+    ///
+    /// * `cross_process_refresh_lock_id` - A process ID to use for
+    ///   cross-process token refresh locks.
     #[uniffi::constructor]
     // TODO: This has too many arguments, even clippy agrees. Many of these methods are the same as
     // for the `ClientBuilder`. We should let people pass in a `ClientBuilder` and possibly convert
@@ -429,8 +458,8 @@ impl AuthenticationService {
 }
 
 impl AuthenticationService {
-    /// Create a new client builder pre-configured with the store path and the
-    /// service's HTTP configuration if needed.
+    /// Create a new client builder that is pre-configured with the parameters
+    /// passed to the service along with some other sensible defaults
     fn new_client_builder(&self) -> Result<Arc<ClientBuilder>, AuthenticationError> {
         let mut builder = ClientBuilder::new()
             .session_path(self.session_path.clone())

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -19,7 +19,6 @@ use matrix_sdk::{
     },
     ruma::{
         api::client::{
-            account::whoami,
             media::get_content_thumbnail::v3::Method,
             push::{EmailPusherData, PusherIds, PusherInit, PusherKind as RumaPusherKind},
             room::{create_room, Visibility},
@@ -378,11 +377,6 @@ impl Client {
             .iter()
             .any(|login_type| matches!(login_type, get_login_types::v3::LoginType::Password(_)));
         Ok(supports_password)
-    }
-
-    /// Gets information about the owner of a given access token.
-    pub(crate) async fn whoami(&self) -> anyhow::Result<whoami::v3::Response> {
-        Ok(self.inner.whoami().await?)
     }
 }
 


### PR DESCRIPTION
This PR removes the concept of a base_path from the FFI. Instead we do the following:

1. Provide a direct path to the OIDC registrations.json file instead of building it - this was weird using a base_path directly in the main SDK crate.
2. Remove all the ClientBuilder logic that creates the store path from the base_path + user_id and instead have the caller generate one (using a UUID for new logins and saving it for restoration) themselves.
3. Remove the in-memory client from the authentication service, as now we don't need to worry about the whole "we don't know the final path until the login is complete".

Have tested with password, OIDC and QR logins.