### PR TITLE
send queue: allow editing local echoes

### DIFF
--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,8 +1,9 @@
 use std::fmt::Display;
 
 use matrix_sdk::{
-    encryption::CryptoStoreError, event_cache::EventCacheError, oidc::OidcError, HttpError,
-    IdParseError, NotificationSettingsError as SdkNotificationSettingsError, StoreError,
+    encryption::CryptoStoreError, event_cache::EventCacheError, oidc::OidcError,
+    send_queue::RoomSendQueueError, HttpError, IdParseError,
+    NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
 use matrix_sdk_ui::{encryption_sync_service, notification_client, sync_service, timeline};
 use uniffi::UnexpectedUniFFICallbackError;
@@ -91,6 +92,12 @@ impl From<timeline::Error> for ClientError {
     }
 }
 
+impl From<timeline::UnsupportedEditItem> for ClientError {
+    fn from(e: timeline::UnsupportedEditItem) -> Self {
+        Self::new(e)
+    }
+}
+
 impl From<notification_client::Error> for ClientError {
     fn from(e: notification_client::Error) -> Self {
         Self::new(e)
@@ -117,6 +124,12 @@ impl From<RoomError> for ClientError {
 
 impl From<EventCacheError> for ClientError {
     fn from(e: EventCacheError) -> Self {
+        Self::new(e)
+    }
+}
+
+impl From<RoomSendQueueError> for ClientError {
+    fn from(e: RoomSendQueueError) -> Self {
         Self::new(e)
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -485,13 +485,9 @@ impl Timeline {
         item: Arc<EventTimelineItem>,
         new_content: Arc<RoomMessageEventContentWithoutRelation>,
     ) -> Result<bool, ClientError> {
-        let edit_info = item.0.edit_info().map_err(|err| anyhow::anyhow!(err))?;
+        let edit_info = item.0.edit_info().map_err(ClientError::from)?;
 
-        Ok(self
-            .inner
-            .edit((*new_content).clone(), edit_info)
-            .await
-            .map_err(|err| anyhow::anyhow!(err))?)
+        self.inner.edit((*new_content).clone(), edit_info).await.map_err(ClientError::from)
     }
 
     /// Edit an event given its event id. Useful when we're not sure a remote
@@ -502,17 +498,10 @@ impl Timeline {
         new_content: Arc<RoomMessageEventContentWithoutRelation>,
     ) -> Result<(), ClientError> {
         let event_id = EventId::parse(event_id)?;
-        let edit_info = self
-            .inner
-            .edit_info_from_event_id(&event_id)
-            .await
-            .map_err(|err| anyhow::anyhow!(err))?;
+        let edit_info =
+            self.inner.edit_info_from_event_id(&event_id).await.map_err(ClientError::from)?;
 
-        self.inner
-            .edit((*new_content).clone(), edit_info)
-            .await
-            .map_err(|err| anyhow::anyhow!(err))?;
-
+        self.inner.edit((*new_content).clone(), edit_info).await.map_err(ClientError::from)?;
         Ok(())
     }
 

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -232,9 +232,9 @@ impl Timeline {
     pub async fn send(
         self: Arc<Self>,
         msg: Arc<RoomMessageEventContentWithoutRelation>,
-    ) -> Result<Arc<AbortSendHandle>, ClientError> {
+    ) -> Result<Arc<SendHandle>, ClientError> {
         match self.inner.send((*msg).to_owned().with_relation(None).into()).await {
-            Ok(handle) => Ok(Arc::new(AbortSendHandle { inner: Mutex::new(Some(handle)) })),
+            Ok(handle) => Ok(Arc::new(SendHandle { inner: Mutex::new(Some(handle)) })),
             Err(err) => {
                 error!("error when sending a message: {err}");
                 Err(anyhow::anyhow!(err).into())
@@ -647,12 +647,12 @@ impl Timeline {
 }
 
 #[derive(uniffi::Object)]
-pub struct AbortSendHandle {
-    inner: Mutex<Option<matrix_sdk::send_queue::AbortSendHandle>>,
+pub struct SendHandle {
+    inner: Mutex<Option<matrix_sdk::send_queue::SendHandle>>,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
-impl AbortSendHandle {
+impl SendHandle {
     /// Try to abort the sending of the current event.
     ///
     /// If this returns `true`, then the sending could be aborted, because the

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -1312,7 +1312,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         // Saving one thing should work.
         let txn0 = TransactionId::new();
         let event0 =
-            SerializableEventContent::new(RoomMessageEventContent::text_plain("msg0").into())
+            SerializableEventContent::new(&RoomMessageEventContent::text_plain("msg0").into())
                 .unwrap();
         self.save_send_queue_event(room_id, txn0.clone(), event0).await.unwrap();
 
@@ -1334,7 +1334,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         for i in 1..=3 {
             let txn = TransactionId::new();
             let event = SerializableEventContent::new(
-                RoomMessageEventContent::text_plain(format!("msg{i}")).into(),
+                &RoomMessageEventContent::text_plain(format!("msg{i}")).into(),
             )
             .unwrap();
 
@@ -1394,7 +1394,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         {
             let txn = TransactionId::new();
             let event =
-                SerializableEventContent::new(RoomMessageEventContent::text_plain("room2").into())
+                SerializableEventContent::new(&RoomMessageEventContent::text_plain("room2").into())
                     .unwrap();
             self.save_send_queue_event(room_id2, txn.clone(), event).await.unwrap();
         }
@@ -1404,7 +1404,7 @@ impl StateStoreIntegrationTests for DynStateStore {
             let room_id3 = room_id!("!test_send_queue_three:localhost");
             let txn = TransactionId::new();
             let event =
-                SerializableEventContent::new(RoomMessageEventContent::text_plain("room3").into())
+                SerializableEventContent::new(&RoomMessageEventContent::text_plain("room3").into())
                     .unwrap();
             self.save_send_queue_event(room_id3, txn.clone(), event).await.unwrap();
 

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -885,6 +885,27 @@ impl StateStore for MemoryStore {
         Ok(())
     }
 
+    async fn update_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: SerializableEventContent,
+    ) -> Result<(), Self::Error> {
+        if let Some(entry) = self
+            .send_queue_events
+            .write()
+            .unwrap()
+            .entry(room_id.to_owned())
+            .or_default()
+            .iter_mut()
+            .find(|item| item.transaction_id == transaction_id)
+        {
+            entry.event = content;
+            entry.is_wedged = false;
+        }
+        Ok(())
+    }
+
     async fn remove_send_queue_event(
         &self,
         room_id: &RoomId,

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -409,6 +409,22 @@ pub trait StateStore: AsyncTraitDeps {
         content: SerializableEventContent,
     ) -> Result<(), Self::Error>;
 
+    /// Updates a send queue event with the given content, and resets its wedged
+    /// status to false.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The `RoomId` of the send queue's room.
+    /// * `transaction_id` - The unique key identifying the event to be sent
+    ///   (and its transaction).
+    /// * `content` - Serializable event content to replace the original one.
+    async fn update_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: SerializableEventContent,
+    ) -> Result<(), Self::Error>;
+
     /// Remove an event previously inserted with [`Self::save_send_queue_event`]
     /// from the database, based on its transaction id.
     async fn remove_send_queue_event(
@@ -664,6 +680,15 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         content: SerializableEventContent,
     ) -> Result<(), Self::Error> {
         self.0.save_send_queue_event(room_id, transaction_id, content).await.map_err(Into::into)
+    }
+
+    async fn update_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: SerializableEventContent,
+    ) -> Result<(), Self::Error> {
+        self.0.update_send_queue_event(room_id, transaction_id, content).await.map_err(Into::into)
     }
 
     async fn remove_send_queue_event(

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -1042,8 +1042,8 @@ impl SerializableEventContent {
 
     /// Create a [`SerializableEventContent`] from an
     /// [`AnyMessageLikeEventContent`].
-    pub fn new(event: AnyMessageLikeEventContent) -> Result<Self, serde_json::Error> {
-        Ok(Self::from_raw(Raw::new(&event)?, event.event_type().to_string()))
+    pub fn new(event: &AnyMessageLikeEventContent) -> Result<Self, serde_json::Error> {
+        Ok(Self::from_raw(Raw::new(event)?, event.event_type().to_string()))
     }
 
     /// Convert a [`SerializableEventContent`] back into a

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -296,6 +296,14 @@ impl TimelineBuilder {
                                     }
                                 }
 
+                                RoomSendQueueUpdate::ReplacedLocalEvent {
+                                    transaction_id,
+                                    new_content,
+                                } => {
+                                    // TODO: handled in a patch later in that
+                                    // queue.
+                                }
+
                                 RoomSendQueueUpdate::SendError {
                                     transaction_id,
                                     error,

--- a/crates/matrix-sdk-ui/src/timeline/builder.rs
+++ b/crates/matrix-sdk-ui/src/timeline/builder.rs
@@ -426,7 +426,7 @@ async fn handle_local_echo(echo: LocalEcho, timeline: &TimelineInner) {
         .handle_local_event(
             echo.transaction_id.clone(),
             TimelineEventKind::Message { content, relations: Default::default() },
-            Some(echo.abort_handle),
+            Some(echo.send_handle),
         )
         .await;
 

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -99,8 +99,6 @@ pub enum UnsupportedReplyItem {
 
 #[derive(Debug, Error)]
 pub enum UnsupportedEditItem {
-    #[error("local messages whose event ID is not known can't be edited currently")]
-    MissingEventId,
     #[error("tried to edit a non-message event")]
     NotRoomMessage,
     #[error("tried to edit a non-poll event")]

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -18,8 +18,7 @@ use as_variant::as_variant;
 use eyeball_im::{ObservableVectorTransaction, ObservableVectorTransactionEntry};
 use indexmap::{map::Entry, IndexMap};
 use matrix_sdk::{
-    crypto::types::events::UtdCause, deserialized_responses::EncryptionInfo,
-    send_queue::AbortSendHandle,
+    crypto::types::events::UtdCause, deserialized_responses::EncryptionInfo, send_queue::SendHandle,
 };
 use ruma::{
     events::{
@@ -72,8 +71,8 @@ pub(super) enum Flow {
         /// The transaction id we've used in requests associated to this event.
         txn_id: OwnedTransactionId,
 
-        /// A handle to abort sending this event.
-        abort_handle: Option<AbortSendHandle>,
+        /// A handle to manipulate this event.
+        send_handle: Option<SendHandle>,
     },
 
     /// The event has been received from a remote source (sync, pagination,
@@ -875,10 +874,10 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
         let mut reactions = self.pending_reactions().unwrap_or_default();
 
         let kind: EventTimelineItemKind = match &self.ctx.flow {
-            Flow::Local { txn_id, abort_handle } => LocalEventTimelineItem {
+            Flow::Local { txn_id, send_handle } => LocalEventTimelineItem {
                 send_state: EventSendState::NotSentYet,
                 transaction_id: txn_id.to_owned(),
-                abort_handle: abort_handle.clone(),
+                send_handle: send_handle.clone(),
             }
             .into(),
 

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -346,17 +346,20 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                 AnyMessageLikeEventContent::Reaction(c) => {
                     self.handle_reaction(c);
                 }
+
                 AnyMessageLikeEventContent::RoomMessage(RoomMessageEventContent {
                     relates_to: Some(message::Relation::Replacement(re)),
                     ..
                 }) => {
                     self.handle_room_message_edit(re);
                 }
+
                 AnyMessageLikeEventContent::RoomMessage(c) => {
                     if should_add {
                         self.add_item(TimelineItemContent::message(c, relations, self.items));
                     }
                 }
+
                 AnyMessageLikeEventContent::RoomEncrypted(c) => {
                     // TODO: Handle replacements if the replaced event is also UTD
                     let cause = UtdCause::determine(raw_event);
@@ -370,24 +373,31 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                         }
                     }
                 }
+
                 AnyMessageLikeEventContent::Sticker(content) => {
                     if should_add {
                         self.add_item(TimelineItemContent::Sticker(Sticker { content }));
                     }
                 }
+
                 AnyMessageLikeEventContent::UnstablePollStart(
                     UnstablePollStartEventContent::Replacement(c),
                 ) => self.handle_poll_start_edit(c.relates_to),
+
                 AnyMessageLikeEventContent::UnstablePollStart(
                     UnstablePollStartEventContent::New(c),
                 ) => self.handle_poll_start(c, should_add),
+
                 AnyMessageLikeEventContent::UnstablePollResponse(c) => self.handle_poll_response(c),
+
                 AnyMessageLikeEventContent::UnstablePollEnd(c) => self.handle_poll_end(c),
+
                 AnyMessageLikeEventContent::CallInvite(_) => {
                     if should_add {
                         self.add_item(TimelineItemContent::CallInvite);
                     }
                 }
+
                 AnyMessageLikeEventContent::CallNotify(_) => {
                     if should_add {
                         self.add_item(TimelineItemContent::CallNotify)
@@ -487,7 +497,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
             let TimelineItemContent::Message(msg) = event_item.content() else {
                 info!(
-                    "Edit of message event applies to {}, discarding",
+                    "Edit of message event applies to {:?}, discarding",
                     event_item.content().debug_string(),
                 );
                 return None;

--- a/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use as_variant::as_variant;
-use matrix_sdk::{send_queue::AbortSendHandle, Error};
+use matrix_sdk::{send_queue::SendHandle, Error};
 use ruma::{EventId, OwnedEventId, OwnedTransactionId};
 
 /// An item for an event that was created locally and not yet echoed back by
@@ -26,8 +26,8 @@ pub(in crate::timeline) struct LocalEventTimelineItem {
     pub send_state: EventSendState,
     /// The transaction ID.
     pub transaction_id: OwnedTransactionId,
-    /// A handle to abort sending this event, if possible.
-    pub abort_handle: Option<AbortSendHandle>,
+    /// A handle to manipulate this event before it is sent, if possible.
+    pub send_handle: Option<SendHandle>,
 }
 
 impl LocalEventTimelineItem {

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -805,6 +805,53 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         }
     }
 
+    pub(super) async fn replace_local_echo(
+        &self,
+        txn_id: &TransactionId,
+        content: AnyMessageLikeEventContent,
+    ) -> bool {
+        let AnyMessageLikeEventContent::RoomMessage(content) = content else {
+            // Ideally, we'd support replacing local echoes for a reaction, etc., but
+            // handling RoomMessage should be sufficient in most cases. Worst
+            // case, the local echo will be sent Soon™ and we'll get another chance at
+            // editing the event then.
+            warn!("Replacing a local echo for a non-RoomMessage-like event NYI");
+            return false;
+        };
+
+        let mut state = self.state.write().await;
+
+        let Some((idx, prev_item)) =
+            rfind_event_item(&state.items, |it| it.transaction_id() == Some(txn_id))
+        else {
+            debug!("Can't find local echo to replace");
+            return false;
+        };
+
+        // Reuse the previous local echo's state, but reset the send state to not sent
+        // (per API contract).
+        let ti_kind = {
+            let Some(prev_local_item) = prev_item.as_local() else {
+                warn!("We looked for a local item, but it transitioned as remote??");
+                return false;
+            };
+            prev_local_item.with_send_state(EventSendState::NotSentYet)
+        };
+
+        // Replace the local-related state (kind) and the content state.
+        let new_item = TimelineItem::new(
+            prev_item.with_kind(ti_kind).with_content(
+                TimelineItemContent::message(content, Default::default(), &state.items),
+                None,
+            ),
+            prev_item.internal_id.to_owned(),
+        );
+
+        state.items.set(idx, new_item);
+        debug!("Replaced local echo");
+        true
+    }
+
     #[cfg(test)]
     pub(super) async fn set_fully_read_event(&self, fully_read_event_id: OwnedEventId) {
         self.state.write().await.set_fully_read_event(fully_read_event_id);

--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -27,7 +27,7 @@ use matrix_sdk::crypto::OlmMachine;
 use matrix_sdk::{
     deserialized_responses::SyncTimelineEvent,
     event_cache::{paginator::Paginator, RoomEventCache},
-    send_queue::AbortSendHandle,
+    send_queue::SendHandle,
     Result, Room,
 };
 #[cfg(test)]
@@ -646,13 +646,13 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         &self,
         txn_id: OwnedTransactionId,
         content: TimelineEventKind,
-        abort_handle: Option<AbortSendHandle>,
+        send_handle: Option<SendHandle>,
     ) {
         let sender = self.room_data_provider.own_user_id().to_owned();
         let profile = self.room_data_provider.profile_from_user_id(&sender).await;
 
         let mut state = self.state.write().await;
-        state.handle_local_event(sender, profile, txn_id, abort_handle, content).await;
+        state.handle_local_event(sender, profile, txn_id, send_handle, content).await;
     }
 
     /// Update the send state of a local event represented by a transaction ID.

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -16,7 +16,7 @@ use std::{collections::VecDeque, future::Future, sync::Arc};
 
 use eyeball_im::{ObservableVector, ObservableVectorTransaction, ObservableVectorTransactionEntry};
 use indexmap::IndexMap;
-use matrix_sdk::{deserialized_responses::SyncTimelineEvent, send_queue::AbortSendHandle};
+use matrix_sdk::{deserialized_responses::SyncTimelineEvent, send_queue::SendHandle};
 use matrix_sdk_base::deserialized_responses::TimelineEvent;
 #[cfg(test)]
 use ruma::events::receipt::ReceiptEventContent;
@@ -163,7 +163,7 @@ impl TimelineInnerState {
         own_user_id: OwnedUserId,
         own_profile: Option<Profile>,
         txn_id: OwnedTransactionId,
-        abort_handle: Option<AbortSendHandle>,
+        send_handle: Option<SendHandle>,
         content: TimelineEventKind,
     ) {
         let ctx = TimelineEventContext {
@@ -176,7 +176,7 @@ impl TimelineInnerState {
             read_receipts: Default::default(),
             // An event sent by ourself is never matched against push rules.
             is_highlighted: false,
-            flow: Flow::Local { txn_id, abort_handle },
+            flow: Flow::Local { txn_id, send_handle },
         };
 
         let mut txn = self.transaction();

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -27,7 +27,7 @@ use matrix_sdk::{
     event_handler::EventHandlerHandle,
     executor::JoinHandle,
     room::{Receipts, Room},
-    send_queue::{AbortSendHandle, RoomSendQueueError},
+    send_queue::{RoomSendQueueError, SendHandle},
     Client, Result,
 };
 use matrix_sdk_base::RoomState;
@@ -326,7 +326,7 @@ impl Timeline {
     pub async fn send(
         &self,
         content: AnyMessageLikeEventContent,
-    ) -> Result<AbortSendHandle, RoomSendQueueError> {
+    ) -> Result<SendHandle, RoomSendQueueError> {
         self.room().send_queue().send(content).await
     }
 
@@ -701,7 +701,7 @@ impl Timeline {
     ) -> Result<bool, RedactEventError> {
         match &event.kind {
             EventTimelineItemKind::Local(local) => {
-                if let Some(handle) = local.abort_handle.clone() {
+                if let Some(handle) = local.send_handle.clone() {
                     Ok(handle.abort().await.map_err(RedactEventError::RoomQueueError)?)
                 } else {
                     // No abort handle; theoretically unreachable for regular usage of the

--- a/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/edit.rs
@@ -17,12 +17,12 @@ use std::time::Duration;
 use assert_matches::assert_matches;
 use assert_matches2::assert_let;
 use eyeball_im::VectorDiff;
-use futures_util::StreamExt;
+use futures_util::{FutureExt, StreamExt};
 use matrix_sdk::{config::SyncSettings, test_utils::logged_in_client_with_server};
 use matrix_sdk_test::{
     async_test, EventBuilder, JoinedRoomBuilder, SyncResponseBuilder, ALICE, BOB,
 };
-use matrix_sdk_ui::timeline::{RoomExt, TimelineDetails, TimelineItemContent};
+use matrix_sdk_ui::timeline::{EventSendState, RoomExt, TimelineDetails, TimelineItemContent};
 use ruma::{
     assign, event_id,
     events::{
@@ -151,6 +151,118 @@ async fn test_edit() {
     assert_eq!(text.body, "hi");
     assert_matches!(edited.in_reply_to(), None);
     assert!(edited.is_edited());
+}
+
+#[async_test]
+async fn test_edit_local_echo() {
+    let room_id = room_id!("!a98sd12bjh:example.org");
+    let (client, server) = logged_in_client_with_server().await;
+    let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+    let mut sync_builder = SyncResponseBuilder::new();
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    let room = client.get_room(room_id).unwrap();
+    let timeline = room.timeline().await.unwrap();
+    let (_, mut timeline_stream) = timeline.subscribe().await;
+
+    sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+    mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+    let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+    server.reset().await;
+
+    mock_encryption_state(&server, false).await;
+    let mounted_send = Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(413).set_body_json(json!({
+            "errcode": "M_TOO_LARGE",
+        })))
+        .expect(1)
+        .mount_as_scoped(&server)
+        .await;
+
+    // Redacting a local event works.
+    timeline.send(RoomMessageEventContent::text_plain("hello, just you").into()).await.unwrap();
+
+    assert_let!(Some(VectorDiff::PushBack { value: item }) = timeline_stream.next().await);
+
+    let internal_id = item.unique_id();
+
+    let item = item.as_event().unwrap();
+    assert_matches!(item.send_state(), Some(EventSendState::NotSentYet));
+
+    assert_let!(Some(VectorDiff::PushFront { value: day_divider }) = timeline_stream.next().await);
+    assert!(day_divider.is_day_divider());
+
+    // We haven't set a route for sending events, so this will fail.
+
+    assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = timeline_stream.next().await);
+
+    let item = item.as_event().unwrap();
+    assert!(item.is_local_echo());
+    assert!(item.is_editable());
+
+    assert_matches!(
+        item.send_state(),
+        Some(EventSendState::SendingFailed { is_recoverable: false, .. })
+    );
+
+    assert!(timeline_stream.next().now_or_never().is_none());
+
+    // Let's edit the local echo.
+    let edit_info = item.edit_info().expect("getting the edit info for the local echo");
+
+    let did_edit = timeline
+        .edit(RoomMessageEventContent::text_plain("hello, world").into(), edit_info)
+        .await
+        .unwrap();
+
+    // We could edit the local echo, since it was in the failed state.
+    assert!(did_edit);
+
+    // Observe local echo being replaced.
+    assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = timeline_stream.next().await);
+
+    assert_eq!(item.unique_id(), internal_id);
+
+    let item = item.as_event().unwrap();
+    assert!(item.is_local_echo());
+
+    // The send state has been reset.
+    assert_matches!(item.send_state(), Some(EventSendState::NotSentYet));
+
+    let edit_message = item.content().as_message().unwrap();
+    assert_eq!(edit_message.body(), "hello, world");
+
+    // Now, reenable the send queue for that room, and observe the new event being
+    // sent.
+    drop(mounted_send);
+    Mock::given(method("PUT"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/send/.*"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "event_id": "$1" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    room.send_queue().set_enabled(true);
+
+    // Observe the event being sent, and replacing the local echo.
+    assert_let!(Some(VectorDiff::Set { index: 1, value: item }) = timeline_stream.next().await);
+
+    let item = item.as_event().unwrap();
+    assert!(item.is_local_echo());
+
+    let edit_message = item.content().as_message().unwrap();
+    assert_eq!(edit_message.body(), "hello, world");
+
+    // No new updates.
+    assert!(timeline_stream.next().now_or_never().is_none());
 }
 
 #[async_test]

--- a/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/queue.rs
@@ -87,11 +87,11 @@ async fn test_message_order() {
 
     // Local echoes are available after the send queue has processed these.
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
-        assert!(!value.is_editable(), "local echo for first can't be edited");
+        assert!(value.is_editable(), "local echo of first can be edited");
         assert_eq!(value.content().as_message().unwrap().body(), "First!");
     });
     assert_next_matches!(timeline_stream, VectorDiff::PushBack { value } => {
-        assert!(!value.is_editable(), "local echo for second can't be edited");
+        assert!(value.is_editable(), "local echo of second can be edited");
         assert_eq!(value.content().as_message().unwrap().body(), "Second.");
     });
 


### PR DESCRIPTION
Final step of #3361, as a bonus.

Fixes #3361.