### PR TITLE
feat (bindings): added APIs to save and load composer drafts

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use matrix_sdk::{
     event_cache::paginator::PaginatorError,
     room::{power_levels::RoomPowerLevelChanges, Room as SdkRoom, RoomMemberRole},
-    RoomMemberships, RoomState,
+    ComposerDraft, RoomMemberships, RoomState,
 };
 use matrix_sdk_ui::timeline::{PaginationError, RoomExt, TimelineFocus};
 use mime::Mime;
@@ -697,6 +697,22 @@ impl Room {
     /// Enable or disable the send queue for that particular room.
     pub fn enable_send_queue(&self, enable: bool) {
         self.inner.send_queue().set_enabled(enable);
+    }
+
+    /// Store the given `ComposerDraft` in the state store using the current
+    /// room id, as identifier.
+    pub async fn save_composer_draft(&self, draft: ComposerDraft) -> Result<(), ClientError> {
+        Ok(self.inner.save_composer_draft(draft).await?)
+    }
+
+    /// Retrieve the `ComposerDraft` stored in the state store for this room.
+    pub async fn load_composer_draft(&self) -> Result<Option<ComposerDraft>, ClientError> {
+        Ok(self.inner.load_composer_draft().await?)
+    }
+
+    /// Remove the `ComposerDraft` stored in the state store for this room.
+    pub async fn clear_composer_draft(&self) -> Result<(), ClientError> {
+        Ok(self.inner.clear_composer_draft().await?)
     }
 }
 

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -55,7 +55,9 @@ pub use rooms::{
     DisplayName, Room, RoomCreateWithCreatorEventContent, RoomInfo, RoomInfoUpdate, RoomMember,
     RoomMemberships, RoomState, RoomStateFilter,
 };
-pub use store::{StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError};
+pub use store::{
+    ComposerDraft, StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError,
+};
 pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,
 };

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -70,8 +70,8 @@ pub use self::integration_tests::StateStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
     traits::{
-        DynStateStore, IntoStateStore, StateStore, StateStoreDataKey, StateStoreDataValue,
-        StateStoreExt,
+        ComposerDraft, DynStateStore, IntoStateStore, StateStore, StateStoreDataKey,
+        StateStoreDataValue, StateStoreExt,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -70,8 +70,8 @@ pub use self::integration_tests::StateStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
     traits::{
-        ComposerDraft, DynStateStore, IntoStateStore, StateStore, StateStoreDataKey,
-        StateStoreDataValue, StateStoreExt,
+        ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, StateStore,
+        StateStoreDataKey, StateStoreDataValue, StateStoreExt,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -35,6 +35,7 @@ use ruma::{
     serde::Raw,
     EventId, MxcUri, OwnedEventId, OwnedUserId, RoomId, UserId,
 };
+use serde::{Deserialize, Serialize};
 
 use super::{StateChanges, StoreError};
 use crate::{
@@ -813,6 +814,37 @@ pub enum StateStoreDataValue {
     /// Persistent data for
     /// `matrix_sdk_ui::unable_to_decrypt_hook::UtdHookManager`.
     UtdHookManagerData(GrowableBloom),
+
+    /// A composer draft for the room.
+    /// To learn more, see [`ComposerDraft`].
+    ///
+    /// [`ComposerDraft`]: Self::ComposerDraft
+    ComposerDraft(ComposerDraft),
+}
+
+/// Current draft of the composer for the room.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct ComposerDraft {
+    /// The draft content in plain text.
+    plain_text: String,
+    /// If the message is formatted in HTML, the HTML representation of the
+    /// message.
+    html_text: Option<String>,
+    /// The type of draft.
+    draft_type: ComposerDraftType,
+}
+
+/// The type of draft of the composer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum ComposerDraftType {
+    /// The draft is a new message.
+    NewMessage,
+    /// The draft is a rseply to an event.
+    Reply { event_id: String },
+    /// The draft is an edit of an event.
+    Edit { event_id: String },
 }
 
 impl StateStoreDataValue {
@@ -840,6 +872,11 @@ impl StateStoreDataValue {
     pub fn into_utd_hook_manager_data(self) -> Option<GrowableBloom> {
         as_variant!(self, Self::UtdHookManagerData)
     }
+
+    /// Get this value if it is a composer draft.
+    pub fn into_composer_draft(self) -> Option<ComposerDraft> {
+        as_variant!(self, Self::ComposerDraft)
+    }
 }
 
 /// A key for key-value data.
@@ -860,6 +897,12 @@ pub enum StateStoreDataKey<'a> {
     /// Persistent data for
     /// `matrix_sdk_ui::unable_to_decrypt_hook::UtdHookManager`.
     UtdHookManagerData,
+
+    /// A composer draft for the room.
+    /// To learn more, see [`ComposerDraft`].
+    ///
+    /// [`ComposerDraft`]: Self::ComposerDraft
+    ComposerDraft(&'a RoomId),
 }
 
 impl StateStoreDataKey<'_> {
@@ -878,4 +921,8 @@ impl StateStoreDataKey<'_> {
     /// Key to use for the [`UtdHookManagerData`][Self::UtdHookManagerData]
     /// variant.
     pub const UTD_HOOK_MANAGER_DATA: &'static str = "utd_hook_manager_data";
+
+    /// Key prefix to use for the [`ComposerDraft`][Self::ComposerDraft]
+    /// variant.
+    pub const COMPOSER_DRAFT: &'static str = "composer_draft";
 }

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -823,28 +823,34 @@ pub enum StateStoreDataValue {
 }
 
 /// Current draft of the composer for the room.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ComposerDraft {
     /// The draft content in plain text.
-    plain_text: String,
+    pub plain_text: String,
     /// If the message is formatted in HTML, the HTML representation of the
     /// message.
-    html_text: Option<String>,
+    pub html_text: Option<String>,
     /// The type of draft.
-    draft_type: ComposerDraftType,
+    pub draft_type: ComposerDraftType,
 }
 
 /// The type of draft of the composer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ComposerDraftType {
     /// The draft is a new message.
     NewMessage,
