### PR TITLE
chore(ui): Make `TimelineInnerMetadata::next_internal_id` private

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1005,16 +1005,14 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 // pending local echo, or at the start if there is no such item.
                 let insert_idx = latest_event_idx.map_or(0, |idx| idx + 1);
 
-                let id = match removed_event_item_id {
+                trace!("Adding new remote timeline item after all non-pending events");
+                let new_item = match removed_event_item_id {
                     // If a previous version of the same item (usually a local
                     // echo) was removed and we now need to add it again, reuse
                     // the previous item's ID.
-                    Some(id) => id,
-                    None => self.meta.next_internal_id(),
+                    Some(id) => TimelineItem::new(item, id),
+                    None => self.meta.new_timeline_item(item),
                 };
-
-                trace!("Adding new remote timeline item after all non-pending events");
-                let new_item = TimelineItem::new(item, id);
 
                 // Keep push semantics, if we're inserting at the front or the back.
                 if insert_idx == self.items.len() {

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -788,7 +788,7 @@ impl TimelineInnerMetadata {
 
     /// Returns the next internal id for a timeline item (and increment our
     /// internal counter).
-    pub fn next_internal_id(&mut self) -> String {
+    fn next_internal_id(&mut self) -> String {
         let val = self.next_internal_id;
         self.next_internal_id += 1;
         let prefix = self.internal_id_prefix.as_deref().unwrap_or("");


### PR DESCRIPTION
This patch updates `TimelineEventHandler` to re-use the public API and avoid using `TimelineInnerMeta::next_internal_id`. The consequence is that `next_internal_id` can now be private instead of public. It's better to have isolated API in this code.

---

* Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3512.
* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280.