### PR TITLE
sdk: rename "sending queue" to "send queue"

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -147,10 +147,10 @@ pub trait ProgressWatcher: Send + Sync {
     fn transmission_progress(&self, progress: TransmissionProgress);
 }
 
-/// A listener to the global (client-wide) status of the sending queue.
+/// A listener to the global (client-wide) status of the send queue.
 #[uniffi::export(callback_interface)]
-pub trait SendingQueueStatusListener: Sync + Send {
-    /// Called every time the sending queue has received a new status.
+pub trait SendQueueStatusListener: Sync + Send {
+    /// Called every time the send queue has received a new status.
     ///
     /// This can be set automatically (in case of sending failure), or manually
     /// via an API call.
@@ -316,9 +316,9 @@ impl Client {
         Ok(())
     }
 
-    /// Enables or disables the sending queue, according to the given parameter.
+    /// Enables or disables the send queue, according to the given parameter.
     ///
-    /// The sending queue automatically disables itself whenever sending an
+    /// The send queue automatically disables itself whenever sending an
     /// event with it failed (e.g., sending an event via the high-level Timeline
     /// object), so it's required to manually re-enable it as soon as
     /// connectivity is back on the device.
@@ -330,14 +330,14 @@ impl Client {
         }
     }
 
-    /// Subscribe to the global enablement status of the sending queue, at the
+    /// Subscribe to the global enablement status of the send queue, at the
     /// client-wide level.
     ///
     /// The given listener will be immediately called with the initial value of
     /// the enablement status.
     pub fn subscribe_to_sending_queue_status(
         &self,
-        listener: Box<dyn SendingQueueStatusListener>,
+        listener: Box<dyn SendQueueStatusListener>,
     ) -> Arc<TaskHandle> {
         let mut subscriber = self.inner.sending_queue().subscribe_status();
 

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -219,7 +219,7 @@ impl Timeline {
         Ok(())
     }
 
-    /// Queues an event in the room's sending queue so it's processed for
+    /// Queues an event in the room's send queue so it's processed for
     /// sending later.
     ///
     /// Returns an abort handle that allows to abort sending, if it hasn't

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -18,7 +18,7 @@ use futures_util::{pin_mut, StreamExt};
 use matrix_sdk::{
     event_cache::{EventsOrigin, RoomEventCacheUpdate},
     executor::spawn,
-    send_queue::{LocalEcho, RoomSendingQueueUpdate},
+    send_queue::{LocalEcho, RoomSendQueueUpdate},
     Room,
 };
 use ruma::{events::AnySyncTimelineEvent, RoomVersionId};
@@ -295,7 +295,7 @@ impl TimelineBuilder {
                     loop {
                         match listener.recv().await {
                             Ok(update) => match update {
-                                RoomSendingQueueUpdate::NewLocalEvent(LocalEcho {
+                                RoomSendQueueUpdate::NewLocalEvent(LocalEcho {
                                     transaction_id,
                                     content,
                                     abort_handle,
@@ -312,13 +312,13 @@ impl TimelineBuilder {
                                         .await;
                                 }
 
-                                RoomSendingQueueUpdate::CancelledLocalEvent { transaction_id } => {
+                                RoomSendQueueUpdate::CancelledLocalEvent { transaction_id } => {
                                     if !timeline.discard_local_echo(&transaction_id).await {
                                         warn!("couldn't find the local echo to discard");
                                     }
                                 }
 
-                                RoomSendingQueueUpdate::SendError { transaction_id, error } => {
+                                RoomSendQueueUpdate::SendError { transaction_id, error } => {
                                     timeline
                                         .update_event_send_state(
                                             &transaction_id,
@@ -327,7 +327,7 @@ impl TimelineBuilder {
                                         .await;
                                 }
 
-                                RoomSendingQueueUpdate::SentEvent { transaction_id, event_id } => {
+                                RoomSendQueueUpdate::SentEvent { transaction_id, event_id } => {
                                     timeline
                                         .update_event_send_state(
                                             &transaction_id,

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 use matrix_sdk::{
     event_cache::{paginator::PaginatorError, EventCacheError},
-    send_queue::RoomSendingQueueError,
+    send_queue::RoomSendQueueError,
 };
 use ruma::OwnedTransactionId;
 use thiserror::Error;
@@ -144,7 +144,7 @@ pub enum SendEventError {
     UnsupportedEditItem(#[from] UnsupportedEditItem),
 
     #[error(transparent)]
-    SendError(#[from] RoomSendingQueueError),
+    SendError(#[from] RoomSendQueueError),
 }
 
 #[derive(Debug, Error)]

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -27,7 +27,7 @@ use matrix_sdk::{
     event_handler::EventHandlerHandle,
     executor::JoinHandle,
     room::{Receipts, Room},
-    send_queue::{AbortSendHandle, RoomSendingQueueError},
+    send_queue::{AbortSendHandle, RoomSendQueueError},
     Client, Result,
 };
 use matrix_sdk_base::RoomState;
@@ -300,7 +300,7 @@ impl Timeline {
     pub async fn send(
         &self,
         content: AnyMessageLikeEventContent,
-    ) -> Result<AbortSendHandle, RoomSendingQueueError> {
+    ) -> Result<AbortSendHandle, RoomSendQueueError> {
         self.room().sending_queue().send(content).await
     }
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2539,7 +2539,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
     // Insert a local event in the `Timeline`.
     timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await.unwrap();
 
-    // Let the sending queue send the message, and the timeline process it.
+    // Let the send queue send the message, and the timeline process it.
     yield_now().await;
 
     // The latest event of the `Timeline` is a local event.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -151,7 +151,7 @@ async fn test_retry_failed() {
 
     timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await.unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     // First, local echo is added
@@ -177,7 +177,7 @@ async fn test_retry_failed() {
 
     client.sending_queue().enable();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     // After mocking the endpoint and retrying, it succeeds.
@@ -281,7 +281,7 @@ async fn test_cancel_failed() {
     let handle =
         timeline.send(RoomMessageEventContent::text_plain("Hello, World!").into()).await.unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     // Local echo is added (immediately)

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -206,7 +206,7 @@ async fn test_send_edit() {
         .await
         .unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     let edit_item =
@@ -296,7 +296,7 @@ async fn test_send_reply_edit() {
         .await
         .unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     let edit_item =
@@ -387,7 +387,7 @@ async fn test_send_edit_poll() {
         UnstablePollStartContentBlock::new("Edited Test".to_owned(), edited_poll_answers);
     timeline.edit_poll("poll_fallback_text", edited_poll, &poll_event).await.unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     let edit_item =

--- a/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/focus_event.rs
@@ -328,7 +328,7 @@ async fn test_focused_timeline_doesnt_show_local_echoes() {
     // Send a message in the room, expect no local echo.
     timeline.send(RoomMessageEventContent::text_plain("h4xx0r").into()).await.unwrap();
 
-    // Let a bit of time for the sending queue to process the event.
+    // Let a bit of time for the send queue to process the event.
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     // And nothing more.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -82,10 +82,10 @@ async fn test_message_order() {
     timeline.send(RoomMessageEventContent::text_plain("First!").into()).await.unwrap();
     timeline.send(RoomMessageEventContent::text_plain("Second.").into()).await.unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
-    // Local echoes are available after the sending queue has processed these.
+    // Local echoes are available after the send queue has processed these.
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
         assert!(!value.is_editable(), "local echo for first can't be edited");
         assert_eq!(value.content().as_message().unwrap().body(), "First!");
@@ -140,10 +140,10 @@ async fn test_retry_order() {
     timeline.send(RoomMessageEventContent::text_plain("First!").into()).await.unwrap();
     timeline.send(RoomMessageEventContent::text_plain("Second.").into()).await.unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
-    // Local echoes are available after the sending queue has processed these.
+    // Local echoes are available after the send queue has processed these.
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
         assert_eq!(value.content().as_message().unwrap().body(), "First!");
     });
@@ -187,7 +187,7 @@ async fn test_retry_order() {
     // Wait 200ms for the first msg, 100ms for the second, 300ms for overhead
     sleep(Duration::from_millis(600)).await;
 
-    // With the sending queue, sending is retried in the same order as the events
+    // With the send queue, sending is retried in the same order as the events
     // were sent. So we first see the first message.
     assert_next_matches!(timeline_stream, VectorDiff::Set { index: 0, value } => {
         assert_eq!(value.content().as_message().unwrap().body(), "First!");
@@ -336,7 +336,7 @@ async fn test_no_duplicate_day_divider() {
     timeline.send(RoomMessageEventContent::text_plain("First!").into()).await.unwrap();
     timeline.send(RoomMessageEventContent::text_plain("Second.").into()).await.unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     // Local echoes are available as soon as `timeline.send` returns.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -323,7 +323,7 @@ async fn test_send_reply() {
         .await
         .unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     let reply_item = assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
@@ -430,7 +430,7 @@ async fn test_send_reply_to_self() {
         .await
         .unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     let reply_item = assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);
@@ -520,7 +520,7 @@ async fn test_send_reply_to_threaded() {
         .await
         .unwrap();
 
-    // Let the sending queue handle the event.
+    // Let the send queue handle the event.
     yield_now().await;
 
     let reply_item = assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => value);

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -38,7 +38,7 @@ use crate::http_client::HttpSettings;
 use crate::oidc::OidcCtx;
 use crate::{
     authentication::AuthCtx, config::RequestConfig, error::RumaApiError, http_client::HttpClient,
-    send_queue::SendingQueueData, HttpError, IdParseError,
+    send_queue::SendQueueData, HttpError, IdParseError,
 };
 
 /// Builder that allows creating and configuring various parts of a [`Client`].
@@ -453,7 +453,7 @@ impl ClientBuilder {
         });
 
         let event_cache = OnceCell::new();
-        let sending_queue = Arc::new(SendingQueueData::new(true));
+        let sending_queue = Arc::new(SendQueueData::new(true));
         let inner = ClientInner::new(
             auth_ctx,
             homeserver,

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -83,7 +83,7 @@ use crate::{
     matrix_auth::MatrixAuth,
     notification_settings::NotificationSettings,
     room_preview::RoomPreview,
-    send_queue::SendingQueueData,
+    send_queue::SendQueueData,
     sync::{RoomUpdate, SyncResponse},
     Account, AuthApi, AuthSession, Error, Media, Pusher, RefreshTokenError, Result, Room,
     TransmissionProgress,
@@ -284,10 +284,10 @@ pub(crate) struct ClientInner {
     #[cfg(feature = "e2e-encryption")]
     pub(crate) verification_state: SharedObservable<VerificationState>,
 
-    /// Data related to the [`SendingQueue`].
+    /// Data related to the [`SendQueue`].
     ///
-    /// [`SendingQueue`]: crate::send_queue::SendingQueue
-    pub(crate) sending_queue_data: Arc<SendingQueueData>,
+    /// [`SendQueue`]: crate::send_queue::SendQueue
+    pub(crate) sending_queue_data: Arc<SendQueueData>,
 }
 
 impl ClientInner {
@@ -307,7 +307,7 @@ impl ClientInner {
         unstable_features: Option<BTreeMap<String, bool>>,
         respect_login_well_known: bool,
         event_cache: OnceCell<EventCache>,
-        sending_queue: Arc<SendingQueueData>,
+        sending_queue: Arc<SendQueueData>,
         #[cfg(feature = "e2e-encryption")] encryption_settings: EncryptionSettings,
     ) -> Arc<Self> {
         let client = Self {

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -818,7 +818,7 @@ impl App {
                     "\nUse j/k to move, s/S to start/stop the sync service, m to mark as read, t to show the timeline.".to_owned()
                 }
                 DetailsMode::TimelineItems => {
-                    "\nUse j/k to move, s/S to start/stop the sync service, r to show read receipts, Q to enable/disable the sending queue, M to send a message.".to_owned()
+                    "\nUse j/k to move, s/S to start/stop the sync service, r to show read receipts, Q to enable/disable the send queue, M to send a message.".to_owned()
                 }
             }
         };


### PR DESCRIPTION
Let's use uniform naming. Just a renaming PR. Easy to review. Thank you in advance for smashing that "approve" button.