### PR TITLE
sdk: Allow to limit the number of concurrent network requests

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -20,6 +20,7 @@ Breaking changes:
 
 Additions:
 
+- new `RequestConfig.max_concurrent_requests` which allows to limit the maximum number of concurrent requests the internal HTTP client issues (all others have to wait until the number drops below that threshold again)
 - Expose new method `Client::Oidc::login_with_qr_code()`.
   ([#3466](https://github.com/matrix-org/matrix-rust-sdk/pull/3466))
 - Add the `ClientBuilder::add_root_certificates()` method which re-exposes the

--- a/crates/matrix-sdk/src/config/request.rs
+++ b/crates/matrix-sdk/src/config/request.rs
@@ -44,18 +44,21 @@ pub struct RequestConfig {
     pub(crate) timeout: Duration,
     pub(crate) retry_limit: Option<u64>,
     pub(crate) retry_timeout: Option<Duration>,
+    pub(crate) max_concurrent_requests: usize,
     pub(crate) force_auth: bool,
 }
 
 #[cfg(not(tarpaulin_include))]
 impl Debug for RequestConfig {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { timeout, retry_limit, retry_timeout, force_auth } = self;
+        let Self { timeout, retry_limit, retry_timeout, force_auth, max_concurrent_requests } =
+            self;
 
         let mut res = fmt.debug_struct("RequestConfig");
         res.field("timeout", timeout)
             .maybe_field("retry_limit", retry_limit)
-            .maybe_field("retry_timeout", retry_timeout);
+            .maybe_field("retry_timeout", retry_timeout)
+            .field("max_concurrent_requests", max_concurrent_requests);
 
         if *force_auth {
             res.field("force_auth", &true);
@@ -71,6 +74,7 @@ impl Default for RequestConfig {
             timeout: DEFAULT_REQUEST_TIMEOUT,
             retry_limit: Default::default(),
             retry_timeout: Default::default(),
+            max_concurrent_requests: 0,
             force_auth: false,
         }
     }
@@ -106,6 +110,22 @@ impl RequestConfig {
         self
     }
 
+    /// The total limit of request that are pending or run concurrently.
+    /// Any additional request beyond that number will be waiting until another
+    /// concurrent requests finished. Requests are queued fairly.
+    #[must_use]
+    pub fn max_concurrent_requests(mut self, limit: usize) -> Self {
+        self.max_concurrent_requests = limit;
+        self
+    }
+
+    /// Disable the limit of concurrent requests. Setting the limit to 0
+    /// has the same effect.
+    #[must_use]
+    pub fn disable_max_concurrent_requests(mut self) -> Self {
+        self.max_concurrent_requests = 0;
+        self
+    }
     /// Set the timeout duration for all HTTP requests.
     #[must_use]
     pub fn timeout(mut self, timeout: Duration) -> Self {

--- a/crates/matrix-sdk/src/config/request.rs
+++ b/crates/matrix-sdk/src/config/request.rs
@@ -14,6 +14,7 @@
 
 use std::{
     fmt::{self, Debug},
+    num::NonZeroUsize,
     time::Duration,
 };
 
@@ -44,7 +45,7 @@ pub struct RequestConfig {
     pub(crate) timeout: Duration,
     pub(crate) retry_limit: Option<u64>,
     pub(crate) retry_timeout: Option<Duration>,
-    pub(crate) max_concurrent_requests: usize,
+    pub(crate) max_concurrent_requests: Option<NonZeroUsize>,
     pub(crate) force_auth: bool,
 }
 
@@ -58,7 +59,7 @@ impl Debug for RequestConfig {
         res.field("timeout", timeout)
             .maybe_field("retry_limit", retry_limit)
             .maybe_field("retry_timeout", retry_timeout)
-            .field("max_concurrent_requests", max_concurrent_requests);
+            .maybe_field("max_concurrent_requests", max_concurrent_requests);
 
         if *force_auth {
             res.field("force_auth", &true);
@@ -74,7 +75,7 @@ impl Default for RequestConfig {
             timeout: DEFAULT_REQUEST_TIMEOUT,
             retry_limit: Default::default(),
             retry_timeout: Default::default(),
-            max_concurrent_requests: 0,
+            max_concurrent_requests: Default::default(),
             force_auth: false,
         }
     }
@@ -114,18 +115,11 @@ impl RequestConfig {
     /// Any additional request beyond that number will be waiting until another
     /// concurrent requests finished. Requests are queued fairly.
     #[must_use]
-    pub fn max_concurrent_requests(mut self, limit: usize) -> Self {
+    pub fn max_concurrent_requests(mut self, limit: Option<NonZeroUsize>) -> Self {
         self.max_concurrent_requests = limit;
         self
     }
 
-    /// Disable the limit of concurrent requests. Setting the limit to 0
-    /// has the same effect.
-    #[must_use]
-    pub fn disable_max_concurrent_requests(mut self) -> Self {
-        self.max_concurrent_requests = 0;
-        self
-    }
     /// Set the timeout duration for all HTTP requests.
     #[must_use]
     pub fn timeout(mut self, timeout: Duration) -> Self {

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -397,7 +397,7 @@ mod tests {
         });
 
         // give it some time to issue the requests
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
 
         assert_eq!(counter.load(Ordering::SeqCst), 254, "Not all requests passed through");
         bg_task.abort();

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -321,13 +321,13 @@ mod tests {
     #[async_test]
     async fn ensure_concurrent_request_limit_is_observed() {
         let (client_builder, server) = test_client_builder_with_server().await;
-        let mut client = client_builder
+        let client = client_builder
             .request_config(RequestConfig::default().max_concurrent_requests(NonZeroUsize::new(5)))
             .build()
             .await
             .unwrap();
 
-        set_client_session(&mut client).await;
+        set_client_session(&client).await;
 
         let counter = Arc::new(AtomicU8::new(0));
         let inner_counter = counter.clone();
@@ -366,13 +366,13 @@ mod tests {
     #[async_test]
     async fn ensure_no_max_concurrent_request_does_not_limit() {
         let (client_builder, server) = test_client_builder_with_server().await;
-        let mut client = client_builder
+        let client = client_builder
             .request_config(RequestConfig::default().max_concurrent_requests(None))
             .build()
             .await
             .unwrap();
 
-        set_client_session(&mut client).await;
+        set_client_session(&client).await;
 
         let counter = Arc::new(AtomicU8::new(0));
         let inner_counter = counter.clone();

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -61,7 +61,7 @@ impl MaybeSemaphore {
         MaybeSemaphore(Arc::new(inner))
     }
 
-    async fn acquire(&self) -> MaybeSemaphorePermit {
+    async fn acquire(&self) -> MaybeSemaphorePermit<'_> {
         match self.0.as_ref() {
             Some(inner) => {
                 // ignoring errors as we never close this

--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -296,7 +296,7 @@ impl tower::Service<http_old::Request<Bytes>> for HttpClient {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use std::{
         num::NonZeroUsize,


### PR DESCRIPTION
Add a new `max_concurrent_requests` parameter in the `RequestConfig` limits the number of http(s) requests the internal sdk client issues concurrently (if > 0). The default behavior is the same as before: there is no limit on concurrent requests issued.

This is especially useful for resource constrained platforms (e.g. mobile platforms), and if your pattern might lead to issuing many requests at the same time (like downloading and caching all avatars at startup).

- [x] Public API changes documented in changelogs (optional)

Signed-off-by: Benjamin Kampmann <ben.kampmann@gmail.com>
