### PR TITLE
feature(crypto): Add support for master key local pinning

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1969,7 +1969,7 @@ pub(crate) mod tests {
         assert!(!first_device.is_cross_signed_by_owner(&identity));
 
         let remember_previous_identity = other_identity.clone();
-        // We receive a new keys update for that user, with no identity anymore
+        // We receive updated keys for that user, with no identity anymore.
         // Notice that there is no server API to delete identity, but we want to test
         // here that a home server cannot clear the identity and serve a new one
         // after that would get automatically approved.

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -1922,8 +1922,8 @@ pub(crate) mod tests {
         let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
         let other_identity = identity.other().unwrap();
 
-        // There should be now an identity and no pin violation (pinned msk is the
-        // current one)
+        // We should now have an identity for the user but no pin violation
+        // (pinned master key is the current one)
         assert!(!other_identity.has_pin_violation());
         let first_device = manager
             .store
@@ -1970,9 +1970,9 @@ pub(crate) mod tests {
 
         let remember_previous_identity = other_identity.clone();
         // We receive updated keys for that user, with no identity anymore.
-        // Notice that there is no server API to delete identity, but we want to test
-        // here that a home server cannot clear the identity and serve a new one
-        // after that would get automatically approved.
+        // Notice that there is no server API to delete identity, but we want to
+        // test here that a home server cannot clear the identity and
+        // subsequently serve a new one which would get automatically approved.
         manager
             .receive_keys_query_response(
                 &TransactionId::new(),
@@ -1989,7 +1989,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn test_manager_resolve_identity_mismatch() {
+    async fn test_manager_resolve_identity_pin_violation() {
         use test_json::keys_query_sets::IdentityChangeDataSet as DataSet;
 
         let manager = manager_test_helper(user_id(), device_id()).await;
@@ -2018,7 +2018,7 @@ pub(crate) mod tests {
         // We have a new identity now, so there should be a pin violation
         assert!(other_identity.has_pin_violation());
 
-        // Resolve the misatch by pinning the new identity
+        // Resolve the violation by pinning the new identity
         other_identity.pin();
 
         assert!(!other_identity.has_pin_violation());

--- a/crates/matrix-sdk-crypto/src/identities/manager.rs
+++ b/crates/matrix-sdk-crypto/src/identities/manager.rs
@@ -512,6 +512,7 @@ impl IdentityManager {
             *changed_private_identity = self.check_private_identity(&identity).await;
             Ok(identity.into())
         } else {
+            // First time seen, create the identity. The current MSK will be pinned.
             let identity = OtherUserIdentityData::new(master_key, self_signing)?;
             Ok(identity.into())
         }
@@ -1338,7 +1339,7 @@ pub(crate) mod tests {
     use std::ops::Deref;
 
     use futures_util::pin_mut;
-    use matrix_sdk_test::{async_test, response_from_file};
+    use matrix_sdk_test::{async_test, response_from_file, test_json};
     use ruma::{
         api::{client::keys::get_keys::v3::Response as KeysQueryResponse, IncomingResponse},
         device_id, user_id, TransactionId,
@@ -1896,5 +1897,130 @@ pub(crate) mod tests {
         assert_eq!(devices.devices().count(), 1);
 
         manager.store.get_device_data(other_user, device_id!("OBEBOSKTBE")).await.unwrap().unwrap();
+    }
+
+    #[async_test]
+    async fn test_manager_identity_updates() {
+        use test_json::keys_query_sets::IdentityChangeDataSet as DataSet;
+
+        let manager = manager_test_helper(user_id(), device_id()).await;
+        let other_user = DataSet::user_id();
+        let devices = manager.store.get_user_devices(other_user).await.unwrap();
+        assert_eq!(devices.devices().count(), 0);
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap();
+        assert!(identity.is_none());
+
+        manager
+            .receive_keys_query_response(
+                &TransactionId::new(),
+                &DataSet::key_query_with_identity_a(),
+            )
+            .await
+            .unwrap();
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
+        let other_identity = identity.other().unwrap();
+
+        // There should be now an identity and no pin violation (pinned msk is the
+        // current one)
+        assert!(!other_identity.has_pin_violation());
+        let first_device = manager
+            .store
+            .get_device_data(other_user, DataSet::first_device_id())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(first_device.is_cross_signed_by_owner(&identity));
+
+        // We receive a new keys update for that user, with a new identity
+        manager
+            .receive_keys_query_response(
+                &TransactionId::new(),
+                &DataSet::key_query_with_identity_b(),
+            )
+            .await
+            .unwrap();
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
+        let other_identity = identity.other().unwrap();
+
+        // The previous known identity has been replaced, there should be a pin
+        // violation
+        assert!(other_identity.has_pin_violation());
+
+        let second_device = manager
+            .store
+            .get_device_data(other_user, DataSet::second_device_id())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // There is a new device signed by the new identity
+        assert!(second_device.is_cross_signed_by_owner(&identity));
+
+        // The first device should not be signed by the new identity
+        let first_device = manager
+            .store
+            .get_device_data(other_user, DataSet::first_device_id())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!first_device.is_cross_signed_by_owner(&identity));
+
+        let remember_previous_identity = other_identity.clone();
+        // We receive a new keys update for that user, with no identity anymore
+        // Notice that there is no server API to delete identity, but we want to test
+        // here that a home server cannot clear the identity and serve a new one
+        // after that would get automatically approved.
+        manager
+            .receive_keys_query_response(
+                &TransactionId::new(),
+                &DataSet::key_query_with_identity_no_identity(),
+            )
+            .await
+            .unwrap();
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
+        let other_identity = identity.other().unwrap();
+
+        assert_eq!(other_identity, &remember_previous_identity);
+        assert!(other_identity.has_pin_violation());
+    }
+
+    #[async_test]
+    async fn test_manager_resolve_identity_mismatch() {
+        use test_json::keys_query_sets::IdentityChangeDataSet as DataSet;
+
+        let manager = manager_test_helper(user_id(), device_id()).await;
+        let other_user = DataSet::user_id();
+
+        manager
+            .receive_keys_query_response(
+                &TransactionId::new(),
+                &DataSet::key_query_with_identity_a(),
+            )
+            .await
+            .unwrap();
+
+        // We receive a new keys update for that user, with a new identity
+        manager
+            .receive_keys_query_response(
+                &TransactionId::new(),
+                &DataSet::key_query_with_identity_b(),
+            )
+            .await
+            .unwrap();
+
+        let identity = manager.store.get_user_identity(other_user).await.unwrap().unwrap();
+        let other_identity = identity.other().unwrap();
+
+        // We have a new identity now, so there should be a pin violation
+        assert!(other_identity.has_pin_violation());
+
+        // Resolve the misatch by pinning the new identity
+        other_identity.pin();
+
+        assert!(!other_identity.has_pin_violation());
     }
 }

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -612,7 +612,10 @@ impl OtherUserIdentityData {
     ) -> Result<bool, SignatureError> {
         master_key.verify_subkey(&self_signing_key)?;
 
-        // The pin is maintained.
+        // We update the identity with the new master and self signing key, but we keep
+        // the previous pinned master key.
+        // This identity will have a pin violation until the new master key is pinned
+        // (see [`has_pin_violation`]).
         let pinned_master_key = self.pinned_master_key.read().unwrap().clone();
 
         let new = Self {

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -467,7 +467,7 @@ impl TryFrom<ReadOnlyUserIdentitySerializer> for OtherUserIdentityData {
                     master_key: Arc::new(v0.master_key.clone()),
                     self_signing_key: Arc::new(v0.self_signing_key),
                     // We migrate by pinning the current master key
-                    pinned_master_key: Arc::new(RwLock::new(v0.master_key.clone())),
+                    pinned_master_key: Arc::new(RwLock::new(v0.master_key)),
                 })
             }
             Some(v) if v == "1" => {

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1225,7 +1225,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn resolve_identity_mismacth_with_verification() {
+    async fn resolve_identity_mismatch_with_verification() {
         use test_json::keys_query_sets::IdentityChangeDataSet as DataSet;
 
         let my_user_id = user_id!("@me:localhost");

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -309,14 +309,17 @@ impl UserIdentity {
         Ok(())
     }
 
+    /// Returns true if the identity is not verified and did change since the
+    /// last time we pinned it.
+    ///
     /// An identity mismatch is detected when there is a trust problem with the
     /// user identity. There is an identity mismatch if the current identity
     /// is not verified and there is a pinning violation. An identity
     /// mismatch must be reported to the user, and can be resolved by:
     /// - Verifying the new identity (see
     ///   [`UserIdentity::request_verification`])
-    /// - Or by updating the pinned key
-    ///   ([`UserIdentity::pin_current_master_key`]).
+    /// - Or by updating the pinned key (see
+    ///   [`UserIdentity::pin_current_master_key`]).
     pub fn has_identity_mismatch(&self) -> bool {
         // First check if the current identity is verified.
         if self.is_verified() {
@@ -577,6 +580,8 @@ impl OtherUserIdentityData {
         *m = self.master_key.as_ref().clone()
     }
 
+    /// Returns true if the identity has changed since we last pinned it.
+    ///
     /// Key pinning acts as a trust on first use mechanism, the first time an
     /// identity is known for a user it will be pinned.
     /// For future interaction with a user, the identity is expected to be the

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -615,7 +615,7 @@ impl OtherUserIdentityData {
         // We update the identity with the new master and self signing key, but we keep
         // the previous pinned master key.
         // This identity will have a pin violation until the new master key is pinned
-        // (see [`has_pin_violation`]).
+        // (see `has_pin_violation()`).
         let pinned_master_key = self.pinned_master_key.read().unwrap().clone();
 
         let new = Self {

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -297,7 +297,7 @@ impl UserIdentity {
         )
     }
 
-    /// Pin the current identity (Master public key).
+    /// Pin the current identity (public part of the master signing key).
     pub async fn pin_current_master_key(&self) -> Result<(), CryptoStoreError> {
         self.inner.pin();
         let to_save = UserIdentityData::Other(self.inner.clone());
@@ -309,18 +309,21 @@ impl UserIdentity {
         Ok(())
     }
 
-    /// Returns true if the identity is not verified and did change since the
-    /// last time we pinned it.
+    /// Did the identity change after an initial observation in a way that
+    /// requires approval from the user?
     ///
-    /// An identity mismatch is detected when there is a trust problem with the
-    /// user identity. There is an identity mismatch if the current identity
-    /// is not verified and there is a pinning violation. An identity
-    /// mismatch must be reported to the user, and can be resolved by:
-    /// - Verifying the new identity (see
-    ///   [`UserIdentity::request_verification`])
-    /// - Or by updating the pinned key (see
-    ///   [`UserIdentity::pin_current_master_key`]).
-    pub fn has_identity_mismatch(&self) -> bool {
+    /// A user identity needs approval if it changed after the crypto machine
+    /// has already observed ("pinned") a different identity for that user *and*
+    /// it is not an explicitly verified identity (using for example interactive
+    /// verification).
+    ///
+    /// Such a change is to be considered a pinning violation which the
+    /// application should report to the local user, and can be resolved by:
+    ///
+    /// - Verifying the new identity with [`UserIdentity::request_verification`]
+    /// - Or by updating the pin to the new identity with
+    ///   [`UserIdentity::pin_current_master_key`].
+    pub fn identity_needs_user_approval(&self) -> bool {
         // First check if the current identity is verified.
         if self.is_verified() {
             return false;
@@ -411,13 +414,16 @@ impl UserIdentityData {
 /// only contain a master key and a self signing key, meaning that only device
 /// signatures can be checked with this identity.
 ///
-/// This struct also contains the currently pinned master key for that user.
-/// The first time a cryptographic identity is seen for a given user, it
-/// will be associated to that user (i.e. pinned). Future interactions
-/// will expect this user crypto identity to stay the same,
-/// this will help prevent some MITM attacks.
-/// In case of identity change, it will be possible to pin the new identity
-/// is the user wants.
+/// This struct also contains the currently pinned user identity (public master
+/// key) for that user.
+///
+/// The first time a cryptographic user identity is seen for a given user, it
+/// will be associated with that user ("pinned"). Future interactions
+/// will expect this identity to stay the same, to avoid MITM attacks from the
+/// homeserver.
+///
+/// The user can explicitly pin the new identity to allow for legitimate
+/// identity changes (for example, in case of key material or device loss).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(try_from = "OtherUserIdentityDataSerializer", into = "OtherUserIdentityDataSerializer")]
 pub struct OtherUserIdentityData {
@@ -429,8 +435,9 @@ pub struct OtherUserIdentityData {
 
 /// Intermediate struct to help serialize OtherUserIdentityData and support
 /// versioning and migration.
+///
 /// Version v1 is adding support for identity pinning (`pinned_master_key`), as
-/// part of migration we just pin the currently known master key.
+/// part of migration we just pin the currently known public master key.
 #[derive(Deserialize, Serialize)]
 struct OtherUserIdentityDataSerializer {
     version: Option<String>,
@@ -1233,7 +1240,7 @@ pub(crate) mod tests {
     }
 
     #[async_test]
-    async fn resolve_identity_mismatch_with_verification() {
+    async fn resolve_identity_pin_violation_with_verification() {
         use test_json::keys_query_sets::IdentityChangeDataSet as DataSet;
 
         let my_user_id = user_id!("@me:localhost");
@@ -1243,12 +1250,11 @@ pub(crate) mod tests {
         let my_id = machine.get_identity(my_user_id, None).await.unwrap().unwrap().own().unwrap();
         let usk_key_id = my_id.inner.user_signing_key().keys().iter().next().unwrap().0;
 
-        println!("USK ID: {}", usk_key_id);
         let keys_query = DataSet::key_query_with_identity_a();
         let txn_id = TransactionId::new();
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
 
-        // Simulate an identity hange
+        // Simulate an identity change
         let keys_query = DataSet::key_query_with_identity_b();
         let txn_id = TransactionId::new();
         machine.mark_request_as_sent(&txn_id, &keys_query).await.unwrap();
@@ -1258,8 +1264,8 @@ pub(crate) mod tests {
         let other_identity =
             machine.get_identity(other_user_id, None).await.unwrap().unwrap().other().unwrap();
 
-        // There should be an identity mismatch
-        assert!(other_identity.has_identity_mismatch());
+        // The identity should need user approval now
+        assert!(other_identity.identity_needs_user_approval());
 
         // Manually verify for the purpose of this test
         let sig_upload = other_identity.verify().await.unwrap();
@@ -1294,10 +1300,10 @@ pub(crate) mod tests {
             .expect("Can't parse the `/keys/upload` response");
         machine.mark_request_as_sent(&TransactionId::new(), &kq_response).await.unwrap();
 
-        // There should not be an identity mismatch anymore
+        // The identity should not need any user approval now
         let other_identity =
             machine.get_identity(other_user_id, None).await.unwrap().unwrap().other().unwrap();
-        assert!(!other_identity.has_identity_mismatch());
+        assert!(!other_identity.identity_needs_user_approval());
         // But there is still a pin violation
         assert!(other_identity.inner.has_pin_violation());
     }

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -616,7 +616,8 @@ impl IdentityChangeDataSet {
         })
     }
     /// A key query with a new identity (Ib) and a new device `ATWKQFSFRN`.
-    /// `ATWKQFSFRN` is signed with the new identity but
+    /// `ATWKQFSFRN` is signed with the new identity but `GYKSNAWLVK` is still
+    /// signed by the old identity (Ia).
     pub fn key_query_with_identity_b() -> KeyQueryResponse {
         let data = response_from_file(&json!({
             "device_keys": {
@@ -633,8 +634,8 @@ impl IdentityChangeDataSet {
             .expect("Can't parse the `/keys/upload` response")
     }
 
-    /// A key query with a new identity (Ib) and a new device `ATWKQFSFRN`.
-    /// `ATWKQFSFRN` is signed with the new identity but
+    /// A key query with no identity and a new device `OPABMDDXGX` (not
+    /// cross-signed).
     pub fn key_query_with_identity_no_identity() -> KeyQueryResponse {
         let data = response_from_file(&json!({
             "device_keys": {
@@ -657,9 +658,6 @@ impl IdentityChangeDataSet {
                             }
                         },
                         "user_id": "@bob:localhost",
-                        "unsigned": {
-                            "device_display_name": "develop.element.io: Chrome on macOS"
-                        }
                     }
                 }
             },

--- a/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
+++ b/testing/matrix-sdk-test/src/test_json/keys_query_sets.rs
@@ -2,7 +2,7 @@ use ruma::{
     api::{client::keys::get_keys::v3::Response as KeyQueryResponse, IncomingResponse},
     device_id, user_id, DeviceId, UserId,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 
 use crate::response_from_file;
 
@@ -105,7 +105,7 @@ impl KeyDistributionTestData {
     /// but not the other one `FRGNMZVOKA`.
     /// `@dan` identity is signed by `@me` identity (alice trust dan)
     pub fn dan_keys_query_response() -> KeyQueryResponse {
-        let data: serde_json::Value = json!({
+        let data: Value = json!({
                 "device_keys": {
                     "@dan:localhost": {
                         "JHPUERYQUW": {
@@ -455,5 +455,217 @@ impl KeyDistributionTestData {
 
     pub fn good_id() -> &'static UserId {
         user_id!("@good:localhost")
+    }
+}
+
+/// A set of keys query to test identity changes,
+/// For user @bob, several payloads with no identities then identity A and B.
+pub struct IdentityChangeDataSet {}
+
+#[allow(dead_code)]
+impl IdentityChangeDataSet {
+    pub fn user_id() -> &'static UserId {
+        user_id!("@bob:localhost")
+    }
+
+    pub fn first_device_id() -> &'static DeviceId {
+        device_id!("GYKSNAWLVK")
+    }
+
+    pub fn second_device_id() -> &'static DeviceId {
+        device_id!("ATWKQFSFRN")
+    }
+
+    pub fn third_device_id() -> &'static DeviceId {
+        device_id!("OPABMDDXGX")
+    }
+
+    fn device_keys_payload_1_signed_by_a() -> Value {
+        json!({
+            "algorithms": [
+                "m.olm.v1.curve25519-aes-sha2",
+                "m.megolm.v1.aes-sha2"
+            ],
+            "device_id": "GYKSNAWLVK",
+            "keys": {
+                "curve25519:GYKSNAWLVK": "dBcZBzQaiQYWf6rBPh2QypIOB/dxSoTeyaFaxNNbeHs",
+                "ed25519:GYKSNAWLVK": "6melQNnhoI9sT2b4VzNPAwa8aB179ym45fON8Yo7kVk"
+            },
+            "signatures": {
+                "@bob:localhost": {
+                    "ed25519:GYKSNAWLVK": "Fk45zHAbrd+1j9wZXLjL2Y/+DU/Mnz9yuvlfYBOOT7qExN2Jdud+5BAuNs8nZ/caS4wTF39Kg3zQpzaGERoCBg",
+                    "ed25519:dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw": "md0Pa1MYlneFb1fp6KCsvZpi2ySb6/G+ULoCbQDWBeDxNEcoNMzf7PEKY04UToCZKUU4LifvRWmiWFDanOlkCQ"
+                }
+            },
+            "user_id": "@bob:localhost",
+        })
+    }
+
+    fn msk_a() -> Value {
+        json!({
+            "@bob:localhost": {
+                "keys": {
+                    "ed25519:/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY": "/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY"
+                },
+                "signatures": {
+                    "@bob:localhost": {
+                        "ed25519:/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY": "6vGDbPO5XzlcwbU3aV+kcck+iHHEBtX85ow2gW5U05/DZdtda/JNVa5Nn7B9lQHNnnrMqt1sX00y/JrIkSS1Aw",
+                        "ed25519:GYKSNAWLVK": "jLxmUPr0Ny2Ai9+NGKGhed9BAuKikOc7r6gr7MQVawePYS95w8NJ8Tzaq9zFFOmIiojACNdQ/ksy3QAdwD6vBQ"
+                    }
+                },
+                "usage": [
+                    "master"
+                ],
+                "user_id": "@bob:localhost"
+            }
+        })
+    }
+    fn ssk_a() -> Value {
+        json!({
+            "@bob:localhost": {
+                "keys": {
+                    "ed25519:dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw": "dO4gmBNW7WC0bXBK81j8uh4me6085fP+keoOm0pH3gw"
+                },
+                "signatures": {
+                    "@bob:localhost": {
+                        "ed25519:/mULSzYNTdHJOBWnBmsvDHhqdHQcWnXRHHmqwzwC7DY": "7md6mwjUK8zjintmffJ0+kImC59/Y8PdySy99EZz5Neu+VMX3LT7txhKO2gC/hmDduRw+JGfGXIiDxR7GmQqDw"
+                    }
+                },
+                "usage": [
+                    "self_signing"
+                ],
+                "user_id": "@bob:localhost"
+            }
+        })
+    }
+    /// A key query with an identity (Ia), and a first device `GYKSNAWLVK`
+    /// signed by Ia.
+    pub fn key_query_with_identity_a() -> KeyQueryResponse {
+        let data = response_from_file(&json!({
+            "device_keys": {
+                "@bob:localhost": {
+                    "GYKSNAWLVK": Self::device_keys_payload_1_signed_by_a()
+                }
+            },
+            "failures": {},
+            "master_keys": Self::msk_a(),
+            "self_signing_keys": Self::ssk_a(),
+            "user_signing_keys": {}
+        }));
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    pub fn msk_b() -> Value {
+        json!({
+            "@bob:localhost": {
+                "keys": {
+                    "ed25519:NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4": "NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4"
+                },
+                "signatures": {
+                    "@bob:localhost": {
+                        "ed25519:ATWKQFSFRN": "MBOzCKYPQLQMpBY2lFZJ4c8451xJfQCdhPBb1AHlTUSxKFiWi6V+k1oRRnhQein/PjkIY7ZO+HoOrIeOtbRMAw",
+                        "ed25519:NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4": "xqLhC3sIUci1W2CNVW7HZWXreQApgjv2RDwB0WPiMd1P4vbZ/qJM0KWqK2piGPWliPi8YVREMrg216KXM3IhCA"
+                    }
+                },
+                "usage": [
+                    "master"
+                ],
+                "user_id": "@bob:localhost"
+            }
+        })
+    }
+
+    pub fn ssk_b() -> Value {
+        json!({
+            "@bob:localhost": {
+                "keys": {
+                    "ed25519:At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc": "At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc"
+                },
+                "signatures": {
+                    "@bob:localhost": {
+                        "ed25519:NmI78hY54kE7OZsIjbRE/iCox59t4nzScCNEO6fvtY4": "Ls6CeoA4LoPCHuSwG96kbhd1dEV09TgdMROIZi6vFz/MT9Wtik6joQi/tQ3zCwIZCSR53ksLO4jG1DD31AiBAA"
+                    }
+                },
+                "usage": [
+                    "self_signing"
+                ],
+                "user_id": "@bob:localhost"
+            }
+        })
+    }
+
+    pub fn device_keys_payload_2_signed_by_b() -> Value {
+        json!({
+            "algorithms": [
+                "m.olm.v1.curve25519-aes-sha2",
+                "m.megolm.v1.aes-sha2"
+            ],
+            "device_id": "ATWKQFSFRN",
+            "keys": {
+                "curve25519:ATWKQFSFRN": "CY0TWVK1/Kj3ZADuBcGe3UKvpT+IKAPMUsMeJhSDqno",
+                "ed25519:ATWKQFSFRN": "TyTQqd6j2JlWZh97r+kTYuCbvqnPoNwO6EGovYsjY00"
+            },
+            "signatures": {
+                "@bob:localhost": {
+                    "ed25519:ATWKQFSFRN": "BQ9Gp0p+6srF+c8OyruqKKd9R4yaub3THYAyyBB/7X/rG8BwcAqFynzl1aGyFYun4Q+087a5OSiglCXI+/kQAA",
+                    "ed25519:At1ai1VUZrCncCI7V7fEAJmBShfpqZ30xRzqcEjTjdc": "TWmDPaG7t0rZ6luauonELD3dmBDTIRryqXhgsIQRiGint2rJdic8RVyZ6a61bgu6mtBjfvU3prqMNp6sVi16Cg"
+                }
+            },
+            "user_id": "@bob:localhost",
+        })
+    }
+    /// A key query with a new identity (Ib) and a new device `ATWKQFSFRN`.
+    /// `ATWKQFSFRN` is signed with the new identity but
+    pub fn key_query_with_identity_b() -> KeyQueryResponse {
+        let data = response_from_file(&json!({
+            "device_keys": {
+                "@bob:localhost": {
+                    "ATWKQFSFRN": Self::device_keys_payload_2_signed_by_b(),
+                    "GYKSNAWLVK": Self::device_keys_payload_1_signed_by_a(),
+                }
+            },
+            "failures": {},
+            "master_keys": Self::msk_b(),
+            "self_signing_keys": Self::ssk_b(),
+        }));
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
+    }
+
+    /// A key query with a new identity (Ib) and a new device `ATWKQFSFRN`.
+    /// `ATWKQFSFRN` is signed with the new identity but
+    pub fn key_query_with_identity_no_identity() -> KeyQueryResponse {
+        let data = response_from_file(&json!({
+            "device_keys": {
+                "@bob:localhost": {
+                    "ATWKQFSFRN": Self::device_keys_payload_2_signed_by_b(),
+                    "GYKSNAWLVK": Self::device_keys_payload_1_signed_by_a(),
+                    "OPABMDDXGX": {
+                        "algorithms": [
+                            "m.olm.v1.curve25519-aes-sha2",
+                            "m.megolm.v1.aes-sha2"
+                        ],
+                        "device_id": "OPABMDDXGX",
+                        "keys": {
+                            "curve25519:OPABMDDXGX": "O6bwa9Op0E+PQPCrbTOfdYwU+j95RRPhXIHuNpe94ns",
+                            "ed25519:OPABMDDXGX": "DvjkSNOM9XrR1gWrr2YSDvTnwnLIgKDMRr5v8HgMKak"
+                        },
+                        "signatures": {
+                            "@bob:localhost": {
+                                "ed25519:OPABMDDXGX": "o+BBnw/SIJWxSf799Adq6jEl9X3lwCg5MJkS8GlfId+pW3ReEETK0l+9bhCAgBsNSKRtB/fmZQBhjMx4FJr+BA"
+                            }
+                        },
+                        "user_id": "@bob:localhost",
+                        "unsigned": {
+                            "device_display_name": "develop.element.io: Chrome on macOS"
+                        }
+                    }
+                }
+            },
+            "failures": {},
+        }));
+        KeyQueryResponse::try_from_http_response(data)
+            .expect("Can't parse the `/keys/upload` response")
     }
 }


### PR DESCRIPTION
<!-- description of the changes in this PR -->
part of invisible crypto, follow up of https://github.com/matrix-org/matrix-rust-sdk/pull/3607
Alternative fix for  https://github.com/matrix-org/matrix-rust-sdk/issues/3564
Alternative PR https://github.com/matrix-org/matrix-rust-sdk/pull/3610

Add the capability to locally pin a public MSK for a `ReadOnlyUserIdentity`. 
The first time an identity is seen for a user, the msk is pinned. Pin violation will be reported when an identity is rotated.

This PR only adds support for pinning, support for serialization/migration, persistance. 
This could be used later by other PRs to report specific errors or show pinning violation to users.

Note about verification and pinning.
As part of this PR, if a new identity is detected it will still be seen as a pinning violation even if the new identity is signed by our usk. But the `UserIdentity::has_identity_mismatch()` will be ok. There is a pinning violation, but the new identity is verified and verification has priority. 
That is to say that there is no auto-pinning if verified so far. To be discussed if we want it later


- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
