### PR TITLE
Client Builder: Add support for requiring Sliding Sync.

### DIFF
--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -84,6 +84,8 @@ use crate::{
 pub struct ClientBuilder {
     homeserver_cfg: Option<HomeserverConfig>,
     #[cfg(feature = "experimental-sliding-sync")]
+    requires_sliding_sync: bool,
+    #[cfg(feature = "experimental-sliding-sync")]
     sliding_sync_proxy: Option<String>,
     http_cfg: Option<HttpConfig>,
     store_config: BuilderStoreConfig,
@@ -100,6 +102,8 @@ impl ClientBuilder {
     pub(crate) fn new() -> Self {
         Self {
             homeserver_cfg: None,
+            #[cfg(feature = "experimental-sliding-sync")]
+            requires_sliding_sync: false,
             #[cfg(feature = "experimental-sliding-sync")]
             sliding_sync_proxy: None,
             http_cfg: None,
@@ -124,6 +128,18 @@ impl ClientBuilder {
     /// If you set more than one, then whatever was set last will be used.
     pub fn homeserver_url(mut self, url: impl AsRef<str>) -> Self {
         self.homeserver_cfg = Some(HomeserverConfig::Url(url.as_ref().to_owned()));
+        self
+    }
+
+    /// Ensures that the client is built with support for sliding-sync, either
+    /// by discovering a proxy through the homeserver's well-known or by
+    /// providing one through [`Self::sliding_sync_proxy`].
+    ///
+    /// In the future this may also perform a check for native support on the
+    /// homeserver.
+    #[cfg(feature = "experimental-sliding-sync")]
+    pub fn requires_sliding_sync(mut self) -> Self {
+        self.requires_sliding_sync = true;
         self
     }
 
@@ -439,6 +455,12 @@ impl ClientBuilder {
             }
         }
 
+        #[cfg(feature = "experimental-sliding-sync")]
+        if self.requires_sliding_sync && sliding_sync_proxy.is_none() {
+            // In the future we will need to check for native support on the homeserver too.
+            return Err(ClientBuildError::SlidingSyncNotAvailable);
+        }
+
         let homeserver = Url::parse(&homeserver)?;
 
         let auth_ctx = Arc::new(AuthCtx {
@@ -746,6 +768,10 @@ pub enum ClientBuildError {
     #[error("Error looking up the .well-known endpoint on auto-discovery")]
     AutoDiscovery(FromHttpResponseError<RumaApiError>),
 
+    /// The builder requires support for sliding sync but it isn't available.
+    #[error("The homeserver doesn't support sliding sync and a custom proxy wasn't configured.")]
+    SlidingSyncNotAvailable,
+
     /// An error encountered when trying to parse the homeserver url.
     #[error(transparent)]
     Url(#[from] url::ParseError),
@@ -1000,6 +1026,77 @@ pub(crate) mod tests {
         // proxy.
         #[cfg(feature = "experimental-sliding-sync")]
         assert_eq!(client.sliding_sync_proxy(), Some("https://localhost:9012".parse().unwrap()));
+    }
+
+    /* Requires sliding sync */
+
+    #[async_test]
+    #[cfg(feature = "experimental-sliding-sync")]
+    async fn test_requires_sliding_sync_with_legacy_well_known() {
+        // Given a base server with a well-known file that points to a homeserver that
+        // doesn't support sliding sync.
+        let server = MockServer::start().await;
+        let homeserver = make_mock_homeserver().await;
+        let mut builder = ClientBuilder::new();
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/matrix/client"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(make_well_known_json(&homeserver.uri(), None)),
+            )
+            .mount(&server)
+            .await;
+
+        // When building a client that requires sliding sync with the base server.
+        builder = builder.requires_sliding_sync().server_name_or_homeserver_url(server.uri());
+        let error = builder.build().await.unwrap_err();
+
+        // Then the operation should fail due to the lack of sliding sync support.
+        assert_matches!(error, ClientBuildError::SlidingSyncNotAvailable);
+    }
+
+    #[async_test]
+    #[cfg(feature = "experimental-sliding-sync")]
+    async fn test_requires_sliding_sync_with_well_known() {
+        // Given a base server with a well-known file that points to a homeserver with a
+        // sliding sync proxy.
+        let server = MockServer::start().await;
+        let homeserver = make_mock_homeserver().await;
+        let mut builder = ClientBuilder::new();
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/matrix/client"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_well_known_json(
+                &homeserver.uri(),
+                Some("https://localhost:1234"),
+            )))
+            .mount(&server)
+            .await;
+
+        // When building a client that requires sliding sync with the base server.
+        builder = builder.requires_sliding_sync().server_name_or_homeserver_url(server.uri());
+        let _client = builder.build().await.unwrap();
+
+        // Then a client should be built with support for sliding sync.
+        assert_eq!(_client.sliding_sync_proxy(), Some("https://localhost:1234".parse().unwrap()));
+    }
+
+    #[async_test]
+    #[cfg(feature = "experimental-sliding-sync")]
+    async fn test_requires_sliding_sync_with_custom_proxy() {
+        // Given a homeserver without a well-known file and with a custom sliding sync
+        // proxy injected.
+        let homeserver = make_mock_homeserver().await;
+        let mut builder = ClientBuilder::new();
+        builder = builder.sliding_sync_proxy("https://localhost:1234");
+
+        // When building a client that requires sliding sync with the server's URL.
+        builder = builder.requires_sliding_sync().server_name_or_homeserver_url(homeserver.uri());
+        let _client = builder.build().await.unwrap();
+
+        // Then a client should be built with support for sliding sync.
+        assert_eq!(_client.sliding_sync_proxy(), Some("https://localhost:1234".parse().unwrap()));
     }
 
     /* Helper functions */


### PR DESCRIPTION
This PR is a small part of #3029 that moves (and tests) the check for mandatory sliding sync from the FFI into the SDK with the use of a `ClientBuilder::requires_sliding_sync` method.