### PR TITLE
feat(base): New `RoomInfoNotableUpdateReasons::READ_RECEIPT`

### DIFF
--- a/crates/matrix-sdk-base/src/read_receipts.rs
+++ b/crates/matrix-sdk-base/src/read_receipts.rs
@@ -449,8 +449,6 @@ fn events_intersects<'a>(
 /// that has been just received for an event that came in a previous sync.
 ///
 /// See this module's documentation for more information.
-///
-/// Returns a boolean indicating if a field changed value in the read receipts.
 #[instrument(skip_all, fields(room_id = %room_id))]
 pub(crate) fn compute_unread_counts(
     user_id: &UserId,

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -96,6 +96,9 @@ bitflags! {
 
         /// The latest event of the `Room` has changed.
         const LATEST_EVENT = 0b0000_0010;
+
+        /// A read receipt has changed.
+        const READ_RECEIPT = 0b0000_0100;
     }
 }
 

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -1866,7 +1866,8 @@ mod tests {
         let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
-        // Then a room info notable update is NOT received, because it's the first time the room is seen.
+        // Then a room info notable update is NOT received, because it's the first time
+        // the room is seen.
         assert_matches!(
             room_info_notable_update_stream.recv().await,
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
@@ -1913,7 +1914,8 @@ mod tests {
             }
         );
 
-        // When I send sliding sync response containing a couple of events with no read receipt.
+        // When I send sliding sync response containing a couple of events with no read
+        // receipt.
         let room_id = room_id!("!r:e.uk");
         let events = vec![
             make_raw_event("m.room.message", "$3"),

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -275,6 +275,11 @@ impl BaseClient {
                 );
 
                 if prev_read_receipts != room_info.read_receipts {
+                    room_info_notable_updates
+                        .entry(room_id.clone())
+                        .or_default()
+                        .insert(RoomInfoNotableUpdateReasons::READ_RECEIPT);
+
                     changes.add_room(room_info);
                 }
             }
@@ -1887,6 +1892,50 @@ mod tests {
         );
     }
 
+    #[async_test]
+    async fn test_read_receipt_can_trigger_a_notable_update_reason() {
+        // Given a logged-in client
+        let client = logged_in_base_client(None).await;
+        let mut room_info_notable_update_stream = client.room_info_notable_update_receiver();
+
+        // When I send sliding sync response containing a new room.
+        let room_id = room_id!("!r:e.uk");
+        let room = v4::SlidingSyncRoom::new();
+        let response = response_with_room(room_id, room);
+        client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+
+        // Then a room info notable update is NOT received.
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(!received_reasons.contains(RoomInfoNotableUpdateReasons::READ_RECEIPT));
+            }
+        );
+
+        // When I send sliding sync response containing a couple of events with no read receipt.
+        let room_id = room_id!("!r:e.uk");
+        let events = vec![
+            make_raw_event("m.room.message", "$3"),
+            make_raw_event("m.room.message", "$4"),
+            make_raw_event("m.read", "$5"),
+        ];
+        let room = assign!(v4::SlidingSyncRoom::new(), {
+            timeline: events,
+        });
+        let response = response_with_room(room_id, room);
+        client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+
+        // Then a room info notable update is received.
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::READ_RECEIPT));
+            }
+        );
+    }
+
     async fn choose_event_to_cache(events: &[SyncTimelineEvent]) -> Option<SyncTimelineEvent> {
         let room = make_room();
         let mut room_info = room.clone_info();
@@ -1923,20 +1972,22 @@ mod tests {
         )
     }
 
-    fn make_event(typ: &str, id: &str) -> SyncTimelineEvent {
-        SyncTimelineEvent::new(
-            Raw::from_json_string(
-                json!({
-                    "type": typ,
-                    "event_id": id,
-                    "content": { "msgtype": "m.text", "body": "my msg" },
-                    "sender": "@u:h.uk",
-                    "origin_server_ts": 12344445,
-                })
-                .to_string(),
-            )
-            .unwrap(),
+    fn make_raw_event(typ: &str, id: &str) -> Raw<AnySyncTimelineEvent> {
+        Raw::from_json_string(
+            json!({
+                "type": typ,
+                "event_id": id,
+                "content": { "msgtype": "m.text", "body": "my msg" },
+                "sender": "@u:h.uk",
+                "origin_server_ts": 12344445,
+            })
+            .to_string(),
         )
+        .unwrap()
+    }
+
+    fn make_event(typ: &str, id: &str) -> SyncTimelineEvent {
+        SyncTimelineEvent::new(make_raw_event(typ, id))
     }
 
     fn make_encrypted_event(id: &str) -> SyncTimelineEvent {

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -190,6 +190,8 @@ fn merge_stream_and_receiver(
     raw_stream: impl Stream<Item = Vec<VectorDiff<Room>>>,
     mut room_info_notable_update_receiver: broadcast::Receiver<RoomInfoNotableUpdate>,
 ) -> impl Stream<Item = Vec<VectorDiff<Room>>> {
+    use RoomInfoNotableUpdateReasons as NotableUpdate;
+
     stream! {
         pin_mut!(raw_stream);
 
@@ -215,8 +217,9 @@ fn merge_stream_and_receiver(
                     let reasons = &update.reasons;
 
                     // We are interested by these _reasons_.
-                    if reasons.contains(RoomInfoNotableUpdateReasons::LATEST_EVENT) ||
-                        reasons.contains(RoomInfoNotableUpdateReasons::RECENCY_TIMESTAMP) {
+                    if reasons.contains(NotableUpdate::LATEST_EVENT) ||
+                        reasons.contains(NotableUpdate::RECENCY_TIMESTAMP) ||
+                        reasons.contains(NotableUpdate::READ_RECEIPT) {
                         // Emit a `VectorDiff::Set` for the specific rooms.
                         if let Some(index) = raw_current_values.iter().position(|room| room.room_id() == update.room_id) {
                             let update = VectorDiff::Set { index, value: raw_current_values[index].clone() };


### PR DESCRIPTION
Please review this PR patch-by-patch.

tl;dr: this PR adds the `READ_RECEIPT` reason for the room info notable update, in order to refresh the room list for this particular reason. This PR also adds a missing test for the `LATEST_EVENT` reason (it was tested in `matrix-sdk-ui` but it's better to also unit test it in `matrix-sdk-base` directly).