### PR TITLE
tests: get rid of the `non_sync_events` macro

### DIFF
--- a/crates/matrix-sdk/src/test_utils/events.rs
+++ b/crates/matrix-sdk/src/test_utils/events.rs
@@ -126,6 +126,15 @@ where
     }
 }
 
+impl<E: EventContent> From<EventBuilder<E>> for Raw<AnyTimelineEvent>
+where
+    E::EventType: Serialize,
+{
+    fn from(val: EventBuilder<E>) -> Self {
+        val.into_raw_timeline()
+    }
+}
+
 impl<E: EventContent> From<EventBuilder<E>> for SyncTimelineEvent
 where
     E::EventType: Serialize,


### PR DESCRIPTION
It's actually simpler to not use a macro here, and the `EventFactory` "curried" parameters make this a breeze to avoid repetition.

(Only last commit applies, will rebase before review.)