### PR TITLE
ui: Improvements for replies and edits

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
@@ -18,6 +18,8 @@ use as_variant::as_variant;
 use matrix_sdk::{send_queue::SendHandle, Error};
 use ruma::{EventId, OwnedEventId, OwnedTransactionId};
 
+use super::EventItemIdentifier;
+
 /// An item for an event that was created locally and not yet echoed back by
 /// the homeserver.
 #[derive(Debug, Clone)]
@@ -31,6 +33,20 @@ pub(in crate::timeline) struct LocalEventTimelineItem {
 }
 
 impl LocalEventTimelineItem {
+    /// Get the unique identifier of this item.
+    ///
+    /// Returns the transaction ID for a local echo item that has not been sent
+    /// and the event ID for a local echo item that has been sent.
+    pub(crate) fn identifier(&self) -> EventItemIdentifier {
+        if let Some(event_id) =
+            as_variant!(&self.send_state, EventSendState::Sent { event_id } => event_id)
+        {
+            EventItemIdentifier::EventId(event_id.clone())
+        } else {
+            EventItemIdentifier::TransactionId(self.transaction_id.clone())
+        }
+    }
+
     /// Get the event ID of this item.
     ///
     /// Will be `Some` if and only if `send_state` is

--- a/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/local.rs
@@ -18,7 +18,7 @@ use as_variant::as_variant;
 use matrix_sdk::{send_queue::SendHandle, Error};
 use ruma::{EventId, OwnedEventId, OwnedTransactionId};
 
-use super::EventItemIdentifier;
+use super::TimelineEventItemId;
 
 /// An item for an event that was created locally and not yet echoed back by
 /// the homeserver.
@@ -37,13 +37,13 @@ impl LocalEventTimelineItem {
     ///
     /// Returns the transaction ID for a local echo item that has not been sent
     /// and the event ID for a local echo item that has been sent.
-    pub(crate) fn identifier(&self) -> EventItemIdentifier {
+    pub(crate) fn identifier(&self) -> TimelineEventItemId {
         if let Some(event_id) =
             as_variant!(&self.send_state, EventSendState::Sent { event_id } => event_id)
         {
-            EventItemIdentifier::EventId(event_id.clone())
+            TimelineEventItemId::EventId(event_id.clone())
         } else {
-            EventItemIdentifier::TransactionId(self.transaction_id.clone())
+            TimelineEventItemId::TransactionId(self.transaction_id.clone())
         }
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -76,7 +76,7 @@ pub(super) enum EventTimelineItemKind {
 
 /// A wrapper that can contain either a transaction id, or an event id.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub enum EventItemIdentifier {
+pub enum TimelineEventItemId {
     /// The item is local, identified by its transaction id (to be used in
     /// subsequent requests).
     TransactionId(OwnedTransactionId),
@@ -206,11 +206,11 @@ impl EventTimelineItem {
     /// Returns the transaction ID for a local echo item that has not been sent
     /// and the event ID for a local echo item that has been sent or a
     /// remote item.
-    pub(crate) fn identifier(&self) -> EventItemIdentifier {
+    pub(crate) fn identifier(&self) -> TimelineEventItemId {
         match &self.kind {
             EventTimelineItemKind::Local(local) => local.identifier(),
             EventTimelineItemKind::Remote(remote) => {
-                EventItemIdentifier::EventId(remote.event_id.clone())
+                TimelineEventItemId::EventId(remote.event_id.clone())
             }
         }
     }

--- a/crates/matrix-sdk-ui/src/timeline/event_item/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/reactions.rs
@@ -18,7 +18,7 @@ use indexmap::IndexMap;
 use itertools::Itertools as _;
 use ruma::{OwnedEventId, OwnedTransactionId, UserId};
 
-use super::EventItemIdentifier;
+use super::TimelineEventItemId;
 use crate::timeline::ReactionSenderData;
 
 /// The reactions grouped by key.
@@ -32,7 +32,7 @@ pub type BundledReactions = IndexMap<String, ReactionGroup>;
 /// This is a map of the event ID or transaction ID of the reactions to the ID
 /// of the sender of the reaction.
 #[derive(Clone, Debug, Default)]
-pub struct ReactionGroup(pub(in crate::timeline) IndexMap<EventItemIdentifier, ReactionSenderData>);
+pub struct ReactionGroup(pub(in crate::timeline) IndexMap<TimelineEventItemId, ReactionSenderData>);
 
 impl ReactionGroup {
     /// The (deduplicated) senders of the reactions in this group.
@@ -51,15 +51,15 @@ impl ReactionGroup {
     ) -> impl Iterator<Item = (Option<&OwnedTransactionId>, Option<&OwnedEventId>)> + 'a {
         self.iter().filter_map(move |(k, v)| {
             (v.sender_id == user_id).then_some(match k {
-                EventItemIdentifier::TransactionId(txn_id) => (Some(txn_id), None),
-                EventItemIdentifier::EventId(event_id) => (None, Some(event_id)),
+                TimelineEventItemId::TransactionId(txn_id) => (Some(txn_id), None),
+                TimelineEventItemId::EventId(event_id) => (None, Some(event_id)),
             })
         })
     }
 }
 
 impl Deref for ReactionGroup {
-    type Target = IndexMap<EventItemIdentifier, ReactionSenderData>;
+    type Target = IndexMap<TimelineEventItemId, ReactionSenderData>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -38,7 +38,7 @@ use crate::{
             Flow, HandleEventResult, TimelineEventContext, TimelineEventHandler, TimelineEventKind,
             TimelineItemPosition,
         },
-        event_item::{EventItemIdentifier, RemoteEventOrigin},
+        event_item::{RemoteEventOrigin, TimelineEventItemId},
         polls::PollPendingEvents,
         reactions::{ReactionToggleResult, Reactions},
         read_receipts::ReadReceipts,
@@ -294,7 +294,7 @@ impl TimelineInnerState {
 
             // Remove the local echo from the related event.
             if let Some(txn_id) = local_echo_to_remove {
-                let id = EventItemIdentifier::TransactionId(txn_id.clone());
+                let id = TimelineEventItemId::TransactionId(txn_id.clone());
                 if reaction_group.0.swap_remove(&id).is_none() {
                     warn!(
                         "Tried to remove reaction by transaction ID, but didn't \
@@ -306,7 +306,7 @@ impl TimelineInnerState {
             // Add the remote echo to the related event
             if let Some(event_id) = remote_echo_to_add {
                 reaction_group.0.insert(
-                    EventItemIdentifier::EventId(event_id.clone()),
+                    TimelineEventItemId::EventId(event_id.clone()),
                     reaction_sender_data.clone(),
                 );
             };
@@ -324,7 +324,7 @@ impl TimelineInnerState {
             // Remove the local echo from reaction_map
             // (should the local echo already be up-to-date after event handling?)
             if let Some(txn_id) = local_echo_to_remove {
-                let id = EventItemIdentifier::TransactionId(txn_id.clone());
+                let id = TimelineEventItemId::TransactionId(txn_id.clone());
                 if self.meta.reactions.map.remove(&id).is_none() {
                     warn!(
                         "Tried to remove reaction by transaction ID, but didn't \
@@ -335,7 +335,7 @@ impl TimelineInnerState {
             // Add the remote echo to the reaction_map
             if let Some(event_id) = remote_echo_to_add {
                 self.meta.reactions.map.insert(
-                    EventItemIdentifier::EventId(event_id.clone()),
+                    TimelineEventItemId::EventId(event_id.clone()),
                     (reaction_sender_data, annotation.clone()),
                 );
             }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -18,7 +18,7 @@
 
 use std::{path::PathBuf, pin::Pin, sync::Arc, task::Poll};
 
-use event_item::EventItemIdentifier;
+use event_item::TimelineEventItemId;
 use eyeball_im::VectorDiff;
 use futures_core::Stream;
 use imbl::Vector;
@@ -112,7 +112,7 @@ use self::{
 #[derive(Debug, Clone)]
 pub struct EditInfo {
     /// The event ID of the event that needs editing.
-    id: EventItemIdentifier,
+    id: TimelineEventItemId,
     /// The original content of the event that needs editing.
     original_message: Message,
 }
@@ -493,7 +493,7 @@ impl Timeline {
         edit_info: EditInfo,
     ) -> Result<bool, RoomSendQueueError> {
         let event_id = match edit_info.id {
-            EventItemIdentifier::TransactionId(txn_id) => {
+            TimelineEventItemId::TransactionId(txn_id) => {
                 let Some(item) = self.item_by_transaction_id(&txn_id).await else {
                     warn!("Couldn't find the local echo anymore");
                     return Ok(false);
@@ -509,7 +509,7 @@ impl Timeline {
                 return Ok(false);
             }
 
-            EventItemIdentifier::EventId(event_id) => event_id,
+            TimelineEventItemId::EventId(event_id) => event_id,
         };
 
         let original_content = edit_info.original_message;
@@ -582,7 +582,7 @@ impl Timeline {
                     &self.items().await,
                 );
                 return Ok(EditInfo {
-                    id: EventItemIdentifier::EventId(event_id.to_owned()),
+                    id: TimelineEventItemId::EventId(event_id.to_owned()),
                     original_message: message,
                 });
             }

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -109,12 +109,19 @@ use self::{
 };
 
 /// Information needed to edit an event.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EditInfo {
     /// The event ID of the event that needs editing.
     id: EventItemIdentifier,
     /// The original content of the event that needs editing.
     original_message: Message,
+}
+
+impl EditInfo {
+    /// The original content of the event that needs editing.
+    pub fn original_message(&self) -> &Message {
+        &self.original_message
+    }
 }
 
 /// Information needed to reply to an event.
@@ -130,12 +137,24 @@ pub struct RepliedToInfo {
     content: ReplyContent,
 }
 
+impl RepliedToInfo {
+    /// The sender of the event to reply to.
+    pub fn sender(&self) -> &UserId {
+        &self.sender
+    }
+
+    /// The content of the event to reply to.
+    pub fn content(&self) -> &ReplyContent {
+        &self.content
+    }
+}
+
 /// The content of a reply.
-#[derive(Debug)]
-enum ReplyContent {
+#[derive(Debug, Clone)]
+pub enum ReplyContent {
     /// Content of a message event.
     Message(Message),
-    /// Content of any other kind of event stored as raw.
+    /// Content of any other kind of event stored as raw JSON.
     Raw(Raw<AnySyncTimelineEvent>),
 }
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -418,7 +418,7 @@ impl Timeline {
         Ok(())
     }
 
-    /// Gives the information needed to reply to an event from an event id.
+    /// Get the information needed to reply to the event with the given ID.
     pub async fn replied_to_info_from_event_id(
         &self,
         event_id: &EventId,
@@ -468,17 +468,24 @@ impl Timeline {
         })
     }
 
-    /// Send an edit to the given event.
+    /// Edit an event.
     ///
-    /// Currently only supports `m.room.message` events whose event ID is known.
-    /// Please check [`EventTimelineItem::is_editable`] before calling this.
+    /// Only supports events for which [`EventTimelineItem::is_editable()`]
+    /// returns `true`.
     ///
     /// # Arguments
     ///
-    /// * `new_content` - The content of the reply
+    /// * `new_content` - The new content of the event.
     ///
     /// * `edit_info` - A wrapper that contains the event ID and the content of
-    ///  the event to edit
+    ///  the event to edit.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(true)` if the edit was added to the send queue. Returns
+    /// `Ok(false)` if the edit targets a local item but the edit could not be
+    /// applied, which could mean that the event was already sent. Returns an
+    /// error if there was an issue adding the edit to the send queue.
     #[instrument(skip(self, new_content))]
     pub async fn edit(
         &self,
@@ -536,7 +543,7 @@ impl Timeline {
         Ok(true)
     }
 
-    /// Give the information needed to edit an event from an event id.
+    /// Get the information needed to edit the event with the given ID.
     pub async fn edit_info_from_event_id(
         &self,
         event_id: &EventId,

--- a/crates/matrix-sdk-ui/src/timeline/reactions.rs
+++ b/crates/matrix-sdk-ui/src/timeline/reactions.rs
@@ -20,7 +20,7 @@ use ruma::{
     OwnedUserId,
 };
 
-use super::event_item::EventItemIdentifier;
+use super::event_item::TimelineEventItemId;
 
 /// Data associated with a reaction sender. It can be used to display
 /// a details UI component for a reaction with both sender
@@ -36,7 +36,7 @@ pub struct ReactionSenderData {
 #[derive(Clone, Debug, Default)]
 pub(super) struct Reactions {
     /// Reaction event / txn ID => sender and reaction data.
-    pub(super) map: HashMap<EventItemIdentifier, (ReactionSenderData, Annotation)>,
+    pub(super) map: HashMap<TimelineEventItemId, (ReactionSenderData, Annotation)>,
     /// ID of event that is not in the timeline yet => List of reaction event
     /// IDs.
     pub(super) pending: HashMap<OwnedEventId, IndexSet<OwnedEventId>>,

--- a/crates/matrix-sdk-ui/src/timeline/tests/reaction_group.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/reaction_group.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use matrix_sdk_test::{ALICE, BOB};
 use ruma::{server_name, uint, user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedUserId, UserId};
 
-use crate::timeline::{event_item::EventItemIdentifier, ReactionGroup, ReactionSenderData};
+use crate::timeline::{event_item::TimelineEventItemId, ReactionGroup, ReactionSenderData};
 
 #[test]
 fn test_by_sender() {
@@ -35,7 +35,7 @@ fn test_by_sender() {
 
     let reaction = alice_reactions[0];
 
-    assert_let!(EventItemIdentifier::EventId(event_id) = reaction_1);
+    assert_let!(TimelineEventItemId::EventId(event_id) = reaction_1);
     assert_eq!(reaction.1.unwrap(), &event_id);
 }
 
@@ -121,9 +121,9 @@ fn insert(group: &mut ReactionGroup, sender: &UserId, count: u64) {
     }
 }
 
-fn new_reaction() -> EventItemIdentifier {
+fn new_reaction() -> TimelineEventItemId {
     let event_id = EventId::new(server_name!("example.org"));
-    EventItemIdentifier::EventId(event_id)
+    TimelineEventItemId::EventId(event_id)
 }
 
 fn new_sender_data(sender: OwnedUserId) -> ReactionSenderData {


### PR DESCRIPTION
Each commit should be rather self-explanatory.

The motivation behind the second commit is for the use with `Room::restore_composer_draft`. When restoring a draft, but the edited/replied-to item is not available locally, that would result in two requests to the homeserver:

1. When restoring the composer state, the client makes a request with `Room::event()` to get the content of the edited/replied-to event to be able to display it in the UI.
2. When the user sends the message, the client must first call `Timeline::{edit/replied_to}_info_from_event_id()`, which makes a request to the homeserver, to be able to call `Timeline::edit/send_reply()` to send the event.

By exposing the content of the edit/replied-to info, the client needs only to make a single homeserver request with `Timeline::{edit/replied_to}_info_from_event_id()` and can display the edited/replied-to event in the UI with it.
