### PR TITLE
sdk: provide a way to create edit events

### DIFF
--- a/bindings/matrix-sdk-ffi/src/error.rs
+++ b/bindings/matrix-sdk-ffi/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use matrix_sdk::{
     encryption::CryptoStoreError, event_cache::EventCacheError, oidc::OidcError, reqwest,
-    send_queue::RoomSendQueueError, HttpError, IdParseError,
+    room::edit::EditError, send_queue::RoomSendQueueError, HttpError, IdParseError,
     NotificationSettingsError as SdkNotificationSettingsError, StoreError,
 };
 use matrix_sdk_ui::{encryption_sync_service, notification_client, sync_service, timeline};
@@ -136,6 +136,12 @@ impl From<EventCacheError> for ClientError {
 
 impl From<RoomSendQueueError> for ClientError {
     fn from(e: RoomSendQueueError) -> Self {
+        Self::new(e)
+    }
+}
+
+impl From<EditError> for ClientError {
+    fn from(e: EditError) -> Self {
         Self::new(e)
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -475,8 +475,6 @@ impl Timeline {
 
     /// Edits an event from the timeline.
     ///
-    /// Only works for events that exist as timeline items.
-    ///
     /// If it was a local event, this will *try* to edit it, if it was not
     /// being sent already. If the event was a remote event, then it will be
     /// redacted by sending an edit request to the server.
@@ -488,24 +486,7 @@ impl Timeline {
         item: Arc<EventTimelineItem>,
         new_content: Arc<RoomMessageEventContentWithoutRelation>,
     ) -> Result<bool, ClientError> {
-        let edit_info = item.0.edit_info().map_err(ClientError::from)?;
-
-        self.inner.edit((*new_content).clone(), edit_info).await.map_err(ClientError::from)
-    }
-
-    /// Edit an event given its event id. Useful when we're not sure a remote
-    /// timeline event has been fetched by the timeline.
-    pub async fn edit_by_event_id(
-        &self,
-        event_id: String,
-        new_content: Arc<RoomMessageEventContentWithoutRelation>,
-    ) -> Result<(), ClientError> {
-        let event_id = EventId::parse(event_id)?;
-        let edit_info =
-            self.inner.edit_info_from_event_id(&event_id).await.map_err(ClientError::from)?;
-
-        self.inner.edit((*new_content).clone(), edit_info).await.map_err(ClientError::from)?;
-        Ok(())
+        self.inner.edit(&item.0, (*new_content).clone()).await.map_err(ClientError::from)
     }
 
     pub async fn edit_poll(

--- a/crates/matrix-sdk-ui/src/timeline/error.rs
+++ b/crates/matrix-sdk-ui/src/timeline/error.rs
@@ -14,6 +14,7 @@
 
 use matrix_sdk::{
     event_cache::{paginator::PaginatorError, EventCacheError},
+    room::edit::EditError,
     send_queue::{RoomSendQueueError, RoomSendQueueStorageError},
 };
 use ruma::OwnedTransactionId;
@@ -70,6 +71,10 @@ pub enum Error {
     /// An error happened while operating the room's send queue.
     #[error(transparent)]
     SendQueueError(#[from] RoomSendQueueError),
+
+    /// An error happened while attempting to edit an event.
+    #[error(transparent)]
+    EditError(#[from] EditError),
 }
 
 #[derive(Error, Debug)]

--- a/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/mod.rs
@@ -45,7 +45,7 @@ pub(super) use self::{
     local::LocalEventTimelineItem,
     remote::{RemoteEventOrigin, RemoteEventTimelineItem},
 };
-use super::{EditInfo, RepliedToInfo, ReplyContent, UnsupportedEditItem, UnsupportedReplyItem};
+use super::{RepliedToInfo, ReplyContent, UnsupportedReplyItem};
 
 /// An item in the timeline that represents at least one event.
 ///
@@ -458,20 +458,6 @@ impl EventTimelineItem {
             timestamp: self.timestamp(),
             content: reply_content,
         })
-    }
-
-    /// Gives the information needed to edit the event of the item.
-    pub fn edit_info(&self) -> Result<EditInfo, UnsupportedEditItem> {
-        // Steps here should be in sync with [`EventTimelineItem::is_editable`].
-        if !self.is_own() {
-            return Err(UnsupportedEditItem::NotOwnEvent);
-        }
-
-        let TimelineItemContent::Message(original_content) = self.content() else {
-            return Err(UnsupportedEditItem::NotRoomMessage);
-        };
-
-        Ok(EditInfo { id: self.identifier(), original_message: original_content.clone() })
     }
 }
 

--- a/crates/matrix-sdk/src/error.rs
+++ b/crates/matrix-sdk/src/error.rs
@@ -41,7 +41,7 @@ use serde_json::Error as JsonError;
 use thiserror::Error;
 use url::ParseError as UrlParseError;
 
-use crate::store_locks::LockStoreError;
+use crate::{event_cache::EventCacheError, store_locks::LockStoreError};
 
 /// Result type of the matrix-sdk.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -321,6 +321,10 @@ pub enum Error {
     /// but not here and that raised.
     #[error("unknown error: {0}")]
     UnknownError(Box<dyn std::error::Error + Send + Sync>),
+
+    /// An error coming from the event cache subsystem.
+    #[error(transparent)]
+    EventCache(#[from] EventCacheError),
 }
 
 #[rustfmt::skip] // stop rustfmt breaking the `<code>` in docs across multiple lines

--- a/crates/matrix-sdk/src/event_cache/mod.rs
+++ b/crates/matrix-sdk/src/event_cache/mod.rs
@@ -108,11 +108,6 @@ pub enum EventCacheError {
     /// times where we try to use the client.
     #[error("The owning client of the event cache has been dropped.")]
     ClientDropped,
-
-    /// Another error caused by the SDK happened somewhere, and we report it to
-    /// the caller.
-    #[error("SDK error: {0}")]
-    SdkError(#[source] crate::Error),
 }
 
 /// A result using the [`EventCacheError`].

--- a/crates/matrix-sdk/src/event_cache/paginator.rs
+++ b/crates/matrix-sdk/src/event_cache/paginator.rs
@@ -64,7 +64,7 @@ pub enum PaginatorError {
 
     /// There was another SDK error while paginating.
     #[error("an error happened while paginating")]
-    SdkError(#[source] crate::Error),
+    SdkError(#[from] Box<crate::Error>),
 }
 
 /// Pagination token data, indicating in which state is the current pagination.
@@ -484,7 +484,7 @@ impl PaginableRoom for Room {
                 }
 
                 // Otherwise, just return a wrapped error.
-                return Err(PaginatorError::SdkError(err));
+                return Err(PaginatorError::SdkError(Box::new(err)));
             }
         };
 
@@ -492,7 +492,7 @@ impl PaginableRoom for Room {
     }
 
     async fn messages(&self, opts: MessagesOptions) -> Result<Messages, PaginatorError> {
-        self.messages(opts).await.map_err(PaginatorError::SdkError)
+        self.messages(opts).await.map_err(|err| PaginatorError::SdkError(Box::new(err)))
     }
 }
 

--- a/crates/matrix-sdk/src/room/edit.rs
+++ b/crates/matrix-sdk/src/room/edit.rs
@@ -1,0 +1,385 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Facilities to edit existing events.
+
+use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
+use ruma::{
+    events::{
+        room::message::{Relation, ReplacementMetadata, RoomMessageEventContentWithoutRelation},
+        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent,
+        AnySyncTimelineEvent, AnyTimelineEvent, MessageLikeEvent, SyncMessageLikeEvent,
+    },
+    EventId, RoomId, UserId,
+};
+use thiserror::Error;
+use tracing::{instrument, warn};
+
+use crate::Room;
+
+/// The new content that will replace the previous event's content.
+pub enum EditedContent {
+    /// The content is a `m.room.message`.
+    RoomMessage(RoomMessageEventContentWithoutRelation),
+}
+
+#[cfg(not(tarpaulin_include))]
+impl std::fmt::Debug for EditedContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RoomMessage(_) => f.debug_tuple("RoomMessage").finish(),
+        }
+    }
+}
+
+/// An error occurring while editing an event.
+#[derive(Debug, Error)]
+pub enum EditError {
+    /// We tried to edit a state event, which is not allowed, per spec.
+    #[error("State events can't be edited")]
+    StateEvent,
+
+    /// We tried to edit an event which sender isn't the current user, which is
+    /// forbidden, per spec.
+    #[error("You're not the author of the event you'd like to edit.")]
+    NotAuthor,
+
+    /// We couldn't fetch the remote event with /room/event.
+    #[error("Couldn't fetch the remote event: {0}")]
+    Fetch(Box<crate::Error>),
+
+    /// We couldn't properly deserialize the target event.
+    #[error(transparent)]
+    Deserialize(#[from] serde_json::Error),
+
+    /// We tried to edit an event of type A with content of type B.
+    #[error("The original event type ({target}) isn't the same as the parameter's new content type ({new_content})")]
+    IncompatibleEditType {
+        /// The type of the target event.
+        target: String,
+        /// The type of the new content.
+        new_content: &'static str,
+    },
+}
+
+impl Room {
+    /// Create a new edit event for the target event id with the new content.
+    ///
+    /// The event can then be sent with [`Room::send`] or a
+    /// [`crate::send_queue::RoomSendQueue`].
+    #[instrument(skip(self, new_content), fields(room = %self.room_id()))]
+    pub async fn make_edit_event(
+        &self,
+        event_id: &EventId,
+        new_content: EditedContent,
+    ) -> Result<AnyMessageLikeEventContent, EditError> {
+        make_edit_event(self, self.room_id(), self.own_user_id(), event_id, new_content).await
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+trait EventSource {
+    async fn get_event(&self, event_id: &EventId) -> Result<SyncTimelineEvent, EditError>;
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl<'a> EventSource for &'a Room {
+    async fn get_event(&self, event_id: &EventId) -> Result<SyncTimelineEvent, EditError> {
+        let (event_cache, _drop_handles) =
+            self.event_cache().await.map_err(|err| EditError::Fetch(Box::new(err.into())))?;
+
+        match event_cache.event(event_id).await {
+            Some(ev) => Ok(ev),
+            None => self
+                .event(event_id)
+                .await
+                .map(Into::into)
+                .map_err(|err| EditError::Fetch(Box::new(err))),
+        }
+    }
+}
+
+async fn make_edit_event<S: EventSource>(
+    source: S,
+    room_id: &RoomId,
+    own_user_id: &UserId,
+    event_id: &EventId,
+    new_content: EditedContent,
+) -> Result<AnyMessageLikeEventContent, EditError> {
+    let target = source.get_event(event_id).await?;
+
+    let event = target.event.deserialize().map_err(EditError::Deserialize)?;
+
+    // The event must be message-like.
+    let AnySyncTimelineEvent::MessageLike(message_like_event) = event else {
+        return Err(EditError::StateEvent);
+    };
+
+    // The event must have been sent by the current user.
+    if message_like_event.sender() != own_user_id {
+        return Err(EditError::NotAuthor);
+    }
+
+    match new_content {
+        EditedContent::RoomMessage(new_content) => {
+            // Handle edits of m.room.message.
+            let AnySyncMessageLikeEvent::RoomMessage(SyncMessageLikeEvent::Original(original)) =
+                message_like_event
+            else {
+                return Err(EditError::IncompatibleEditType {
+                    target: message_like_event.event_type().to_string(),
+                    new_content: "room message",
+                });
+            };
+
+            let mentions = original.content.mentions.clone();
+
+            // Do a best effort at finding the replied-to original event.
+            let replied_to_sync_timeline_event =
+                if let Some(Relation::Reply { in_reply_to }) = original.content.relates_to {
+                    source
+                        .get_event(&in_reply_to.event_id)
+                        .await
+                        .map_err(|err| {
+                            warn!("couldn't fetch the replied-to event, when editing: {err}");
+                            err
+                        })
+                        .ok()
+                } else {
+                    None
+                };
+
+            let replied_to_original_room_msg = replied_to_sync_timeline_event
+                .and_then(|sync_timeline_event| {
+                    sync_timeline_event
+                        .event
+                        .deserialize()
+                        .map_err(|err| warn!("unable to deserialize replied-to event: {err}"))
+                        .ok()
+                })
+                .and_then(|event| {
+                    if let AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
+                        MessageLikeEvent::Original(original),
+                    )) = event.into_full_event(room_id.to_owned())
+                    {
+                        Some(original)
+                    } else {
+                        None
+                    }
+                });
+
+            return Ok(new_content
+                .make_replacement(
+                    ReplacementMetadata::new(event_id.to_owned(), mentions),
+                    replied_to_original_room_msg.as_ref(),
+                )
+                .into());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use assert_matches2::{assert_let, assert_matches};
+    use matrix_sdk_base::deserialized_responses::SyncTimelineEvent;
+    use matrix_sdk_test::async_test;
+    use ruma::{
+        event_id,
+        events::{
+            room::message::{Relation, RoomMessageEventContentWithoutRelation},
+            AnyMessageLikeEventContent, AnySyncTimelineEvent,
+        },
+        room_id,
+        serde::Raw,
+        user_id, EventId, OwnedEventId,
+    };
+    use serde_json::json;
+
+    use super::{make_edit_event, EditError, EventSource};
+    use crate::{room::edit::EditedContent, test_utils::events::EventFactory};
+
+    #[derive(Default)]
+    struct TestEventCache {
+        events: BTreeMap<OwnedEventId, SyncTimelineEvent>,
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl EventSource for TestEventCache {
+        async fn get_event(&self, event_id: &EventId) -> Result<SyncTimelineEvent, EditError> {
+            Ok(self.events.get(event_id).unwrap().clone())
+        }
+    }
+
+    #[async_test]
+    async fn test_edit_state_event() {
+        let event_id = event_id!("$1");
+        let own_user_id = user_id!("@me:saucisse.bzh");
+
+        let mut cache = TestEventCache::default();
+
+        cache.events.insert(
+            event_id.to_owned(),
+            // TODO: use the EventFactory for state events too.
+            SyncTimelineEvent::new(
+                Raw::<AnySyncTimelineEvent>::from_json_string(
+                    json!({
+                        "content": {
+                            "name": "The room name"
+                        },
+                        "event_id": event_id,
+                        "sender": own_user_id,
+                        "state_key": "",
+                        "origin_server_ts": 1,
+                        "type": "m.room.name",
+                    })
+                    .to_string(),
+                )
+                .unwrap(),
+            ),
+        );
+
+        let room_id = room_id!("!galette:saucisse.bzh");
+        let new_content = RoomMessageEventContentWithoutRelation::text_plain("the edit");
+
+        assert_matches!(
+            make_edit_event(
+                cache,
+                room_id,
+                own_user_id,
+                event_id,
+                EditedContent::RoomMessage(new_content),
+            )
+            .await,
+            Err(EditError::StateEvent)
+        );
+    }
+
+    #[async_test]
+    async fn test_edit_event_other_user() {
+        let event_id = event_id!("$1");
+        let f = EventFactory::new();
+
+        let mut cache = TestEventCache::default();
+
+        cache.events.insert(
+            event_id.to_owned(),
+            f.text_msg("hi").event_id(event_id).sender(user_id!("@other:saucisse.bzh")).into(),
+        );
+
+        let room_id = room_id!("!galette:saucisse.bzh");
+        let own_user_id = user_id!("@me:saucisse.bzh");
+        let new_content = RoomMessageEventContentWithoutRelation::text_plain("the edit");
+
+        assert_matches!(
+            make_edit_event(
+                cache,
+                room_id,
+                own_user_id,
+                event_id,
+                EditedContent::RoomMessage(new_content),
+            )
+            .await,
+            Err(EditError::NotAuthor)
+        );
+    }
+
+    #[async_test]
+    async fn test_make_edit_event_success() {
+        let event_id = event_id!("$1");
+        let own_user_id = user_id!("@me:saucisse.bzh");
+
+        let mut cache = TestEventCache::default();
+        let f = EventFactory::new();
+        cache.events.insert(
+            event_id.to_owned(),
+            f.text_msg("hi").event_id(event_id).sender(own_user_id).into(),
+        );
+
+        let room_id = room_id!("!galette:saucisse.bzh");
+        let new_content = RoomMessageEventContentWithoutRelation::text_plain("the edit");
+
+        let edit_event = make_edit_event(
+            cache,
+            room_id,
+            own_user_id,
+            event_id,
+            EditedContent::RoomMessage(new_content),
+        )
+        .await
+        .unwrap();
+
+        assert_let!(AnyMessageLikeEventContent::RoomMessage(msg) = &edit_event);
+        // This is the fallback text, for clients not supporting edits.
+        assert_eq!(msg.body(), "* the edit");
+        assert_let!(Some(Relation::Replacement(repl)) = &msg.relates_to);
+
+        assert_eq!(repl.event_id, event_id);
+        assert_eq!(repl.new_content.msgtype.body(), "the edit");
+    }
+
+    #[async_test]
+    async fn test_make_edit_event_success_with_response() {
+        let event_id = event_id!("$1");
+        let resp_event_id = event_id!("$resp");
+        let own_user_id = user_id!("@me:saucisse.bzh");
+
+        let mut cache = TestEventCache::default();
+        let f = EventFactory::new();
+
+        cache.events.insert(
+            event_id.to_owned(),
+            f.text_msg("hi").event_id(event_id).sender(user_id!("@steb:saucisse.bzh")).into(),
+        );
+
+        cache.events.insert(
+            resp_event_id.to_owned(),
+            f.text_msg("you're the hi")
+                .event_id(resp_event_id)
+                .sender(own_user_id)
+                .reply_to(event_id)
+                .into(),
+        );
+
+        let room_id = room_id!("!galette:saucisse.bzh");
+        let new_content = RoomMessageEventContentWithoutRelation::text_plain("uh i mean hi too");
+
+        let edit_event = make_edit_event(
+            cache,
+            room_id,
+            own_user_id,
+            resp_event_id,
+            EditedContent::RoomMessage(new_content),
+        )
+        .await
+        .unwrap();
+
+        assert_let!(AnyMessageLikeEventContent::RoomMessage(msg) = &edit_event);
+        // This is the fallback text, for clients not supporting edits.
+        assert_eq!(
+            msg.body(),
+            r#"> <@steb:saucisse.bzh> hi
+
+* uh i mean hi too"#
+        );
+        assert_let!(Some(Relation::Replacement(repl)) = &msg.relates_to);
+
+        assert_eq!(repl.event_id, resp_event_id);
+        assert_eq!(repl.new_content.msgtype.body(), "uh i mean hi too");
+    }
+}

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -108,6 +108,7 @@ use crate::{
     BaseRoom, Client, Error, HttpResult, Result, RoomState, TransmissionProgress,
 };
 
+pub mod edit;
 pub mod futures;
 mod member;
 mod messages;

--- a/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/timeline.rs
@@ -321,9 +321,8 @@ async fn test_stale_local_echo_time_abort_edit() {
     }
 
     // Now do a crime: try to edit the local echo.
-    let edit_info = local_echo.edit_info().unwrap();
     let did_edit = timeline
-        .edit(RoomMessageEventContent::text_plain("bonjour").into(), edit_info)
+        .edit(&local_echo, RoomMessageEventContent::text_plain("bonjour").into())
         .await
         .unwrap();
 


### PR DESCRIPTION
Part of my quest to move functionality from the `Timeline` to the SDK, this makes it possible to create a replacement event for another one (edit), for all the `m.room.message`s to start with. The timeline can now use this, instead of trying to look into its items for the data it needs for the edit to work correctly; this helps get rid of `EditInfo`, which was an oversight from yours truly.

Part of #3663 too.