-    /// The draft is a rseply to an event.
-    Reply { event_id: String },
+    /// The draft is a reply to an event.
+    Reply {
+        /// The ID of the event being replied to.
+        event_id: String,
+    },
     /// The draft is an edit of an event.
-    Edit { event_id: String },
+    Edit {
+        /// The ID of the event being edited.
+        event_id: String,
+    },
 }
 
 impl StateStoreDataValue {

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -281,6 +281,9 @@ impl SqliteStateStore {
             StateStoreDataKey::UtdHookManagerData => {
                 Cow::Borrowed(StateStoreDataKey::UTD_HOOK_MANAGER_DATA)
             }
+            StateStoreDataKey::ComposerDraft(room_id) => {
+                Cow::Owned(format!("{}:{room_id}", StateStoreDataKey::COMPOSER_DRAFT))
+            }
         };
 
         self.encode_key(keys::KV_BLOB, &*key_s)
@@ -902,6 +905,9 @@ impl StateStore for SqliteStateStore {
                     StateStoreDataKey::UtdHookManagerData => {
                         StateStoreDataValue::UtdHookManagerData(self.deserialize_value(&data)?)
                     }
+                    StateStoreDataKey::ComposerDraft(_) => {
+                        StateStoreDataValue::ComposerDraft(self.deserialize_value(&data)?)
+                    }
                 })
             })
             .transpose()
@@ -927,6 +933,9 @@ impl StateStore for SqliteStateStore {
             )?,
             StateStoreDataKey::UtdHookManagerData => self.serialize_value(
                 &value.into_utd_hook_manager_data().expect("Session data not UtdHookManagerData"),
+            )?,
+            StateStoreDataKey::ComposerDraft(_) => self.serialize_value(
+                &value.into_composer_draft().expect("Session data not a composer draft"),
             )?,
         };
 

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -22,7 +22,7 @@ pub use bytes;
 pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
     deserialized_responses,
-    store::{DynStateStore, MemoryStore, StateStoreExt},
+    store::{ComposerDraft, DynStateStore, MemoryStore, StateStoreExt},
     DisplayName, Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomInfo,
     RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
     StateStore, StoreError,


### PR DESCRIPTION
This PR is the first piece of the breakdown of the following PR: https://github.com/matrix-org/matrix-rust-sdk/pull/3439 where only the core functionalities of the feature are implemented, without addressing the issue of editing and replying to events that have not yet been paginated.