### PR TITLE
feat(crypto): Add new strategy to share room keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,7 +3875,7 @@ name = "oauth2"
 version = "5.0.0-alpha.4"
 source = "git+https://github.com/poljar/oauth2-rs?rev=f8e28ce5a7f3278ac85b8593ecdd86f2cf51fa2e#f8e28ce5a7f3278ac85b8593ecdd86f2cf51fa2e"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom",
  "http 1.1.0",
@@ -4565,7 +4565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.63",

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -31,7 +31,7 @@ pub use logger::{set_logger, Logger};
 pub use machine::{KeyRequestPair, OlmMachine, SignatureVerification};
 use matrix_sdk_common::deserialized_responses::ShieldState as RustShieldState;
 use matrix_sdk_crypto::{
-    olm::{IdentityKeys, InboundGroupSession, Session},
+    olm::{IdentityKeys, InboundGroupSession, RoomKeySharingStrategy, Session},
     store::{Changes, CryptoStore, PendingChanges, RoomSettings as RustRoomSettings},
     types::{EventEncryptionAlgorithm as RustEventEncryptionAlgorithm, SigningKey},
     EncryptionSettings as RustEncryptionSettings,
@@ -650,7 +650,7 @@ impl From<EncryptionSettings> for RustEncryptionSettings {
             rotation_period: Duration::from_secs(v.rotation_period),
             rotation_period_msgs: v.rotation_period_msgs,
             history_visibility: v.history_visibility.into(),
-            only_allow_trusted_devices: v.only_allow_trusted_devices,
+            sharing_strategy: RoomKeySharingStrategy::new_legacy(v.only_allow_trusted_devices),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -226,7 +226,8 @@ impl Encryption {
         self.inner.curve25519_key().await.map(|k| k.to_base64())
     }
 
-    /// Lab: Enable the new Invisible Crypto key distribution mode for all rooms.
+    /// Lab: Enable the new Invisible Crypto key distribution mode for all
+    /// rooms.
     pub async fn set_invisible_crypto_enabled(&self, enabled: bool) {
         self.inner.set_invisible_crypto_enabled(enabled).await
     }

--- a/bindings/matrix-sdk-ffi/src/encryption.rs
+++ b/bindings/matrix-sdk-ffi/src/encryption.rs
@@ -226,6 +226,11 @@ impl Encryption {
         self.inner.curve25519_key().await.map(|k| k.to_base64())
     }
 
+    /// Lab: Enable the new Invisible Crypto key distribution mode for all rooms.
+    pub async fn set_invisible_crypto_enabled(&self, enabled: bool) {
+        self.inner.set_invisible_crypto_enabled(enabled).await
+    }
+
     pub fn backup_state_listener(&self, listener: Box<dyn BackupStateListener>) -> Arc<TaskHandle> {
         let mut stream = self.inner.backups().state_stream();
 

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -76,24 +76,27 @@ use crate::{
 };
 
 ///
-/// Lab Feature: Allows to switch to the new key distribution mode used by Invisible Crypto
+/// Lab Feature: Allows to switch to the new key distribution mode used by
+/// Invisible Crypto
 #[cfg(feature = "e2e-encryption")]
 #[derive(Default, Clone, Debug)]
 pub enum CryptoDistributionMode {
     /// The legacy mode, distribute to all devices in the room
     #[default]
     Legacy,
-    /// Distribute to tofu/trusted identities, and only to device signed by their owner.
-    InvisibleCrypto
+    /// Distribute to tofu/trusted identities, and only to device signed by
+    /// their owner.
+    InvisibleCrypto,
 }
 
-/// Global default encryption settings. Some of them could be defined per room, here
-/// is the global value that should be used by default when not specified by the room.
+/// Global default encryption settings. Some of them could be defined per room,
+/// here is the global value that should be used by default when not specified
+/// by the room.
 #[cfg(feature = "e2e-encryption")]
 #[derive(Default, Clone, Debug)]
 pub struct GlobalEncryptionSettings {
     /// The distribution mode to use
-    pub key_distribution_mode: CryptoDistributionMode
+    pub key_distribution_mode: CryptoDistributionMode,
 }
 /// A no IO Client implementation.
 ///
@@ -1322,13 +1325,24 @@ impl BaseClient {
 
                 let global_settings = self.global_encryption_settings.lock().await.clone();
                 let crypto_settings = match global_settings.key_distribution_mode {
-                    CryptoDistributionMode::InvisibleCrypto => EncryptionSettings::new_with_strategy(settings, history_visibility, RoomKeySharingStrategy::new_modern()),
-                    CryptoDistributionMode::Legacy => EncryptionSettings::new_with_strategy(settings, history_visibility, RoomKeySharingStrategy::new_legacy(false)),
-                }; 
+                    CryptoDistributionMode::InvisibleCrypto => {
+                        EncryptionSettings::new_with_strategy(
+                            settings,
+                            history_visibility,
+                            RoomKeySharingStrategy::new_modern(),
+                        )
+                    }
+                    CryptoDistributionMode::Legacy => EncryptionSettings::new_with_strategy(
+                        settings,
+                        history_visibility,
+                        RoomKeySharingStrategy::new_legacy(false),
+                    ),
+                };
 
                 // let settings = EncryptionSettings::new(settings, history_visibility, false);
 
-                Ok(o.share_room_key(room_id, members.iter().map(Deref::deref), crypto_settings).await?)
+                Ok(o.share_room_key(room_id, members.iter().map(Deref::deref), crypto_settings)
+                    .await?)
             }
             None => panic!("Olm machine wasn't started"),
         }

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -60,6 +60,10 @@ pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,
 };
 
+
+#[cfg(feature = "e2e-encryption")]
+pub use client::{ GlobalEncryptionSettings, CryptoDistributionMode };
+
 #[cfg(test)]
 matrix_sdk_test::init_tracing_for_tests!();
 

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -46,6 +46,8 @@ mod utils;
 uniffi::setup_scaffolding!();
 
 pub use client::BaseClient;
+#[cfg(feature = "e2e-encryption")]
+pub use client::{CryptoDistributionMode, GlobalEncryptionSettings};
 #[cfg(any(test, feature = "testing"))]
 pub use http;
 #[cfg(feature = "e2e-encryption")]
@@ -59,10 +61,6 @@ pub use store::{StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue
 pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,
 };
-
-
-#[cfg(feature = "e2e-encryption")]
-pub use client::{ GlobalEncryptionSettings, CryptoDistributionMode };
 
 #[cfg(test)]
 matrix_sdk_test::init_tracing_for_tests!();

--- a/crates/matrix-sdk-crypto/src/error.rs
+++ b/crates/matrix-sdk-crypto/src/error.rs
@@ -69,6 +69,21 @@ pub enum OlmError {
             have a valid Olm session with us"
     )]
     MissingSession,
+
+    /// When encrypting using the IdentityBased strategy.
+    /// Will be thrown when sharing room keys when there is a new identity for a
+    /// user that has not been confirmed by the user.
+    /// Application should display identity changes to the user as soon as
+    /// possible to avoid hitting this case. If it happens the app might
+    /// just retry automatically after the identity change has been
+    /// notified, or offer option to cancel.
+    #[error("Encryption failed because there is a new unknown identity for a user")]
+    UnconfirmedIdentityChange(Vec<OwnedUserId>),
+    /// The current device needs to be verified when encrypting using the
+    /// IdentityBased strategy. Apps should prevent sending in the UI to
+    /// avoid hitting this case.
+    #[error("Encryption failed: Verify your device to send encrypted messages")]
+    SendingFromUnverifiedDevice,
 }
 
 /// Error representing a failure during a group encryption operation.

--- a/crates/matrix-sdk-crypto/src/identities/device.rs
+++ b/crates/matrix-sdk-crypto/src/identities/device.rs
@@ -764,6 +764,24 @@ impl ReadOnlyDevice {
         )
     }
 
+    pub(crate) fn is_cross_signing_by_owner(
+        &self,
+        device_owner_identity: &ReadOnlyUserIdentities,
+    ) -> bool {
+        match device_owner_identity {
+            // If it's one of our own devices, just check that
+            // we signed the device.
+            ReadOnlyUserIdentities::Own(identity) => identity.is_device_signed(self).is_ok(),
+
+            // If it's a device from someone else, first check
+            // that our user has signed the other user and then
+            // check if the other user has signed this device.
+            ReadOnlyUserIdentities::Other(device_identity) => {
+                device_identity.is_device_signed(self).is_ok()
+            }
+        }
+    }
+
     /// Encrypt the given content for this device.
     ///
     /// # Arguments

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -542,7 +542,7 @@ impl IdentityManager {
             *changed_private_identity = self.check_private_identity(&identity).await;
             Ok(identity.into())
         } else {
-            let identity = ReadOnlyUserIdentity::new(master_key, self_signing)?;
+            let identity = ReadOnlyUserIdentity::new(master_key, self_signing, true)?;
             Ok(identity.into())
         }
     }
@@ -1892,5 +1892,93 @@ pub(crate) mod tests {
             .await
             .unwrap()
             .unwrap();
+    }
+
+    #[async_test]
+    async fn test_manager_identity_updates() {
+        use crate::testing_data::keys_query::IdentityChangeDataSet as DataSet;
+
+        let manager = manager_test_helper(user_id(), device_id()).await;
+        let other_user = DataSet::user_id();
+        let devices = manager.store.get_user_devices(other_user).await.unwrap();
+        assert_eq!(devices.devices().count(), 0);
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap();
+        assert!(identity.is_none());
+
+        manager
+            .receive_keys_query_response(
+                &TransactionId::new(),
+                &DataSet::key_query_with_identity_a(),
+            )
+            .await
+            .unwrap();
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
+        let other_identity = identity.other().unwrap();
+
+        // There should be now an identity and it should be tofu trusted as it is the
+        // first time we see an identity for that user
+        assert!(other_identity.is_tofu_trusted());
+        let first_device = manager
+            .store
+            .get_readonly_device(&other_user, DataSet::first_device_id())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(first_device.is_cross_signing_by_owner(&identity));
+
+        // We receive a new keys update for that user, with a new identity
+        manager
+            .receive_keys_query_response(
+                &TransactionId::new(),
+                &DataSet::key_query_with_identity_b(),
+            )
+            .await
+            .unwrap();
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
+        let other_identity = identity.other().unwrap();
+
+        // The previous tofu identity has been replaced, it is not tofu trusted until
+        // validated by the user
+        assert!(!other_identity.is_tofu_trusted());
+
+        let second_device = manager
+            .store
+            .get_readonly_device(&other_user, DataSet::second_device_id())
+            .await
+            .unwrap()
+            .unwrap();
+        // There is a new device signed by the new identity
+        assert!(second_device.is_cross_signing_by_owner(&identity));
+
+        // The first device should not be signed by the new identity
+        let first_device = manager
+            .store
+            .get_readonly_device(&other_user, DataSet::first_device_id())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!first_device.is_cross_signing_by_owner(&identity));
+
+        let remember_previous_identity = other_identity.clone();
+        // We receive a new keys update for that user, with no identity anymore
+        // Notice that there is no server API to delete identity, but we want to test
+        // here that a home server cannot clear the identity and serve a new one
+        // after that would get automatically tofu trusted.
+        manager
+            .receive_keys_query_response(
+                &TransactionId::new(),
+                &DataSet::key_query_with_identity_no_identity(),
+            )
+            .await
+            .unwrap();
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
+        let other_identity = identity.other().unwrap();
+
+        assert_eq!(other_identity, &remember_previous_identity);
+        assert!(!other_identity.is_tofu_trusted());
     }
 }

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -375,6 +375,24 @@ pub struct ReadOnlyUserIdentity {
     user_id: OwnedUserId,
     pub(crate) master_key: Arc<MasterPubkey>,
     self_signing_key: Arc<SelfSigningPubkey>,
+    /// The first time an identity is seen for a given user it will be marked as
+    /// tofu trusted. If a new identity is detected for that user, we must
+    /// ensure that this change has been shown and validated by the user. If
+    /// this boolean is set to `false`, sharing room keys to this user might
+    /// fail depending on the room key sharing strategy.
+    #[serde(
+        default = "tofu_validated_default",
+        serialize_with = "atomic_bool_serializer",
+        deserialize_with = "atomic_bool_deserializer"
+    )]
+    tofu_validated: Arc<AtomicBool>,
+}
+
+// The tofu_validated field introduced a new field in the database
+// schema, for backwards compatibility we assume that if the identity is
+// already in the database we considered it as tofu trusted.
+fn tofu_validated_default() -> Arc<AtomicBool> {
+    Arc::new(true.into())
 }
 
 impl PartialEq for ReadOnlyUserIdentity {
@@ -395,6 +413,7 @@ impl PartialEq for ReadOnlyUserIdentity {
             && self.master_key == other.master_key
             && self.self_signing_key == other.self_signing_key
             && self.master_key.signatures() == other.master_key.signatures()
+            && self.is_tofu_trusted() == other.is_tofu_trusted()
     }
 }
 
@@ -412,6 +431,7 @@ impl ReadOnlyUserIdentity {
     pub(crate) fn new(
         master_key: MasterPubkey,
         self_signing_key: SelfSigningPubkey,
+        tofu_validated: bool,
     ) -> Result<Self, SignatureError> {
         master_key.verify_subkey(&self_signing_key)?;
 
@@ -419,6 +439,7 @@ impl ReadOnlyUserIdentity {
             user_id: master_key.user_id().into(),
             master_key: master_key.into(),
             self_signing_key: self_signing_key.into(),
+            tofu_validated: AtomicBool::new(tofu_validated).into(),
         })
     }
 
