### PR TITLE
send queue: add state store backend for persisting pending events to disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4581,9 +4581,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
 dependencies = [
  "bitflags 2.5.0",
  "memchr",
@@ -4593,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "qoi"
@@ -5009,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "assign",
  "js_int",
@@ -5026,7 +5026,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "as_variant",
  "assign",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5081,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -5117,7 +5117,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5129,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5138,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -5153,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=c21817436979acbe66d43064498920a6d289b562#c21817436979acbe66d43064498920a6d289b562"
+source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "c21817436979acbe66d43064498920a6d289b562", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "fec2152d879a6c6c2bccce984d4b8f424f460cb2", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -55,7 +55,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "c21817436979acbe66d4306449
     "unstable-msc3266",
     "unstable-msc4075"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "c21817436979acbe66d43064498920a6d289b562" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "fec2152d879a6c6c2bccce984d4b8f424f460cb2" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -661,12 +661,15 @@ impl AbortSendHandle {
     ///
     /// This has an effect only on the first call; subsequent calls will always
     /// return `false`.
-    async fn abort(self: Arc<Self>) -> bool {
+    async fn abort(self: Arc<Self>) -> Result<bool, ClientError> {
         if let Some(inner) = self.inner.lock().await.take() {
-            inner.abort().await
+            Ok(inner
+                .abort()
+                .await
+                .map_err(|err| anyhow::anyhow!("error when saving in store: {err}"))?)
         } else {
             warn!("trying to abort an send handle that's already been actioned");
-            false
+            Ok(false)
         }
     }
 }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -72,8 +72,9 @@ pub use self::integration_tests::StateStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
     traits::{
-        ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, StateStore,
-        StateStoreDataKey, StateStoreDataValue, StateStoreExt,
+        ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, QueuedEvent,
+        SerializableEventContent, StateStore, StateStoreDataKey, StateStoreDataValue,
+        StateStoreExt,
     },
 };
 

--- a/crates/matrix-sdk-sqlite/migrations/state_store/003_send_queue.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/003_send_queue.sql
@@ -1,0 +1,9 @@
+-- Send queue events, keyed by room id and transaction id.
+CREATE TABLE "send_queue_events" (
+    "room_id" BLOB NOT NULL,
+    "transaction_id" BLOB NOT NULL,
+    "content" BLOB NOT NULL,
+    "wedged" BOOLEAN NOT NULL,
+
+    PRIMARY KEY ("room_id", "transaction_id")
+);

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -11,7 +11,7 @@ use deadpool_sqlite::{Object as SqliteConn, Pool as SqlitePool, Runtime};
 use matrix_sdk_base::{
     deserialized_responses::{RawAnySyncOrStrippedState, SyncOrStrippedState},
     media::{MediaRequest, UniqueKey},
-    store::migration_helpers::RoomInfoV1,
+    store::{migration_helpers::RoomInfoV1, QueuedEvent, SerializableEventContent},
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue,
 };
@@ -29,7 +29,8 @@ use ruma::{
         GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
     },
     serde::Raw,
-    CanonicalJsonObject, EventId, OwnedEventId, OwnedUserId, RoomId, RoomVersionId, UserId,
+    CanonicalJsonObject, EventId, OwnedEventId, OwnedTransactionId, OwnedUserId, RoomId,
+    RoomVersionId, TransactionId, UserId,
 };
 use rusqlite::{OptionalExtension, Transaction};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -55,9 +56,10 @@ mod keys {
     pub const RECEIPT: &str = "receipt";
     pub const DISPLAY_NAME: &str = "display_name";
     pub const MEDIA: &str = "media";
+    pub const SEND_QUEUE: &str = "send_queue_events";
 }
 
-const DATABASE_VERSION: u8 = 3;
+const DATABASE_VERSION: u8 = 4;
 
 /// A sqlite based cryptostore.
 #[derive(Clone)]
@@ -208,6 +210,15 @@ impl SqliteStateStore {
                         .execute((data, room_id))?;
                 }
 
