### PR TITLE
feat (bindings): added an API to retrieve a loaded reply

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
     room::{power_levels::RoomPowerLevelChanges, Room as SdkRoom, RoomMemberRole},
     ComposerDraft, RoomMemberships, RoomState,
 };
-use matrix_sdk_ui::timeline::{PaginationError, RepliedToEvent, RoomExt, TimelineFocus};
+use matrix_sdk_ui::timeline::{PaginationError, RoomExt, TimelineFocus};
 use mime::Mime;
 use ruma::{
     api::client::room::report_content,
@@ -32,10 +32,7 @@ use crate::{
     room_info::RoomInfo,
     room_member::RoomMember,
     ruma::{ImageInfo, Mentions, NotifyType},
-    timeline::{
-        content::{InReplyToDetails, RepliedToEventDetails, TimelineItemContent},
-        EventTimelineItem, FocusEventError, ReceiptType, Timeline,
-    },
+    timeline::{EventTimelineItem, FocusEventError, ReceiptType, Timeline},
     utils::u64_to_uint,
     TaskHandle,
 };
@@ -716,39 +713,6 @@ impl Room {
     /// Remove the `ComposerDraft` stored in the state store for this room.
     pub async fn clear_composer_draft(&self) -> Result<(), ClientError> {
         Ok(self.inner.clear_composer_draft().await?)
-    }
-
-    /// Load the reply details for the given event id.
-    ///
-    /// This will return an `InReplyToDetails` object that contains the details
-    /// which will either be ready or an error.
-    pub async fn load_reply_details(
-        &self,
-        event_id_str: String,
-    ) -> Result<InReplyToDetails, ClientError> {
-        let event_id = EventId::parse(&event_id_str)?;
-
-        match self.inner.event(&event_id).await {
-            Ok(timeline_event) => {
-                let replied_to =
-                    RepliedToEvent::try_from_timeline_event_for_room(timeline_event, &self.inner)
-                        .await?;
-
-                Ok(InReplyToDetails {
-                    event_id: event_id_str,
-                    event: RepliedToEventDetails::Ready {
-                        content: Arc::new(TimelineItemContent(replied_to.content().clone())),
-                        sender: replied_to.sender().to_string(),
-                        sender_profile: replied_to.sender_profile().into(),
-                    },
-                })
-            }
-
-            Err(e) => Ok(InReplyToDetails {
-                event_id: event_id_str,
-                event: RepliedToEventDetails::Error { message: e.to_string() },
-            }),
-        }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -6,7 +6,7 @@ use matrix_sdk::{
     room::{power_levels::RoomPowerLevelChanges, Room as SdkRoom, RoomMemberRole},
     ComposerDraft, RoomMemberships, RoomState,
 };
-use matrix_sdk_ui::timeline::{PaginationError, RoomExt, TimelineFocus};
+use matrix_sdk_ui::timeline::{PaginationError, RepliedToEvent, RoomExt, TimelineFocus};
 use mime::Mime;
 use ruma::{
     api::client::room::report_content,
@@ -32,7 +32,10 @@ use crate::{
     room_info::RoomInfo,
     room_member::RoomMember,
     ruma::{ImageInfo, Mentions, NotifyType},
-    timeline::{EventTimelineItem, FocusEventError, ReceiptType, Timeline},
+    timeline::{
+        content::{InReplyToDetails, RepliedToEventDetails, TimelineItemContent},
+        EventTimelineItem, FocusEventError, ReceiptType, Timeline,
+    },
     utils::u64_to_uint,
     TaskHandle,
 };
@@ -713,6 +716,39 @@ impl Room {
     /// Remove the `ComposerDraft` stored in the state store for this room.
     pub async fn clear_composer_draft(&self) -> Result<(), ClientError> {
         Ok(self.inner.clear_composer_draft().await?)
+    }
+
+    /// Load the reply details for the given event id.
+    ///
+    /// This will return an `InReplyToDetails` object that contains the details
+    /// which will either be ready or an error.
+    pub async fn load_reply_details(
+        &self,
+        event_id_str: String,
+    ) -> Result<InReplyToDetails, ClientError> {
+        let event_id = EventId::parse(&event_id_str)?;
+
+        match self.inner.event(&event_id).await {
+            Ok(timeline_event) => {
+                let replied_to =
+                    RepliedToEvent::try_from_timeline_event_for_room(timeline_event, &self.inner)
+                        .await?;
+
+                Ok(InReplyToDetails {
+                    event_id: event_id_str,
+                    event: RepliedToEventDetails::Ready {
+                        content: Arc::new(TimelineItemContent(replied_to.content().clone())),
+                        sender: replied_to.sender().to_string(),
+                        sender_profile: replied_to.sender_profile().into(),
+                    },
+                })
+            }
+
+            Err(e) => Ok(InReplyToDetails {
+                event_id: event_id_str,
+                event: RepliedToEventDetails::Error { message: e.to_string() },
+            }),
+        }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -189,8 +189,8 @@ impl Message {
 
 #[derive(uniffi::Record)]
 pub struct InReplyToDetails {
-    event_id: String,
-    event: RepliedToEventDetails,
+    pub(crate) event_id: String,
+    pub(crate) event: RepliedToEventDetails,
 }
 
 impl From<&matrix_sdk_ui::timeline::InReplyToDetails> for InReplyToDetails {

--- a/bindings/matrix-sdk-ffi/src/timeline/content.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/content.rs
@@ -189,8 +189,14 @@ impl Message {
 
 #[derive(uniffi::Record)]
 pub struct InReplyToDetails {
-    pub(crate) event_id: String,
-    pub(crate) event: RepliedToEventDetails,
+    event_id: String,
+    event: RepliedToEventDetails,
+}
+
+impl InReplyToDetails {
+    pub(crate) fn new(event_id: String, event: RepliedToEventDetails) -> Self {
+        Self { event_id, event }
+    }
 }
 
 impl From<&matrix_sdk_ui::timeline::InReplyToDetails> for InReplyToDetails {

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -16,6 +16,7 @@ use std::{collections::HashMap, fmt::Write as _, fs, sync::Arc};
 
 use anyhow::{Context, Result};
 use as_variant::as_variant;
+use content::{InReplyToDetails, RepliedToEventDetails};
 use eyeball_im::VectorDiff;
 use futures_util::{pin_mut, StreamExt as _};
 use matrix_sdk::attachment::{
@@ -23,7 +24,7 @@ use matrix_sdk::attachment::{
     BaseThumbnailInfo, BaseVideoInfo, Thumbnail,
 };
 use matrix_sdk_ui::timeline::{
-    EventItemOrigin, LiveBackPaginationStatus, Profile, TimelineDetails,
+    EventItemOrigin, LiveBackPaginationStatus, Profile, RepliedToEvent, TimelineDetails,
 };
 use mime::Mime;
 use ruma::{
@@ -67,7 +68,7 @@ use crate::{
     RUNTIME,
 };
 
-pub mod content;
+mod content;
 
 #[derive(uniffi::Object)]
 #[repr(transparent)]
@@ -595,6 +596,41 @@ impl Timeline {
             .map_err(|err| anyhow::anyhow!(err))?;
 
         Ok(removed)
+    }
+
+    /// Load the reply details for the given event id.
+    ///
+    /// This will return an `InReplyToDetails` object that contains the details
+    /// which will either be ready or an error.
+    pub async fn load_reply_details(
+        &self,
+        event_id_str: String,
+    ) -> Result<InReplyToDetails, ClientError> {
+        let event_id = EventId::parse(&event_id_str)?;
+
+        match self.inner.room().event(&event_id).await {
+            Ok(timeline_event) => {
+                let replied_to = RepliedToEvent::try_from_timeline_event_for_room(
+                    timeline_event,
+                    self.inner.room(),
+                )
+                .await?;
+
+                Ok(InReplyToDetails {
+                    event_id: event_id_str,
+                    event: RepliedToEventDetails::Ready {
+                        content: Arc::new(TimelineItemContent(replied_to.content().clone())),
+                        sender: replied_to.sender().to_string(),
+                        sender_profile: replied_to.sender_profile().into(),
+                    },
+                })
+            }
+
+            Err(e) => Ok(InReplyToDetails {
+                event_id: event_id_str,
+                event: RepliedToEventDetails::Error { message: e.to_string() },
+            }),
+        }
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -616,20 +616,20 @@ impl Timeline {
                 )
                 .await?;
 
-                Ok(InReplyToDetails {
-                    event_id: event_id_str,
-                    event: RepliedToEventDetails::Ready {
+                Ok(InReplyToDetails::new(
+                    event_id_str,
+                    RepliedToEventDetails::Ready {
                         content: Arc::new(TimelineItemContent(replied_to.content().clone())),
                         sender: replied_to.sender().to_string(),
                         sender_profile: replied_to.sender_profile().into(),
                     },
-                })
+                ))
             }
 
-            Err(e) => Ok(InReplyToDetails {
-                event_id: event_id_str,
-                event: RepliedToEventDetails::Error { message: e.to_string() },
-            }),
+            Err(e) => Ok(InReplyToDetails::new(
+                event_id_str,
+                RepliedToEventDetails::Error { message: e.to_string() },
+            )),
         }
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -67,7 +67,7 @@ use crate::{
     RUNTIME,
 };
 
-mod content;
+pub mod content;
 
 #[derive(uniffi::Object)]
 #[repr(transparent)]

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -17,7 +17,7 @@
 use std::{fmt, sync::Arc};
 
 use imbl::{vector, Vector};
-use matrix_sdk::deserialized_responses::TimelineEvent;
+use matrix_sdk::{deserialized_responses::TimelineEvent, Room};
 use ruma::{
     assign,
     events::{
@@ -277,6 +277,15 @@ impl RepliedToEvent {
             sender: self.sender.clone(),
             sender_profile: self.sender_profile.clone(),
         }
+    }
+
+    /// Try to create a `RepliedToEvent` from a `TimelineEvent` by providing the
+    /// room.
+    pub async fn try_from_timeline_event_for_room(
+        timeline_event: TimelineEvent,
+        room_data_provider: &Room,
+    ) -> Result<Self, TimelineError> {
+        Self::try_from_timeline_event(timeline_event, room_data_provider).await
     }
 
     pub(in crate::timeline) async fn try_from_timeline_event<P: RoomDataProvider>(


### PR DESCRIPTION
second part of the #3439 breakdown

The context for this API, is for the composer preview an reply without the need of it being actively in the timeline.