### PR TITLE
Stores: Remove `StoreCipher::{en,de}crypt_value_[base64_]typed`

### DIFF
--- a/crates/matrix-sdk-indexeddb/src/crypto_store/indexeddb_serializer.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/indexeddb_serializer.rs
@@ -25,6 +25,7 @@ use matrix_sdk_store_encryption::{EncryptedValueBase64, StoreCipher};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use wasm_bindgen::JsValue;
 use web_sys::IdbKeyRange;
+use zeroize::Zeroizing;
 
 use crate::{safe_encode::SafeEncode, IndexeddbCryptoStoreError};
 
@@ -145,18 +146,29 @@ impl IndexeddbSerializer {
         }
     }
 
-    /// Encode an InboundGroupSession for storage as a value in indexeddb.
+    /// Encode an object for storage as a value in indexeddb.
+    ///
+    /// First serializes the object as JSON bytes.
+    ///
+    /// Then, if a cipher is set, encrypts the JSON with a nonce into binary
+    /// blobs, and base64-encodes the blobs.
+    ///
+    /// If no cipher is set, just base64-encodes the JSON bytes.
+    ///
+    /// Finally, returns an object encapsulating the result.
     pub fn maybe_encrypt_value(
         &self,
         value: PickledInboundGroupSession,
     ) -> Result<MaybeEncrypted, CryptoStoreError> {
+        // First serialize the object as JSON.
+        let serialized = serde_json::to_vec(&value).map_err(CryptoStoreError::backend)?;
+
+        // Then either encrypt the JSON, or just base64-encode it.
         Ok(match &self.store_cipher {
             Some(cipher) => MaybeEncrypted::Encrypted(
-                cipher.encrypt_value_base64_typed(&value).map_err(CryptoStoreError::backend)?,
+                cipher.encrypt_value_base64_data(serialized).map_err(CryptoStoreError::backend)?,
             ),
-            None => MaybeEncrypted::Unencrypted(
-                BASE64.encode(serde_json::to_vec(&value).map_err(CryptoStoreError::backend)?),
-            ),
+            None => MaybeEncrypted::Unencrypted(BASE64.encode(serialized)),
         })
     }
 
