### PR TITLE
feat(ui): `RoomListService::room` is no longer async!

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -125,11 +125,11 @@ impl RoomListService {
         })))
     }
 
-    async fn room(&self, room_id: String) -> Result<Arc<RoomListItem>, RoomListError> {
+    fn room(&self, room_id: String) -> Result<Arc<RoomListItem>, RoomListError> {
         let room_id = <&RoomId>::try_from(room_id.as_str()).map_err(RoomListError::from)?;
 
         Ok(Arc::new(RoomListItem {
-            inner: Arc::new(self.inner.room(room_id).await?),
+            inner: Arc::new(self.inner.room(room_id)?),
             utd_hook: self.utd_hook.clone(),
         }))
     }
@@ -172,7 +172,7 @@ pub struct RoomList {
     inner: Arc<matrix_sdk_ui::room_list_service::RoomList>,
 }
 
-#[uniffi::export(async_runtime = "tokio")]
+#[uniffi::export]
 impl RoomList {
     fn loading_state(
         &self,
@@ -233,8 +233,8 @@ impl RoomList {
         }
     }
 
-    async fn room(&self, room_id: String) -> Result<Arc<RoomListItem>, RoomListError> {
-        self.room_list_service.room(room_id).await
+    fn room(&self, room_id: String) -> Result<Arc<RoomListItem>, RoomListError> {
+        self.room_list_service.room(room_id)
     }
 }
 

--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -433,10 +433,7 @@ impl RoomListService {
             }
         }
 
-        let room = match self.sliding_sync.get_room(room_id).await {
-            Some(room) => Room::new(self.sliding_sync.clone(), room)?,
-            None => return Err(Error::RoomNotFound(room_id.to_owned())),
-        };
+        let room = Room::new(&self.client, room_id, &self.sliding_sync)?;
 
         self.rooms.write().await.push(room.clone());
 

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -2072,7 +2072,7 @@ async fn test_room() -> Result<(), Error> {
         },
     };
 
-    let room0 = room_list.room(room_id_0).await?;
+    let room0 = room_list.room(room_id_0)?;
 
     // Room has received a name from sliding sync.
     assert_eq!(room0.cached_display_name(), Some("Room #0".to_owned()));
@@ -2080,7 +2080,7 @@ async fn test_room() -> Result<(), Error> {
     // Room has received an avatar from sliding sync.
     assert_eq!(room0.avatar_url(), Some(mxc_uri!("mxc://homeserver/media").to_owned()));
 
-    let room1 = room_list.room(room_id_1).await?;
+    let room1 = room_list.room(room_id_1)?;
 
     // Room has not received a name from sliding sync, then it's calculated.
     assert_eq!(room1.cached_display_name(), Some("Empty Room".to_owned()));
@@ -2144,7 +2144,7 @@ async fn test_room_not_found() -> Result<(), Error> {
     let room_id = room_id!("!foo:bar.org");
 
     assert_matches!(
-        room_list.room(room_id).await,
+        room_list.room(room_id),
         Err(Error::RoomNotFound(error_room_id)) => {
             assert_eq!(error_room_id, room_id.to_owned());
         }
@@ -2208,7 +2208,7 @@ async fn test_room_subscription() -> Result<(), Error> {
         },
     };
 
-    let room1 = room_list.room(room_id_1).await.unwrap();
+    let room1 = room_list.room(room_id_1).unwrap();
 
     // Subscribe.
 
@@ -2253,7 +2253,7 @@ async fn test_room_subscription() -> Result<(), Error> {
     // Unsubscribe.
 
     room1.unsubscribe();
-    room_list.room(room_id_2).await?.unsubscribe(); // unsubscribe from a room that has no subscription.
+    room_list.room(room_id_2)?.unsubscribe(); // unsubscribe from a room that has no subscription.
 
     sync_then_assert_request_and_fake_response! {
         [server, room_list, sync]
@@ -2316,7 +2316,7 @@ async fn test_room_unread_notifications() -> Result<(), Error> {
         },
     };
 
-    let room = room_list.room(room_id).await.unwrap();
+    let room = room_list.room(room_id).unwrap();
 
     assert_matches!(
         room.unread_notification_counts(),
@@ -2391,7 +2391,7 @@ async fn test_room_timeline() -> Result<(), Error> {
         },
     };
 
-    let room = room_list.room(room_id).await?;
+    let room = room_list.room(room_id)?;
     room.init_timeline_with_builder(room.default_room_timeline_builder().await.unwrap()).await?;
     let timeline = room.timeline().unwrap();
 
@@ -2473,7 +2473,7 @@ async fn test_room_latest_event() -> Result<(), Error> {
         },
     };
 
-    let room = room_list.room(room_id).await?;
+    let room = room_list.room(room_id)?;
     room.init_timeline_with_builder(room.default_room_timeline_builder().await.unwrap()).await?;
 
     // The latest event does not exist.

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -227,7 +227,7 @@ impl App {
                     all_rooms.into_iter().filter(|room_id| !previous_ui_rooms.contains_key(room_id))
                 {
                     // Retrieve the room list service's Room.
-                    let Ok(ui_room) = sync_service.room_list_service().room(&room_id).await else {
+                    let Ok(ui_room) = sync_service.room_list_service().room(&room_id) else {
                         error!("error when retrieving room after an update");
                         continue;
                     };


### PR DESCRIPTION
This patch is twofold:

* it updates `room_list_service::Room::new` to take a `&Client` and a `&RoomId` instead of a `SlidingSyncRoom`. The `SlidingSyncRoom` is only used in `Room::default_room_timeline_builder` and is fetched there from the `SlidingSync` instance lazily. It confines the `SlidingSyncRoom` to one single method for `Room` now.
* it makes `RoomListService::room` synchronous. It no longer reads a `SlidingSyncRoom` from `SlidingSync`, then it not needs to be async anymore. This patch replaces the `RwLock` of `RoomListService::rooms` from `tokio::sync` to `std::sync`.

--- 

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3079