### PR TITLE
timeline: move `TimelineEventContext::encryption_info` to the remote flow

### DIFF
--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -87,6 +87,8 @@ pub(super) enum Flow {
         raw_event: Raw<AnySyncTimelineEvent>,
         /// Where should this be added in the timeline.
         position: TimelineItemPosition,
+        /// Information about the encryption for this event.
+        encryption_info: Option<EncryptionInfo>,
         /// Should this event actually be added, based on the event filters.
         should_add: bool,
     },
@@ -98,7 +100,6 @@ pub(super) struct TimelineEventContext {
     pub(super) sender_profile: Option<Profile>,
     pub(super) timestamp: MilliSecondsSinceUnixEpoch,
     pub(super) is_own_event: bool,
-    pub(super) encryption_info: Option<EncryptionInfo>,
     pub(super) read_receipts: IndexMap<OwnedUserId, Receipt>,
     pub(super) is_highlighted: bool,
     pub(super) flow: Flow,
@@ -891,7 +892,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             }
             .into(),
 
-            Flow::Remote { event_id, raw_event, position, txn_id, .. } => {
+            Flow::Remote { event_id, raw_event, position, txn_id, encryption_info, .. } => {
                 // Drop pending reactions if the message is redacted.
                 if let TimelineItemContent::RedactedMessage = content {
                     if !reactions.is_empty() {
@@ -921,7 +922,7 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
                     read_receipts: self.ctx.read_receipts.clone(),
                     is_own: self.ctx.is_own_event,
                     is_highlighted: self.ctx.is_highlighted,
-                    encryption_info: self.ctx.encryption_info.clone(),
+                    encryption_info: encryption_info.clone(),
                     original_json: Some(raw_event.clone()),
                     latest_edit_json: None,
                     origin,

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -171,8 +171,6 @@ impl TimelineInnerState {
             sender_profile: own_profile,
             timestamp: MilliSecondsSinceUnixEpoch::now(),
             is_own_event: true,
-            // FIXME: Should we supply something here for encrypted rooms?
-            encryption_info: None,
             read_receipts: Default::default(),
             // An event sent by ourself is never matched against push rules.
             is_highlighted: false,
@@ -557,7 +555,6 @@ impl TimelineInnerStateTransaction<'_> {
             sender_profile,
             timestamp,
             is_own_event,
-            encryption_info: event.encryption_info,
             read_receipts: if settings.track_read_receipts && should_add {
                 self.meta.read_receipts.compute_event_receipts(
                     &event_id,
@@ -571,6 +568,7 @@ impl TimelineInnerStateTransaction<'_> {
             flow: Flow::Remote {
                 event_id: event_id.clone(),
                 raw_event: raw.clone(),
+                encryption_info: event.encryption_info,
                 txn_id,
                 position,
                 should_add,


### PR DESCRIPTION
Since it's only used for remote events, and a local echo couldn't figure that out anyways (since it's not sent yet, and that information makes sense after sending).