### PR TITLE
ui: Expose identifier of `RepliedToInfo` and `EditInfo`

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -129,7 +129,7 @@ impl EditInfo {
 }
 
 /// Information needed to reply to an event.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RepliedToInfo {
     /// The event ID of the event to reply to.
     event_id: OwnedEventId,


### PR DESCRIPTION
That way, users of the crate don't need to keep track of the ID separately.