### PR TITLE
chore(ui): Remove a useless clone

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -425,8 +425,7 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         let user_id = self.room_data_provider.own_user_id();
 
         let related_event = {
-            let items = state.items.clone();
-            let Some((_, item)) = rfind_event_by_id(&items, &annotation.event_id) else {
+            let Some((_, item)) = rfind_event_by_id(&state.items, &annotation.event_id) else {
                 warn!("Timeline item not found, can't update reaction ID");
                 return Err(Error::FailedToToggleReaction);
             };


### PR DESCRIPTION
This patch removes a useless clone of `TimelineInner::items`. This clone was technically cheap because it's a `Vector` behind the scene, which is cheap to clone, but still, it's not necessary at all to clone it.

---

* Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3512.
* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280.