@@ -429,7 +450,12 @@ impl ReadOnlyUserIdentity {
         let self_signing_key =
             identity.self_signing_key.lock().await.as_ref().unwrap().public_key().clone().into();
 
-        Self { user_id: identity.user_id().into(), master_key, self_signing_key }
+        Self {
+            user_id: identity.user_id().into(),
+            master_key,
+            self_signing_key,
+            tofu_validated: AtomicBool::new(true).into(),
+        }
     }
 
     /// Get the user id of this identity.
@@ -445,6 +471,21 @@ impl ReadOnlyUserIdentity {
     /// Get the public self-signing key of the identity.
     pub fn self_signing_key(&self) -> &SelfSigningPubkey {
         &self.self_signing_key
+    }
+
+    /// Check if our identity is verified.
+    pub fn is_tofu_trusted(&self) -> bool {
+        self.tofu_validated.load(Ordering::SeqCst)
+    }
+
+    /// Mark this identity as tofu trusted by the user
+    pub fn mark_as_tofu_trusted(&self) {
+        self.tofu_validated.store(true, Ordering::SeqCst)
+    }
+
+    #[cfg(test)]
+    pub fn mark_as_not_tofu_trusted(&self) {
+        self.tofu_validated.store(false, Ordering::SeqCst)
     }
 
     /// Update the identity with a new master key and self signing key.
@@ -465,7 +506,7 @@ impl ReadOnlyUserIdentity {
     ) -> Result<bool, SignatureError> {
         master_key.verify_subkey(&self_signing_key)?;
 
-        let new = Self::new(master_key, self_signing_key)?;
+        let new = Self::new(master_key, self_signing_key, false)?;
         let changed = new != *self;
 
         *self = new;
@@ -776,8 +817,12 @@ pub(crate) mod testing {
         let self_signing: CrossSigningKey =
             response.self_signing_keys.get(user_id).unwrap().deserialize_as().unwrap();
 
-        ReadOnlyUserIdentity::new(master_key.try_into().unwrap(), self_signing.try_into().unwrap())
-            .unwrap()
+        ReadOnlyUserIdentity::new(
+            master_key.try_into().unwrap(),
+            self_signing.try_into().unwrap(),
+            true,
+        )
+        .unwrap()
     }
 }
 

--- a/crates/matrix-sdk-crypto/src/lib.rs
+++ b/crates/matrix-sdk-crypto/src/lib.rs
@@ -34,6 +34,9 @@ mod utilities;
 mod verification;
 
 #[cfg(any(test, feature = "testing"))]
+mod testing_data;
+
+#[cfg(any(test, feature = "testing"))]
 /// Testing facilities and helpers for crypto tests
 pub mod testing {
     pub use crate::identities::{

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2263,7 +2263,8 @@ pub(crate) mod tests {
         error::{EventError, SetRoomSettingsError},
         machine::{EncryptionSyncChanges, OlmMachine},
         olm::{
-            BackedUpRoomKey, ExportedRoomKey, InboundGroupSession, OutboundGroupSession, VerifyJson,
+            BackedUpRoomKey, ExportedRoomKey, InboundGroupSession, OutboundGroupSession,
+            RoomKeySharingStrategy, VerifyJson,
         },
         store::{BackupDecryptionKey, Changes, CryptoStore, MemoryStore, RoomSettings},
         types::{
@@ -3083,8 +3084,10 @@ pub(crate) mod tests {
         let room_id = room_id!("!test:example.org");
 
         let encryption_settings = EncryptionSettings::default();
-        let encryption_settings =
-            EncryptionSettings { only_allow_trusted_devices: true, ..encryption_settings };
+        let encryption_settings = EncryptionSettings {
+            sharing_strategy: RoomKeySharingStrategy::new_legacy(true),
+            ..encryption_settings
+        };
 
         let to_device_requests = alice
             .share_room_key(room_id, iter::once(bob.user_id()), encryption_settings)

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -17,12 +17,15 @@ use serde::{Deserialize, Serialize};
 
 mod inbound;
 mod outbound;
+mod share_strategy;
 
 pub use inbound::{InboundGroupSession, PickledInboundGroupSession};
 pub(crate) use outbound::ShareState;
 pub use outbound::{
     EncryptionSettings, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo,
 };
+pub(crate) use share_strategy::CollectRecipientsResult;
+pub use share_strategy::{DeviceBasedStrategy, IdentityBasedStrategy, RoomKeySharingStrategy};
 use thiserror::Error;
 pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};
 use vodozemac::{megolm::SessionKeyDecodeError, Curve25519PublicKey};

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -42,10 +42,7 @@ pub use vodozemac::{
     PickleError,
 };
 
-use super::{
-    share_strategy::{DeviceBasedStrategy, RoomKeySharingStrategy},
-    SessionCreationError,
-};
+use super::{share_strategy::RoomKeySharingStrategy, SessionCreationError};
 #[cfg(feature = "experimental-algorithms")]
 use crate::types::events::room::encrypted::MegolmV2AesSha2Content;
 use crate::{
@@ -130,10 +127,9 @@ impl EncryptionSettings {
         }
     }
 
-
     /// Create new encryption settings using an `RoomEncryptionEventContent`,
-    /// a history visibility, and setting to define what devices should or should not
-    /// be allowed in the conversation.
+    /// a history visibility, and setting to define what devices should or
+    /// should not be allowed in the conversation.
     pub fn new_with_strategy(
         content: RoomEncryptionEventContent,
         history_visibility: HistoryVisibility,

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -110,6 +110,7 @@ impl EncryptionSettings {
     /// Create new encryption settings using an `RoomEncryptionEventContent`,
     /// a history visibility, and setting if only trusted devices should receive
     /// a room key.
+    #[deprecated = "Use new_with_strategy with RoomKeySharingStrategy instead"]
     pub fn new(
         content: RoomEncryptionEventContent,
         history_visibility: HistoryVisibility,
@@ -125,9 +126,30 @@ impl EncryptionSettings {
             rotation_period,
             rotation_period_msgs,
             history_visibility,
-            sharing_strategy: RoomKeySharingStrategy::Legacy(DeviceBasedStrategy {
-                only_allow_trusted_devices,
-            }),
+            sharing_strategy: RoomKeySharingStrategy::new_legacy(only_allow_trusted_devices),
+        }
+    }
+
+
+    /// Create new encryption settings using an `RoomEncryptionEventContent`,
+    /// a history visibility, and setting to define what devices should or should not
+    /// be allowed in the conversation.
+    pub fn new_with_strategy(
+        content: RoomEncryptionEventContent,
+        history_visibility: HistoryVisibility,
+        sharing_strategy: RoomKeySharingStrategy,
+    ) -> Self {
+        let rotation_period: Duration =
+            content.rotation_period_ms.map_or(ROTATION_PERIOD, |r| Duration::from_millis(r.into()));
+        let rotation_period_msgs: u64 =
+            content.rotation_period_msgs.map_or(ROTATION_MESSAGES, Into::into);
+
+        Self {
+            algorithm: EventEncryptionAlgorithm::from(content.algorithm.as_str()),
+            rotation_period,
+            rotation_period_msgs,
+            history_visibility,
+            sharing_strategy,
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -42,7 +42,10 @@ pub use vodozemac::{
     PickleError,
 };
 
-use super::SessionCreationError;
+use super::{
+    share_strategy::{DeviceBasedStrategy, RoomKeySharingStrategy},
+    SessionCreationError,
+};
 #[cfg(feature = "experimental-algorithms")]
 use crate::types::events::room::encrypted::MegolmV2AesSha2Content;
 use crate::{
@@ -85,10 +88,10 @@ pub struct EncryptionSettings {
     pub rotation_period_msgs: u64,
     /// The history visibility of the room when the session was created.
     pub history_visibility: HistoryVisibility,
-    /// Should untrusted devices receive the room key, or should they be
-    /// excluded from the conversation.
+    /// The strategy used to distribute the room keys to participant.
+    /// Default will send to all devices.
     #[serde(default)]
-    pub only_allow_trusted_devices: bool,
+    pub sharing_strategy: RoomKeySharingStrategy,
 }
 
 impl Default for EncryptionSettings {
@@ -98,7 +101,7 @@ impl Default for EncryptionSettings {
             rotation_period: ROTATION_PERIOD,
             rotation_period_msgs: ROTATION_MESSAGES,
             history_visibility: HistoryVisibility::Shared,
-            only_allow_trusted_devices: false,
+            sharing_strategy: RoomKeySharingStrategy::default(),
         }
     }
 }
@@ -122,7 +125,9 @@ impl EncryptionSettings {
             rotation_period,
             rotation_period_msgs,
             history_visibility,
-            only_allow_trusted_devices,
+            sharing_strategy: RoomKeySharingStrategy::Legacy(DeviceBasedStrategy {
+                only_allow_trusted_devices,
+            }),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/share_strategy.rs
@@ -324,394 +324,51 @@ mod tests {
 
     use std::sync::Arc;
 
-    use matrix_sdk_test::{async_test, response_from_file};
-    use ruma::{
-        api::{client::keys::get_keys, IncomingResponse},
-        device_id, room_id, user_id, DeviceId, TransactionId, UserId,
-    };
-    use serde_json::json;
+    use matrix_sdk_test::async_test;
+    use ruma::{room_id, TransactionId};
 
     use super::RoomKeySharingStrategy;
     use crate::{
-        olm::OutboundGroupSession, types::events::room_key_withheld::WithheldCode,
-        CrossSigningKeyExport, EncryptionSettings, OlmMachine,
+        olm::OutboundGroupSession,
+        testing_data::keys_query::KeyDistributionTestData as KeyDistributionDataSet,
+        types::events::room_key_withheld::WithheldCode, CrossSigningKeyExport, EncryptionSettings,
+        OlmMachine,
     };
 
-    /// ============================================================================
-    /// ============================================================================
-    ///
-    /// This set of keys/query response was generated using a local synapse.
-    /// Each users was created, device added according to needs and the payload
-    /// of the keys query have been copy/pasted here.
-    ///
-    /// The current user is `@me:localhost`, the private part of the
-    /// cross-signing keys have been exported using the console with the
-    /// following snippet:  `await mxMatrixClientPeg.get().getCrypto().
-    /// olmMachine.exportCrossSigningKeys()`.
-    ///
-    /// They are imported in the test here in order to verify user signatures.
-    ///
-    /// * `@me:localhost` is the current user mxId.
-    ///
-    /// * `@dan:localhost` is a user with cross-signing enabled, with 2 devices.
-    ///   One device (`JHPUERYQUW`) is self signed by @dan, but not the other
-    ///   one (`FRGNMZVOKA`). `@me` has verified `@dan`, can be seen because
-    ///   `@dan` master key has a signature by `@me` ssk
-    ///
-    /// * `@dave` is a user that has not enabled cross-signing. And has one
-    ///   device (`HVCXJTHMBM`).
-    ///
-    ///
-    /// * `@good` is a user with cross-signing enabled, with 2 devices. The 2
-    ///   devices are properly signed by `@good` (i.e were self-verified by
-    ///   @good)
-    /// ============================================================================
-    /// ============================================================================
-
-    /// Current user keys query response containing the cross-signing keys
-    fn me_keys_query_response() -> get_keys::v3::Response {
-        let data = json!({
-            "master_keys": {
-                "@me:localhost": {
-                    "keys": {
-                        "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4"
-                    },
-                    "signatures": {
-                        "@me:localhost": {
-                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "5G9+Ns28rzNd+2DvP73Y0orr8sxduRQcrJj0YB7ZygH7oeXshvGLeQn6mcNs7q7ZrMR5bYlXxopufKSWWoKpCg",
-                            "ed25519:YVKUSVBKWX": "ih1Kmj4dTB1AjjkwrLA2qIL3e/oPUFisP5Ic8kGp29wrpoHokasKKnkRl1zS7zq6iBcOL6aOZLPPX/ZHYCX5BQ"
-                        }
-                    },
-                    "usage": [
-                        "master"
-                    ],
-                    "user_id": "@me:localhost"
-                }
-            },
-            "self_signing_keys": {
-                "@me:localhost": {
-                    "keys": {
-                        "ed25519:9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw": "9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw"
-                    },
-                    "signatures": {
-                        "@me:localhost": {
-                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "amiKDLpWIwUQPzq+eov6KJsoskkWA1YzrGNb7HF3OcGV0nm4t7df0tUdZB/OpREtT5D78BKtzOPUipde2DxUAw"
-                        }
-                    },
-                    "usage": [
-                        "self_signing"
-                    ],
-                    "user_id": "@me:localhost"
-                }
-            },
-            "user_signing_keys": {
-                "@me:localhost": {
-                    "keys": {
-                        "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY"
-                    },
-                    "signatures": {
-                        "@me:localhost": {
-                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "Cv56vTHAzRkvdcELleOlhECZQP0pXcikCdEZrnXbkjXQ/k0ZvVOJ1beG/SiH8xc6zh1bCIMYv96C9p8o+7VZCQ"
-                        }
-                    },
-                    "usage": [
-                        "user_signing"
-                    ],
-                    "user_id": "@me:localhost"
-                }
-            }
-        });
-
-        let data = response_from_file(&data);
-
-        get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
-    }
-
-    /// Dan has cross-signing setup, one device is cross signed `JHPUERYQUW`,
-    /// but not the other one `FRGNMZVOKA`.
-    /// `@dan` identity is signed by `@me` identity (alice trust dan)
-    fn dan_keys_query_response() -> get_keys::v3::Response {
-        let data = json!({
-                "device_keys": {
-                    "@dan:localhost": {
-                        "JHPUERYQUW": {
-                            "algorithms": [
-                                "m.olm.v1.curve25519-aes-sha2",
-                                "m.megolm.v1.aes-sha2"
-                            ],
-                            "device_id": "JHPUERYQUW",
-                            "keys": {
-                                "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
-                                "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
-                            },
-                            "signatures": {
-                                "@dan:localhost": {
-                                    "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
-                                    "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
-                                }
-                            },
-                            "user_id": "@dan:localhost",
-                        },
-                        "FRGNMZVOKA": {
-                            "algorithms": [
-                                "m.olm.v1.curve25519-aes-sha2",
-                                "m.megolm.v1.aes-sha2"
-                            ],
-                            "device_id": "FRGNMZVOKA",
-                            "keys": {
-                                "curve25519:FRGNMZVOKA": "Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4",
-                                "ed25519:FRGNMZVOKA": "jVroR0JoRemjF0vJslY3HirJgwfX5gm5DCM64hZgkI0"
-                            },
-                            "signatures": {
-                                "@dan:localhost": {
-                                    "ed25519:FRGNMZVOKA": "+row23EcWR2D8EKgwzZmy3dWz/l5DHvEHR6jHKnBohphEIsBl0o3Cp9rIztFpStFGRPSAa3xEqfMVW2dIaKkCg"
-                                }
-                            },
-                            "user_id": "@dan:localhost",
-                        },
-                    }
-                },
-                "failures": {},
-                "master_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
-                                "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
-                            },
-                            "@me:localhost": {
-                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
-                            }
-                        },
-                        "usage": [
-                            "master"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                },
-                "self_signing_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
-                            }
-                        },
-                        "usage": [
-                            "self_signing"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                },
-                "user_signing_keys": {
-                    "@dan:localhost": {
-                        "keys": {
-                            "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
-                        },
-                        "signatures": {
-                            "@dan:localhost": {
-                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
-                            }
-                        },
-                        "usage": [
-                            "user_signing"
-                        ],
-                        "user_id": "@dan:localhost"
-                    }
-                }
-        });
-
-        let data = response_from_file(&data);
-
-        get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
-    }
-
-    /// Dave is a user that has not enabled cross-signing
-    fn dave_keys_query_response() -> get_keys::v3::Response {
-        let data = json!({
-            "device_keys": {
-                "@dave:localhost": {
-                    "HVCXJTHMBM": {
-                        "algorithms": [
-                            "m.olm.v1.curve25519-aes-sha2",
-                            "m.megolm.v1.aes-sha2"
-                        ],
-                        "device_id": "HVCXJTHMBM",
-                        "keys": {
-                            "curve25519:HVCXJTHMBM": "0GPOoQwhAGVu1lIvOZway3/XjdxVNHEi5z/4by8TzxU",
-                            "ed25519:HVCXJTHMBM": "/4ZzD1Ou70/Ojj5aaPqBopCN8SzQpKM7itiWZ/07fXc"
-                        },
-                        "signatures": {
-                            "@dave:localhost": {
-                                "ed25519:HVCXJTHMBM": "b1DV7xN2My2oXbZVVtTeJR9hzXIg1Cx4h+W51+tVq5GAoSYtrWR31PyKPROk28CvQ9Pu++/jdomaW7/oYPxoCg",
-                            }
-                        },
-                        "user_id": "@dave:localhost",
-                    }
-                }
-            }
-        });
-
-        let data = response_from_file(&data);
-
-        get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
-    }
-
-    /// Good is a user that has all his devices correctly cross-signed
-    fn good_keys_query_response() -> get_keys::v3::Response {
-        let data = json!({
-            "device_keys": {
-                "@good:localhost": {
-                    "JAXGBVZYLA": {
-                        "algorithms": [
-                            "m.olm.v1.curve25519-aes-sha2",
-                            "m.megolm.v1.aes-sha2"
-                        ],
-                        "device_id": "JAXGBVZYLA",
-                        "keys": {
-                            "curve25519:JAXGBVZYLA": "a4vWxnHUKvELfB7WYLCW07vEbwybZReyKReWHxQhgW0",
-                            "ed25519:JAXGBVZYLA": "m22nVxqJK72iph+FhOMqX/MDd7AoF9BJ033MlMLnDCg"
-                        },
-                        "signatures": {
-                            "@good:localhost": {
-                                "ed25519:JAXGBVZYLA": "EXKQiXNKjWSE76WxF8TUvxjCyw/qsV27gcbsgpSN1zzHzGzVdY1Qr4EB8t/76SL5rZP/9hqcAvqPSJW/N7iKCg",
-                                "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "sXJUXKE7hqXnsNbqlzS/1MGlGmeJU54v6/UMWAs+6bCzOFUC1+uqU1KlzfmpsVG3MKxR4r/ZLZdxoKVfUuQMAA"
-                            }
-                        },
-                        "user_id": "@good:localhost"
-                    },
-                    "ZGLCFWEPCY": {
-                        "algorithms": [
-                            "m.olm.v1.curve25519-aes-sha2",
-                            "m.megolm.v1.aes-sha2"
-                        ],
-                        "device_id": "ZGLCFWEPCY",
-                        "keys": {
-                            "curve25519:ZGLCFWEPCY": "kfcIEf6ZRgTP184yuIJYabfsBFsGXiVQE/cyW9qYnQA",
-                            "ed25519:ZGLCFWEPCY": "WLSA1tSe0eOZCeESH5WMb9cp3AgRZzm4ooSud+NwcEw"
-                        },
-                        "signatures": {
-                            "@good:localhost": {
-                                "ed25519:ZGLCFWEPCY": "AVXFgHk/QcAbOVBF5Xu4OW+03CZKBs2qAYh0fjIA49r+X+aX7QIKrbRyXU/ictPBLMpj1yXF+2J5vwR/KQYVCA",
-                                "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "VZk70FWiYN/YSwGykt2CygcOl1bq2D+dVSSKBL5GA5uHXxt6ypDlYvtWprM1l7re3llp5j105MevsjQ+2sWmCw"
-                            }
-                        },
-                        "user_id": "@good:localhost"
-                    }
-                }
-            },
-            "failures": {},
-            "master_keys": {
-                "@good:localhost": {
-                    "keys": {
-                        "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8"
-                    },
-                    "signatures": {
-                        "@good:localhost": {
-                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "imAhrTIlPuf6hNqlbcSUnC2ndZPk5NwQLzbi9kZ8nmnPGjmv39f4U4Vh/KiweqQnI4ActGpcYyM7k9S2Ef8/CQ",
-                            "ed25519:HPNYOQGUEE": "6w3egsvd+oVPCclef+hF1CfFMZrGTf/plFvPU5iP69WNw4w0UPAKSV1jOzh7Wv4LVGX5O3afjA9DG+O7aHZmBw"
-                        }
-                    },
-                    "usage": [
-                        "master"
-                    ],
-                    "user_id": "@good:localhost"
-                }
-            },
-            "self_signing_keys": {
-                "@good:localhost": {
-                    "keys": {
-                        "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U"
-                    },
-                    "signatures": {
-                        "@good:localhost": {
-                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "2AyR8lovFv8J1DwPwdCsAM9Tw877QhaVHmVkPopsmSokS2fst8LDQtsg/PiftVc+74NGz5tnYIMDxn4BjAisAg"
-                        }
-                    },
-                    "usage": [
-                        "self_signing"
-                    ],
-                    "user_id": "@good:localhost"
-                }
-            },
-            "user_signing_keys": {
-                "@good:localhost": {
-                    "keys": {
-                        "ed25519:u1PwO3/a/HTnN9IF7BVa2dJQ7bc00J22eNS0vM4FjTA": "u1PwO3/a/HTnN9IF7BVa2dJQ7bc00J22eNS0vM4FjTA"
-                    },
-                    "signatures": {
-                        "@good:localhost": {
-                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "88v9/Z3TJeY2lsu3cFQaEuhHH5ixjJs22ALQRKY+O6VPGCT/BAzH6kUb7teinFfpvQjoXN3t5fVJxbP9mVlxDg"
-                        }
-                    },
-                    "usage": [
-                        "user_signing"
-                    ],
-                    "user_id": "@good:localhost"
-                }
-            }
-        });
-
-        let data = response_from_file(&data);
-
-        get_keys::v3::Response::try_from_http_response(data)
-            .expect("Can't parse the `/keys/upload` response")
-    }
-
-    fn me_id() -> &'static UserId {
-        user_id!("@me:localhost")
-    }
-
-    fn me_device_id() -> &'static DeviceId {
-        device_id!("ABCDEFGH")
-    }
-
-    fn dan_id() -> &'static UserId {
-        user_id!("@dan:localhost")
-    }
-
-    fn dave_id() -> &'static UserId {
-        user_id!("@dave:localhost")
-    }
-
-    fn good_id() -> &'static UserId {
-        user_id!("@good:localhost")
-    }
-
     async fn set_up_test_machine() -> OlmMachine {
-        let machine = OlmMachine::new(me_id(), me_device_id()).await;
+        let machine = OlmMachine::new(
+            KeyDistributionDataSet::me_id(),
+            KeyDistributionDataSet::me_device_id(),
+        )
+        .await;
 
-        let keys_query = me_keys_query_response();
+        let keys_query = KeyDistributionDataSet::me_keys_query_response();
         let txn_id = TransactionId::new();
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
 
         machine
             .import_cross_signing_keys(CrossSigningKeyExport {
-                master_key: Some("9kquJqAtEUoTXljh5W2QSsCm4FH9WvWzIkDkIMUsM2k".to_owned()),
-                self_signing_key: Some("QifnGfudByh/GpBgJYEMzq7/DGbp6fZjp58faQj3n1M".to_owned()),
-                user_signing_key: Some("zQSosK46giUFs2ACsaf32bA7drcIXbmViyEt+TLfloI".to_owned()),
+                master_key: Some(KeyDistributionDataSet::MASTER_KEY_PRIVATE_EXPORT.to_owned()),
+                self_signing_key: Some(
+                    KeyDistributionDataSet::SELF_SIGNING_KEY_PRIVATE_EXPORT.to_owned(),
+                ),
+                user_signing_key: Some(
+                    KeyDistributionDataSet::USER_SIGNING_KEY_PRIVATE_EXPORT.to_owned(),
+                ),
             })
             .await
             .unwrap();
 
-        let keys_query = dan_keys_query_response();
+        let keys_query = KeyDistributionDataSet::dan_keys_query_response();
         let txn_id = TransactionId::new();
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
 
         let txn_id_dave = TransactionId::new();
-        let keys_query_dave = dave_keys_query_response();
+        let keys_query_dave = KeyDistributionDataSet::dave_keys_query_response();
         machine.mark_request_as_sent(&txn_id_dave, &keys_query_dave).await.unwrap();
 
         let txn_id_good = TransactionId::new();
-        let keys_query_good = good_keys_query_response();
+        let keys_query_good = KeyDistributionDataSet::good_keys_query_response();
         machine.mark_request_as_sent(&txn_id_good, &keys_query_good).await.unwrap();
 
         machine
@@ -744,7 +401,12 @@ mod tests {
             .collect_session_recipients(
                 &encryption_settings,
                 machine.store(),
-                vec![dan_id(), dave_id(), good_id()].into_iter(),
+                vec![
+                    KeyDistributionDataSet::dan_id(),
+                    KeyDistributionDataSet::dave_id(),
+                    KeyDistributionDataSet::good_id(),
+                ]
+                .into_iter(),
                 &group_session,
             )
             .await
@@ -752,9 +414,12 @@ mod tests {
 
         assert!(!share_result.should_rotate);
 
-        let dan_devices_shared = share_result.devices.get(dan_id()).unwrap();
-        let dave_devices_shared = share_result.devices.get(dave_id()).unwrap();
-        let good_devices_shared = share_result.devices.get(good_id()).unwrap();
+        let dan_devices_shared =
+            share_result.devices.get(KeyDistributionDataSet::dan_id()).unwrap();
+        let dave_devices_shared =
+            share_result.devices.get(KeyDistributionDataSet::dave_id()).unwrap();
+        let good_devices_shared =
+            share_result.devices.get(KeyDistributionDataSet::good_id()).unwrap();
 
         // With this strategy the room key would be distributed to all devices
         assert_eq!(dan_devices_shared.len(), 2);
@@ -787,7 +452,12 @@ mod tests {
             .collect_session_recipients(
                 &encryption_settings,
                 machine.store(),
-                vec![dan_id(), dave_id(), good_id()].into_iter(),
+                vec![
+                    KeyDistributionDataSet::dan_id(),
+                    KeyDistributionDataSet::dave_id(),
+                    KeyDistributionDataSet::good_id(),
+                ]
+                .into_iter(),
                 &group_session,
             )
             .await
@@ -795,8 +465,8 @@ mod tests {
 
         assert!(!share_result.should_rotate);
 
-        let dave_devices_shared = share_result.devices.get(dave_id());
-        let good_devices_shared = share_result.devices.get(good_id());
+        let dave_devices_shared = share_result.devices.get(KeyDistributionDataSet::dave_id());
+        let good_devices_shared = share_result.devices.get(KeyDistributionDataSet::good_id());
         tracing::debug!(?dave_devices_shared, "Dave share result is");
         // dave and good wouldn't receive any key
         assert!(dave_devices_shared.is_none());
@@ -804,7 +474,8 @@ mod tests {
 
         // dan is verified ny me and has one of his devices self signed, so should get
         // the key
-        let dan_devices_shared = share_result.devices.get(dan_id()).unwrap();
+        let dan_devices_shared =
+            share_result.devices.get(KeyDistributionDataSet::dan_id()).unwrap();
 
         assert_eq!(dan_devices_shared.len(), 1);
         let dan_device_that_will_get_the_key = &dan_devices_shared[0];
@@ -838,7 +509,12 @@ mod tests {
             .collect_session_recipients(
                 &encryption_settings,
                 machine.store(),
-                vec![dan_id(), dave_id(), good_id()].into_iter(),
+                vec![
+                    KeyDistributionDataSet::dan_id(),
+                    KeyDistributionDataSet::dave_id(),
+                    KeyDistributionDataSet::good_id(),
+                ]
+                .into_iter(),
                 &group_session,
             )
             .await
@@ -846,7 +522,8 @@ mod tests {
 
         assert!(!share_result.should_rotate);
 
-        let dan_devices_shared = share_result.devices.get(dan_id()).unwrap();
+        let dan_devices_shared =
+            share_result.devices.get(KeyDistributionDataSet::dan_id()).unwrap();
 
         // With this strategy the key would be only distributed to 1 of dan devices, the
         // only one that is signed by dan.
@@ -864,7 +541,7 @@ mod tests {
 
         // With this strategy the key would not be distributed to any dave devices as he
         // has not setup cross-signing
-        let dave_devices_shared = share_result.devices.get(dave_id());
+        let dave_devices_shared = share_result.devices.get(KeyDistributionDataSet::dave_id());
         assert!(dave_devices_shared.is_none());
         // The other device should reveive a withheld code
         let (_, code) = share_result
@@ -876,7 +553,8 @@ mod tests {
         assert_eq!(code.as_str(), WithheldCode::Unauthorised.as_str());
 
         // Good has all his devices signed correctly, so they should all get the key
-        let good_devices_shared = share_result.devices.get(good_id()).unwrap();
+        let good_devices_shared =
+            share_result.devices.get(KeyDistributionDataSet::good_id()).unwrap();
         assert_eq!(good_devices_shared.len(), 2);
     }
 
@@ -908,7 +586,7 @@ mod tests {
             .collect_session_recipients(
                 &encryption_settings,
                 machine.store(),
-                vec![good_id()].into_iter(),
+                vec![KeyDistributionDataSet::good_id()].into_iter(),
                 &group_session,
             )
             .await
@@ -924,7 +602,7 @@ mod tests {
             .collect_session_recipients(
                 &encryption_settings,
                 machine.store(),
-                vec![good_id()].into_iter(),
+                vec![KeyDistributionDataSet::good_id()].into_iter(),
                 &group_session,
             )
             .await

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/share_strategy.rs
@@ -1,0 +1,937 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+};
+
+use itertools::{Either, Itertools};
+use ruma::{DeviceId, OwnedDeviceId, OwnedUserId, UserId};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, trace};
+
+use super::OutboundGroupSession;
+use crate::{
+    error::OlmResult, store::Store, types::events::room_key_withheld::WithheldCode,
+    EncryptionSettings, ReadOnlyDevice,
+};
+
+/// Returned by `collect_session_recipients`.
+///
+/// Information indicating whether the session needs to be rotated
+/// (`should_rotate`) and the list of users/devices that should receive
+/// (`devices`) or not the session,  including withheld reason
+/// `withheld_devices`.
+#[derive(Debug)]
+pub(crate) struct CollectRecipientsResult {
+    /// If true the outbound group session should be rotated
+    pub should_rotate: bool,
+    /// The map of user|device that should receive the session
+    pub devices: BTreeMap<OwnedUserId, Vec<ReadOnlyDevice>>,
+    /// The map of user|device that won't receive the key with the withheld
+    /// code.
+    pub withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)>,
+}
+
+struct KeySharingResult {
+    /// The map of user|device that should have access to current room key
+    pub allowed_devices: BTreeMap<OwnedUserId, Vec<ReadOnlyDevice>>,
+    /// The map of user|device that won't receive the room key with the withheld
+    /// code.
+    pub withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)>,
+}
+
+trait RoomKeyShareStrategy {
+    async fn collect_session_recipients(
+        &self,
+        store: &Store,
+        users: BTreeSet<&UserId>,
+    ) -> OlmResult<KeySharingResult>;
+}
+
+/// Defines the sharing strategy for the room key. That is what devices are
+/// included in the conversation, and what are not.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum RoomKeySharingStrategy {
+    /** Simple strategy, send to all devices or only to trusted devices */
+    Legacy(DeviceBasedStrategy),
+    /** Cross-Signing TOFU strategy. Will only distribute keys to devices
+     * that are cross-signed by their owner */
+    Modern(IdentityBasedStrategy),
+}
+
+impl Default for RoomKeySharingStrategy {
+    fn default() -> Self {
+        RoomKeySharingStrategy::Legacy(DeviceBasedStrategy { only_allow_trusted_devices: false })
+    }
+}
+
+/// Device based sharing strategy.
+/// With this strategy every device will be considered for sharing, looking at
+/// their individual trust level.
+/// By default all devices will receive the key unless
+/// `only_allow_trusted_devices` is set to true. Individual devices can be
+/// blacklisted.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DeviceBasedStrategy {
+    /// If `true`, devices that are not trusted will be excluded from the
+    /// conversation. A device is trusted if any of the following is true:
+    ///     - It was manually marked as trusted.
+    ///     - It was marked as verified via interactive verification.
+    ///     - It is signed by it's owner identity, and this identity has been
+    ///       trusted via interactive verification.
+    ///     - It is the current own device of the user.
+    pub only_allow_trusted_devices: bool,
+}
+
+/// Idenity based sharing strategy.
+/// In this mode only user identities are considered, and all devices that are
+/// signed by their owner identity will receive the keys.
+/// Users with no identity (cross-signing not enabled) will not receive any key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct IdentityBasedStrategy {
+    // pub throw_on_unknown_identy: bool,
+}
+
+impl RoomKeySharingStrategy {
+    /// Creates a new legacy strategy, based on per device trust.
+    pub const fn new_legacy(only_allow_trusted_devices: bool) -> Self {
+        return Self::Legacy(DeviceBasedStrategy { only_allow_trusted_devices });
+    }
+
+    /// Creates a new modern strategy, based on per identity trust.
+    pub const fn new_modern() -> Self {
+        return Self::Modern(IdentityBasedStrategy {});
+    }
+
+    pub(crate) async fn collect_session_recipients(
+        &self,
+        settings: &EncryptionSettings,
+        store: &Store,
+        users: impl Iterator<Item = &UserId>,
+        outbound: &OutboundGroupSession,
+    ) -> OlmResult<CollectRecipientsResult> {
+        let users: BTreeSet<&UserId> = users.collect();
+
+        let users_shared_with: BTreeSet<OwnedUserId> =
+            outbound.shared_with_set.read().unwrap().keys().cloned().collect();
+
+        let users_shared_with: BTreeSet<&UserId> =
+            users_shared_with.iter().map(Deref::deref).collect();
+
+        // A user left if a user is missing from the set of users that should
+        // get the session but is in the set of users that received the session.
+        let user_left = !users_shared_with.difference(&users).collect::<BTreeSet<_>>().is_empty();
+
+        let visibility_changed =
+            outbound.settings().history_visibility != settings.history_visibility;
+        let algorithm_changed = outbound.settings().algorithm != settings.algorithm;
+
+        let sharing_strategy_changed =
+            outbound.settings().sharing_strategy != settings.sharing_strategy;
+
+        let mut should_rotate =
+            user_left || visibility_changed || algorithm_changed || sharing_strategy_changed;
+
+        if should_rotate {
+            debug!(
+                should_rotate,
+                user_left,
+                visibility_changed,
+                algorithm_changed,
+                "Rotating room key to protect room history",
+            );
+        }
+
+        let sharing_result = match self {
+            RoomKeySharingStrategy::Legacy(legacy) => {
+                legacy.collect_session_recipients(store, users).await?
+            }
+            RoomKeySharingStrategy::Modern(modern) => {
+                modern.collect_session_recipients(store, users).await?
+            }
+        };
+
+        // If we haven't already concluded that the session should be
+        // rotated for other reasons, we also need to check whether any
+        // of the devices in the session got deleted or blacklisted in the
+        // meantime. If so, we should also rotate the session.
+        if !should_rotate {
+            for (user_id, devices) in &sharing_result.allowed_devices {
+                // Device IDs that should receive this session
+                let recipient_device_ids: BTreeSet<&DeviceId> =
+                    devices.iter().map(|d| d.device_id()).collect();
+
+                if let Some(shared) = outbound.shared_with_set.read().unwrap().get(user_id) {
+                    // Devices that received this session
+                    let shared: BTreeSet<OwnedDeviceId> = shared.keys().cloned().collect();
+                    let shared: BTreeSet<&DeviceId> = shared.iter().map(|d| d.as_ref()).collect();
+
+                    // The set difference between
+                    //
+                    // 1. Devices that had previously received the session, and
+                    // 2. Devices that would now receive the session
+                    //
+                    // Represents newly deleted, unauthorised or blacklisted devices. If this
+                    // set is non-empty, we must rotate.
+                    let newly_excluded =
+                        shared.difference(&recipient_device_ids).collect::<BTreeSet<_>>();
+
+                    should_rotate = !newly_excluded.is_empty();
+                    if should_rotate {
+                        // We have concluded that it should rotate, no need to continue checking
+                        // other users
+                        debug!(
+                                "Rotating a room key due to at least these devices being deleted/blacklisted {:?}",
+                                newly_excluded,
+                            );
+                        break;
+                    }
+                };
+            }
+        }
+
+        trace!(should_rotate, "Done calculating group session recipients");
+
+        Ok(CollectRecipientsResult {
+            should_rotate,
+            devices: sharing_result.allowed_devices,
+            withheld_devices: sharing_result.withheld_devices,
+        })
+    }
+}
+
+impl RoomKeyShareStrategy for DeviceBasedStrategy {
+    async fn collect_session_recipients(
+        &self,
+        store: &Store,
+        users: BTreeSet<&UserId>,
+    ) -> OlmResult<KeySharingResult> {
+        let mut allowed_devices: BTreeMap<OwnedUserId, Vec<ReadOnlyDevice>> = Default::default();
+        let mut withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)> = Default::default();
+
+        trace!(?users, ?self, "Calculating group session recipients");
+
+        let own_identity =
+            store.get_user_identity(store.user_id()).await?.and_then(|i| i.into_own());
+
+        for user_id in users {
+            let user_devices = store.get_readonly_devices_filtered(user_id).await?;
+
+            // We only need the user identity if settings.only_allow_trusted_devices is set.
+            let device_owner_identity = if self.only_allow_trusted_devices {
+                store.get_user_identity(user_id).await?
+            } else {
+                None
+            };
+
+            // From all the devices a user has, we're splitting them into two
+            // buckets, a bucket of devices that should receive the
+            // room key and a bucket of devices that should receive
+            // a withheld code.
+            let (recipients, withheld_recipients): (
+                Vec<ReadOnlyDevice>,
+                Vec<(ReadOnlyDevice, WithheldCode)>,
+            ) = user_devices.into_values().partition_map(|d| {
+                if d.is_blacklisted() {
+                    Either::Right((d, WithheldCode::Blacklisted))
+                } else if self.only_allow_trusted_devices
+                    && !d.is_verified(&own_identity, &device_owner_identity)
+                {
+                    Either::Right((d, WithheldCode::Unverified))
+                } else {
+                    Either::Left(d)
+                }
+            });
+
+            if recipients.len() > 0 {
+                allowed_devices.entry(user_id.to_owned()).or_default().extend(recipients);
+            }
+            withheld_devices.extend(withheld_recipients);
+        }
+
+        Ok(KeySharingResult { allowed_devices, withheld_devices })
+    }
+}
+
+impl RoomKeyShareStrategy for IdentityBasedStrategy {
+    async fn collect_session_recipients(
+        &self,
+        store: &Store,
+        users: BTreeSet<&UserId>,
+    ) -> OlmResult<KeySharingResult> {
+        let mut allowed_devices: BTreeMap<OwnedUserId, Vec<ReadOnlyDevice>> = Default::default();
+        let mut withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)> = Default::default();
+
+        trace!(?users, ?self, "Calculating group session recipients");
+
+        for user_id in users {
+            let user_devices = store.get_readonly_devices_filtered(user_id).await?;
+
+            // Get device owner identity
+            let device_owner_identity = store.get_user_identity(user_id).await?;
+
+            match device_owner_identity {
+                None => {
+                    // withheld all the users devices, we need to have an identity for TOFU
+                    // distribution
+                    withheld_devices.extend(
+                        user_devices.into_values().map(|d| (d, WithheldCode::Unauthorised)),
+                    );
+                }
+                Some(device_owner_identity) => {
+                    // From all the devices a user has, we're splitting them into two
+                    // buckets, a bucket of devices that should receive the
+                    // room key and a bucket of devices that should receive
+                    // a withheld code.
+                    let (recipients, withheld_recipients): (
+                        Vec<ReadOnlyDevice>,
+                        Vec<(ReadOnlyDevice, WithheldCode)>,
+                    ) = user_devices.into_values().partition_map(|d| {
+                        if d.is_cross_signing_by_owner(&device_owner_identity) {
+                            Either::Left(d)
+                        } else {
+                            Either::Right((d, WithheldCode::Unauthorised))
+                        }
+                    });
+
+                    if recipients.len() > 0 {
+                        allowed_devices.entry(user_id.to_owned()).or_default().extend(recipients);
+                    }
+                    withheld_devices.extend(withheld_recipients);
+                }
+            }
+        }
+
+        Ok(KeySharingResult { allowed_devices, withheld_devices })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::sync::Arc;
+
+    use matrix_sdk_test::{async_test, response_from_file};
+    use ruma::{
+        api::{client::keys::get_keys, IncomingResponse},
+        device_id, room_id, user_id, DeviceId, TransactionId, UserId,
+    };
+    use serde_json::json;
+
+    use super::RoomKeySharingStrategy;
+    use crate::{
+        olm::OutboundGroupSession, types::events::room_key_withheld::WithheldCode,
+        CrossSigningKeyExport, EncryptionSettings, OlmMachine,
+    };
+
+    /// ============================================================================
+    /// ============================================================================
+    ///
+    /// This set of keys/query response was generated using a local synapse.
+    /// Each users was created, device added according to needs and the payload
+    /// of the keys query have been copy/pasted here.
+    ///
+    /// The current user is `@me:localhost`, the private part of the
+    /// cross-signing keys have been exported using the console with the
+    /// following snippet:  `await mxMatrixClientPeg.get().getCrypto().
+    /// olmMachine.exportCrossSigningKeys()`.
+    ///
+    /// They are imported in the test here in order to verify user signatures.
+    ///
+    /// * `@me:localhost` is the current user mxId.
+    ///
+    /// * `@dan:localhost` is a user with cross-signing enabled, with 2 devices.
+    ///   One device (`JHPUERYQUW`) is self signed by @dan, but not the other
+    ///   one (`FRGNMZVOKA`). `@me` has verified `@dan`, can be seen because
+    ///   `@dan` master key has a signature by `@me` ssk
+    ///
+    /// * `@dave` is a user that has not enabled cross-signing. And has one
+    ///   device (`HVCXJTHMBM`).
+    ///
+    ///
+    /// * `@good` is a user with cross-signing enabled, with 2 devices. The 2
+    ///   devices are properly signed by `@good` (i.e were self-verified by
+    ///   @good)
+    /// ============================================================================
+    /// ============================================================================
+
+    /// Current user keys query response containing the cross-signing keys
+    fn me_keys_query_response() -> get_keys::v3::Response {
+        let data = json!({
+            "master_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "5G9+Ns28rzNd+2DvP73Y0orr8sxduRQcrJj0YB7ZygH7oeXshvGLeQn6mcNs7q7ZrMR5bYlXxopufKSWWoKpCg",
+                            "ed25519:YVKUSVBKWX": "ih1Kmj4dTB1AjjkwrLA2qIL3e/oPUFisP5Ic8kGp29wrpoHokasKKnkRl1zS7zq6iBcOL6aOZLPPX/ZHYCX5BQ"
+                        }
+                    },
+                    "usage": [
+                        "master"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            },
+            "self_signing_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw": "9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "amiKDLpWIwUQPzq+eov6KJsoskkWA1YzrGNb7HF3OcGV0nm4t7df0tUdZB/OpREtT5D78BKtzOPUipde2DxUAw"
+                        }
+                    },
+                    "usage": [
+                        "self_signing"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            },
+            "user_signing_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "Cv56vTHAzRkvdcELleOlhECZQP0pXcikCdEZrnXbkjXQ/k0ZvVOJ1beG/SiH8xc6zh1bCIMYv96C9p8o+7VZCQ"
+                        }
+                    },
+                    "usage": [
+                        "user_signing"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        get_keys::v3::Response::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Dan has cross-signing setup, one device is cross signed `JHPUERYQUW`,
+    /// but not the other one `FRGNMZVOKA`.
+    /// `@dan` identity is signed by `@me` identity (alice trust dan)
+    fn dan_keys_query_response() -> get_keys::v3::Response {
+        let data = json!({
+                "device_keys": {
+                    "@dan:localhost": {
+                        "JHPUERYQUW": {
+                            "algorithms": [
+                                "m.olm.v1.curve25519-aes-sha2",
+                                "m.megolm.v1.aes-sha2"
+                            ],
+                            "device_id": "JHPUERYQUW",
+                            "keys": {
+                                "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
+                                "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+                            },
+                            "signatures": {
+                                "@dan:localhost": {
+                                    "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
+                                    "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
+                                }
+                            },
+                            "user_id": "@dan:localhost",
+                        },
+                        "FRGNMZVOKA": {
+                            "algorithms": [
+                                "m.olm.v1.curve25519-aes-sha2",
+                                "m.megolm.v1.aes-sha2"
+                            ],
+                            "device_id": "FRGNMZVOKA",
+                            "keys": {
+                                "curve25519:FRGNMZVOKA": "Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4",
+                                "ed25519:FRGNMZVOKA": "jVroR0JoRemjF0vJslY3HirJgwfX5gm5DCM64hZgkI0"
+                            },
+                            "signatures": {
+                                "@dan:localhost": {
+                                    "ed25519:FRGNMZVOKA": "+row23EcWR2D8EKgwzZmy3dWz/l5DHvEHR6jHKnBohphEIsBl0o3Cp9rIztFpStFGRPSAa3xEqfMVW2dIaKkCg"
+                                }
+                            },
+                            "user_id": "@dan:localhost",
+                        },
+                    }
+                },
+                "failures": {},
+                "master_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
+                                "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+                            },
+                            "@me:localhost": {
+                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+                            }
+                        },
+                        "usage": [
+                            "master"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                },
+                "self_signing_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+                            }
+                        },
+                        "usage": [
+                            "self_signing"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                },
+                "user_signing_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+                            }
+                        },
+                        "usage": [
+                            "user_signing"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                }
+        });
+
+        let data = response_from_file(&data);
+
+        get_keys::v3::Response::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Dave is a user that has not enabled cross-signing
+    fn dave_keys_query_response() -> get_keys::v3::Response {
+        let data = json!({
+            "device_keys": {
+                "@dave:localhost": {
+                    "HVCXJTHMBM": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "HVCXJTHMBM",
+                        "keys": {
+                            "curve25519:HVCXJTHMBM": "0GPOoQwhAGVu1lIvOZway3/XjdxVNHEi5z/4by8TzxU",
+                            "ed25519:HVCXJTHMBM": "/4ZzD1Ou70/Ojj5aaPqBopCN8SzQpKM7itiWZ/07fXc"
+                        },
+                        "signatures": {
+                            "@dave:localhost": {
+                                "ed25519:HVCXJTHMBM": "b1DV7xN2My2oXbZVVtTeJR9hzXIg1Cx4h+W51+tVq5GAoSYtrWR31PyKPROk28CvQ9Pu++/jdomaW7/oYPxoCg",
+                            }
+                        },
+                        "user_id": "@dave:localhost",
+                    }
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        get_keys::v3::Response::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Good is a user that has all his devices correctly cross-signed
+    fn good_keys_query_response() -> get_keys::v3::Response {
+        let data = json!({
+            "device_keys": {
+                "@good:localhost": {
+                    "JAXGBVZYLA": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "JAXGBVZYLA",
+                        "keys": {
+                            "curve25519:JAXGBVZYLA": "a4vWxnHUKvELfB7WYLCW07vEbwybZReyKReWHxQhgW0",
+                            "ed25519:JAXGBVZYLA": "m22nVxqJK72iph+FhOMqX/MDd7AoF9BJ033MlMLnDCg"
+                        },
+                        "signatures": {
+                            "@good:localhost": {
+                                "ed25519:JAXGBVZYLA": "EXKQiXNKjWSE76WxF8TUvxjCyw/qsV27gcbsgpSN1zzHzGzVdY1Qr4EB8t/76SL5rZP/9hqcAvqPSJW/N7iKCg",
+                                "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "sXJUXKE7hqXnsNbqlzS/1MGlGmeJU54v6/UMWAs+6bCzOFUC1+uqU1KlzfmpsVG3MKxR4r/ZLZdxoKVfUuQMAA"
+                            }
+                        },
+                        "user_id": "@good:localhost"
+                    },
+                    "ZGLCFWEPCY": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "ZGLCFWEPCY",
+                        "keys": {
+                            "curve25519:ZGLCFWEPCY": "kfcIEf6ZRgTP184yuIJYabfsBFsGXiVQE/cyW9qYnQA",
+                            "ed25519:ZGLCFWEPCY": "WLSA1tSe0eOZCeESH5WMb9cp3AgRZzm4ooSud+NwcEw"
+                        },
+                        "signatures": {
+                            "@good:localhost": {
+                                "ed25519:ZGLCFWEPCY": "AVXFgHk/QcAbOVBF5Xu4OW+03CZKBs2qAYh0fjIA49r+X+aX7QIKrbRyXU/ictPBLMpj1yXF+2J5vwR/KQYVCA",
+                                "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "VZk70FWiYN/YSwGykt2CygcOl1bq2D+dVSSKBL5GA5uHXxt6ypDlYvtWprM1l7re3llp5j105MevsjQ+2sWmCw"
+                            }
+                        },
+                        "user_id": "@good:localhost"
+                    }
+                }
+            },
+            "failures": {},
+            "master_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "imAhrTIlPuf6hNqlbcSUnC2ndZPk5NwQLzbi9kZ8nmnPGjmv39f4U4Vh/KiweqQnI4ActGpcYyM7k9S2Ef8/CQ",
+                            "ed25519:HPNYOQGUEE": "6w3egsvd+oVPCclef+hF1CfFMZrGTf/plFvPU5iP69WNw4w0UPAKSV1jOzh7Wv4LVGX5O3afjA9DG+O7aHZmBw"
+                        }
+                    },
+                    "usage": [
+                        "master"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            },
+            "self_signing_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "2AyR8lovFv8J1DwPwdCsAM9Tw877QhaVHmVkPopsmSokS2fst8LDQtsg/PiftVc+74NGz5tnYIMDxn4BjAisAg"
+                        }
+                    },
+                    "usage": [
+                        "self_signing"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            },
+            "user_signing_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:u1PwO3/a/HTnN9IF7BVa2dJQ7bc00J22eNS0vM4FjTA": "u1PwO3/a/HTnN9IF7BVa2dJQ7bc00J22eNS0vM4FjTA"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "88v9/Z3TJeY2lsu3cFQaEuhHH5ixjJs22ALQRKY+O6VPGCT/BAzH6kUb7teinFfpvQjoXN3t5fVJxbP9mVlxDg"
+                        }
+                    },
+                    "usage": [
+                        "user_signing"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        get_keys::v3::Response::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    fn me_id() -> &'static UserId {
+        user_id!("@me:localhost")
+    }
+
+    fn me_device_id() -> &'static DeviceId {
+        device_id!("ABCDEFGH")
+    }
+
+    fn dan_id() -> &'static UserId {
+        user_id!("@dan:localhost")
+    }
+
+    fn dave_id() -> &'static UserId {
+        user_id!("@dave:localhost")
+    }
+
+    fn good_id() -> &'static UserId {
+        user_id!("@good:localhost")
+    }
+
+    async fn set_up_test_machine() -> OlmMachine {
+        let machine = OlmMachine::new(me_id(), me_device_id()).await;
+
+        let keys_query = me_keys_query_response();
+        let txn_id = TransactionId::new();
+        machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
+
+        machine
+            .import_cross_signing_keys(CrossSigningKeyExport {
+                master_key: Some("9kquJqAtEUoTXljh5W2QSsCm4FH9WvWzIkDkIMUsM2k".to_owned()),
+                self_signing_key: Some("QifnGfudByh/GpBgJYEMzq7/DGbp6fZjp58faQj3n1M".to_owned()),
+                user_signing_key: Some("zQSosK46giUFs2ACsaf32bA7drcIXbmViyEt+TLfloI".to_owned()),
+            })
+            .await
+            .unwrap();
+
+        let keys_query = dan_keys_query_response();
+        let txn_id = TransactionId::new();
+        machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
+
+        let txn_id_dave = TransactionId::new();
+        let keys_query_dave = dave_keys_query_response();
+        machine.mark_request_as_sent(&txn_id_dave, &keys_query_dave).await.unwrap();
+
+        let txn_id_good = TransactionId::new();
+        let keys_query_good = good_keys_query_response();
+        machine.mark_request_as_sent(&txn_id_good, &keys_query_good).await.unwrap();
+
+        machine
+    }
+
+    /// Perform a key share for the same set of users but with different
+    /// strategy.
+    #[async_test]
+    async fn test_share_with_per_device_strategy_to_all() {
+        let machine = set_up_test_machine().await;
+
+        let legacy_strategy = RoomKeySharingStrategy::new_legacy(false);
+
+        let encryption_settings =
+            EncryptionSettings { sharing_strategy: legacy_strategy, ..Default::default() };
+
+        let fake_room_id = room_id!("!roomid:localhost");
+
+        let id_keys = machine.identity_keys();
+        let group_session = OutboundGroupSession::new(
+            machine.device_id().into(),
+            Arc::new(id_keys),
+            fake_room_id,
+            encryption_settings.clone(),
+        )
+        .unwrap();
+
+        let share_result = encryption_settings
+            .sharing_strategy
+            .collect_session_recipients(
+                &encryption_settings,
+                machine.store(),
+                vec![dan_id(), dave_id(), good_id()].into_iter(),
+                &group_session,
+            )
+            .await
+            .unwrap();
+
+        assert!(!share_result.should_rotate);
+
+        let dan_devices_shared = share_result.devices.get(dan_id()).unwrap();
+        let dave_devices_shared = share_result.devices.get(dave_id()).unwrap();
+        let good_devices_shared = share_result.devices.get(good_id()).unwrap();
+
+        // With this strategy the room key would be distributed to all devices
+        assert_eq!(dan_devices_shared.len(), 2);
+        assert_eq!(dave_devices_shared.len(), 1);
+        assert_eq!(good_devices_shared.len(), 2);
+    }
+
+    #[async_test]
+    async fn test_share_with_per_device_strategy_only_trusted() {
+        let machine = set_up_test_machine().await;
+
+        let fake_room_id = room_id!("!roomid:localhost");
+
+        let legacy_strategy = RoomKeySharingStrategy::new_legacy(true);
+
+        let encryption_settings =
+            EncryptionSettings { sharing_strategy: legacy_strategy, ..Default::default() };
+
+        let id_keys = machine.identity_keys();
+        let group_session = OutboundGroupSession::new(
+            machine.device_id().into(),
+            Arc::new(id_keys),
+            fake_room_id,
+            encryption_settings.clone(),
+        )
+        .unwrap();
+
+        let share_result = encryption_settings
+            .sharing_strategy
+            .collect_session_recipients(
+                &encryption_settings,
+                machine.store(),
+                vec![dan_id(), dave_id(), good_id()].into_iter(),
+                &group_session,
+            )
+            .await
+            .unwrap();
+
+        assert!(!share_result.should_rotate);
+
+        let dave_devices_shared = share_result.devices.get(dave_id());
+        let good_devices_shared = share_result.devices.get(good_id());
+        tracing::debug!(?dave_devices_shared, "Dave share result is");
+        // dave and good wouldn't receive any key
+        assert!(dave_devices_shared.is_none());
+        assert!(good_devices_shared.is_none());
+
+        // dan is verified ny me and has one of his devices self signed, so should get
+        // the key
+        let dan_devices_shared = share_result.devices.get(dan_id()).unwrap();
+
+        assert_eq!(dan_devices_shared.len(), 1);
+        let dan_device_that_will_get_the_key = &dan_devices_shared[0];
+        assert_eq!(dan_device_that_will_get_the_key.device_id().as_str(), "JHPUERYQUW");
+    }
+
+    /// Perform a key share for the same set of users but with different
+    /// strategy.
+    #[async_test]
+    async fn test_share_with_per_identity_strategy() {
+        let machine = set_up_test_machine().await;
+
+        let modern_strategy = RoomKeySharingStrategy::new_modern();
+
+        let encryption_settings =
+            EncryptionSettings { sharing_strategy: modern_strategy, ..Default::default() };
+
+        let fake_room_id = room_id!("!roomid:localhost");
+
+        let id_keys = machine.identity_keys();
+        let group_session = OutboundGroupSession::new(
+            machine.device_id().into(),
+            Arc::new(id_keys),
+            fake_room_id,
+            encryption_settings.clone(),
+        )
+        .unwrap();
+
+        let share_result = encryption_settings
+            .sharing_strategy
+            .collect_session_recipients(
+                &encryption_settings,
+                machine.store(),
+                vec![dan_id(), dave_id(), good_id()].into_iter(),
+                &group_session,
+            )
+            .await
+            .unwrap();
+
+        assert!(!share_result.should_rotate);
+
+        let dan_devices_shared = share_result.devices.get(dan_id()).unwrap();
+
+        // With this strategy the key would be only distributed to 1 of dan devices, the
+        // only one that is signed by dan.
+        assert_eq!(dan_devices_shared.len(), 1);
+        let dan_device_that_will_get_the_key = &dan_devices_shared[0];
+        assert_eq!(dan_device_that_will_get_the_key.device_id().as_str(), "JHPUERYQUW");
+        // The other device should reveive a withheld code
+        let (_, code) = share_result
+            .withheld_devices
+            .iter()
+            .filter(|(d, _)| d.device_id().as_str() == "FRGNMZVOKA")
+            .nth(0)
+            .expect("This dan's device should receive a withheld codee");
+        assert_eq!(code.as_str(), WithheldCode::Unauthorised.as_str());
+
+        // With this strategy the key would not be distributed to any dave devices as he
+        // has not setup cross-signing
+        let dave_devices_shared = share_result.devices.get(dave_id());
+        assert!(dave_devices_shared.is_none());
+        // The other device should reveive a withheld code
+        let (_, code) = share_result
+            .withheld_devices
+            .iter()
+            .filter(|(d, _)| d.device_id().as_str() == "HVCXJTHMBM")
+            .nth(0)
+            .expect("This dan's device should receive a withheld codee");
+        assert_eq!(code.as_str(), WithheldCode::Unauthorised.as_str());
+
+        // Good has all his devices signed correctly, so they should all get the key
+        let good_devices_shared = share_result.devices.get(good_id()).unwrap();
+        assert_eq!(good_devices_shared.len(), 2);
+    }
+
+    /// In that test we try to share to `@good:localhost.com`. For this user the
+    /// 2 strategies will share to the same set of devices, nonetheless test
+    /// that changing the strategy forces a session rotation.
+    #[async_test]
+    async fn test_rotate_key_when_sharing_strategy_changes() {
+        let machine = set_up_test_machine().await;
+
+        let legacy_strategy = RoomKeySharingStrategy::new_legacy(false);
+
+        let encryption_settings =
+            EncryptionSettings { sharing_strategy: legacy_strategy, ..Default::default() };
+
+        let fake_room_id = room_id!("!roomid:localhost");
+
+        let id_keys = machine.identity_keys();
+        let group_session = OutboundGroupSession::new(
+            machine.device_id().into(),
+            Arc::new(id_keys),
+            fake_room_id,
+            encryption_settings.clone(),
+        )
+        .unwrap();
+
+        let _ = encryption_settings
+            .sharing_strategy
+            .collect_session_recipients(
+                &encryption_settings,
+                machine.store(),
+                vec![good_id()].into_iter(),
+                &group_session,
+            )
+            .await
+            .unwrap();
+
+        // now share with another strategy
+        let identity_strategy = RoomKeySharingStrategy::new_modern();
+        let encryption_settings =
+            EncryptionSettings { sharing_strategy: identity_strategy, ..Default::default() };
+
+        let result = encryption_settings
+            .sharing_strategy
+            .collect_session_recipients(
+                &encryption_settings,
+                machine.store(),
+                vec![good_id()].into_iter(),
+                &group_session,
+            )
+            .await
+            .unwrap();
+
+        // In that case no devices have left follwing the strategy change, yet as we
+        // have changed the strategy it should rotate
+        assert!(result.should_rotate)
+    }
+}

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -25,12 +25,13 @@ mod utility;
 
 pub use account::{Account, OlmMessageHash, PickledAccount, StaticAccountData};
 pub(crate) use account::{OlmDecryptionInfo, SessionType};
