### PR TITLE
Crypto store: clear db before integ tests

### DIFF
--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -1387,7 +1387,7 @@ mod encrypted_tests {
 
     #[async_test]
     async fn cache_cleared() {
-        let store = get_store("cache_cleared", None).await;
+        let store = get_store("cache_cleared", None, true).await;
         // Given we created a session and saved it in the store
         let (account, session) = cryptostore_integration_tests::get_account_and_session().await;
         let sender_key = session.sender_key.to_base64();
@@ -1414,7 +1414,7 @@ mod encrypted_tests {
 
     #[async_test]
     async fn cache_cleared_after_device_update() {
-        let store = get_store("cache_cleared_after_device_update", None).await;
+        let store = get_store("cache_cleared_after_device_update", None, true).await;
         // Given we created a session and saved it in the store
         let (account, session) = cryptostore_integration_tests::get_account_and_session().await;
         let sender_key = session.sender_key.to_base64();

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -1326,13 +1326,22 @@ mod tests {
     use matrix_sdk_crypto::{cryptostore_integration_tests, cryptostore_integration_tests_time};
     use once_cell::sync::Lazy;
     use tempfile::{tempdir, TempDir};
+    use tokio::fs;
 
     use super::SqliteCryptoStore;
 
     static TMP_DIR: Lazy<TempDir> = Lazy::new(|| tempdir().unwrap());
 
-    async fn get_store(name: &str, passphrase: Option<&str>) -> SqliteCryptoStore {
+    async fn get_store(
+        name: &str,
+        passphrase: Option<&str>,
+        clear_data: bool,
+    ) -> SqliteCryptoStore {
         let tmpdir_path = TMP_DIR.path().join(name);
+
+        if clear_data {
+            let _ = fs::remove_dir_all(&tmpdir_path).await;
+        }
 
         SqliteCryptoStore::open(tmpdir_path.to_str().unwrap(), passphrase)
             .await
@@ -1353,14 +1362,23 @@ mod encrypted_tests {
     use matrix_sdk_test::async_test;
     use once_cell::sync::Lazy;
     use tempfile::{tempdir, TempDir};
+    use tokio::fs;
 
     use super::SqliteCryptoStore;
 
     static TMP_DIR: Lazy<TempDir> = Lazy::new(|| tempdir().unwrap());
 
-    async fn get_store(name: &str, passphrase: Option<&str>) -> SqliteCryptoStore {
+    async fn get_store(
+        name: &str,
+        passphrase: Option<&str>,
+        clear_data: bool,
+    ) -> SqliteCryptoStore {
         let tmpdir_path = TMP_DIR.path().join(name);
         let pass = passphrase.unwrap_or("default_test_password");
+
+        if clear_data {
+            let _ = fs::remove_dir_all(&tmpdir_path).await;
+        }
 
         SqliteCryptoStore::open(tmpdir_path.to_str().unwrap(), Some(pass))
             .await


### PR DESCRIPTION
It's currently possible for integ test results to leak from one test run to the next (for example, the indexeddb stores hang around in the browser), causing bad test results.

Extend the test setup routine to clear out the store before the test starts.