+                Result::<_, Error>::Ok(())
+            })
+            .await?;
+        }
+
+        if from < 4 && to >= 4 {
+            conn.with_transaction(move |txn| {
+                // Create new table.
+                txn.execute_batch(include_str!("../migrations/state_store/003_send_queue.sql"))?;
                 Result::<_, Error>::Ok(())
             })
             .await?;
@@ -403,6 +414,7 @@ trait SqliteConnectionStateStoreExt {
     fn set_display_name(&self, room_id: &[u8], name: &[u8], data: &[u8]) -> rusqlite::Result<()>;
     fn remove_display_name(&self, room_id: &[u8], name: &[u8]) -> rusqlite::Result<()>;
     fn remove_room_display_names(&self, room_id: &[u8]) -> rusqlite::Result<()>;
+    fn remove_room_send_queue(&self, room_id: &[u8]) -> rusqlite::Result<()>;
 }
 
 impl SqliteConnectionStateStoreExt for rusqlite::Connection {
@@ -607,6 +619,11 @@ impl SqliteConnectionStateStoreExt for rusqlite::Connection {
 
     fn remove_room_display_names(&self, room_id: &[u8]) -> rusqlite::Result<()> {
         self.prepare("DELETE FROM display_name WHERE room_id = ?")?.execute((room_id,))?;
+        Ok(())
+    }
+
+    fn remove_room_send_queue(&self, room_id: &[u8]) -> rusqlite::Result<()> {
+        self.prepare("DELETE FROM send_queue_events WHERE room_id = ?")?.execute((room_id,))?;
         Ok(())
     }
 }
@@ -1643,6 +1660,109 @@ impl StateStore for SqliteStateStore {
                 let display_name_room_id = this.encode_key(keys::DISPLAY_NAME, &room_id);
                 txn.remove_room_display_names(&display_name_room_id)?;
 
+                let send_queue_room_id = this.encode_key(keys::SEND_QUEUE, &room_id);
+                txn.remove_room_send_queue(&send_queue_room_id)?;
+
+                Ok(())
+            })
+            .await
+    }
+
+    async fn save_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: OwnedTransactionId,
+        content: SerializableEventContent,
+    ) -> Result<(), Self::Error> {
+        let room_id = self.encode_key(keys::SEND_QUEUE, room_id);
+
+        let content = self.serialize_json(&content)?;
+
+        // The transaction id is used both as a key (in remove/update) and a value (as
+        // it's useful for the callers), so we keep it as is, and neither hash
+        // it (with encode_key) or encrypt it (through serialize_value). After
+        // all, it carries no personal information, so this is considered fine.
+
+        self.acquire()
+            .await?
+            .with_transaction(move |txn| {
+                txn.prepare_cached("INSERT INTO send_queue_events (room_id, transaction_id, content, wedged) VALUES (?, ?, ?, false)")?.execute((room_id, transaction_id.to_string(), content))?;
+                Ok(())
+            })
+            .await
+    }
+
+    async fn remove_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+    ) -> Result<(), Self::Error> {
+        let room_id = self.encode_key(keys::SEND_QUEUE, room_id);
+
+        // See comment in `save_send_queue_event`.
+        let transaction_id = transaction_id.to_string();
+
+        self.acquire()
+            .await?
+            .with_transaction(move |txn| {
+                txn.prepare_cached(
+                    "DELETE FROM send_queue_events WHERE room_id = ? AND transaction_id = ?",
+                )?
+                .execute((room_id, transaction_id))?;
+                Ok(())
+            })
+            .await
+    }
+
+    async fn load_send_queue_events(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<QueuedEvent>, Self::Error> {
+        let room_id = self.encode_key(keys::SEND_QUEUE, room_id);
+
+        // Note: ROWID is always present and is an auto-incremented integer counter. We
+        // want to maintain the insertion order, so we can sort using it.
+        // Note 2: transaction_id is not encoded, see why in `save_send_queue_event`.
+        let res: Vec<(String, Vec<u8>, bool)> = self
+            .acquire()
+            .await?
+            .prepare(
+                "SELECT transaction_id, content, wedged FROM send_queue_events WHERE room_id = ? ORDER BY ROWID",
+                |mut stmt| {
+                    stmt.query((room_id,))?
+                        .mapped(|row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+                        .collect()
+                },
+            )
+            .await?;
+
+        let mut queued_events = Vec::with_capacity(res.len());
+        for entry in res {
+            queued_events.push(QueuedEvent {
+                transaction_id: entry.0.into(),
+                event: self.deserialize_json(&entry.1)?,
+                is_wedged: entry.2,
+            });
+        }
+
+        Ok(queued_events)
+    }
+
+    async fn update_send_queue_event_status(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        wedged: bool,
+    ) -> Result<(), Self::Error> {
+        let room_id = self.encode_key(keys::SEND_QUEUE, room_id);
+
+        // See comment in `save_send_queue_event`.
+        let transaction_id = transaction_id.to_string();
+
+        self.acquire()
+            .await?
+            .with_transaction(move |txn| {
+                txn.prepare_cached("UPDATE send_queue_events SET wedged = ? WHERE room_id = ? AND transaction_id = ?")?.execute((wedged, room_id, transaction_id))?;
                 Ok(())
             })
             .await
@@ -1673,6 +1793,8 @@ mod tests {
         let name = NUM.fetch_add(1, SeqCst).to_string();
         let tmpdir_path = TMP_DIR.path().join(name);
 
+        tracing::info!("using store @ {}", tmpdir_path.to_str().unwrap());
+
         Ok(SqliteStateStore::open(tmpdir_path.to_str().unwrap(), None).await.unwrap())
     }
 
@@ -1695,6 +1817,8 @@ mod encrypted_tests {
     async fn get_store() -> Result<impl StateStore, StoreError> {
         let name = NUM.fetch_add(1, SeqCst).to_string();
         let tmpdir_path = TMP_DIR.path().join(name);
+
+        tracing::info!("using store @ {}", tmpdir_path.to_str().unwrap());
 
         Ok(SqliteStateStore::open(tmpdir_path.to_str().unwrap(), Some("default_test_password"))
             .await

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -267,10 +267,10 @@ impl TimelineBuilder {
         });
 
         let local_echo_listener_handle = if is_live {
-            Some(spawn({
-                let timeline = inner.clone();
-                let (local_echoes, mut listener) = room.send_queue().subscribe().await;
+            let timeline = inner.clone();
+            let (local_echoes, mut listener) = room.send_queue().subscribe().await?;
 
+            Some(spawn({
                 // Handles existing local echoes first.
                 for echo in local_echoes {
                     timeline

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use matrix_sdk::{
     event_cache::{paginator::PaginatorError, EventCacheError},
     send_queue::RoomSendQueueError,
+    StoreError,
 };
 use ruma::OwnedTransactionId;
 use thiserror::Error;
@@ -68,6 +69,10 @@ pub enum Error {
     /// An error happened during pagination.
     #[error("An error happened during pagination.")]
     PaginationError(#[from] PaginationError),
+
+    /// An error happened while operating the room's send queue.
+    #[error(transparent)]
+    SendQueueError(#[from] RoomSendQueueError),
 }
 
 #[derive(Error, Debug)]
@@ -161,7 +166,7 @@ pub enum SendEventError {
     UnsupportedEditItem(#[from] UnsupportedEditItem),
 
     #[error(transparent)]
-    SendError(#[from] RoomSendQueueError),
+    RoomQueueError(#[from] RoomSendQueueError),
 }
 
 #[derive(Debug, Error)]
@@ -171,4 +176,7 @@ pub enum RedactEventError {
 
     #[error(transparent)]
     SdkError(#[from] matrix_sdk::Error),
+
+    #[error("an error happened while interacting with the room queue")]
+    RoomQueueError(#[source] StoreError),
 }

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -16,8 +16,7 @@ use std::fmt;
 
 use matrix_sdk::{
     event_cache::{paginator::PaginatorError, EventCacheError},
-    send_queue::RoomSendQueueError,
-    StoreError,
+    send_queue::{RoomSendQueueError, RoomSendQueueStorageError},
 };
 use ruma::OwnedTransactionId;
 use thiserror::Error;
@@ -178,5 +177,5 @@ pub enum RedactEventError {
     SdkError(#[from] matrix_sdk::Error),
 
     #[error("an error happened while interacting with the room queue")]
-    RoomQueueError(#[source] StoreError),
+    RoomQueueError(#[source] RoomSendQueueStorageError),
 }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -720,7 +720,7 @@ impl Timeline {
         match &event.kind {
             EventTimelineItemKind::Local(local) => {
                 if let Some(handle) = local.abort_handle.clone() {
-                    Ok(handle.abort().await)
+                    Ok(handle.abort().await.map_err(RedactEventError::RoomQueueError)?)
                 } else {
                     // No abort handle; theoretically unreachable for regular usage of the
                     // timeline, but this may happen in testing contexts.

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -312,7 +312,7 @@ async fn test_cancel_failed() {
     assert_matches!(value.send_state(), Some(EventSendState::SendingFailed { .. }));
 
     // Discard, assert the local echo is found
-    assert!(handle.abort().await);
+    assert!(handle.abort().await.unwrap());
 
     // Observable local echo being removed
     assert_matches!(timeline_stream.next().await, Some(VectorDiff::Remove { index: 0 }));

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -271,6 +271,7 @@ impl Media {
 
         let content: Vec<u8> = match &request.source {
             MediaSource::Encrypted(file) => {
+                #[allow(deprecated)]
                 let request = get_content::v3::Request::from_url(&file.url)?;
                 let content: Vec<u8> = self.client.send(request, None).await?.file;
 
@@ -296,10 +297,12 @@ impl Media {
             }
             MediaSource::Plain(uri) => {
                 if let MediaFormat::Thumbnail(size) = &request.format {
+                    #[allow(deprecated)]
                     let request =
                         get_content_thumbnail::v3::Request::from_url(uri, size.width, size.height)?;
                     self.client.send(request, None).await?.file
                 } else {
+                    #[allow(deprecated)]
                     let request = get_content::v3::Request::from_url(uri)?;
                     self.client.send(request, None).await?.file
                 }

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -209,7 +209,7 @@ async fn test_smoke() {
 
     let q = room.send_queue();
 
-    let (local_echoes, mut watch) = q.subscribe().await;
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
 
@@ -250,7 +250,7 @@ async fn test_smoke() {
     let (txn1, _) = assert_update!(watch => local echo { body = "1" });
 
     {
-        let (local_echoes, _) = q.subscribe().await;
+        let (local_echoes, _) = q.subscribe().await.unwrap();
 
         assert_eq!(local_echoes.len(), 1);
         assert_eq!(local_echoes[0].transaction_id, txn1);
@@ -290,7 +290,7 @@ async fn test_error_then_locally_reenabling() {
 
     let q = room.send_queue();
 
-    let (local_echoes, mut watch) = q.subscribe().await;
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
 
@@ -326,7 +326,7 @@ async fn test_error_then_locally_reenabling() {
     let (txn1, _) = assert_update!(watch => local echo { body = "1" });
 
     {
-        let (local_echoes, _) = q.subscribe().await;
+        let (local_echoes, _) = q.subscribe().await.unwrap();
         assert_eq!(local_echoes.len(), 1);
         assert_eq!(local_echoes[0].transaction_id, txn1);
     }
@@ -401,7 +401,7 @@ async fn test_error_then_globally_reenabling() {
 
     let q = room.send_queue();
 
-    let (local_echoes, mut watch) = q.subscribe().await;
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
 
@@ -479,7 +479,7 @@ async fn test_reenabling_queue() {
 
     let q = room.send_queue();
 
-    let (local_echoes, mut watch) = q.subscribe().await;
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
 
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
@@ -494,7 +494,7 @@ async fn test_reenabling_queue() {
     }
 
     {
-        let (local_echoes, _) = q.subscribe().await;
+        let (local_echoes, _) = q.subscribe().await.unwrap();
         assert_eq!(local_echoes.len(), 3);
     }
 
@@ -606,7 +606,7 @@ async fn test_cancellation() {
 
     let q = room.send_queue();
 
-    let (local_echoes, mut watch) = q.subscribe().await;
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
 
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
@@ -664,24 +664,24 @@ async fn test_cancellation() {
     tokio::task::yield_now().await;
 
     // The first item is already being sent, so we can't abort it.
-    assert!(!handle1.abort().await);
+    assert!(!handle1.abort().await.unwrap());
     assert!(watch.is_empty());
 
     // The second item is pending, so we can abort it, using the handle returned by
     // `send()`.
-    assert!(handle2.abort().await);
+    assert!(handle2.abort().await.unwrap());
     assert_update!(watch => cancelled { txn = txn2 });
     assert!(watch.is_empty());
 
     // The third item is pending, so we can abort it, using the handle received from
     // the update.
-    assert!(handle3.abort().await);
+    assert!(handle3.abort().await.unwrap());
     assert_update!(watch => cancelled { txn = txn3 });
     assert!(watch.is_empty());
 
     // The fourth item is pending, so we can abort it, using an handle provided by
     // the initial array of values.
-    let (mut local_echoes, _) = q.subscribe().await;
+    let (mut local_echoes, _) = q.subscribe().await.unwrap();
 
     // At this point, local echoes = txn1, txn4, txn5.
     assert_eq!(local_echoes.len(), 3);
@@ -691,7 +691,7 @@ async fn test_cancellation() {
 
     let handle4 = local_echo4.abort_handle;
 
-    assert!(handle4.abort().await);
+    assert!(handle4.abort().await.unwrap());
     assert_update!(watch => cancelled { txn = txn4 });
     assert!(watch.is_empty());
 
@@ -732,7 +732,7 @@ async fn test_abort_after_disable() {
 
     let q = room.send_queue();
 
-    let (local_echoes, mut watch) = q.subscribe().await;
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
 
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
@@ -763,7 +763,7 @@ async fn test_abort_after_disable() {
     assert!(client.send_queue().is_enabled());
 
     // Aborting the sending should work.
-    assert!(abort_send_handle.abort().await);
+    assert!(abort_send_handle.abort().await.unwrap());
 
     assert_update!(watch => cancelled { txn = txn });
 
@@ -799,7 +799,7 @@ async fn test_unrecoverable_errors() {
 
     let q = room.send_queue();
 
-    let (local_echoes, mut watch) = q.subscribe().await;
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
 
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());
@@ -895,7 +895,7 @@ async fn test_no_network_access_error_is_recoverable() {
     assert!(client.send_queue().is_enabled());
 
     let q = room.send_queue();
-    let (local_echoes, mut watch) = q.subscribe().await;
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
 
     assert!(local_echoes.is_empty());
     assert!(watch.is_empty());

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -687,7 +687,7 @@ async fn test_cancellation() {
     assert_eq!(local_echoes.len(), 3);
 
     let local_echo4 = local_echoes.remove(1);
-    assert_eq!(local_echo4.transaction_id, txn4);
+    assert_eq!(local_echo4.transaction_id, txn4, "local echoes: {local_echoes:?}");
 
     let handle4 = local_echo4.abort_handle;
 


### PR DESCRIPTION
Ruma needs https://github.com/ruma/ruma/pull/1850. I need an Advil.

Part of #3361. The remaining bit will be to, at start, reload all the rooms' send queues that had _some_ pending event (right now, pending events will be automatically re-sent as soon as a timeline is opened for that room).