### PR TITLE
send queue: allow sending raw events from the send queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5009,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "assign",
  "js_int",
@@ -5026,7 +5026,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "as_variant",
  "assign",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5081,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -5117,7 +5117,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5129,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5138,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -5153,7 +5153,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/ruma/ruma?rev=fec2152d879a6c6c2bccce984d4b8f424f460cb2#fec2152d879a6c6c2bccce984d4b8f424f460cb2"
+source = "git+https://github.com/ruma/ruma?rev=e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0#e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/ruma/ruma", rev = "fec2152d879a6c6c2bccce984d4b8f424f460cb2", features = [
+ruma = { git = "https://github.com/ruma/ruma", rev = "e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -55,7 +55,7 @@ ruma = { git = "https://github.com/ruma/ruma", rev = "fec2152d879a6c6c2bccce984d
     "unstable-msc3266",
     "unstable-msc4075"
 ] }
-ruma-common = { git = "https://github.com/ruma/ruma", rev = "fec2152d879a6c6c2bccce984d4b8f424f460cb2" }
+ruma-common = { git = "https://github.com/ruma/ruma", rev = "e5a370f7e5fcebb0da6e4945e51c5fafba9aa5f0" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1323,7 +1323,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         {
             assert_eq!(pending[0].transaction_id, txn0);
 
-            let deserialized = pending[0].event.as_content().unwrap();
+            let deserialized = pending[0].event.deserialize().unwrap();
             assert_let!(AnyMessageLikeEventContent::RoomMessage(content) = deserialized);
             assert_eq!(content.body(), "msg0");
 
@@ -1350,7 +1350,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         assert_eq!(pending[0].transaction_id, txn0);
 
         for i in 0..4 {
-            let deserialized = pending[i].event.as_content().unwrap();
+            let deserialized = pending[i].event.deserialize().unwrap();
             assert_let!(AnyMessageLikeEventContent::RoomMessage(content) = deserialized);
             assert_eq!(content.body(), format!("msg{i}"));
             assert!(!pending[i].is_wedged);

--- a/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/replies.rs
@@ -535,7 +535,7 @@ async fn test_send_reply_to_threaded() {
     // The reply should be considered part of the thread.
     assert!(reply_message.is_threaded());
 
-    // Some extra assertions
+    // Some extra assertions.
     assert_eq!(reply_message.body(), "Hello, Bob!");
     let in_reply_to = reply_message.in_reply_to().unwrap();
     assert_eq!(in_reply_to.event_id, event_id_1);
@@ -543,13 +543,13 @@ async fn test_send_reply_to_threaded() {
     assert_let!(TimelineDetails::Ready(replied_to_event) = &in_reply_to.event);
     assert_eq!(replied_to_event.sender(), *BOB);
 
-    // Wait for remote echo
+    // Wait for remote echo.
     let diff = timeout(timeline_stream.next(), Duration::from_secs(1)).await.unwrap().unwrap();
     assert_let!(VectorDiff::Set { index: 1, value: reply_item_remote_echo } = diff);
 
     assert_matches!(reply_item_remote_echo.send_state(), Some(EventSendState::Sent { .. }));
 
-    // Same assertions as before still hold on the contained message
+    // Same assertions as before still hold on the contained message.
     assert!(reply_message.is_threaded());
 
     assert_eq!(reply_message.body(), "Hello, Bob!");

--- a/crates/matrix-sdk/src/room/futures.rs
+++ b/crates/matrix-sdk/src/room/futures.rs
@@ -150,6 +150,13 @@ impl<'a> SendRawMessageLikeEvent<'a> {
         self.transaction_id = Some(txn_id.to_owned());
         self
     }
+
+    /// Assign a given [`RequestConfig`] to configure how this request should
+    /// behave with respect to the network.
+    pub fn with_request_config(mut self, request_config: RequestConfig) -> Self {
+        self.request_config = Some(request_config);
+        self
+    }
 }
 
 impl<'a> IntoFuture for SendRawMessageLikeEvent<'a> {


### PR DESCRIPTION
This requires a bit of API rejiggering, but turns out not so bad actually.

Requires a [Ruma fix](https://github.com/ruma/ruma/pull/1866) first, otherwise it'll break all message responses in threads (as a test failure will show).

Part of #3361.

Note: draft only because this is waiting for the Ruma fix, otherwise the code is ready for review.