### PR TITLE
day dividers: demote an assert to an error message

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
+++ b/crates/matrix-sdk-ui/src/timeline/day_dividers.rs
@@ -41,8 +41,8 @@ pub(super) struct DayDividerAdjuster {
 impl Drop for DayDividerAdjuster {
     fn drop(&mut self) {
         // Only run the assert if we're not currently panicking.
-        if !std::thread::panicking() {
-            assert!(self.consumed, "the DayDividerAdjuster must be consumed with run()");
+        if !std::thread::panicking() && !self.consumed {
+            error!("a DayDividerAdjuster has not been consumed with run()");
         }
     }
 }


### PR DESCRIPTION
Because of the task cancellation that can happen at any place in the code base, it's really hard to predict in which situation a day-divider-adjuster should have run or not, so just demote the assert to an error. The intent is that, if we see errors with day dividers in the future, they'll be reported along rageshakes and we'll notice this in the logs.