### PR TITLE
refactor(sdk-crypto): Room key sharing, introduce extensible strategy

### DIFF
--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -31,7 +31,7 @@ pub use logger::{set_logger, Logger};
 pub use machine::{KeyRequestPair, OlmMachine, SignatureVerification};
 use matrix_sdk_common::deserialized_responses::ShieldState as RustShieldState;
 use matrix_sdk_crypto::{
-    olm::{IdentityKeys, InboundGroupSession, Session},
+    olm::{CollectStrategy, IdentityKeys, InboundGroupSession, Session},
     store::{Changes, CryptoStore, PendingChanges, RoomSettings as RustRoomSettings},
     types::{EventEncryptionAlgorithm as RustEventEncryptionAlgorithm, SigningKey},
     EncryptionSettings as RustEncryptionSettings,
@@ -650,7 +650,7 @@ impl From<EncryptionSettings> for RustEncryptionSettings {
             rotation_period: Duration::from_secs(v.rotation_period),
             rotation_period_msgs: v.rotation_period_msgs,
             history_visibility: v.history_visibility.into(),
-            only_allow_trusted_devices: v.only_allow_trusted_devices,
+            sharing_strategy: CollectStrategy::new_device_based(v.only_allow_trusted_devices),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2263,7 +2263,8 @@ pub(crate) mod tests {
         error::{EventError, SetRoomSettingsError},
         machine::{EncryptionSyncChanges, OlmMachine},
         olm::{
-            BackedUpRoomKey, ExportedRoomKey, InboundGroupSession, OutboundGroupSession, VerifyJson,
+            BackedUpRoomKey, CollectStrategy, ExportedRoomKey, InboundGroupSession,
+            OutboundGroupSession, VerifyJson,
         },
         store::{BackupDecryptionKey, Changes, CryptoStore, MemoryStore, RoomSettings},
         types::{
@@ -3083,8 +3084,10 @@ pub(crate) mod tests {
         let room_id = room_id!("!test:example.org");
 
         let encryption_settings = EncryptionSettings::default();
-        let encryption_settings =
-            EncryptionSettings { only_allow_trusted_devices: true, ..encryption_settings };
+        let encryption_settings = EncryptionSettings {
+            sharing_strategy: CollectStrategy::new_device_based(true),
+            ..encryption_settings
+        };
 
         let to_device_requests = alice
             .share_room_key(room_id, iter::once(bob.user_id()), encryption_settings)

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -24,8 +24,8 @@ pub(crate) use outbound::ShareState;
 pub use outbound::{
     EncryptionSettings, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo,
 };
+pub use share_strategy::CollectStrategy;
 pub(crate) use share_strategy::{CollectRecipientsHelper, CollectRecipientsResult};
-pub use share_strategy::{CollectStrategy, DeviceBasedStrategy};
 use thiserror::Error;
 pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};
 use vodozemac::{megolm::SessionKeyDecodeError, Curve25519PublicKey};

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/mod.rs
@@ -17,12 +17,15 @@ use serde::{Deserialize, Serialize};
 
 mod inbound;
 mod outbound;
+mod share_strategy;
 
 pub use inbound::{InboundGroupSession, PickledInboundGroupSession};
 pub(crate) use outbound::ShareState;
 pub use outbound::{
     EncryptionSettings, OutboundGroupSession, PickledOutboundGroupSession, ShareInfo,
 };
+pub(crate) use share_strategy::{CollectRecipientsHelper, CollectRecipientsResult};
+pub use share_strategy::{CollectStrategy, DeviceBasedStrategy};
 use thiserror::Error;
 pub use vodozemac::megolm::{ExportedSessionKey, SessionKey};
 use vodozemac::{megolm::SessionKeyDecodeError, Curve25519PublicKey};

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -42,7 +42,7 @@ pub use vodozemac::{
     PickleError,
 };
 
-use super::SessionCreationError;
+use super::{share_strategy::CollectStrategy, SessionCreationError};
 #[cfg(feature = "experimental-algorithms")]
 use crate::types::events::room::encrypted::MegolmV2AesSha2Content;
 use crate::{
@@ -85,10 +85,10 @@ pub struct EncryptionSettings {
     pub rotation_period_msgs: u64,
     /// The history visibility of the room when the session was created.
     pub history_visibility: HistoryVisibility,
-    /// Should untrusted devices receive the room key, or should they be
-    /// excluded from the conversation.
+    /// The strategy used to distribute the room keys to participant.
+    /// Default will send to all devices.
     #[serde(default)]
-    pub only_allow_trusted_devices: bool,
+    pub sharing_strategy: CollectStrategy,
 }
 
 impl Default for EncryptionSettings {
@@ -98,7 +98,7 @@ impl Default for EncryptionSettings {
             rotation_period: ROTATION_PERIOD,
             rotation_period_msgs: ROTATION_MESSAGES,
             history_visibility: HistoryVisibility::Shared,
-            only_allow_trusted_devices: false,
+            sharing_strategy: CollectStrategy::default(),
         }
     }
 }
@@ -122,7 +122,7 @@ impl EncryptionSettings {
             rotation_period,
             rotation_period_msgs,
             history_visibility,
-            only_allow_trusted_devices,
+            sharing_strategy: CollectStrategy::new_device_based(only_allow_trusted_devices),
         }
     }
 }

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/share_strategy.rs
@@ -65,7 +65,7 @@ pub enum CollectStrategy {
         /// conversation. A device is trusted if any of the following is true:
         ///     - It was manually marked as trusted.
         ///     - It was marked as verified via interactive verification.
-        ///     - It is signed by it's owner identity, and this identity has
+        ///     - It is signed by its owner identity, and this identity has
         ///       been trusted via interactive verification.
         ///     - It is the current own device of the user.
         only_allow_trusted_devices: bool,

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/share_strategy.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/share_strategy.rs
@@ -244,7 +244,7 @@ impl DeviceCollector for DeviceBasedStrategy {
                 }
             });
 
-            if recipients.len() > 0 {
+            if !recipients.is_empty() {
                 allowed_devices.entry(user_id.to_owned()).or_default().extend(recipients);
             }
             withheld_devices.extend(withheld_recipients);
@@ -416,8 +416,7 @@ mod tests {
         let (_, code) = share_result
             .withheld_devices
             .iter()
-            .filter(|(d, _)| d.device_id().as_str() == "FRGNMZVOKA")
-            .nth(0)
+            .find(|(d, _)| d.device_id().as_str() == "FRGNMZVOKA")
             .expect("This dan's device should receive a withheld code");
 
         assert_eq!(code.as_str(), WithheldCode::Unverified.as_str());
@@ -425,8 +424,7 @@ mod tests {
         let (_, code) = share_result
             .withheld_devices
             .iter()
-            .filter(|(d, _)| d.device_id().as_str() == "HVCXJTHMBM")
-            .nth(0)
+            .find(|(d, _)| d.device_id().as_str() == "HVCXJTHMBM")
             .expect("This daves's device should receive a withheld code");
 
         assert_eq!(code.as_str(), WithheldCode::Unverified.as_str());

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -26,9 +26,9 @@ mod utility;
 pub use account::{Account, OlmMessageHash, PickledAccount, StaticAccountData};
 pub(crate) use account::{OlmDecryptionInfo, SessionType};
 pub use group_sessions::{
-    BackedUpRoomKey, CollectStrategy, DeviceBasedStrategy, EncryptionSettings, ExportedRoomKey,
-    InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,
-    PickledOutboundGroupSession, SessionCreationError, SessionExportError, SessionKey, ShareInfo,
+    BackedUpRoomKey, CollectStrategy, EncryptionSettings, ExportedRoomKey, InboundGroupSession,
+    OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession,
+    SessionCreationError, SessionExportError, SessionKey, ShareInfo,
 };
 pub(crate) use group_sessions::{CollectRecipientsHelper, CollectRecipientsResult, ShareState};
 pub use session::{PickledSession, Session};

--- a/crates/matrix-sdk-crypto/src/olm/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/mod.rs
@@ -25,12 +25,12 @@ mod utility;
 
 pub use account::{Account, OlmMessageHash, PickledAccount, StaticAccountData};
 pub(crate) use account::{OlmDecryptionInfo, SessionType};
-pub(crate) use group_sessions::ShareState;
 pub use group_sessions::{
-    BackedUpRoomKey, EncryptionSettings, ExportedRoomKey, InboundGroupSession,
-    OutboundGroupSession, PickledInboundGroupSession, PickledOutboundGroupSession,
-    SessionCreationError, SessionExportError, SessionKey, ShareInfo,
+    BackedUpRoomKey, CollectStrategy, DeviceBasedStrategy, EncryptionSettings, ExportedRoomKey,
+    InboundGroupSession, OutboundGroupSession, PickledInboundGroupSession,
+    PickledOutboundGroupSession, SessionCreationError, SessionExportError, SessionKey, ShareInfo,
 };
+pub(crate) use group_sessions::{CollectRecipientsHelper, CollectRecipientsResult, ShareState};
 pub use session::{PickledSession, Session};
 pub use signing::{CrossSigningStatus, PickledCrossSigningIdentity, PrivateCrossSigningIdentity};
 pub(crate) use utility::{SignedJsonObject, VerifyJson};

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -15,26 +15,27 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
-    ops::Deref,
     sync::{Arc, RwLock as StdRwLock},
 };
 
 use futures_util::future::join_all;
-use itertools::{Either, Itertools};
+use itertools::Itertools;
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     events::{AnyMessageLikeEventContent, ToDeviceEventType},
     serde::Raw,
     to_device::DeviceIdOrAllDevices,
-    DeviceId, OwnedDeviceId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId,
-    UserId,
+    OwnedDeviceId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, TransactionId, UserId,
 };
 use tracing::{debug, error, info, instrument, trace};
 
 use crate::{
     error::{EventError, MegolmResult, OlmResult},
     identities::device::MaybeEncryptedRoomKey,
-    olm::{InboundGroupSession, OutboundGroupSession, Session, ShareInfo, ShareState},
+    olm::{
+        CollectRecipientsHelper, CollectRecipientsResult, CollectStrategy, InboundGroupSession,
+        OutboundGroupSession, Session, ShareInfo, ShareState,
+    },
     store::{Changes, CryptoStoreWrapper, Result as StoreResult, Store},
     types::events::{room::encrypted::RoomEncryptedEventContent, room_key_withheld::WithheldCode},
     EncryptionSettings, OlmError, ReadOnlyDevice, ToDeviceRequest,
@@ -114,23 +115,6 @@ impl GroupSessionCache {
     fn mark_as_being_shared(&self, id: OwnedTransactionId, session: OutboundGroupSession) {
         self.sessions_being_shared.write().unwrap().insert(id, session);
     }
-}
-
-/// Returned by `collect_session_recipients`.
-///
-/// Information indicating whether the session needs to be rotated
-/// (`should_rotate`) and the list of users/devices that should receive
-/// (`devices`) or not the session,  including withheld reason
-/// `withheld_devices`.
-#[derive(Debug)]
-pub(crate) struct CollectRecipientsResult {
-    /// If true the outbound group session should be rotated
-    pub should_rotate: bool,
-    /// The map of user|device that should receive the session
-    pub devices: BTreeMap<OwnedUserId, Vec<ReadOnlyDevice>>,
-    /// The map of user|device that won't receive the key with the withheld
-    /// code.
-    pub withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)>,
 }
 
 #[derive(Debug, Clone)]
@@ -350,118 +334,9 @@ impl GroupSessionManager {
         settings: &EncryptionSettings,
         outbound: &OutboundGroupSession,
     ) -> OlmResult<CollectRecipientsResult> {
-        let users: BTreeSet<&UserId> = users.collect();
-        let mut devices: BTreeMap<OwnedUserId, Vec<ReadOnlyDevice>> = Default::default();
-        let mut withheld_devices: Vec<(ReadOnlyDevice, WithheldCode)> = Default::default();
-
-        trace!(?users, ?settings, "Calculating group session recipients");
-
-        let users_shared_with: BTreeSet<OwnedUserId> =
-            outbound.shared_with_set.read().unwrap().keys().cloned().collect();
-
-        let users_shared_with: BTreeSet<&UserId> =
-            users_shared_with.iter().map(Deref::deref).collect();
-
-        // A user left if a user is missing from the set of users that should
-        // get the session but is in the set of users that received the session.
-        let user_left = !users_shared_with.difference(&users).collect::<BTreeSet<_>>().is_empty();
-
-        let visibility_changed =
-            outbound.settings().history_visibility != settings.history_visibility;
-        let algorithm_changed = outbound.settings().algorithm != settings.algorithm;
-
-        // To protect the room history we need to rotate the session if either:
-        //
-        // 1. Any user left the room.
-        // 2. Any of the users' devices got deleted or blacklisted.
-        // 3. The history visibility changed.
-        // 4. The encryption algorithm changed.
-        //
-        // This is calculated in the following code and stored in this variable.
-        let mut should_rotate = user_left || visibility_changed || algorithm_changed;
-
-        let own_identity =
-            self.store.get_user_identity(self.store.user_id()).await?.and_then(|i| i.into_own());
-
-        for user_id in users {
-            let user_devices = self.store.get_readonly_devices_filtered(user_id).await?;
-
-            // We only need the user identity if settings.only_allow_trusted_devices is set.
-            let device_owner_identity = if settings.only_allow_trusted_devices {
-                self.store.get_user_identity(user_id).await?
-            } else {
-                None
-            };
-
-            // From all the devices a user has, we're splitting them into two
-            // buckets, a bucket of devices that should receive the
-            // room key and a bucket of devices that should receive
-            // a withheld code.
-            let (recipients, withheld_recipients): (
-                Vec<ReadOnlyDevice>,
-                Vec<(ReadOnlyDevice, WithheldCode)>,
-            ) = user_devices.into_values().partition_map(|d| {
-                if d.is_blacklisted() {
-                    Either::Right((d, WithheldCode::Blacklisted))
-                } else if settings.only_allow_trusted_devices
-                    && !d.is_verified(&own_identity, &device_owner_identity)
-                {
-                    Either::Right((d, WithheldCode::Unverified))
-                } else {
-                    Either::Left(d)
-                }
-            });
-
-            // If we haven't already concluded that the session should be
-            // rotated for other reasons, we also need to check whether any
-            // of the devices in the session got deleted or blacklisted in the
-            // meantime. If so, we should also rotate the session.
-            if !should_rotate {
-                // Device IDs that should receive this session
-                let recipient_device_ids: BTreeSet<&DeviceId> =
-                    recipients.iter().map(|d| d.device_id()).collect();
-
-                if let Some(shared) = outbound.shared_with_set.read().unwrap().get(user_id) {
-                    // Devices that received this session
-                    let shared: BTreeSet<OwnedDeviceId> = shared.keys().cloned().collect();
-                    let shared: BTreeSet<&DeviceId> = shared.iter().map(|d| d.as_ref()).collect();
-
-                    // The set difference between
-                    //
-                    // 1. Devices that had previously received the session, and
-                    // 2. Devices that would now receive the session
-                    //
-                    // Represents newly deleted or blacklisted devices. If this
-                    // set is non-empty, we must rotate.
-                    let newly_deleted_or_blacklisted =
-                        shared.difference(&recipient_device_ids).collect::<BTreeSet<_>>();
-
-                    should_rotate = !newly_deleted_or_blacklisted.is_empty();
-                    if should_rotate {
-                        debug!(
-                            "Rotating a room key due to these devices being deleted/blacklisted {:?}",
-                            newly_deleted_or_blacklisted,
-                        );
-                    }
-                };
-            }
-
-            devices.entry(user_id.to_owned()).or_default().extend(recipients);
-            withheld_devices.extend(withheld_recipients);
-        }
-
-        if should_rotate {
-            debug!(
-                should_rotate,
-                user_left,
-                visibility_changed,
-                algorithm_changed,
-                "Rotating room key to protect room history",
-            );
-        }
-        trace!(should_rotate, "Done calculating group session recipients");
-
-        Ok(CollectRecipientsResult { should_rotate, devices, withheld_devices })
+        let collection_helper =
+            CollectRecipientsHelper { collection_strategy: settings.sharing_strategy.clone() };
+        collection_helper.collect_session_recipients(settings, &self.store, users, outbound).await
     }
 
     async fn encrypt_request(
@@ -871,10 +746,12 @@ mod tests {
     use serde_json::{json, Value};
 
     use crate::{
+        olm::{CollectRecipientsHelper, CollectStrategy},
         session_manager::group_sessions::CollectRecipientsResult,
         types::{
             events::room_key_withheld::{
-                RoomKeyWithheldContent, RoomKeyWithheldContent::MegolmV1AesSha2, WithheldCode,
+                RoomKeyWithheldContent::{self, MegolmV1AesSha2},
+                WithheldCode,
             },
             EventEncryptionAlgorithm,
         },
@@ -1237,8 +1114,10 @@ mod tests {
             .iter()
             .any(|d| d.user_id() == user_id && d.device_id() == device_id));
 
-        let settings =
-            EncryptionSettings { only_allow_trusted_devices: true, ..Default::default() };
+        let settings = EncryptionSettings {
+            sharing_strategy: CollectStrategy::new_device_based(true),
+            ..Default::default()
+        };
         let users = [user_id].into_iter();
 
         let CollectRecipientsResult { devices: recipients, .. } = machine
@@ -1295,8 +1174,10 @@ mod tests {
         let keys_claim = keys_claim_response();
 
         let users = keys_claim.one_time_keys.keys().map(Deref::deref);
-        let settings =
-            EncryptionSettings { only_allow_trusted_devices: true, ..Default::default() };
+        let settings = EncryptionSettings {
+            sharing_strategy: CollectStrategy::new_device_based(true),
+            ..Default::default()
+        };
 
         // Trust only one
         let user_id = user_id!("@example:localhost");

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -746,7 +746,7 @@ mod tests {
     use serde_json::{json, Value};
 
     use crate::{
-        olm::{CollectRecipientsHelper, CollectStrategy},
+        olm::CollectStrategy,
         session_manager::group_sessions::CollectRecipientsResult,
         types::{
             events::room_key_withheld::{
@@ -1127,7 +1127,7 @@ mod tests {
             .await
             .expect("We should be able to collect the session recipients");
 
-        assert!(recipients[user_id].is_empty());
+        assert!(!recipients.contains_key(user_id));
 
         let device_id = "AFGUOBTZWM".into();
         let device = machine.get_device(user_id, device_id, None).await.unwrap().unwrap();

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -334,9 +334,8 @@ impl GroupSessionManager {
         settings: &EncryptionSettings,
         outbound: &OutboundGroupSession,
     ) -> OlmResult<CollectRecipientsResult> {
-        let collection_helper =
-            CollectRecipientsHelper { collection_strategy: settings.sharing_strategy.clone() };
-        collection_helper.collect_session_recipients(settings, &self.store, users, outbound).await
+        CollectRecipientsHelper::collect_session_recipients(settings, &self.store, users, outbound)
+            .await
     }
 
     async fn encrypt_request(

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs
@@ -33,7 +33,7 @@ use crate::{
     error::{EventError, MegolmResult, OlmResult},
     identities::device::MaybeEncryptedRoomKey,
     olm::{
-        CollectRecipientsHelper, CollectRecipientsResult, CollectStrategy, InboundGroupSession,
+        CollectRecipientsHelper, CollectRecipientsResult, InboundGroupSession,
         OutboundGroupSession, Session, ShareInfo, ShareState,
     },
     store::{Changes, CryptoStoreWrapper, Result as StoreResult, Store},

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -1,0 +1,366 @@
+use ruma::{
+    api::{client::keys::get_keys::v3::Response as KeyQueryResponse, IncomingResponse},
+    device_id, user_id, DeviceId, UserId,
+};
+use serde_json::json;
+
+use crate::response_from_file;
+
+/// ============================================================================
+/// ============================================================================
+///
+/// This set of keys/query response was generated using a local synapse.
+/// Each users was created, device added according to needs and the payload
+/// of the keys query have been copy/pasted here.
+///
+/// The current user is `@me:localhost`, the private part of the
+/// cross-signing keys have been exported using the console with the
+/// following snippet:  `await mxMatrixClientPeg.get().getCrypto().
+/// olmMachine.exportCrossSigningKeys()`.
+///
+/// They are imported in the test here in order to verify user signatures.
+///
+/// * `@me:localhost` is the current user mxId.
+///
+/// * `@dan:localhost` is a user with cross-signing enabled, with 2 devices. One
+///   device (`JHPUERYQUW`) is self signed by @dan, but not the other one
+///   (`FRGNMZVOKA`). `@me` has verified `@dan`, can be seen because `@dan`
+///   master key has a signature by `@me` ssk
+///
+/// * `@dave` is a user that has not enabled cross-signing. And has one device
+///   (`HVCXJTHMBM`).
+///
+///
+/// * `@good` is a user with cross-signing enabled, with 2 devices. The 2
+///   devices are properly signed by `@good` (i.e were self-verified by @good)
+/// ============================================================================
+/// ============================================================================
+pub struct KeyDistributionTestData {}
+
+#[allow(dead_code)]
+impl KeyDistributionTestData {
+    pub const MASTER_KEY_PRIVATE_EXPORT: &'static str =
+        "9kquJqAtEUoTXljh5W2QSsCm4FH9WvWzIkDkIMUsM2k";
+    pub const SELF_SIGNING_KEY_PRIVATE_EXPORT: &'static str =
+        "QifnGfudByh/GpBgJYEMzq7/DGbp6fZjp58faQj3n1M";
+    pub const USER_SIGNING_KEY_PRIVATE_EXPORT: &'static str =
+        "zQSosK46giUFs2ACsaf32bA7drcIXbmViyEt+TLfloI";
+
+    /// Current user keys query response containing the cross-signing keys
+    pub fn me_keys_query_response() -> KeyQueryResponse {
+        let data = json!({
+            "master_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "5G9+Ns28rzNd+2DvP73Y0orr8sxduRQcrJj0YB7ZygH7oeXshvGLeQn6mcNs7q7ZrMR5bYlXxopufKSWWoKpCg",
+                            "ed25519:YVKUSVBKWX": "ih1Kmj4dTB1AjjkwrLA2qIL3e/oPUFisP5Ic8kGp29wrpoHokasKKnkRl1zS7zq6iBcOL6aOZLPPX/ZHYCX5BQ"
+                        }
+                    },
+                    "usage": [
+                        "master"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            },
+            "self_signing_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw": "9gXJQzvqZ+KQunfBTd0g9AkrulwEeFfspyWTSQFqqrw"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "amiKDLpWIwUQPzq+eov6KJsoskkWA1YzrGNb7HF3OcGV0nm4t7df0tUdZB/OpREtT5D78BKtzOPUipde2DxUAw"
+                        }
+                    },
+                    "usage": [
+                        "self_signing"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            },
+            "user_signing_keys": {
+                "@me:localhost": {
+                    "keys": {
+                        "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY"
+                    },
+                    "signatures": {
+                        "@me:localhost": {
+                            "ed25519:KOS8zz9SJnMOxpfPOx9LO2+abuEcnZP/lxDo5RsXao4": "Cv56vTHAzRkvdcELleOlhECZQP0pXcikCdEZrnXbkjXQ/k0ZvVOJ1beG/SiH8xc6zh1bCIMYv96C9p8o+7VZCQ"
+                        }
+                    },
+                    "usage": [
+                        "user_signing"
+                    ],
+                    "user_id": "@me:localhost"
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Dan has cross-signing setup, one device is cross signed `JHPUERYQUW`,
+    /// but not the other one `FRGNMZVOKA`.
+    /// `@dan` identity is signed by `@me` identity (alice trust dan)
+    pub fn dan_keys_query_response() -> KeyQueryResponse {
+        let data = json!({
+                "device_keys": {
+                    "@dan:localhost": {
+                        "JHPUERYQUW": {
+                            "algorithms": [
+                                "m.olm.v1.curve25519-aes-sha2",
+                                "m.megolm.v1.aes-sha2"
+                            ],
+                            "device_id": "JHPUERYQUW",
+                            "keys": {
+                                "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
+                                "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+                            },
+                            "signatures": {
+                                "@dan:localhost": {
+                                    "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
+                                    "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
+                                }
+                            },
+                            "user_id": "@dan:localhost",
+                        },
+                        "FRGNMZVOKA": {
+                            "algorithms": [
+                                "m.olm.v1.curve25519-aes-sha2",
+                                "m.megolm.v1.aes-sha2"
+                            ],
+                            "device_id": "FRGNMZVOKA",
+                            "keys": {
+                                "curve25519:FRGNMZVOKA": "Hc/BC/xyQIEnScyZkEk+ilDMfOARxHMFoEcggPqqRw4",
+                                "ed25519:FRGNMZVOKA": "jVroR0JoRemjF0vJslY3HirJgwfX5gm5DCM64hZgkI0"
+                            },
+                            "signatures": {
+                                "@dan:localhost": {
+                                    "ed25519:FRGNMZVOKA": "+row23EcWR2D8EKgwzZmy3dWz/l5DHvEHR6jHKnBohphEIsBl0o3Cp9rIztFpStFGRPSAa3xEqfMVW2dIaKkCg"
+                                }
+                            },
+                            "user_id": "@dan:localhost",
+                        },
+                    }
+                },
+                "failures": {},
+                "master_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
+                                "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+                            },
+                            "@me:localhost": {
+                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+                            }
+                        },
+                        "usage": [
+                            "master"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                },
+                "self_signing_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+                            }
+                        },
+                        "usage": [
+                            "self_signing"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                },
+                "user_signing_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+                            }
+                        },
+                        "usage": [
+                            "user_signing"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Dave is a user that has not enabled cross-signing
+    pub fn dave_keys_query_response() -> KeyQueryResponse {
+        let data = json!({
+            "device_keys": {
+                "@dave:localhost": {
+                    "HVCXJTHMBM": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "HVCXJTHMBM",
+                        "keys": {
+                            "curve25519:HVCXJTHMBM": "0GPOoQwhAGVu1lIvOZway3/XjdxVNHEi5z/4by8TzxU",
+                            "ed25519:HVCXJTHMBM": "/4ZzD1Ou70/Ojj5aaPqBopCN8SzQpKM7itiWZ/07fXc"
+                        },
+                        "signatures": {
+                            "@dave:localhost": {
+                                "ed25519:HVCXJTHMBM": "b1DV7xN2My2oXbZVVtTeJR9hzXIg1Cx4h+W51+tVq5GAoSYtrWR31PyKPROk28CvQ9Pu++/jdomaW7/oYPxoCg",
+                            }
+                        },
+                        "user_id": "@dave:localhost",
+                    }
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Good is a user that has all his devices correctly cross-signed
+    pub fn good_keys_query_response() -> KeyQueryResponse {
+        let data = json!({
+            "device_keys": {
+                "@good:localhost": {
+                    "JAXGBVZYLA": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "JAXGBVZYLA",
+                        "keys": {
+                            "curve25519:JAXGBVZYLA": "a4vWxnHUKvELfB7WYLCW07vEbwybZReyKReWHxQhgW0",
+                            "ed25519:JAXGBVZYLA": "m22nVxqJK72iph+FhOMqX/MDd7AoF9BJ033MlMLnDCg"
+                        },
+                        "signatures": {
+                            "@good:localhost": {
+                                "ed25519:JAXGBVZYLA": "EXKQiXNKjWSE76WxF8TUvxjCyw/qsV27gcbsgpSN1zzHzGzVdY1Qr4EB8t/76SL5rZP/9hqcAvqPSJW/N7iKCg",
+                                "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "sXJUXKE7hqXnsNbqlzS/1MGlGmeJU54v6/UMWAs+6bCzOFUC1+uqU1KlzfmpsVG3MKxR4r/ZLZdxoKVfUuQMAA"
+                            }
+                        },
+                        "user_id": "@good:localhost"
+                    },
+                    "ZGLCFWEPCY": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "ZGLCFWEPCY",
+                        "keys": {
+                            "curve25519:ZGLCFWEPCY": "kfcIEf6ZRgTP184yuIJYabfsBFsGXiVQE/cyW9qYnQA",
+                            "ed25519:ZGLCFWEPCY": "WLSA1tSe0eOZCeESH5WMb9cp3AgRZzm4ooSud+NwcEw"
+                        },
+                        "signatures": {
+                            "@good:localhost": {
+                                "ed25519:ZGLCFWEPCY": "AVXFgHk/QcAbOVBF5Xu4OW+03CZKBs2qAYh0fjIA49r+X+aX7QIKrbRyXU/ictPBLMpj1yXF+2J5vwR/KQYVCA",
+                                "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "VZk70FWiYN/YSwGykt2CygcOl1bq2D+dVSSKBL5GA5uHXxt6ypDlYvtWprM1l7re3llp5j105MevsjQ+2sWmCw"
+                            }
+                        },
+                        "user_id": "@good:localhost"
+                    }
+                }
+            },
+            "failures": {},
+            "master_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "imAhrTIlPuf6hNqlbcSUnC2ndZPk5NwQLzbi9kZ8nmnPGjmv39f4U4Vh/KiweqQnI4ActGpcYyM7k9S2Ef8/CQ",
+                            "ed25519:HPNYOQGUEE": "6w3egsvd+oVPCclef+hF1CfFMZrGTf/plFvPU5iP69WNw4w0UPAKSV1jOzh7Wv4LVGX5O3afjA9DG+O7aHZmBw"
+                        }
+                    },
+                    "usage": [
+                        "master"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            },
+            "self_signing_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U": "YwQVBWn2sA5lLqp/dQsNk7fiYOuQuQhujefOPjejc+U"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "2AyR8lovFv8J1DwPwdCsAM9Tw877QhaVHmVkPopsmSokS2fst8LDQtsg/PiftVc+74NGz5tnYIMDxn4BjAisAg"
+                        }
+                    },
+                    "usage": [
+                        "self_signing"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            },
+            "user_signing_keys": {
+                "@good:localhost": {
+                    "keys": {
+                        "ed25519:u1PwO3/a/HTnN9IF7BVa2dJQ7bc00J22eNS0vM4FjTA": "u1PwO3/a/HTnN9IF7BVa2dJQ7bc00J22eNS0vM4FjTA"
+                    },
+                    "signatures": {
+                        "@good:localhost": {
+                            "ed25519:5vTK2S2wVXo4xGT4BhcwpINVjRLjorkkJgCjnrHgtl8": "88v9/Z3TJeY2lsu3cFQaEuhHH5ixjJs22ALQRKY+O6VPGCT/BAzH6kUb7teinFfpvQjoXN3t5fVJxbP9mVlxDg"
+                        }
+                    },
+                    "usage": [
+                        "user_signing"
+                    ],
+                    "user_id": "@good:localhost"
+                }
+            }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    pub fn me_id() -> &'static UserId {
+        user_id!("@me:localhost")
+    }
+
+    pub fn me_device_id() -> &'static DeviceId {
+        device_id!("ABCDEFGH")
+    }
+
+    pub fn dan_id() -> &'static UserId {
+        user_id!("@dan:localhost")
+    }
+
+    pub fn dave_id() -> &'static UserId {
+        user_id!("@dave:localhost")
+    }
+
+    pub fn good_id() -> &'static UserId {
+        user_id!("@good:localhost")
+    }
+}

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -110,7 +110,7 @@ impl KeyDistributionTestData {
     /// but not the other one `FRGNMZVOKA`.
     /// `@dan` identity is signed by `@me` identity (alice trust dan)
     pub fn dan_keys_query_response() -> KeyQueryResponse {
-        let data = json!({
+        let data: serde_json::Value = json!({
                 "device_keys": {
                     "@dan:localhost": {
                         "JHPUERYQUW": {
@@ -144,6 +144,92 @@ impl KeyDistributionTestData {
                             "signatures": {
                                 "@dan:localhost": {
                                     "ed25519:FRGNMZVOKA": "+row23EcWR2D8EKgwzZmy3dWz/l5DHvEHR6jHKnBohphEIsBl0o3Cp9rIztFpStFGRPSAa3xEqfMVW2dIaKkCg"
+                                }
+                            },
+                            "user_id": "@dan:localhost",
+                        },
+                    }
+                },
+                "failures": {},
+                "master_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "DI/zpWA/wG1tdK9aLof1TGBHtihtQZQ+7e62QRSBbo+RAHlQ+akGcaVskLbtLdEKbcJEt61F+Auol+XVGlCEBA",
+                                "ed25519:SNEBMNPLHN": "5Y8byBteGZo1SvPf8QM88pvThJu+2mJ4020YsTLPhCQ4DfdalHWTPOvE7gw09cCONhX/cKY7YHMyH8R26Yd9DA"
+                            },
+                            "@me:localhost": {
+                                "ed25519:mvzOc2EuHoVfZTk1hX3y0hyjUs4MrfPv2V/PUFzMQJY": "vg2MLJx36Usti4NfsbOfk0ipW7koOoTlBibZkQNrPTMX88V+geTgDjvIMEU/OAyEsgsDHjg3C+2t/yUUDE7hBA"
+                            }
+                        },
+                        "usage": [
+                            "master"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                },
+                "self_signing_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "vxUCzOO4EGwLp+tzfoFbPOVicynvmWgxVx/bv/3fG/Xfl7piJVmeHP+1qDstOewiREuO4W+ti/tYkOXd7GgoAw"
+                            }
+                        },
+                        "usage": [
+                            "self_signing"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                },
+                "user_signing_keys": {
+                    "@dan:localhost": {
+                        "keys": {
+                            "ed25519:N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU": "N4y+jN6GctRXyNDa1CFRdjofTTxHkNK9t430jE9DxrU"
+                        },
+                        "signatures": {
+                            "@dan:localhost": {
+                                "ed25519:Nj4qZEmWplA8tofkjcR+YOvRCYMRLDKY71BT9GFO32k": "gbcD579EGVDRePnKV9j6YNwGhssgFeJWhF1NRJhFNAcpbGL8911cW54jyiFKFCev89QemfqyFFljldFLfyN9DA"
+                            }
+                        },
+                        "usage": [
+                            "user_signing"
+                        ],
+                        "user_id": "@dan:localhost"
+                    }
+                }
+        });
+
+        let data = response_from_file(&data);
+
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// Same as `dan_keys_query_response` but `FRGNMZVOKA` was removed.
+    pub fn dan_keys_query_response_device_loggedout() -> KeyQueryResponse {
+        let data = json!({
+                "device_keys": {
+                    "@dan:localhost": {
+                        "JHPUERYQUW": {
+                            "algorithms": [
+                                "m.olm.v1.curve25519-aes-sha2",
+                                "m.megolm.v1.aes-sha2"
+                            ],
+                            "device_id": "JHPUERYQUW",
+                            "keys": {
+                                "curve25519:JHPUERYQUW": "PBo2nKbink/HxgzMrBftGPogsD0d47LlIMsViTpCRn4",
+                                "ed25519:JHPUERYQUW": "jZ5Ca/J5RXn3qnNWIHFz9EQBZ4637QI/9ExSiEcGC7I"
+                            },
+                            "signatures": {
+                                "@dan:localhost": {
+                                    "ed25519:JHPUERYQUW": "PaVfCE9QODgluq0gYMpjCarfDbraRXU71uRcUN5MoqtiJYlB0bjzY6bD5/qxugrsgcx4DZOgCLgiyoEZ/vW4DQ",
+                                    "ed25519:aX+O6rO/RxzkygPd7XXilKM07aSFK4gSPK1Zxenr6ak": "2sZcF5aSyEuryTfWgsw3rNDevnZisH2Df6fCO5pmGwweiaD+n6+pyrzB75mvA1sOwzm9jfTsjv/2+Uj1CNOTBA"
                                 }
                             },
                             "user_id": "@dan:localhost",
@@ -350,6 +436,18 @@ impl KeyDistributionTestData {
 
     pub fn me_device_id() -> &'static DeviceId {
         device_id!("ABCDEFGH")
+    }
+
+    pub fn dan_unsigned_device_id() -> &'static DeviceId {
+        device_id!("FRGNMZVOKA")
+    }
+
+    pub fn dan_signed_device_id() -> &'static DeviceId {
+        device_id!("JHPUERYQUW")
+    }
+
+    pub fn dave_device_id() -> &'static DeviceId {
+        device_id!("HVCXJTHMBM")
     }
 
     pub fn dan_id() -> &'static UserId {

--- a/testing/matrix-sdk-test/src/test_json/mod.rs
+++ b/testing/matrix-sdk-test/src/test_json/mod.rs
@@ -10,6 +10,7 @@ use serde_json::{json, Value as JsonValue};
 use crate::DEFAULT_TEST_ROOM_ID;
 
 pub mod api_responses;
+pub mod keys_query_sets;
 pub mod members;
 pub mod search_users;
 pub mod sync;


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Fixes: https://github.com/matrix-org/matrix-rust-sdk/issues/3562

Extracted the logic to collect the devices that should receive a room key.
Introduce a new `CollectStrategy` that will define how to sort devices that should receive the room_key and those that should receive a witheld code.
The common part of sharing (checking if the session should be rotated) is done by the `CollectRecipientsHelper`, then the actual selection is delegated depending on th  `CollectStrategy`

There is no functional changes in this PR, a following PR will introduce an `IdentityBased` strategy that will select devices depending on if they are signed by their owner.

Also created some testing data that can be reused for various tests, will be used by the new strategy also. This is isolated in the first commit.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
