### PR TITLE
ui: Make public all timeline module errors

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -60,12 +60,7 @@ use ruma::{
 use thiserror::Error;
 use tracing::{error, instrument, trace, warn};
 
-use self::{
-    error::{RedactEventError, SendEventError},
-    event_item::EventTimelineItemKind,
-    futures::SendAttachment,
-    util::rfind_event_item,
-};
+use self::{event_item::EventTimelineItemKind, futures::SendAttachment, util::rfind_event_item};
 
 mod builder;
 mod day_dividers;
@@ -90,7 +85,7 @@ mod virtual_item;
 
 pub use self::{
     builder::TimelineBuilder,
-    error::{Error, PaginationError, UnsupportedEditItem, UnsupportedReplyItem},
+    error::*,
     event_item::{
         AnyOtherFullStateEventContent, BundledReactions, EncryptedMessage, EventItemOrigin,
         EventSendState, EventTimelineItem, InReplyToDetails, MemberProfileChange, MembershipChange,


### PR DESCRIPTION
A few were missing in the public API like `SendEventError` and `RedactEventError` and their dependencies.

This uses a wildcard because it should be rare to not want to expose an error type.
