### PR TITLE
feat(sdk): `room_list_service::Room::new` is now infallible

### DIFF
--- a/crates/matrix-sdk-ui/src/room_list_service/mod.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/mod.rs
@@ -433,7 +433,10 @@ impl RoomListService {
             return Ok(room.clone());
         }
 
-        let room = Room::new(&self.client, room_id, &self.sliding_sync)?;
+        let room = Room::new(
+            self.client.get_room(room_id).ok_or_else(|| Error::RoomNotFound(room_id.to_owned()))?,
+            &self.sliding_sync,
+        );
 
         // Save for later.
         rooms.push(room.clone());

--- a/crates/matrix-sdk-ui/src/room_list_service/room.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room.rs
@@ -17,7 +17,7 @@
 use std::{ops::Deref, sync::Arc};
 
 use async_once_cell::OnceCell as AsyncOnceCell;
-use matrix_sdk::{Client, SlidingSync};
+use matrix_sdk::SlidingSync;
 use ruma::{api::client::sync::sync_events::v4::RoomSubscription, events::StateEventType, RoomId};
 
 use super::Error;
@@ -56,21 +56,14 @@ impl Deref for Room {
 
 impl Room {
     /// Create a new `Room`.
-    pub(super) fn new(
-        client: &Client,
-        room_id: &RoomId,
-        sliding_sync: &Arc<SlidingSync>,
-    ) -> Result<Self, Error> {
-        let room =
-            client.get_room(room_id).ok_or_else(|| Error::RoomNotFound(room_id.to_owned()))?;
-
-        Ok(Self {
+    pub(super) fn new(room: matrix_sdk::Room, sliding_sync: &Arc<SlidingSync>) -> Self {
+        Self {
             inner: Arc::new(RoomInner {
                 sliding_sync: sliding_sync.clone(),
                 room,
                 timeline: AsyncOnceCell::new(),
             }),
-        })
+        }
     }
 
     /// Get the room ID.


### PR DESCRIPTION
This patch makes `Room::new` infallible, i.e. it no longer returns a `Result<Self, _>` but `Self` directly.

---

* Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3585.