### PR TITLE
chore(ffi): Remove `RoomInfo::latest_event`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -1,10 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use matrix_sdk::RoomState;
 
 use crate::{
     notification_settings::RoomNotificationMode, room::Membership, room_member::RoomMember,
-    timeline::EventTimelineItem,
 };
 
 #[derive(uniffi::Record)]
@@ -25,7 +24,6 @@ pub struct RoomInfo {
     canonical_alias: Option<String>,
     alternative_aliases: Vec<String>,
     membership: Membership,
-    latest_event: Option<Arc<EventTimelineItem>>,
     /// Member who invited the current user to a room that's in the invited
     /// state.
     ///
@@ -55,10 +53,7 @@ pub struct RoomInfo {
 }
 
 impl RoomInfo {
-    pub(crate) async fn new(
-        room: &matrix_sdk::Room,
-        latest_event: Option<Arc<EventTimelineItem>>,
-    ) -> matrix_sdk::Result<Self> {
+    pub(crate) async fn new(room: &matrix_sdk::Room) -> matrix_sdk::Result<Self> {
         let unread_notification_counts = room.unread_notification_counts();
 
         let power_levels_map = room.users_with_power_levels().await;
@@ -81,7 +76,6 @@ impl RoomInfo {
             canonical_alias: room.canonical_alias().map(Into::into),
             alternative_aliases: room.alt_aliases().into_iter().map(Into::into).collect(),
             membership: room.state().into(),
-            latest_event,
             inviter: match room.state() {
                 RoomState::Invited => room
                     .invite_details()

--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -505,9 +505,7 @@ impl RoomListItem {
     }
 
     pub async fn room_info(&self) -> Result<RoomInfo, ClientError> {
-        let latest_event = self.inner.latest_event().await.map(EventTimelineItem).map(Arc::new);
-
-        Ok(RoomInfo::new(self.inner.inner_room(), latest_event).await?)
+        Ok(RoomInfo::new(self.inner.inner_room()).await?)
     }
 
     /// Build a full `Room` FFI object, filling its associated timeline.


### PR DESCRIPTION
This patch removes `RoomInfo::latest_event`. To get the latest event,
one has to use `RoomListItem::latest_event` because it supports
local events and remote events. It was supposed to be the case of
`Room::room_info` too, but only when the method was called: Once the
`RoomInfo` was created, the latest event inside `RoomInfo`
was static, not dynamic. Also, this code wasn't tested
contrary to `RoomListItem::latest_event` which uses
`matrix_sdk_ui::room_list_service::Room::latest_event` which is itself
tested.

---

* Based on https://github.com/matrix-org/matrix-rust-sdk/pull/3540. It must be merged after #3540 is merged. Please review only the last commit.