### PR TITLE
sdk: Rewrite key-backup download task

### DIFF
--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -878,6 +878,13 @@ impl Backups {
         }
     }
 
+    /// Handle UTD events by triggering download from key backup.
+    ///
+    /// This function is registered as an event handler; it exists to deal
+    /// with cases where [`Room::decrypt_event`] is not called and instead the
+    /// event should be decrypted by the time this crate sees the event, such as
+    /// for events received via `/sync` (as opposed to via `/messages`,
+    /// `/context`, etc.)
     #[allow(clippy::unused_async)] // Because it's used as an event handler, which must be async.
     pub(crate) async fn utd_event_handler(
         event: SyncRoomEncryptedEvent,

--- a/crates/matrix-sdk/src/encryption/backups/mod.rs
+++ b/crates/matrix-sdk/src/encryption/backups/mod.rs
@@ -37,7 +37,7 @@ use ruma::{
         error::ErrorKind,
     },
     events::{
-        room::encrypted::{EncryptedEventScheme, SyncRoomEncryptedEvent},
+        room::encrypted::{EncryptedEventScheme, OriginalSyncRoomEncryptedEvent},
         secret::{request::SecretName, send::ToDeviceSecretSendEvent},
     },
     serde::Raw,
@@ -887,11 +887,11 @@ impl Backups {
     /// `/context`, etc.)
     #[allow(clippy::unused_async)] // Because it's used as an event handler, which must be async.
     pub(crate) async fn utd_event_handler(
-        event: SyncRoomEncryptedEvent,
+        event: Raw<OriginalSyncRoomEncryptedEvent>,
         room: Room,
         client: Client,
     ) {
-        if let Some(event) = event.as_original() {
+        if let Ok(event) = event.deserialize() {
             if let EncryptedEventScheme::MegolmV1AesSha2(c) = &event.content.scheme {
                 client
                     .encryption()

--- a/crates/matrix-sdk/src/encryption/tasks.rs
+++ b/crates/matrix-sdk/src/encryption/tasks.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 The Matrix.org Foundation C.I.C.
+// Copyright 2023-2024 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, time::Duration};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
-use futures_util::future::join_all;
 use matrix_sdk_common::failures_cache::FailuresCache;
 use ruma::{
     events::room::encrypted::{EncryptedEventScheme, OriginalSyncRoomEncryptedEvent},
     serde::Raw,
     OwnedEventId, OwnedRoomId,
 };
-use tokio::sync::mpsc::{self, UnboundedReceiver};
-use tracing::{trace, warn};
+use tokio::sync::{
+    mpsc::{self, UnboundedReceiver},
+    Mutex,
+};
+use tracing::{debug, trace, warn};
 
 use crate::{
     client::WeakClient,
@@ -114,7 +120,6 @@ impl RoomKeyDownloadRequest {
 }
 
 pub type RoomKeyInfo = (OwnedRoomId, String);
-pub type TaskQueue = BTreeMap<RoomKeyInfo, JoinHandle<()>>;
 
 pub(crate) struct BackupDownloadTask {
     sender: mpsc::UnboundedSender<RoomKeyDownloadRequest>,
@@ -137,12 +142,7 @@ impl BackupDownloadTask {
         let (sender, receiver) = mpsc::unbounded_channel();
 
         let join_handle = spawn(async move {
-            Self::listen(
-                client,
-                receiver,
-                FailuresCache::with_settings(Duration::from_secs(60 * 60 * 24), 60),
-            )
-            .await;
+            Self::listen(client, receiver).await;
         });
 
         Self { sender, join_handle }
@@ -169,70 +169,199 @@ impl BackupDownloadTask {
         }
     }
 
-    pub(crate) async fn download(
-        client: Client,
-        room_key_info: RoomKeyInfo,
-        failures_cache: FailuresCache<RoomKeyInfo>,
+    /// Listen for incoming [`RoomKeyDownloadRequest`]s and process them.
+    ///
+    /// This will keep running until either the request channel is closed, or
+    /// all other references to `Client` are dropped.
+    ///
+    /// # Arguments
+    ///
+    /// * `receiver` - The source of incoming [`RoomKeyDownloadRequest`]s.
+    async fn listen(client: WeakClient, mut receiver: UnboundedReceiver<RoomKeyDownloadRequest>) {
+        let state = Arc::new(Mutex::new(BackupDownloadTaskListenerState::new(client)));
+
+        while let Some(room_key_download_request) = receiver.recv().await {
+            let mut state_guard = state.lock().await;
+
+            if state_guard.client.strong_count() == 0 {
+                trace!("Client got dropped, shutting down the task");
+                break;
+            }
+
+            // Check that we don't already have a task to process this event, and fire one
+            // off else if not.
+            let event_id = &room_key_download_request.event_id;
+            if !state_guard.active_tasks.contains_key(event_id) {
+                let event_id = event_id.to_owned();
+                let task =
+                    spawn(Self::handle_download_request(state.clone(), room_key_download_request));
+                state_guard.active_tasks.insert(event_id, task);
+            }
+        }
+    }
+
+    /// Handle a request to download a session for a given event.
+    ///
+    /// Sleeps for a while to see if the key turns up; then checks if we still
+    /// want to do a download, and does the download if so.
+    async fn handle_download_request(
+        state: Arc<Mutex<BackupDownloadTaskListenerState>>,
+        download_request: RoomKeyDownloadRequest,
     ) {
         // Wait a bit, perhaps the room key will arrive in the meantime.
         tokio::time::sleep(Duration::from_millis(Self::DOWNLOAD_DELAY_MILLIS)).await;
 
-        if let Some(machine) = client.olm_machine().await.as_ref() {
-            let (room_id, session_id) = &room_key_info;
+        // Now take the lock, and check that we still want to do a download. If we do,
+        // keep hold of a strong reference to the `Client`.
+        let client = {
+            let mut state = state.lock().await;
 
-            if !machine.is_room_key_available(room_id, session_id).await.unwrap() {
-                match client.encryption().backups().download_room_key(room_id, session_id).await {
-                    Ok(_) => failures_cache.remove(std::iter::once(&room_key_info)),
-                    Err(_) => failures_cache.insert(room_key_info),
+            let Some(client) = state.client.get() else {
+                // The client was dropped while we were sleeping. We should just bail out;
+                // the main BackupDownloadTask loop will bail out too.
+                return;
+            };
+
+            // Check that we still want to do a download.
+            if !state.should_download(&client, &download_request).await {
+                // We decided against doing a download. Mark the job done for this event before
+                // dropping the lock.
+                state.active_tasks.remove(&download_request.event_id);
+                return;
+            }
+
+            // Before we drop the lock, indicate to other tasks that may be considering this
+            // session that we're going to go ahead and do a download.
+            state.downloaded_sessions.insert(download_request.to_room_key_info());
+            client
+        };
+
+        // Do the download without holding the lock.
+        let result = client
+            .encryption()
+            .backups()
+            .download_room_key(&download_request.room_id, &download_request.megolm_session_id)
+            .await;
+
+        // Then take the lock again to update the state.
+        {
+            let mut state = state.lock().await;
+            let room_key_info = download_request.to_room_key_info();
+            match result {
+                Ok(_) => {
+                    // We successfully downloaded the session. We can clear any record of previous
+                    // backoffs from the failures cache, because we won't be needing them again.
+                    state.failures_cache.remove(std::iter::once(&room_key_info))
+                }
+                Err(_) => {
+                    // We were unable to download the session. Update the failure cache so that we
+                    // back off from more requests, and also remove the entry from the list of
+                    // sessions that we are downloading.
+                    state.downloaded_sessions.remove(&room_key_info);
+                    state.failures_cache.insert(room_key_info);
                 }
             }
+            state.active_tasks.remove(&download_request.event_id);
+        }
+    }
+}
+
+/// The state for an active [`BackupDownloadTask`].
+struct BackupDownloadTaskListenerState {
+    /// Reference to the `Client`, which will be used to fire off the download
+    /// requests.
+    client: WeakClient,
+
+    /// A record of backup download attempts that have recently failed.
+    failures_cache: FailuresCache<RoomKeyInfo>,
+
+    /// Map from event ID to download task
+    active_tasks: BTreeMap<OwnedEventId, JoinHandle<()>>,
+
+    /// A list of megolm sessions that we have already downloaded, or are about
+    /// to download.
+    ///
+    /// The idea here is that once we've (successfully) downloaded a session
+    /// from the backup, there's not much point trying again even if we get
+    /// another UTD event that uses the same session.
+    ///
+    /// TODO: that's not quite right though. In theory another client could
+    ///   update the backup with an earlier ratchet state, giving us access
+    ///   to earlier messages in the session. In which case, maybe this
+    ///   should expire?
+    downloaded_sessions: HashSet<RoomKeyInfo>,
+}
+
+impl BackupDownloadTaskListenerState {
+    /// Prepare a new `BackupDownloadTaskListenerState`.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - A reference to the `Client`, which is used to fire off the
+    ///   backup download request.
+    pub fn new(client: WeakClient) -> Self {
+        Self {
+            client,
+            failures_cache: FailuresCache::with_settings(Duration::from_secs(60 * 60 * 24), 60),
+            active_tasks: Default::default(),
+            downloaded_sessions: Default::default(),
         }
     }
 
-    pub(crate) async fn prune_tasks(task_queue: &mut TaskQueue) {
-        let mut handles = Vec::with_capacity(task_queue.len());
+    /// Check if we should set off a download for the given request.
+    ///
+    /// Checks if:
+    ///  * we already have the key,
+    ///  * we have already downloaded this session, or are about to do so, or
+    ///  * we've backed off from trying to download this session.
+    ///
+    /// If any of the above are true, returns `false`. Otherwise, returns
+    /// `true`.
+    pub async fn should_download(
+        &self,
+        client: &Client,
+        download_request: &RoomKeyDownloadRequest,
+    ) -> bool {
+        // Check that the Client has an OlmMachine
+        let machine_guard = client.olm_machine().await;
+        let Some(machine) = machine_guard.as_ref() else {
+            return false;
+        };
 
-        while let Some((_, handle)) = task_queue.pop_first() {
-            handles.push(handle);
+        // Check if the keys for this message have arrived in the meantime.
+        // If we get a StoreError doing the lookup, we assume the keys haven't arrived
+        // (though if the store is returning errors, probably something else is
+        // going to go wrong very soon).
+        if machine
+            .is_room_key_available(&download_request.room_id, &download_request.megolm_session_id)
+            .await
+            .unwrap_or(false)
+        {
+            debug!(?download_request, "Not performing backup download because key became available while we were sleeping");
+            return false;
         }
 
-        join_all(handles).await;
-    }
+        // Check if we already downloaded this session, or another task is in the
+        // process of doing so.
+        let room_key_info = download_request.to_room_key_info();
+        if self.downloaded_sessions.contains(&room_key_info) {
+            debug!(
+                ?download_request,
+                "Not performing backup download because this session has already been downloaded"
+            );
+            return false;
+        };
 
-    pub(crate) async fn listen(
-        client: WeakClient,
-        mut receiver: UnboundedReceiver<RoomKeyDownloadRequest>,
-        failures_cache: FailuresCache<RoomKeyInfo>,
-    ) {
-        let mut task_queue = TaskQueue::new();
-
-        while let Some(room_key_download_request) = receiver.recv().await {
-            let room_key_info = room_key_download_request.to_room_key_info();
-            trace!(?room_key_info, "Got a request to download a room key from the backup");
-
-            if task_queue.len() >= 10 {
-                Self::prune_tasks(&mut task_queue).await
-            }
-
-            if let Some(client) = client.get() {
-                let backups = client.encryption().backups();
-
-                let already_tried = failures_cache.contains(&room_key_info);
-                let task_exists = task_queue.contains_key(&room_key_info);
-
-                if !already_tried && !task_exists && backups.are_enabled().await {
-                    let task = spawn(Self::download(
-                        client,
-                        room_key_info.to_owned(),
-                        failures_cache.to_owned(),
-                    ));
-
-                    task_queue.insert(room_key_info, task);
-                }
-            } else {
-                trace!("Client got dropped, shutting down the task");
-                break;
-            }
+        // Check if we're backing off from attempts to download this session
+        if self.failures_cache.contains(&room_key_info) {
+            debug!(
+                ?download_request,
+                "Not performing backup download because this session failed to download recently"
+            );
+            return false;
         }
+
+        debug!(?download_request, "Performing backup download");
+        true
     }
 }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1120,8 +1120,6 @@ impl Room {
         &self,
         event: &Raw<OriginalSyncRoomEncryptedEvent>,
     ) -> Result<TimelineEvent> {
-        use ruma::events::room::encrypted::EncryptedEventScheme;
-
         let machine = self.client.olm_machine().await;
         let machine = machine.as_ref().ok_or(Error::NoOlmMachine)?;
 
@@ -1129,13 +1127,10 @@ impl Room {
             match machine.decrypt_room_event(event.cast_ref(), self.inner.room_id()).await {
                 Ok(event) => event,
                 Err(e) => {
-                    let event = event.deserialize()?;
-                    if let EncryptedEventScheme::MegolmV1AesSha2(c) = event.content.scheme {
-                        self.client
-                            .encryption()
-                            .backups()
-                            .maybe_download_room_key(self.room_id().to_owned(), c.session_id);
-                    }
+                    self.client
+                        .encryption()
+                        .backups()
+                        .maybe_download_room_key(self.room_id().to_owned(), event.clone());
 
                     return Err(e.into());
                 }


### PR DESCRIPTION
More groundwork for fixing #3446, and a follow up to #3560 .

Currently (prior to this PR), the `BackupDownloadTask` fires off an async task for each megolm session we get a UTD for. Each task then waits for a bit to see if the key turns up, and if not, makes a backup download request.

The primary goal of this PR is to change that behaviour so that it fires off a task for each *event* and waits to see if the key for that *event* becomes available. That does necessitate a bit of extra bookkeeping to make sure that we don't end up doing multiple backup downloads for the same megolm session, but the point is that each event needs its own `sleep`.

It doesn't actually fix the bug yet, because we still just check `is_key_available` for the session as a whole. This PR is just groundwork for actually fixing the bug.