### PR TITLE
fix(ffi): Downgrade security-framework to 2.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5371,11 +5371,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",


### PR DESCRIPTION
Fixes: #3596

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)
