### PR TITLE
send queue: wake up the sending task after editing an event

### DIFF
--- a/crates/matrix-sdk/src/send_queue.rs
+++ b/crates/matrix-sdk/src/send_queue.rs
@@ -899,6 +899,9 @@ impl SendHandle {
         if self.room.inner.queue.replace(&self.transaction_id, serializable.clone()).await? {
             trace!("successful edit");
 
+            // Wake up the queue, in case the room was asleep before the edit.
+            self.room.inner.notifier.notify_one();
+
             // Propagate a replaced update too.
             let _ = self.room.inner.updates.send(RoomSendQueueUpdate::ReplacedLocalEvent {
                 transaction_id: self.transaction_id.clone(),


### PR DESCRIPTION
It could be that the last event in a room's send queue has been marked as wedged. In that case, the task will sleep until it's notified again. If the event is being edited, then nothing would wake up the task; a manual wakeup might be required in that case.

The new integration test shows the issue; the last `assert_update` would fail with a timeout before this patch.

Part of #3361.
