### PR TITLE
crypto: Pass room id and session id to `room_keys_withheld_received_stream`

### DIFF
--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -63,7 +63,8 @@ Additions:
 - Expose new method `OlmMachine::room_keys_withheld_received_stream`, to allow
   applications to receive notifications about received `m.room_key.withheld`
   events.
-  ([#3660](https://github.com/matrix-org/matrix-rust-sdk/pull/3660))
+  ([#3660](https://github.com/matrix-org/matrix-rust-sdk/pull/3660)),
+  ([#3674](https://github.com/matrix-org/matrix-rust-sdk/pull/3674))
 
 - Expose new method `OlmMachine::clear_crypto_cache()`, with FFI bindings
   ([#3462](https://github.com/matrix-org/matrix-rust-sdk/pull/3462))

--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -3292,8 +3292,10 @@ pub(crate) mod tests {
             .flatten()
             .expect("We should have received a notification of room key being withheld");
         assert_eq!(withheld_received.len(), 1);
+
+        assert_eq!(&withheld_received[0].room_id, room_id);
         assert_matches!(
-            &withheld_received[0].content,
+            &withheld_received[0].withheld_event.content,
             RoomKeyWithheldContent::MegolmV1AesSha2(MegolmV1AesSha2WithheldContent::Unverified(
                 unverified_withheld_content
             ))

--- a/crates/matrix-sdk-crypto/src/store/mod.rs
+++ b/crates/matrix-sdk-crypto/src/store/mod.rs
@@ -913,6 +913,20 @@ impl From<&InboundGroupSession> for RoomKeyInfo {
     }
 }
 
+/// Information on a room key that has been withheld
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RoomKeyWithheldInfo {
+    /// The room where the key is used.
+    pub room_id: OwnedRoomId,
+
+    /// The ID of the session that the key is for.
+    pub session_id: String,
+
+    /// The `m.room_key.withheld` event that notified us that the key is being
+    /// withheld.
+    pub withheld_event: RoomKeyWithheldEvent,
+}
+
 impl Store {
     /// Create a new Store.
     pub(crate) fn new(
@@ -1473,7 +1487,7 @@ impl Store {
     /// logged and items will be dropped.
     pub fn room_keys_withheld_received_stream(
         &self,
-    ) -> impl Stream<Item = Vec<RoomKeyWithheldEvent>> {
+    ) -> impl Stream<Item = Vec<RoomKeyWithheldInfo>> {
         self.inner.store.room_keys_withheld_received_stream()
     }
 


### PR DESCRIPTION
Followup on #3660: I realised I didn't want to have to parse the room_id and session_id out of the messages again.