### PR TITLE
sdk: Use strongly-typed strings where it makes sense

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -548,7 +548,7 @@ impl Client {
 
     /// Retrieves an avatar cached from a previous call to [`Self::avatar_url`].
     pub fn cached_avatar_url(&self) -> Result<Option<String>, ClientError> {
-        Ok(RUNTIME.block_on(self.inner.account().get_cached_avatar_url())?)
+        Ok(RUNTIME.block_on(self.inner.account().get_cached_avatar_url())?.map(Into::into))
     }
 
     pub fn device_id(&self) -> Result<String, ClientError> {
@@ -873,11 +873,19 @@ impl Client {
     }
 
     pub async fn get_recently_visited_rooms(&self) -> Result<Vec<String>, ClientError> {
-        Ok(self.inner.account().get_recently_visited_rooms().await?)
+        Ok(self
+            .inner
+            .account()
+            .get_recently_visited_rooms()
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect())
     }
 
     pub async fn track_recently_visited_room(&self, room: String) -> Result<(), ClientError> {
-        self.inner.account().track_recently_visited_room(room).await?;
+        let room_id = RoomId::parse(room)?;
+        self.inner.account().track_recently_visited_room(room_id).await?;
         Ok(())
     }
 

--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -4,7 +4,8 @@ use anyhow::{Context, Result};
 use matrix_sdk::{
     event_cache::paginator::PaginatorError,
     room::{power_levels::RoomPowerLevelChanges, Room as SdkRoom, RoomMemberRole},
-    ComposerDraft, RoomHero as SdkRoomHero, RoomMemberships, RoomState,
+    ComposerDraft as SdkComposerDraft, ComposerDraftType as SdkComposerDraftType,
+    RoomHero as SdkRoomHero, RoomMemberships, RoomState,
 };
 use matrix_sdk_ui::timeline::{PaginationError, RoomExt, TimelineFocus};
 use mime::Mime;
@@ -677,12 +678,12 @@ impl Room {
     /// Store the given `ComposerDraft` in the state store using the current
     /// room id, as identifier.
     pub async fn save_composer_draft(&self, draft: ComposerDraft) -> Result<(), ClientError> {
-        Ok(self.inner.save_composer_draft(draft).await?)
+        Ok(self.inner.save_composer_draft(draft.try_into()?).await?)
     }
 
     /// Retrieve the `ComposerDraft` stored in the state store for this room.
     pub async fn load_composer_draft(&self) -> Result<Option<ComposerDraft>, ClientError> {
-        Ok(self.inner.load_composer_draft().await?)
+        Ok(self.inner.load_composer_draft().await?.map(Into::into))
     }
 
     /// Remove the `ComposerDraft` stored in the state store for this room.
@@ -846,5 +847,74 @@ impl From<RtcApplicationType> for notify::ApplicationType {
         match value {
             RtcApplicationType::Call => notify::ApplicationType::Call,
         }
+    }
+}
+
+/// Current draft of the composer for the room.
+#[derive(uniffi::Record)]
+pub struct ComposerDraft {
+    /// The draft content in plain text.
+    pub plain_text: String,
+    /// If the message is formatted in HTML, the HTML representation of the
+    /// message.
+    pub html_text: Option<String>,
+    /// The type of draft.
+    pub draft_type: ComposerDraftType,
+}
+
+impl From<SdkComposerDraft> for ComposerDraft {
+    fn from(value: SdkComposerDraft) -> Self {
+        let SdkComposerDraft { plain_text, html_text, draft_type } = value;
+        Self { plain_text, html_text, draft_type: draft_type.into() }
+    }
+}
+
+impl TryFrom<ComposerDraft> for SdkComposerDraft {
+    type Error = ruma::IdParseError;
+
+    fn try_from(value: ComposerDraft) -> std::result::Result<Self, Self::Error> {
+        let ComposerDraft { plain_text, html_text, draft_type } = value;
+        Ok(Self { plain_text, html_text, draft_type: draft_type.try_into()? })
+    }
+}
+
+/// The type of draft of the composer.
+#[derive(uniffi::Enum)]
+pub enum ComposerDraftType {
+    /// The draft is a new message.
+    NewMessage,
+    /// The draft is a reply to an event.
+    Reply {
+        /// The ID of the event being replied to.
+        event_id: String,
+    },
+    /// The draft is an edit of an event.
+    Edit {
+        /// The ID of the event being edited.
+        event_id: String,
+    },
+}
+
+impl From<SdkComposerDraftType> for ComposerDraftType {
+    fn from(value: SdkComposerDraftType) -> Self {
+        match value {
+            SdkComposerDraftType::NewMessage => Self::NewMessage,
+            SdkComposerDraftType::Reply { event_id } => Self::Reply { event_id: event_id.into() },
+            SdkComposerDraftType::Edit { event_id } => Self::Edit { event_id: event_id.into() },
+        }
+    }
+}
+
+impl TryFrom<ComposerDraftType> for SdkComposerDraftType {
+    type Error = ruma::IdParseError;
+
+    fn try_from(value: ComposerDraftType) -> std::result::Result<Self, Self::Error> {
+        let draft_type = match value {
+            ComposerDraftType::NewMessage => Self::NewMessage,
+            ComposerDraftType::Reply { event_id } => Self::Reply { event_id: event_id.try_into()? },
+            ComposerDraftType::Edit { event_id } => Self::Edit { event_id: event_id.try_into()? },
+        };
+
+        Ok(draft_type)
     }
 }

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -56,7 +56,8 @@ pub use rooms::{
     RoomMember, RoomMemberships, RoomState, RoomStateFilter,
 };
 pub use store::{
-    ComposerDraft, StateChanges, StateStore, StateStoreDataKey, StateStoreDataValue, StoreError,
+    ComposerDraft, ComposerDraftType, StateChanges, StateStore, StateStoreDataKey,
+    StateStoreDataValue, StoreError,
 };
 pub use utils::{
     MinimalRoomMemberEvent, MinimalStateEvent, OriginalMinimalStateEvent, RedactedMinimalStateEvent,

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -28,7 +28,7 @@ use ruma::{
         AnySyncStateEvent, GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType,
         SyncStateEvent,
     },
-    mxc_uri, room_id,
+    mxc_uri, owned_mxc_uri, room_id,
     serde::Raw,
     uint, user_id, EventId, OwnedEventId, OwnedUserId, RoomId, TransactionId, UserId,
 };
@@ -548,11 +548,11 @@ impl StateStoreIntegrationTests for DynStateStore {
 
     async fn test_user_avatar_url_saving(&self) {
         let user_id = user_id!("@alice:example.org");
-        let url = "https://example.org";
+        let url = owned_mxc_uri!("mxc://example.org/poiuyt098");
 
         self.set_kv_data(
             StateStoreDataKey::UserAvatarUrl(user_id),
-            StateStoreDataValue::UserAvatarUrl(url.to_owned()),
+            StateStoreDataValue::UserAvatarUrl(url.clone()),
         )
         .await
         .unwrap();

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -52,9 +52,9 @@ use crate::{
 #[allow(clippy::type_complexity)]
 #[derive(Debug)]
 pub struct MemoryStore {
-    recently_visited_rooms: StdRwLock<HashMap<String, Vec<String>>>,
+    recently_visited_rooms: StdRwLock<HashMap<OwnedUserId, Vec<OwnedRoomId>>>,
     composer_drafts: StdRwLock<HashMap<OwnedRoomId, ComposerDraft>>,
-    user_avatar_url: StdRwLock<HashMap<String, String>>,
+    user_avatar_url: StdRwLock<HashMap<OwnedUserId, OwnedMxcUri>>,
     sync_token: StdRwLock<Option<String>>,
     filters: StdRwLock<HashMap<String, String>>,
     utd_hook_manager_data: StdRwLock<Option<GrowableBloom>>,
@@ -186,14 +186,14 @@ impl StateStore for MemoryStore {
                 .user_avatar_url
                 .read()
                 .unwrap()
-                .get(user_id.as_str())
+                .get(user_id)
                 .cloned()
                 .map(StateStoreDataValue::UserAvatarUrl),
             StateStoreDataKey::RecentlyVisitedRooms(user_id) => self
                 .recently_visited_rooms
                 .read()
                 .unwrap()
-                .get(user_id.as_str())
+                .get(user_id)
                 .cloned()
                 .map(StateStoreDataValue::RecentlyVisitedRooms),
             StateStoreDataKey::UtdHookManagerData => self
@@ -230,13 +230,13 @@ impl StateStore for MemoryStore {
             }
             StateStoreDataKey::UserAvatarUrl(user_id) => {
                 self.user_avatar_url.write().unwrap().insert(
-                    user_id.to_string(),
+                    user_id.to_owned(),
                     value.into_user_avatar_url().expect("Session data not a user avatar url"),
                 );
             }
             StateStoreDataKey::RecentlyVisitedRooms(user_id) => {
                 self.recently_visited_rooms.write().unwrap().insert(
-                    user_id.to_string(),
+                    user_id.to_owned(),
                     value
                         .into_recently_visited_rooms()
                         .expect("Session data not a list of recently visited rooms"),
@@ -267,10 +267,10 @@ impl StateStore for MemoryStore {
                 self.filters.write().unwrap().remove(filter_name);
             }
             StateStoreDataKey::UserAvatarUrl(user_id) => {
-                self.user_avatar_url.write().unwrap().remove(user_id.as_str());
+                self.user_avatar_url.write().unwrap().remove(user_id);
             }
             StateStoreDataKey::RecentlyVisitedRooms(user_id) => {
-                self.recently_visited_rooms.write().unwrap().remove(user_id.as_str());
+                self.recently_visited_rooms.write().unwrap().remove(user_id);
             }
             StateStoreDataKey::UtdHookManagerData => {
                 *self.utd_hook_manager_data.write().unwrap() = None

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -34,8 +34,8 @@ use ruma::{
         StateEventType, StaticEventContent, StaticStateEventContent,
     },
     serde::Raw,
-    EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId,
-    TransactionId, UserId,
+    EventId, MxcUri, OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedTransactionId, OwnedUserId,
+    RoomId, TransactionId, UserId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -914,10 +914,10 @@ pub enum StateStoreDataValue {
     Filter(String),
 
     /// The user avatar url
-    UserAvatarUrl(String),
+    UserAvatarUrl(OwnedMxcUri),
 
     /// A list of recently visited room identifiers for the current user
-    RecentlyVisitedRooms(Vec<String>),
+    RecentlyVisitedRooms(Vec<OwnedRoomId>),
 
     /// Persistent data for
     /// `matrix_sdk_ui::unable_to_decrypt_hook::UtdHookManager`.
@@ -932,7 +932,6 @@ pub enum StateStoreDataValue {
 
 /// Current draft of the composer for the room.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
 pub struct ComposerDraft {
     /// The draft content in plain text.
     pub plain_text: String,
@@ -945,19 +944,18 @@ pub struct ComposerDraft {
 
 /// The type of draft of the composer.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
 pub enum ComposerDraftType {
     /// The draft is a new message.
     NewMessage,
     /// The draft is a reply to an event.
     Reply {
         /// The ID of the event being replied to.
-        event_id: String,
+        event_id: OwnedEventId,
     },
     /// The draft is an edit of an event.
     Edit {
         /// The ID of the event being edited.
-        event_id: String,
+        event_id: OwnedEventId,
     },
 }
 
@@ -973,12 +971,12 @@ impl StateStoreDataValue {
     }
 
     /// Get this value if it is a user avatar url.
-    pub fn into_user_avatar_url(self) -> Option<String> {
+    pub fn into_user_avatar_url(self) -> Option<OwnedMxcUri> {
         as_variant!(self, Self::UserAvatarUrl)
     }
 
     /// Get this value if it is a list of recently visited rooms.
-    pub fn into_recently_visited_rooms(self) -> Option<Vec<String>> {
+    pub fn into_recently_visited_rooms(self) -> Option<Vec<OwnedRoomId>> {
         as_variant!(self, Self::RecentlyVisitedRooms)
     }
 

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -44,8 +44,8 @@ use ruma::{
         GlobalAccountDataEventType, RoomAccountDataEventType, StateEventType, SyncStateEvent,
     },
     serde::Raw,
-    CanonicalJsonObject, EventId, MxcUri, OwnedEventId, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
+    CanonicalJsonObject, EventId, MxcUri, OwnedEventId, OwnedMxcUri, OwnedRoomId,
+    OwnedTransactionId, OwnedUserId, RoomId, RoomVersionId, TransactionId, UserId,
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tracing::{debug, warn};
@@ -471,11 +471,11 @@ impl_state_store!({
                 .transpose()?
                 .map(StateStoreDataValue::Filter),
             StateStoreDataKey::UserAvatarUrl(_) => value
-                .map(|f| self.deserialize_value::<String>(&f))
+                .map(|f| self.deserialize_value::<OwnedMxcUri>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::UserAvatarUrl),
             StateStoreDataKey::RecentlyVisitedRooms(_) => value
-                .map(|f| self.deserialize_value::<Vec<String>>(&f))
+                .map(|f| self.deserialize_value::<Vec<OwnedRoomId>>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::RecentlyVisitedRooms),
             StateStoreDataKey::UtdHookManagerData => value

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -2209,7 +2209,10 @@ pub(crate) mod tests {
     #[cfg(target_arch = "wasm32")]
     wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-    use ruma::{events::ignored_user_list::IgnoredUserListEventContent, room_id, UserId};
+    use ruma::{
+        events::ignored_user_list::IgnoredUserListEventContent, owned_room_id, room_id, RoomId,
+        UserId,
+    };
     use url::Url;
     use wiremock::{
         matchers::{body_json, header, method, path},
@@ -2473,7 +2476,7 @@ pub(crate) mod tests {
         // Tracking recently visited rooms requires authentication
         let client = no_retry_test_client(Some("http://localhost".to_owned())).await;
         assert_matches!(
-            client.account().track_recently_visited_room("!alpha:localhost".to_owned()).await,
+            client.account().track_recently_visited_room(owned_room_id!("!alpha:localhost")).await,
             Err(Error::AuthenticationRequired)
         );
 
@@ -2484,45 +2487,39 @@ pub(crate) mod tests {
         assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 0);
 
         // Tracking a valid room id should add it to the list
-        account.track_recently_visited_room("!alpha:localhost".to_owned()).await.unwrap();
+        account.track_recently_visited_room(owned_room_id!("!alpha:localhost")).await.unwrap();
         assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 1);
         assert_eq!(account.get_recently_visited_rooms().await.unwrap(), ["!alpha:localhost"]);
-
-        // Trying to track an invalid room id should return an error
-        assert_matches!(
-            account.track_recently_visited_room("this_is_not_a_valid_room_id".to_owned()).await,
-            Err(Error::Identifier { .. })
-        );
 
         // And the existing list shouldn't be changed
         assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 1);
         assert_eq!(account.get_recently_visited_rooms().await.unwrap(), ["!alpha:localhost"]);
 
         // Tracking the same room again shouldn't change the list
-        account.track_recently_visited_room("!alpha:localhost".to_owned()).await.unwrap();
+        account.track_recently_visited_room(owned_room_id!("!alpha:localhost")).await.unwrap();
         assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 1);
         assert_eq!(account.get_recently_visited_rooms().await.unwrap(), ["!alpha:localhost"]);
 
         // Tracking a second room should add it to the front of the list
-        account.track_recently_visited_room("!beta:localhost".to_owned()).await.unwrap();
+        account.track_recently_visited_room(owned_room_id!("!beta:localhost")).await.unwrap();
         assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 2);
         assert_eq!(
             account.get_recently_visited_rooms().await.unwrap(),
-            ["!beta:localhost", "!alpha:localhost"]
+            [room_id!("!beta:localhost"), room_id!("!alpha:localhost")]
         );
 
         // Tracking the first room yet again should move it to the front of the list
-        account.track_recently_visited_room("!alpha:localhost".to_owned()).await.unwrap();
+        account.track_recently_visited_room(owned_room_id!("!alpha:localhost")).await.unwrap();
         assert_eq!(account.get_recently_visited_rooms().await.unwrap().len(), 2);
         assert_eq!(
             account.get_recently_visited_rooms().await.unwrap(),
-            ["!alpha:localhost", "!beta:localhost"]
+            [room_id!("!alpha:localhost"), room_id!("!beta:localhost")]
         );
 
         // Tracking should be capped at 20
         for n in 0..20 {
             account
-                .track_recently_visited_room(format!("!{n}:localhost").to_owned())
+                .track_recently_visited_room(RoomId::parse(format!("!{n}:localhost")).unwrap())
                 .await
                 .unwrap();
         }
@@ -2531,11 +2528,11 @@ pub(crate) mod tests {
 
         // And the initial rooms should've been pushed out
         let rooms = account.get_recently_visited_rooms().await.unwrap();
-        assert!(!rooms.contains(&"!alpha:localhost".to_owned()));
-        assert!(!rooms.contains(&"!beta:localhost".to_owned()));
+        assert!(!rooms.contains(&owned_room_id!("!alpha:localhost")));
+        assert!(!rooms.contains(&owned_room_id!("!beta:localhost")));
 
         // And the last tracked room should be the first
-        assert_eq!(rooms.first().unwrap(), "!19:localhost");
+        assert_eq!(rooms.first().unwrap(), room_id!("!19:localhost"));
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/lib.rs
+++ b/crates/matrix-sdk/src/lib.rs
@@ -22,10 +22,10 @@ pub use bytes;
 pub use matrix_sdk_base::crypto;
 pub use matrix_sdk_base::{
     deserialized_responses,
-    store::{ComposerDraft, DynStateStore, MemoryStore, StateStoreExt},
-    DisplayName, Room as BaseRoom, RoomCreateWithCreatorEventContent, RoomHero, RoomInfo,
-    RoomMember as BaseRoomMember, RoomMemberships, RoomState, SessionMeta, StateChanges,
-    StateStore, StoreError,
+    store::{DynStateStore, MemoryStore, StateStoreExt},
+    ComposerDraft, ComposerDraftType, DisplayName, Room as BaseRoom,
+    RoomCreateWithCreatorEventContent, RoomHero, RoomInfo, RoomMember as BaseRoomMember,
+    RoomMemberships, RoomState, SessionMeta, StateChanges, StateStore, StoreError,
 };
 pub use matrix_sdk_common::*;
 pub use reqwest;


### PR DESCRIPTION
Where a string is clearly documented as a room ID, event ID or mxc URI, use `OwnedRoomId`, `OwnedEventId` and `OwnedMxcURI`, respectively.

Leave the conversion to the bindings.

