### PR TITLE
chore: Fix more nightly warnings and bump nightly in CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-05-19
+        toolchain: nightly-2024-06-24
         components: rustfmt
 
     - name: Run Benchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-06-24
+        toolchain: nightly-2024-06-25
         components: rustfmt
 
     - name: Run Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-05-19
+          toolchain: nightly-2024-06-24
           components: rustfmt
 
       - name: Cargo fmt
@@ -316,7 +316,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-05-19
+          toolchain: nightly-2024-06-24
           components: clippy
 
       - name: Load cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-06-24
+          toolchain: nightly-2024-06-25
           components: rustfmt
 
       - name: Cargo fmt
@@ -316,7 +316,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-06-24
+          toolchain: nightly-2024-06-25
           components: clippy
 
       - name: Load cache

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-06-24
+          toolchain: nightly-2024-06-25
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-05-19
+          toolchain: nightly-2024-06-24
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -185,11 +185,11 @@ impl From<anyhow::Error> for MigrationError {
 /// * `path` - The path where the SQLite store should be created.
 ///
 /// * `passphrase` - The passphrase that should be used to encrypt the data at
-/// rest in the SQLite store. **Warning**, if no passphrase is given, the store
-/// and all its data will remain unencrypted.
+///   rest in the SQLite store. **Warning**, if no passphrase is given, the store
+///   and all its data will remain unencrypted.
 ///
 /// * `progress_listener` - A callback that can be used to introspect the
-/// progress of the migration.
+///   progress of the migration.
 #[uniffi::export]
 pub fn migrate(
     data: MigrationData,
@@ -348,11 +348,11 @@ async fn save_changes(
 /// * `path` - The path where the SQLite store should be created.
 ///
 /// * `passphrase` - The passphrase that should be used to encrypt the data at
-/// rest in the SQLite store. **Warning**, if no passphrase is given, the store
-/// and all its data will remain unencrypted.
+///   rest in the SQLite store. **Warning**, if no passphrase is given, the store
+///   and all its data will remain unencrypted.
 ///
 /// * `progress_listener` - A callback that can be used to introspect the
-/// progress of the migration.
+///   progress of the migration.
 #[uniffi::export]
 pub fn migrate_sessions(
     data: SessionMigrationData,
@@ -503,8 +503,8 @@ fn collect_sessions(
 /// * `path` - The path where the Sqlite store should be created.
 ///
 /// * `passphrase` - The passphrase that should be used to encrypt the data at
-/// rest in the Sqlite store. **Warning**, if no passphrase is given, the store
-/// and all its data will remain unencrypted.
+///   rest in the Sqlite store. **Warning**, if no passphrase is given, the store
+///   and all its data will remain unencrypted.
 #[uniffi::export]
 pub fn migrate_room_settings(
     room_settings: HashMap<String, RoomSettings>,

--- a/bindings/matrix-sdk-crypto-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/lib.rs
@@ -185,8 +185,8 @@ impl From<anyhow::Error> for MigrationError {
 /// * `path` - The path where the SQLite store should be created.
 ///
 /// * `passphrase` - The passphrase that should be used to encrypt the data at
-///   rest in the SQLite store. **Warning**, if no passphrase is given, the store
-///   and all its data will remain unencrypted.
+///   rest in the SQLite store. **Warning**, if no passphrase is given, the
+///   store and all its data will remain unencrypted.
 ///
 /// * `progress_listener` - A callback that can be used to introspect the
 ///   progress of the migration.
@@ -348,8 +348,8 @@ async fn save_changes(
 /// * `path` - The path where the SQLite store should be created.
 ///
 /// * `passphrase` - The passphrase that should be used to encrypt the data at
-///   rest in the SQLite store. **Warning**, if no passphrase is given, the store
-///   and all its data will remain unencrypted.
+///   rest in the SQLite store. **Warning**, if no passphrase is given, the
+///   store and all its data will remain unencrypted.
 ///
 /// * `progress_listener` - A callback that can be used to introspect the
 ///   progress of the migration.
@@ -503,8 +503,8 @@ fn collect_sessions(
 /// * `path` - The path where the Sqlite store should be created.
 ///
 /// * `passphrase` - The passphrase that should be used to encrypt the data at
-///   rest in the Sqlite store. **Warning**, if no passphrase is given, the store
-///   and all its data will remain unencrypted.
+///   rest in the Sqlite store. **Warning**, if no passphrase is given, the
+///   store and all its data will remain unencrypted.
 #[uniffi::export]
 pub fn migrate_room_settings(
     room_settings: HashMap<String, RoomSettings>,

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -252,11 +252,11 @@ impl OlmMachine {
     /// * `user_id` - The unique id of the user that the identity belongs to
     ///
     /// * `timeout` - The time in seconds we should wait before returning if
-    /// the user's device list has been marked as stale. Passing a 0 as the
-    /// timeout means that we won't wait at all. **Note**, this assumes that
-    /// the requests from [`OlmMachine::outgoing_requests`] are being processed
-    /// and sent out. Namely, this waits for a `/keys/query` response to be
-    /// received.
+    ///   the user's device list has been marked as stale. Passing a 0 as the
+    ///   timeout means that we won't wait at all. **Note**, this assumes that
+    ///   the requests from [`OlmMachine::outgoing_requests`] are being processed
+    ///   and sent out. Namely, this waits for a `/keys/query` response to be
+    ///   received.
     pub fn get_identity(
         &self,
         user_id: String,
@@ -334,11 +334,11 @@ impl OlmMachine {
     /// * `device_id` - The id of the device itself.
     ///
     /// * `timeout` - The time in seconds we should wait before returning if
-    /// the user's device list has been marked as stale. Passing a 0 as the
-    /// timeout means that we won't wait at all. **Note**, this assumes that
-    /// the requests from [`OlmMachine::outgoing_requests`] are being processed
-    /// and sent out. Namely, this waits for a `/keys/query` response to be
-    /// received.
+    ///   the user's device list has been marked as stale. Passing a 0 as the
+    ///   timeout means that we won't wait at all. **Note**, this assumes that
+    ///   the requests from [`OlmMachine::outgoing_requests`] are being processed
+    ///   and sent out. Namely, this waits for a `/keys/query` response to be
+    ///   received.
     pub fn get_device(
         &self,
         user_id: String,
@@ -417,11 +417,11 @@ impl OlmMachine {
     /// * `user_id` - The id of the device owner.
     ///
     /// * `timeout` - The time in seconds we should wait before returning if
-    /// the user's device list has been marked as stale. Passing a 0 as the
-    /// timeout means that we won't wait at all. **Note**, this assumes that
-    /// the requests from [`OlmMachine::outgoing_requests`] are being processed
-    /// and sent out. Namely, this waits for a `/keys/query` response to be
-    /// received.
+    ///   the user's device list has been marked as stale. Passing a 0 as the
+    ///   timeout means that we won't wait at all. **Note**, this assumes that
+    ///   the requests from [`OlmMachine::outgoing_requests`] are being processed
+    ///   and sent out. Namely, this waits for a `/keys/query` response to be
+    ///   received.
     pub fn get_user_devices(
         &self,
         user_id: String,
@@ -517,7 +517,7 @@ impl OlmMachine {
     ///   current sync response.
     ///
     /// * `device_changes` - The list of devices that have changed in some way
-    /// since the previous sync.
+    ///   since the previous sync.
     ///
     /// * `key_counts` - The map of uploaded one-time key types and counts.
     pub fn receive_sync_changes(
@@ -608,7 +608,7 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `users` - The list of users for which we would like to establish 1:1
-    /// Olm sessions for.
+    ///   Olm sessions for.
     pub fn get_missing_sessions(
         &self,
         users: Vec<String>,
@@ -729,11 +729,11 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `room_id` - The unique id of the room, note that this doesn't strictly
-    /// need to be a Matrix room, it just needs to be an unique identifier for
-    /// the group that will participate in the conversation.
+    ///   need to be a Matrix room, it just needs to be an unique identifier for
+    ///   the group that will participate in the conversation.
     ///
     /// * `users` - The list of users which are considered to be members of the
-    /// room and should receive the room key.
+    ///   room and should receive the room key.
     ///
     /// * `settings` - The settings that should be used for the room key.
     pub fn share_room_key(
@@ -935,7 +935,7 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `event` - The undecryptable event that we would wish to request a room
-    /// key for.
+    ///   key for.
     ///
     /// * `room_id` - The id of the room the event was sent to.
     pub fn request_room_key(
@@ -960,10 +960,10 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `passphrase` - The passphrase that should be used to encrypt the key
-    /// export.
+    ///   export.
     ///
     /// * `rounds` - The number of rounds that should be used when expanding the
-    /// passphrase into an key.
+    ///   passphrase into an key.
     pub fn export_room_keys(
         &self,
         passphrase: String,
@@ -986,7 +986,7 @@ impl OlmMachine {
     /// * `passphrase` - The passphrase that was used to encrypt the key export.
     ///
     /// * `progress_listener` - A callback that can be used to introspect the
-    /// progress of the key import.
+    ///   progress of the key import.
     pub fn import_room_keys(
         &self,
         keys: String,
@@ -1013,7 +1013,7 @@ impl OlmMachine {
     /// * `keys` - The serialized version of the unencrypted key export.
     ///
     /// * `progress_listener` - A callback that can be used to introspect the
-    /// progress of the key import.
+    ///   progress of the key import.
     pub fn import_decrypted_room_keys(
         &self,
         keys: String,
@@ -1038,10 +1038,10 @@ impl OlmMachine {
     /// * `keys` - The serialized version of the unencrypted key export.
     ///
     /// * `backup_version` - The version of the backup that these keys came
-    /// from.
+    ///   from.
     ///
     /// * `progress_listener` - A callback that can be used to introspect the
-    /// progress of the key import.
+    ///   progress of the key import.
     pub fn import_room_keys_from_backup(
         &self,
         keys: String,
@@ -1101,7 +1101,7 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user for which we would like to fetch the
-    /// verification requests.
+    ///   verification requests.
     pub fn get_verification_requests(&self, user_id: String) -> Vec<Arc<VerificationRequest>> {
         let Ok(user_id) = UserId::parse(user_id) else {
             return vec![];
@@ -1122,7 +1122,7 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user for which we would like to fetch the
-    /// verification requests.
+    ///   verification requests.
     ///
     /// * `flow_id` - The ID that uniquely identifies the verification flow.
     pub fn get_verification_request(
@@ -1142,10 +1142,10 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user which we would like to request to
-    /// verify.
+    ///   verify.
     ///
     /// * `methods` - The list of verification methods we want to advertise to
-    /// support.
+    ///   support.
     pub fn verification_request_content(
         &self,
         user_id: String,
@@ -1171,18 +1171,18 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user which we would like to request to
-    /// verify.
+    ///   verify.
     ///
     /// * `room_id` - The ID of the room that represents a DM with the given
-    /// user.
+    ///   user.
     ///
     /// * `event_id` - The event ID of the `m.key.verification.request` event
-    /// that we sent out to request the verification to begin. The content for
-    /// this request can be created using the [verification_request_content()]
-    /// method.
+    ///   that we sent out to request the verification to begin. The content for
+    ///   this request can be created using the [verification_request_content()]
+    ///   method.
     ///
     /// * `methods` - The list of verification methods we advertised as
-    /// supported in the `m.key.verification.request` event.
+    ///   supported in the `m.key.verification.request` event.
     ///
     /// [verification_request_content()]: Self::verification_request_content
     pub fn request_verification(
@@ -1217,12 +1217,12 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user which we would like to request to
-    /// verify.
+    ///   verify.
     ///
     /// * `device_id` - The ID of the device that we wish to verify.
     ///
     /// * `methods` - The list of verification methods we advertised as
-    /// supported in the `m.key.verification.request` event.
+    ///   supported in the `m.key.verification.request` event.
     pub fn request_verification_with_device(
         &self,
         user_id: String,
@@ -1291,7 +1291,7 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user for which we would like to fetch the
-    /// verification.
+    ///   verification.
     ///
     /// * `flow_id` - The ID that uniquely identifies the verification flow.
     pub fn get_verification(&self, user_id: String, flow_id: String) -> Option<Arc<Verification>> {
@@ -1311,7 +1311,7 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user for which we would like to start the
-    /// SAS verification.
+    ///   SAS verification.
     ///
     /// * `device_id` - The ID of device we would like to verify.
     ///

--- a/bindings/matrix-sdk-crypto-ffi/src/machine.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/machine.rs
@@ -251,12 +251,12 @@ impl OlmMachine {
     ///
     /// * `user_id` - The unique id of the user that the identity belongs to
     ///
-    /// * `timeout` - The time in seconds we should wait before returning if
-    ///   the user's device list has been marked as stale. Passing a 0 as the
+    /// * `timeout` - The time in seconds we should wait before returning if the
+    ///   user's device list has been marked as stale. Passing a 0 as the
     ///   timeout means that we won't wait at all. **Note**, this assumes that
-    ///   the requests from [`OlmMachine::outgoing_requests`] are being processed
-    ///   and sent out. Namely, this waits for a `/keys/query` response to be
-    ///   received.
+    ///   the requests from [`OlmMachine::outgoing_requests`] are being
+    ///   processed and sent out. Namely, this waits for a `/keys/query`
+    ///   response to be received.
     pub fn get_identity(
         &self,
         user_id: String,
@@ -333,12 +333,12 @@ impl OlmMachine {
     ///
     /// * `device_id` - The id of the device itself.
     ///
-    /// * `timeout` - The time in seconds we should wait before returning if
-    ///   the user's device list has been marked as stale. Passing a 0 as the
+    /// * `timeout` - The time in seconds we should wait before returning if the
+    ///   user's device list has been marked as stale. Passing a 0 as the
     ///   timeout means that we won't wait at all. **Note**, this assumes that
-    ///   the requests from [`OlmMachine::outgoing_requests`] are being processed
-    ///   and sent out. Namely, this waits for a `/keys/query` response to be
-    ///   received.
+    ///   the requests from [`OlmMachine::outgoing_requests`] are being
+    ///   processed and sent out. Namely, this waits for a `/keys/query`
+    ///   response to be received.
     pub fn get_device(
         &self,
         user_id: String,
@@ -416,12 +416,12 @@ impl OlmMachine {
     ///
     /// * `user_id` - The id of the device owner.
     ///
-    /// * `timeout` - The time in seconds we should wait before returning if
-    ///   the user's device list has been marked as stale. Passing a 0 as the
+    /// * `timeout` - The time in seconds we should wait before returning if the
+    ///   user's device list has been marked as stale. Passing a 0 as the
     ///   timeout means that we won't wait at all. **Note**, this assumes that
-    ///   the requests from [`OlmMachine::outgoing_requests`] are being processed
-    ///   and sent out. Namely, this waits for a `/keys/query` response to be
-    ///   received.
+    ///   the requests from [`OlmMachine::outgoing_requests`] are being
+    ///   processed and sent out. Namely, this waits for a `/keys/query`
+    ///   response to be received.
     pub fn get_user_devices(
         &self,
         user_id: String,

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -169,8 +169,8 @@ impl Sas {
     /// # Arguments
     ///
     /// * `cancel_code` - The error code for why the verification was cancelled,
-    /// manual cancellatio usually happens with `m.user` cancel code. The full
-    /// list of cancel codes can be found in the [spec]
+    ///   manual cancellatio usually happens with `m.user` cancel code. The full
+    ///   list of cancel codes can be found in the [spec]
     ///
     /// [spec]: https://spec.matrix.org/unstable/client-server-api/#mkeyverificationcancel
     pub fn cancel(&self, cancel_code: String) -> Option<OutgoingVerificationRequest> {
@@ -391,8 +391,8 @@ impl QrCode {
     /// # Arguments
     ///
     /// * `cancel_code` - The error code for why the verification was cancelled,
-    /// manual cancellatio usually happens with `m.user` cancel code. The full
-    /// list of cancel codes can be found in the [spec]
+    ///   manual cancellatio usually happens with `m.user` cancel code. The full
+    ///   list of cancel codes can be found in the [spec]
     ///
     /// [spec]: https://spec.matrix.org/unstable/client-server-api/#mkeyverificationcancel
     pub fn cancel(&self, cancel_code: String) -> Option<OutgoingVerificationRequest> {
@@ -640,12 +640,12 @@ impl VerificationRequest {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user for which we would like to accept the
-    /// verification requests.
+    ///   verification requests.
     ///
     /// * `flow_id` - The ID that uniquely identifies the verification flow.
     ///
     /// * `methods` - A list of verification methods that we want to advertise
-    /// as supported.
+    ///   as supported.
     pub fn accept(&self, methods: Vec<String>) -> Option<OutgoingVerificationRequest> {
         let methods = methods.into_iter().map(VerificationMethod::from).collect();
         self.inner.accept_with_methods(methods).map(|r| r.into())
@@ -663,10 +663,10 @@ impl VerificationRequest {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user for which we would like to start the
-    /// SAS verification.
+    ///   SAS verification.
     ///
     /// * `flow_id` - The ID of the verification request that initiated the
-    /// verification flow.
+    ///   verification flow.
     pub fn start_sas_verification(&self) -> Result<Option<StartSasResult>, CryptoStoreError> {
         Ok(self.runtime.block_on(self.inner.start_sas())?.map(|(sas, r)| StartSasResult {
             sas: Arc::new(Sas { inner: sas, runtime: self.runtime.clone() }),
@@ -682,10 +682,10 @@ impl VerificationRequest {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user for which we would like to start the
-    /// QR code verification.
+    ///   QR code verification.
     ///
     /// * `flow_id` - The ID of the verification request that initiated the
-    /// verification flow.
+    ///   verification flow.
     pub fn start_qr_verification(&self) -> Result<Option<Arc<QrCode>>, CryptoStoreError> {
         Ok(self
             .runtime
@@ -702,13 +702,13 @@ impl VerificationRequest {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user for which we would like to start the
-    /// QR code verification.
+    ///   QR code verification.
     ///
     /// * `flow_id` - The ID of the verification request that initiated the
-    /// verification flow.
+    ///   verification flow.
     ///
     /// * `data` - The data that was extracted from the scanned QR code as an
-    /// base64 encoded string, without padding.
+    ///   base64 encoded string, without padding.
     pub fn scan_qr_code(&self, data: String) -> Option<ScanResult> {
         let data = base64_decode(data).ok()?;
         let data = QrVerificationData::from_bytes(data).ok()?;

--- a/bindings/matrix-sdk-crypto-ffi/src/verification.rs
+++ b/bindings/matrix-sdk-crypto-ffi/src/verification.rs
@@ -681,8 +681,8 @@ impl VerificationRequest {
     ///
     /// # Arguments
     ///
-    /// * `user_id` - The ID of the user for which we would like to start the
-    ///   QR code verification.
+    /// * `user_id` - The ID of the user for which we would like to start the QR
+    ///   code verification.
     ///
     /// * `flow_id` - The ID of the verification request that initiated the
     ///   verification flow.
@@ -701,8 +701,8 @@ impl VerificationRequest {
     ///
     /// # Arguments
     ///
-    /// * `user_id` - The ID of the user for which we would like to start the
-    ///   QR code verification.
+    /// * `user_id` - The ID of the user for which we would like to start the QR
+    ///   code verification.
     ///
     /// * `flow_id` - The ID of the verification request that initiated the
     ///   verification flow.

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -307,7 +307,7 @@ impl Room {
     /// * `event_id` - The ID of the event to redact
     ///
     /// * `reason` - The reason for the event being redacted (optional).
-    /// its transaction ID (optional). If not given one is created.
+    ///   its transaction ID (optional). If not given one is created.
     pub async fn redact(
         &self,
         event_id: String,
@@ -625,6 +625,7 @@ impl Room {
     /// This function is supposed to be called whenever the user creates a room
     /// call. It will send a `m.call.notify` event if:
     ///  - there is not yet a running call.
+    ///
     /// It will configure the notify type: ring or notify based on:
     ///  - is this a DM room -> ring
     ///  - is this a group with more than one other member -> notify

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -306,8 +306,8 @@ impl Room {
     ///
     /// * `event_id` - The ID of the event to redact
     ///
-    /// * `reason` - The reason for the event being redacted (optional).
-    ///   its transaction ID (optional). If not given one is created.
+    /// * `reason` - The reason for the event being redacted (optional). its
+    ///   transaction ID (optional). If not given one is created.
     pub async fn redact(
         &self,
         event_id: String,

--- a/bindings/matrix-sdk-ffi/src/tracing.rs
+++ b/bindings/matrix-sdk-ffi/src/tracing.rs
@@ -107,10 +107,10 @@ impl Span {
     /// target passed for second and following creation of a span with the same
     /// callsite will be ignored.
     ///
-    /// This function leaks a little bit of memory for each unique (file + line
-    /// + level + target + name) it is called with. Please make sure that the
-    /// number of different combinations of those parameters this can be called
-    /// with is constant in the final executable.
+    /// This function leaks a little bit of memory for each unique (file +
+    /// line + level + target + name) it is called with. Please make sure that
+    /// the number of different combinations of those parameters this can be
+    /// called with is constant in the final executable.
     ///
     /// For a span to have an effect, you must `.enter()` it at the start of a
     /// logical unit of work and `.exit()` it at the end of the same (including

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -236,8 +236,10 @@ impl From<VirtualElementCallWidgetOptions> for matrix_sdk::widget::VirtualElemen
 /// This function returns a `WidgetSettings` object which can be used
 /// to setup a widget using `run_client_widget_api`
 /// and to generate the correct url for the widget.
-///  # Arguments
-/// * - `props` A struct containing the configuration parameters for a element
+/// 
+/// # Arguments
+/// 
+/// * `props` - A struct containing the configuration parameters for a element
 ///   call widget.
 #[uniffi::export]
 pub fn new_virtual_element_call_widget(

--- a/bindings/matrix-sdk-ffi/src/widget.rs
+++ b/bindings/matrix-sdk-ffi/src/widget.rs
@@ -236,9 +236,9 @@ impl From<VirtualElementCallWidgetOptions> for matrix_sdk::widget::VirtualElemen
 /// This function returns a `WidgetSettings` object which can be used
 /// to setup a widget using `run_client_widget_api`
 /// and to generate the correct url for the widget.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `props` - A struct containing the configuration parameters for a element
 ///   call widget.
 #[uniffi::export]

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -128,7 +128,7 @@ impl BaseClient {
     /// # Arguments
     ///
     /// * `config` - An optional session if the user already has one from a
-    /// previous login call.
+    ///   previous login call.
     pub fn with_store_config(config: StoreConfig) -> Self {
         let (roominfo_update_sender, _roominfo_update_receiver) = broadcast::channel(100);
 
@@ -1236,11 +1236,10 @@ impl BaseClient {
     /// # Arguments
     ///
     /// * `filter_name` - The name that should be used to persist the filter id
-    ///   in
-    /// the store.
+    ///   in the store.
     ///
     /// * `response` - The successful filter upload response containing the
-    /// filter id.
+    ///   filter id.
     ///
     /// [`get_filter`]: #method.get_filter
     pub async fn receive_filter_upload(
@@ -1265,7 +1264,7 @@ impl BaseClient {
     /// # Arguments
     ///
     /// * `filter_name` - The name of the filter that was previously used to
-    /// persist the filter.
+    ///   persist the filter.
     ///
     /// [`receive_filter_upload`]: #method.receive_filter_upload
     pub async fn get_filter(&self, filter_name: &str) -> StoreResult<Option<String>> {

--- a/crates/matrix-sdk-crypto/src/backups/mod.rs
+++ b/crates/matrix-sdk-crypto/src/backups/mod.rs
@@ -312,8 +312,8 @@ impl BackupMachine {
     ///
     /// # Arguments
     ///
-    /// * `backup_info`: The backup info that should be verified. Should
-    /// be fetched from the server using the [`/room_keys/version`] endpoint.
+    /// * `backup_info`: The backup info that should be verified. Should be
+    ///   fetched from the server using the [`/room_keys/version`] endpoint.
     ///
     /// * `compute_all_signatures`: *Useful for debugging only*. If this
     ///   parameter is `true`, the internal machinery will compute the trust
@@ -341,9 +341,9 @@ impl BackupMachine {
     ///
     /// # Arguments
     ///
-    /// * `backup_info`: The backup version that should be verified. Should
-    /// be created from the [`BackupDecryptionKey`] using the
-    /// [`BackupDecryptionKey::to_backup_info()`] method.
+    /// * `backup_info`: The backup version that should be verified. Should be
+    ///   created from the [`BackupDecryptionKey`] using the
+    ///   [`BackupDecryptionKey::to_backup_info()`] method.
     pub async fn sign_backup(
         &self,
         backup_info: &mut RoomKeyBackupInfo,
@@ -595,8 +595,8 @@ impl BackupMachine {
     /// # Arguments
     ///
     /// * `room_keys` - A list of previously exported keys that should be
-    /// imported into our store. If we already have a better version of a key
-    /// the key will *not* be imported.
+    ///   imported into our store. If we already have a better version of a key
+    ///   the key will *not* be imported.
     ///
     /// Returns a [`RoomKeyImportResult`] containing information about room keys
     /// which were imported.

--- a/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/attachments.rs
@@ -104,7 +104,7 @@ impl<'a, R: Read + 'a> AttachmentDecryptor<'a, R> {
     /// * `reader` - The `Reader` that should be wrapped and decrypted.
     ///
     /// * `info` - The encryption info that is necessary to decrypt data from
-    /// the reader.
+    ///   the reader.
     ///
     /// # Examples
     /// ```

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -110,11 +110,11 @@ pub fn decrypt_room_key_export(
 /// * `passphrase` - The passphrase that will be used to encrypt the exported
 ///   room keys.
 ///
-/// * `rounds` - The number of rounds that should be used for the key
-///   derivation when the passphrase gets turned into an AES key. More rounds are
-///   increasingly computationally intensive and as such help against brute-force
-///   attacks. Should be at least `10_000`, while values in the `100_000` ranges
-///   should be preferred.
+/// * `rounds` - The number of rounds that should be used for the key derivation
+///   when the passphrase gets turned into an AES key. More rounds are
+///   increasingly computationally intensive and as such help against
+///   brute-force attacks. Should be at least `10_000`, while values in the
+///   `100_000` ranges should be preferred.
 ///
 /// # Panics
 ///

--- a/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
+++ b/crates/matrix-sdk-crypto/src/file_encryption/key_export.rs
@@ -108,13 +108,13 @@ pub fn decrypt_room_key_export(
 /// * `keys` - A list of sessions that should be encrypted.
 ///
 /// * `passphrase` - The passphrase that will be used to encrypt the exported
-/// room keys.
+///   room keys.
 ///
 /// * `rounds` - The number of rounds that should be used for the key
-/// derivation when the passphrase gets turned into an AES key. More rounds are
-/// increasingly computationally intensive and as such help against brute-force
-/// attacks. Should be at least `10_000`, while values in the `100_000` ranges
-/// should be preferred.
+///   derivation when the passphrase gets turned into an AES key. More rounds are
+///   increasingly computationally intensive and as such help against brute-force
+///   attacks. Should be at least `10_000`, while values in the `100_000` ranges
+///   should be preferred.
 ///
 /// # Panics
 ///

--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -268,7 +268,7 @@ impl GossipMachine {
     /// # Arguments
     ///
     /// * `user_id` - The user id of the device that we created the Olm session
-    /// with.
+    ///   with.
     ///
     /// * `device_id` - The device ID of the device that got the Olm session.
     pub fn retry_keyshare(&self, user_id: &UserId, device_id: &DeviceId) {
@@ -588,14 +588,14 @@ impl GossipMachine {
     /// The logic for this is currently as follows:
     ///
     /// * Share the session in full, starting from the earliest known index, if
-    /// the requesting device is our own, trusted (verified) device.
+    ///   the requesting device is our own, trusted (verified) device.
     ///
     /// * For other requesting devices, share only a limited session and only if
-    /// we originally shared with that device because it was present when the
-    /// message was initially sent. By limited, we mean that the session will
-    /// not be shared in full, but only from the message index at that moment.
-    /// Since this information is recorded in the outbound session, we need to
-    /// have it for this to work.
+    ///   we originally shared with that device because it was present when the
+    ///   message was initially sent. By limited, we mean that the session will
+    ///   not be shared in full, but only from the message index at that moment.
+    ///   Since this information is recorded in the outbound session, we need to
+    ///   have it for this to work.
     ///
     /// * In all other cases, refuse to share the session.
     ///
@@ -661,7 +661,7 @@ impl GossipMachine {
     /// # Arguments
     ///
     /// * `key_info` - The info of our key request containing information about
-    /// the key we wish to request.
+    ///   the key we wish to request.
     #[cfg(feature = "automatic-room-key-forwarding")]
     async fn should_request_key(&self, key_info: &SecretInfo) -> Result<bool, CryptoStoreError> {
         if self.inner.room_key_requests_enabled.load(Ordering::SeqCst) {

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -115,7 +115,7 @@ impl IdentityManager {
     /// * `request_id` - The request_id returned by `users_for_key_query` or
     ///   `build_key_query_for_users`
     /// * `response` - The response of the `/keys/query` request that the client
-    /// performed.
+    ///   performed.
     pub async fn receive_keys_query_response(
         &self,
         request_id: &TransactionId,
@@ -369,7 +369,7 @@ impl IdentityManager {
     /// # Arguments
     ///
     /// * `device_keys_map` - A map holding the device keys of the users for
-    /// which the key query was done.
+    ///   which the key query was done.
     ///
     /// Returns a list of devices that changed. Changed here means either
     /// they are new, one of their properties has changed or they got deleted.

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -609,7 +609,7 @@ impl ReadOnlyOwnUserIdentity {
     /// # Arguments
     ///
     /// * `identity` - The identity of another user that we want to check if
-    /// it's has been signed.
+    ///   it has been signed.
     ///
     /// Returns an empty result if the signature check succeeded, otherwise a
     /// SignatureError indicating why the check failed.

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -608,8 +608,8 @@ impl ReadOnlyOwnUserIdentity {
     ///
     /// # Arguments
     ///
-    /// * `identity` - The identity of another user that we want to check if
-    ///   it has been signed.
+    /// * `identity` - The identity of another user that we want to check if it
+    ///   has been signed.
     ///
     /// Returns an empty result if the signature check succeeded, otherwise a
     /// SignatureError indicating why the check failed.

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -508,10 +508,10 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `request_id` - The unique id of the request that was sent out. This is
-    /// needed to couple the response with the now sent out request.
+    ///   needed to couple the response with the now sent out request.
     ///
     /// * `response` - The response that was received from the server after the
-    /// outgoing request was sent out.
+    ///   outgoing request was sent out.
     pub async fn mark_request_as_sent<'a>(
         &self,
         request_id: &TransactionId,
@@ -921,10 +921,10 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `room_id` - The id of the room for which the message should be
-    /// encrypted.
+    ///   encrypted.
     ///
     /// * `content` - The plaintext content of the message that should be
-    /// encrypted.
+    ///   encrypted.
     ///
     /// # Panics
     ///
@@ -948,10 +948,10 @@ impl OlmMachine {
     /// # Arguments
     ///
     /// * `room_id` - The id of the room for which the message should be
-    /// encrypted.
+    ///   encrypted.
     ///
     /// * `content` - The plaintext content of the message that should be
-    /// encrypted as a raw JSON value.
+    ///   encrypted as a raw JSON value.
     ///
     /// * `event_type` - The plaintext type of the event.
     ///
@@ -2111,7 +2111,7 @@ impl OlmMachine {
     /// ## Requirements
     ///
     /// - This assumes that `initialize_crypto_store_generation` has been called
-    /// beforehand.
+    ///   beforehand.
     /// - This requires that the crypto store lock has been acquired.
     ///
     /// # Arguments

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -774,6 +774,8 @@ impl Account {
         &self,
         cross_signing_key: &mut CrossSigningKey,
     ) -> Result<(), SignatureError> {
+        #[allow(clippy::needless_borrows_for_generic_args)]
+        // XXX: false positive, see https://github.com/rust-lang/rust-clippy/issues/12856
         let signature = self.sign_json(serde_json::to_value(&cross_signing_key)?)?;
 
         cross_signing_key.signatures.add_signature(

--- a/crates/matrix-sdk-crypto/src/olm/account.rs
+++ b/crates/matrix-sdk-crypto/src/olm/account.rs
@@ -192,7 +192,7 @@ impl StaticAccountData {
     /// * `room_id` - The ID of the room where the group session will be used.
     ///
     /// * `settings` - Settings determining the algorithm and rotation period of
-    /// the outbound group session.
+    ///   the outbound group session.
     pub async fn create_group_session_pair(
         &self,
         room_id: &RoomId,
@@ -720,8 +720,7 @@ impl Account {
     /// * `pickle` - The pickled version of the Account.
     ///
     /// * `pickle_mode` - The mode that was used to pickle the account, either
-    ///   an
-    /// unencrypted mode or an encrypted using passphrase.
+    ///   an unencrypted mode or an encrypted using passphrase.
     pub fn from_pickle(pickle: PickledAccount) -> Result<Self, PickleError> {
         let account: vodozemac::olm::Account = pickle.pickle.into();
         let identity_keys = account.identity_keys();
@@ -811,7 +810,7 @@ impl Account {
     /// # Arguments
     ///
     /// * `json` - The value that should be converted into a canonical JSON
-    /// string.
+    ///   string.
     pub fn sign_json(&self, json: Value) -> Result<Ed25519Signature, SignatureError> {
         self.inner.sign_json(json)
     }
@@ -894,12 +893,14 @@ impl Account {
     /// session failed.
     ///
     /// # Arguments
+    ///
     /// * `config` - The session config that should be used when creating the
-    /// Session.
+    ///   Session.
+    ///
     /// * `identity_key` - The other account's identity/curve25519 key.
     ///
-    /// * `one_time_key` - A signed one-time key that the other account
-    /// created and shared with us.
+    /// * `one_time_key` - A signed one-time key that the other account created
+    ///   and shared with us.
     ///
     /// * `fallback_used` - Was the one-time key a fallback key.
     pub fn create_outbound_session_helper(
@@ -1020,10 +1021,11 @@ impl Account {
     /// session failed.
     ///
     /// # Arguments
+    ///
     /// * `their_identity_key` - The other account's identity/curve25519 key.
     ///
     /// * `message` - A pre-key Olm message that was sent to us by the other
-    /// account.
+    ///   account.
     pub fn create_inbound_session(
         &mut self,
         their_identity_key: Curve25519PublicKey,

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -154,15 +154,15 @@ impl InboundGroupSession {
     /// # Arguments
     ///
     /// * `sender_key` - The public Curve25519 key of the account that
-    /// sent us the session.
+    ///   sent us the session.
     ///
     /// * `signing_key` - The public Ed25519 key of the account that
-    /// sent us the session.
+    ///   sent us the session.
     ///
     /// * `room_id` - The id of the room that the session is used in.
     ///
     /// * `session_key` - The private session key that is used to decrypt
-    /// messages.
+    ///   messages.
     pub fn new(
         sender_key: Curve25519PublicKey,
         signing_key: Ed25519PublicKey,
@@ -233,7 +233,7 @@ impl InboundGroupSession {
     /// # Arguments
     ///
     /// * `pickle_mode` - The mode that was used to pickle the group session,
-    /// either an unencrypted mode or an encrypted using passphrase.
+    ///   either an unencrypted mode or an encrypted using passphrase.
     pub async fn pickle(&self) -> PickledInboundGroupSession {
         let pickle = self.inner.lock().await.pickle();
 
@@ -311,7 +311,7 @@ impl InboundGroupSession {
     /// * `pickle` - The pickled version of the `InboundGroupSession`.
     ///
     /// * `pickle_mode` - The mode that was used to pickle the session, either
-    /// an unencrypted mode or an encrypted using passphrase.
+    ///   an unencrypted mode or an encrypted using passphrase.
     pub fn from_pickle(pickle: PickledInboundGroupSession) -> Result<Self, PickleError> {
         let session: InnerSession = pickle.pickle.into();
         let first_known_index = session.first_known_index();

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -153,11 +153,11 @@ impl InboundGroupSession {
     ///
     /// # Arguments
     ///
-    /// * `sender_key` - The public Curve25519 key of the account that
-    ///   sent us the session.
+    /// * `sender_key` - The public Curve25519 key of the account that sent us
+    ///   the session.
     ///
-    /// * `signing_key` - The public Ed25519 key of the account that
-    ///   sent us the session.
+    /// * `signing_key` - The public Ed25519 key of the account that sent us the
+    ///   session.
     ///
     /// * `room_id` - The id of the room that the session is used in.
     ///

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -208,12 +208,12 @@ impl OutboundGroupSession {
     /// * `device_id` - The id of the device that created this session.
     ///
     /// * `identity_keys` - The identity keys of the account that created this
-    /// session.
+    ///   session.
     ///
     /// * `room_id` - The id of the room that the session is used in.
     ///
     /// * `settings` - Settings determining the algorithm and rotation period of
-    /// the outbound group session.
+    ///   the outbound group session.
     pub fn new(
         device_id: OwnedDeviceId,
         identity_keys: Arc<IdentityKeys>,
@@ -363,10 +363,10 @@ impl OutboundGroupSession {
     /// # Arguments
     ///
     /// * `event_type` - The plaintext type of the event, the outer type of the
-    /// event will become `m.room.encrypted`.
+    ///   event will become `m.room.encrypted`.
     ///
     /// * `content` - The plaintext content of the message that should be
-    /// encrypted in raw JSON form.
+    ///   encrypted in raw JSON form.
     ///
     /// # Panics
     ///
@@ -651,7 +651,7 @@ impl OutboundGroupSession {
     /// * `pickle` - The pickled version of the `OutboundGroupSession`.
     ///
     /// * `pickle_mode` - The mode that was used to pickle the session, either
-    /// an unencrypted mode or an encrypted using passphrase.
+    ///   an unencrypted mode or an encrypted using passphrase.
     pub fn from_pickle(
         device_id: OwnedDeviceId,
         identity_keys: Arc<IdentityKeys>,
@@ -682,8 +682,7 @@ impl OutboundGroupSession {
     /// # Arguments
     ///
     /// * `pickle_mode` - The mode that should be used to pickle the group
-    ///   session,
-    /// either an unencrypted mode or an encrypted using passphrase.
+    ///   session, either an unencrypted mode or an encrypted using passphrase.
     pub async fn pickle(&self) -> PickledOutboundGroupSession {
         let pickle = self.inner.read().await.pickle();
 

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -207,7 +207,7 @@ impl Session {
     /// # Arguments
     ///
     /// * `pickle_mode` - The mode that was used to pickle the session, either
-    /// an unencrypted mode or an encrypted using passphrase.
+    ///   an unencrypted mode or an encrypted using passphrase.
     pub async fn pickle(&self) -> PickledSession {
         let pickle = self.inner.lock().await.pickle();
 
@@ -236,7 +236,7 @@ impl Session {
     /// * `pickle` - The pickled version of the `Session`.
     ///
     /// * `pickle_mode` - The mode that was used to pickle the session, either
-    /// an unencrypted mode or an encrypted using passphrase.
+    ///   an unencrypted mode or an encrypted using passphrase.
     pub fn from_pickle(
         user_id: OwnedUserId,
         device_id: OwnedDeviceId,

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -193,7 +193,7 @@ impl PrivateCrossSigningIdentity {
     /// # Arguments
     ///
     /// * `secret_name` - The type of the cross signing key that should be
-    /// exported.
+    ///   exported.
     pub async fn export_secret(&self, secret_name: &SecretName) -> Option<String> {
         match secret_name {
             SecretName::CrossSigningMasterKey => {
@@ -508,8 +508,8 @@ impl PrivateCrossSigningIdentity {
     /// # Arguments
     ///
     /// * `account` - The Olm account that is creating the new identity. The
-    /// account will sign the master key and the self signing key will sign the
-    /// account.
+    ///   account will sign the master key and the self signing key will sign the
+    ///   account.
     pub(crate) async fn with_account(
         account: &Account,
     ) -> (Self, UploadSigningKeysRequest, SignatureUploadRequest) {
@@ -578,7 +578,7 @@ impl PrivateCrossSigningIdentity {
     /// # Arguments
     ///
     /// * `pickle_key` - The key that should be used to encrypt the signing
-    /// object, must be 32 bytes long.
+    ///   object, must be 32 bytes long.
     ///
     /// # Panics
     ///

--- a/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/mod.rs
@@ -508,8 +508,8 @@ impl PrivateCrossSigningIdentity {
     /// # Arguments
     ///
     /// * `account` - The Olm account that is creating the new identity. The
-    ///   account will sign the master key and the self signing key will sign the
-    ///   account.
+    ///   account will sign the master key and the self signing key will sign
+    ///   the account.
     pub(crate) async fn with_account(
         account: &Account,
     ) -> (Self, UploadSigningKeysRequest, SignatureUploadRequest) {

--- a/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
+++ b/crates/matrix-sdk-crypto/src/olm/signing/pk_signing.rs
@@ -184,6 +184,8 @@ impl MasterSigning {
     }
 
     pub fn sign_subkey(&self, subkey: &mut CrossSigningKey) {
+        #[allow(clippy::needless_borrows_for_generic_args)]
+        // XXX: false positive, see https://github.com/rust-lang/rust-clippy/issues/12856
         let json_subkey = serde_json::to_value(&subkey).expect("Can't serialize cross signing key");
         let signature = self.inner.sign_json(json_subkey).expect("Can't sign cross signing keys");
 
@@ -289,6 +291,8 @@ impl SelfSigning {
     }
 
     pub(crate) fn sign_device(&self, device_keys: &mut DeviceKeys) -> Result<(), SignatureError> {
+        #[allow(clippy::needless_borrows_for_generic_args)]
+        // XXX: false positive, see https://github.com/rust-lang/rust-clippy/issues/12856
         let serialized = serde_json::to_value(&device_keys)?;
         let signature = self.inner.sign_json(serialized)?;
 

--- a/crates/matrix-sdk-crypto/src/olm/utility.rs
+++ b/crates/matrix-sdk-crypto/src/olm/utility.rs
@@ -67,7 +67,7 @@ pub trait VerifyJson {
     ///   signature.
     ///
     /// * `signed_object` - The signed object that we should check for a valid
-    /// signature.
+    ///   signature.
     ///
     /// Returns Ok if the signature was successfully verified, otherwise an
     /// SignatureError.
@@ -92,7 +92,7 @@ pub trait VerifyJson {
     ///   signature.
     ///
     /// * `canonicalized_json` - The canonicalized version of a signed JSON
-    /// object.
+    ///   object.
     ///
     /// This method should only be used if an object's signature needs to be
     /// checked multiple times, and you'd like to avoid performing the

--- a/crates/matrix-sdk-crypto/src/requests.rs
+++ b/crates/matrix-sdk-crypto/src/requests.rs
@@ -71,10 +71,10 @@ impl ToDeviceRequest {
     /// # Arguments
     ///
     /// * `recipient` - The ID of the user that should receive this to-device
-    /// event.
+    ///   event.
     ///
     /// * `recipient_device` - The device that should receive this to-device
-    /// event, or all devices.
+    ///   event, or all devices.
     ///
     /// * `event_type` - The type of the event content that is getting sent out.
     ///

--- a/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
+++ b/crates/matrix-sdk-crypto/src/session_manager/group_sessions/mod.rs
@@ -99,7 +99,7 @@ impl GroupSessionCache {
     /// # Arguments
     ///
     /// * `room_id` - The id of the room for which we should get the outbound
-    /// group session.
+    ///   group session.
     fn get(&self, room_id: &RoomId) -> Option<OutboundGroupSession> {
         self.sessions.read().unwrap().get(room_id).cloned()
     }

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1717,8 +1717,8 @@ impl Store {
     /// # Arguments
     ///
     /// * `exported_keys` - A list of previously exported keys that should be
-    /// imported into our store. If we already have a better version of a key
-    /// the key will *not* be imported.
+    ///   imported into our store. If we already have a better version of a key
+    ///   the key will *not* be imported.
     ///
     /// Returns a tuple of numbers that represent the number of sessions that
     /// were imported and the total number of sessions that were found in the
@@ -1755,9 +1755,9 @@ impl Store {
     /// # Arguments
     ///
     /// * `predicate` - A closure that will be called for every known
-    /// `InboundGroupSession`, which represents a room key. If the closure
-    /// returns `true` the `InboundGroupSession` will be included in the export,
-    /// if the closure returns `false` it will not be included.
+    ///   `InboundGroupSession`, which represents a room key. If the closure
+    ///   returns `true` the `InboundGroupSession` will be included in the export,
+    ///   if the closure returns `false` it will not be included.
     ///
     /// # Examples
     ///
@@ -1795,9 +1795,9 @@ impl Store {
     /// # Arguments
     ///
     /// * `predicate` - A closure that will be called for every known
-    /// `InboundGroupSession`, which represents a room key. If the closure
-    /// returns `true` the `InboundGroupSession` will be included in the export,
-    /// if the closure returns `false` it will not be included.
+    ///   `InboundGroupSession`, which represents a room key. If the closure
+    ///   returns `true` the `InboundGroupSession` will be included in the export,
+    ///   if the closure returns `false` it will not be included.
     ///
     /// # Examples
     ///

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -1756,8 +1756,8 @@ impl Store {
     ///
     /// * `predicate` - A closure that will be called for every known
     ///   `InboundGroupSession`, which represents a room key. If the closure
-    ///   returns `true` the `InboundGroupSession` will be included in the export,
-    ///   if the closure returns `false` it will not be included.
+    ///   returns `true` the `InboundGroupSession` will be included in the
+    ///   export, if the closure returns `false` it will not be included.
     ///
     /// # Examples
     ///
@@ -1796,8 +1796,8 @@ impl Store {
     ///
     /// * `predicate` - A closure that will be called for every known
     ///   `InboundGroupSession`, which represents a room key. If the closure
-    ///   returns `true` the `InboundGroupSession` will be included in the export,
-    ///   if the closure returns `false` it will not be included.
+    ///   returns `true` the `InboundGroupSession` will be included in the
+    ///   export, if the closure returns `false` it will not be included.
     ///
     /// # Examples
     ///

--- a/crates/matrix-sdk-crypto/src/types/cross_signing/user_signing.rs
+++ b/crates/matrix-sdk-crypto/src/types/cross_signing/user_signing.rs
@@ -34,7 +34,7 @@ impl UserSigningPubkey {
     /// # Arguments
     ///
     /// * `master_key` - The master key that should be checked for a valid
-    /// signature.
+    ///   signature.
     ///
     /// Returns an empty result if the signature check succeeded, otherwise a
     /// SignatureError indicating why the check failed.

--- a/crates/matrix-sdk-crypto/src/types/events/to_device.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/to_device.rs
@@ -155,8 +155,8 @@ impl ToDeviceEvents {
     /// * `m.room_key` - The `session_key` field.
     /// * `m.forwarded_room_key` - The `session_key` field.
     /// * `m.secret.send` - The `secret` field will be zeroized, unless the
-    /// secret name of the matching `m.secret.request` event was
-    /// `m.megolm_backup.v1`.
+    ///   secret name of the matching `m.secret.request` event was
+    ///   `m.megolm_backup.v1`.
     ///
     /// **Warning**: Some events won't be able to be deserialized into the
     /// `ToDeviceEvents` type again since they might expect a valid `SessionKey`
@@ -165,12 +165,12 @@ impl ToDeviceEvents {
     /// You can do a couple of things to avoid this problem:
     ///
     /// 1. Call `Raw::cast()` to convert the event to another, less strict type.
-    /// [`AnyToDeviceEvent`] from Ruma will work.
+    ///    [`AnyToDeviceEvent`] from Ruma will work.
     ///
     /// 2. Call `Raw::deserialize_as()` to deserialize into a less strict type.
     ///
     /// 3. Pass the event over FFI, losing the exact type information, this will
-    /// mostl likely end up using a less strict type naturally.
+    ///    most likely end up using a less strict type naturally.
     ///
     /// [`AnyToDeviceEvent`]: ruma::events::AnyToDeviceEvent
     pub(crate) fn serialize_zeroized(self) -> Result<Raw<ToDeviceEvents>, serde_json::Error> {

--- a/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
@@ -190,8 +190,8 @@ fn extra_mac_info_receive(ids: &SasIds, flow_id: &str) -> String {
 ///
 /// * `flow_id` - The unique id that identifies this SAS verification process.
 ///
-/// * `event` - The m.key.verification.mac event that was sent to us by
-///   the other side.
+/// * `event` - The m.key.verification.mac event that was sent to us by the
+///   other side.
 pub fn receive_mac_event(
     sas: &EstablishedSas,
     ids: &SasIds,

--- a/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/helpers.rs
@@ -52,10 +52,10 @@ pub struct SasIds {
 /// # Arguments
 ///
 /// * `public_key` - Our own ephemeral public key that is used for the
-/// interactive verification.
+///   interactive verification.
 ///
 /// * `content` - The `m.key.verification.start` event content that started the
-/// interactive verification process.
+///   interactive verification process.
 pub fn calculate_commitment(public_key: Curve25519PublicKey, content: &StartContent<'_>) -> Base64 {
     let content = content.canonical_json();
     let content_string = content.to_string();
@@ -191,7 +191,7 @@ fn extra_mac_info_receive(ids: &SasIds, flow_id: &str) -> String {
 /// * `flow_id` - The unique id that identifies this SAS verification process.
 ///
 /// * `event` - The m.key.verification.mac event that was sent to us by
-/// the other side.
+///   the other side.
 pub fn receive_mac_event(
     sas: &EstablishedSas,
     ids: &SasIds,
@@ -379,7 +379,7 @@ fn extra_info_sas(
 /// # Arguments
 ///
 /// * `sas` - The Olm SAS object that can be used to generate bytes using the
-/// shared secret.
+///   shared secret.
 ///
 /// * `ids` - The ids that are used for this SAS authentication flow.
 ///
@@ -426,7 +426,7 @@ pub fn get_emoji(
 /// # Arguments
 ///
 /// * `sas` - The Olm SAS object that can be used to generate bytes using the
-/// shared secret.
+///   shared secret.
 ///
 /// * `ids` - The ids that are used for this SAS authentication flow.
 ///
@@ -462,7 +462,7 @@ pub fn get_emoji_index(
 /// # Arguments
 ///
 /// * `sas` - The Olm SAS object that can be used to generate bytes using the
-/// shared secret.
+///   shared secret.
 ///
 /// * `ids` - The ids that are used for this SAS authentication flow.
 ///

--- a/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/mod.rs
@@ -399,7 +399,7 @@ impl Sas {
     /// * `other_device` - The other device which we are going to verify.
     ///
     /// * `event` - The m.key.verification.start event that was sent to us by
-    /// the other side.
+    ///   the other side.
     pub(crate) fn from_start_event(
         flow_id: FlowId,
         content: &StartContent<'_>,

--- a/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
+++ b/crates/matrix-sdk-crypto/src/verification/sas/sas_state.rs
@@ -624,7 +624,7 @@ impl SasState<Created> {
     /// # Arguments
     ///
     /// * `event` - The m.key.verification.accept event that was sent to us by
-    /// the other side.
+    ///   the other side.
     pub fn into_accepted(
         self,
         sender: &UserId,
@@ -672,7 +672,7 @@ impl SasState<Started> {
     /// * `other_device` - The other device which we are going to verify.
     ///
     /// * `event` - The m.key.verification.start event that was sent to us by
-    /// the other side.
+    ///   the other side.
     pub fn from_start_event(
         account: StaticAccountData,
         other_device: ReadOnlyDevice,
@@ -825,7 +825,7 @@ impl SasState<Started> {
     /// # Arguments
     ///
     /// * `event` - The m.key.verification.accept event that was sent to us by
-    /// the other side.
+    ///   the other side.
     pub fn into_accepted(
         self,
         sender: &UserId,
@@ -905,9 +905,9 @@ impl SasState<WeAccepted> {
     ///
     /// # Arguments
     ///
-    /// * `event` - The m.key.verification.key event that was sent to us by
-    /// the other side. The event will be modified so it doesn't contain any key
-    /// anymore.
+    /// * `event` - The m.key.verification.key event that was sent to us by the
+    ///   other side. The event will be modified so it doesn't contain any key
+    ///   anymore.
     pub fn into_key_received(
         self,
         sender: &UserId,
@@ -940,9 +940,9 @@ impl SasState<Accepted> {
     ///
     /// # Arguments
     ///
-    /// * `event` - The m.key.verification.key event that was sent to us by
-    /// the other side. The event will be modified so it doesn't contain any key
-    /// anymore.
+    /// * `event` - The m.key.verification.key event that was sent to us by the
+    ///   other side. The event will be modified so it doesn't contain any key
+    ///   anymore.
     pub fn into_key_received(
         self,
         sender: &UserId,
@@ -1165,8 +1165,8 @@ impl SasState<KeysExchanged> {
     ///
     /// # Arguments
     ///
-    /// * `event` - The m.key.verification.mac event that was sent to us by
-    /// the other side.
+    /// * `event` - The m.key.verification.mac event that was sent to us by the
+    ///   other side.
     pub fn into_mac_received(
         self,
         sender: &UserId,
@@ -1229,8 +1229,8 @@ impl SasState<Confirmed> {
     ///
     /// # Arguments
     ///
-    /// * `event` - The m.key.verification.mac event that was sent to us by
-    /// the other side.
+    /// * `event` - The m.key.verification.mac event that was sent to us by the
+    ///   other side.
     pub fn into_done(
         self,
         sender: &UserId,
@@ -1273,8 +1273,8 @@ impl SasState<Confirmed> {
     ///
     /// # Arguments
     ///
-    /// * `event` - The m.key.verification.mac event that was sent to us by
-    /// the other side.
+    /// * `event` - The m.key.verification.mac event that was sent to us by the
+    ///   other side.
     pub fn into_waiting_for_done(
         self,
         sender: &UserId,
@@ -1445,8 +1445,8 @@ impl SasState<WaitingForDone> {
     ///
     /// # Arguments
     ///
-    /// * `event` - The m.key.verification.mac event that was sent to us by
-    /// the other side.
+    /// * `event` - The m.key.verification.mac event that was sent to us by the
+    ///   other side.
     pub fn into_done(
         self,
         sender: &UserId,

--- a/crates/matrix-sdk-qrcode/src/types.rs
+++ b/crates/matrix-sdk-qrcode/src/types.rs
@@ -209,8 +209,7 @@ impl QrVerificationData {
     /// * the ASCII string MATRIX
     /// * one byte indicating the QR code version (must be 0x02)
     /// * one byte indicating the QR code verification mode. one of the
-    ///   following
-    /// values:
+    ///   following values:
     ///     * 0x00 verifying another user with cross-signing
     ///     * 0x01 self-verifying in which the current device does trust the
     ///       master key
@@ -351,15 +350,15 @@ impl VerificationData {
     ///
     /// # Arguments
     /// * `flow_id` - The event ID or transaction ID of the
-    /// `m.key.verification.request` event that initiated the
-    /// verification flow this QR code should be part of.
+    ///   `m.key.verification.request` event that initiated the verification
+    ///   flow this QR code should be part of.
     ///
     /// * `first_master_key` - Our own cross signing master key.
     ///
     /// * `second_master_key` - The cross signing master key of the other user.
     ///
     /// * `shared_secret` - A random bytestring encoded as unpadded base64,
-    /// needs to be at least 8 bytes long.
+    ///   needs to be at least 8 bytes long.
     pub fn new(
         flow_id: String,
         first_master_key: Ed25519PublicKey,
@@ -451,15 +450,15 @@ impl SelfVerificationData {
     ///
     /// # Arguments
     /// * `transaction_id` - The transaction id of this verification flow, the
-    /// transaction id was sent by the `m.key.verification.request` event
-    /// that initiated the verification flow this QR code should be part of.
+    ///   transaction id was sent by the `m.key.verification.request` event
+    ///   that initiated the verification flow this QR code should be part of.
     ///
     /// * `master_key` - Our own cross signing master key.
     ///
     /// * `device_key` - The ed25519 key of the other device.
     ///
     /// * `shared_secret` - A random bytestring encoded as unpadded base64,
-    /// needs to be at least 8 bytes long.
+    ///   needs to be at least 8 bytes long.
     pub fn new(
         transaction_id: String,
         master_key: Ed25519PublicKey,
@@ -551,15 +550,15 @@ impl SelfVerificationNoMasterKey {
     ///
     /// # Arguments
     /// * `transaction_id` - The transaction id of this verification flow, the
-    /// transaction id was sent by the `m.key.verification.request` event
-    /// that initiated the verification flow this QR code should be part of.
+    ///   transaction id was sent by the `m.key.verification.request` event
+    ///   that initiated the verification flow this QR code should be part of.
     ///
     /// * `device_key` - The ed25519 key of our own device.
     ///
     /// * `master_key` - Our own cross signing master key.
     ///
     /// * `shared_secret` - A random bytestring encoded as unpadded base64,
-    /// needs to be at least 8 bytes long.
+    ///   needs to be at least 8 bytes long.
     pub fn new(
         transaction_id: String,
         device_key: Ed25519PublicKey,

--- a/crates/matrix-sdk-qrcode/src/types.rs
+++ b/crates/matrix-sdk-qrcode/src/types.rs
@@ -450,8 +450,8 @@ impl SelfVerificationData {
     ///
     /// # Arguments
     /// * `transaction_id` - The transaction id of this verification flow, the
-    ///   transaction id was sent by the `m.key.verification.request` event
-    ///   that initiated the verification flow this QR code should be part of.
+    ///   transaction id was sent by the `m.key.verification.request` event that
+    ///   initiated the verification flow this QR code should be part of.
     ///
     /// * `master_key` - Our own cross signing master key.
     ///
@@ -550,8 +550,8 @@ impl SelfVerificationNoMasterKey {
     ///
     /// # Arguments
     /// * `transaction_id` - The transaction id of this verification flow, the
-    ///   transaction id was sent by the `m.key.verification.request` event
-    ///   that initiated the verification flow this QR code should be part of.
+    ///   transaction id was sent by the `m.key.verification.request` event that
+    ///   initiated the verification flow this QR code should be part of.
     ///
     /// * `device_key` - The ed25519 key of our own device.
     ///

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -126,8 +126,8 @@ impl StoreCipher {
     ///
     /// # Arguments
     ///
-    /// * `passphrase` - The passphrase that should be used to encrypt the
-    /// store cipher.
+    /// * `passphrase` - The passphrase that should be used to encrypt the store
+    ///   cipher.
     ///
     /// # Examples
     ///
@@ -159,7 +159,7 @@ impl StoreCipher {
     /// # Arguments
     ///
     /// * `key` - The 32-byte key to be used to encrypt the store cipher. It's
-    /// recommended to use a freshly and securely generated random key.
+    ///   recommended to use a freshly and securely generated random key.
     ///
     /// # Examples
     ///
@@ -260,7 +260,7 @@ impl StoreCipher {
     /// # Arguments
     ///
     /// * `passphrase` - The passphrase that was used to encrypt the store
-    /// cipher.
+    ///   cipher.
     ///
     /// * `encrypted` - The exported and encrypted version of the store cipher.
     ///
@@ -310,8 +310,8 @@ impl StoreCipher {
     ///
     /// # Arguments
     ///
-    /// * `key` - The 32-byte decryption key that was previously used to
-    /// encrypt the store cipher.
+    /// * `key` - The 32-byte decryption key that was previously used to encrypt
+    ///   the store cipher.
     ///
     /// * `encrypted` - The exported and encrypted version of the store cipher.
     ///
@@ -353,10 +353,10 @@ impl StoreCipher {
     /// # Arguments
     ///
     /// * `table_name` - The name of the key/value table this key will be
-    /// inserted into. This can also contain additional unique data. It will be
-    /// used to derive a table-specific cryptographic key which will be used
-    /// in a keyed hash function. This ensures data independence between the
-    /// different tables of the key/value store.
+    ///   inserted into. This can also contain additional unique data. It will
+    ///   be used to derive a table-specific cryptographic key which will be
+    ///   used in a keyed hash function. This ensures data independence between
+    ///   the different tables of the key/value store.
     ///
     /// * `key` - The key to be hashed, prior to insertion into the key/value
     ///   store.
@@ -395,8 +395,8 @@ impl StoreCipher {
     /// # Arguments
     ///
     /// * `value` - A value that should be encrypted, any value that implements
-    /// `Serialize` can be given to this method. The value will be serialized as
-    /// json before it is encrypted.
+    ///   `Serialize` can be given to this method. The value will be serialized
+    ///   as json before it is encrypted.
     ///
     /// # Examples
     ///
@@ -431,8 +431,8 @@ impl StoreCipher {
     /// # Arguments
     ///
     /// * `value` - A value that should be encrypted, any value that implements
-    /// `Serialize` can be given to this method. The value will be serialized as
-    /// json before it is encrypted.
+    ///   `Serialize` can be given to this method. The value will be serialized
+    ///   as json before it is encrypted.
     ///
     ///
     /// # Examples
@@ -507,8 +507,8 @@ impl StoreCipher {
     /// # Arguments
     ///
     /// * `value` - A value that should be encrypted, any value that implements
-    /// `Serialize` can be given to this method. The value will be serialized as
-    /// json before it is encrypted.
+    ///   `Serialize` can be given to this method. The value will be serialized
+    ///   as json before it is encrypted.
     ///
     ///
     /// # Examples

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -446,12 +446,11 @@ impl Account {
     ///
     /// # Returns
     ///
-    /// * `sid` - The session ID to be used in following requests for
-    ///   this 3PID.
+    /// * `sid` - The session ID to be used in following requests for this 3PID.
     ///
-    /// * `submit_url` - If present, the user will submit the token to
-    ///   the client, that must send it to this URL. If not, the client will not
-    ///   be involved in the token submission.
+    /// * `submit_url` - If present, the user will submit the token to the
+    ///   client, that must send it to this URL. If not, the client will not be
+    ///   involved in the token submission.
     ///
     /// This method might return an [`ErrorKind::ThreepidInUse`] error if the
     /// email address is already registered for this account or another, or an
@@ -628,8 +627,8 @@ impl Account {
     /// * `medium` - The type of the 3PID.
     ///
     /// * `id_server` - The identity server to unbind from. If not provided, the
-    ///   homeserver should unbind the 3PID from the identity server it was bound
-    ///   to previously.
+    ///   homeserver should unbind the 3PID from the identity server it was
+    ///   bound to previously.
     ///
     /// # Returns
     ///
@@ -637,8 +636,8 @@ impl Account {
     ///   from the identity server.
     ///
     /// * [`ThirdPartyIdRemovalStatus::NoSupport`] if the 3PID was not unbound
-    ///   from the identity server. This can also mean that the 3PID was not bound
-    ///   to an identity server in the first place.
+    ///   from the identity server. This can also mean that the 3PID was not
+    ///   bound to an identity server in the first place.
     ///
     /// # Examples
     ///

--- a/crates/matrix-sdk/src/account.rs
+++ b/crates/matrix-sdk/src/account.rs
@@ -301,10 +301,10 @@ impl Account {
     /// * `new_password` - The new password to set.
     ///
     /// * `auth_data` - This request uses the [User-Interactive Authentication
-    /// API][uiaa]. The first request needs to set this to `None` and will
-    /// always fail with an [`UiaaResponse`]. The response will contain
-    /// information for the interactive auth and the same request needs to be
-    /// made but this time with some `auth_data` provided.
+    ///   API][uiaa]. The first request needs to set this to `None` and will
+    ///   always fail with an [`UiaaResponse`]. The response will contain
+    ///   information for the interactive auth and the same request needs to be
+    ///   made but this time with some `auth_data` provided.
     ///
     /// # Returns
     ///
@@ -352,13 +352,13 @@ impl Account {
     /// # Arguments
     ///
     /// * `id_server` - The identity server from which to unbind the user’s
-    /// [Third Party Identifiers][3pid].
+    ///   [Third Party Identifiers][3pid].
     ///
     /// * `auth_data` - This request uses the [User-Interactive Authentication
-    /// API][uiaa]. The first request needs to set this to `None` and will
-    /// always fail with an [`UiaaResponse`]. The response will contain
-    /// information for the interactive auth and the same request needs to be
-    /// made but this time with some `auth_data` provided.
+    ///   API][uiaa]. The first request needs to set this to `None` and will
+    ///   always fail with an [`UiaaResponse`]. The response will contain
+    ///   information for the interactive auth and the same request needs to be
+    ///   made but this time with some `auth_data` provided.
     ///
     /// # Examples
     ///
@@ -436,22 +436,22 @@ impl Account {
     /// # Arguments
     ///
     /// * `client_secret` - A client-generated secret string used to protect
-    /// this session.
+    ///   this session.
     ///
     /// * `email` - The email address to validate.
     ///
     /// * `send_attempt` - The attempt number. This number needs to be
-    /// incremented if you want to request another token for the same
-    /// validation.
+    ///   incremented if you want to request another token for the same
+    ///   validation.
     ///
     /// # Returns
     ///
     /// * `sid` - The session ID to be used in following requests for
-    /// this 3PID.
+    ///   this 3PID.
     ///
     /// * `submit_url` - If present, the user will submit the token to
-    /// the client, that must send it to this URL. If not, the client will not
-    /// be involved in the token submission.
+    ///   the client, that must send it to this URL. If not, the client will not
+    ///   be involved in the token submission.
     ///
     /// This method might return an [`ErrorKind::ThreepidInUse`] error if the
     /// email address is already registered for this account or another, or an
@@ -508,25 +508,25 @@ impl Account {
     /// # Arguments
     ///
     /// * `client_secret` - A client-generated secret string used to protect
-    /// this session.
+    ///   this session.
     ///
     /// * `country` - The two-letter uppercase ISO-3166-1 alpha-2 country code
-    /// that the number in phone_number should be parsed as if it were dialled
-    /// from.
+    ///   that the number in phone_number should be parsed as if it were dialled
+    ///   from.
     ///
     /// * `phone_number` - The phone number to validate.
     ///
     /// * `send_attempt` - The attempt number. This number needs to be
-    /// incremented if you want to request another token for the same
-    /// validation.
+    ///   incremented if you want to request another token for the same
+    ///   validation.
     ///
     /// # Returns
     ///
     /// * `sid` - The session ID to be used in following requests for this 3PID.
     ///
     /// * `submit_url` - If present, the user will submit the token to the
-    /// client, that must send it to this URL. If not, the client will not be
-    /// involved in the token submission.
+    ///   client, that must send it to this URL. If not, the client will not be
+    ///   involved in the token submission.
     ///
     /// This method might return an [`ErrorKind::ThreepidInUse`] error if the
     /// phone number is already registered for this account or another, or an
@@ -588,18 +588,18 @@ impl Account {
     /// # Arguments
     ///
     /// * `client_secret` - The same client secret used in
-    /// [`Account::request_3pid_email_token()`] or
-    /// [`Account::request_3pid_msisdn_token()`].
+    ///   [`Account::request_3pid_email_token()`] or
+    ///   [`Account::request_3pid_msisdn_token()`].
     ///
     /// * `sid` - The session ID returned in
-    /// [`Account::request_3pid_email_token()`] or
-    /// [`Account::request_3pid_msisdn_token()`].
+    ///   [`Account::request_3pid_email_token()`] or
+    ///   [`Account::request_3pid_msisdn_token()`].
     ///
     /// * `auth_data` - This request uses the [User-Interactive Authentication
-    /// API][uiaa]. The first request needs to set this to `None` and will
-    /// always fail with an [`UiaaResponse`]. The response will contain
-    /// information for the interactive auth and the same request needs to be
-    /// made but this time with some `auth_data` provided.
+    ///   API][uiaa]. The first request needs to set this to `None` and will
+    ///   always fail with an [`UiaaResponse`]. The response will contain
+    ///   information for the interactive auth and the same request needs to be
+    ///   made but this time with some `auth_data` provided.
     ///
     /// [3pid]: https://spec.matrix.org/v1.2/appendices/#3pid-types
     /// [uiaa]: https://spec.matrix.org/v1.2/client-server-api/#user-interactive-authentication-api
@@ -628,17 +628,17 @@ impl Account {
     /// * `medium` - The type of the 3PID.
     ///
     /// * `id_server` - The identity server to unbind from. If not provided, the
-    /// homeserver should unbind the 3PID from the identity server it was bound
-    /// to previously.
+    ///   homeserver should unbind the 3PID from the identity server it was bound
+    ///   to previously.
     ///
     /// # Returns
     ///
     /// * [`ThirdPartyIdRemovalStatus::Success`] if the 3PID was also unbound
-    /// from the identity server.
+    ///   from the identity server.
     ///
     /// * [`ThirdPartyIdRemovalStatus::NoSupport`] if the 3PID was not unbound
-    /// from the identity server. This can also mean that the 3PID was not bound
-    /// to an identity server in the first place.
+    ///   from the identity server. This can also mean that the 3PID was not bound
+    ///   to an identity server in the first place.
     ///
     /// # Examples
     ///
@@ -822,7 +822,7 @@ impl Account {
     ///
     /// * `room_id` - The room ID of the direct message room.
     /// * `user_ids` - The user IDs to be associated with this direct message
-    /// room.
+    ///   room.
     pub async fn mark_as_dm(&self, room_id: &RoomId, user_ids: &[OwnedUserId]) -> Result<()> {
         use ruma::events::direct::DirectEventContent;
 

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -228,7 +228,7 @@ impl AttachmentConfig {
     /// # Arguments
     ///
     /// * `size` - The size of the thumbnail in pixels as a `(width, height)`
-    /// tuple. If set to `None`, defaults to `(800, 600)`.
+    ///   tuple. If set to `None`, defaults to `(800, 600)`.
     ///
     /// * `format` - The image format to use to encode the thumbnail.
     #[cfg(feature = "image-proc")]
@@ -245,7 +245,7 @@ impl AttachmentConfig {
     /// # Arguments
     ///
     /// * `thumbnail` - The thumbnail of the media. If the `content_type` does
-    /// not support it (eg audio clips), it is ignored.
+    ///   not support it (eg audio clips), it is ignored.
     ///
     /// To generate automatically a thumbnail from an image, use
     /// [`AttachmentConfig::new()`] and
@@ -259,8 +259,8 @@ impl AttachmentConfig {
     /// # Arguments
     ///
     /// * `txn_id` - A unique ID that can be attached to a `MessageEvent` held
-    /// in its unsigned field as `transaction_id`. If not given, one is created
-    /// for the message.
+    ///   in its unsigned field as `transaction_id`. If not given, one is created
+    ///   for the message.
     #[must_use]
     pub fn txn_id(mut self, txn_id: &TransactionId) -> Self {
         self.txn_id = Some(txn_id.to_owned());
@@ -272,7 +272,7 @@ impl AttachmentConfig {
     /// # Arguments
     ///
     /// * `info` - The metadata of the media. If the `AttachmentInfo` type
-    /// doesn't match the `content_type`, it is ignored.
+    ///   doesn't match the `content_type`, it is ignored.
     #[must_use]
     pub fn info(mut self, info: AttachmentInfo) -> Self {
         self.info = Some(info);

--- a/crates/matrix-sdk/src/attachment.rs
+++ b/crates/matrix-sdk/src/attachment.rs
@@ -259,8 +259,8 @@ impl AttachmentConfig {
     /// # Arguments
     ///
     /// * `txn_id` - A unique ID that can be attached to a `MessageEvent` held
-    ///   in its unsigned field as `transaction_id`. If not given, one is created
-    ///   for the message.
+    ///   in its unsigned field as `transaction_id`. If not given, one is
+    ///   created for the message.
     #[must_use]
     pub fn txn_id(mut self, txn_id: &TransactionId) -> Self {
         self.txn_id = Some(txn_id.to_owned());

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -1165,8 +1165,8 @@ impl Client {
     ///
     /// # Arguments
     ///
-    /// * `alias` - The `RoomId` or `RoomAliasId` of the room to be joined.
-    /// An alias looks like `#name:example.com`.
+    /// * `alias` - The `RoomId` or `RoomAliasId` of the room to be joined. An
+    ///   alias looks like `#name:example.com`.
     pub async fn join_room_by_id_or_alias(
         &self,
         alias: &RoomOrAliasId,
@@ -1311,7 +1311,7 @@ impl Client {
     /// # Arguments
     ///
     /// * `room_search` - The easiest way to create this request is using the
-    /// `get_public_rooms_filtered::Request` itself.
+    ///   `get_public_rooms_filtered::Request` itself.
     ///
     /// # Examples
     ///
@@ -1357,7 +1357,7 @@ impl Client {
     /// * `request` - A filled out and valid request for the endpoint to be hit
     ///
     /// * `timeout` - An optional request timeout setting, this overrides the
-    /// default request setting if one was set.
+    ///   default request setting if one was set.
     ///
     /// # Examples
     ///
@@ -1565,13 +1565,13 @@ impl Client {
     /// # Arguments
     ///
     /// * `devices` - The list of devices that should be deleted from the
-    /// server.
+    ///   server.
     ///
     /// * `auth_data` - This request requires user interactive auth, the first
-    /// request needs to set this to `None` and will always fail with an
-    /// `UiaaResponse`. The response will contain information for the
-    /// interactive auth and the same request needs to be made but this time
-    /// with some `auth_data` provided.
+    ///   request needs to set this to `None` and will always fail with an
+    ///   `UiaaResponse`. The response will contain information for the
+    ///   interactive auth and the same request needs to be made but this time
+    ///   with some `auth_data` provided.
     ///
     /// ```no_run
     /// # use matrix_sdk::{

--- a/crates/matrix-sdk/src/encryption/identities/devices.rs
+++ b/crates/matrix-sdk/src/encryption/identities/devices.rs
@@ -154,7 +154,7 @@ impl Device {
     /// # Arguments
     ///
     /// * `methods` - The verification methods that we want to support. Must be
-    /// non-empty.
+    ///   non-empty.
     ///
     /// # Panics
     ///
@@ -359,7 +359,7 @@ impl Device {
     ///
     /// * The device has been signed by the user's self-signing key
     /// * The user's master-signing key has been signed by our own user-signing
-    /// key, i.e. our own identity trusts the other users identity.
+    ///   key, i.e. our own identity trusts the other users identity.
     /// * Our own user identity is considered to be [verified]
     ///
     /// ```text
@@ -474,7 +474,7 @@ impl Device {
     ///
     /// * The device has been signed by the user's self-signing key
     /// * The user's master-signing key has been signed by our own user-signing
-    /// key, i.e. our own identity trusts the other users identity.
+    ///   key, i.e. our own identity trusts the other users identity.
     /// * Our own user identity is considered to be [verified]
     ///
     /// ```text

--- a/crates/matrix-sdk/src/encryption/identities/mod.rs
+++ b/crates/matrix-sdk/src/encryption/identities/mod.rs
@@ -22,9 +22,9 @@
 //!
 //! 2. User identities, which are backed by [cross signing keys]. The user
 //!    identity represent a unique E2EE capable identity of any given user. This
-//!    identity is generally created and uploaded to the server by the first E2EE
-//!    capable client the user logs in with. We represent user identities using the
-//!    [`UserIdentity`] struct.
+//!    identity is generally created and uploaded to the server by the first
+//!    E2EE capable client the user logs in with. We represent user identities
+//!    using the [`UserIdentity`] struct.
 //!
 //! A [`Device`] or an [`UserIdentity`] can be used to inspect the public keys
 //! of the device/identity, or it can be used to initiate a interactive

--- a/crates/matrix-sdk/src/encryption/identities/mod.rs
+++ b/crates/matrix-sdk/src/encryption/identities/mod.rs
@@ -17,14 +17,14 @@
 //! There are two types of cryptographic identities in Matrix.
 //!
 //! 1. Devices, which are backed by [device keys], they represent each
-//! individual log in by an E2EE capable Matrix client. We represent devices
-//! using the [`Device`] struct.
+//!    individual log in by an E2EE capable Matrix client. We represent devices
+//!    using the [`Device`] struct.
 //!
 //! 2. User identities, which are backed by [cross signing keys]. The user
-//! identity represent a unique E2EE capable identity of any given user. This
-//! identity is generally created and uploaded to the server by the first E2EE
-//! capable client the user logs in with. We represent user identities using the
-//! [`UserIdentity`] struct.
+//!    identity represent a unique E2EE capable identity of any given user. This
+//!    identity is generally created and uploaded to the server by the first E2EE
+//!    capable client the user logs in with. We represent user identities using the
+//!    [`UserIdentity`] struct.
 //!
 //! A [`Device`] or an [`UserIdentity`] can be used to inspect the public keys
 //! of the device/identity, or it can be used to initiate a interactive

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -86,9 +86,9 @@ impl IdentityUpdates {
 ///
 /// Each key has a separate role:
 /// * Master key, signs only the sub-keys, can be used as a fingerprint of the
-/// identity.
+///   identity.
 /// * Self-signing key, signs devices belonging to the user that owns this
-/// identity.
+///   identity.
 /// * User-signing key, signs Master keys belonging to other users.
 ///
 /// The User-signing key and its signatures of other user's Master keys are
@@ -144,10 +144,10 @@ impl UserIdentity {
     /// someone else's:
     ///
     /// * Our own identity - All our E2EE capable devices will receive the event
-    /// over to-device messaging.
+    ///   over to-device messaging.
     /// * Someone else's identity - The event will be sent to a DM room we share
-    /// with the user, if we don't share a DM with the user, one will be
-    /// created.
+    ///   with the user, if we don't share a DM with the user, one will be
+    ///   created.
     ///
     /// The default methods that are supported are:
     ///
@@ -203,7 +203,7 @@ impl UserIdentity {
     /// # Arguments
     ///
     /// * `methods` - The verification methods that we want to support. Must be
-    /// non-empty.
+    ///   non-empty.
     ///
     /// # Panics
     ///
@@ -316,9 +316,9 @@ impl UserIdentity {
     /// A user identity is considered to be verified if:
     ///
     /// * It has been signed by our User-signing key, if the identity belongs
-    /// to another user
+    ///   to another user
     /// * If it has been locally marked as verified, if the user identity
-    /// belongs to us.
+    ///   belongs to us.
     ///
     /// If the identity belongs to another user, our own user identity needs to
     /// be verified as well for the identity to be considered to be verified.

--- a/crates/matrix-sdk/src/encryption/identities/users.rs
+++ b/crates/matrix-sdk/src/encryption/identities/users.rs
@@ -315,8 +315,8 @@ impl UserIdentity {
     ///
     /// A user identity is considered to be verified if:
     ///
-    /// * It has been signed by our User-signing key, if the identity belongs
-    ///   to another user
+    /// * It has been signed by our User-signing key, if the identity belongs to
+    ///   another user
     /// * If it has been locally marked as verified, if the user identity
     ///   belongs to us.
     ///

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -980,10 +980,10 @@ impl Encryption {
     /// # Arguments
     ///
     /// * `auth_data` - This request requires user interactive auth, the first
-    /// request needs to set this to `None` and will always fail with an
-    /// `UiaaResponse`. The response will contain information for the
-    /// interactive auth and the same request needs to be made but this time
-    /// with some `auth_data` provided.
+    ///   request needs to set this to `None` and will always fail with an
+    ///   `UiaaResponse`. The response will contain information for the
+    ///   interactive auth and the same request needs to be made but this time
+    ///   with some `auth_data` provided.
     ///
     /// # Examples
     ///
@@ -1067,10 +1067,10 @@ impl Encryption {
     /// # Arguments
     ///
     /// * `auth_data` - This request requires user interactive auth, the first
-    /// request needs to set this to `None` and will always fail with an
-    /// `UiaaResponse`. The response will contain information for the
-    /// interactive auth and the same request needs to be made but this time
-    /// with some `auth_data` provided.
+    ///   request needs to set this to `None` and will always fail with an
+    ///   `UiaaResponse`. The response will contain information for the
+    ///   interactive auth and the same request needs to be made but this time
+    ///   with some `auth_data` provided.
     ///
     /// # Examples
     /// ```no_run
@@ -1126,13 +1126,12 @@ impl Encryption {
     /// * `path` - The file path where the exported key file will be saved.
     ///
     /// * `passphrase` - The passphrase that will be used to encrypt the
-    ///   exported
-    /// room keys.
+    ///   exported room keys.
     ///
     /// * `predicate` - A closure that will be called for every known
-    /// `InboundGroupSession`, which represents a room key. If the closure
-    /// returns `true` the `InboundGroupSessoin` will be included in the export,
-    /// if the closure returns `false` it will not be included.
+    ///   `InboundGroupSession`, which represents a room key. If the closure
+    ///   returns `true` the `InboundGroupSessoin` will be included in the export,
+    ///   if the closure returns `false` it will not be included.
     ///
     /// # Panics
     ///
@@ -1202,7 +1201,7 @@ impl Encryption {
     /// * `path` - The file path where the exported key file will can be found.
     ///
     /// * `passphrase` - The passphrase that should be used to decrypt the
-    /// exported room keys.
+    ///   exported room keys.
     ///
     /// Returns a tuple of numbers that represent the number of sessions that
     /// were imported and the total number of sessions that were found in the
@@ -1416,12 +1415,12 @@ impl Encryption {
     /// # Arguments
     ///
     /// * `auth_data` - Some requests may require re-authentication. To prevent
-    /// the user from having to re-enter their password (or use other methods),
-    /// we can provide the authentication data here. This is necessary for
-    /// uploading cross-signing keys. However, please note that there is a
-    /// proposal (MSC3967) to remove this requirement, which would allow for
-    /// the initial upload of cross-signing keys without authentication,
-    /// rendering this parameter obsolete.
+    ///   the user from having to re-enter their password (or use other methods),
+    ///   we can provide the authentication data here. This is necessary for
+    ///   uploading cross-signing keys. However, please note that there is a
+    ///   proposal (MSC3967) to remove this requirement, which would allow for
+    ///   the initial upload of cross-signing keys without authentication,
+    ///   rendering this parameter obsolete.
     pub(crate) fn spawn_initialization_task(&self, auth_data: Option<AuthData>) {
         let mut tasks = self.client.inner.e2ee.tasks.lock().unwrap();
 

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -1130,8 +1130,8 @@ impl Encryption {
     ///
     /// * `predicate` - A closure that will be called for every known
     ///   `InboundGroupSession`, which represents a room key. If the closure
-    ///   returns `true` the `InboundGroupSessoin` will be included in the export,
-    ///   if the closure returns `false` it will not be included.
+    ///   returns `true` the `InboundGroupSessoin` will be included in the
+    ///   export, if the closure returns `false` it will not be included.
     ///
     /// # Panics
     ///
@@ -1415,12 +1415,12 @@ impl Encryption {
     /// # Arguments
     ///
     /// * `auth_data` - Some requests may require re-authentication. To prevent
-    ///   the user from having to re-enter their password (or use other methods),
-    ///   we can provide the authentication data here. This is necessary for
-    ///   uploading cross-signing keys. However, please note that there is a
-    ///   proposal (MSC3967) to remove this requirement, which would allow for
-    ///   the initial upload of cross-signing keys without authentication,
-    ///   rendering this parameter obsolete.
+    ///   the user from having to re-enter their password (or use other
+    ///   methods), we can provide the authentication data here. This is
+    ///   necessary for uploading cross-signing keys. However, please note that
+    ///   there is a proposal (MSC3967) to remove this requirement, which would
+    ///   allow for the initial upload of cross-signing keys without
+    ///   authentication, rendering this parameter obsolete.
     pub(crate) fn spawn_initialization_task(&self, auth_data: Option<AuthData>) {
         let mut tasks = self.client.inner.e2ee.tasks.lock().unwrap();
 

--- a/crates/matrix-sdk/src/encryption/verification/mod.rs
+++ b/crates/matrix-sdk/src/encryption/verification/mod.rs
@@ -26,8 +26,7 @@
 //! transition into one of the supported verification flows:
 //!
 //! * [`SasVerification`] - Interactive verification using a short
-//!   authentication
-//! string.
+//!   authentication string.
 //! * [`QrVerification`] - Interactive verification using QR codes.
 
 #[cfg(feature = "qrcode")]

--- a/crates/matrix-sdk/src/event_handler/mod.rs
+++ b/crates/matrix-sdk/src/event_handler/mod.rs
@@ -692,6 +692,7 @@ mod tests {
     }
 
     #[async_test]
+    #[allow(dependency_on_unit_never_type_fallback)]
     async fn add_room_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 
@@ -753,6 +754,7 @@ mod tests {
     }
 
     #[async_test]
+    #[allow(dependency_on_unit_never_type_fallback)]
     async fn remove_event_handler() -> crate::Result<()> {
         let client = logged_in_client(None).await;
 

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -129,10 +129,10 @@ impl Media {
     /// # Arguments
     ///
     /// * `content_type` - The type of the media, this will be used as the
-    /// content-type header.
+    ///   content-type header.
     ///
     /// * `reader` - A `Reader` that will be used to fetch the raw bytes of the
-    /// media.
+    ///   media.
     ///
     /// # Examples
     ///

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -608,7 +608,7 @@ impl Room {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user that should be fetched out of the
-    /// store.
+    ///   store.
     pub async fn get_member(&self, user_id: &UserId) -> Result<Option<RoomMember>> {
         self.sync_members().await?;
         self.get_member_no_sync(user_id).await
@@ -626,7 +626,7 @@ impl Room {
     /// # Arguments
     ///
     /// * `user_id` - The ID of the user that should be fetched out of the
-    /// store.
+    ///   store.
     pub async fn get_member_no_sync(&self, user_id: &UserId) -> Result<Option<RoomMember>> {
         Ok(self
             .inner
@@ -1770,10 +1770,10 @@ impl Room {
     /// * `filename` - The file name.
     ///
     /// * `content_type` - The type of the media, this will be used as the
-    /// content-type header.
+    ///   content-type header.
     ///
     /// * `reader` - A `Reader` that will be used to fetch the raw bytes of the
-    /// media.
+    ///   media.
     ///
     /// * `config` - Metadata and configuration for the attachment.
     pub(super) async fn prepare_and_send_attachment<'a>(
@@ -1953,8 +1953,8 @@ impl Room {
     /// # Arguments
     /// * `mime` - The mime type describing the data
     /// * `data` - The data representation of the avatar
-    /// * `info` - The optional image info provided for the avatar,
-    /// the blurhash and the mimetype will always be updated
+    /// * `info` - The optional image info provided for the avatar, the blurhash
+    ///   and the mimetype will always be updated
     pub async fn upload_avatar(
         &self,
         mime: &Mime,
@@ -2632,6 +2632,7 @@ impl Room {
     /// This function is supposed to be called whenever the user creates a room
     /// call. It will send a `m.call.notify` event if:
     ///  - there is not yet a running call.
+    ///
     /// It will configure the notify type: ring or notify based on:
     ///  - is this a DM room -> ring
     ///  - is this a group with more than one other member -> notify

--- a/crates/matrix-sdk/src/room_preview.rs
+++ b/crates/matrix-sdk/src/room_preview.rs
@@ -186,8 +186,7 @@ impl RoomPreview {
     /// of these two conditions is true:
     ///
     /// - the user has joined the room at some point (i.e. they're still joined
-    ///   or they've joined
-    /// it and left it later).
+    ///   or they've joined it and left it later).
     /// - the room has an history visibility set to world-readable.
     ///
     /// This method is exposed for testing purposes; clients should prefer

--- a/crates/matrix-sdk/src/widget/settings/element_call.rs
+++ b/crates/matrix-sdk/src/widget/settings/element_call.rs
@@ -152,8 +152,8 @@ impl WidgetSettings {
     ///
     /// # Arguments
     ///
-    /// * - `props` A struct containing the configuration parameters for a
-    /// element call widget.
+    /// * `props` - A struct containing the configuration parameters for a
+    ///   element call widget.
     pub fn new_virtual_element_call_widget(
         props: VirtualElementCallWidgetOptions,
     ) -> Result<Self, url::ParseError> {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,7 +11,7 @@ use kotlin::KotlinArgs;
 use swift::SwiftArgs;
 use xshell::cmd;
 
-const NIGHTLY: &str = "nightly-2024-05-19";
+const NIGHTLY: &str = "nightly-2024-06-24";
 
 type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,7 +11,7 @@ use kotlin::KotlinArgs;
 use swift::SwiftArgs;
 use xshell::cmd;
 
-const NIGHTLY: &str = "nightly-2024-06-24";
+const NIGHTLY: &str = "nightly-2024-06-25";
 
 type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 


### PR DESCRIPTION
This should be reviewed commit by commit.

I could not find a satisfying solution for the 3rd commit. [`dependency_on_unit_never_type_fallback`](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#dependency-on-unit-never-type-fallback) is a warning to prepare for the 2024 edition but it applies to the [never](https://doc.rust-lang.org/std/primitive.never.html) type that is still unstable.

It seems that [another temporary solution](https://github.com/rust-lang/rust/issues/126466#issuecomment-2171025116) is to add `#![feature(never_type, never_type_fallback)]` in the crate root. The proper solution might be to implement `EventHandlerResult` for `!`, if I understand the problem correctly.

This bumps Rust nightly in CI so the lint from the first commit is applied to future PRs.