-pub(crate) use group_sessions::ShareState;
 pub use group_sessions::{
-    BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession,
-    OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession,
-    SessionCreationError, SessionExportError, SessionKey, ShareInfo,
+    BackedUpRoomKey, DeviceBasedStrategy, EncryptionSettings, ExportedRoomKey,
+    IdentityBasedStrategy, InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,
+    PickledOutboundGroupSession, RoomKeySharingStrategy, SessionCreationError, SessionExportError,
+    SessionKey, ShareInfo,
 };
+pub(crate) use group_sessions::{CollectRecipientsResult, ShareState};
 pub use session::{PickledSession, Session};
 pub use signing::{CrossSigningStatus, PickledCrossSigningIdentity, PrivateCrossSigningIdentity};
 pub(crate) use utility::{SignedJsonObject, VerifyJson};

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -15,26 +15,27 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
-    ops::Deref,
     sync::{Arc, RwLock as StdRwLock},
 };
 
 use futures_util::future::join_all;
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     events::{AnyMessageLikeEventContent, ToDeviceEventType},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
-    DeviceId, OwnedDeviceId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId,
-    UserId,
+    OwnedDeviceId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use tracing::{debug, error, info, instrument, trace};
 
 use crate::{
     error::{EventError, MegolmResult, OlmResult},
     identities::device::MaybeEncryptedRoomKey,
-    olm::{InboundGroupSession, OutboundGroupSession, Session, ShareInfo, ShareState},
+    olm::{
+        CollectRecipientsResult, InboundGroupSession, OutboundGroupSession, Session, ShareInfo,
+        ShareState,
+    },
     store::{Changes, CryptoStoreWrapper, Result as StoreResult, Store},
     types::events::{room::encrypted::RoomEncryptedEventContent, room_key_withheld::WithheldCode},
     EncryptionSettings, OlmError, ReadOnlyDevice, ToDeviceRequest,
@@ -114,23 +115,6 @@ impl GroupSessionCache {
     fn mark_as_being_shared(&self, id: OwnedTransactionId, session: OutboundGroupSession) {
         self.sessions_being_shared.write().unwrap().insert(id, session);
     }
-}
-
-/// Returned by `collect_session_recipients`.
-///
-/// Information indicating whether the session needs to be rotated
-/// (`should_rotate`) and the list of users/devices that should receive
-/// (`devices`) or not the session,  including withheld reason
-/// `withheld_devices`.
-#[derive(Debug)]
-pub(crate) struct CollectRecipientsResult {
-    /// If true the outbound group session should be rotated
-    pub should_rotate: bool,
-    /// The map of user|device that should receive the session
-    pub devices: BTreeMap<OwnedUserId, Vec<ReadOnlyDevice>>,
-    /// The map of user|device that won't receive the key with the withheld
-    /// code.
-    pub withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)>,
 }
 
 #[derive(Debug, Clone)]
