### PR TITLE
http_client: log each backed-off attempt at sending a request

### DIFF
--- a/crates/matrix-sdk/src/http_client/mod.rs
+++ b/crates/matrix-sdk/src/http_client/mod.rs
@@ -221,8 +221,6 @@ impl HttpClient {
         // will be automatically dropped at the end of this function
         let _handle = self.concurrent_request_semaphore.acquire().await;
 
-        debug!("Sending request");
-
         // There's a bunch of state in send_request, factor out a pinned inner
         // future to reduce this size of futures that await this function.
         match Box::pin(self.send_request::<R>(request, config, send_progress)).await {

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -26,7 +26,7 @@ use eyeball::SharedObservable;
 use http::header::CONTENT_LENGTH;
 use reqwest::Certificate;
 use ruma::api::{error::FromHttpResponseError, IncomingResponse, OutgoingRequest};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::{response_to_http_response, HttpClient, TransmissionProgress, DEFAULT_REQUEST_TIMEOUT};
 use crate::{
@@ -52,6 +52,8 @@ impl HttpClient {
         let send_request = || {
             let send_progress = send_progress.clone();
             async {
+                debug!(num_attempt = retry_count.load(Ordering::SeqCst), "Sending request");
+
                 let stop = if let Some(retry_limit) = config.retry_limit {
                     retry_count.fetch_add(1, Ordering::Relaxed) >= retry_limit
                 } else {

--- a/crates/matrix-sdk/src/http_client/wasm.rs
+++ b/crates/matrix-sdk/src/http_client/wasm.rs
@@ -33,6 +33,8 @@ impl HttpClient {
         R: OutgoingRequest + Debug,
         HttpError: From<FromHttpResponseError<R::EndpointError>>,
     {
+        tracing::debug!("Sending request");
+
         let request = reqwest::Request::try_from(request)?;
         let response = response_to_http_response(self.inner.execute(request).await?).await?;
 


### PR DESCRIPTION
When a request fails because of the exponential backoff, it won't be re-logged again. It would be useful, for the purposes of the send queue notably, to see when a request is re-attempted.

Since the HTTP client has two implementations, one native that does the retries and another one for wasm that doesn't, we have to duplicate the log statement; it's fine IMO, since this is code that shouldn't change much over time.