### PR TITLE
crypto: Remove assert_matches2 from regular dependencies

### DIFF
--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -30,7 +30,6 @@ testing = ["dep:http"]
 [dependencies]
 aes = "0.8.1"
 as_variant = { workspace = true }
-assert_matches2 = { workspace = true }
 async-trait = { workspace = true }
 bs58 = { version = "0.5.0" }
 byteorder = { workspace = true }


### PR DESCRIPTION
It was added as a regular dependency in #3517 but it is only used in tests.
