### PR TITLE
send queue: mark `ConcurrentRequestFailed` as recoverable

### DIFF
--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -320,8 +320,9 @@ pub enum Error {
     #[error("a concurrent request failed; see logs for details")]
     ConcurrentRequestFailed,
 
-    /// An other error was raised
-    /// this might happen because encryption was enabled on the base-crate
+    /// An other error was raised.
+    ///
+    /// This might happen because encryption was enabled on the base-crate
     /// but not here and that raised.
     #[error("unknown error: {0}")]
     UnknownError(Box<dyn std::error::Error + Send + Sync>),

--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -471,11 +471,20 @@ impl RoomSendQueue {
                 }
 
                 Err(err) => {
-                    let is_recoverable = if let crate::Error::Http(ref http_err) = err {
-                        // All transient errors are recoverable.
-                        matches!(http_err.retry_kind(), RetryKind::Transient { .. })
-                    } else {
-                        false
+                    let is_recoverable = match err {
+                        crate::Error::Http(ref http_err) => {
+                            // All transient errors are recoverable.
+                            matches!(http_err.retry_kind(), RetryKind::Transient { .. })
+                        }
+
+                        // `ConcurrentRequestFailed` typically happens because of an HTTP failure;
+                        // since we don't get the underlying error, be lax and consider it
+                        // recoverable, and let observers decide to retry it or not. At some point
+                        // we'll get the actual underlying error.
+                        crate::Error::ConcurrentRequestFailed => true,
+
+                        // As of 2024-06-27, all other error types are considered unrecoverable.
+                        _ => false,
                     };
 
                     if is_recoverable {


### PR DESCRIPTION
This will still disable the room's send queue, but the embedder may then decide whether to re-enable the queue or not, based on network connectivity. Ideally, we'd implement some retry mechanism here too, but since we're at a different layer than the HTTP one, we can't get that "for free", so let the embedder decide what to do here.

---

No test because the only way to trigger this is likely by having an encrypted room, start a /member query for that room, then try to send an encrypted message into that room. Sending encrypted messages require lots of endpoints, and I'm not sure whether we have all the testing setup for that; I'll ask on the Matrix room. But since this is a tiny change in behavior (and we're likely to have other tweaks like that related to error handling, I don't think each new error type marked as recoverable would need to require its own test).

---

Part of #3361.