### PR TITLE
chore: Fix the compilation of the benchmarks outside of the workspace root

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -13,7 +13,7 @@ matrix-sdk-base = { workspace = true }
 matrix-sdk-crypto = { workspace = true }
 matrix-sdk-sqlite = { workspace = true, features = ["crypto-store"] }
 matrix-sdk-test = { workspace = true }
-matrix-sdk = { workspace = true }
+matrix-sdk = { workspace = true, features = ["native-tls", "e2e-encryption", "sqlite"] }
 ruma = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
The workspace root enables some features which are required to compile the benchmarks, but if you decide to just compile the benchmarks these features won't be enabled since they aren't specified in the Cargo.toml file of the benchmarks.

Let's define all the required features so compilation works in both cases.