@@ -350,118 +334,10 @@ impl GroupSessionManager {
         settings: &EncryptionSettings,
         outbound: &OutboundGroupSession,
     ) -> OlmResult<CollectRecipientsResult> {
-        let users: BTreeSet<&UserId> = users.collect();
-        let mut devices: BTreeMap<OwnedUserId, Vec<ReadOnlyDevice>> = Default::default();
-        let mut withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)> = Default::default();
-
-        trace!(?users, ?settings, "Calculating group session recipients");
-
-        let users_shared_with: BTreeSet<OwnedUserId> =
-            outbound.shared_with_set.read().unwrap().keys().cloned().collect();
-
-        let users_shared_with: BTreeSet<&UserId> =
-            users_shared_with.iter().map(Deref::deref).collect();
-
-        // A user left if a user is missing from the set of users that should
-        // get the session but is in the set of users that received the session.
-        let user_left = !users_shared_with.difference(&users).collect::<BTreeSet<_>>().is_empty();
-
-        let visibility_changed =
-            outbound.settings().history_visibility != settings.history_visibility;
-        let algorithm_changed = outbound.settings().algorithm != settings.algorithm;
-
-        // To protect the room history we need to rotate the session if either:
-        //
-        // 1. Any user left the room.
-        // 2. Any of the users' devices got deleted or blacklisted.
-        // 3. The history visibility changed.
-        // 4. The encryption algorithm changed.
-        //
-        // This is calculated in the following code and stored in this variable.
-        let mut should_rotate = user_left || visibility_changed || algorithm_changed;
-
-        let own_identity =
-            self.store.get_user_identity(self.store.user_id()).await?.and_then(|i| i.into_own());
-
-        for user_id in users {
-            let user_devices = self.store.get_readonly_devices_filtered(user_id).await?;
-
-            // We only need the user identity if settings.only_allow_trusted_devices is set.
-            let device_owner_identity = if settings.only_allow_trusted_devices {
-                self.store.get_user_identity(user_id).await?
-            } else {
-                None
-            };
-
-            // From all the devices a user has, we're splitting them into two
-            // buckets, a bucket of devices that should receive the
-            // room key and a bucket of devices that should receive
-            // a withheld code.
-            let (recipients, withheld_recipients): (
-                Vec<ReadOnlyDevice>,
-                Vec<(ReadOnlyDevice, WithheldCode)>,
-            ) = user_devices.into_values().partition_map(|d| {
-                if d.is_blacklisted() {
-                    Either::Right((d, WithheldCode::Blacklisted))
-                } else if settings.only_allow_trusted_devices
-                    && !d.is_verified(&own_identity, &device_owner_identity)
-                {
-                    Either::Right((d, WithheldCode::Unverified))
-                } else {
-                    Either::Left(d)
-                }
-            });
-
-            // If we haven't already concluded that the session should be
-            // rotated for other reasons, we also need to check whether any
-            // of the devices in the session got deleted or blacklisted in the
-            // meantime. If so, we should also rotate the session.
-            if !should_rotate {
-                // Device IDs that should receive this session
-                let recipient_device_ids: BTreeSet<&DeviceId> =
-                    recipients.iter().map(|d| d.device_id()).collect();
-
-                if let Some(shared) = outbound.shared_with_set.read().unwrap().get(user_id) {
-                    // Devices that received this session
-                    let shared: BTreeSet<OwnedDeviceId> = shared.keys().cloned().collect();
-                    let shared: BTreeSet<&DeviceId> = shared.iter().map(|d| d.as_ref()).collect();
-
-                    // The set difference between
-                    //
-                    // 1. Devices that had previously received the session, and
-                    // 2. Devices that would now receive the session
-                    //
-                    // Represents newly deleted or blacklisted devices. If this
-                    // set is non-empty, we must rotate.
-                    let newly_deleted_or_blacklisted =
-                        shared.difference(&recipient_device_ids).collect::<BTreeSet<_>>();
-
-                    should_rotate = !newly_deleted_or_blacklisted.is_empty();
-                    if should_rotate {
-                        debug!(
-                            "Rotating a room key due to these devices being deleted/blacklisted {:?}",
-                            newly_deleted_or_blacklisted,
-                        );
-                    }
-                };
-            }
-
-            devices.entry(user_id.to_owned()).or_default().extend(recipients);
-            withheld_devices.extend(withheld_recipients);
-        }
-
-        if should_rotate {
-            debug!(
-                should_rotate,
-                user_left,
-                visibility_changed,
-                algorithm_changed,
-                "Rotating room key to protect room history",
-            );
-        }
-        trace!(should_rotate, "Done calculating group session recipients");
-
-        Ok(CollectRecipientsResult { should_rotate, devices, withheld_devices })
+        settings
+            .sharing_strategy
+            .collect_session_recipients(settings, &self.store, users, outbound)
+            .await
     }
 
     async fn encrypt_request(
@@ -871,10 +747,12 @@ mod tests {
     use serde_json::{json, Value};
 
     use crate::{
+        olm::RoomKeySharingStrategy,
         session_manager::group_sessions::CollectRecipientsResult,
         types::{
             events::room_key_withheld::{
-                RoomKeyWithheldContent, RoomKeyWithheldContent::MegolmV1AesSha2, WithheldCode,
+                RoomKeyWithheldContent::{self, MegolmV1AesSha2},
+                WithheldCode,
             },
             EventEncryptionAlgorithm,
         },
@@ -1237,8 +1115,10 @@ mod tests {
             .iter()
             .any(|d| d.user_id() == user_id && d.device_id() == device_id));
 
-        let settings =
-            EncryptionSettings { only_allow_trusted_devices: true, ..Default::default() };
+        let settings = EncryptionSettings {
+            sharing_strategy: RoomKeySharingStrategy::new_legacy(true),
+            ..Default::default()
+        };
         let users = [user_id].into_iter();
 
         let CollectRecipientsResult { devices: recipients, .. } = machine
@@ -1295,8 +1175,10 @@ mod tests {
         let keys_claim = keys_claim_response();
 
         let users = keys_claim.one_time_keys.keys().map(Deref::deref);
-        let settings =
-            EncryptionSettings { only_allow_trusted_devices: true, ..Default::default() };
+        let settings = EncryptionSettings {
+            sharing_strategy: RoomKeySharingStrategy::new_legacy(true),
+            ..Default::default()
+        };
 
         // Trust only one
         let user_id = user_id!("@example:localhost");

--- a/crates/matrix-sdk-crypto/src/testing_data/keys_query.rs
+++ b/crates/matrix-sdk-crypto/src/testing_data/keys_query.rs
@@ -1,0 +1,217 @@
+use ruma::{
+    api::{client::keys::get_keys::v3::Response as KeyQueryResponse, IncomingResponse},
+    device_id, user_id, DeviceId, UserId,
+};
+use serde_json::{json, Value};
+
+use crate::machine::testing::response_from_file;
+
+pub(crate) struct IdentityChangeDataSet {}
+
+#[allow(dead_code)]
+impl IdentityChangeDataSet {
+    pub fn user_id() -> &'static UserId {
+        user_id!("@bob:localhost")
+    }
+
+    pub fn first_device_id() -> &'static DeviceId {
+        device_id!("GYKSNAWLVK")
+    }
+
+    pub fn second_device_id() -> &'static DeviceId {
+        device_id!("ATWKQFSFRN")
+    }
+
+    pub fn third_device_id() -> &'static DeviceId {
+        device_id!("OPABMDDXGX")
+    }
+
+    fn device_keys_payload_1_signed_by_a() -> Value {
+        json!({
+            "algorithms": [
+                "m.olm.v1.curve25519-aes-sha2",
+                "m.megolm.v1.aes-sha2"
+            ],
+            "device_id": "GYKSNAWLVK",
+            "keys": {
+                "curve25519:GYKSNAWLVK": "dBcZBzQaiQYWf6rBPh2QypIOB/dxSoTeyaFaxNNbeHs",
+                "ed25519:GYKSNAWLVK": "6melQNnhoI9sT2b4VzNPAwa8aB179ym45fON8Yo7kVk"
+            },
+            "signatures": {
+                "@bob:localhost": {
+                    "ed25519:GYKSNAWLVK": "Fk45zHAbrd+1j9wZXLjL2Y/+DU/Mnz9yuvlfYBOOT7qExN2Jdud+5BAuNs8nZ/caS4wTF39Kg3zQpzaGERoCBg",
+                    "ed25519:dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw": "md0Pa1MYlneFb1fp6KCsvZpi2ySb6/G+ULoCbQDWBeDxNEcoNMzf7PEKY04UToCZKUU4LifvRWmiWFDanOlkCQ"
+                }
+            },
+            "user_id": "@bob:localhost",
+        })
+    }
+
+    fn msk_a() -> Value {
+        json!({
+            "@bob:localhost": {
+                "keys": {
+                    "ed25519:/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY": "/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY"
+                },
+                "signatures": {
+                    "@bob:localhost": {
+                        "ed25519:/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY": "6vGDbPO5XzlcwbU3aV+kcck+iHHEBtX85ow2gW5U05/DZdtda/JNVa5Nn7B9lQHNnnrMqt1sX00y/JrIkSS1Aw",
+                        "ed25519:GYKSNAWLVK": "jLxmUPr0Ny2Ai9+NGKGhed9BAuKikOc7r6gr7MQVawePYS95w8NJ8Tzaq9zFFOmIiojACNdQ/ksy3QAdwD6vBQ"
+                    }
+                },
+                "usage": [
+                    "master"
+                ],
+                "user_id": "@bob:localhost"
+            }
+        })
+    }
+    fn ssk_a() -> Value {
+        json!({
+            "@bob:localhost": {
+                "keys": {
+                    "ed25519:dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw": "dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw"
+                },
+                "signatures": {
+                    "@bob:localhost": {
+                        "ed25519:/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY": "7md6mwjUK8zjintmffJ0+kImC59/Y8PdySy99EZz5Neu+VMX3LT7txhKO2gC/hmDduRw+JGfGXIiDxR7GmQqDw"
+                    }
+                },
+                "usage": [
+                    "self_signing"
+                ],
+                "user_id": "@bob:localhost"
+            }
+        })
+    }
+    /// A key query with an identity (Ia), and a first device `GYKSNAWLVK`
+    /// signed by Ia.
+    pub fn key_query_with_identity_a() -> KeyQueryResponse {
+        let data = response_from_file(&json!({
+            "device_keys": {
+                "@bob:localhost": {
+                    "GYKSNAWLVK": Self::device_keys_payload_1_signed_by_a()
+                }
+            },
+            "failures": {},
+            "master_keys": Self::msk_a(),
+            "self_signing_keys": Self::ssk_a(),
+            "user_signing_keys": {}
+        }));
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    fn msk_b() -> Value {
+        json!({
+            "@bob:localhost": {
+                "keys": {
+                    "ed25519:NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4": "NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4"
+                },
+                "signatures": {
+                    "@bob:localhost": {
+                        "ed25519:ATWKQFSFRN": "MBOzCKYPQLQMpBY2lFZJ4c8451xJfQCdhPBb1AHlTUSxKFiWi6V+k1oRRnhQein/PjkIY7ZO+HoOrIeOtbRMAw",
+                        "ed25519:NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4": "xqLhC3sIUci1W2CNVW7HZWXreQApgjv2RDwB0WPiMd1P4vbZ/qJM0KWqK2piGPWliPi8YVREMrg216KXM3IhCA"
+                    }
+                },
+                "usage": [
+                    "master"
+                ],
+                "user_id": "@bob:localhost"
+            }
+        })
+    }
+
+    fn ssk_b() -> Value {
+        json!({
+            "@bob:localhost": {
+                "keys": {
+                    "ed25519:At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc": "At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc"
+                },
+                "signatures": {
+                    "@bob:localhost": {
+                        "ed25519:NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4": "Ls6CeoA4LoPCHuSwG96kbhd1dEV09TgdMROIZi6vFz/MT9Wtik6joQi/tQ3zCwIZCSR53ksLO4jG1DD31AiBAA"
+                    }
+                },
+                "usage": [
+                    "self_signing"
+                ],
+                "user_id": "@bob:localhost"
+            }
+        })
+    }
+
+    fn device_keys_payload_2_signed_by_b() -> Value {
+        json!({
+            "algorithms": [
+                "m.olm.v1.curve25519-aes-sha2",
+                "m.megolm.v1.aes-sha2"
+            ],
+            "device_id": "ATWKQFSFRN",
+            "keys": {
+                "curve25519:ATWKQFSFRN": "CY0TWVK1/Kj3ZADuBcGe3UKvpT+IKAPMUsMeJhSDqno",
+                "ed25519:ATWKQFSFRN": "TyTQqd6j2JlWZh97r+kTYuCbvqnPoNwO6EGovYsjY00"
+            },
+            "signatures": {
+                "@bob:localhost": {
+                    "ed25519:ATWKQFSFRN": "BQ9Gp0p+6srF+c8OyruqKKd9R4yaub3THYAyyBB/7X/rG8BwcAqFynzl1aGyFYun4Q+087a5OSiglCXI+/kQAA",
+                    "ed25519:At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc": "TWmDPaG7t0rZ6luauonELD3dmBDTIRryqXhgsIQRiGint2rJdic8RVyZ6a61bgu6mtBjfvU3prqMNp6sVi16Cg"
+                }
+            },
+            "user_id": "@bob:localhost",
+        })
+    }
+    /// A key query with a new identity (Ib) and a new device `ATWKQFSFRN`.
+    /// `ATWKQFSFRN` is signed with the new identity but
+    pub fn key_query_with_identity_b() -> KeyQueryResponse {
+        let data = response_from_file(&json!({
+            "device_keys": {
+                "@bob:localhost": {
+                    "ATWKQFSFRN": Self::device_keys_payload_2_signed_by_b(),
+                    "GYKSNAWLVK": Self::device_keys_payload_1_signed_by_a(),
+                }
+            },
+            "failures": {},
+            "master_keys": Self::msk_b(),
+            "self_signing_keys": Self::ssk_b(),
+        }));
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// A key query with a new identity (Ib) and a new device `ATWKQFSFRN`.
+    /// `ATWKQFSFRN` is signed with the new identity but
+    pub fn key_query_with_identity_no_identity() -> KeyQueryResponse {
+        let data = response_from_file(&json!({
+            "device_keys": {
+                "@bob:localhost": {
+                    "ATWKQFSFRN": Self::device_keys_payload_2_signed_by_b(),
+                    "GYKSNAWLVK": Self::device_keys_payload_1_signed_by_a(),
+                    "OPABMDDXGX": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "OPABMDDXGX",
+                        "keys": {
+                            "curve25519:OPABMDDXGX": "O6bwa9Op0E+PQPCrbTOfdYwU+j95RRPhXIHuNpe94ns",
+                            "ed25519:OPABMDDXGX": "DvjkSNOM9XrR1gWrr2YSDvTnwnLIgKDMRr5v8HgMKak"
+                        },
+                        "signatures": {
+                            "@bob:localhost": {
+                                "ed25519:OPABMDDXGX": "o+BBnw/SIJWxSf799Adq6jEl9X3lwCg5MJkS8GlfId+pW3ReEETK0l+9bhCAgBsNSKRtB/fmZQBhjMx4FJr+BA"
+                            }
+                        },
+                        "user_id": "@bob:localhost",
+                        "unsigned": {
+                            "device_display_name": "develop.element.io: Chrome on macOS"
+                        }
+                    }
+                }
+            },
+            "failures": {},
+        }));
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+}

--- a/crates/matrix-sdk-crypto/src/testing_data/keys_query.rs
+++ b/crates/matrix-sdk-crypto/src/testing_data/keys_query.rs
@@ -256,9 +256,37 @@ impl KeyDistributionTestData {
     pub const USER_SIGNING_KEY_PRIVATE_EXPORT: &'static str =
         "zQSosK46giUFs2ACsaf32bA7drcIXbmViyEt+TLfloI";
 
+    /// A device for @me, notice that it is not the current device of the olm
+    /// machine (we don't need it for this test)
+    fn me_device() -> Value {
+        json!({
+            "algorithms": [
+                "m.olm.v1.curve25519-aes-sha2",
+                "m.megolm.v1.aes-sha2"
+            ],
+            "device_id": "MGZZKAKBCG",
+            "keys": {
+                "curve25519:MGZZKAKBCG": "ThkvfM4Ay97QWjw8gigYVUKr9xMLJj1vKZp+3uXKHRY",
+                "ed25519:MGZZKAKBCG": "z5MXB64O+LCKfbywMSJkoaWQi8HaNn1E/DxU+mrKh7Q"
+            },
+            "signatures": {
+                "@me:localhost": {
+                    "ed25519:MGZZKAKBCG": "dXXLn/PECKFioCMsWKueQ5rcGcfqjPcOVljZX9U0y15vZpwRgMRGJcv9KCgjc1in7sNYu61Ec+qfCXeAEs0BAg",
+                    "ed25519:9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw": "kyFZD4p9EcFvT0f+UUOq0sBrDY7rfuhREODSTTylSEaBnsVwRxH7lqi1xpNkCrN9ZDlbqoIYz3436k0cILABAg"
+                }
+            },
+            "user_id": "@me:localhost",
+        })
+    }
+
     /// Current user keys query response containing the cross-signing keys
     pub fn me_keys_query_response() -> KeyQueryResponse {
         let data = json!({
+            "device_keys": {
+                "@me:localhost": {
+                    "MGZZKAKBCG": Self::me_device()
+                }
+            },
             "master_keys": {
                 "@me:localhost": {
                     "keys": {

--- a/crates/matrix-sdk-crypto/src/testing_data/keys_query.rs
+++ b/crates/matrix-sdk-crypto/src/testing_data/keys_query.rs
@@ -215,3 +215,362 @@ impl IdentityChangeDataSet {
             .expect("Can't parse the `/keys/upload` response")
     }
 }
+
+/// ============================================================================
+/// ============================================================================
+///
+/// This set of keys/query response was generated using a local synapse.
+/// Each users was created, device added according to needs and the payload
+/// of the keys query have been copy/pasted here.
+///
+/// The current user is `@me:localhost`, the private part of the
+/// cross-signing keys have been exported using the console with the
+/// following snippet:  `await mxMatrixClientPeg.get().getCrypto().
+/// olmMachine.exportCrossSigningKeys()`.
+///
+/// They are imported in the test here in order to verify user signatures.
+///
+/// * `@me:localhost` is the current user mxId.
+///
+/// * `@dan:localhost` is a user with cross-signing enabled, with 2 devices. One
+///   device (`JHPUERYQUW`) is self signed by @dan, but not the other one
+///   (`FRGNMZVOKA`). `@me` has verified `@dan`, can be seen because `@dan`
+///   master key has a signature by `@me` ssk
+///
+/// * `@dave` is a user that has not enabled cross-signing. And has one device
+///   (`HVCXJTHMBM`).
+///
+///
+/// * `@good` is a user with cross-signing enabled, with 2 devices. The 2
+///   devices are properly signed by `@good` (i.e were self-verified by @good)
+/// ============================================================================
+/// ============================================================================
+pub(crate) struct KeyDistributionTestData {}
+
+#[allow(dead_code)]
+impl KeyDistributionTestData {
+    pub const MASTER_KEY_PRIVATE_EXPORT: &'static str =
+        "9kquJqAtEUoTXljh5W2QSsCm4FH9WvWzIkDkIMUsM2k";
+    pub const SELF_SIGNING_KEY_PRIVATE_EXPORT: &'static str =
+        "QifnGfudByh/GpBgJYEMzq7/DGbp6fZjp58faQj3n1M";
+    pub const USER_SIGNING_KEY_PRIVATE_EXPORT: &'static str =
+        "zQSosK46giUFs2ACsaf32bA7drcIXbmViyEt+TLfloI";
+
+    /// Current user keys query response containing the cross-signing keys
+    pub fn me_keys_query_response() -> KeyQueryResponse {
+        let data = json!({
+            "master_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "5G9+Ns28rzNd+2DvP73Y0orr8sxduRQcrJj0YB7ZygH7oeXshvGLeQn6mcNs7q7ZrMR5bYlXxopufKSWWoKpCg",
+                            "ed25519:YVKUSVBKWX": "ih1Kmj4dTB1AjjkwrLA2qIL3e/oPUFisP5Ic8kGp29wrpoHokasKKnkRl1zS7zq6iBcOL6aOZLPPX/ZHYCX5BQ"
+                        }
+                    },
+                    "usage": [
+                        "master"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            },
+            "self_signing_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw": "9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "amiKDLpWIwUQPzq+eov6KJsoskkWA1YzrGNb7HF3OcGV0nm4t7df0tUdZB/OpREtT5D78BKtzOPUipde2DxUAw"
+                        }
+                    },
+                    "usage": [
+                        "self_signing"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            },
+            "user_signing_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "Cv56vTHAzRkvdcELleOlhECZQP0pXcikCdEZrnXbkjXQ/k0ZvVOJ1beG/SiH8xc6zh1bCIMYv96C9p8o+7VZCQ"
+                        }
+                    },
+                    "usage": [
+                        "user_signing"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Dan has cross-signing setup, one device is cross signed `JHPUERYQUW`,
+    /// but not the other one `FRGNMZVOKA`.
+    /// `@dan` identity is signed by `@me` identity (alice trust dan)
+    pub fn dan_keys_query_response() -> KeyQueryResponse {
+        let data = json!({
+                "device_keys": {
+                    "@dan:localhost": {
+                        "JHPUERYQUW": {
+                            "algorithms": [
+                                "m.olm.v1.curve25519-aes-sha2",
+                                "m.megolm.v1.aes-sha2"
+                            ],
+                            "device_id": "JHPUERYQUW",
+                            "keys": {
+                                "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
+                                "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+                            },
+                            "signatures": {
+                                "@dan:localhost": {
+                                    "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
+                                    "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
+                                }
+                            },
+                            "user_id": "@dan:localhost",
+                        },
+                        "FRGNMZVOKA": {
+                            "algorithms": [
+                                "m.olm.v1.curve25519-aes-sha2",
+                                "m.megolm.v1.aes-sha2"
+                            ],
+                            "device_id": "FRGNMZVOKA",
+                            "keys": {
+                                "curve25519:FRGNMZVOKA": "Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4",
+                                "ed25519:FRGNMZVOKA": "jVroR0JoRemjF0vJslY3HirJgwfX5gm5DCM64hZgkI0"
+                            },
+                            "signatures": {
+                                "@dan:localhost": {
+                                    "ed25519:FRGNMZVOKA": "+row23EcWR2D8EKgwzZmy3dWz/l5DHvEHR6jHKnBohphEIsBl0o3Cp9rIztFpStFGRPSAa3xEqfMVW2dIaKkCg"
+                                }
+                            },
+                            "user_id": "@dan:localhost",
+                        },
+                    }
+                },
+                "failures": {},
+                "master_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
+                                "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+                            },
+                            "@me:localhost": {
+                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+                            }
+                        },
+                        "usage": [
+                            "master"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                },
+                "self_signing_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+                            }
+                        },
+                        "usage": [
+                            "self_signing"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                },
+                "user_signing_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+                            }
+                        },
+                        "usage": [
+                            "user_signing"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Dave is a user that has not enabled cross-signing
+    pub fn dave_keys_query_response() -> KeyQueryResponse {
+        let data = json!({
+            "device_keys": {
+                "@dave:localhost": {
+                    "HVCXJTHMBM": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "HVCXJTHMBM",
+                        "keys": {
+                            "curve25519:HVCXJTHMBM": "0GPOoQwhAGVu1lIvOZway3/XjdxVNHEi5z/4by8TzxU",
+                            "ed25519:HVCXJTHMBM": "/4ZzD1Ou70/Ojj5aaPqBopCN8SzQpKM7itiWZ/07fXc"
+                        },
+                        "signatures": {
+                            "@dave:localhost": {
+                                "ed25519:HVCXJTHMBM": "b1DV7xN2My2oXbZVVtTeJR9hzXIg1Cx4h+W51+tVq5GAoSYtrWR31PyKPROk28CvQ9Pu++/jdomaW7/oYPxoCg",
+                            }
+                        },
+                        "user_id": "@dave:localhost",
+                    }
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Good is a user that has all his devices correctly cross-signed
+    pub fn good_keys_query_response() -> KeyQueryResponse {
+        let data = json!({
+            "device_keys": {
+                "@good:localhost": {
+                    "JAXGBVZYLA": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "JAXGBVZYLA",
+                        "keys": {
+                            "curve25519:JAXGBVZYLA": "a4vWxnHUKvELfB7WYLCW07vEbwybZReyKReWHxQhgW0",
+                            "ed25519:JAXGBVZYLA": "m22nVxqJK72iph+FhOMqX/MDd7AoF9BJ033MlMLnDCg"
+                        },
+                        "signatures": {
+                            "@good:localhost": {
+                                "ed25519:JAXGBVZYLA": "EXKQiXNKjWSE76WxF8TUvxjCyw/qsV27gcbsgpSN1zzHzGzVdY1Qr4EB8t/76SL5rZP/9hqcAvqPSJW/N7iKCg",
+                                "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "sXJUXKE7hqXnsNbqlzS/1MGlGmeJU54v6/UMWAs+6bCzOFUC1+uqU1KlzfmpsVG3MKxR4r/ZLZdxoKVfUuQMAA"
+                            }
+                        },
+                        "user_id": "@good:localhost"
+                    },
+                    "ZGLCFWEPCY": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "ZGLCFWEPCY",
+                        "keys": {
+                            "curve25519:ZGLCFWEPCY": "kfcIEf6ZRgTP184yuIJYabfsBFsGXiVQE/cyW9qYnQA",
+                            "ed25519:ZGLCFWEPCY": "WLSA1tSe0eOZCeESH5WMb9cp3AgRZzm4ooSud+NwcEw"
+                        },
+                        "signatures": {
+                            "@good:localhost": {
+                                "ed25519:ZGLCFWEPCY": "AVXFgHk/QcAbOVBF5Xu4OW+03CZKBs2qAYh0fjIA49r+X+aX7QIKrbRyXU/ictPBLMpj1yXF+2J5vwR/KQYVCA",
+                                "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "VZk70FWiYN/YSwGykt2CygcOl1bq2D+dVSSKBL5GA5uHXxt6ypDlYvtWprM1l7re3llp5j105MevsjQ+2sWmCw"
+                            }
+                        },
+                        "user_id": "@good:localhost"
+                    }
+                }
+            },
+            "failures": {},
+            "master_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "imAhrTIlPuf6hNqlbcSUnC2ndZPk5NwQLzbi9kZ8nmnPGjmv39f4U4Vh/KiweqQnI4ActGpcYyM7k9S2Ef8/CQ",
+                            "ed25519:HPNYOQGUEE": "6w3egsvd+oVPCclef+hF1CfFMZrGTf/plFvPU5iP69WNw4w0UPAKSV1jOzh7Wv4LVGX5O3afjA9DG+O7aHZmBw"
+                        }
+                    },
+                    "usage": [
+                        "master"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            },
+            "self_signing_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "2AyR8lovFv8J1DwPwdCsAM9Tw877QhaVHmVkPopsmSokS2fst8LDQtsg/PiftVc+74NGz5tnYIMDxn4BjAisAg"
+                        }
+                    },
+                    "usage": [
+                        "self_signing"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            },
+            "user_signing_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:u1PwO3/a/HTnN9IF7BVa2dJQ7bc00J22eNS0vM4FjTA": "u1PwO3/a/HTnN9IF7BVa2dJQ7bc00J22eNS0vM4FjTA"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "88v9/Z3TJeY2lsu3cFQaEuhHH5ixjJs22ALQRKY+O6VPGCT/BAzH6kUb7teinFfpvQjoXN3t5fVJxbP9mVlxDg"
+                        }
+                    },
+                    "usage": [
+                        "user_signing"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    pub fn me_id() -> &'static UserId {
+        user_id!("@me:localhost")
+    }
+
+    pub fn me_device_id() -> &'static DeviceId {
+        device_id!("ABCDEFGH")
+    }
+
+    pub fn dan_id() -> &'static UserId {
+        user_id!("@dan:localhost")
+    }
+
+    pub fn dave_id() -> &'static UserId {
+        user_id!("@dave:localhost")
+    }
+
+    pub fn good_id() -> &'static UserId {
+        user_id!("@good:localhost")
+    }
+}

--- a/crates/matrix-sdk-crypto/src/testing_data/mod.rs
+++ b/crates/matrix-sdk-crypto/src/testing_data/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) mod keys_query;

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -30,9 +30,9 @@ use futures_util::{
     future::try_join,
     stream::{self, StreamExt},
 };
-use matrix_sdk_base::crypto::{
+use matrix_sdk_base::{crypto::{
     CrossSigningBootstrapRequests, OlmMachine, OutgoingRequest, RoomMessageRequest, ToDeviceRequest,
-};
+}, CryptoDistributionMode, GlobalEncryptionSettings};
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     api::client::{
@@ -614,6 +614,17 @@ impl Encryption {
     /// Get the public Curve25519 key of our own device.
     pub async fn curve25519_key(&self) -> Option<Curve25519PublicKey> {
         self.client.olm_machine().await.as_ref().map(|o| o.identity_keys().curve25519)
+    }
+
+    /// Set the lab flag to enable invisible crypto key distribution mode
+    pub async fn set_invisible_crypto_enabled(&self, enabled: bool) {
+        let key_distribution_mode = if enabled {
+            GlobalEncryptionSettings { key_distribution_mode: CryptoDistributionMode::InvisibleCrypto  }
+        } else {
+
+            GlobalEncryptionSettings { key_distribution_mode: CryptoDistributionMode::Legacy   }
+        };
+        self.client.base_client().set_global_encryption_settings(key_distribution_mode).await
     }
 
     #[cfg(feature = "experimental-oidc")]

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -30,9 +30,13 @@ use futures_util::{
     future::try_join,
     stream::{self, StreamExt},
 };
-use matrix_sdk_base::{crypto::{
-    CrossSigningBootstrapRequests, OlmMachine, OutgoingRequest, RoomMessageRequest, ToDeviceRequest,
-}, CryptoDistributionMode, GlobalEncryptionSettings};
+use matrix_sdk_base::{
+    crypto::{
+        CrossSigningBootstrapRequests, OlmMachine, OutgoingRequest, RoomMessageRequest,
+        ToDeviceRequest,
+    },
+    CryptoDistributionMode, GlobalEncryptionSettings,
+};
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     api::client::{
@@ -619,10 +623,11 @@ impl Encryption {
     /// Set the lab flag to enable invisible crypto key distribution mode
     pub async fn set_invisible_crypto_enabled(&self, enabled: bool) {
         let key_distribution_mode = if enabled {
-            GlobalEncryptionSettings { key_distribution_mode: CryptoDistributionMode::InvisibleCrypto  }
+            GlobalEncryptionSettings {
+                key_distribution_mode: CryptoDistributionMode::InvisibleCrypto,
+            }
         } else {
-
-            GlobalEncryptionSettings { key_distribution_mode: CryptoDistributionMode::Legacy   }
+            GlobalEncryptionSettings { key_distribution_mode: CryptoDistributionMode::Legacy }
         };
         self.client.base_client().set_global_encryption_settings(key_distribution_mode).await
     }


### PR DESCRIPTION
## POC -- Do Not Merge --

Related to https://github.com/element-hq/crypto-internal/issues/307

Refactoring of encryption settings to allow to have several possible key sharing strategy:
```rust
/// Defines the sharing strategy for the room key. That is what devices are
/// included in the conversation, and what are not.
#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
pub enum RoomKeySharingStrategy {
    /** Simple strategy, send to all devices or only to trusted devices */
    Legacy(DeviceBasedStrategy),
    /** Cross-Signing TOFU strategy. Will only distribute keys to devices
     * that are cross-signed by their owner */
    Modern(IdentityBasedStrategy),
}
```

The code that decides what devices should receive the key has been extracted and is now the responsability of the `sharing_strategy`, see `RoomKeyShareStrategy` trait
https://github.com/matrix-org/matrix-rust-sdk/pull/3532

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
