### PR TITLE
sdk: cache server versions and unstable features

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -442,6 +442,15 @@ impl Client {
         let http_client = self.inner.http_client();
         Ok(http_client.get(url).send().await?.text().await?)
     }
+
+    /// Empty the server version and unstable features cache.
+    ///
+    /// Since the SDK caches server capabilities (versions and unstable
+    /// features), it's possible to have a stale entry in the cache. This
+    /// functions makes it possible to force reset it.
+    pub async fn reset_server_capabilities(&self) -> Result<(), ClientError> {
+        Ok(self.inner.reset_server_capabilities().await?)
+    }
 }
 
 impl Client {

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -6,10 +6,7 @@ use matrix_sdk::{
     crypto::types::qr_login::{LoginQrCodeDecodeError, QrCodeModeData},
     encryption::{BackupDownloadStrategy, EncryptionSettings},
     reqwest::Certificate,
-    ruma::{
-        api::{error::UnknownVersionError, MatrixVersion},
-        ServerName, UserId,
-    },
+    ruma::{ServerName, UserId},
     Client as MatrixClient, ClientBuildError as MatrixClientBuildError, HttpError, IdParseError,
     RumaApiError,
 };
@@ -250,7 +247,6 @@ pub struct ClientBuilder {
     session_path: Option<String>,
     username: Option<String>,
     homeserver_cfg: Option<HomeserverConfig>,
-    server_versions: Option<Vec<String>>,
     passphrase: Zeroizing<Option<String>>,
     user_agent: Option<String>,
     requires_sliding_sync: bool,
@@ -272,7 +268,6 @@ impl ClientBuilder {
             session_path: None,
             username: None,
             homeserver_cfg: None,
-            server_versions: None,
             passphrase: Zeroizing::new(None),
             user_agent: None,
             requires_sliding_sync: false,
@@ -326,12 +321,6 @@ impl ClientBuilder {
     pub fn username(self: Arc<Self>, username: String) -> Arc<Self> {
         let mut builder = unwrap_or_clone_arc(self);
         builder.username = Some(username);
-        Arc::new(builder)
-    }
-
-    pub fn server_versions(self: Arc<Self>, versions: Vec<String>) -> Arc<Self> {
-        let mut builder = unwrap_or_clone_arc(self);
-        builder.server_versions = Some(versions);
         Arc::new(builder)
     }
 
@@ -506,16 +495,6 @@ impl ClientBuilder {
 
         if let Some(user_agent) = builder.user_agent {
             inner_builder = inner_builder.user_agent(user_agent);
-        }
-
-        if let Some(server_versions) = builder.server_versions {
-            inner_builder = inner_builder.server_versions(
-                server_versions
-                    .iter()
-                    .map(|s| MatrixVersion::try_from(s.as_str()))
-                    .collect::<Result<Vec<MatrixVersion>, UnknownVersionError>>()
-                    .map_err(|e| ClientBuildError::Generic { message: e.to_string() })?,
-            );
         }
 
         inner_builder = inner_builder.with_encryption_settings(builder.encryption_settings);

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloomBuilder;
 use matrix_sdk_test::test_json;
 use ruma::{
-    api::client::media::get_content_thumbnail::v3::Method,
+    api::{client::media::get_content_thumbnail::v3::Method, MatrixVersion},
     event_id,
     events::{
         presence::PresenceEvent,
@@ -34,7 +34,7 @@ use ruma::{
 };
 use serde_json::{json, value::Value as JsonValue};
 
-use super::DynStateStore;
+use super::{DynStateStore, ServerCapabilities};
 use crate::{
     deserialized_responses::MemberEvent,
     media::{MediaFormat, MediaRequest, MediaThumbnailSize},
@@ -89,6 +89,8 @@ pub trait StateStoreIntegrationTests {
     async fn test_display_names_saving(&self);
     /// Test operations with the send queue.
     async fn test_send_queue(&self);
+    /// Test saving/restoring server capabilities.
+    async fn test_server_capabilities_saving(&self);
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -568,6 +570,36 @@ impl StateStoreIntegrationTests for DynStateStore {
             self.get_kv_data(StateStoreDataKey::UserAvatarUrl(user_id)).await,
             Ok(None)
         );
+    }
+
+    async fn test_server_capabilities_saving(&self) {
+        let versions = &[MatrixVersion::V1_1, MatrixVersion::V1_2, MatrixVersion::V1_11];
+        let server_caps = ServerCapabilities::new(
+            versions,
+            [("org.matrix.experimental".to_owned(), true)].into(),
+        );
+
+        self.set_kv_data(
+            StateStoreDataKey::ServerCapabilities,
+            StateStoreDataValue::ServerCapabilities(server_caps.clone()),
+        )
+        .await
+        .unwrap();
+
+        assert_let!(
+            Ok(Some(StateStoreDataValue::ServerCapabilities(stored_caps))) =
+                self.get_kv_data(StateStoreDataKey::ServerCapabilities).await
+        );
+        assert_eq!(stored_caps, server_caps);
+
+        let (stored_versions, stored_features) = stored_caps.decode();
+
+        assert_eq!(stored_versions, versions);
+        assert_eq!(stored_features.len(), 1);
+        assert_eq!(stored_features.get("org.matrix.experimental"), Some(&true));
+
+        self.remove_kv_data(StateStoreDataKey::ServerCapabilities).await.unwrap();
+        assert_matches!(self.get_kv_data(StateStoreDataKey::ServerCapabilities).await, Ok(None));
     }
 
     async fn test_sync_token_saving(&self) {
@@ -1532,6 +1564,12 @@ macro_rules! statestore_integration_tests {
         async fn test_user_avatar_url_saving() {
             let store = get_store().await.unwrap().into_state_store();
             store.test_user_avatar_url_saving().await
+        }
+
+        #[async_test]
+        async fn test_server_capabilities_saving() {
+            let store = get_store().await.unwrap().into_state_store();
+            store.test_server_capabilities_saving().await
         }
 
         #[async_test]

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -592,7 +592,7 @@ impl StateStoreIntegrationTests for DynStateStore {
         );
         assert_eq!(stored_caps, server_caps);
 
-        let (stored_versions, stored_features) = stored_caps.decode();
+        let (stored_versions, stored_features) = stored_caps.maybe_decode().unwrap();
 
         assert_eq!(stored_versions, versions);
         assert_eq!(stored_features.len(), 1);

--- a/crates/matrix-sdk-base/src/store/memory_store.rs
+++ b/crates/matrix-sdk-base/src/store/memory_store.rs
@@ -37,7 +37,7 @@ use ruma::{
 use tracing::{debug, instrument, trace, warn};
 
 use super::{
-    traits::{ComposerDraft, QueuedEvent, SerializableEventContent},
+    traits::{ComposerDraft, QueuedEvent, SerializableEventContent, ServerCapabilities},
     Result, RoomInfo, StateChanges, StateStore, StoreError,
 };
 use crate::{
@@ -56,6 +56,7 @@ pub struct MemoryStore {
     composer_drafts: StdRwLock<HashMap<OwnedRoomId, ComposerDraft>>,
     user_avatar_url: StdRwLock<HashMap<OwnedUserId, OwnedMxcUri>>,
     sync_token: StdRwLock<Option<String>>,
+    server_capabilities: StdRwLock<Option<ServerCapabilities>>,
     filters: StdRwLock<HashMap<String, String>>,
     utd_hook_manager_data: StdRwLock<Option<GrowableBloom>>,
     account_data: StdRwLock<HashMap<GlobalAccountDataEventType, Raw<AnyGlobalAccountDataEvent>>>,
@@ -101,6 +102,7 @@ impl Default for MemoryStore {
             composer_drafts: Default::default(),
             user_avatar_url: Default::default(),
             sync_token: Default::default(),
+            server_capabilities: Default::default(),
             filters: Default::default(),
             utd_hook_manager_data: Default::default(),
             account_data: Default::default(),
@@ -175,6 +177,12 @@ impl StateStore for MemoryStore {
             StateStoreDataKey::SyncToken => {
                 self.sync_token.read().unwrap().clone().map(StateStoreDataValue::SyncToken)
             }
+            StateStoreDataKey::ServerCapabilities => self
+                .server_capabilities
+                .read()
+                .unwrap()
+                .clone()
+                .map(StateStoreDataValue::ServerCapabilities),
             StateStoreDataKey::Filter(filter_name) => self
                 .filters
                 .read()
@@ -255,6 +263,13 @@ impl StateStore for MemoryStore {
                     value.into_composer_draft().expect("Session data not a composer draft"),
                 );
             }
+            StateStoreDataKey::ServerCapabilities => {
+                *self.server_capabilities.write().unwrap() = Some(
+                    value
+                        .into_server_capabilities()
+                        .expect("Session data not containing server capabilities"),
+                );
+            }
         }
 
         Ok(())
@@ -263,6 +278,9 @@ impl StateStore for MemoryStore {
     async fn remove_kv_data(&self, key: StateStoreDataKey<'_>) -> Result<()> {
         match key {
             StateStoreDataKey::SyncToken => *self.sync_token.write().unwrap() = None,
+            StateStoreDataKey::ServerCapabilities => {
+                *self.server_capabilities.write().unwrap() = None
+            }
             StateStoreDataKey::Filter(filter_name) => {
                 self.filters.write().unwrap().remove(filter_name);
             }

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -73,8 +73,8 @@ pub use self::{
     memory_store::MemoryStore,
     traits::{
         ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, QueuedEvent,
-        SerializableEventContent, StateStore, StateStoreDataKey, StateStoreDataValue,
-        StateStoreExt,
+        SerializableEventContent, ServerCapabilities, StateStore, StateStoreDataKey,
+        StateStoreDataValue, StateStoreExt,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -22,8 +22,9 @@ use std::{
 use as_variant::as_variant;
 use async_trait::async_trait;
 use growable_bloom_filter::GrowableBloom;
-use matrix_sdk_common::AsyncTraitDeps;
+use matrix_sdk_common::{instant, AsyncTraitDeps};
 use ruma::{
+    api::MatrixVersion,
     events::{
         presence::PresenceEvent,
         receipt::{Receipt, ReceiptThread, ReceiptType},
@@ -908,11 +909,48 @@ where
     }
 }
 
+/// Server capabilities returned by the /client/versions endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ServerCapabilities {
+    /// Versions supported by the remote server.
+    ///
+    /// This contains [`MatrixVersion`]s converted to strings.
+    pub versions: Vec<String>,
+
+    /// List of unstable features and their enablement status.
+    pub unstable_features: BTreeMap<String, bool>,
+
+    /// Last time we fetched this data from the server.
+    last_fetch_ts: f64,
+}
+
+impl ServerCapabilities {
+    /// Encode server capabilities into this serializable struct.
+    pub fn new(versions: &[MatrixVersion], unstable_features: BTreeMap<String, bool>) -> Self {
+        Self {
+            versions: versions.iter().map(|item| item.to_string()).collect(),
+            unstable_features,
+            last_fetch_ts: instant::now(),
+        }
+    }
+
+    /// Decode server capabilities from this serializable struct.
+    pub fn decode(&self) -> (Vec<MatrixVersion>, BTreeMap<String, bool>) {
+        (
+            self.versions.iter().filter_map(|item| item.parse().ok()).collect(),
+            self.unstable_features.clone(),
+        )
+    }
+}
+
 /// A value for key-value data that should be persisted into the store.
 #[derive(Debug, Clone)]
 pub enum StateStoreDataValue {
     /// The sync token.
     SyncToken(String),
+
+    /// The server capabilities.
+    ServerCapabilities(ServerCapabilities),
 
     /// A filter with the given ID.
     Filter(String),
@@ -993,6 +1031,11 @@ impl StateStoreDataValue {
     pub fn into_composer_draft(self) -> Option<ComposerDraft> {
         as_variant!(self, Self::ComposerDraft)
     }
+
+    /// Get this value if it is the server capabilities metadata.
+    pub fn into_server_capabilities(self) -> Option<ServerCapabilities> {
+        as_variant!(self, Self::ServerCapabilities)
+    }
 }
 
 /// A key for key-value data.
@@ -1000,6 +1043,9 @@ impl StateStoreDataValue {
 pub enum StateStoreDataKey<'a> {
     /// The sync token.
     SyncToken,
+
+    /// The server capabilities,
+    ServerCapabilities,
 
     /// A filter with the given name.
     Filter(&'a str),
@@ -1024,6 +1070,9 @@ pub enum StateStoreDataKey<'a> {
 impl StateStoreDataKey<'_> {
     /// Key to use for the [`SyncToken`][Self::SyncToken] variant.
     pub const SYNC_TOKEN: &'static str = "sync_token";
+    /// Key to use for the [`ServerCapabilities`][Self::ServerCapabilities]
+    /// variant.
+    pub const SERVER_CAPABILITIES: &'static str = "server_capabilities";
     /// Key prefix to use for the [`Filter`][Self::Filter] variant.
     pub const FILTER: &'static str = "filter";
     /// Key prefix to use for the [`UserAvatarUrl`][Self::UserAvatarUrl]

--- a/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/state_store/mod.rs
@@ -26,7 +26,8 @@ use matrix_sdk_base::{
     deserialized_responses::RawAnySyncOrStrippedState,
     media::{MediaRequest, UniqueKey},
     store::{
-        ComposerDraft, QueuedEvent, SerializableEventContent, StateChanges, StateStore, StoreError,
+        ComposerDraft, QueuedEvent, SerializableEventContent, ServerCapabilities, StateChanges,
+        StateStore, StoreError,
     },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateStoreDataKey,
     StateStoreDataValue,
@@ -398,6 +399,10 @@ impl IndexeddbStateStore {
             StateStoreDataKey::SyncToken => {
                 self.encode_key(StateStoreDataKey::SYNC_TOKEN, StateStoreDataKey::SYNC_TOKEN)
             }
+            StateStoreDataKey::ServerCapabilities => self.encode_key(
+                StateStoreDataKey::SERVER_CAPABILITIES,
+                StateStoreDataKey::SERVER_CAPABILITIES,
+            ),
             StateStoreDataKey::Filter(filter_name) => {
                 self.encode_key(StateStoreDataKey::FILTER, (StateStoreDataKey::FILTER, filter_name))
             }
@@ -475,6 +480,10 @@ impl_state_store!({
                 .map(|f| self.deserialize_value::<String>(&f))
                 .transpose()?
                 .map(StateStoreDataValue::SyncToken),
+            StateStoreDataKey::ServerCapabilities => value
+                .map(|f| self.deserialize_value::<ServerCapabilities>(&f))
+                .transpose()?
+                .map(StateStoreDataValue::ServerCapabilities),
             StateStoreDataKey::Filter(_) => value
                 .map(|f| self.deserialize_value::<String>(&f))
                 .transpose()?
@@ -510,6 +519,11 @@ impl_state_store!({
         let serialized_value = match key {
             StateStoreDataKey::SyncToken => self
                 .serialize_value(&value.into_sync_token().expect("Session data not a sync token")),
+            StateStoreDataKey::ServerCapabilities => self.serialize_value(
+                &value
+                    .into_server_capabilities()
+                    .expect("Session data not containing server capabilities"),
+            ),
             StateStoreDataKey::Filter(_) => {
                 self.serialize_value(&value.into_filter().expect("Session data not a filter"))
             }

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -291,6 +291,9 @@ impl SqliteStateStore {
     fn encode_state_store_data_key(&self, key: StateStoreDataKey<'_>) -> Key {
         let key_s = match key {
             StateStoreDataKey::SyncToken => Cow::Borrowed(StateStoreDataKey::SYNC_TOKEN),
+            StateStoreDataKey::ServerCapabilities => {
+                Cow::Borrowed(StateStoreDataKey::SERVER_CAPABILITIES)
+            }
             StateStoreDataKey::Filter(f) => {
                 Cow::Owned(format!("{}:{f}", StateStoreDataKey::FILTER))
             }
@@ -921,6 +924,9 @@ impl StateStore for SqliteStateStore {
                     StateStoreDataKey::SyncToken => {
                         StateStoreDataValue::SyncToken(self.deserialize_value(&data)?)
                     }
+                    StateStoreDataKey::ServerCapabilities => {
+                        StateStoreDataValue::ServerCapabilities(self.deserialize_value(&data)?)
+                    }
                     StateStoreDataKey::Filter(_) => {
                         StateStoreDataValue::Filter(self.deserialize_value(&data)?)
                     }
@@ -949,6 +955,11 @@ impl StateStore for SqliteStateStore {
         let serialized_value = match key {
             StateStoreDataKey::SyncToken => self.serialize_value(
                 &value.into_sync_token().expect("Session data not a sync token"),
+            )?,
+            StateStoreDataKey::ServerCapabilities => self.serialize_value(
+                &value
+                    .into_server_capabilities()
+                    .expect("Session data not containing server capabilities"),
             )?,
             StateStoreDataKey::Filter(_) => {
                 self.serialize_value(&value.into_filter().expect("Session data not a filter"))?

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -37,8 +37,9 @@ use crate::http_client::HttpSettings;
 #[cfg(feature = "experimental-oidc")]
 use crate::oidc::OidcCtx;
 use crate::{
-    authentication::AuthCtx, config::RequestConfig, error::RumaApiError, http_client::HttpClient,
-    send_queue::SendQueueData, HttpError, IdParseError,
+    authentication::AuthCtx, client::ClientServerCapabilities, config::RequestConfig,
+    error::RumaApiError, http_client::HttpClient, send_queue::SendQueueData, HttpError,
+    IdParseError,
 };
 
 /// Builder that allows creating and configuring various parts of a [`Client`].
@@ -477,6 +478,11 @@ impl ClientBuilder {
         // Enable the send queue by default.
         let send_queue = Arc::new(SendQueueData::new(true));
 
+        let server_capabilities = ClientServerCapabilities {
+            server_versions: self.server_versions,
+            unstable_features: None,
+        };
+
         let event_cache = OnceCell::new();
         let inner = ClientInner::new(
             auth_ctx,
@@ -485,8 +491,7 @@ impl ClientBuilder {
             sliding_sync_proxy,
             http_client,
             base_client,
-            self.server_versions,
-            None,
+            server_capabilities,
             self.respect_login_well_known,
             event_cache,
             send_queue,

--- a/crates/matrix-sdk/src/matrix_auth/mod.rs
+++ b/crates/matrix-sdk/src/matrix_auth/mod.rs
@@ -130,13 +130,13 @@ impl MatrixAuth {
                 .try_into_http_request::<Vec<u8>>(
                     homeserver.as_str(),
                     SendAccessToken::None,
-                    server_versions,
+                    &server_versions,
                 )
         } else {
             sso_login::v3::Request::new(redirect_url.to_owned()).try_into_http_request::<Vec<u8>>(
                 homeserver.as_str(),
                 SendAccessToken::None,
-                server_versions,
+                &server_versions,
             )
         };
 

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -273,8 +273,6 @@ impl Media {
         };
 
         // Use the authenticated endpoints when the server supports Matrix 1.11.
-        // TODO: Add an option in ClientBuilder to force the use of the authenticated
-        // endpoints.
         let use_auth = self.client.server_versions().await?.contains(&MatrixVersion::V1_11);
 
         let content: Vec<u8> = match &request.source {


### PR DESCRIPTION
This series of commits makes it possible to cache the server versions and unstable features, with a cache duration of one day (can be tweaked easily!). Caching works this way:

- if we have already filled the in-memory cache, use that
- instead, try to reload the disk caches,
- if they have expired, do a network request to get the latest server version (and cache the results in both memory and disk)

Fixes #2372.