### PR TITLE
Element specific well-known support

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -421,7 +421,8 @@ impl Client {
         })))
     }
 
-    /// Allows generic GET requests to be made through the SDKs internal HTTP client
+    /// Allows generic GET requests to be made through the SDKs internal HTTP
+    /// client
     pub async fn get_url(&self, url: String) -> Result<String, ClientError> {
         let http_client = self.inner.http_client();
         Ok(http_client.get(url).send().await?.text().await?)

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -421,6 +421,7 @@ impl Client {
         })))
     }
 
+    /// Allows generic GET requests to be made through the SDKs internal HTTP client
     pub async fn get_url(&self, url: String) -> Result<String, ClientError> {
         let http_client = self.inner.http_client();
         Ok(http_client.get(url).send().await?.text().await?)
@@ -502,6 +503,12 @@ impl Client {
     pub fn user_id(&self) -> Result<String, ClientError> {
         let user_id = self.inner.user_id().context("No User ID found")?;
         Ok(user_id.to_string())
+    }
+
+    /// The server name part of the current user ID
+    pub fn user_id_server_name(&self) -> Result<String, ClientError> {
+        let user_id = self.inner.user_id().context("No User ID found")?;
+        Ok(user_id.server_name().to_string())
     }
 
     pub async fn display_name(&self) -> Result<String, ClientError> {

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -420,6 +420,11 @@ impl Client {
             }
         })))
     }
+
+    pub async fn get_url(&self, url: String) -> Result<String, ClientError> {
+        let http_client = self.inner.http_client();
+        Ok(http_client.get(url).send().await?.text().await?)
+    }
 }
 
 impl Client {

--- a/bindings/matrix-sdk-ffi/src/element.rs
+++ b/bindings/matrix-sdk-ffi/src/element.rs
@@ -1,0 +1,21 @@
+use serde::Deserialize;
+
+use crate::ClientError;
+
+/// Well-known settings specific to ElementCall
+#[derive(Deserialize, uniffi::Record)]
+pub struct ElementCallWellKnown {
+    widget_url: String,
+}
+
+/// Element specific well-known settings
+#[derive(Deserialize, uniffi::Record)]
+pub struct ElementWellKnown {
+    call: ElementCallWellKnown,
+}
+
+/// Helper function to parse a string into a ElementWellKnown struct
+#[uniffi::export]
+pub fn make_element_well_known(string: String) -> Result<ElementWellKnown, ClientError> {
+    serde_json::from_str(&string).map_err(ClientError::new)
+}

--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use matrix_sdk::{
-    encryption::CryptoStoreError, event_cache::EventCacheError, oidc::OidcError,
+    encryption::CryptoStoreError, event_cache::EventCacheError, oidc::OidcError, reqwest,
     send_queue::RoomSendQueueError, HttpError, IdParseError,
     NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
@@ -23,6 +23,12 @@ impl ClientError {
 impl From<anyhow::Error> for ClientError {
     fn from(e: anyhow::Error) -> ClientError {
         ClientError::Generic { msg: format!("{e:#}") }
+    }
+}
+
+impl From<reqwest::Error> for ClientError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::new(e)
     }
 }
 

--- a/bindings/matrix-sdk-ffi/src/lib.rs
+++ b/bindings/matrix-sdk-ffi/src/lib.rs
@@ -24,6 +24,7 @@ mod authentication;
 mod chunk_iterator;
 mod client;
 mod client_builder;
+mod element;
 mod encryption;
 mod error;
 mod event;

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -394,6 +394,11 @@ impl Client {
         &self.inner.base_client
     }
 
+    /// The underlying HTTP client.
+    pub fn http_client(&self) -> &reqwest::Client {
+        &self.inner.http_client.inner
+    }
+
     pub(crate) fn locks(&self) -> &ClientLocks {
         &self.inner.locks
     }


### PR DESCRIPTION
Handles part of element-hq/element-meta/issues/2441

* exposes a generic method to make GET requests throgh the SDKs internal HTTP client. This avoids various configuration differences between the SDK stack and that of the client
* exposes a way to read the server name part of the current user's identifier (already built into ruma, make sense to use it across clients)
* adds an Element specific well-known struct that the FFI clients can use to deserialize a response JSON

Powers https://github.com/element-hq/element-x-ios/pull/2971