### PR TITLE
chore(ui): Rewrite a bit `TimelineEventHandler::add`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -354,12 +354,14 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     self.handle_room_message_edit(re);
                 }
                 AnyMessageLikeEventContent::RoomMessage(c) => {
-                    self.add(should_add, TimelineItemContent::message(c, relations, self.items));
+                    if should_add {
+                        self.add_item(TimelineItemContent::message(c, relations, self.items));
+                    }
                 }
                 AnyMessageLikeEventContent::RoomEncrypted(c) => {
                     // TODO: Handle replacements if the replaced event is also UTD
                     let cause = UtdCause::determine(raw_event);
-                    self.add(true, TimelineItemContent::unable_to_decrypt(c, cause));
+                    self.add_item(TimelineItemContent::unable_to_decrypt(c, cause));
 
                     // Let the hook know that we ran into an unable-to-decrypt that is added to the
                     // timeline.
@@ -370,7 +372,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     }
                 }
                 AnyMessageLikeEventContent::Sticker(content) => {
-                    self.add(should_add, TimelineItemContent::Sticker(Sticker { content }));
+                    if should_add {
+                        self.add_item(TimelineItemContent::Sticker(Sticker { content }));
+                    }
                 }
                 AnyMessageLikeEventContent::UnstablePollStart(
                     UnstablePollStartEventContent::Replacement(c),
@@ -381,10 +385,14 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 AnyMessageLikeEventContent::UnstablePollResponse(c) => self.handle_poll_response(c),
                 AnyMessageLikeEventContent::UnstablePollEnd(c) => self.handle_poll_end(c),
                 AnyMessageLikeEventContent::CallInvite(_) => {
-                    self.add(should_add, TimelineItemContent::CallInvite);
+                    if should_add {
+                        self.add_item(TimelineItemContent::CallInvite);
+                    }
                 }
                 AnyMessageLikeEventContent::CallNotify(_) => {
-                    self.add(should_add, TimelineItemContent::CallNotify)
+                    if should_add {
+                        self.add_item(TimelineItemContent::CallNotify)
+                    }
                 }
 
                 // TODO
@@ -397,8 +405,8 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             },
 
             TimelineEventKind::RedactedMessage { event_type } => {
-                if event_type != MessageLikeEventType::Reaction {
-                    self.add(should_add, TimelineItemContent::RedactedMessage);
+                if event_type != MessageLikeEventType::Reaction && should_add {
+                    self.add_item(TimelineItemContent::RedactedMessage);
                 }
             }
 
@@ -410,28 +418,37 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
 
             TimelineEventKind::RoomMember { user_id, content, sender } => {
-                self.add(should_add, TimelineItemContent::room_member(user_id, content, sender));
+                if should_add {
+                    self.add_item(TimelineItemContent::room_member(user_id, content, sender));
+                }
             }
 
             TimelineEventKind::OtherState { state_key, content } => {
-                self.add(
-                    should_add,
-                    TimelineItemContent::OtherState(OtherState { state_key, content }),
-                );
+                if should_add {
+                    self.add_item(TimelineItemContent::OtherState(OtherState {
+                        state_key,
+                        content,
+                    }));
+                }
             }
 
             TimelineEventKind::FailedToParseMessageLike { event_type, error } => {
-                self.add(
-                    should_add,
-                    TimelineItemContent::FailedToParseMessageLike { event_type, error },
-                );
+                if should_add {
+                    self.add_item(TimelineItemContent::FailedToParseMessageLike {
+                        event_type,
+                        error,
+                    });
+                }
             }
 
             TimelineEventKind::FailedToParseState { event_type, state_key, error } => {
-                self.add(
-                    should_add,
-                    TimelineItemContent::FailedToParseState { event_type, state_key, error },
-                );
+                if should_add {
+                    self.add_item(TimelineItemContent::FailedToParseState {
+                        event_type,
+                        state_key,
+                        error,
+                    });
+                }
             }
         }
 
@@ -636,7 +653,10 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             // don't have an event ID that could be referenced by responses yet.
             self.meta.poll_pending_events.apply(&event_id, &mut poll_state);
         }
-        self.add(should_add, TimelineItemContent::Poll(poll_state));
+
+        if should_add {
+            self.add_item(TimelineItemContent::Poll(poll_state));
+        }
     }
 
     fn handle_poll_response(&mut self, c: UnstablePollResponseEventContent) {
@@ -846,11 +866,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
     }
 
     /// Add a new event item in the timeline.
-    fn add(&mut self, should_add: bool, content: TimelineItemContent) {
-        if !should_add {
-            return;
-        }
-
+    fn add_item(&mut self, content: TimelineItemContent) {
         self.result.item_added = true;
 
         let sender = self.ctx.sender.to_owned();
@@ -859,12 +875,10 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         let mut reactions = self.pending_reactions().unwrap_or_default();
 
         let kind: EventTimelineItemKind = match &self.ctx.flow {
-            Flow::Local { txn_id, abort_handle } => {
-                LocalEventTimelineItem {
-                    send_state: EventSendState::NotSentYet,
-                    transaction_id: txn_id.to_owned(),
-                    abort_handle: abort_handle.clone(),
-                }
+            Flow::Local { txn_id, abort_handle } => LocalEventTimelineItem {
+                send_state: EventSendState::NotSentYet,
+                transaction_id: txn_id.to_owned(),
+                abort_handle: abort_handle.clone(),
             }
             .into(),
 


### PR DESCRIPTION
This patch renames `TimelineEventHandler::add` to `add_item`.

This patch also removes the `should_add` argument. The `add_item` is called conditionally everytime. I believe this is much cleaner. Otherwise the method should have been called `maybe_add_item` with a return type or something that indicates whether the item is added. This patch makes it clear and remove one possible state in `add_item`.

---

* Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3512.
* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280.