### PR TITLE
feat(sdk): Implement `event_cache::Deduplicator`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,16 +640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bloomfilter"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64d54e47a7f4fd723f082e8f11429f3df6ba8adaeca355a76556f9f0602bbcf"
-dependencies = [
- "bit-vec",
- "siphasher 1.0.1",
-]
-
-[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,7 +3115,6 @@ dependencies = [
  "async-trait",
  "axum",
  "backoff",
- "bloomfilter",
  "bytes",
  "bytesize",
  "chrono",
@@ -3138,6 +3127,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "gloo-timers",
+ "growable-bloom-filter",
  "http",
  "image",
  "imbl",
@@ -4216,7 +4206,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher 0.3.11",
+ "siphasher",
 ]
 
 [[package]]
@@ -4225,7 +4215,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher 0.3.11",
+ "siphasher",
 ]
 
 [[package]]
@@ -5642,12 +5632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6477,7 +6461,7 @@ checksum = "7663eacdbd9fbf4a88907ddcfe2e6fa85838eb6dc2418a7d91eebb3786f8e20b"
 dependencies = [
  "anyhow",
  "bytes",
- "siphasher 0.3.11",
+ "siphasher",
  "uniffi_checksum_derive",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bloomfilter"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64d54e47a7f4fd723f082e8f11429f3df6ba8adaeca355a76556f9f0602bbcf"
+dependencies = [
+ "bit-vec",
+ "siphasher 1.0.1",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3125,7 @@ dependencies = [
  "async-trait",
  "axum",
  "backoff",
+ "bloomfilter",
  "bytes",
  "bytesize",
  "chrono",
@@ -4205,7 +4216,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -4214,7 +4225,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -5631,6 +5642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6460,7 +6477,7 @@ checksum = "7663eacdbd9fbf4a88907ddcfe2e6fa85838eb6dc2418a7d91eebb3786f8e20b"
 dependencies = [
  "anyhow",
  "bytes",
- "siphasher",
+ "siphasher 0.3.11",
  "uniffi_checksum_derive",
 ]
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -75,6 +75,7 @@ async-channel = "2.2.1"
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 axum = { version = "0.7.4", optional = true }
+bloomfilter = { version = "1.0.13", default-features = false }
 bytes = "1.1.0"
 bytesize = "1.1"
 chrono = { version = "0.4.23", optional = true }

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -75,7 +75,6 @@ async-channel = "2.2.1"
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 axum = { version = "0.7.4", optional = true }
-bloomfilter = { version = "1.0.13", default-features = false }
 bytes = "1.1.0"
 bytesize = "1.1"
 chrono = { version = "0.4.23", optional = true }
@@ -85,6 +84,7 @@ eyeball-im = { workspace = true }
 eyre = { version = "0.6.8", optional = true }
 futures-core = { workspace = true }
 futures-util = { workspace = true }
+growable-bloom-filter = { workspace = true }
 http = { workspace = true }
 imbl = { workspace = true, features = ["serde"] }
 indexmap = "2.0.2"

--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -89,14 +89,14 @@ impl Deduplicator {
                 if duplicated {
                     Decoration::Duplicated(event)
                 } else {
-                    Decoration::Ok(event)
+                    Decoration::Unique(event)
                 }
             } else {
                 already_seen.insert(event_id);
 
                 // Bloom filter has no false negatives. We are sure the event is NOT present: we
                 // can keep it in the iterator.
-                Decoration::Ok(event)
+                Decoration::Unique(event)
             }
         })
     }
