### PR TITLE
ui: Reexport eyeball-im

### DIFF
--- a/crates/matrix-sdk-ui/src/lib.rs
+++ b/crates/matrix-sdk-ui/src/lib.rs
@@ -16,6 +16,8 @@ use ruma::html::HtmlSanitizerMode;
 
 mod events;
 
+pub use eyeball_im;
+
 pub mod encryption_sync_service;
 pub mod notification_client;
 pub mod room_list_service;


### PR DESCRIPTION
A user of the library needs to add this crate as a dependency just to be able to match on `VectorDiff`.
