### PR TITLE
fix(ui): Change the behaviour when a duplicated event is received by the `Timeline`

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -416,10 +416,6 @@ async fn test_timeline_duplicated_events() -> Result<()> {
         assert_timeline_stream! {
             [timeline_stream]
             update[3] "$x3:bar.org";
-            update[1] "$x1:bar.org";
-            remove[1];
-            append    "$x1:bar.org";
-            update[3] "$x1:bar.org";
             append    "$x4:bar.org";
         };
     }


### PR DESCRIPTION
This patch changes the behaviour of the `Timeline` when a duplicated event is received. Prior to this patch, the old event was removed, and the one was added. With this patch, the old event is kept, and the new one is skipped.

This is important for https://github.com/matrix-org/matrix-rust-sdk/pull/3512 where events are mapped to the timeline item indices. When an event is removed, it becomes difficult to keep the mapping correct.

This patch also adds duplication detection for pagination (with `TimelineItemPosition::Start`).

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280