@@ -106,7 +106,7 @@ impl Deduplicator {
 #[derive(Debug)]
 pub enum Decoration<I> {
     /// This event is not duplicated.
-    Ok(I),
+    Unique(I),
 
     /// This event is duplicated.
     Duplicated(I),
@@ -149,13 +149,13 @@ mod tests {
         let mut events =
             deduplicator.scan_and_learn([event_0, event_1, event_2].into_iter(), &existing_events);
 
-        assert_let!(Some(Decoration::Ok(event)) = events.next());
+        assert_let!(Some(Decoration::Unique(event)) = events.next());
         assert_eq!(event.event_id(), Some(event_id_0));
 
-        assert_let!(Some(Decoration::Ok(event)) = events.next());
+        assert_let!(Some(Decoration::Unique(event)) = events.next());
         assert_eq!(event.event_id(), Some(event_id_1));
 
-        assert_let!(Some(Decoration::Ok(event)) = events.next());
+        assert_let!(Some(Decoration::Unique(event)) = events.next());
         assert_eq!(event.event_id(), Some(event_id_2));
 
         assert!(events.next().is_none());
@@ -184,13 +184,13 @@ mod tests {
             &existing_events,
         );
 
-        assert_let!(Some(Decoration::Ok(event)) = events.next());
+        assert_let!(Some(Decoration::Unique(event)) = events.next());
         assert_eq!(event.event_id(), Some(event_id_0.clone()));
 
         assert_let!(Some(Decoration::Duplicated(event)) = events.next());
         assert_eq!(event.event_id(), Some(event_id_0));
 
-        assert_let!(Some(Decoration::Ok(event)) = events.next());
+        assert_let!(Some(Decoration::Unique(event)) = events.next());
         assert_eq!(event.event_id(), Some(event_id_1));
 
         assert!(events.next().is_none());
@@ -216,7 +216,7 @@ mod tests {
             let mut events =
                 deduplicator.scan_and_learn([event_1.clone()].into_iter(), &existing_events);
 
-            assert_let!(Some(Decoration::Ok(event_1)) = events.next());
+            assert_let!(Some(Decoration::Unique(event_1)) = events.next());
             assert_eq!(event_1.event_id(), Some(event_id_1.clone()));
 
             assert!(events.next().is_none());
@@ -239,13 +239,13 @@ mod tests {
                 &existing_events,
             );
 
-            assert_let!(Some(Decoration::Ok(event)) = events.next());
+            assert_let!(Some(Decoration::Unique(event)) = events.next());
             assert_eq!(event.event_id(), Some(event_id_0));
 
             assert_let!(Some(Decoration::Duplicated(event)) = events.next());
             assert_eq!(event.event_id(), Some(event_id_1));
 
-            assert_let!(Some(Decoration::Ok(event)) = events.next());
+            assert_let!(Some(Decoration::Unique(event)) = events.next());
             assert_eq!(event.event_id(), Some(event_id_2));
 
             assert!(events.next().is_none());

--- a/crates/matrix-sdk/src/event_cache/deduplicator.rs
+++ b/crates/matrix-sdk/src/event_cache/deduplicator.rs
@@ -1,0 +1,169 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Not;
+
+use bloomfilter::Bloom;
+use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
+use ruma::OwnedEventId;
+
+use super::store::RoomEvents;
+
+pub struct Deduplicator {
+    bloom_filter: Bloom<OwnedEventId>,
+}
+
+impl Deduplicator {
+    const APPROXIMATED_MAXIMUM_NUMBER_OF_EVENTS: usize = 800_000;
+    const DESIRED_FALSE_POSITIVE_RATE: f64 = 0.001;
+    const SEED_FOR_HASHER: &'static [u8; 32] = b"matrix_sdk_event_cache_deduptor!";
+
+    pub fn new() -> Self {
+        Self {
+            bloom_filter: Bloom::new_for_fp_rate_with_seed(
+                Self::APPROXIMATED_MAXIMUM_NUMBER_OF_EVENTS,
+                Self::DESIRED_FALSE_POSITIVE_RATE,
+                Self::SEED_FOR_HASHER,
+            ),
+        }
+    }
+
+    pub fn filter_and_learn<'a, I>(
+        &'a mut self,
+        events: I,
+        room_events: &'a RoomEvents,
+    ) -> impl Iterator<Item = I::Item> + 'a
+    where
+        I: Iterator<Item = SyncTimelineEvent> + 'a,
+    {
+        events.filter(|event| {
+            let Some(event_id) = event.event_id() else {
+                // The event has no `event_id`. Safe path: filter it out.
+                return false;
+            };
+
+            if self.bloom_filter.check_and_set(&event_id) {
+                // Bloom filter has false positives. We are NOT sure the event
+                // is NOT present. Even if the false positive rate is low, we
+                // need to iterate over all events to ensure it isn't present.
+
+                room_events
+                    .revents()
+                    .any(|(_position, other_event)| {
+                        other_event.event_id().as_ref() == Some(&event_id)
+                    })
+                    .not()
+            } else {
+                // Bloom filter has no false negatives. We are sure the event is NOT present: we
+                // can keep it in the iterator.
+                true
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::assert_let;
+    use matrix_sdk_test::{EventBuilder, ALICE};
+    use ruma::{events::room::message::RoomMessageEventContent, owned_event_id, EventId};
+
+    use super::*;
+
+    fn sync_timeline_event(event_builder: &EventBuilder, event_id: &EventId) -> SyncTimelineEvent {
+        SyncTimelineEvent::new(event_builder.make_sync_message_event_with_id(
+            &*ALICE,
+            &event_id,
+            RoomMessageEventContent::text_plain("foo"),
+        ))
+    }
+
+    #[test]
+    fn test_filter_no_duplicate() {
+        let event_builder = EventBuilder::new();
+
+        let event_id_0 = owned_event_id!("$ev0");
+        let event_id_1 = owned_event_id!("$ev1");
+        let event_id_2 = owned_event_id!("$ev2");
+
+        let event_0 = sync_timeline_event(&event_builder, &event_id_0);
+        let event_1 = sync_timeline_event(&event_builder, &event_id_1);
+        let event_2 = sync_timeline_event(&event_builder, &event_id_2);
+
+        let mut deduplicator = Deduplicator::new();
+        let room_events = RoomEvents::new();
+
+        let mut events =
+            deduplicator.filter_and_learn([event_0, event_1, event_2].into_iter(), &room_events);
+
+        assert_let!(Some(event) = events.next());
+        assert_eq!(event.event_id(), Some(event_id_0));
+
+        assert_let!(Some(event) = events.next());
+        assert_eq!(event.event_id(), Some(event_id_1));
+
+        assert_let!(Some(event) = events.next());
+        assert_eq!(event.event_id(), Some(event_id_2));
+
+        assert!(events.next().is_none());
+    }
+
+    #[test]
+    fn test_filter_duplicates() {
+        let event_builder = EventBuilder::new();
+
+        let event_id_0 = owned_event_id!("$ev0");
+        let event_id_1 = owned_event_id!("$ev1");
+        let event_id_2 = owned_event_id!("$ev2");
+
+        let event_0 = sync_timeline_event(&event_builder, &event_id_0);
+        let event_1 = sync_timeline_event(&event_builder, &event_id_1);
+        let event_2 = sync_timeline_event(&event_builder, &event_id_2);
+
+        let mut deduplicator = Deduplicator::new();
+        let mut room_events = RoomEvents::new();
+
+        // Simulate `event_1` is inserted inside `room_events`.
+        {
+            let mut events =
+                deduplicator.filter_and_learn([event_1.clone()].into_iter(), &room_events);
+
+            assert_let!(Some(event_1) = events.next());
+            assert_eq!(event_1.event_id(), Some(event_id_1));
+
+            assert!(events.next().is_none());
+
+            drop(events); // make the borrow checker happy.
+
+            // Now we can push `event_1` inside `room_events`.
+            room_events.push_event(event_1);
+        }
+
+        // `event_1` will be duplicated.
+        {
+            let mut events = deduplicator
+                .filter_and_learn([event_0, event_1, event_2].into_iter(), &room_events);
+
+            assert_let!(Some(event) = events.next());
+            assert_eq!(event.event_id(), Some(event_id_0));
+
+            // `event_1` is missing.
+
+            assert_let!(Some(event) = events.next());
+            assert_eq!(event.event_id(), Some(event_id_2));
+
+            assert!(events.next().is_none());
+        }
+    }
+}

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
@@ -359,15 +359,15 @@ impl UpdateToVectorDiff {
                     todo!()
                 }
 
-                Update::DetachLastItems { at } => {
-                    let expected_chunk_identifier = at.chunk_identifier();
-                    let new_length = at.index();
+                Update::DetachLastItems { at: position } => {
+                    let expected_chunk_identifier = position.chunk_identifier();
+                    let new_length = position.index();
 
-                    let length = self
+                    let chunk_length = self
                         .chunks
                         .iter_mut()
-                        .find_map(|(chunk_identifier, length)| {
-                            (*chunk_identifier == expected_chunk_identifier).then_some(length)
+                        .find_map(|(chunk_identifier, chunk_length)| {
+                            (*chunk_identifier == expected_chunk_identifier).then_some(chunk_length)
                         })
                         // SAFETY: Assuming `LinkedChunk` and `ObservableUpdates` are not buggy, and
                         // assuming `Self::chunks` is correctly initialized, it is not possible to
@@ -375,7 +375,7 @@ impl UpdateToVectorDiff {
                         // it means `LinkedChunk` or `ObservableUpdates` contain a bug.
                         .expect("Detach last items: The chunk is not found");
 
-                    *length = new_length;
+                    *chunk_length = new_length;
                 }
 
                 Update::StartReattachItems => {

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/as_vector.rs
@@ -379,6 +379,10 @@ impl UpdateToVectorDiff {
                     }
                 }
 
+                Update::RemoveItem { at } => {
+                    todo!()
+                }
+
                 Update::DetachLastItems { at } => {
                     let expected_chunk_identifier = at.chunk_identifier();
                     let new_length = at.index();

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
@@ -947,6 +947,13 @@ impl Position {
     pub fn index(&self) -> usize {
         self.1
     }
+
+    pub(super) fn move_index_to_the_left(&mut self) {
+        self.1 = self
+            .1
+            .checked_sub(1)
+            .expect("Cannot move position's index to the left because it's already 0");
+    }
 }
 
 /// An iterator over a [`LinkedChunk`] that traverses the chunk in backward

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
@@ -948,6 +948,11 @@ impl Position {
         self.1
     }
 
+    /// Move the index part (see [`Self::index`]) to the left, i.e. subtract 1.
+    ///
+    /// # Panic
+    ///
+    /// This method will panic if it will overflow, i.e. if the index is 0.
     pub(super) fn move_index_to_the_left(&mut self) {
         self.1 = self
             .1

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
@@ -852,6 +852,12 @@ impl ChunkIdentifierGenerator {
 #[repr(transparent)]
 pub struct ChunkIdentifier(u64);
 
+impl PartialEq<u64> for ChunkIdentifier {
+    fn eq(&self, other: &u64) -> bool {
+        self.0 == *other
+    }
+}
+
 /// The position of something inside a [`Chunk`].
 ///
 /// It's a pair of a chunk position and an item index.

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/mod.rs
@@ -406,6 +406,79 @@ impl<const CAP: usize, Item, Gap> LinkedChunk<CAP, Item, Gap> {
         Ok(())
     }
 
+    /// Remove item at a specified position in the [`LinkedChunk`].
+    ///
+    /// Because the `position` can be invalid, this method returns a
+    /// `Result`.
+    pub fn remove_item_at(&mut self, position: Position) -> Result<Item, Error> {
+        let chunk_identifier = position.chunk_identifier();
+        let item_index = position.index();
+
+        let mut chunk_ptr = None;
+        let removed_item;
+
+        {
+            let chunk = self
+                .links
+                .chunk_mut(chunk_identifier)
+                .ok_or(Error::InvalidChunkIdentifier { identifier: chunk_identifier })?;
+
+            let can_unlink_chunk = match &mut chunk.content {
+                ChunkContent::Gap(..) => {
+                    return Err(Error::ChunkIsAGap { identifier: chunk_identifier })
+                }
+
+                ChunkContent::Items(current_items) => {
+                    let current_items_length = current_items.len();
+
+                    if item_index > current_items_length {
+                        return Err(Error::InvalidItemIndex { index: item_index });
+                    }
+
+                    removed_item = current_items.remove(item_index);
+
+                    if let Some(updates) = self.updates.as_mut() {
+                        updates
+                            .push(Update::RemoveItem { at: Position(chunk_identifier, item_index) })
+                    }
+
+                    current_items.is_empty()
+                }
+            };
+
+            // If the `chunk` can be unlinked, and if the `chunk` is not the first one, we
+            // can remove it.
+            if can_unlink_chunk && chunk.is_first_chunk().not() {
+                // Unlink `chunk`.
+                chunk.unlink(&mut self.updates);
+
+                chunk_ptr = Some(chunk.as_ptr());
+
+                // We need to update `self.last` if and only if `chunk` _is_ the last chunk. The
+                // new last chunk is the chunk before `chunk`.
+                if chunk.is_last_chunk() {
+                    self.links.last = chunk.previous;
+                }
+            }
+
+            self.length -= 1;
+
+            // Stop borrowing `chunk`.
+        }
+
+        if let Some(chunk_ptr) = chunk_ptr {
+            // `chunk` has been unlinked.
+
+            // Re-box the chunk, and let Rust does its job.
+            //
+            // SAFETY: `chunk` is unlinked and not borrowed anymore. `LinkedChunk` doesn't
+            // use it anymore, it's a leak. It is time to re-`Box` it and drop it.
+            let _chunk_boxed = unsafe { Box::from_raw(chunk_ptr.as_ptr()) };
+        }
+
+        Ok(removed_item)
+    }
+
     /// Insert a gap at a specified position in the [`LinkedChunk`].
     ///
     /// Because the `position` can be invalid, this method returns a
@@ -1847,6 +1920,206 @@ mod tests {
         }
 
         assert_eq!(linked_chunk.len(), 18);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_remove_item_at() -> Result<(), Error> {
+        use super::Update::*;
+
+        let mut linked_chunk = LinkedChunk::<3, char, ()>::new_with_update_history();
+        linked_chunk.push_items_back(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']);
+        assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['d', 'e', 'f'] ['g', 'h', 'i'] ['j', 'k']);
+        assert_eq!(linked_chunk.len(), 11);
+
+        // Ignore previous updates.
+        let _ = linked_chunk.updates().unwrap().take();
+
+        // Remove the last item of the middle chunk, 3 times. The chunk is empty after
+        // that. The chunk is removed.
+        {
+            let position_of_f = linked_chunk.item_position(|item| *item == 'f').unwrap();
+            let removed_item = linked_chunk.remove_item_at(position_of_f)?;
+
+            assert_eq!(removed_item, 'f');
+            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['d', 'e'] ['g', 'h', 'i'] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 10);
+
+            let position_of_e = linked_chunk.item_position(|item| *item == 'e').unwrap();
+            let removed_item = linked_chunk.remove_item_at(position_of_e)?;
+
+            assert_eq!(removed_item, 'e');
+            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['d'] ['g', 'h', 'i'] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 9);
+
+            let position_of_d = linked_chunk.item_position(|item| *item == 'd').unwrap();
+            let removed_item = linked_chunk.remove_item_at(position_of_d)?;
+
+            assert_eq!(removed_item, 'd');
+            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['g', 'h', 'i'] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 8);
+
+            assert_eq!(
+                linked_chunk.updates().unwrap().take(),
+                &[
+                    RemoveItem { at: Position(ChunkIdentifier(1), 2) },
+                    RemoveItem { at: Position(ChunkIdentifier(1), 1) },
+                    RemoveItem { at: Position(ChunkIdentifier(1), 0) },
+                    RemoveChunk(ChunkIdentifier(1)),
+                ]
+            );
+        }
+
+        // Remove the first item of the first chunk, 3 times. The chunk is empty after
+        // that. The chunk is NOT removed because it's the first chunk.
+        {
+            let first_position = linked_chunk.item_position(|item| *item == 'a').unwrap();
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
+
+            assert_eq!(removed_item, 'a');
+            assert_items_eq!(linked_chunk, ['b', 'c'] ['g', 'h', 'i'] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 7);
+
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
+
+            assert_eq!(removed_item, 'b');
+            assert_items_eq!(linked_chunk, ['c'] ['g', 'h', 'i'] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 6);
+
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
+
+            assert_eq!(removed_item, 'c');
+            assert_items_eq!(linked_chunk, [] ['g', 'h', 'i'] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 5);
+
+            assert_eq!(
+                linked_chunk.updates().unwrap().take(),
+                &[
+                    RemoveItem { at: Position(ChunkIdentifier(0), 0) },
+                    RemoveItem { at: Position(ChunkIdentifier(0), 0) },
+                    RemoveItem { at: Position(ChunkIdentifier(0), 0) },
+                ]
+            );
+        }
+
+        // Remove the first item of the middle chunk, 3 times. The chunk is empty after
+        // that. The chunk is removed.
+        {
+            let first_position = linked_chunk.item_position(|item| *item == 'g').unwrap();
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
+
+            assert_eq!(removed_item, 'g');
+            assert_items_eq!(linked_chunk, [] ['h', 'i'] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 4);
+
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
+
+            assert_eq!(removed_item, 'h');
+            assert_items_eq!(linked_chunk, [] ['i'] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 3);
+
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
+
+            assert_eq!(removed_item, 'i');
+            assert_items_eq!(linked_chunk, [] ['j', 'k']);
+            assert_eq!(linked_chunk.len(), 2);
+
+            assert_eq!(
+                linked_chunk.updates().unwrap().take(),
+                &[
+                    RemoveItem { at: Position(ChunkIdentifier(2), 0) },
+                    RemoveItem { at: Position(ChunkIdentifier(2), 0) },
+                    RemoveItem { at: Position(ChunkIdentifier(2), 0) },
+                    RemoveChunk(ChunkIdentifier(2)),
+                ]
+            );
+        }
+
+        // Remove the last item of the last chunk, twice. The chunk is empty after that.
+        // The chunk is removed.
+        {
+            let position_of_k = linked_chunk.item_position(|item| *item == 'k').unwrap();
+            let removed_item = linked_chunk.remove_item_at(position_of_k)?;
+
+            assert_eq!(removed_item, 'k');
+            #[rustfmt::skip]
+            assert_items_eq!(linked_chunk, [] ['j']);
+            assert_eq!(linked_chunk.len(), 1);
+
+            let position_of_j = linked_chunk.item_position(|item| *item == 'j').unwrap();
+            let removed_item = linked_chunk.remove_item_at(position_of_j)?;
+
+            assert_eq!(removed_item, 'j');
+            assert_items_eq!(linked_chunk, []);
+            assert_eq!(linked_chunk.len(), 0);
+
+            assert_eq!(
+                linked_chunk.updates().unwrap().take(),
+                &[
+                    RemoveItem { at: Position(ChunkIdentifier(3), 1) },
+                    RemoveItem { at: Position(ChunkIdentifier(3), 0) },
+                    RemoveChunk(ChunkIdentifier(3)),
+                ]
+            );
+        }
+
+        // Add a couple more items, delete one, add a gap, and delete more items.
+        {
+            linked_chunk.push_items_back(['a', 'b', 'c', 'd']);
+
+            #[rustfmt::skip]
+            assert_items_eq!(linked_chunk, ['a', 'b', 'c'] ['d']);
+            assert_eq!(linked_chunk.len(), 4);
+
+            let position_of_c = linked_chunk.item_position(|item| *item == 'c').unwrap();
+            linked_chunk.insert_gap_at((), position_of_c)?;
+
+            assert_items_eq!(linked_chunk, ['a', 'b'] [-] ['c'] ['d']);
+            assert_eq!(linked_chunk.len(), 4);
+
+            // Ignore updates.
+            let _ = linked_chunk.updates().unwrap().take();
+
+            let position_of_c = linked_chunk.item_position(|item| *item == 'c').unwrap();
+            let removed_item = linked_chunk.remove_item_at(position_of_c)?;
+
+            assert_eq!(removed_item, 'c');
+            assert_items_eq!(linked_chunk, ['a', 'b'] [-] ['d']);
+            assert_eq!(linked_chunk.len(), 3);
+
+            let position_of_d = linked_chunk.item_position(|item| *item == 'd').unwrap();
+            let removed_item = linked_chunk.remove_item_at(position_of_d)?;
+
+            assert_eq!(removed_item, 'd');
+            assert_items_eq!(linked_chunk, ['a', 'b'] [-]);
+            assert_eq!(linked_chunk.len(), 2);
+
+            let first_position = linked_chunk.item_position(|item| *item == 'a').unwrap();
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
+
+            assert_eq!(removed_item, 'a');
+            assert_items_eq!(linked_chunk, ['b'] [-]);
+            assert_eq!(linked_chunk.len(), 1);
+
+            let removed_item = linked_chunk.remove_item_at(first_position)?;
+
+            assert_eq!(removed_item, 'b');
+            assert_items_eq!(linked_chunk, [] [-]);
+            assert_eq!(linked_chunk.len(), 0);
+
+            assert_eq!(
+                linked_chunk.updates().unwrap().take(),
+                &[
+                    RemoveItem { at: Position(ChunkIdentifier(6), 0) },
+                    RemoveChunk(ChunkIdentifier(6)),
+                    RemoveItem { at: Position(ChunkIdentifier(4), 0) },
+                    RemoveChunk(ChunkIdentifier(4)),
+                    RemoveItem { at: Position(ChunkIdentifier(0), 0) },
+                    RemoveItem { at: Position(ChunkIdentifier(0), 0) },
+                ]
+            );
+        }
 
         Ok(())
     }

--- a/crates/matrix-sdk/src/event_cache/linked_chunk/updates.rs
+++ b/crates/matrix-sdk/src/event_cache/linked_chunk/updates.rs
@@ -76,6 +76,12 @@ pub enum Update<Item, Gap> {
         items: Vec<Item>,
     },
 
+    /// An item has been removed inside a chunk of kind Items.
+    RemoveItem {
+        /// The [`Position`] of the item.
+        at: Position,
+    },
+
     /// The last items of a chunk have been detached, i.e. the chunk has been
     /// truncated.
     DetachLastItems {

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -77,6 +77,7 @@ use self::{
 };
 use crate::{client::WeakClient, room::WeakRoom, Client};
 
+mod deduplicator;
 mod linked_chunk;
 mod pagination;
 mod store;

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -61,6 +61,9 @@ impl RoomEvents {
     }
 
     /// Deduplicate `events` considering all events in `Self::chunks`.
+    ///
+    /// For the moment, duplicated events will be logged but not removed from
+    /// the resulting iterator.
     fn deduplicate<'a, I>(&'a self, events: I) -> impl Iterator<Item = Event> + 'a
     where
         I: Iterator<Item = Event> + 'a,
@@ -167,5 +170,388 @@ impl RoomEvents {
 impl fmt::Debug for RoomEvents {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         formatter.debug_struct("RoomEvents").field("chunk", &self.chunks).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::assert_let;
+    use matrix_sdk_test::{EventBuilder, ALICE};
+    use ruma::{events::room::message::RoomMessageEventContent, EventId, OwnedEventId};
+
+    use super::*;
+
+    fn new_event(event_builder: &EventBuilder, event_id: &str) -> (OwnedEventId, Event) {
+        let event_id = EventId::parse(event_id).unwrap();
+
+        let event = SyncTimelineEvent::new(event_builder.make_sync_message_event_with_id(
+            *ALICE,
+            &event_id,
+            RoomMessageEventContent::text_plain("foo"),
+        ));
+
+        (event_id, event)
+    }
+
+    #[test]
+    fn test_new_room_events_has_zero_events() {
+        let room_events = RoomEvents::new();
+
+        assert_eq!(room_events.chunks.len(), 0);
+    }
+
+    #[test]
+    fn test_push_events() {
+        let event_builder = EventBuilder::new();
+
+        let (event_id_0, event_0) = new_event(&event_builder, "$ev0");
+        let (event_id_1, event_1) = new_event(&event_builder, "$ev1");
+        let (event_id_2, event_2) = new_event(&event_builder, "$ev2");
+
+        let mut room_events = RoomEvents::new();
+
+        room_events.push_events([event_0, event_1]);
+        room_events.push_events([event_2]);
+
+        {
+            let mut events = room_events.events();
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 1);
+            assert_eq!(event.event_id().unwrap(), event_id_1);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 2);
+            assert_eq!(event.event_id().unwrap(), event_id_2);
+
+            assert!(events.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_push_events_with_duplicates() {
+        let event_builder = EventBuilder::new();
+
+        let (event_id_0, event_0) = new_event(&event_builder, "$ev0");
+
+        let mut room_events = RoomEvents::new();
+
+        room_events.push_events([event_0.clone()]);
+        room_events.push_events([event_0]);
+
+        {
+            let mut events = room_events.events();
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 1);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert!(events.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_push_gap() {
+        let event_builder = EventBuilder::new();
+
+        let (event_id_0, event_0) = new_event(&event_builder, "$ev0");
+        let (event_id_1, event_1) = new_event(&event_builder, "$ev1");
+
+        let mut room_events = RoomEvents::new();
+
+        room_events.push_events([event_0]);
+        room_events.push_gap(Gap { prev_token: "hello".to_owned() });
+        room_events.push_events([event_1]);
+
+        {
+            let mut events = room_events.events();
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 2);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_1);
+
+            assert!(events.next().is_none());
+        }
+
+        {
+            let mut chunks = room_events.chunks();
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_items());
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_gap());
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_items());
+
+            assert!(chunks.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_insert_events_at() {
+        let event_builder = EventBuilder::new();
+
+        let (event_id_0, event_0) = new_event(&event_builder, "$ev0");
+        let (event_id_1, event_1) = new_event(&event_builder, "$ev1");
+        let (event_id_2, event_2) = new_event(&event_builder, "$ev2");
+
+        let mut room_events = RoomEvents::new();
+
+        room_events.push_events([event_0, event_1]);
+
+        let position_of_event_1 = room_events
+            .events()
+            .find_map(|(position, event)| {
+                (event.event_id().unwrap() == event_id_1).then_some(position)
+            })
+            .unwrap();
+
+        room_events.insert_events_at([event_2], position_of_event_1).unwrap();
+
+        {
+            let mut events = room_events.events();
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 1);
+            assert_eq!(event.event_id().unwrap(), event_id_2);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 2);
+            assert_eq!(event.event_id().unwrap(), event_id_1);
+
+            assert!(events.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_insert_events_at_with_dupicates() {
+        let event_builder = EventBuilder::new();
+
+        let (event_id_0, event_0) = new_event(&event_builder, "$ev0");
+        let (event_id_1, event_1) = new_event(&event_builder, "$ev1");
+
+        let mut room_events = RoomEvents::new();
+
+        room_events.push_events([event_0, event_1.clone()]);
+
+        let position_of_event_1 = room_events
+            .events()
+            .find_map(|(position, event)| {
+                (event.event_id().unwrap() == event_id_1).then_some(position)
+            })
+            .unwrap();
+
+        room_events.insert_events_at([event_1], position_of_event_1).unwrap();
+
+        {
+            let mut events = room_events.events();
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 1);
+            assert_eq!(event.event_id().unwrap(), event_id_1);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 2);
+            assert_eq!(event.event_id().unwrap(), event_id_1);
+
+            assert!(events.next().is_none());
+        }
+    }
+    #[test]
+    fn test_insert_gap_at() {
+        let event_builder = EventBuilder::new();
+
+        let (event_id_0, event_0) = new_event(&event_builder, "$ev0");
+        let (event_id_1, event_1) = new_event(&event_builder, "$ev1");
+
+        let mut room_events = RoomEvents::new();
+
+        room_events.push_events([event_0, event_1]);
+
+        let position_of_event_1 = room_events
+            .events()
+            .find_map(|(position, event)| {
+                (event.event_id().unwrap() == event_id_1).then_some(position)
+            })
+            .unwrap();
+
+        room_events
+            .insert_gap_at(Gap { prev_token: "hello".to_owned() }, position_of_event_1)
+            .unwrap();
+
+        {
+            let mut events = room_events.events();
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 2);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_1);
+
+            assert!(events.next().is_none());
+        }
+
+        {
+            let mut chunks = room_events.chunks();
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_items());
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_gap());
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_items());
+
+            assert!(chunks.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_replace_gap_at() {
+        let event_builder = EventBuilder::new();
+
+        let (event_id_0, event_0) = new_event(&event_builder, "$ev0");
+        let (event_id_1, event_1) = new_event(&event_builder, "$ev1");
+        let (event_id_2, event_2) = new_event(&event_builder, "$ev2");
+
+        let mut room_events = RoomEvents::new();
+
+        room_events.push_events([event_0]);
+        room_events.push_gap(Gap { prev_token: "hello".to_owned() });
+
+        let chunk_identifier_of_gap = room_events
+            .chunks()
+            .find_map(|chunk| chunk.is_gap().then_some(chunk.first_position()))
+            .unwrap()
+            .chunk_identifier();
+
+        room_events.replace_gap_at([event_1, event_2], chunk_identifier_of_gap).unwrap();
+
+        {
+            let mut events = room_events.events();
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 2);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_1);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 2);
+            assert_eq!(position.index(), 1);
+            assert_eq!(event.event_id().unwrap(), event_id_2);
+
+            assert!(events.next().is_none());
+        }
+
+        {
+            let mut chunks = room_events.chunks();
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_items());
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_items());
+
+            assert!(chunks.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_replace_gap_at_with_duplicates() {
+        let event_builder = EventBuilder::new();
+
+        let (event_id_0, event_0) = new_event(&event_builder, "$ev0");
+        let (event_id_1, event_1) = new_event(&event_builder, "$ev1");
+
+        let mut room_events = RoomEvents::new();
+
+        room_events.push_events([event_0.clone()]);
+        room_events.push_gap(Gap { prev_token: "hello".to_owned() });
+
+        let chunk_identifier_of_gap = room_events
+            .chunks()
+            .find_map(|chunk| chunk.is_gap().then_some(chunk.first_position()))
+            .unwrap()
+            .chunk_identifier();
+
+        room_events.replace_gap_at([event_0, event_1], chunk_identifier_of_gap).unwrap();
+
+        {
+            let mut events = room_events.events();
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 0);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 2);
+            assert_eq!(position.index(), 0);
+            assert_eq!(event.event_id().unwrap(), event_id_0);
+
+            assert_let!(Some((position, event)) = events.next());
+            assert_eq!(position.chunk_identifier(), 2);
+            assert_eq!(position.index(), 1);
+            assert_eq!(event.event_id().unwrap(), event_id_1);
+
+            assert!(events.next().is_none());
+        }
+
+        {
+            let mut chunks = room_events.chunks();
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_items());
+
+            assert_let!(Some(chunk) = chunks.next());
+            assert!(chunk.is_items());
+
+            assert!(chunks.next().is_none());
+        }
     }
 }

--- a/crates/matrix-sdk/src/event_cache/store.rs
+++ b/crates/matrix-sdk/src/event_cache/store.rs
@@ -34,8 +34,12 @@ pub struct Gap {
 
 const DEFAULT_CHUNK_CAPACITY: usize = 128;
 
+/// This type represents all events of a single room.
 pub struct RoomEvents {
+    /// The real in-memory storage for all the events.
     chunks: LinkedChunk<DEFAULT_CHUNK_CAPACITY, Event, Gap>,
+
+    /// The events deduplicator instance to help finding duplicates.
     deduplicator: Deduplicator,
 }
 
@@ -46,6 +50,7 @@ impl Default for RoomEvents {
 }
 
 impl RoomEvents {
+    /// Build a new `Self` with zero events.
     pub fn new() -> Self {
         Self { chunks: LinkedChunk::new(), deduplicator: Deduplicator::new() }
     }


### PR DESCRIPTION
This is WIP of an event deduplicator implemented on top of a Bloom filter. It works great, but it doesn't solve all issues we have right now. Right now, it filters duplicated events; instead, it should collect duplicated events with their positions, so that they can be removed from the `LinkedChunk` before being re-inserted. It's the basis to implement a naive reconciliation in the `EventCache`.

---

* Address https://github.com/matrix-org/matrix-rust-sdk/issues/3280