### PR TITLE
sdk: Move the OIDC helper methods from the FFI's `AuthenticationService` into `Client`

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -381,6 +381,7 @@ impl Client {
 
         let data =
             self.inner.oidc().url_for_oidc_login(oidc_metadata, registrations).await.map_err(
+                // TODO: Introduce an OidcError in the FFI with a From implementation.
                 |e| match e {
                     OidcError::MissingAuthenticationIssuer => AuthenticationError::OidcNotSupported,
                     OidcError::MissingRedirectUri => AuthenticationError::OidcMetadataInvalid,
@@ -400,6 +401,7 @@ impl Client {
         let url = Url::parse(&callback_url).or(Err(AuthenticationError::OidcCallbackUrlInvalid))?;
 
         self.inner.oidc().login_with_oidc_callback(&authorization_data, url).await.map_err(
+            // TODO: Introduce an OidcError in the FFI with a From implementation.
             |e| match e {
                 Error::Oidc(OidcError::InvalidCallbackUrl) => {
                     AuthenticationError::OidcCallbackUrlInvalid

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -392,6 +392,11 @@ impl Client {
         Ok(Arc::new(data))
     }
 
+    #[allow(dead_code)] // Will be exposed when AuthenticationService is removed.
+    pub(crate) async fn abort_oidc_login(&self, authorization_data: Arc<OidcAuthorizationData>) {
+        self.inner.oidc().abort_authorization(&authorization_data.state).await;
+    }
+
     /// Completes the OIDC login process.
     pub(crate) async fn login_with_oidc_callback(
         &self,

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     mem::ManuallyDrop,
+    path::Path,
     sync::{Arc, RwLock},
 };
 
@@ -8,15 +9,19 @@ use anyhow::{anyhow, Context as _};
 use matrix_sdk::{
     media::{MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSize},
     oidc::{
+        registrations::{ClientId, OidcRegistrations},
         requests::account_management::AccountManagementActionFull,
         types::{
             client_credentials::ClientCredentials,
+            errors::ClientErrorCode::AccessDenied,
             registration::{
                 ClientMetadata, ClientMetadataVerificationError, VerifiedClientMetadata,
             },
+            requests::Prompt,
         },
-        OidcSession,
+        AuthorizationResponse, Oidc, OidcSession,
     },
+    reqwest::StatusCode,
     ruma::{
         api::client::{
             media::get_content_thumbnail::v3::Method,
@@ -58,6 +63,7 @@ use url::Url;
 
 use super::{room::Room, session_verification::SessionVerificationController, RUNTIME};
 use crate::{
+    authentication_service::{AuthenticationError, OidcAuthenticationData, OidcConfiguration},
     client,
     encryption::Encryption,
     notification::NotificationClient,
@@ -350,6 +356,82 @@ impl Client {
 }
 
 impl Client {
+    /// Requests the URL needed for login in a web view using OIDC. Once the web
+    /// view has succeeded, call `login_with_oidc_callback` with the callback it
+    /// returns.
+    pub(crate) async fn url_for_oidc_login(
+        &self,
+        oidc_configuration: &OidcConfiguration,
+    ) -> Result<Arc<OidcAuthenticationData>, AuthenticationError> {
+        let oidc = self.inner.oidc();
+
+        let issuer = match oidc.fetch_authentication_issuer().await {
+            Ok(issuer) => issuer,
+            Err(error) => {
+                if error
+                    .as_client_api_error()
+                    .is_some_and(|err| err.status_code == StatusCode::NOT_FOUND)
+                {
+                    return Err(AuthenticationError::OidcNotSupported);
+                } else {
+                    return Err(AuthenticationError::ServerUnreachable(error));
+                }
+            }
+        };
+
+        let redirect_url = Url::parse(&oidc_configuration.redirect_uri)
+            .map_err(|_e| AuthenticationError::OidcMetadataInvalid)?;
+
+        self.configure_oidc(&oidc, issuer, oidc_configuration).await?;
+
+        let mut data_builder = oidc.login(redirect_url, None)?;
+        // TODO: Add a check for the Consent prompt when MAS is updated.
+        data_builder = data_builder.prompt(vec![Prompt::Consent]);
+        let data = data_builder.build().await?;
+
+        Ok(Arc::new(OidcAuthenticationData { url: data.url, state: data.state }))
+    }
+
+    /// Completes the OIDC login process.
+    pub(crate) async fn login_with_oidc_callback(
+        &self,
+        authentication_data: Arc<OidcAuthenticationData>,
+        callback_url: String,
+    ) -> Result<(), AuthenticationError> {
+        let oidc = self.inner.oidc();
+
+        let url =
+            Url::parse(&callback_url).map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
+
+        let response = AuthorizationResponse::parse_uri(&url)
+            .map_err(|_| AuthenticationError::OidcCallbackUrlInvalid)?;
+
+        let code = match response {
+            AuthorizationResponse::Success(code) => code,
+            AuthorizationResponse::Error(err) => {
+                if err.error.error == AccessDenied {
+                    // The user cancelled the login in the web view.
+                    return Err(AuthenticationError::OidcCancelled);
+                }
+                return Err(AuthenticationError::OidcError {
+                    message: err.error.error.to_string(),
+                });
+            }
+        };
+
+        if code.state != authentication_data.state {
+            return Err(AuthenticationError::OidcCallbackUrlInvalid);
+        };
+
+        oidc.finish_authorization(code).await?;
+
+        oidc.finish_login()
+            .await
+            .map_err(|e| AuthenticationError::OidcError { message: e.to_string() })?;
+
+        Ok(())
+    }
+
     /// Restores the client from an `AuthSession`.
     pub(crate) async fn restore_session_inner(
         &self,
@@ -374,6 +456,126 @@ impl Client {
             .iter()
             .any(|login_type| matches!(login_type, get_login_types::v3::LoginType::Password(_)));
         Ok(supports_password)
+    }
+
+    /// Handle any necessary configuration in order for login via OIDC to
+    /// succeed. This includes performing dynamic client registration against
+    /// the homeserver's issuer or restoring a previous registration if one has
+    /// been stored.
+    async fn configure_oidc(
+        &self,
+        oidc: &Oidc,
+        issuer: String,
+        configuration: &OidcConfiguration,
+    ) -> Result<(), AuthenticationError> {
+        if oidc.client_credentials().is_some() {
+            tracing::info!("OIDC is already configured.");
+            return Ok(());
+        };
+
+        let oidc_metadata: VerifiedClientMetadata = configuration.try_into()?;
+        let registrations_file = Path::new(&configuration.dynamic_registrations_file);
+        let static_registrations = configuration
+            .static_registrations
+            .iter()
+            .filter_map(|(issuer, client_id)| {
+                let Ok(issuer) = Url::parse(issuer) else {
+                    tracing::error!("Failed to parse {:?}", issuer);
+                    return None;
+                };
+                Some((issuer, ClientId(client_id.clone())))
+            })
+            .collect::<HashMap<_, _>>();
+
+        if self.load_client_registration(
+            oidc,
+            issuer.clone(),
+            oidc_metadata.clone(),
+            registrations_file,
+            static_registrations.clone(),
+        ) {
+            tracing::info!("OIDC configuration loaded from disk.");
+            return Ok(());
+        }
+
+        tracing::info!("Registering this client for OIDC.");
+        let registration_response =
+            oidc.register_client(&issuer, oidc_metadata.clone(), None).await?;
+
+        // The format of the credentials changes according to the client metadata that
+        // was sent. Public clients only get a client ID.
+        let credentials =
+            ClientCredentials::None { client_id: registration_response.client_id.clone() };
+        oidc.restore_registered_client(issuer, oidc_metadata, credentials);
+
+        tracing::info!("Persisting OIDC registration data.");
+        self.store_client_registration(oidc, registrations_file, static_registrations)?;
+
+        Ok(())
+    }
+
+    /// Stores the current OIDC dynamic client registration so it can be re-used
+    /// if we ever log in via the same issuer again.
+    fn store_client_registration(
+        &self,
+        oidc: &Oidc,
+        registrations_file: &Path,
+        static_registrations: HashMap<Url, ClientId>,
+    ) -> Result<(), AuthenticationError> {
+        let issuer = Url::parse(oidc.issuer().ok_or(AuthenticationError::OidcNotSupported)?)
+            .map_err(|_| AuthenticationError::OidcError {
+                message: String::from("Failed to parse issuer URL."),
+            })?;
+        let client_id = oidc
+            .client_credentials()
+            .ok_or(AuthenticationError::OidcError {
+                message: String::from("Missing client registration."),
+            })?
+            .client_id()
+            .to_owned();
+
+        let metadata = oidc.client_metadata().ok_or(AuthenticationError::OidcError {
+            message: String::from("Missing client metadata."),
+        })?;
+
+        let registrations =
+            OidcRegistrations::new(registrations_file, metadata.clone(), static_registrations)?;
+        registrations.set_and_write_client_id(ClientId(client_id), issuer)?;
+
+        Ok(())
+    }
+
+    /// Attempts to load an existing OIDC dynamic client registration for the
+    /// currently configured issuer.
+    fn load_client_registration(
+        &self,
+        oidc: &Oidc,
+        issuer: String,
+        oidc_metadata: VerifiedClientMetadata,
+        registrations_file: &Path,
+        static_registrations: HashMap<Url, ClientId>,
+    ) -> bool {
+        let Ok(issuer_url) = Url::parse(&issuer) else {
+            tracing::error!("Failed to parse {issuer:?}");
+            return false;
+        };
+        let Some(registrations) =
+            OidcRegistrations::new(registrations_file, oidc_metadata.clone(), static_registrations)
+                .ok()
+        else {
+            return false;
+        };
+        let Some(client_id) = registrations.client_id(&issuer_url) else {
+            return false;
+        };
+
+        oidc.restore_registered_client(
+            issuer,
+            oidc_metadata,
+            ClientCredentials::None { client_id: client_id.0 },
+        );
+
+        true
     }
 }
 

--- a/crates/matrix-sdk/src/oidc/auth_code_builder.rs
+++ b/crates/matrix-sdk/src/oidc/auth_code_builder.rs
@@ -236,9 +236,20 @@ impl OidcAuthCodeUrlBuilder {
 
 /// The data needed to perform authorization using OpenID Connect.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub struct OidcAuthorizationData {
     /// The URL that should be presented.
     pub url: Url,
-    /// A unique identifier for the request.
+    /// A unique identifier for the request, used to ensure the response
+    /// originated from the authentication issuer.
     pub state: String,
+}
+
+#[cfg(feature = "uniffi")]
+#[uniffi::export]
+impl OidcAuthorizationData {
+    /// The login URL to use for authorization.
+    pub fn login_url(&self) -> String {
+        self.url.to_string()
+    }
 }

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -552,7 +552,7 @@ impl Oidc {
         registrations: &OidcRegistrations,
     ) -> std::result::Result<(), OidcError> {
         let issuer = Url::parse(self.issuer().ok_or(OidcError::MissingAuthenticationIssuer)?)
-            .map_err(|e| OidcError::Url(e))?;
+            .map_err(OidcError::Url)?;
         let client_id =
             self.client_credentials().ok_or(OidcError::NotRegistered)?.client_id().to_owned();
 
@@ -565,6 +565,8 @@ impl Oidc {
 
     /// Attempts to load an existing OIDC dynamic client registration for a
     /// given issuer.
+    ///
+    /// Returns `true` if an existing registration was found and `false` if not.
     fn load_client_registration(
         &self,
         issuer: String,

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -498,8 +498,9 @@ impl Oidc {
             }
         };
 
-        // Given the InvalidState error already exists, I wonder if this was ever
-        // necessary to manually check?
+        // This check will also be done in `finish_authorization`, however it requires
+        // the client to have called `abort_authorization` which we can't guarantee so
+        // lets double check with their supplied authorization data to be safe.
         if code.state != authorization_data.state {
             return Err(OidcError::InvalidState.into());
         };

--- a/crates/matrix-sdk/src/oidc/mod.rs
+++ b/crates/matrix-sdk/src/oidc/mod.rs
@@ -170,6 +170,7 @@ use std::{collections::HashMap, fmt, sync::Arc};
 use as_variant::as_variant;
 use eyeball::SharedObservable;
 use futures_core::Stream;
+use http::StatusCode;
 pub use mas_oidc_client::{error, requests, types};
 use mas_oidc_client::{
     requests::{
@@ -178,10 +179,11 @@ use mas_oidc_client::{
     },
     types::{
         client_credentials::ClientCredentials,
-        errors::ClientError,
+        errors::{ClientError, ClientErrorCode::AccessDenied},
         iana::oauth::OAuthTokenTypeHint,
         oidc::{AccountManagementAction, VerifiedProviderMetadata},
         registration::{ClientRegistrationResponse, VerifiedClientMetadata},
+        requests::Prompt,
         scope::{MatrixApiScopeToken, Scope, ScopeToken},
         IdToken,
     },
@@ -219,6 +221,7 @@ use self::{
 use crate::{
     authentication::{qrcode::LoginWithQrCode, AuthData},
     client::SessionChange,
+    oidc::registrations::{ClientId, OidcRegistrations},
     Client, HttpError, RefreshTokenError, Result,
 };
 
@@ -432,6 +435,157 @@ impl Oidc {
         client_metadata: VerifiedClientMetadata,
     ) -> LoginWithQrCode<'a> {
         LoginWithQrCode::new(&self.client, client_metadata, data)
+    }
+
+    /// A higher level wrapper around the configuration and login methods that
+    /// will take some client metadata, register the client if needed and begin
+    /// the login process, returning the authorization data required to show a
+    /// webview for a user to login to their account. Call
+    /// [`Oidc::login_with_oidc_callback`] to finish the process when the
+    /// webview is complete.
+    pub async fn url_for_oidc_login(
+        &self,
+        client_metadata: VerifiedClientMetadata,
+        registrations: OidcRegistrations,
+    ) -> Result<OidcAuthorizationData, OidcError> {
+        let issuer = match self.fetch_authentication_issuer().await {
+            Ok(issuer) => issuer,
+            Err(error) => {
+                if error
+                    .as_client_api_error()
+                    .is_some_and(|err| err.status_code == StatusCode::NOT_FOUND)
+                {
+                    return Err(OidcError::MissingAuthenticationIssuer);
+                } else {
+                    return Err(OidcError::UnknownError(Box::new(error)));
+                }
+            }
+        };
+
+        let redirect_uris =
+            client_metadata.redirect_uris.clone().ok_or(OidcError::MissingRedirectUri)?;
+
+        let redirect_url = redirect_uris.first().ok_or(OidcError::MissingRedirectUri)?;
+
+        self.configure(issuer, client_metadata, registrations).await?;
+
+        let mut data_builder = self.login(redirect_url.clone(), None)?;
+        data_builder = data_builder.prompt(vec![Prompt::Consent]);
+        let data = data_builder.build().await?;
+
+        Ok(data)
+    }
+
+    /// A higher level wrapper around the methods to complete a login after the
+    /// user has logged in through a webview. This method should be used in
+    /// tandem with [`Oidc::url_for_oidc_login`].
+    pub async fn login_with_oidc_callback(
+        &self,
+        authorization_data: &OidcAuthorizationData,
+        callback_url: Url,
+    ) -> Result<()> {
+        let response = AuthorizationResponse::parse_uri(&callback_url)
+            .or(Err(OidcError::InvalidCallbackUrl))?;
+
+        let code = match response {
+            AuthorizationResponse::Success(code) => code,
+            AuthorizationResponse::Error(err) => {
+                if err.error.error == AccessDenied {
+                    // The user cancelled the login in the web view.
+                    return Err(OidcError::CancelledAuthorization.into());
+                }
+                return Err(OidcError::Authorization(err).into());
+            }
+        };
+
+        // Given the InvalidState error already exists, I wonder if this was ever
+        // necessary to manually check?
+        if code.state != authorization_data.state {
+            return Err(OidcError::InvalidState.into());
+        };
+
+        self.finish_authorization(code).await?;
+        self.finish_login().await?;
+
+        Ok(())
+    }
+
+    /// Higher level wrapper that restores the OIDC client with automatic
+    /// static/dynamic client registration.
+    async fn configure(
+        &self,
+        issuer: String,
+        client_metadata: VerifiedClientMetadata,
+        registrations: OidcRegistrations,
+    ) -> std::result::Result<(), OidcError> {
+        if self.client_credentials().is_some() {
+            tracing::info!("OIDC is already configured.");
+            return Ok(());
+        };
+
+        if self.load_client_registration(issuer.clone(), client_metadata.clone(), &registrations) {
+            tracing::info!("OIDC configuration loaded from disk.");
+            return Ok(());
+        }
+
+        tracing::info!("Registering this client for OIDC.");
+        let registration_response =
+            self.register_client(&issuer, client_metadata.clone(), None).await?;
+
+        // The format of the credentials changes according to the client metadata that
+        // was sent. Public clients only get a client ID.
+        let credentials =
+            ClientCredentials::None { client_id: registration_response.client_id.clone() };
+        self.restore_registered_client(issuer, client_metadata, credentials);
+
+        tracing::info!("Persisting OIDC registration data.");
+        self.store_client_registration(&registrations)
+            .map_err(|e| OidcError::UnknownError(Box::new(e)))?;
+
+        Ok(())
+    }
+
+    /// Stores the current OIDC dynamic client registration so it can be re-used
+    /// if we ever log in via the same issuer again.
+    fn store_client_registration(
+        &self,
+        registrations: &OidcRegistrations,
+    ) -> std::result::Result<(), OidcError> {
+        let issuer = Url::parse(self.issuer().ok_or(OidcError::MissingAuthenticationIssuer)?)
+            .map_err(|e| OidcError::Url(e))?;
+        let client_id =
+            self.client_credentials().ok_or(OidcError::NotRegistered)?.client_id().to_owned();
+
+        registrations
+            .set_and_write_client_id(ClientId(client_id), issuer)
+            .map_err(|e| OidcError::UnknownError(Box::new(e)))?;
+
+        Ok(())
+    }
+
+    /// Attempts to load an existing OIDC dynamic client registration for a
+    /// given issuer.
+    fn load_client_registration(
+        &self,
+        issuer: String,
+        oidc_metadata: VerifiedClientMetadata,
+        registrations: &OidcRegistrations,
+    ) -> bool {
+        let Ok(issuer_url) = Url::parse(&issuer) else {
+            error!("Failed to parse {issuer:?}");
+            return false;
+        };
+        let Some(client_id) = registrations.client_id(&issuer_url) else {
+            return false;
+        };
+
+        self.restore_registered_client(
+            issuer,
+            oidc_metadata,
+            ClientCredentials::None { client_id: client_id.0 },
+        );
+
+        true
     }
 
     /// The OpenID Connect Provider used for authorization.
@@ -1499,6 +1653,14 @@ pub enum OidcError {
     #[error("no dynamic registration support")]
     NoRegistrationSupport,
 
+    /// The client has not registered while the operation requires it.
+    #[error("client not registered")]
+    NotRegistered,
+
+    /// The supplied redirect URIs are missing or empty.
+    #[error("missing or empty redirect URIs")]
+    MissingRedirectUri,
+
     /// The device ID was not returned by the homeserver after login.
     #[error("missing device ID in response")]
     MissingDeviceId,
@@ -1511,6 +1673,18 @@ pub enum OidcError {
     /// value.
     #[error("the supplied state is unexpected")]
     InvalidState,
+
+    /// The user cancelled authorization in the web view.
+    #[error("authorization cancelled")]
+    CancelledAuthorization,
+
+    /// The login was completed with an invalid callback.
+    #[error("the supplied callback URL is invalid")]
+    InvalidCallbackUrl,
+
+    /// An error occurred during authorization.
+    #[error("authorization failed")]
+    Authorization(AuthorizationError),
 
     /// The device ID is invalid.
     #[error("invalid device ID")]

--- a/crates/matrix-sdk/src/oidc/registrations.rs
+++ b/crates/matrix-sdk/src/oidc/registrations.rs
@@ -42,7 +42,7 @@ pub enum OidcRegistrationsError {
     InvalidFilePath,
     /// An error occurred whilst saving the registration data.
     #[error("Failed to save the registration data {0}.")]
-    SaveFailure(#[source] Box<dyn std::error::Error>),
+    SaveFailure(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// A client ID that has been registered with an OpenID Connect provider.

--- a/crates/matrix-sdk/src/oidc/tests.rs
+++ b/crates/matrix-sdk/src/oidc/tests.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context as _;
 use assert_matches::assert_matches;
@@ -14,7 +14,9 @@ use mas_oidc_client::{
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::{async_test, test_json};
 use ruma::ServerName;
+use serde_json::json;
 use stream_assert::{assert_next_matches, assert_pending};
+use tempfile::tempdir;
 use url::Url;
 use wiremock::{
     matchers::{method, path},
@@ -26,15 +28,20 @@ use super::{
     AuthorizationCode, AuthorizationError, AuthorizationResponse, Oidc, OidcError, OidcSession,
     OidcSessionTokens, RedirectUriQueryParseError, UserSession,
 };
-use crate::{test_utils::test_client_builder, Client};
+use crate::{
+    oidc::registrations::{ClientId, OidcRegistrations},
+    test_utils::test_client_builder,
+    Client, Error,
+};
 
 const CLIENT_ID: &str = "test_client_id";
+const REDIRECT_URI_STRING: &str = "http://matrix.example.com/oidc/callback";
 
 pub fn mock_registered_client_data() -> (ClientCredentials, VerifiedClientMetadata) {
     (
         ClientCredentials::None { client_id: CLIENT_ID.to_owned() },
         ClientMetadata {
-            redirect_uris: Some(vec![]), // empty vector is ok lol
+            redirect_uris: Some(vec![Url::parse(REDIRECT_URI_STRING).unwrap()]),
             token_endpoint_auth_method: Some(OAuthClientAuthenticationMethod::None),
             ..ClientMetadata::default()
         }
@@ -59,6 +66,122 @@ pub fn mock_session(tokens: OidcSessionTokens) -> OidcSession {
     }
 }
 
+pub async fn mock_environment(
+) -> anyhow::Result<(Oidc, MockServer, VerifiedClientMetadata, OidcRegistrations)> {
+    let server = MockServer::start().await;
+    let issuer = ISSUER_URL.to_owned();
+    let issuer_url = Url::parse(&issuer).unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/unstable/org.matrix.msc2965/auth_issuer"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"issuer": issuer})))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/r0/account/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "user_id": "@joe:example.org",
+            "device_id": "D3V1C31D"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = test_client_builder(Some(server.uri())).build().await?;
+
+    let session_tokens = OidcSessionTokens {
+        access_token: "4cc3ss".to_owned(),
+        refresh_token: Some("r3fr3$h".to_owned()),
+        latest_id_token: None,
+    };
+
+    let oidc = Oidc {
+        client: client.clone(),
+        backend: Arc::new(
+            MockImpl::new().mark_insecure().next_session_tokens(session_tokens.clone()),
+        ),
+    };
+
+    let (client_credentials, client_metadata) = mock_registered_client_data();
+
+    // The mock backend doesn't support registration so set a static registration.
+    let mut static_registrations = HashMap::new();
+    static_registrations.insert(issuer_url, ClientId(client_credentials.client_id().to_owned()));
+
+    let registrations_path = tempdir().unwrap().path().join("oidc").join("registrations.json");
+    let registrations =
+        OidcRegistrations::new(&registrations_path, client_metadata.clone(), static_registrations)
+            .unwrap();
+
+    Ok((oidc, server, client_metadata, registrations))
+}
+
+#[async_test]
+async fn test_high_level_login() -> anyhow::Result<()> {
+    let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
+
+    assert!(oidc.issuer().is_none());
+    assert!(oidc.client_metadata().is_none());
+    assert!(oidc.client_credentials().is_none());
+
+    let authorization_data =
+        oidc.url_for_oidc_login(metadata.clone(), registrations).await.unwrap();
+
+    assert!(oidc.issuer().is_some());
+    assert!(oidc.client_metadata().is_some());
+    assert!(oidc.client_credentials().is_some());
+
+    let mut callback_uri = metadata.redirect_uris.clone().unwrap().first().unwrap().clone();
+    callback_uri.set_query(Some(&format!("code=42&state={}", authorization_data.state)));
+
+    oidc.login_with_oidc_callback(&authorization_data, callback_uri).await?;
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_high_level_login_cancellation() -> anyhow::Result<()> {
+    let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
+
+    let authorization_data =
+        oidc.url_for_oidc_login(metadata.clone(), registrations).await.unwrap();
+
+    assert!(oidc.issuer().is_some());
+    assert!(oidc.client_metadata().is_some());
+    assert!(oidc.client_credentials().is_some());
+
+    let mut callback_uri = metadata.redirect_uris.clone().unwrap().first().unwrap().clone();
+    callback_uri
+        .set_query(Some(&format!("error=access_denied&state={}", authorization_data.state)));
+
+    let error = oidc.login_with_oidc_callback(&authorization_data, callback_uri).await.unwrap_err();
+
+    assert_matches!(error, Error::Oidc(OidcError::CancelledAuthorization));
+
+    Ok(())
+}
+
+#[async_test]
+async fn test_high_level_login_invalid_state() -> anyhow::Result<()> {
+    let (oidc, _server, metadata, registrations) = mock_environment().await.unwrap();
+
+    let authorization_data =
+        oidc.url_for_oidc_login(metadata.clone(), registrations).await.unwrap();
+
+    assert!(oidc.issuer().is_some());
+    assert!(oidc.client_metadata().is_some());
+    assert!(oidc.client_credentials().is_some());
+
+    let mut callback_uri = metadata.redirect_uris.clone().unwrap().first().unwrap().clone();
+    callback_uri.set_query(Some("code=42&state=imposter_alert"));
+
+    let error = oidc.login_with_oidc_callback(&authorization_data, callback_uri).await.unwrap_err();
+
+    assert_matches!(error, Error::Oidc(OidcError::InvalidState));
+
+    Ok(())
+}
+
 #[async_test]
 async fn test_login() -> anyhow::Result<()> {
     let client = test_client_builder(Some("https://example.org".to_owned())).build().await?;
@@ -70,7 +193,7 @@ async fn test_login() -> anyhow::Result<()> {
     let (client_credentials, client_metadata) = mock_registered_client_data();
     oidc.restore_registered_client(ISSUER_URL.to_owned(), client_metadata, client_credentials);
 
-    let redirect_uri_str = "http://matrix.example.com/oidc/callback";
+    let redirect_uri_str = REDIRECT_URI_STRING;
     let redirect_uri = Url::parse(redirect_uri_str)?;
     let mut authorization_data = oidc.login(redirect_uri, Some(device_id.clone()))?.build().await?;
 
@@ -181,7 +304,7 @@ async fn test_finish_authorization() -> anyhow::Result<()> {
 
     // Assuming a non-empty state "123"...
     let state = "state".to_owned();
-    let redirect_uri = "http://matrix.example.com/oidc/callback";
+    let redirect_uri = REDIRECT_URI_STRING;
     let auth_validation_data = AuthorizationValidationData {
         state: state.clone(),
         nonce: "nonce".to_owned(),


### PR DESCRIPTION
This PR moves the remaining logic from the `AuthenticationService` into the SDK. For now this doesn't expose anything new in the FFI and simply calls the inner methods. I'll leave that and deleting the service for a follow-up PR.

Another part of #3029.