### PR TITLE
tests(timeline): make use of the `EventFactory` more

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/mod.rs
@@ -626,20 +626,6 @@ impl<P: RoomDataProvider> TimelineInner<P> {
         state.handle_ephemeral_events(events, &self.room_data_provider).await;
     }
 
-    #[cfg(test)]
-    pub(super) async fn handle_live_event(&self, event: SyncTimelineEvent) {
-        let mut state = self.state.write().await;
-        state
-            .add_remote_events_at(
-                vec![event],
-                TimelineEnd::Back,
-                RemoteEventOrigin::Sync,
-                &self.room_data_provider,
-                &self.settings,
-            )
-            .await;
-    }
-
     /// Creates the local echo for an event we're sending.
     #[instrument(skip_all)]
     pub(super) async fn handle_local_event(

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -125,7 +125,7 @@ async fn test_sticker() {
     let mut stream = timeline.subscribe_events().await;
 
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {
                 "body": "Happy sticker",
                 "info": {
@@ -291,7 +291,7 @@ async fn test_dedup_pagination() {
     let event = timeline
         .event_builder
         .make_sync_message_event(*ALICE, RoomMessageEventContent::text_plain("o/"));
-    timeline.handle_live_custom_event(event.clone()).await;
+    timeline.handle_live_event(event.clone()).await;
     // This cast is not actually correct, sync events aren't valid
     // back-paginated events, as they are missing `room_id`. However, the
     // timeline doesn't care about that `room_id` and casts back to

--- a/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/basic.rs
@@ -296,7 +296,7 @@ async fn test_dedup_pagination() {
     // back-paginated events, as they are missing `room_id`. However, the
     // timeline doesn't care about that `room_id` and casts back to
     // `Raw<AnySyncTimelineEvent>` before attempting to deserialize.
-    timeline.handle_back_paginated_custom_event(event.cast()).await;
+    timeline.handle_back_paginated_event(event.cast()).await;
 
     let timeline_items = timeline.inner.items().await;
     assert_eq!(timeline_items.len(), 2);

--- a/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/echo.rs
@@ -104,7 +104,7 @@ async fn test_remote_echo_full_trip() {
     // Now, a sync has been run against the server, and an event with the same ID
     // comes in.
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {
                 "body": "echo",
                 "msgtype": "m.text",
@@ -153,7 +153,7 @@ async fn test_remote_echo_new_position() {
 
     // When the remote echo comes in…
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {
                 "body": "echo",
                 "msgtype": "m.text",
@@ -201,7 +201,7 @@ async fn test_day_divider_duplication() {
     // … when the second remote event is re-received (day still the same)
     let event_id = items[2].as_event().unwrap().event_id().unwrap();
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {
                 "body": "B",
                 "msgtype": "m.text",

--- a/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/event_filter.rs
@@ -180,7 +180,7 @@ async fn test_hide_failed_to_parse() {
     // m.room.message events must have a msgtype and body in content, so this
     // event with an empty content object should fail to deserialize.
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {},
             "event_id": "$eeG0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 10,
@@ -192,7 +192,7 @@ async fn test_hide_failed_to_parse() {
     // Similar to above, the m.room.member state event must also not have an
     // empty content object.
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {},
             "event_id": "$d5G0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 2179,

--- a/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/invalid.rs
@@ -63,7 +63,7 @@ async fn invalid_event_content() {
     // m.room.message events must have a msgtype and body in content, so this
     // event with an empty content object should fail to deserialize.
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {},
             "event_id": "$eeG0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 10,
@@ -82,7 +82,7 @@ async fn invalid_event_content() {
     // Similar to above, the m.room.member state event must also not have an
     // empty content object.
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {},
             "event_id": "$d5G0HA0FAZ37wP8kXlNkxx3I",
             "origin_server_ts": 2179,
@@ -110,7 +110,7 @@ async fn invalid_event() {
     // This event is missing the sender field which the homeserver must add to
     // all timeline events. Because the event is malformed, it will be ignored.
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {
                 "body": "hello world",
                 "msgtype": "m.text"

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -47,7 +47,7 @@ use ruma::{
     room_id,
     serde::Raw,
     server_name, uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId,
-    OwnedUserId, RoomId, RoomVersionId, TransactionId, UInt, UserId,
+    OwnedUserId, RoomVersionId, TransactionId, UInt, UserId,
 };
 
 use super::{
@@ -251,19 +251,6 @@ impl TestTimeline {
             )
             .await;
         txn_id
-    }
-
-    async fn handle_back_paginated_message_event_with_id<C>(
-        &self,
-        sender: &UserId,
-        room_id: &RoomId,
-        event_id: &EventId,
-        content: C,
-    ) where
-        C: MessageLikeEventContent,
-    {
-        let ev = self.event_builder.make_message_event_with_id(sender, room_id, event_id, content);
-        self.handle_back_paginated_custom_event(ev).await;
     }
 
     async fn handle_back_paginated_custom_event(&self, event: Raw<AnyTimelineEvent>) {

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -37,9 +37,8 @@ use ruma::{
     events::{
         receipt::{Receipt, ReceiptThread, ReceiptType},
         relation::Annotation,
-        AnyMessageLikeEventContent, AnySyncTimelineEvent, AnyTimelineEvent, EmptyStateKey,
-        MessageLikeEventContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
-        StaticStateEventContent,
+        AnyMessageLikeEventContent, AnyTimelineEvent, EmptyStateKey, MessageLikeEventContent,
+        RedactedMessageLikeEventContent, RedactedStateEventContent, StaticStateEventContent,
     },
     int,
     power_levels::NotificationPowerLevels,
@@ -212,11 +211,6 @@ impl TestTimeline {
         self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
     }
 
-    async fn handle_live_redaction(&self, sender: &UserId, redacts: &EventId) {
-        let ev = self.event_builder.make_redaction_event(sender, redacts);
-        self.handle_live_event(ev).await;
-    }
-
     async fn handle_live_reaction(&self, sender: &UserId, annotation: &Annotation) -> OwnedEventId {
         let event_id = EventId::new(server_name!("dummy.server"));
         let ev = self.event_builder.make_reaction_event(sender, &event_id, annotation);
@@ -224,8 +218,8 @@ impl TestTimeline {
         event_id
     }
 
-    async fn handle_live_event(&self, event: Raw<AnySyncTimelineEvent>) {
-        let event = SyncTimelineEvent::new(event);
+    async fn handle_live_event(&self, event: impl Into<SyncTimelineEvent>) {
+        let event = event.into();
         self.inner.add_events_at(vec![event], TimelineEnd::Back, RemoteEventOrigin::Sync).await;
     }
 

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -253,7 +253,7 @@ impl TestTimeline {
         txn_id
     }
 
-    async fn handle_back_paginated_custom_event(&self, event: Raw<AnyTimelineEvent>) {
+    async fn handle_back_paginated_event(&self, event: Raw<AnyTimelineEvent>) {
         let timeline_event = TimelineEvent::new(event.cast());
         self.inner
             .add_events_at(vec![timeline_event], TimelineEnd::Front, RemoteEventOrigin::Pagination)

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -212,10 +212,6 @@ impl TestTimeline {
         self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
     }
 
-    async fn handle_live_custom_event(&self, event: Raw<AnySyncTimelineEvent>) {
-        self.handle_live_event(event).await;
-    }
-
     async fn handle_live_redaction(&self, sender: &UserId, redacts: &EventId) {
         let ev = self.event_builder.make_redaction_event(sender, redacts);
         self.handle_live_event(ev).await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -226,7 +226,7 @@ impl TestTimeline {
 
     async fn handle_live_event(&self, event: Raw<AnySyncTimelineEvent>) {
         let event = SyncTimelineEvent::new(event);
-        self.inner.handle_live_event(event).await
+        self.inner.add_events_at(vec![event], TimelineEnd::Back, RemoteEventOrigin::Sync).await;
     }
 
     async fn handle_local_event(&self, content: AnyMessageLikeEventContent) -> OwnedTransactionId {

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -45,8 +45,8 @@ use ruma::{
     push::{PushConditionPowerLevelsCtx, PushConditionRoomCtx, Ruleset},
     room_id,
     serde::Raw,
-    server_name, uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId,
-    OwnedUserId, RoomVersionId, TransactionId, UInt, UserId,
+    uint, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
+    RoomVersionId, TransactionId, UInt, UserId,
 };
 
 use super::{
@@ -197,13 +197,6 @@ impl TestTimeline {
         let ev =
             self.event_builder.make_sync_redacted_state_event(sender, state_key.as_ref(), content);
         self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
-    }
-
-    async fn handle_live_reaction(&self, sender: &UserId, annotation: &Annotation) -> OwnedEventId {
-        let event_id = EventId::new(server_name!("dummy.server"));
-        let ev = self.event_builder.make_reaction_event(sender, &event_id, annotation);
-        self.handle_live_event(ev).await;
-        event_id
     }
 
     async fn handle_live_event(&self, event: impl Into<SyncTimelineEvent>) {

--- a/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/mod.rs
@@ -144,18 +144,6 @@ impl TestTimeline {
         self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
     }
 
-    async fn handle_live_message_event_with_id<C>(
-        &self,
-        sender: &UserId,
-        event_id: &EventId,
-        content: C,
-    ) where
-        C: MessageLikeEventContent,
-    {
-        let ev = self.event_builder.make_sync_message_event_with_id(sender, event_id, content);
-        self.handle_live_event(Raw::new(&ev).unwrap().cast()).await;
-    }
-
     async fn handle_live_redacted_message_event<C>(&self, sender: &UserId, content: C)
     where
         C: RedactedMessageLikeEventContent,

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -109,12 +109,12 @@ async fn test_read_receipts_updates_on_back_paginated_events() {
     let f = EventFactory::new().room(room_id);
 
     timeline
-        .handle_back_paginated_custom_event(
+        .handle_back_paginated_event(
             f.text_msg("A").sender(*BOB).event_id(event_id!("$event_a")).into_raw_timeline(),
         )
         .await;
     timeline
-        .handle_back_paginated_custom_event(
+        .handle_back_paginated_event(
             f.text_msg("B")
                 .sender(*CAROL)
                 .event_id(event_id!("$event_with_bob_receipt"))
@@ -289,12 +289,12 @@ async fn test_read_receipts_updates_on_back_paginated_filtered_events() {
     let f = EventFactory::new().room(room_id);
 
     timeline
-        .handle_back_paginated_custom_event(
+        .handle_back_paginated_event(
             f.text_msg("A").sender(*ALICE).event_id(event_id!("$event_a")).into_raw_timeline(),
         )
         .await;
     timeline
-        .handle_back_paginated_custom_event(
+        .handle_back_paginated_event(
             f.notice("B")
                 .sender(*CAROL)
                 .event_id(event_id!("$event_with_bob_receipt"))
@@ -312,7 +312,7 @@ async fn test_read_receipts_updates_on_back_paginated_filtered_events() {
 
     // Add non-filtered event to show read receipts.
     timeline
-        .handle_back_paginated_custom_event(
+        .handle_back_paginated_event(
             f.text_msg("C").sender(*CAROL).event_id(event_id!("$event_c")).into_raw_timeline(),
         )
         .await;
@@ -606,7 +606,7 @@ async fn test_clear_read_receipts() {
 
     // Old message via back-pagination.
     timeline
-        .handle_back_paginated_custom_event(
+        .handle_back_paginated_event(
             f.event(event_a_content)
                 .sender(*BOB)
                 .room(room_id)

--- a/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/read_receipts.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use eyeball_im::VectorDiff;
+use matrix_sdk::test_utils::events::EventFactory;
 use matrix_sdk_test::{async_test, ALICE, BOB, CAROL};
 use ruma::{
     event_id,
@@ -105,20 +106,19 @@ async fn test_read_receipts_updates_on_back_paginated_events() {
         .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
     let room_id = room_id!("!room:localhost");
 
+    let f = EventFactory::new().room(room_id);
+
     timeline
-        .handle_back_paginated_message_event_with_id(
-            *BOB,
-            room_id,
-            event_id!("$event_a"),
-            RoomMessageEventContent::text_plain("A"),
+        .handle_back_paginated_custom_event(
+            f.text_msg("A").sender(*BOB).event_id(event_id!("$event_a")).into_raw_timeline(),
         )
         .await;
     timeline
-        .handle_back_paginated_message_event_with_id(
-            *CAROL,
-            room_id,
-            event_id!("$event_with_bob_receipt"),
-            RoomMessageEventContent::text_plain("B"),
+        .handle_back_paginated_custom_event(
+            f.text_msg("B")
+                .sender(*CAROL)
+                .event_id(event_id!("$event_with_bob_receipt"))
+                .into_raw_timeline(),
         )
         .await;
 
@@ -176,6 +176,7 @@ async fn test_read_receipts_updates_on_filtered_events() {
 
     // Populate more events.
     let event_d_id = owned_event_id!("$event_d");
+
     timeline
         .handle_live_message_event_with_id(
             *ALICE,
@@ -285,20 +286,19 @@ async fn test_read_receipts_updates_on_back_paginated_filtered_events() {
     let mut stream = timeline.subscribe().await;
     let room_id = room_id!("!room:localhost");
 
+    let f = EventFactory::new().room(room_id);
+
     timeline
-        .handle_back_paginated_message_event_with_id(
-            *ALICE,
-            room_id,
-            event_id!("$event_a"),
-            RoomMessageEventContent::text_plain("A"),
+        .handle_back_paginated_custom_event(
+            f.text_msg("A").sender(*ALICE).event_id(event_id!("$event_a")).into_raw_timeline(),
         )
         .await;
     timeline
-        .handle_back_paginated_message_event_with_id(
-            *CAROL,
-            room_id,
-            event_id!("$event_with_bob_receipt"),
-            RoomMessageEventContent::notice_plain("B"),
+        .handle_back_paginated_custom_event(
+            f.notice("B")
+                .sender(*CAROL)
+                .event_id(event_id!("$event_with_bob_receipt"))
+                .into_raw_timeline(),
         )
         .await;
 
@@ -312,11 +312,8 @@ async fn test_read_receipts_updates_on_back_paginated_filtered_events() {
 
     // Add non-filtered event to show read receipts.
     timeline
-        .handle_back_paginated_message_event_with_id(
-            *CAROL,
-            room_id,
-            event_id!("$event_c"),
-            RoomMessageEventContent::text_plain("C"),
+        .handle_back_paginated_custom_event(
+            f.text_msg("C").sender(*CAROL).event_id(event_id!("$event_c")).into_raw_timeline(),
         )
         .await;
 
@@ -579,6 +576,8 @@ async fn test_clear_read_receipts() {
     let event_a_id = event_id!("$event_a");
     let event_b_id = event_id!("$event_b");
 
+    let f = EventFactory::new();
+
     let timeline = TestTimeline::new()
         .with_settings(TimelineInnerSettings { track_read_receipts: true, ..Default::default() });
 
@@ -604,9 +603,16 @@ async fn test_clear_read_receipts() {
             RoomMessageEventContent::text_plain("B"),
         )
         .await;
+
     // Old message via back-pagination.
     timeline
-        .handle_back_paginated_message_event_with_id(*BOB, room_id, event_a_id, event_a_content)
+        .handle_back_paginated_custom_event(
+            f.event(event_a_content)
+                .sender(*BOB)
+                .room(room_id)
+                .event_id(event_a_id)
+                .into_raw_timeline(),
+        )
         .await;
 
     let items = timeline.inner.items().await;

--- a/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
+++ b/crates/matrix-sdk-ui/src/timeline/tests/redaction.rs
@@ -218,7 +218,7 @@ async fn test_receive_unredacted() {
 
     // send new events with the same event ID as the previous ones
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {
                 "body": "unredacted #1",
                 "msgtype": "m.text",
@@ -230,7 +230,7 @@ async fn test_receive_unredacted() {
         }))
         .await;
     timeline
-        .handle_live_custom_event(sync_timeline_event!({
+        .handle_live_event(sync_timeline_event!({
             "content": {
                 "body": "unredacted #2",
                 "msgtype": "m.text",

--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -155,8 +155,14 @@ impl EventFactory {
         }
     }
 
+    /// Create a new plain text `m.room.message`.
     pub fn text_msg(&self, content: impl Into<String>) -> EventBuilder<RoomMessageEventContent> {
         self.event(RoomMessageEventContent::text_plain(content.into()))
+    }
+
+    /// Create a new plain notice `m.room.message`.
+    pub fn notice(&self, content: impl Into<String>) -> EventBuilder<RoomMessageEventContent> {
+        self.event(RoomMessageEventContent::notice_plain(content))
     }
 
     /// Set the next server timestamp.

--- a/testing/matrix-sdk-test/src/event_builder.rs
+++ b/testing/matrix-sdk-test/src/event_builder.rs
@@ -235,27 +235,6 @@ impl EventBuilder {
         ev_content
     }
 
-    pub fn make_reaction_event(
-        &self,
-        sender: &UserId,
-        event_id: &EventId,
-        annotation: &Annotation,
-    ) -> Raw<AnySyncTimelineEvent> {
-        sync_timeline_event!({
-            "type": "m.reaction",
-            "content": {
-                "m.relates_to": {
-                    "rel_type": "m.annotation",
-                    "event_id": annotation.event_id,
-                    "key": annotation.key,
-                },
-            },
-            "event_id": event_id,
-            "sender": sender,
-            "origin_server_ts": self.next_server_ts(),
-        })
-    }
-
     fn make_redacted_unsigned(&self, sender: &UserId) -> JsonValue {
         json!({
             "redacted_because": {

--- a/testing/matrix-sdk-test/src/event_builder.rs
+++ b/testing/matrix-sdk-test/src/event_builder.rs
@@ -57,23 +57,6 @@ impl EventBuilder {
         self.next_ts.store(value, SeqCst);
     }
 
-    pub fn make_message_event_with_id<C: MessageLikeEventContent>(
-        &self,
-        sender: &UserId,
-        room_id: &RoomId,
-        event_id: &EventId,
-        content: C,
-    ) -> Raw<AnyTimelineEvent> {
-        timeline_event!({
-            "type": content.event_type(),
-            "content": content,
-            "event_id": event_id,
-            "sender": sender,
-            "room_id": room_id,
-            "origin_server_ts": self.next_server_ts(),
-        })
-    }
-
     pub fn make_state_event<C: StateEventContent>(
         &self,
         sender: &UserId,

--- a/testing/matrix-sdk-test/src/event_builder.rs
+++ b/testing/matrix-sdk-test/src/event_builder.rs
@@ -235,21 +235,6 @@ impl EventBuilder {
         ev_content
     }
 
-    pub fn make_redaction_event(
-        &self,
-        sender: &UserId,
-        redacts: &EventId,
-    ) -> Raw<AnySyncTimelineEvent> {
-        sync_timeline_event!({
-            "type": "m.room.redaction",
-            "content": {},
-            "redacts": redacts,
-            "event_id": EventId::new(server_name!("dummy.server")),
-            "sender": sender,
-            "origin_server_ts": self.next_server_ts(),
-        })
-    }
-
     pub fn make_reaction_event(
         &self,
         sender: &UserId,


### PR DESCRIPTION
The `TestTimeline` had lots and lots of custom methods for creating test events and handling them immediately. Since the `EventFactory` helper makes it possible to easily create events, there's no need to repeat those responsibilities in the timeline testing code itself, and we can make more use of the `EventFactory` instead.

There's much more to do there; ideally, we'd get rid of most of `TestTimeline::handle_` methods (we'd keep `handle_live_events`), as well as `EventBuilder` entirely, which API isn't flexible at all. Could be some nice and fun good-first-bugs :sunglasses: