### PR TITLE
timeline: when deduplicating event meta, keep the most recent instead of the oldest

### DIFF
--- a/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/sliding_sync.rs
@@ -416,6 +416,10 @@ async fn test_timeline_duplicated_events() -> Result<()> {
         assert_timeline_stream! {
             [timeline_stream]
             update[3] "$x3:bar.org";
+            update[1] "$x1:bar.org";
+            remove[1];
+            append    "$x1:bar.org";
+            update[3] "$x1:bar.org";
             append    "$x4:bar.org";
         };
     }


### PR DESCRIPTION
Not doing this leads to an invalid ordering of events, as shown in the test: if we increase the timeline limit of a room using sliding sync, we'll receive a duplicate event, and if we ignore it, it'll be in an invalid position. The solution is to keep the most recent event (and remove the old one from event_meta).