### PR TITLE
 feat(base): Revisit the `roominfo_update` API

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room_list.rs
+++ b/bindings/matrix-sdk-ffi/src/room_list.rs
@@ -243,7 +243,7 @@ impl RoomList {
         let (entries_stream, dynamic_entries_controller) =
             this.inner.entries_with_dynamic_adapters(
                 page_size.try_into().unwrap(),
-                client.roominfo_update_receiver(),
+                client.room_info_notable_update_receiver(),
             );
 
         // FFI dance to make those values consumable by foreign language, nothing fancy

--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -713,12 +713,6 @@ impl BaseClient {
         // encrypted events
         if let Some((found, found_index)) = self.decrypt_latest_suitable_event(room).await {
             room.on_latest_event_decrypted(found, found_index, changes);
-
-            changes
-                .room_info_notable_updates
-                .entry(room.room_id().to_owned())
-                .or_default()
-                .insert(RoomInfoNotableUpdateReasons::LATEST_EVENT);
         }
     }
 

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -6,16 +6,13 @@
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::{
-    poll::unstable_start::SyncUnstablePollStartEvent, room::message::SyncRoomMessageEvent,
+    call::{invite::SyncCallInviteEvent, notify::SyncCallNotifyEvent},
+    poll::unstable_start::SyncUnstablePollStartEvent,
+    relation::RelationType,
+    room::message::SyncRoomMessageEvent,
     AnySyncMessageLikeEvent, AnySyncTimelineEvent,
 };
-use ruma::{
-    events::{
-        call::{invite::SyncCallInviteEvent, notify::SyncCallNotifyEvent},
-        relation::RelationType,
-    },
-    MxcUri, OwnedEventId,
-};
+use ruma::{MxcUri, OwnedEventId};
 use serde::{Deserialize, Serialize};
 
 use crate::MinimalRoomMemberEvent;

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -53,7 +53,7 @@ pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{
     DisplayName, Room, RoomCreateWithCreatorEventContent, RoomHero, RoomInfo,
-    RoomInfoNotableUpdate, RoomMember, RoomMemberships, RoomState,
+    RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomMember, RoomMemberships, RoomState,
     RoomStateFilter,
 };
 pub use store::{

--- a/crates/matrix-sdk-base/src/lib.rs
+++ b/crates/matrix-sdk-base/src/lib.rs
@@ -52,8 +52,9 @@ pub use http;
 pub use matrix_sdk_crypto as crypto;
 pub use once_cell;
 pub use rooms::{
-    DisplayName, Room, RoomCreateWithCreatorEventContent, RoomHero, RoomInfo, RoomInfoUpdate,
-    RoomMember, RoomMemberships, RoomState, RoomStateFilter,
+    DisplayName, Room, RoomCreateWithCreatorEventContent, RoomHero, RoomInfo,
+    RoomInfoNotableUpdate, RoomMember, RoomMemberships, RoomState,
+    RoomStateFilter,
 };
 pub use store::{
     ComposerDraft, ComposerDraftType, StateChanges, StateStore, StateStoreDataKey,

--- a/crates/matrix-sdk-base/src/rooms/mod.rs
+++ b/crates/matrix-sdk-base/src/rooms/mod.rs
@@ -11,7 +11,10 @@ use std::{
 
 use bitflags::bitflags;
 pub use members::RoomMember;
-pub use normal::{Room, RoomHero, RoomInfo, RoomInfoUpdate, RoomState, RoomStateFilter};
+pub use normal::{
+    Room, RoomHero, RoomInfo, RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons, RoomState,
+    RoomStateFilter,
+};
 use ruma::{
     assign,
     events::{

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -16,6 +16,7 @@ use std::collections::BTreeMap;
 #[cfg(feature = "e2e-encryption")]
 use std::ops::Deref;
 
+#[cfg(feature = "e2e-encryption")]
 use matrix_sdk_common::deserialized_responses::SyncTimelineEvent;
 #[cfg(feature = "e2e-encryption")]
 use ruma::events::AnyToDeviceEvent;

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -475,7 +475,7 @@ impl BaseClient {
             let room = store.get_or_create_room(
                 room_id,
                 RoomState::Invited,
-                self.roominfo_update_sender.clone(),
+                self.room_info_notable_update_sender.clone(),
             );
             let mut room_info = room.clone_info();
 
@@ -497,7 +497,7 @@ impl BaseClient {
             let room = store.get_or_create_room(
                 room_id,
                 RoomState::Joined,
-                self.roominfo_update_sender.clone(),
+                self.room_info_notable_update_sender.clone(),
             );
             let mut room_info = room.clone_info();
 

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -60,7 +60,7 @@ use tokio::sync::{broadcast, Mutex, RwLock};
 
 use crate::{
     rooms::{normal::RoomInfoNotableUpdate, RoomInfo, RoomState},
-    MinimalRoomMemberEvent, Room, RoomInfoNotableUpdateReasons, RoomStateFilter, SessionMeta,
+    MinimalRoomMemberEvent, Room, RoomStateFilter, SessionMeta,
 };
 
 pub(crate) mod ambiguity_map;
@@ -322,17 +322,6 @@ pub struct StateChanges {
 
     /// A map of `OwnedRoomId` to `RoomInfo`.
     pub room_infos: BTreeMap<OwnedRoomId, RoomInfo>,
-
-    /// A map of `OwnedRoomId` to `RoomInfoNotableUpdateReason`.
-    ///
-    /// A room info notable update is an update that can be interested for other
-    /// parts of the code. This mechanism is used in coordination with
-    /// [`BaseClient::room_info_notable_update_receiver`][baseclient] where
-    /// `RoomInfo` can be observed and some of its updates can be spread to
-    /// listeners.
-    ///
-    /// [baseclient]: crate::BaseClient::room_info_notable_update_receiver
-    pub room_info_notable_updates: BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
 
     /// A map of `RoomId` to `ReceiptEventContent`.
     pub receipts: BTreeMap<OwnedRoomId, ReceiptEventContent>,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -240,6 +240,12 @@ impl Store {
         self.rooms.read().unwrap().get(room_id).cloned()
     }
 
+    /// Check if a room exists.
+    #[cfg(feature = "experimental-sliding-sync")]
+    pub(crate) fn room_exists(&self, room_id: &RoomId) -> bool {
+        self.rooms.read().unwrap().get(room_id).is_some()
+    }
+
     /// Lookup the `Room` for the given `RoomId`, or create one, if it didn't
     /// exist yet in the store
     pub fn get_or_create_room(

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -59,7 +59,7 @@ use ruma::{
 use tokio::sync::{broadcast, Mutex, RwLock};
 
 use crate::{
-    rooms::{normal::RoomInfoUpdate, RoomInfo, RoomState},
+    rooms::{normal::RoomInfoNotableUpdate, RoomInfo, RoomState},
     MinimalRoomMemberEvent, Room, RoomStateFilter, SessionMeta,
 };
 
@@ -178,7 +178,7 @@ impl Store {
     pub async fn set_session_meta(
         &self,
         session_meta: SessionMeta,
-        roominfo_update_sender: &broadcast::Sender<RoomInfoUpdate>,
+        room_info_notable_update_sender: &broadcast::Sender<RoomInfoNotableUpdate>,
     ) -> Result<()> {
         {
             let room_infos = self.inner.get_room_infos().await?;
@@ -190,7 +190,7 @@ impl Store {
                     &session_meta.user_id,
                     self.inner.clone(),
                     room_info,
-                    roominfo_update_sender.clone(),
+                    room_info_notable_update_sender.clone(),
                 );
                 let new_room_id = new_room.room_id().to_owned();
 
@@ -246,7 +246,7 @@ impl Store {
         &self,
         room_id: &RoomId,
         room_type: RoomState,
-        roominfo_update_sender: broadcast::Sender<RoomInfoUpdate>,
+        room_info_notable_update_sender: broadcast::Sender<RoomInfoNotableUpdate>,
     ) -> Room {
         let user_id =
             &self.session_meta.get().expect("Creating room while not being logged in").user_id;
@@ -255,7 +255,13 @@ impl Store {
             .write()
             .unwrap()
             .get_or_create(room_id, || {
-                Room::new(user_id, self.inner.clone(), room_id, room_type, roominfo_update_sender)
+                Room::new(
+                    user_id,
+                    self.inner.clone(),
+                    room_id,
+                    room_type,
+                    room_info_notable_update_sender,
+                )
             })
             .clone()
     }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -60,7 +60,7 @@ use tokio::sync::{broadcast, Mutex, RwLock};
 
 use crate::{
     rooms::{normal::RoomInfoNotableUpdate, RoomInfo, RoomState},
-    MinimalRoomMemberEvent, Room, RoomStateFilter, SessionMeta,
+    MinimalRoomMemberEvent, Room, RoomInfoNotableUpdateReasons, RoomStateFilter, SessionMeta,
 };
 
 pub(crate) mod ambiguity_map;
@@ -313,8 +313,21 @@ pub struct StateChanges {
     /// A mapping of `RoomId` to a map of event type string to `AnyBasicEvent`.
     pub room_account_data:
         BTreeMap<OwnedRoomId, BTreeMap<RoomAccountDataEventType, Raw<AnyRoomAccountDataEvent>>>,
-    /// A map of `RoomId` to `RoomInfo`.
+
+    /// A map of `OwnedRoomId` to `RoomInfo`.
     pub room_infos: BTreeMap<OwnedRoomId, RoomInfo>,
+
+    /// A map of `OwnedRoomId` to `RoomInfoNotableUpdateReason`.
+    ///
+    /// A room info notable update is an update that can be interested for other
+    /// parts of the code. This mechanism is used in coordination with
+    /// [`BaseClient::room_info_notable_update_receiver`][baseclient] where
+    /// `RoomInfo` can be observed and some of its updates can be spread to
+    /// listeners.
+    ///
+    /// [baseclient]: crate::BaseClient::room_info_notable_update_receiver
+    pub room_info_notable_updates: BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
+
     /// A map of `RoomId` to `ReceiptEventContent`.
     pub receipts: BTreeMap<OwnedRoomId, ReceiptEventContent>,
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -992,7 +992,6 @@ impl StateStore for SqliteStateStore {
                     state,
                     room_account_data,
                     room_infos,
-                    room_info_notable_updates: _,
                     receipts,
                     redactions,
                     stripped_state,

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -992,6 +992,7 @@ impl StateStore for SqliteStateStore {
                     state,
                     room_account_data,
                     room_infos,
+                    room_info_notable_updates: _,
                     receipts,
                     redactions,
                     stripped_state,

--- a/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
+++ b/crates/matrix-sdk-ui/tests/integration/room_list_service.rs
@@ -1269,7 +1269,7 @@ async fn test_dynamic_entries_stream() -> Result<(), Error> {
     let all_rooms = room_list.all_rooms().await?;
 
     let (dynamic_entries_stream, dynamic_entries) =
-        all_rooms.entries_with_dynamic_adapters(5, client.roominfo_update_receiver());
+        all_rooms.entries_with_dynamic_adapters(5, client.room_info_notable_update_receiver());
     pin_mut!(dynamic_entries_stream);
 
     sync_then_assert_request_and_fake_response! {
@@ -1663,7 +1663,7 @@ async fn test_room_sorting() -> Result<(), Error> {
     let all_rooms = room_list.all_rooms().await?;
 
     let (stream, dynamic_entries) =
-        all_rooms.entries_with_dynamic_adapters(10, client.roominfo_update_receiver());
+        all_rooms.entries_with_dynamic_adapters(10, client.room_info_notable_update_receiver());
     pin_mut!(stream);
 
     sync_then_assert_request_and_fake_response! {

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -35,7 +35,7 @@ use matrix_sdk_base::crypto::store::LockableCryptoStore;
 use matrix_sdk_base::{
     store::DynStateStore,
     sync::{Notification, RoomUpdates},
-    BaseClient, RoomInfoUpdate, RoomState, RoomStateFilter, SendOutsideWasm, SessionMeta,
+    BaseClient, RoomInfoNotableUpdate, RoomState, RoomStateFilter, SendOutsideWasm, SessionMeta,
     SyncOutsideWasm,
 };
 use matrix_sdk_common::instant::Instant;
@@ -487,8 +487,8 @@ impl Client {
     /// Returns a receiver that gets events for each room info update. To watch
     /// for new events, use `receiver.resubscribe()`. Each event contains the
     /// room and a boolean whether this event should trigger a room list update.
-    pub fn roominfo_update_receiver(&self) -> broadcast::Receiver<RoomInfoUpdate> {
-        self.base_client().roominfo_update_receiver()
+    pub fn room_info_notable_update_receiver(&self) -> broadcast::Receiver<RoomInfoNotableUpdate> {
+        self.base_client().room_info_notable_update_receiver()
     }
 
     /// Performs a search for users.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -20,7 +20,8 @@ use matrix_sdk_base::{
     },
     instant::Instant,
     store::StateStoreExt,
-    ComposerDraft, RoomMemberships, StateChanges, StateStoreDataKey, StateStoreDataValue,
+    ComposerDraft, RoomInfoNotableUpdateReasons, RoomMemberships, StateChanges, StateStoreDataKey,
+    StateStoreDataValue,
 };
 use matrix_sdk_common::timeout::timeout;
 use mime::Mime;
@@ -495,7 +496,7 @@ impl Room {
                 changes.add_room(room_info.clone());
 
                 self.client.store().save_changes(&changes).await?;
-                self.set_room_info(room_info, false);
+                self.set_room_info(room_info, RoomInfoNotableUpdateReasons::empty());
 
                 Ok(())
             })

--- a/labs/multiverse/src/main.rs
+++ b/labs/multiverse/src/main.rs
@@ -195,8 +195,8 @@ impl App {
             let ui_rooms = ur;
             let timelines = t;
 
-            let (stream, entries_controller) =
-                all_rooms.entries_with_dynamic_adapters(50_000, client.roominfo_update_receiver());
+            let (stream, entries_controller) = all_rooms
+                .entries_with_dynamic_adapters(50_000, client.room_info_notable_update_receiver());
             entries_controller.set_filter(Box::new(new_filter_non_left()));
 
             pin_mut!(stream);

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -802,7 +802,7 @@ async fn test_delayed_decryption_latest_event() -> Result<()> {
 
     let alice_all_rooms = alice_sync_service.room_list_service().all_rooms().await.unwrap();
     let (stream, entries) =
-        alice_all_rooms.entries_with_dynamic_adapters(10, alice.roominfo_update_receiver());
+        alice_all_rooms.entries_with_dynamic_adapters(10, alice.room_info_notable_update_receiver());
     entries.set_filter(Box::new(new_filter_all(vec![])));
     pin_mut!(stream);
 
@@ -866,7 +866,7 @@ async fn test_delayed_decryption_latest_event() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_roominfo_update_deduplication() -> Result<()> {
+async fn test_room_info_notable_update_deduplication() -> Result<()> {
     let alice = TestClientBuilder::new("alice").use_sqlite().build().await?;
     let bob = TestClientBuilder::new("bob").use_sqlite().build().await?;
 
@@ -928,7 +928,7 @@ async fn test_roominfo_update_deduplication() -> Result<()> {
 
     let alice_all_rooms = alice_sync_service.room_list_service().all_rooms().await.unwrap();
     let (stream, entries) =
-        alice_all_rooms.entries_with_dynamic_adapters(10, alice.roominfo_update_receiver());
+        alice_all_rooms.entries_with_dynamic_adapters(10, alice.room_info_notable_update_receiver());
     entries.set_filter(Box::new(new_filter_all(vec![])));
 
     pin_mut!(stream);


### PR DESCRIPTION
This patch updates several parts of the code but it's basically just
renamings.

First off, the patch renames `RoomInfoUpdate` to
`RoomInfoNotableUpdate`. The functions, methods or variables
whose names start with `roominfo_update(.*)` are renamed
`room_info_notable_update$1`.

Second, this patch removes the
`RoomInfoNotableUpdate::trigger_room_list_update` field. It is replaced
by a `reasons: RoomInfoNotableUpdateReasons` 8-bit unsigned integer.
It addresses the following issues:

1. When a subscriber receives a `RoomInfoNotableUpdate`, they have no
   idea what has triggered this update.
2. In
   `matrix_sdk_base::sliding_sync::BaseClient::process_sliding_sync_e2ee`,
   we were triggering an update even if the latest event wasn't
   modified: it is a false-positive, it was a bug and a waste of
   resources. Now it's more refined, see the why below.

Third, this patch removes the second `trigger_room_list_update` argument
of `matrix_sdk_base::BaseClient::apply_changes`. This method now knows
where to find the reasons for the room info notable updates, see next
point.

Fourth, this patch adds a new
`matrix_sdk::StateChanges::room_info_notable_updates` field which is a
B-tree map between an `OwnedRoomId` and a
`RoomInfoNotableUpdateReasons`. The idea is that all places that receive
a `StateChanges` can also create a room info notable update with a
specific reason. This is a finer grained mechanism, and it avoids to
pass new arguments everywhere. It's cleaner.

Finally, it's easier than ever to add a new reason and to propagate it
to subscribers.

---

Another patch is being added straight afterward to avoid emitting a
`RoomInfoNotableUpdateReasons::RECENCY_TIMESTAMP` for rooms that are new.
Otherwise the entries in `matrix_sdk_ui::room_list_service::RoomList`
receive a `VectorDiff` because a new room is inserted, and then a
`VectorDiff` because the recency timestamp is updated. The second
`VectorDiff` is useless in this case.

---

I think we can improve the `RoomInfo` _updates_ in FFI by adding more reasons.
We need to ask the Element's teams, or Fractal, for example.