### PR TITLE
typos: Exclude specific words from typo checking instead of whole files

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -27,6 +27,7 @@ Nd = "Nd"
 Abl = "Abl"
 Som = "Som"
 Ba = "Ba"
+Yur = "Yur" # as found in crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs
 
 [files]
 extend-exclude = [
@@ -34,7 +35,4 @@ extend-exclude = [
     "*.json",
     # Fuzzy match patterns that can be understood as typos confusingly.
     "crates/matrix-sdk-ui/tests/integration/room_list_service.rs",
-    # Hand-crafted base64 session keys that are understood as typos.
-    "crates/matrix-sdk-indexeddb/src/crypto_store/migrations/mod.rs",
-    "crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs",
 ]


### PR DESCRIPTION
As suggested by @poljar in https://github.com/matrix-org/matrix-rust-sdk/pull/3556