### PR TITLE
chore(base): Use constructors of `SyncTimelineEvent` to simplify code

### DIFF
--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -762,18 +762,16 @@ mod tests {
     #[test]
     fn test_count_unread_and_mentions() {
         fn make_event(user_id: &UserId, push_actions: Vec<Action>) -> SyncTimelineEvent {
-            SyncTimelineEvent {
-                event: sync_timeline_event!({
+            SyncTimelineEvent::new_with_push_actions(
+                sync_timeline_event!({
                     "sender": user_id,
                     "type": "m.room.message",
                     "event_id": "$ida",
                     "origin_server_ts": 12344446,
                     "content": { "body":"A", "msgtype": "m.text" },
                 }),
-                encryption_info: None,
                 push_actions,
-                unsigned_encryption_info: None,
-            }
+            )
         }
 
         let user_id = user_id!("@alice:example.org");
@@ -848,18 +846,13 @@ mod tests {
         // When provided with one event, that's not the receipt event, we don't count
         // it.
         fn make_event(event_id: &EventId) -> SyncTimelineEvent {
-            SyncTimelineEvent {
-                event: sync_timeline_event!({
-                    "sender": "@bob:example.org",
-                    "type": "m.room.message",
-                    "event_id": event_id,
-                    "origin_server_ts": 12344446,
-                    "content": { "body":"A", "msgtype": "m.text" },
-                }),
-                encryption_info: None,
-                push_actions: Vec::new(),
-                unsigned_encryption_info: None,
-            }
+            SyncTimelineEvent::new(sync_timeline_event!({
+                "sender": "@bob:example.org",
+                "type": "m.room.message",
+                "event_id": event_id,
+                "origin_server_ts": 12344446,
+                "content": { "body":"A", "msgtype": "m.text" },
+            }))
         }
 
         let mut receipts = RoomReadReceipts {

--- a/crates/matrix-sdk-common/src/deserialized_responses.rs
+++ b/crates/matrix-sdk-common/src/deserialized_responses.rs
@@ -251,6 +251,18 @@ impl SyncTimelineEvent {
         Self { event, encryption_info: None, push_actions: vec![], unsigned_encryption_info: None }
     }
 
+    /// Create a new `SyncTimelineEvent` from the given raw event and push
+    /// actions.
+    ///
+    /// This is a convenience constructor for when you don't need to set
+    /// `encryption_info`, for example inside a test.
+    pub fn new_with_push_actions(
+        event: Raw<AnySyncTimelineEvent>,
+        push_actions: Vec<Action>,
+    ) -> Self {
+        Self { event, encryption_info: None, push_actions, unsigned_encryption_info: None }
+    }
+
     /// Get the event id of this `SyncTimelineEvent` if the event has any valid
     /// id.
     pub fn event_id(&self) -> Option<OwnedEventId> {


### PR DESCRIPTION
Extracted from https://github.com/matrix-org/matrix-rust-sdk/pull/3585. Just a simple refactoring.