### PR TITLE
sdk: Add a higher level method to reset the cross-signing keys

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -2313,7 +2313,7 @@ impl OlmMachine {
 
 /// A set of requests to be executed when bootstrapping cross-signing using
 /// [`OlmMachine::bootstrap_cross_signing`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CrossSigningBootstrapRequests {
     /// An optional request to upload a device key.
     ///

--- a/crates/matrix-sdk/src/encryption/mod.rs
+++ b/crates/matrix-sdk/src/encryption/mod.rs
@@ -36,14 +36,16 @@ use matrix_sdk_base::crypto::{
 use matrix_sdk_common::executor::spawn;
 use ruma::{
     api::client::{
+        error::{ErrorBody, ErrorKind},
         keys::{
-            get_keys, upload_keys, upload_signing_keys::v3::Request as UploadSigningKeysRequest,
+            get_keys, upload_keys, upload_signatures::v3::Request as UploadSignaturesRequest,
+            upload_signing_keys::v3::Request as UploadSigningKeysRequest,
         },
         message::send_message_event,
         to_device::send_event_to_device::v3::{
             Request as RumaToDeviceRequest, Response as ToDeviceResponse,
         },
-        uiaa::AuthData,
+        uiaa::{AuthData, UiaaInfo},
     },
     assign,
     events::room::{
@@ -57,6 +59,7 @@ use ruma::{
 };
 use tokio::sync::RwLockReadGuard;
 use tracing::{debug, error, instrument, trace, warn};
+use url::Url;
 use vodozemac::Curve25519PublicKey;
 
 use self::{
@@ -73,7 +76,7 @@ use crate::{
     client::{ClientInner, WeakClient},
     error::HttpResult,
     store_locks::CrossProcessStoreLockGuard,
-    Client, Error, Result, Room, TransmissionProgress,
+    Client, Error, HttpError, Result, Room, TransmissionProgress,
 };
 
 pub mod backups;
@@ -224,6 +227,121 @@ impl CrossProcessLockStoreGuardWithGeneration {
     /// Return the Crypto Store generation associated with this store lock.
     pub fn generation(&self) -> u64 {
         self.generation
+    }
+}
+
+/// A stateful struct remembering the cross-signing keys we need to upload.
+///
+/// Since the `/_matrix/client/v3/keys/device_signing/upload` might require
+/// additional authentication, this struct will contain information on the type
+/// of authentication the user needs to complete before the upload might be
+/// continued.
+///
+/// More info can be found in the [spec].
+///
+/// [spec]: https://spec.matrix.org/v1.11/client-server-api/#post_matrixclientv3keysdevice_signingupload
+#[derive(Debug)]
+pub struct CrossSigningResetHandle {
+    client: Client,
+    upload_request: UploadSigningKeysRequest,
+    signatures_request: UploadSignaturesRequest,
+    auth_type: CrossSigningResetAuthType,
+}
+
+impl CrossSigningResetHandle {
+    /// Get the [`CrossSigningResetAuthType`] this cross-signing reset process
+    /// is using.
+    pub fn auth_type(&self) -> &CrossSigningResetAuthType {
+        &self.auth_type
+    }
+
+    /// Continue the cross-signing reset by either waiting for the
+    /// authentication to be done on the side of the OIDC issuer or by
+    /// providing additional [`AuthData`] the homeserver requires.
+    pub async fn auth(&self, auth: Option<AuthData>) -> Result<()> {
+        let mut upload_request = self.upload_request.clone();
+        upload_request.auth = auth;
+
+        // TODO: Do we want to put a limit on this infinite loop? 🤷
+        while let Err(e) = self.client.send(upload_request.clone(), None).await {
+            if e.client_api_error_kind() != Some(&ErrorKind::Unrecognized) {
+                return Err(e.into());
+            }
+        }
+
+        self.client.send(self.signatures_request.clone(), None).await?;
+
+        Ok(())
+    }
+}
+
+/// information about the additional authentication that is required before the
+/// cross-signing keys can be uploaded.
+#[derive(Debug, Clone)]
+pub enum CrossSigningResetAuthType {
+    /// The homeserver requires user-interactive authentication.
+    Uiaa(UiaaInfo),
+    /// OIDC is used for authentication and the user needs to open a URL to
+    /// approve the upload of cross-signing keys.
+    Oidc(OidcCrossSigningResetInfo),
+}
+
+impl CrossSigningResetAuthType {
+    async fn new(client: &Client, error: &HttpError) -> Result<Option<Self>> {
+        if let Some(auth_info) = error.as_uiaa_response() {
+            Ok(Some(CrossSigningResetAuthType::Uiaa(auth_info.clone())))
+        } else if let Some(ErrorBody::Standard { kind, message }) =
+            error.as_client_api_error().map(|e| &e.body)
+        {
+            OidcCrossSigningResetInfo::from_matrix_error(client, kind, message)
+                .await
+                .map(|t| t.map(CrossSigningResetAuthType::Oidc))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// OIDC specific information about the required authentication for the upload
+/// of cross-signing keys.
+#[derive(Debug, Clone)]
+pub struct OidcCrossSigningResetInfo {
+    /// The error message we received from the homeserver after we attempted to
+    /// reset the cross-signing keys.
+    pub error: String,
+    /// The URL where the user can approve the reset of the cross-signing keys.
+    pub approval_url: Url,
+}
+
+impl OidcCrossSigningResetInfo {
+    #[allow(clippy::unused_async)]
+    async fn from_matrix_error(
+        // This is used if the OIDC feature is enabled.
+        #[allow(unused_variables)] client: &Client,
+        kind: &ErrorKind,
+        message: &str,
+    ) -> Result<Option<Self>> {
+        #[cfg(feature = "experimental-oidc")]
+        use mas_oidc_client::requests::account_management::AccountManagementActionFull;
+
+        if kind == &ErrorKind::Unrecognized {
+            #[cfg(feature = "experimental-oidc")]
+            let approval_url = client
+                .oidc()
+                .account_management_url(Some(AccountManagementActionFull::CrossSigningReset))
+                .await?;
+
+            #[cfg(not(feature = "experimental-oidc"))]
+            let approval_url = None;
+
+            if let Some(approval_url) = approval_url {
+                Ok(Some(OidcCrossSigningResetInfo { error: message.to_owned(), approval_url }))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
     }
 }
 
@@ -1051,6 +1169,79 @@ impl Encryption {
         self.client.send(upload_signatures_req, None).await?;
 
         Ok(())
+    }
+
+    /// Reset the cross-signing keys.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use matrix_sdk::{ruma::api::client::uiaa, Client, encryption::CrossSigningResetAuthType};
+    /// # use url::Url;
+    /// # async {
+    /// # let homeserver = Url::parse("http://example.com")?;
+    /// # let client = Client::new(homeserver).await?;
+    /// # let user_id = unimplemented!();
+    /// let encryption = client.encryption();
+    ///       
+    /// if let Some(handle) = encryption.reset_cross_signing().await? {
+    ///     match handle.auth_type() {
+    ///         CrossSigningResetAuthType::Uiaa(uiaa) => {
+    ///             use matrix_sdk::ruma::api::client::uiaa;
+    ///
+    ///             let password = "1234".to_owned();
+    ///             let mut password = uiaa::Password::new(user_id, password);
+    ///             password.session = uiaa.session;
+    ///
+    ///             handle.auth(Some(uiaa::AuthData::Password(password))).await?;
+    ///         }
+    ///         CrossSigningResetAuthType::Oidc(o) => {
+    ///             println!("To reset your end-to-end encryption cross-signing identity, you first need to approve it at {}", o.approval_url);
+    ///             handle.auth(None).await?;
+    ///         }
+    ///     }
+    /// }
+    /// # anyhow::Ok(()) };
+    /// ```
+    pub async fn reset_cross_signing(&self) -> Result<Option<CrossSigningResetHandle>> {
+        let olm = self.client.olm_machine().await;
+        let olm = olm.as_ref().ok_or(Error::NoOlmMachine)?;
+
+        let CrossSigningBootstrapRequests {
+            upload_keys_req,
+            upload_signing_keys_req,
+            upload_signatures_req,
+        } = olm.bootstrap_cross_signing(true).await?;
+
+        let upload_signing_keys_req = assign!(UploadSigningKeysRequest::new(), {
+            auth: None,
+            master_key: upload_signing_keys_req.master_key.map(|c| c.to_raw()),
+            self_signing_key: upload_signing_keys_req.self_signing_key.map(|c| c.to_raw()),
+            user_signing_key: upload_signing_keys_req.user_signing_key.map(|c| c.to_raw()),
+        });
+
+        if let Some(req) = upload_keys_req {
+            self.client.send_outgoing_request(req).await?;
+        }
+
+        if let Err(error) = self.client.send(upload_signing_keys_req.clone(), None).await {
+            if let Some(auth_type) = CrossSigningResetAuthType::new(&self.client, &error).await? {
+                let client = self.client.clone();
+
+                Ok(Some(CrossSigningResetHandle {
+                    client,
+                    upload_request: upload_signing_keys_req,
+                    signatures_request: upload_signatures_req,
+                    auth_type,
+                }))
+            } else {
+                Err(error.into())
+            }
+        } else {
+            self.client.send(upload_signatures_req, None).await?;
+
+            Ok(None)
+        }
     }
 
     /// Query the user's own device keys, if, and only if, we didn't have their

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -156,10 +156,9 @@ impl HttpError {
             // If it was a plain network error, it's either that we're disconnected from the
             // internet, or that the remote is, so retry a few times.
             HttpError::Reqwest(_) => RetryKind::Transient { retry_after: None },
-            HttpError::Api(api_error) => match api_error {
-                FromHttpResponseError::Server(api_error) => RetryKind::from_api_error(api_error),
-                _ => RetryKind::Permanent,
-            },
+            HttpError::Api(FromHttpResponseError::Server(api_error)) => {
+                RetryKind::from_api_error(api_error)
+            }
             _ => RetryKind::Permanent,
         }
     }
@@ -196,6 +195,7 @@ impl RetryKind {
                         ErrorKind::LimitExceeded { retry_after } => {
                             RetryKind::from_retry_after(retry_after.as_ref())
                         }
+                        ErrorKind::Unrecognized => RetryKind::Permanent,
                         _ => RetryKind::from_status_code(*status_code),
                     },
                     _ => RetryKind::from_status_code(*status_code),

--- a/crates/matrix-sdk/tests/integration/encryption.rs
+++ b/crates/matrix-sdk/tests/integration/encryption.rs
@@ -1,4 +1,5 @@
 mod backups;
+mod cross_signing;
 mod recovery;
 mod secret_storage;
 mod verification;

--- a/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
@@ -12,16 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use assert_matches2::assert_let;
 use matrix_sdk::{
+    encryption::CrossSigningResetAuthType,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
     test_utils::no_retry_test_client_with_server,
     SessionMeta,
 };
 use matrix_sdk_test::async_test;
-use ruma::{device_id, user_id};
+use ruma::{api::client::uiaa, device_id, user_id};
+use serde_json::json;
+use wiremock::{
+    matchers::{method, path},
+    Mock, ResponseTemplate,
+};
 
 #[async_test]
-async fn reset_oidc() {
+async fn test_reset_legacy_auth() {
     let user_id = user_id!("@example:morpheus.localhost");
 
     let session = MatrixSession {
@@ -30,6 +37,7 @@ async fn reset_oidc() {
     };
 
     let (client, server) = no_retry_test_client_with_server().await;
+
     client.restore_session(session).await.unwrap();
 
     assert!(
@@ -37,5 +45,270 @@ async fn reset_oidc() {
         "Initially we shouldn't have any cross-signin keys",
     );
 
-    let handle = client.encryption().reset_cross_signing().await.unwrap();
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/r0/keys/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "one_time_key_counts": {
+                "signed_curve25519": 50
+            }
+        })))
+        .expect(1)
+        .named("Initial device keys upload")
+        .mount(&server)
+        .await;
+
+    let reset_handle = {
+        let _guard = Mock::given(method("POST"))
+            .and(path("/_matrix/client/unstable/keys/device_signing/upload"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "flows": [
+                    {
+                        "stages": [
+                            "m.login.password"
+                        ]
+                    }
+                ],
+                "params": {},
+                "session": "oFIJVvtEOCKmRUTYKTYIIPHL"
+            })))
+            .expect(1)
+            .named("Initial cross-signing upload attempt")
+            .mount_as_scoped(&server)
+            .await;
+
+        client
+            .encryption()
+            .reset_cross_signing()
+            .await
+            .unwrap()
+            .expect("We should have received a reset handle")
+    };
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/unstable/keys/device_signing/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("Retrying to upload the cross-signing keys")
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/unstable/keys/signatures/upload"))
+        .respond_with(move |_: &wiremock::Request| {
+            ResponseTemplate::new(200).set_body_json(json!({}))
+        })
+        .expect(1)
+        .named("Final signatures upload")
+        .mount(&server)
+        .await;
+
+    assert_let!(CrossSigningResetAuthType::Uiaa(uiaa_info) = reset_handle.auth_type());
+
+    let mut password = uiaa::Password::new(user_id.to_owned().into(), "1234".to_owned());
+    password.session = uiaa_info.session.clone();
+    reset_handle.auth(Some(uiaa::AuthData::Password(password))).await.expect("FOO BAR");
+
+    assert!(
+        client.encryption().cross_signing_status().await.unwrap().is_complete(),
+        "After the reset we have the cross-signing available.",
+    );
+}
+
+#[cfg(feature = "experimental-oidc")]
+#[async_test]
+async fn test_reset_oidc() {
+    use std::sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    };
+
+    use assert_matches2::assert_let;
+    use mas_oidc_client::types::{
+        client_credentials::ClientCredentials,
+        iana::oauth::OAuthClientAuthenticationMethod,
+        registration::{ClientMetadata, VerifiedClientMetadata},
+    };
+    use matrix_sdk::{
+        encryption::CrossSigningResetAuthType,
+        oidc::{OidcSession, OidcSessionTokens, UserSession},
+    };
+    use similar_asserts::assert_eq;
+    use url::Url;
+    use wiremock::MockServer;
+
+    const CLIENT_ID: &str = "test_client_id";
+    const REDIRECT_URI_STRING: &str = "http://matrix.example.com/oidc/callback";
+
+    let (client, server) = no_retry_test_client_with_server().await;
+
+    let auth_issuer_body = json!({
+      "issuer": server.uri(),
+      "authorization_endpoint": format!("{}/authorize", server.uri()),
+      "token_endpoint": format!("{}/oauth2/token", server.uri()),
+      "jwks_uri": format!("{}/oauth2/keys.json", server.uri()),
+      "response_types_supported": [
+        "code",
+      ],
+      "response_modes_supported": [
+        "fragment"
+      ],
+      "subject_types_supported": [
+        "public"
+      ],
+      "id_token_signing_alg_values_supported": [
+        "RS256",
+      ],
+      "claim_types_supported": [
+        "normal"
+      ],
+      "account_management_uri": format!("{}/account/", server.uri()),
+      "account_management_actions_supported": [
+        "org.matrix.cross_signing_reset"
+      ]
+    });
+
+    pub fn mock_registered_client_data() -> (ClientCredentials, VerifiedClientMetadata) {
+        (
+            ClientCredentials::None { client_id: CLIENT_ID.to_owned() },
+            ClientMetadata {
+                redirect_uris: Some(vec![Url::parse(REDIRECT_URI_STRING).unwrap()]),
+                token_endpoint_auth_method: Some(OAuthClientAuthenticationMethod::None),
+                ..ClientMetadata::default()
+            }
+            .validate()
+            .expect("validate client metadata"),
+        )
+    }
+
+    pub fn mock_session(tokens: OidcSessionTokens, server: &MockServer) -> OidcSession {
+        let (credentials, metadata) = mock_registered_client_data();
+        OidcSession {
+            credentials,
+            metadata,
+            user: UserSession {
+                meta: SessionMeta {
+                    user_id: ruma::user_id!("@u:e.uk").to_owned(),
+                    device_id: ruma::device_id!("XYZ").to_owned(),
+                },
+                tokens,
+                issuer: server.uri(),
+            },
+        }
+    }
+
+    let tokens = OidcSessionTokens {
+        access_token: "4cc3ss".to_owned(),
+        refresh_token: Some("r3fr3sh".to_owned()),
+        latest_id_token: None,
+    };
+
+    let session = mock_session(tokens.clone(), &server);
+
+    client
+        .oidc()
+        .restore_session(session.clone())
+        .await
+        .expect("We should be able to restore the OIDC session");
+
+    assert!(
+        !client.encryption().cross_signing_status().await.unwrap().is_complete(),
+        "Initially we shouldn't have any cross-signin keys",
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/r0/keys/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "one_time_key_counts": {
+                "signed_curve25519": 50
+            }
+        })))
+        .expect(1)
+        .named("Initial device keys upload")
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(".well-known/openid-configuration"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(auth_issuer_body))
+        .expect(1)
+        .named("Auth issuer discovery")
+        .mount(&server)
+        .await;
+
+    let reset_handle = {
+        let _guard = Mock::given(method("POST"))
+            .and(path("/_matrix/client/unstable/keys/device_signing/upload"))
+            .respond_with(ResponseTemplate::new(501).set_body_json(json!({
+                "errcode": "M_UNRECOGNIZED",
+                "error": "To reset your cross-signing keys you first need to approve it in your auth issuer settings",
+            })))
+            .expect(1)
+            .named("Initial cross-signing upload attempt")
+            .mount_as_scoped(&server)
+            .await;
+
+        let handle = client
+            .encryption()
+            .reset_cross_signing()
+            .await
+            .unwrap()
+            .expect("We should have received a reset handle");
+
+        assert_let!(CrossSigningResetAuthType::Oidc(oidc_info) = handle.auth_type());
+        assert_eq!(
+            oidc_info.approval_url.as_str(),
+            format!("{}/account/?action=org.matrix.cross_signing_reset", server.uri())
+        );
+
+        handle
+    };
+
+    let counter = Arc::new(AtomicU8::default());
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/unstable/keys/device_signing/upload"))
+        .respond_with({
+            let counter = counter.clone();
+
+            move |_: &wiremock::Request| {
+                let current_value = counter.fetch_add(1, Ordering::SeqCst);
+
+                println!("Hello {current_value}");
+                // Only allow us to proceed on the 5th attempt, count started at 0, so if the
+                // current value is at 4 it's the 5th attempt.
+                if current_value >= 4 {
+                    ResponseTemplate::new(200).set_body_json(json!({}))
+                } else {
+                    ResponseTemplate::new(501).set_body_json(json!({
+                        "errcode": "M_UNRECOGNIZED",
+                        "error": "",
+                    }))
+                }
+            }
+        })
+        .expect(1..)
+        .named("Retrying to upload the cross-signing keys")
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/unstable/keys/signatures/upload"))
+        .respond_with(move |_: &wiremock::Request| {
+            ResponseTemplate::new(200).set_body_json(json!({}))
+        })
+        .expect(1)
+        .named("Final signatures upload")
+        .mount(&server)
+        .await;
+
+    reset_handle.auth(None).await.expect("We should be able to reset the cross-signing keys after some attempts, waiting for the auth issue to allow us to upload");
+
+    // 5 because we incremented the counter once more in the request handler
+    // closure.
+    assert_eq!(counter.load(Ordering::SeqCst), 5);
+
+    assert!(
+        client.encryption().cross_signing_status().await.unwrap().is_complete(),
+        "After the reset we have the cross-signing available.",
+    );
 }

--- a/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/cross_signing.rs
@@ -1,0 +1,41 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use matrix_sdk::{
+    matrix_auth::{MatrixSession, MatrixSessionTokens},
+    test_utils::no_retry_test_client_with_server,
+    SessionMeta,
+};
+use matrix_sdk_test::async_test;
+use ruma::{device_id, user_id};
+
+#[async_test]
+async fn reset_oidc() {
+    let user_id = user_id!("@example:morpheus.localhost");
+
+    let session = MatrixSession {
+        meta: SessionMeta { user_id: user_id.into(), device_id: device_id!("DEVICEID").to_owned() },
+        tokens: MatrixSessionTokens { access_token: "1234".to_owned(), refresh_token: None },
+    };
+
+    let (client, server) = no_retry_test_client_with_server().await;
+    client.restore_session(session).await.unwrap();
+
+    assert!(
+        !client.encryption().cross_signing_status().await.unwrap().is_complete(),
+        "Initially we shouldn't have any cross-signin keys",
+    );
+
+    let handle = client.encryption().reset_cross_signing().await.unwrap();
+}


### PR DESCRIPTION
This method supports OIDC as well as the usual UIAA method of cross-signing reset, it attempts to guide the user more easily towards a successful reset.

The cross-signing bootstrap example was modified to use the new method and the functionality was exposed in the oidc-cli example as well.
