### PR TITLE
ci: Add a github workflow to fail when fixup commits exist

### DIFF
--- a/.github/workflows/fixup-block.yml
+++ b/.github/workflows/fixup-block.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
We tend to use fixup commits quite a bit, and in the heat of the moment we sometimes forget to squash them before the final merge.

This should prevent us from doing so.