### PR TITLE
send queue: make `SendHandle::abort()`/`update()` more precise

### DIFF
--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -418,20 +418,24 @@ pub trait StateStore: AsyncTraitDeps {
     /// * `transaction_id` - The unique key identifying the event to be sent
     ///   (and its transaction).
     /// * `content` - Serializable event content to replace the original one.
+    ///
+    /// Returns true if an event has been updated, or false otherwise.
     async fn update_send_queue_event(
         &self,
         room_id: &RoomId,
         transaction_id: &TransactionId,
         content: SerializableEventContent,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<bool, Self::Error>;
 
     /// Remove an event previously inserted with [`Self::save_send_queue_event`]
     /// from the database, based on its transaction id.
+    ///
+    /// Returns true if an event has been removed, or false otherwise.
     async fn remove_send_queue_event(
         &self,
         room_id: &RoomId,
         transaction_id: &TransactionId,
-    ) -> Result<(), Self::Error>;
+    ) -> Result<bool, Self::Error>;
 
     /// Loads all the send queue events for the given room.
     async fn load_send_queue_events(
@@ -687,7 +691,7 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         room_id: &RoomId,
         transaction_id: &TransactionId,
         content: SerializableEventContent,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<bool, Self::Error> {
         self.0.update_send_queue_event(room_id, transaction_id, content).await.map_err(Into::into)
     }
 
@@ -695,7 +699,7 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
         &self,
         room_id: &RoomId,
         transaction_id: &TransactionId,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<bool, Self::Error> {
         self.0.remove_send_queue_event(room_id, transaction_id).await.map_err(Into::into)
     }
 

--- a/crates/matrix-sdk/tests/integration/send_queue.rs
+++ b/crates/matrix-sdk/tests/integration/send_queue.rs
@@ -1,4 +1,5 @@
 use std::{
+    ops::Not as _,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex as StdMutex,
@@ -949,6 +950,55 @@ async fn test_abort_after_disable() {
 
     assert!(watch.is_empty());
     assert!(errors.is_empty());
+}
+
+#[async_test]
+async fn test_abort_or_edit_after_send() {
+    let (client, server) = logged_in_client_with_server().await;
+
+    // Mark the room as joined.
+    let room_id = room_id!("!a:b.c");
+
+    let room = mock_sync_with_new_room(
+        |builder| {
+            builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+        },
+        &client,
+        &server,
+        room_id,
+    )
+    .await;
+
+    // Start with an enabled sending queue.
+    client.send_queue().set_enabled(true).await;
+
+    let q = room.send_queue();
+
+    let (local_echoes, mut watch) = q.subscribe().await.unwrap();
+    assert!(local_echoes.is_empty());
+    assert!(watch.is_empty());
+
+    server.reset().await;
+    mock_encryption_state(&server, false).await;
+    mock_send_event(event_id!("$1")).mount(&server).await;
+
+    let handle = q.send(RoomMessageEventContent::text_plain("hey there").into()).await.unwrap();
+
+    // It is first seen as a local echo,
+    let (txn, _) = assert_update!(watch => local echo { body = "hey there" });
+    // Then sent.
+    assert_update!(watch => sent { txn = txn, });
+
+    // Editing shouldn't work anymore.
+    assert!(handle
+        .edit(RoomMessageEventContent::text_plain("i meant something completely different").into())
+        .await
+        .unwrap()
+        .not());
+    // Neither will aborting.
+    assert!(handle.abort().await.unwrap().not());
+
+    assert!(watch.is_empty());
 }
 
 #[async_test]


### PR DESCRIPTION
Using `SendHandle::abort()` after the event has been sent would look like a successful abort of the event, while it's not the case; this fixes this by having the state store backends return whether they've touched an entry in the database.

Found thanks to `multiverse`.

Part of #3361.