### PR TITLE
ffi: Timeline::load_reply_details checks if the event exists locally

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/message.rs
@@ -263,7 +263,7 @@ impl RepliedToEvent {
         &self.sender_profile
     }
 
-    pub(crate) fn from_timeline_item(timeline_item: &EventTimelineItem) -> Self {
+    pub fn from_timeline_item(timeline_item: &EventTimelineItem) -> Self {
         Self {
             content: timeline_item.content.clone(),
             sender: timeline_item.sender.clone(),


### PR DESCRIPTION
Before it would go fetch the event from the server using a network request.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3589

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
