### PR TITLE
timeline: merge `edit_poll` and `edit`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-
 use matrix_sdk::{
     event_cache::{paginator::PaginatorError, EventCacheError},
     send_queue::RoomSendQueueError,
@@ -81,28 +79,8 @@ pub enum PaginationError {
     Paginator(#[source] PaginatorError),
 }
 
-#[derive(Error)]
-#[error("{0}")]
-pub struct UnsupportedReplyItem(UnsupportedReplyItemInner);
-
-impl UnsupportedReplyItem {
-    pub(super) const MISSING_EVENT_ID: Self = Self(UnsupportedReplyItemInner::MissingEventId);
-    pub(super) const MISSING_JSON: Self = Self(UnsupportedReplyItemInner::MissingJson);
-    pub(super) const MISSING_EVENT: Self = Self(UnsupportedReplyItemInner::MissingEvent);
-    pub(super) const FAILED_TO_DESERIALIZE_EVENT: Self =
-        Self(UnsupportedReplyItemInner::FailedToDeserializeEvent);
-    pub(super) const STATE_EVENT: Self = Self(UnsupportedReplyItemInner::StateEvent);
-}
-
-#[cfg(not(tarpaulin_include))]
-impl fmt::Debug for UnsupportedReplyItem {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 #[derive(Debug, Error)]
-enum UnsupportedReplyItemInner {
+pub enum UnsupportedReplyItem {
     #[error("local messages whose event ID is not known can't be replied to currently")]
     MissingEventId,
     #[error("redacted events whose JSON form isn't available can't be replied")]
@@ -115,29 +93,8 @@ enum UnsupportedReplyItemInner {
     StateEvent,
 }
 
-#[derive(Error)]
-#[error("{0}")]
-pub struct UnsupportedEditItem(UnsupportedEditItemInner);
-
-impl UnsupportedEditItem {
-    pub(super) const MISSING_EVENT_ID: Self = Self(UnsupportedEditItemInner::MissingEventId);
-    pub(super) const NOT_ROOM_MESSAGE: Self = Self(UnsupportedEditItemInner::NotRoomMessage);
-    pub(super) const NOT_POLL_EVENT: Self = Self(UnsupportedEditItemInner::NotPollEvent);
-    pub(super) const NOT_OWN_EVENT: Self = Self(UnsupportedEditItemInner::NotOwnEvent);
-    pub(super) const MISSING_EVENT: Self = Self(UnsupportedEditItemInner::MissingEvent);
-    pub(super) const FAILED_TO_DESERIALIZE_EVENT: Self =
-        Self(UnsupportedEditItemInner::FailedToDeserializeEvent);
-}
-
-#[cfg(not(tarpaulin_include))]
-impl fmt::Debug for UnsupportedEditItem {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 #[derive(Debug, Error)]
-enum UnsupportedEditItemInner {
+pub enum UnsupportedEditItem {
     #[error("local messages whose event ID is not known can't be edited currently")]
     MissingEventId,
     #[error("tried to edit a non-message event")]

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use matrix_sdk::{
-    event_cache::{paginator::PaginatorError, EventCacheError},
-    send_queue::RoomSendQueueError,
-};
+use matrix_sdk::event_cache::{paginator::PaginatorError, EventCacheError};
 use ruma::OwnedTransactionId;
 use thiserror::Error;
 
@@ -107,18 +104,6 @@ pub enum UnsupportedEditItem {
     MissingEvent,
     #[error("failed to deserialize event to edit")]
     FailedToDeserializeEvent,
-}
-
-#[derive(Debug, Error)]
-pub enum SendEventError {
-    #[error(transparent)]
-    UnsupportedReplyItem(#[from] UnsupportedReplyItem),
-
-    #[error(transparent)]
-    UnsupportedEditItem(#[from] UnsupportedEditItem),
-
-    #[error(transparent)]
-    SendError(#[from] RoomSendQueueError),
 }
 
 #[derive(Debug, Error)]

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -429,7 +429,7 @@ impl EventTimelineItem {
             TimelineItemContent::Message(msg) => ReplyContent::Message(msg.to_owned()),
             _ => {
                 let Some(raw_event) = self.latest_json() else {
-                    return Err(UnsupportedReplyItem::MISSING_JSON);
+                    return Err(UnsupportedReplyItem::MissingJson);
                 };
 
                 ReplyContent::Raw(raw_event.clone())
@@ -437,7 +437,7 @@ impl EventTimelineItem {
         };
 
         let Some(event_id) = self.event_id() else {
-            return Err(UnsupportedReplyItem::MISSING_EVENT_ID);
+            return Err(UnsupportedReplyItem::MissingEventId);
         };
 
         Ok(RepliedToInfo {
@@ -451,15 +451,15 @@ impl EventTimelineItem {
     /// Gives the information needed to edit the event of the item.
     pub fn edit_info(&self) -> Result<EditInfo, UnsupportedEditItem> {
         if !self.is_own() {
-            return Err(UnsupportedEditItem::NOT_OWN_EVENT);
+            return Err(UnsupportedEditItem::NotOwnEvent);
         }
         // Early returns here must be in sync with
         // `EventTimelineItem::can_be_edited`
         let Some(event_id) = self.event_id() else {
-            return Err(UnsupportedEditItem::MISSING_EVENT_ID);
+            return Err(UnsupportedEditItem::MissingEventId);
         };
         let TimelineItemContent::Message(original_content) = self.content() else {
-            return Err(UnsupportedEditItem::NOT_ROOM_MESSAGE);
+            return Err(UnsupportedEditItem::NotRoomMessage);
         };
         Ok(EditInfo { event_id: event_id.to_owned(), original_message: original_content.clone() })
     }

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -22,7 +22,7 @@ use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server}
 use matrix_sdk_test::{
     async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
 };
-use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails, TimelineItemContent};
+use matrix_sdk_ui::timeline::{EditNewContent, RoomExt, TimelineDetails, TimelineItemContent};
 use ruma::{
     assign, event_id,
     events::{
@@ -203,7 +203,12 @@ async fn test_send_edit() {
 
     let edit_info = hello_world_item.edit_info().unwrap();
     timeline
-        .edit(RoomMessageEventContentWithoutRelation::text_plain("Hello, Room!"), edit_info)
+        .edit(
+            EditNewContent::Message(RoomMessageEventContentWithoutRelation::text_plain(
+                "Hello, Room!",
+            )),
+            edit_info,
+        )
         .await
         .unwrap();
 
@@ -294,7 +299,12 @@ async fn test_send_reply_edit() {
 
     let edit_info = reply_item.edit_info().unwrap();
     timeline
-        .edit(RoomMessageEventContentWithoutRelation::text_plain("Hello, Room!"), edit_info)
+        .edit(
+            EditNewContent::Message(RoomMessageEventContentWithoutRelation::text_plain(
+                "Hello, Room!",
+            )),
+            edit_info,
+        )
         .await
         .unwrap();
 
@@ -385,9 +395,20 @@ async fn test_send_edit_poll() {
         UnstablePollAnswer::new("2", "Maybe"),
     ])
     .unwrap();
+
     let edited_poll =
         UnstablePollStartContentBlock::new("Edited Test".to_owned(), edited_poll_answers);
-    timeline.edit_poll("poll_fallback_text", edited_poll, &poll_event).await.unwrap();
+
+    timeline
+        .edit(
+            EditNewContent::Poll {
+                fallback_text: "poll_fallback_text".to_owned(),
+                poll: edited_poll,
+            },
+            poll_event.edit_info().unwrap(),
+        )
+        .await
+        .unwrap();
 
     // Let the send queue handle the event.
     yield_now().await;
@@ -482,7 +503,12 @@ async fn test_send_edit_when_timeline_is_clear() {
     let edit_info =
         timeline.edit_info_from_event_id(hello_world_item.event_id().unwrap()).await.unwrap();
     timeline
-        .edit(RoomMessageEventContentWithoutRelation::text_plain("Hello, Room!"), edit_info)
+        .edit(
+            EditNewContent::Message(RoomMessageEventContentWithoutRelation::text_plain(
+                "Hello, Room!",
+            )),
+            edit_info,
+        )
         .await
         .unwrap();
 


### PR DESCRIPTION
So this is an attempt to merge `Timeline::edit` with `Timeline::edit_poll`, since it'd be nice to have a unique method to edit events in general.

Right now it's possible to dynamically provide an invalid combination of parameters (new content is a message while the edited event is a poll), but I think we can avoid that by introducing traits and more static typing.