### PR TITLE
send queue: use an enablement status per room

### DIFF
--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -14,7 +14,7 @@ pub enum ClientError {
 }
 
 impl ClientError {
-    fn new<E: Display>(error: E) -> Self {
+    pub(crate) fn new<E: Display>(error: E) -> Self {
         Self::Generic { msg: error.to_string() }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -687,6 +687,17 @@ impl Room {
             .await?;
         Ok(())
     }
+
+    /// Returns whether the send queue for that particular room is enabled or
+    /// not.
+    pub fn is_send_queue_enabled(&self) -> bool {
+        self.inner.send_queue().is_enabled()
+    }
+
+    /// Enable or disable the send queue for that particular room.
+    pub fn enable_send_queue(&self, enable: bool) {
+        self.inner.send_queue().set_enabled(enable);
+    }
 }
 
 /// Generates a `matrix.to` permalink to the given room alias.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -142,7 +142,7 @@ async fn test_retry_failed() {
 
     mock_encryption_state(&server, false).await;
 
-    client.send_queue().enable();
+    client.send_queue().set_enabled(true);
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());
@@ -173,9 +173,12 @@ async fn test_retry_failed() {
         .mount(&server)
         .await;
 
-    assert!(!client.send_queue().is_enabled());
+    // This doesn't disable the send queue at the global level…
+    assert!(client.send_queue().is_enabled());
+    // …but does so at the local level.
+    assert!(!room.send_queue().is_enabled());
 
-    client.send_queue().enable();
+    room.send_queue().set_enabled(true);
 
     // Let the send queue handle the event.
     tokio::time::sleep(Duration::from_millis(300)).await;

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -182,7 +182,7 @@ async fn test_retry_order() {
         .await;
 
     // Retry the second message first
-    client.send_queue().enable();
+    client.send_queue().set_enabled(true);
 
     // Wait 200ms for the first msg, 100ms for the second, 300ms for overhead
     sleep(Duration::from_millis(600)).await;

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -438,11 +438,7 @@ impl App {
                             Char('Q') => {
                                 let q = self.client.send_queue();
                                 let enabled = q.is_enabled();
-                                if enabled {
-                                    q.disable();
-                                } else {
-                                    q.enable();
-                                }
+                                q.set_enabled(!enabled);
                             }
 
                             Char('M') => {


### PR DESCRIPTION
This makes it so that getting any error (network or API error) will only disable the send queue for a single room. Callers are expected to `SendQueue::subscribe_errors()` to see whenever they get an error:

- if they get an error, and network is disconnected: disable the send queue
- if they get an error, but network is still here: either re-enable the send queue, or display the error somewhere to the user. (It's also reflected live in the timeline.)

Based on top of #3522 to avoid conflicts.