### PR TITLE
send queue: allow to respawn tasks for send queues which had unsent events

### DIFF
--- a/crates/matrix-sdk-common/src/tracing_timer.rs
+++ b/crates/matrix-sdk-common/src/tracing_timer.rs
@@ -98,7 +98,7 @@ macro_rules! timer {
     }};
 
     ($string:expr) => {
-        timer!(tracing::Level::DEBUG, $string)
+        $crate::timer!(tracing::Level::DEBUG, $string)
     };
 }
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/migrations.rs
@@ -41,7 +41,7 @@ use wasm_bindgen::JsValue;
 use web_sys::IdbTransactionMode;
 
 use super::{
-    deserialize_event, encode_key, encode_to_range, keys, serialize_event, Result, RoomMember,
+    deserialize_value, encode_key, encode_to_range, keys, serialize_value, Result, RoomMember,
     ALL_STORES,
 };
 use crate::IndexeddbStateStoreError;
@@ -389,10 +389,10 @@ async fn v3_fix_store(
 
     if let Some(cursor) = cursor {
         loop {
-            let raw_json: Box<RawJsonValue> = deserialize_event(store_cipher, &cursor.value())?;
+            let raw_json: Box<RawJsonValue> = deserialize_value(store_cipher, &cursor.value())?;
 
             if let Some(fixed_json) = maybe_fix_json(&raw_json)? {
-                cursor.update(&serialize_event(store_cipher, &fixed_json)?)?.await?;
+                cursor.update(&serialize_value(store_cipher, &fixed_json)?)?.await?;
             }
 
             if !cursor.continue_cursor()?.await? {
@@ -490,7 +490,7 @@ async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         .get_all()?
         .await?
         .iter()
-        .filter_map(|f| deserialize_event::<RoomInfoV1>(store_cipher, &f).ok())
+        .filter_map(|f| deserialize_value::<RoomInfoV1>(store_cipher, &f).ok())
         .collect::<Vec<_>>();
 
     for room_info in room_infos {
@@ -498,7 +498,7 @@ async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         let range = encode_to_range(store_cipher, old_keys::MEMBERS, room_id)?;
         for value in members_store.get_all_with_key(&range)?.await?.iter() {
             let raw_member_event =
-                deserialize_event::<Raw<SyncRoomMemberEvent>>(store_cipher, &value)?;
+                deserialize_value::<Raw<SyncRoomMemberEvent>>(store_cipher, &value)?;
             let state_key = raw_member_event.get_field::<String>("state_key")?.unwrap_or_default();
             let key = encode_key(
                 store_cipher,
@@ -517,7 +517,7 @@ async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         .get_all()?
         .await?
         .iter()
-        .filter_map(|f| deserialize_event::<RoomInfoV1>(store_cipher, &f).ok())
+        .filter_map(|f| deserialize_value::<RoomInfoV1>(store_cipher, &f).ok())
         .collect::<Vec<_>>();
 
     for room_info in stripped_room_infos {
@@ -525,7 +525,7 @@ async fn migrate_to_v5(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         let range = encode_to_range(store_cipher, old_keys::STRIPPED_MEMBERS, room_id)?;
         for value in stripped_members_store.get_all_with_key(&range)?.await?.iter() {
             let raw_member_event =
-                deserialize_event::<Raw<StrippedRoomMemberEvent>>(store_cipher, &value)?;
+                deserialize_value::<Raw<StrippedRoomMemberEvent>>(store_cipher, &value)?;
             let state_key = raw_member_event.get_field::<String>("state_key")?.unwrap_or_default();
             let key = encode_key(
                 store_cipher,
@@ -567,7 +567,7 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         .get_all()?
         .await?
         .iter()
-        .filter_map(|f| deserialize_event::<RoomInfoV1>(store_cipher, &f).ok())
+        .filter_map(|f| deserialize_value::<RoomInfoV1>(store_cipher, &f).ok())
         .collect::<Vec<_>>();
     let mut values = Vec::new();
 
@@ -576,10 +576,10 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         let range =
             encode_to_range(store_cipher, keys::ROOM_STATE, (room_id, StateEventType::RoomMember))?;
         for value in state_store.get_all_with_key(&range)?.await?.iter() {
-            let member_event = deserialize_event::<Raw<SyncRoomMemberEvent>>(store_cipher, &value)?
+            let member_event = deserialize_value::<Raw<SyncRoomMemberEvent>>(store_cipher, &value)?
                 .deserialize()?;
             let key = encode_key(store_cipher, keys::USER_IDS, (room_id, member_event.state_key()));
-            let value = serialize_event(store_cipher, &RoomMember::from(&member_event))?;
+            let value = serialize_value(store_cipher, &RoomMember::from(&member_event))?;
 
             values.push((key, value));
         }
@@ -591,7 +591,7 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         .get_all()?
         .await?
         .iter()
-        .filter_map(|f| deserialize_event::<RoomInfoV1>(store_cipher, &f).ok())
+        .filter_map(|f| deserialize_value::<RoomInfoV1>(store_cipher, &f).ok())
         .collect::<Vec<_>>();
     let mut stripped_values = Vec::new();
 
@@ -604,14 +604,14 @@ async fn migrate_to_v6(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         )?;
         for value in stripped_state_store.get_all_with_key(&range)?.await?.iter() {
             let stripped_member_event =
-                deserialize_event::<Raw<StrippedRoomMemberEvent>>(store_cipher, &value)?
+                deserialize_value::<Raw<StrippedRoomMemberEvent>>(store_cipher, &value)?
                     .deserialize()?;
             let key = encode_key(
                 store_cipher,
                 keys::STRIPPED_USER_IDS,
                 (room_id, &stripped_member_event.state_key),
             );
-            let value = serialize_event(store_cipher, &RoomMember::from(&stripped_member_event))?;
+            let value = serialize_value(store_cipher, &RoomMember::from(&stripped_member_event))?;
 
             stripped_values.push((key, value));
         }
@@ -654,7 +654,7 @@ async fn migrate_to_v7(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         .await?
         .iter()
         .filter_map(|value| {
-            deserialize_event::<RoomInfoV1>(store_cipher, &value)
+            deserialize_value::<RoomInfoV1>(store_cipher, &value)
                 .ok()
                 .map(|info| (encode_key(store_cipher, keys::ROOM_INFOS, info.room_id()), value))
         })
@@ -690,7 +690,7 @@ async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         .get_all()?
         .await?
         .iter()
-        .map(|value| deserialize_event::<RoomInfoV1>(store_cipher, &value))
+        .map(|value| deserialize_value::<RoomInfoV1>(store_cipher, &value))
         .collect::<Result<Vec<_>, _>>()?;
 
     for room_info_v1 in room_infos_v1 {
@@ -701,7 +701,7 @@ async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
                 (room_info_v1.room_id(), &StateEventType::RoomCreate, ""),
             ))?
             .await?
-            .map(|f| deserialize_event(store_cipher, &f))
+            .map(|f| deserialize_value(store_cipher, &f))
             .transpose()?
         {
             Some(SyncOrStrippedState::<RoomCreateEventContent>::Stripped(event))
@@ -713,7 +713,7 @@ async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
                     (room_info_v1.room_id(), &StateEventType::RoomCreate, ""),
                 ))?
                 .await?
-                .map(|f| deserialize_event(store_cipher, &f))
+                .map(|f| deserialize_value(store_cipher, &f))
                 .transpose()?
                 .map(SyncOrStrippedState::<RoomCreateEventContent>::Sync)
         };
@@ -721,7 +721,7 @@ async fn migrate_to_v8(db: IdbDatabase, store_cipher: Option<&StoreCipher>) -> R
         let room_info = room_info_v1.migrate(create.as_ref());
         room_infos_store.put_key_val(
             &encode_key(store_cipher, keys::ROOM_INFOS, room_info.room_id()),
-            &serialize_event(store_cipher, &room_info)?,
+            &serialize_value(store_cipher, &room_info)?,
         )?;
     }
 
@@ -776,7 +776,7 @@ mod tests {
     use super::{old_keys, MigrationConflictStrategy, CURRENT_DB_VERSION, CURRENT_META_DB_VERSION};
     use crate::{
         safe_encode::SafeEncode,
-        state_store::{encode_key, keys, serialize_event, Result},
+        state_store::{encode_key, keys, serialize_value, Result},
         IndexeddbStateStore, IndexeddbStateStoreError,
     };
 
@@ -922,7 +922,7 @@ mod tests {
             let jskey = JsValue::from_str(
                 core::str::from_utf8(CUSTOM_DATA_KEY).map_err(StoreError::Codec)?,
             );
-            custom.put_key_val(&jskey, &serialize_event(None, &CUSTOM_DATA)?)?;
+            custom.put_key_val(&jskey, &serialize_value(None, &CUSTOM_DATA)?)?;
             tx.await.into_result()?;
             db.close();
         }
@@ -957,7 +957,7 @@ mod tests {
             let jskey = JsValue::from_str(
                 core::str::from_utf8(CUSTOM_DATA_KEY).map_err(StoreError::Codec)?,
             );
-            custom.put_key_val(&jskey, &serialize_event(None, &CUSTOM_DATA)?)?;
+            custom.put_key_val(&jskey, &serialize_value(None, &CUSTOM_DATA)?)?;
             tx.await.into_result()?;
             db.close();
         }
@@ -995,7 +995,7 @@ mod tests {
             let jskey = JsValue::from_str(
                 core::str::from_utf8(CUSTOM_DATA_KEY).map_err(StoreError::Codec)?,
             );
-            custom.put_key_val(&jskey, &serialize_event(None, &CUSTOM_DATA)?)?;
+            custom.put_key_val(&jskey, &serialize_value(None, &CUSTOM_DATA)?)?;
             tx.await.into_result()?;
             db.close();
         }
@@ -1036,7 +1036,7 @@ mod tests {
             let jskey = JsValue::from_str(
                 core::str::from_utf8(CUSTOM_DATA_KEY).map_err(StoreError::Codec)?,
             );
-            custom.put_key_val(&jskey, &serialize_event(None, &CUSTOM_DATA)?)?;
+            custom.put_key_val(&jskey, &serialize_value(None, &CUSTOM_DATA)?)?;
             tx.await.into_result()?;
             db.close();
         }
@@ -1090,7 +1090,7 @@ mod tests {
                 db.transaction_on_one_with_mode(keys::ROOM_STATE, IdbTransactionMode::Readwrite)?;
             let state = tx.object_store(keys::ROOM_STATE)?;
             let key: JsValue = (room_id, StateEventType::RoomTopic, "").as_encoded_string().into();
-            state.put_key_val(&key, &serialize_event(None, &wrong_redacted_state_event)?)?;
+            state.put_key_val(&key, &serialize_value(None, &wrong_redacted_state_event)?)?;
             tx.await.into_result()?;
             db.close();
         }
@@ -1129,17 +1129,17 @@ mod tests {
             let sync_token_store = tx.object_store(old_keys::SYNC_TOKEN)?;
             sync_token_store.put_key_val(
                 &JsValue::from_str(old_keys::SYNC_TOKEN),
-                &serialize_event(None, &sync_token)?,
+                &serialize_value(None, &sync_token)?,
             )?;
 
             let session_store = tx.object_store(old_keys::SESSION)?;
             session_store.put_key_val(
                 &encode_key(None, StateStoreDataKey::FILTER, (StateStoreDataKey::FILTER, filter_1)),
-                &serialize_event(None, &filter_1_id)?,
+                &serialize_value(None, &filter_1_id)?,
             )?;
             session_store.put_key_val(
                 &encode_key(None, StateStoreDataKey::FILTER, (StateStoreDataKey::FILTER, filter_2)),
-                &serialize_event(None, &filter_2_id)?,
+                &serialize_value(None, &filter_2_id)?,
             )?;
 
             tx.await.into_result()?;
@@ -1206,26 +1206,26 @@ mod tests {
             let members_store = tx.object_store(old_keys::MEMBERS)?;
             members_store.put_key_val(
                 &encode_key(None, old_keys::MEMBERS, (room_id, user_id)),
-                &serialize_event(None, &member_event)?,
+                &serialize_value(None, &member_event)?,
             )?;
             let room_infos_store = tx.object_store(keys::ROOM_INFOS)?;
             let room_info = room_info_v1_json(room_id, RoomState::Joined, None, None);
             room_infos_store.put_key_val(
                 &encode_key(None, keys::ROOM_INFOS, room_id),
-                &serialize_event(None, &room_info)?,
+                &serialize_value(None, &room_info)?,
             )?;
 
             let stripped_members_store = tx.object_store(old_keys::STRIPPED_MEMBERS)?;
             stripped_members_store.put_key_val(
                 &encode_key(None, old_keys::STRIPPED_MEMBERS, (stripped_room_id, stripped_user_id)),
-                &serialize_event(None, &stripped_member_event)?,
+                &serialize_value(None, &stripped_member_event)?,
             )?;
             let stripped_room_infos_store = tx.object_store(old_keys::STRIPPED_ROOM_INFOS)?;
             let stripped_room_info =
                 room_info_v1_json(stripped_room_id, RoomState::Invited, None, None);
             stripped_room_infos_store.put_key_val(
                 &encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id),
-                &serialize_event(None, &stripped_room_info)?,
+                &serialize_value(None, &stripped_room_info)?,
             )?;
 
             tx.await.into_result()?;
@@ -1291,7 +1291,7 @@ mod tests {
                     keys::ROOM_STATE,
                     (room_id, StateEventType::RoomMember, invite_user_id),
                 ),
-                &serialize_event(None, &invite_member_event)?,
+                &serialize_value(None, &invite_member_event)?,
             )?;
             state_store.put_key_val(
                 &encode_key(
@@ -1299,13 +1299,13 @@ mod tests {
                     keys::ROOM_STATE,
                     (room_id, StateEventType::RoomMember, ban_user_id),
                 ),
-                &serialize_event(None, &ban_member_event)?,
+                &serialize_value(None, &ban_member_event)?,
             )?;
             let room_infos_store = tx.object_store(keys::ROOM_INFOS)?;
             let room_info = room_info_v1_json(room_id, RoomState::Joined, None, None);
             room_infos_store.put_key_val(
                 &encode_key(None, keys::ROOM_INFOS, room_id),
-                &serialize_event(None, &room_info)?,
+                &serialize_value(None, &room_info)?,
             )?;
 
             let stripped_state_store = tx.object_store(keys::STRIPPED_ROOM_STATE)?;
@@ -1315,26 +1315,26 @@ mod tests {
                     keys::STRIPPED_ROOM_STATE,
                     (stripped_room_id, StateEventType::RoomMember, stripped_user_id),
                 ),
-                &serialize_event(None, &stripped_member_event)?,
+                &serialize_value(None, &stripped_member_event)?,
             )?;
             let stripped_room_infos_store = tx.object_store(old_keys::STRIPPED_ROOM_INFOS)?;
             let stripped_room_info =
                 room_info_v1_json(stripped_room_id, RoomState::Invited, None, None);
             stripped_room_infos_store.put_key_val(
                 &encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id),
-                &serialize_event(None, &stripped_room_info)?,
+                &serialize_value(None, &stripped_room_info)?,
             )?;
 
             // Populate the old user IDs stores to check the data is not reused.
             let joined_user_id = user_id!("@joined_user:localhost");
             tx.object_store(old_keys::JOINED_USER_IDS)?.put_key_val(
                 &encode_key(None, old_keys::JOINED_USER_IDS, (room_id, joined_user_id)),
-                &serialize_event(None, &joined_user_id)?,
+                &serialize_value(None, &joined_user_id)?,
             )?;
             let invited_user_id = user_id!("@invited_user:localhost");
             tx.object_store(old_keys::INVITED_USER_IDS)?.put_key_val(
                 &encode_key(None, old_keys::INVITED_USER_IDS, (room_id, invited_user_id)),
-                &serialize_event(None, &invited_user_id)?,
+                &serialize_value(None, &invited_user_id)?,
             )?;
             let stripped_joined_user_id = user_id!("@stripped_joined_user:localhost");
             tx.object_store(old_keys::STRIPPED_JOINED_USER_IDS)?.put_key_val(
@@ -1343,7 +1343,7 @@ mod tests {
                     old_keys::STRIPPED_JOINED_USER_IDS,
                     (room_id, stripped_joined_user_id),
                 ),
-                &serialize_event(None, &stripped_joined_user_id)?,
+                &serialize_value(None, &stripped_joined_user_id)?,
             )?;
             let stripped_invited_user_id = user_id!("@stripped_invited_user:localhost");
             tx.object_store(old_keys::STRIPPED_INVITED_USER_IDS)?.put_key_val(
@@ -1352,7 +1352,7 @@ mod tests {
                     old_keys::STRIPPED_INVITED_USER_IDS,
                     (room_id, stripped_invited_user_id),
                 ),
-                &serialize_event(None, &stripped_invited_user_id)?,
+                &serialize_value(None, &stripped_invited_user_id)?,
             )?;
 
             tx.await.into_result()?;
@@ -1411,7 +1411,7 @@ mod tests {
             let room_info = room_info_v1_json(room_id, RoomState::Joined, None, None);
             room_infos_store.put_key_val(
                 &encode_key(None, keys::ROOM_INFOS, room_id),
-                &serialize_event(None, &room_info)?,
+                &serialize_value(None, &room_info)?,
             )?;
 
             let stripped_room_infos_store = tx.object_store(old_keys::STRIPPED_ROOM_INFOS)?;
@@ -1419,7 +1419,7 @@ mod tests {
                 room_info_v1_json(stripped_room_id, RoomState::Invited, None, None);
             stripped_room_infos_store.put_key_val(
                 &encode_key(None, old_keys::STRIPPED_ROOM_INFOS, stripped_room_id),
-                &serialize_event(None, &stripped_room_info)?,
+                &serialize_value(None, &stripped_room_info)?,
             )?;
 
             tx.await.into_result()?;
@@ -1447,7 +1447,7 @@ mod tests {
 
         room_infos_store.put_key_val(
             &encode_key(None, keys::ROOM_INFOS, room_id),
-            &serialize_event(None, &room_info_json)?,
+            &serialize_value(None, &room_info_json)?,
         )?;
 
         // Test with or without `m.room.create` event in the room state.
@@ -1473,7 +1473,7 @@ mod tests {
 
         room_state_store.put_key_val(
             &encode_key(None, keys::ROOM_STATE, (room_id, &StateEventType::RoomCreate, "")),
-            &serialize_event(None, &create_event)?,
+            &serialize_value(None, &create_event)?,
         )?;
 
         Ok(())

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -1495,10 +1495,11 @@ impl_state_store!({
             .get_all()?
             .await?
             .into_iter()
-            .map(|item| {
-                self.deserialize_value(&item).map(|event: PersistedQueuedEvent| event.room_id)
-            })
-            .collect::<Result<HashSet<OwnedRoomId>, _>>()?;
+            .map(|item| self.deserialize_value::<Vec<PersistedQueuedEvent>>(&item))
+            .collect::<Result<Vec<Vec<PersistedQueuedEvent>>, _>>()?
+            .into_iter()
+            .flat_map(|vec| vec.into_iter().map(|item| item.room_id))
+            .collect::<BTreeSet<_>>();
 
         Ok(all_entries.into_iter().collect())
     }

--- a/crates/matrix-sdk-sqlite/migrations/state_store/004_send_queue_with_roomid_value.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/004_send_queue_with_roomid_value.sql
@@ -1,0 +1,22 @@
+-- Send queue events, keyed by room id and transaction id, but also include the room id in the
+-- value.
+DROP TABLE "send_queue_events";
+
+CREATE TABLE "send_queue_events" (
+    -- This is used as a key, thus hashed.
+    "room_id" BLOB NOT NULL,
+
+    -- This is used as a value (thus encrypted/decrypted).
+    "room_id_val" BLOB NOT NULL,
+
+    -- This is used as both a key and a value, thus neither encrypted/decrypted/hashed.
+    "transaction_id" BLOB NOT NULL,
+
+    -- Used as a value, thus encrypted/decrypted.
+    "content" BLOB NOT NULL,
+
+    -- In clear.
+    "wedged" BOOLEAN NOT NULL,
+
+    PRIMARY KEY ("room_id", "transaction_id")
+);

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1789,7 +1789,7 @@ impl StateStore for SqliteStateStore {
             .acquire()
             .await?
             .prepare("SELECT room_id_val FROM send_queue_events", |mut stmt| {
-                stmt.query(())?.mapped(|row| Ok(row.get(0)?)).collect()
+                stmt.query(())?.mapped(|row| row.get(0)).collect()
             })
             .await?;
 

--- a/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/echo.rs
@@ -139,7 +139,7 @@ async fn test_retry_failed() {
     mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
     let _response = client.sync_once(sync_settings.clone()).await.unwrap();
 
-    client.send_queue().set_enabled(true);
+    client.send_queue().set_enabled(true).await;
 
     let room = client.get_room(room_id).unwrap();
     let timeline = Arc::new(room.timeline().await.unwrap());

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -165,7 +165,7 @@ async fn test_retry_order() {
     assert_let!(Some(VectorDiff::Set { index: 0, value: first }) = timeline_stream.next().await);
     assert_matches!(first.send_state().unwrap(), EventSendState::SendingFailed { .. });
 
-    // Response for first message takes 100ms to respond
+    // Response for first message takes 100ms to respond.
     drop(scoped_faulty_send);
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
@@ -179,7 +179,7 @@ async fn test_retry_order() {
         .await;
 
     // Response for second message takes 200ms to respond, so should come back
-    // after first if we don't serialize retries
+    // after first if we don't serialize retries.
     Mock::given(method("PUT"))
         .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
         .and(body_string_contains("Second."))
@@ -191,10 +191,10 @@ async fn test_retry_order() {
         .mount(&server)
         .await;
 
-    // Retry the second message first
-    client.send_queue().set_enabled(true);
+    // Retry the second message first.
+    client.send_queue().set_enabled(true).await;
 
-    // Wait 200ms for the first msg, 100ms for the second, 300ms for overhead
+    // Wait 200ms for the first msg, 100ms for the second, 300ms for overhead.
     sleep(Duration::from_millis(600)).await;
 
     // With the send queue, sending is retried in the same order as the events

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -474,8 +474,10 @@ impl ClientBuilder {
             oidc: OidcCtx::new(allow_insecure_oidc),
         });
 
-        let event_cache = OnceCell::new();
+        // Enable the send queue by default.
         let send_queue = Arc::new(SendQueueData::new(true));
+
+        let event_cache = OnceCell::new();
         let inner = ClientInner::new(
             auth_ctx,
             homeserver,

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -13,6 +13,35 @@
 // limitations under the License.
 
 //! A send queue facility to serializing queuing and sending of messages.
+//!
+//! # [`Room`] send queue
+//!
+//! Each room gets its own [`RoomSendQueue`], that's available by calling
+//! [`Room::send_queue()`]. The first time this method is called, it will spawn
+//! a background task that's used to actually send events, in the order they
+//! were passed from calls to [`RoomSendQueue::send()`].
+//!
+//! This queue tries to simplify error management around sending events, using
+//! [`RoomSendQueue::send`] or [`RoomSendQueue::send_raw`]: by default, it will retry to send the
+//! same event a few times, before automatically disabling itself, and emitting
+//! a notification that can be listened to with the global send queue (see
+//! paragraph below) or using [`RoomSendQueue::subscribe()`].
+//!
+//! It is possible to control whether a single room is enabled using
+//! [`RoomSendQueue::set_enabled()`].
+//!
+//! # Global [`SendQueue`] object
+//!
+//! The [`Client::send_queue()`] method returns an API object allowing to
+//! control all the room send queues:
+//!
+//! - enable/disable them all at once with [`SendQueue::set_enabled()`].
+//! - get notifications about send errors with [`SendQueue::subscribe_errors`].
+//! - reload all unsent events that had been persisted in storage using
+//!   [`SendQueue::respawn_tasks_for_rooms_with_unsent_events()`]. It is
+//!   recommended to call this method during initialization of a client,
+//!   otherwise persisted unsent events will only be re-sent after the send
+//!   queue for the given room has been reopened for the first time.
 
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -56,6 +56,27 @@ impl SendQueue {
         Self { client }
     }
 
+    /// Reload all the rooms which had unsent events, and respawn tasks for
+    /// those rooms.
+    pub async fn respawn_tasks_for_rooms_with_unsent_events(&self) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        let room_ids =
+            self.client.store().load_rooms_with_unsent_events().await.unwrap_or_else(|err| {
+                warn!("error when loading rooms with unsent events: {err}");
+                Vec::new()
+            });
+
+        // Getting the [`RoomSendQueue`] is sufficient to spawn the task if needs be.
+        for room_id in room_ids {
+            if let Some(room) = self.client.get_room(&room_id) {
+                let _ = self.for_room(room);
+            }
+        }
+    }
+
     #[inline(always)]
     fn data(&self) -> &SendQueueData {
         &self.client.inner.send_queue_data
@@ -73,7 +94,7 @@ impl SendQueue {
 
         let owned_room_id = room_id.to_owned();
         let room_q = RoomSendQueue::new(
-            data.globally_enabled.load(Ordering::SeqCst),
+            self.is_enabled(),
             data.error_reporter.clone(),
             data.is_dropping.clone(),
             &self.client,
@@ -92,15 +113,19 @@ impl SendQueue {
     ///
     /// This may wake up background tasks and resume sending of events in the
     /// background.
-    pub fn set_enabled(&self, enabled: bool) {
+    pub async fn set_enabled(&self, enabled: bool) {
         debug!(?enabled, "setting global send queue enablement");
 
         self.data().globally_enabled.store(enabled, Ordering::SeqCst);
 
-        let rooms = self.data().rooms.read().unwrap();
-        for room in rooms.values() {
+        // Wake up individual rooms we already know about.
+        for room in self.data().rooms.read().unwrap().values() {
             room.set_enabled(enabled);
         }
+
+        // Reload some extra rooms that might not have been awaken yet, but could have
+        // events from previous sessions.
+        self.respawn_tasks_for_rooms_with_unsent_events().await;
     }
 
     /// Returns whether the send queue is enabled, at a client-wide
@@ -812,7 +837,7 @@ mod tests {
 
                 let _watcher = q.subscribe().await;
 
-                client.send_queue().set_enabled(enabled);
+                client.send_queue().set_enabled(enabled).await;
             }
 
             drop(client);

--- a/crates/matrix-sdk/src/test_utils.rs
+++ b/crates/matrix-sdk/src/test_utils.rs
@@ -52,12 +52,8 @@ pub async fn no_retry_test_client(homeserver_url: Option<String>) -> Client {
         .unwrap()
 }
 
-/// A [`Client`] using the given `homeserver_url` (or localhost:1234), that will
-/// never retry any failed requests, and already logged in with an hardcoded
-/// Matrix authentication session (the user id and device id are hardcoded too).
-pub async fn logged_in_client(homeserver_url: Option<String>) -> Client {
-    let client = no_retry_test_client(homeserver_url).await;
-
+/// Restore the common (Matrix-auth) user session for a client.
+pub async fn set_client_session(client: &Client) {
     client
         .matrix_auth()
         .restore_session(MatrixSession {
@@ -69,7 +65,14 @@ pub async fn logged_in_client(homeserver_url: Option<String>) -> Client {
         })
         .await
         .unwrap();
+}
 
+/// A [`Client`] using the given `homeserver_url` (or localhost:1234), that will
+/// never retry any failed requests, and already logged in with an hardcoded
+/// Matrix authentication session (the user id and device id are hardcoded too).
+pub async fn logged_in_client(homeserver_url: Option<String>) -> Client {
+    let client = no_retry_test_client(homeserver_url).await;
+    set_client_session(&client).await;
     client
 }
 

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1,18 +1,21 @@
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, Mutex as StdMutex,
     },
     time::Duration,
 };
 
 use assert_matches2::{assert_let, assert_matches};
 use matrix_sdk::{
+    config::{RequestConfig, StoreConfig},
     send_queue::{LocalEcho, RoomSendQueueError, RoomSendQueueUpdate},
-    test_utils::{logged_in_client, logged_in_client_with_server},
+    test_utils::{logged_in_client, logged_in_client_with_server, set_client_session},
+    Client, MemoryStore,
 };
 use matrix_sdk_test::{async_test, InvitedRoomBuilder, JoinedRoomBuilder, LeftRoomBuilder};
 use ruma::{
+    api::MatrixVersion,
     event_id,
     events::{
         room::message::RoomMessageEventContent, AnyMessageLikeEventContent, EventContent as _,
@@ -177,7 +180,7 @@ async fn test_nothing_sent_when_disabled() {
     let event_id = event_id!("$1");
     mock_send_event(event_id).expect(0).mount(&server).await;
 
-    client.send_queue().set_enabled(false);
+    client.send_queue().set_enabled(false).await;
 
     // A message is queued, but never sent.
     room.send_queue()
@@ -498,7 +501,7 @@ async fn test_error_then_globally_reenabling() {
     mock_send_event(event_id!("$42")).expect(1).mount(&server).await;
 
     // Re-enabling the global queue will cause the event to be sent.
-    client.send_queue().set_enabled(true);
+    client.send_queue().set_enabled(true).await;
 
     assert!(client.send_queue().is_enabled());
     assert!(room.send_queue().is_enabled());
@@ -531,7 +534,7 @@ async fn test_reenabling_queue() {
     assert!(errors.is_empty());
 
     // When I start with a disabled send queue,
-    client.send_queue().set_enabled(false);
+    client.send_queue().set_enabled(false).await;
 
     assert!(!client.send_queue().is_enabled());
     assert!(!room.send_queue().is_enabled());
@@ -586,7 +589,7 @@ async fn test_reenabling_queue() {
         .await;
 
     // But when reenabling the queue globally,
-    client.send_queue().set_enabled(true);
+    client.send_queue().set_enabled(true).await;
 
     assert!(client.send_queue().is_enabled());
     assert!(room.send_queue().is_enabled());
@@ -623,7 +626,7 @@ async fn test_disjoint_enabled_status() {
     let room2 = client.get_room(room_id2).unwrap();
 
     // When I start with a disabled send queue,
-    client.send_queue().set_enabled(false);
+    client.send_queue().set_enabled(false).await;
 
     // All queues are marked as disabled.
     assert!(!client.send_queue().is_enabled());
@@ -631,7 +634,7 @@ async fn test_disjoint_enabled_status() {
     assert!(!room2.send_queue().is_enabled());
 
     // When I enable globally,
-    client.send_queue().set_enabled(true);
+    client.send_queue().set_enabled(true).await;
 
     // This enables globally and locally.
     assert!(client.send_queue().is_enabled());
@@ -786,7 +789,7 @@ async fn test_abort_after_disable() {
     assert!(errors.is_empty());
 
     // Start with an enabled sending queue.
-    client.send_queue().set_enabled(true);
+    client.send_queue().set_enabled(true).await;
 
     assert!(client.send_queue().is_enabled());
 
@@ -853,7 +856,7 @@ async fn test_unrecoverable_errors() {
     assert!(errors.is_empty());
 
     // Start with an enabled sending queue.
-    client.send_queue().set_enabled(true);
+    client.send_queue().set_enabled(true).await;
 
     assert!(client.send_queue().is_enabled());
 
@@ -951,7 +954,7 @@ async fn test_no_network_access_error_is_recoverable() {
     assert!(errors.is_empty());
 
     // Start with an enabled sending queue.
-    client.send_queue().set_enabled(true);
+    client.send_queue().set_enabled(true).await;
     assert!(client.send_queue().is_enabled());
 
     let q = room.send_queue();
@@ -981,4 +984,108 @@ async fn test_no_network_access_error_is_recoverable() {
     // The room queue is disabled, because the error was recoverable.
     assert!(!room.send_queue().is_enabled());
     assert!(client.send_queue().is_enabled());
+}
+
+#[async_test]
+async fn test_reloading_rooms_with_unsent_events() {
+    let store = Arc::new(MemoryStore::new());
+
+    let room_id = room_id!("!a:b.c");
+    let room_id2 = room_id!("!d:e.f");
+
+    let server = wiremock::MockServer::start().await;
+    let client = Client::builder()
+        .homeserver_url(server.uri())
+        .server_versions([MatrixVersion::V1_0])
+        .store_config(StoreConfig::new().state_store(store.clone()))
+        .request_config(RequestConfig::new().disable_retry())
+        .build()
+        .await
+        .unwrap();
+    set_client_session(&client).await;
+
+    // Mark two rooms as joined.
+    let room = mock_sync_with_new_room(
+        |builder| {
+            builder
+                .add_joined_room(JoinedRoomBuilder::new(room_id))
+                .add_joined_room(JoinedRoomBuilder::new(room_id2));
+        },
+        &client,
+        &server,
+        room_id,
+    )
+    .await;
+
+    let room2 = client.get_room(room_id2).unwrap();
+
+    // Globally disable the send queue.
+    let q = client.send_queue();
+    q.set_enabled(false).await;
+    let watch = q.subscribe_errors();
+
+    // Send one message in each room.
+    room.send_queue()
+        .send(RoomMessageEventContent::text_plain("Hello, World!").into())
+        .await
+        .unwrap();
+
+    room2
+        .send_queue()
+        .send(RoomMessageEventContent::text_plain("Hello there too, World!").into())
+        .await
+        .unwrap();
+
+    // No errors, because the queue has been disabled.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(watch.is_empty());
+
+    server.reset().await;
+
+    {
+        // Kill the client, let it close background tasks.
+        drop(watch);
+        drop(q);
+        drop(client);
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    // Create a new client with the same memory backend. As the send queues are
+    // enabled by default, it will respawn tasks for sending events to those two
+    // rooms in the background.
+    mock_encryption_state(&server, false).await;
+
+    let event_id = StdMutex::new(0);
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(move |_req: &Request| {
+            let mut event_id_guard = event_id.lock().unwrap();
+            let event_id = *event_id_guard;
+            *event_id_guard += 1;
+            ResponseTemplate::new(200).set_body_json(json!({
+                "event_id": event_id
+            }))
+        })
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let client = Client::builder()
+        .homeserver_url(server.uri())
+        .server_versions([MatrixVersion::V1_0])
+        .store_config(StoreConfig::new().state_store(store))
+        .request_config(RequestConfig::new().disable_retry())
+        .build()
+        .await
+        .unwrap();
+    set_client_session(&client).await;
+
+    client.send_queue().respawn_tasks_for_rooms_with_unsent_events().await;
+
+    // Let the sending queues process events.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // The real assertion is on the expect(2) on the above Mock.
+    server.verify().await;
 }

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -438,7 +438,7 @@ impl App {
                             Char('Q') => {
                                 let q = self.client.send_queue();
                                 let enabled = q.is_enabled();
-                                q.set_enabled(!enabled);
+                                q.set_enabled(!enabled).await;
                             }
 
                             Char('M') => {


### PR DESCRIPTION
This changes the database scheme for the send queue: to be able to list all the rooms (room_id) which have unsent events, the `room_id`s need to be saved as *values* (i.e. encrypted/decrypted when the db is encrypted), and not just as *keys* (i.e. one-way hashed when the db is encrypted). To make this work, I've added another `room_id` field in the sqlite/indexeddb database, and introduced a sqlite migration (hoping no one used the indexeddb backend with the new feature since two days ago :sweat_smile:) that drops and recreates the table with the new format.

Then, we can implement a query to retrieve all the rooms which have unsent events. With that, we can add a new public function to the `SendQueue` object, which allows to automatically respawn the background room send queue tasks for each room that had unsent events, and that can be useful when restarting a Client.

This new function is then called, in the FFI layer, at the same time we set the listener for client-wide errors; this means that there's unsent events ending up in the error state would be immediately observable by a client.
 
Review can be done commit by commit.

Part of #3361.