### PR TITLE
crypto: Move device_keys to DecryptedOlmV1Event as per MSC4147

### DIFF
--- a/crates/matrix-sdk-crypto/src/gossiping/machine.rs
+++ b/crates/matrix-sdk-crypto/src/gossiping/machine.rs
@@ -1478,6 +1478,7 @@ mod tests {
             alice_id(),
             alice_id(),
             alice_device.ed25519_key().unwrap(),
+            None,
             content,
         );
 
@@ -1525,6 +1526,7 @@ mod tests {
             alice_id(),
             alice_id(),
             alice_device.ed25519_key().unwrap(),
+            None,
             content,
         );
 
@@ -1543,6 +1545,7 @@ mod tests {
             alice_id(),
             alice_id(),
             alice_device.ed25519_key().unwrap(),
+            None,
             content,
         );
 

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/outbound.rs
@@ -531,7 +531,6 @@ impl OutboundGroupSession {
                 self.room_id().to_owned(),
                 self.session_id().to_owned(),
                 session_key,
-                None,
             )
             .into(),
         )

--- a/crates/matrix-sdk-crypto/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-crypto/src/store/integration_tests.rs
@@ -905,6 +905,7 @@ macro_rules! cryptostore_integration_tests {
                     recipient_keys: OlmV1Keys {
                         ed25519: account.identity_keys().ed25519,
                     },
+                    device_keys: None,
                     content: SecretSendContent::new(id.to_owned(), secret.to_owned()),
                 };
 

--- a/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/olm_v1.rs
@@ -30,7 +30,7 @@ use super::{
     secret_send::SecretSendContent,
     EventType,
 };
-use crate::types::{deserialize_ed25519_key, events::from_str, serialize_ed25519_key};
+use crate::types::{deserialize_ed25519_key, events::from_str, serialize_ed25519_key, DeviceKeys};
 
 /// An `m.dummy` event that was decrypted using the
 /// `m.olm.v1.curve25519-aes-sha2` algorithm
@@ -164,18 +164,28 @@ where
     pub keys: OlmV1Keys,
     /// The recipient's signing keys of the encrypted event.
     pub recipient_keys: OlmV1Keys,
+    /// The device keys if supplied as per MSC4147
+    #[serde(rename = "org.matrix.msc4147.device_keys")]
+    pub device_keys: Option<DeviceKeys>,
     /// The type of the event.
     pub content: C,
 }
 
 impl<C: EventType + Debug + Sized + Serialize> DecryptedOlmV1Event<C> {
     #[cfg(test)]
-    pub fn new(sender: &UserId, recipient: &UserId, key: Ed25519PublicKey, content: C) -> Self {
+    pub fn new(
+        sender: &UserId,
+        recipient: &UserId,
+        key: Ed25519PublicKey,
+        device_keys: Option<DeviceKeys>,
+        content: C,
+    ) -> Self {
         Self {
             sender: sender.to_owned(),
             recipient: recipient.to_owned(),
             keys: OlmV1Keys { ed25519: key },
             recipient_keys: OlmV1Keys { ed25519: key },
+            device_keys,
             content,
         }
     }

--- a/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room/encrypted.rs
@@ -431,7 +431,6 @@ pub(crate) mod tests {
                 "device_id": "DEWRCMENGS",
                 "session_id": "ZFD6+OmV7fVCsJ7Gap8UnORH8EnmiAkes8FAvQuCw/I",
                 "sender_key": "WJ6Ce7U67a6jqkHYHd8o0+5H4bqdi9hInZdk0+swuXs",
-                "device_keys": null,
                 "ciphertext":
                     "AwgAEiBQs2LgBD2CcB+RLH2bsgp9VadFUJhBXOtCmcJuttBDOeDNjL21d9\
                      z0AcVSfQFAh9huh4or7sWuNrHcvu9/sMbweTgc0UtdA5xFLheubHouXy4a\

--- a/crates/matrix-sdk-crypto/src/types/events/room_key.rs
+++ b/crates/matrix-sdk-crypto/src/types/events/room_key.rs
@@ -22,7 +22,7 @@ use serde_json::{value::to_raw_value, Value};
 use vodozemac::megolm::SessionKey;
 
 use super::{EventType, ToDeviceEvent};
-use crate::types::{DeviceKeys, EventEncryptionAlgorithm};
+use crate::types::EventEncryptionAlgorithm;
 
 /// The `m.room_key` to-device event.
 pub type RoomKeyEvent = ToDeviceEvent<RoomKeyContent>;
@@ -113,8 +113,6 @@ pub struct MegolmV1AesSha2Content {
     ///
     /// [`InboundGroupSession`]: vodozemac::megolm::InboundGroupSession
     pub session_key: SessionKey,
-    /// The device keys if supplied as per MSC4147
-    pub device_keys: Option<DeviceKeys>,
     /// Any other, custom and non-specced fields of the content.
     #[serde(flatten)]
     other: BTreeMap<String, Value>,
@@ -122,13 +120,8 @@ pub struct MegolmV1AesSha2Content {
 
 impl MegolmV1AesSha2Content {
     /// Create a new `m.megolm.v1.aes-sha2` `m.room_key` content.
-    pub fn new(
-        room_id: OwnedRoomId,
-        session_id: String,
-        session_key: SessionKey,
-        device_keys: Option<DeviceKeys>,
-    ) -> Self {
-        Self { room_id, session_id, session_key, device_keys, other: Default::default() }
+    pub fn new(room_id: OwnedRoomId, session_id: String, session_key: SessionKey) -> Self {
+        Self { room_id, session_id, session_key, other: Default::default() }
     }
 }
 
@@ -232,7 +225,6 @@ pub(super) mod tests {
                                 QrCexmqfFJzkR/BJ5ogJHrPBQL0LgsPyglIbMTLg7qygIaY\
                                 U5Fe2QdKMH7nTZPNIRHh1RaMfHVETAUJBax88EWZBoifk80\
                                 gdHUwHSgMk77vCc2a5KHKLDA",
-                "device_keys": null
             },
             "type": "m.room_key",
             "m.custom.top": "something custom in the top",


### PR DESCRIPTION
Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3542

Fixes a mistake I made in https://github.com/matrix-org/matrix-rust-sdk/pull/3556 - I included `device_keys` in the `content` and it should be outside as per [MSC4147](https://github.com/matrix-org/matrix-spec-proposals/pull/4147)