### PR TITLE
integration tests: make randomize_username() the default

### DIFF
--- a/testing/matrix-sdk-integration-testing/src/helpers.rs
+++ b/testing/matrix-sdk-integration-testing/src/helpers.rs
@@ -40,19 +40,19 @@ pub struct TestClientBuilder {
 }
 
 impl TestClientBuilder {
-    pub fn new(username: impl Into<String>) -> Self {
+    pub fn new(username: impl AsRef<str>) -> Self {
+        let suffix: u128 = rand::thread_rng().gen();
+        let randomized_username = format!("{}{}", username.as_ref(), suffix);
+        Self::with_exact_username(randomized_username)
+    }
+
+    pub fn with_exact_username(username: String) -> Self {
         Self {
-            username: username.into(),
+            username,
             use_sqlite_dir: None,
             encryption_settings: Default::default(),
             http_proxy: None,
         }
-    }
-
-    pub fn randomize_username(mut self) -> Self {
-        let suffix: u128 = rand::thread_rng().gen();
-        self.username = format!("{}{}", self.username, suffix);
-        self
     }
 
     pub fn use_sqlite(mut self) -> Self {

--- a/testing/matrix-sdk-integration-testing/src/tests/auth.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/auth.rs
@@ -5,7 +5,7 @@ use crate::helpers::TestClientBuilder;
 #[tokio::test(flavor = "multi_thread")]
 async fn register_login_is_one_device() -> Result<()> {
     // registers a fresh client and makes sure we are logged in
-    let client = TestClientBuilder::new("alice").randomize_username().use_sqlite().build().await?;
+    let client = TestClientBuilder::new("alice").use_sqlite().build().await?;
     let devices = client.devices().await?.devices;
     assert_eq!(devices.len(), 1);
     Ok(())

--- a/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/e2ee.rs
@@ -38,7 +38,6 @@ async fn test_mutual_sas_verification() -> Result<()> {
         EncryptionSettings { auto_enable_cross_signing: true, ..Default::default() };
     let alice = SyncTokenAwareClient::new(
         TestClientBuilder::new("alice")
-            .randomize_username()
             .use_sqlite()
             .encryption_settings(encryption_settings)
             .build()
@@ -46,7 +45,6 @@ async fn test_mutual_sas_verification() -> Result<()> {
     );
     let bob = SyncTokenAwareClient::new(
         TestClientBuilder::new("bob")
-            .randomize_username()
             .use_sqlite()
             .encryption_settings(encryption_settings)
             .build()
@@ -301,7 +299,6 @@ async fn test_mutual_qrcode_verification() -> Result<()> {
         EncryptionSettings { auto_enable_cross_signing: true, ..Default::default() };
     let alice = SyncTokenAwareClient::new(
         TestClientBuilder::new("alice")
-            .randomize_username()
             .use_sqlite()
             .encryption_settings(encryption_settings)
             .build()
@@ -309,7 +306,6 @@ async fn test_mutual_qrcode_verification() -> Result<()> {
     );
     let bob = SyncTokenAwareClient::new(
         TestClientBuilder::new("bob")
-            .randomize_username()
             .use_sqlite()
             .encryption_settings(encryption_settings)
             .build()
@@ -538,12 +534,9 @@ async fn test_mutual_qrcode_verification() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_encryption_missing_member_keys() -> Result<()> {
-    let alice = SyncTokenAwareClient::new(
-        TestClientBuilder::new("alice").randomize_username().use_sqlite().build().await?,
-    );
-    let bob = SyncTokenAwareClient::new(
-        TestClientBuilder::new("bob").randomize_username().use_sqlite().build().await?,
-    );
+    let alice =
+        SyncTokenAwareClient::new(TestClientBuilder::new("alice").use_sqlite().build().await?);
+    let bob = SyncTokenAwareClient::new(TestClientBuilder::new("bob").use_sqlite().build().await?);
 
     let invite = vec![bob.user_id().unwrap().to_owned()];
     let request = assign!(CreateRoomRequest::new(), {
@@ -563,9 +556,8 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
     warn!("bob has joined");
 
     // New person joins the room.
-    let carl = SyncTokenAwareClient::new(
-        TestClientBuilder::new("carl").randomize_username().use_sqlite().build().await?,
-    );
+    let carl =
+        SyncTokenAwareClient::new(TestClientBuilder::new("carl").use_sqlite().build().await?);
     alice_room.invite_user_by_id(carl.user_id().unwrap()).await?;
 
     carl.sync_once().await?;
@@ -660,12 +652,9 @@ async fn test_encryption_missing_member_keys() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_failed_members_response() -> Result<()> {
-    let alice = SyncTokenAwareClient::new(
-        TestClientBuilder::new("alice").randomize_username().use_sqlite().build().await?,
-    );
-    let bob = SyncTokenAwareClient::new(
-        TestClientBuilder::new("bob").randomize_username().use_sqlite().build().await?,
-    );
+    let alice =
+        SyncTokenAwareClient::new(TestClientBuilder::new("alice").use_sqlite().build().await?);
+    let bob = SyncTokenAwareClient::new(TestClientBuilder::new("bob").use_sqlite().build().await?);
 
     let invite = vec![bob.user_id().unwrap().to_owned()];
     let request = assign!(CreateRoomRequest::new(), {
@@ -730,7 +719,6 @@ async fn test_backup_enable_new_user() -> Result<()> {
 
     let alice = SyncTokenAwareClient::new(
         TestClientBuilder::new("alice")
-            .randomize_username()
             .use_sqlite()
             .encryption_settings(encryption_settings)
             .build()
@@ -760,7 +748,6 @@ async fn test_cross_signing_bootstrap() -> Result<()> {
 
     let alice = SyncTokenAwareClient::new(
         TestClientBuilder::new("alice")
-            .randomize_username()
             .use_sqlite()
             .encryption_settings(encryption_settings)
             .build()
@@ -801,7 +788,6 @@ async fn test_secret_gossip_after_interactive_verification() -> Result<()> {
 
     let first_client = SyncTokenAwareClient::new(
         TestClientBuilder::new("alice_gossip_test")
-            .randomize_username()
             .encryption_settings(encryption_settings)
             .build()
             .await?,
@@ -827,7 +813,7 @@ async fn test_secret_gossip_after_interactive_verification() -> Result<()> {
     warn!("The first device has created and enabled encryption in the room and sent an event");
 
     let second_client = SyncTokenAwareClient::new(
-        TestClientBuilder::new(user_id.localpart())
+        TestClientBuilder::with_exact_username(user_id.localpart().to_owned())
             .encryption_settings(encryption_settings)
             .build()
             .await?,

--- a/testing/matrix-sdk-integration-testing/src/tests/invitations.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/invitations.rs
@@ -8,8 +8,8 @@ use crate::helpers::TestClientBuilder;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_invitation_details() -> Result<()> {
-    let tamatoa = TestClientBuilder::new("tamatoa".to_owned()).use_sqlite().build().await?;
-    let sebastian = TestClientBuilder::new("sebastian".to_owned()).use_sqlite().build().await?;
+    let tamatoa = TestClientBuilder::new("tamatoa").use_sqlite().build().await?;
+    let sebastian = TestClientBuilder::new("sebastian").use_sqlite().build().await?;
 
     let invite = vec![sebastian.user_id().expect("sebastian has a userid!").to_owned()];
     // create a room and invite sebastian;

--- a/testing/matrix-sdk-integration-testing/src/tests/nse.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/nse.rs
@@ -133,7 +133,7 @@ impl ClientWrapper {
         sqlite_dir: Option<&Path>,
         app_identifier: Option<String>,
     ) -> Self {
-        let builder = TestClientBuilder::new(username).randomize_username();
+        let builder = TestClientBuilder::new(username);
 
         let builder = if let Some(sqlite_dir) = sqlite_dir {
             builder.use_sqlite_dir(sqlite_dir)

--- a/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/reactions.rs
@@ -39,11 +39,7 @@ use crate::helpers::TestClientBuilder;
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_toggling_reaction() -> Result<()> {
     // Set up sync for user Alice, and create a room.
-    let alice = TestClientBuilder::new("alice".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
 
     let alice_clone = alice.clone();
     let alice_sync = spawn(async move {

--- a/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/redaction.rs
@@ -27,7 +27,7 @@ async fn sync_once(client: &Client, sync_token: Option<String>) -> Result<String
 #[ignore = "Broken since synapse update, see #1069"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_redacting_name() -> Result<()> {
-    let tamatoa = TestClientBuilder::new("tamatoa".to_owned()).use_sqlite().build().await?;
+    let tamatoa = TestClientBuilder::new("tamatoa").use_sqlite().build().await?;
     // create a room
     let request = assign!(CreateRoomRequest::new(), {
         is_direct: true,
@@ -99,7 +99,7 @@ async fn test_redacting_name() -> Result<()> {
 #[ignore = "Broken since synapse update, see #1069"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_redacting_name_static() -> Result<()> {
-    let tamatoa = TestClientBuilder::new("tamatoa".to_owned()).use_sqlite().build().await?;
+    let tamatoa = TestClientBuilder::new("tamatoa").use_sqlite().build().await?;
     // create a room
     let request = assign!(CreateRoomRequest::new(), {
         is_direct: true,

--- a/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/repeated_join.rs
@@ -16,9 +16,9 @@ use crate::helpers::TestClientBuilder;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_repeated_join_leave() -> Result<()> {
-    let peter = TestClientBuilder::new("peter".to_owned()).use_sqlite().build().await?;
+    let peter = TestClientBuilder::new("peter").use_sqlite().build().await?;
     // FIXME: Run once with memory, once with SQLite
-    let karl = TestClientBuilder::new("karl".to_owned()).build().await?;
+    let karl = TestClientBuilder::new("karl").build().await?;
     let karl_id = karl.user_id().expect("karl has a userid!").to_owned();
 
     // Create a room and invite karl.

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -20,8 +20,7 @@ use crate::helpers::TestClientBuilder;
 
 #[tokio::test]
 async fn test_event_with_context() -> Result<()> {
-    let bob =
-        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
     // Spawn sync for bob.
     let b = bob.clone();
@@ -34,11 +33,7 @@ async fn test_event_with_context() -> Result<()> {
         }
     });
 
-    let alice = TestClientBuilder::new("alice".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
 
     // Spawn sync for alice too.
     let a = alice.clone();

--- a/testing/matrix-sdk-integration-testing/src/tests/room_directory_search.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room_directory_search.rs
@@ -32,7 +32,7 @@ use crate::helpers::TestClientBuilder;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_room_directory_search_filter() -> Result<()> {
-    let alice = TestClientBuilder::new("alice".to_owned()).use_sqlite().build().await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
     let search_string = random_string(32);
     for index in 0..25 {
         let mut request: CreateRoomRequest = CreateRoomRequest::new();

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/notification_client.rs
@@ -31,8 +31,8 @@ use crate::helpers::TestClientBuilder;
 async fn test_notification() -> Result<()> {
     // Create new users for each test run, to avoid conflicts with invites existing
     // from previous runs.
-    let alice = TestClientBuilder::new("alice").randomize_username().use_sqlite().build().await?;
-    let bob = TestClientBuilder::new("bob").randomize_username().use_sqlite().build().await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
     let dummy_sync_service = Arc::new(SyncService::builder(bob.clone()).build().await?);
     let process_setup =

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -53,16 +53,8 @@ use crate::helpers::TestClientBuilder;
 
 #[tokio::test]
 async fn test_left_room() -> Result<()> {
-    let peter = TestClientBuilder::new("peter".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
-    let steven = TestClientBuilder::new("steven".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
+    let peter = TestClientBuilder::new("peter").use_sqlite().build().await?;
+    let steven = TestClientBuilder::new("steven").use_sqlite().build().await?;
 
     // Set up sliding sync for Peter.
     let sliding_peter = peter
@@ -139,18 +131,9 @@ async fn test_left_room() -> Result<()> {
 
 #[tokio::test]
 async fn test_room_avatar_group_conversation() -> Result<()> {
-    let alice = TestClientBuilder::new("alice".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
-    let bob =
-        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
-    let celine = TestClientBuilder::new("celine".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
+    let celine = TestClientBuilder::new("celine").use_sqlite().build().await?;
 
     // Bob and Celine set their avatars.
     bob.account().set_avatar_url(Some(mxc_uri!("mxc://localhost/bob"))).await?;
@@ -248,14 +231,9 @@ async fn test_joined_user_can_create_push_context_with_room_list_service() -> Re
     // send a message, and fake a new "device" by creating another client for
     // the same user.
 
-    let bob =
-        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
-    let alice = TestClientBuilder::new("alice".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
 
     // Set up regular sync for Alice to start with.
     let a = alice.clone();
@@ -387,8 +365,7 @@ impl UpdateObserver {
 async fn test_room_notification_count() -> Result<()> {
     use tokio::time::timeout;
 
-    let bob =
-        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
     // Spawn sync for bob.
     let b = bob.clone();
@@ -402,11 +379,7 @@ async fn test_room_notification_count() -> Result<()> {
     });
 
     // Set up sliding sync for alice.
-    let alice = TestClientBuilder::new("alice".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
 
     spawn({
         let sync = alice
@@ -755,14 +728,9 @@ async fn test_delayed_decryption_latest_event() -> Result<()> {
 
     server.register(Mock::given(AnyMatcher).respond_with(&**CUSTOM_RESPONDER)).await;
 
-    let alice = TestClientBuilder::new("alice".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .http_proxy(server.uri())
-        .build()
-        .await?;
-    let bob =
-        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+    let alice =
+        TestClientBuilder::new("alice").use_sqlite().http_proxy(server.uri()).build().await?;
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
     let alice_sync_service = SyncService::builder(alice.clone()).build().await.unwrap();
     alice_sync_service.start().await;
@@ -883,13 +851,8 @@ async fn test_delayed_decryption_latest_event() -> Result<()> {
 
 #[tokio::test]
 async fn test_roominfo_update_deduplication() -> Result<()> {
-    let alice = TestClientBuilder::new("alice".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
-    let bob =
-        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
     let alice_sync_service = SyncService::builder(alice.clone()).build().await.unwrap();
     alice_sync_service.start().await;
@@ -1027,13 +990,8 @@ async fn test_roominfo_update_deduplication() -> Result<()> {
 
 #[tokio::test]
 async fn test_room_preview() -> Result<()> {
-    let alice = TestClientBuilder::new("alice".to_owned())
-        .randomize_username()
-        .use_sqlite()
-        .build()
-        .await?;
-    let bob =
-        TestClientBuilder::new("bob".to_owned()).randomize_username().use_sqlite().build().await?;
+    let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
+    let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
     let alice_sync_service = SyncService::builder(alice.clone()).build().await.unwrap();
     alice_sync_service.start().await;


### PR DESCRIPTION
Most tests would randomize the username when creating a `TestClientBuilder`; make it the default, since it's a sensible choice, and avoids interference between different tests / test runs.

A single test required an actual non-randomized username, so a specific way to opt out from this new default behavior has been introduced.