@@ -198,16 +210,19 @@ impl IndexeddbSerializer {
         &self,
         value: MaybeEncrypted,
     ) -> Result<PickledInboundGroupSession, CryptoStoreError> {
-        match (&self.store_cipher, value) {
+        // First extract the plaintext JSON, either by decrypting or un-base64-ing.
+        let plaintext = Zeroizing::new(match (&self.store_cipher, value) {
             (Some(cipher), MaybeEncrypted::Encrypted(enc)) => {
-                cipher.decrypt_value_base64_typed(enc).map_err(CryptoStoreError::backend)
+                cipher.decrypt_value_base64_data(enc).map_err(CryptoStoreError::backend)?
             }
             (None, MaybeEncrypted::Unencrypted(unc)) => {
-                Ok(serde_json::from_slice(&BASE64.decode(unc).map_err(CryptoStoreError::backend)?)
-                    .map_err(CryptoStoreError::backend)?)
+                BASE64.decode(unc).map_err(CryptoStoreError::backend)?
             }
 
-            _ => Err(CryptoStoreError::UnpicklingError),
-        }
+            _ => return Err(CryptoStoreError::UnpicklingError),
+        });
+
+        // Then deserialize the JSON.
+        Ok(serde_json::from_slice(&plaintext)?)
     }
 }

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -418,45 +418,8 @@ impl StoreCipher {
     /// # anyhow::Ok(()) };
     /// ```
     pub fn encrypt_value(&self, value: &impl Serialize) -> Result<Vec<u8>, Error> {
-        Ok(serde_json::to_vec(&self.encrypt_value_typed(value)?)?)
-    }
-
-    /// Encrypt a value before it is inserted into the key/value store.
-    ///
-    /// A value can be decrypted using the
-    /// [`StoreCipher::decrypt_value_typed()`] method. This is the lower
-    /// level function to `encrypt_value`, but returns the
-    /// full `EncryptdValue`-type
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - A value that should be encrypted, any value that implements
-    ///   `Serialize` can be given to this method. The value will be serialized
-    ///   as json before it is encrypted.
-    ///
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # let example = || {
-    /// use matrix_sdk_store_encryption::StoreCipher;
-    /// use serde_json::{json, value::Value};
-    ///
-    /// let store_cipher = StoreCipher::new()?;
-    ///
-    /// let value = json!({
-    ///     "some": "data",
-    /// });
-    ///
-    /// let encrypted = store_cipher.encrypt_value_typed(&value)?;
-    /// let decrypted: Value = store_cipher.decrypt_value_typed(encrypted)?;
-    ///
-    /// assert_eq!(value, decrypted);
-    /// # anyhow::Ok(()) };
-    /// ```
-    pub fn encrypt_value_typed(&self, value: &impl Serialize) -> Result<EncryptedValue, Error> {
         let data = serde_json::to_vec(value)?;
-        self.encrypt_value_data(data)
+        Ok(serde_json::to_vec(&self.encrypt_value_data(data)?)?)
     }
 
     /// Encrypt some data before it is inserted into the key/value store.
@@ -603,44 +566,6 @@ impl StoreCipher {
     /// ```
     pub fn decrypt_value<T: DeserializeOwned>(&self, value: &[u8]) -> Result<T, Error> {
         let value: EncryptedValue = serde_json::from_slice(value)?;
-        self.decrypt_value_typed(value)
-    }
-
-    /// Decrypt a value after it was fetched from the key/value store.
-    ///
-    /// A value can be encrypted using the
-    /// [`StoreCipher::encrypt_value_typed()`] method. Lower level method to
-    /// [`StoreCipher::decrypt_value_typed()`]
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The EncryptedValue of a value that should be decrypted.
-    ///
-    /// The method will deserialize the decrypted value into the expected type.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # let example = || {
-    /// use matrix_sdk_store_encryption::StoreCipher;
-    /// use serde_json::{json, value::Value};
-    ///
-    /// let store_cipher = StoreCipher::new()?;
-    ///
-    /// let value = json!({
-    ///     "some": "data",
-    /// });
-    ///
-    /// let encrypted = store_cipher.encrypt_value_typed(&value)?;
-    /// let decrypted: Value = store_cipher.decrypt_value_typed(encrypted)?;
-    ///
-    /// assert_eq!(value, decrypted);
-    /// # anyhow::Ok(()) };
-    /// ```
-    pub fn decrypt_value_typed<T: DeserializeOwned>(
-        &self,
-        value: EncryptedValue,
-    ) -> Result<T, Error> {
         let mut plaintext = self.decrypt_value_data(value)?;
         let ret = serde_json::from_slice(&plaintext);
         plaintext.zeroize();

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -500,9 +500,9 @@ impl StoreCipher {
     /// Encrypt a value before it is inserted into the key/value store.
     ///
     /// A value can be decrypted using the
-    /// [`StoreCipher::decrypt_value_typed()`] method. This is the lower
-    /// level function to `encrypt_value`, but returns the
-    /// full `EncryptdValue`-type
+    /// [`StoreCipher::decrypt_value_base64_typed()`] method. This is a lower
+    /// level function to [`StoreCipher::encrypt_value()`], but returns the
+    /// full [`EncryptedValueBase64`] type.
     ///
     /// # Arguments
     ///
@@ -524,8 +524,8 @@ impl StoreCipher {
     ///     "some": "data",
     /// });
     ///
-    /// let encrypted = store_cipher.encrypt_value_typed(&value)?;
-    /// let decrypted: Value = store_cipher.decrypt_value_typed(encrypted)?;
+    /// let encrypted = store_cipher.encrypt_value_base64_typed(&value)?;
+    /// let decrypted: Value = store_cipher.decrypt_value_base64_typed(encrypted)?;
     ///
     /// assert_eq!(value, decrypted);
     /// # anyhow::Ok(()) };

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -460,47 +460,6 @@ impl StoreCipher {
         Ok(EncryptedValue { version: VERSION, ciphertext, nonce })
     }
 
-    /// Encrypt a value before it is inserted into the key/value store.
-    ///
-    /// A value can be decrypted using the
-    /// [`StoreCipher::decrypt_value_base64_typed()`] method. This is a lower
-    /// level function to [`StoreCipher::encrypt_value()`], but returns the
-    /// full [`EncryptedValueBase64`] type.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - A value that should be encrypted, any value that implements
-    ///   `Serialize` can be given to this method. The value will be serialized
-    ///   as json before it is encrypted.
-    ///
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # let example = || {
-    /// use matrix_sdk_store_encryption::StoreCipher;
-    /// use serde_json::{json, value::Value};
-    ///
-    /// let store_cipher = StoreCipher::new()?;
-    ///
-    /// let value = json!({
-    ///     "some": "data",
-    /// });
-    ///
-    /// let encrypted = store_cipher.encrypt_value_base64_typed(&value)?;
-    /// let decrypted: Value = store_cipher.decrypt_value_base64_typed(encrypted)?;
-    ///
-    /// assert_eq!(value, decrypted);
-    /// # anyhow::Ok(()) };
-    /// ```
-    pub fn encrypt_value_base64_typed(
-        &self,
-        value: &impl Serialize,
-    ) -> Result<EncryptedValueBase64, Error> {
-        let data = serde_json::to_vec(value)?;
-        self.encrypt_value_base64_data(data)
-    }
-
     /// Encrypt some data before it is inserted into the key/value store,
     /// using base64 for arrays of integers.
     ///
@@ -567,48 +526,6 @@ impl StoreCipher {
     pub fn decrypt_value<T: DeserializeOwned>(&self, value: &[u8]) -> Result<T, Error> {
         let value: EncryptedValue = serde_json::from_slice(value)?;
         let mut plaintext = self.decrypt_value_data(value)?;
-        let ret = serde_json::from_slice(&plaintext);
-        plaintext.zeroize();
-        Ok(ret?)
-    }
-
-    /// Decrypt a base64-encoded value after it was fetched from the key/value
-    /// store.
-    ///
-    /// A value can be encrypted using the
-    /// [`StoreCipher::encrypt_value_base64_typed()`] method.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The EncryptedValueBase64 of a value that should be
-    ///   decrypted.
-    ///
-    /// The method will deserialize the decrypted value into the expected type.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # let example = || {
-    /// use matrix_sdk_store_encryption::StoreCipher;
-    /// use serde_json::{json, value::Value};
-    ///
-    /// let store_cipher = StoreCipher::new()?;
-    ///
-    /// let value = json!({
-    ///     "some": "data",
-    /// });
-    ///
-    /// let encrypted = store_cipher.encrypt_value_base64_typed(&value)?;
-    /// let decrypted: Value = store_cipher.decrypt_value_base64_typed(encrypted)?;
-    ///
-    /// assert_eq!(value, decrypted);
-    /// # anyhow::Ok(()) };
-    /// ```
-    pub fn decrypt_value_base64_typed<T: DeserializeOwned>(
-        &self,
-        value: EncryptedValueBase64,
-    ) -> Result<T, Error> {
-        let mut plaintext = self.decrypt_value_base64_data(value)?;
         let ret = serde_json::from_slice(&plaintext);
         plaintext.zeroize();
         Ok(ret?)
@@ -1030,8 +947,11 @@ mod tests {
 
         let store_cipher = StoreCipher::new()?;
 
-        let encrypted = store_cipher.encrypt_value_base64_typed(&event)?;
-        let decrypted: Value = store_cipher.decrypt_value_base64_typed(encrypted)?;
+        let data = serde_json::to_vec(&event)?;
+        let encrypted = store_cipher.encrypt_value_base64_data(data)?;
+
+        let plaintext = store_cipher.decrypt_value_base64_data(encrypted)?;
+        let decrypted: Value = serde_json::from_slice(&plaintext)?;
 
         assert_eq!(event, decrypted);
 

--- a/crates/matrix-sdk-store-encryption/src/lib.rs
+++ b/crates/matrix-sdk-store-encryption/src/lib.rs
@@ -683,7 +683,10 @@ impl StoreCipher {
         &self,
         value: EncryptedValueBase64,
     ) -> Result<T, Error> {
-        self.decrypt_value_typed(value.try_into()?)
+        let mut plaintext = self.decrypt_value_base64_data(value)?;
+        let ret = serde_json::from_slice(&plaintext);
+        plaintext.zeroize();
+        Ok(ret?)
     }
 
     /// Decrypt a base64-encoded value after it was fetched from the key/value


### PR DESCRIPTION
`StoreCipher`'s interface has grown *baroque* over the years. These four functions aren't giving a whole lot of value: they are only used in a couple of places in the codebase, and are pretty simple.

This PR is a mission to clean that up.

Review commit-by-commit.