### PR TITLE
room: rename the `encrypted` log field to `encrypted_room`

### DIFF
--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -32,7 +32,9 @@ use ruma::{
     serde::Raw,
     OwnedTransactionId, TransactionId,
 };
-use tracing::{debug, info, Instrument, Span};
+#[cfg(feature = "image-proc")]
+use tracing::debug;
+use tracing::{info, trace, Instrument, Span};
 
 use super::Room;
 #[cfg(feature = "image-proc")]
@@ -172,17 +174,17 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
             Span::current().record("transaction_id", tracing::field::debug(&txn_id));
 
             #[cfg(not(feature = "e2e-encryption"))]
-            debug!("Sending plaintext event to room because we don't have encryption support.");
+            trace!("Sending plaintext event to room because we don't have encryption support.");
 
             #[cfg(feature = "e2e-encryption")]
             if room.is_encrypted().await? {
-                Span::current().record("encrypted", true);
+                Span::current().record("encrypted_room", true);
                 // Reactions are currently famously not encrypted, skip encrypting
                 // them until they are.
                 if event_type == "m.reaction" {
-                    debug!("Sending plaintext event because of the event type.");
+                    trace!("Sending plaintext event because of the event type.");
                 } else {
-                    debug!(
+                    trace!(
                         room_id = ?room.room_id(),
                         "Sending encrypted event because the room is encrypted.",
                     );
@@ -210,8 +212,8 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
                     event_type = "m.room.encrypted";
                 }
             } else {
-                Span::current().record("encrypted", false);
-                debug!("Sending plaintext event because the room is NOT encrypted.",);
+                Span::current().record("encrypted_room", false);
+                trace!("Sending plaintext event because the room is NOT encrypted.",);
             };
 
             let request = send_message_event::v3::Request::new_raw(

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -178,7 +178,7 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
 
             #[cfg(feature = "e2e-encryption")]
             if room.is_encrypted().await? {
-                Span::current().record("encrypted_room", true);
+                Span::current().record("is_room_encrypted", true);
                 // Reactions are currently famously not encrypted, skip encrypting
                 // them until they are.
                 if event_type == "m.reaction" {
@@ -212,7 +212,7 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
                     event_type = "m.room.encrypted";
                 }
             } else {
-                Span::current().record("encrypted_room", false);
+                Span::current().record("is_room_encrypted", false);
                 trace!("Sending plaintext event because the room is NOT encrypted.",);
             };
 

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -32,9 +32,7 @@ use ruma::{
     serde::Raw,
     OwnedTransactionId, TransactionId,
 };
-#[cfg(feature = "image-proc")]
-use tracing::debug;
-use tracing::{info, trace, Instrument, Span};
+use tracing::{debug, info, Instrument, Span};
 
 use super::Room;
 #[cfg(feature = "image-proc")]
@@ -174,44 +172,46 @@ impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {
             Span::current().record("transaction_id", tracing::field::debug(&txn_id));
 
             #[cfg(not(feature = "e2e-encryption"))]
-            trace!("Sending plaintext event to room because we don't have encryption support.");
+            debug!("Sending plaintext event to room because we don't have encryption support.");
 
             #[cfg(feature = "e2e-encryption")]
-            if !room.is_encrypted().await? {
-                Span::current().record("encrypted", false);
-                trace!("Sending plaintext event because the room is NOT encrypted.",);
-            } else if event_type == "m.reaction" {
+            if room.is_encrypted().await? {
+                Span::current().record("encrypted", true);
                 // Reactions are currently famously not encrypted, skip encrypting
                 // them until they are.
-                Span::current().record("encrypted", false);
-                trace!("Sending plaintext event because of the event type.");
-            } else {
-                // Encrypt the event, since the room is encrypted.
-                Span::current().record("encrypted", true);
-                trace!(
-                    room_id = ?room.room_id(),
-                    "Sending encrypted event because the room is encrypted.",
-                );
+                if event_type == "m.reaction" {
+                    debug!("Sending plaintext event because of the event type.");
+                } else {
+                    debug!(
+                        room_id = ?room.room_id(),
+                        "Sending encrypted event because the room is encrypted.",
+                    );
 
-                if !room.are_members_synced() {
-                    room.sync_members().await?;
+                    if !room.are_members_synced() {
+                        room.sync_members().await?;
+                    }
+
+                    // Query keys in case we don't have them for newly synced members.
+                    //
+                    // Note we do it all the time, because we might have sync'd members before
+                    // sending a message (so didn't enter the above branch), but
+                    // could have not query their keys ever.
+                    room.query_keys_for_untracked_users().await?;
+
+                    room.preshare_room_key().await?;
+
+                    let olm = room.client.olm_machine().await;
+                    let olm = olm.as_ref().expect("Olm machine wasn't started");
+
+                    content = olm
+                        .encrypt_room_event_raw(room.room_id(), event_type, &content)
+                        .await?
+                        .cast();
+                    event_type = "m.room.encrypted";
                 }
-
-                // Query keys in case we don't have them for newly synced members.
-                //
-                // Note we do it all the time, because we might have sync'd members before
-                // sending a message (so didn't enter the above branch), but
-                // could have not query their keys ever.
-                room.query_keys_for_untracked_users().await?;
-
-                room.preshare_room_key().await?;
-
-                let olm = room.client.olm_machine().await;
-                let olm = olm.as_ref().expect("Olm machine wasn't started");
-
-                content =
-                    olm.encrypt_room_event_raw(room.room_id(), event_type, &content).await?.cast();
-                event_type = "m.room.encrypted";
+            } else {
+                Span::current().record("encrypted", false);
+                debug!("Sending plaintext event because the room is NOT encrypted.",);
             };
 
             let request = send_message_event::v3::Request::new_raw(

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -1690,12 +1690,14 @@ impl Room {
     /// }
     /// # anyhow::Ok(()) };
     /// ```
-    #[instrument(skip_all, fields(event_type, room_id = ?self.room_id(), transaction_id, encrypted, event_id))]
+    #[instrument(skip_all, fields(event_type, room_id = ?self.room_id(), transaction_id, is_room_encrypted, event_id))]
     pub fn send_raw<'a>(
         &'a self,
         event_type: &'a str,
         content: impl IntoRawMessageLikeEventContent,
     ) -> SendRawMessageLikeEvent<'a> {
+        // Note: the recorded instrument fields are saved in
+        // `SendRawMessageLikeEvent::into_future`.
         SendRawMessageLikeEvent::new(self, event_type, content)
     }
 


### PR DESCRIPTION
This adjusts the control flow so we start with the simplest cases (do not encrypt) first, then the encryption path. This then properly records that a reaction is *not* sent encrypted. Also lowers the level of logging from debug to trace for those log events, since they're not particularly interesting.