### PR TITLE
crypto: Rename msk to master_key for consistency with the wider codebase

### DIFF
--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/sender_data.rs
@@ -60,13 +60,13 @@ pub enum SenderData {
         user_id: OwnedUserId,
 
         /// The cross-signing key of the user who established this session.
-        msk: Ed25519PublicKey,
+        master_key: Ed25519PublicKey,
 
         /// Whether, at the time we checked the signature on the device,
-        /// we had actively verified that `msk` belongs to the user.
+        /// we had actively verified that `master_key` belongs to the user.
         /// If false, we had simply accepted the key as this user's latest
         /// key.
-        msk_verified: bool,
+        master_key_verified: bool,
     },
 }
 


### PR DESCRIPTION
As suggested in https://github.com/matrix-org/matrix-rust-sdk/pull/3590#discussion_r1671945866

Part of https://github.com/matrix-org/matrix-rust-sdk/issues/3543