### PR TITLE
feat(base): Make `Store::get_rooms` wayyy faster

### DIFF
--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -142,6 +142,7 @@ pub(crate) struct Store {
     session_meta: Arc<OnceCell<SessionMeta>>,
     /// The current sync token that should be used for the next sync call.
     pub(super) sync_token: Arc<RwLock<Option<String>>>,
+    /// All rooms the store knows about.
     rooms: Arc<StdRwLock<BTreeMap<OwnedRoomId, Room>>>,
     /// A lock to synchronize access to the store, such that data by the sync is
     /// never overwritten.
@@ -203,7 +204,7 @@ impl Store {
 
     /// Get all the rooms this store knows about.
     pub fn get_rooms(&self) -> Vec<Room> {
-        self.rooms.read().unwrap().keys().filter_map(|id| self.get_room(id)).collect()
+        self.rooms.read().unwrap().values().cloned().collect()
     }
 
     /// Get all the rooms this store knows about, filtered by state.


### PR DESCRIPTION
`Store::get_rooms` worked as follows: For each room ID, call

* Take the read lock for `rooms`,
* For each entry in `rooms`, take the room ID (the key), then call `Store::get_room`, which…
* Take the read lock for `rooms`,
* Based on the room ID (the key), read the room (the value) from `rooms`.

So calling `get_rooms` calls `get_room` for each room, which takes the lock every time.

This patch modifies that by fetching the values (the rooms) directly from `rooms`, without calling `get_room`.

In my benchmark, it took 1.2ms to read 10'000 rooms. Now it takes 542µs. Performance time has improved by -55.8%.

---

* Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3068
