### PR TITLE
fix(crypto): Rename the device keys property for Olm messages

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -350,6 +350,9 @@ mod tests {
 
         // Also ensure that the encrypted payload has the device keys.
         let plaintext: Value = serde_json::from_str(&bob_session_result.plaintext).unwrap();
-        assert_eq!(plaintext["device_keys"]["user_id"].as_str(), Some("@alice:localhost"));
+        assert_eq!(
+            plaintext["org.matrix.msc4147.device_keys"]["user_id"].as_str(),
+            Some("@alice:localhost")
+        );
     }
 }

--- a/crates/matrix-sdk-crypto/src/olm/session.rs
+++ b/crates/matrix-sdk-crypto/src/olm/session.rs
@@ -156,7 +156,7 @@ impl Session {
                 "keys": {
                     "ed25519": self.our_device_keys.ed25519_key().expect("Device doesn't have ed25519 key").to_base64(),
                 },
-                "device_keys": self.our_device_keys,
+                "org.matrix.msc4147.device_keys": self.our_device_keys,
                 "recipient": recipient_device.user_id(),
                 "recipient_keys": {
                     "ed25519": recipient_signing_key.to_base64(),


### PR DESCRIPTION
Commit d41af396c implemented MSC4147, which puts the device keys into a Olm message. It failed to adhere to the unstable prefix proposed in the MSC:

> Until this MSC is accepted, the new property should be named
> org.matrix.msc4147.device_keys.

This patch fixes this.