### PR TITLE
fix: Dependencies clean up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ tokio = { version = "1.30.0", default-features = false, features = ["sync"] }
 tokio-stream = "0.1.14"
 tracing = { version = "0.1.40", default-features = false, features = ["std"] }
 tracing-core = "0.1.32"
+tracing-subscriber = "0.3.18"
 uniffi = { version = "0.27.1" }
 uniffi_bindgen = { version = "0.27.1" }
 url = "2.5.0"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@ ruma = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3.3.0"
-tokio = { version = "1.24.2", default-features = false, features = ["rt-multi-thread"] }
+tokio = { workspace = true, default-features = false, features = ["rt-multi-thread"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 pprof = { version = "0.13.0", features = ["flamegraph", "criterion"] }

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -33,7 +33,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # keep in sync with uniffi dependency in matrix-sdk-ffi, and uniffi_bindgen in ffi CI job
 uniffi = { workspace = true , features = ["cli"]}
 vodozemac = { workspace = true }

--- a/bindings/matrix-sdk-crypto-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-crypto-ffi/Cargo.toml
@@ -22,7 +22,7 @@ bundled-sqlite = ["matrix-sdk-sqlite/bundled"]
 
 [dependencies]
 anyhow = { workspace = true }
-futures-util = "0.3.28"
+futures-util = { workspace = true }
 hmac = "0.12.1"
 http = { workspace = true }
 matrix-sdk-common = { workspace = true }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-core = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-appender = { version = "0.2.2" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 uniffi = { workspace = true, features = ["tokio"] }

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true }
 tracing-core = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-appender = { version = "0.2.2" }
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 uniffi = { workspace = true, features = ["tokio"] }
 url = { workspace = true }
 zeroize = { workspace = true }

--- a/crates/matrix-sdk-common/Cargo.toml
+++ b/crates/matrix-sdk-common/Cargo.toml
@@ -34,7 +34,7 @@ futures-util = { workspace = true, features = ["channel"] }
 wasm-bindgen-futures = { version = "0.4.33", optional = true }
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 web-sys = { version = "0.3.60", features = ["console"] }
-tracing-subscriber = { version = "0.3.14", default-features = false, features = ["fmt", "ansi"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "ansi"] }
 wasm-bindgen = "0.2.84"
 
 [dev-dependencies]

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -55,7 +55,7 @@ matrix-sdk-common = { workspace = true, features = ["js"] }
 matrix-sdk-crypto = { workspace = true, features = ["js", "testing"] }
 matrix-sdk-test = { workspace = true }
 rand = { workspace = true }
-tracing-subscriber = { version = "0.3.18", default-features = false, features = ["registry", "tracing-log"] }
+tracing-subscriber = { workspace = true, features = ["registry", "tracing-log"] }
 uuid = "1.3.0"
 wasm-bindgen-test = "0.3.33"
 

--- a/crates/matrix-sdk/Cargo.toml
+++ b/crates/matrix-sdk/Cargo.toml
@@ -148,7 +148,7 @@ once_cell = { workspace = true }
 serde_urlencoded = "0.7.1"
 similar-asserts = { workspace = true }
 stream_assert = { workspace = true }
-tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.33"

--- a/examples/autojoin/Cargo.toml
+++ b/examples/autojoin/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.
 matrix-sdk = { path = "../../crates/matrix-sdk" }

--- a/examples/autojoin/Cargo.toml
+++ b/examples/autojoin/Cargo.toml
@@ -9,8 +9,8 @@ name = "example-autojoin"
 test = false
 
 [dependencies]
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-anyhow = "1"
 tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/autojoin/Cargo.toml
+++ b/examples/autojoin/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-autojoin"
 test = false
 
 [dependencies]
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
 tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/backups/Cargo.toml
+++ b/examples/backups/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 futures-util = "0.3.24"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/backups/Cargo.toml
+++ b/examples/backups/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 anyhow = "1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
-futures-util = "0.3.24"
+futures-util = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/backups/Cargo.toml
+++ b/examples/backups/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 futures-util = "0.3.24"
 tracing-subscriber = { workspace = true }

--- a/examples/backups/Cargo.toml
+++ b/examples/backups/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-backups"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 futures-util = { workspace = true }

--- a/examples/command_bot/Cargo.toml
+++ b/examples/command_bot/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.
 matrix-sdk = { path = "../../crates/matrix-sdk" }

--- a/examples/command_bot/Cargo.toml
+++ b/examples/command_bot/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/command_bot/Cargo.toml
+++ b/examples/command_bot/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-command-bot"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/cross_signing_bootstrap/Cargo.toml
+++ b/examples/cross_signing_bootstrap/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/cross_signing_bootstrap/Cargo.toml
+++ b/examples/cross_signing_bootstrap/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/cross_signing_bootstrap/Cargo.toml
+++ b/examples/cross_signing_bootstrap/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-cross-signing-bootstrap"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/examples/custom_events/Cargo.toml
+++ b/examples/custom_events/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 serde = "1.0"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/custom_events/Cargo.toml
+++ b/examples/custom_events/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 anyhow = "1"
 serde = "1.0"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.
 matrix-sdk = { path = "../../crates/matrix-sdk" }

--- a/examples/custom_events/Cargo.toml
+++ b/examples/custom_events/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-custom-events"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 serde = "1.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }

--- a/examples/emoji_verification/Cargo.toml
+++ b/examples/emoji_verification/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 futures-util = "0.3.24"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/emoji_verification/Cargo.toml
+++ b/examples/emoji_verification/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-emoji-verification"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 futures-util = { workspace = true }

--- a/examples/emoji_verification/Cargo.toml
+++ b/examples/emoji_verification/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 anyhow = "1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
-futures-util = "0.3.24"
+futures-util = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/emoji_verification/Cargo.toml
+++ b/examples/emoji_verification/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 futures-util = "0.3.24"
 tracing-subscriber = { workspace = true }

--- a/examples/get_profiles/Cargo.toml
+++ b/examples/get_profiles/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/get_profiles/Cargo.toml
+++ b/examples/get_profiles/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/get_profiles/Cargo.toml
+++ b/examples/get_profiles/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-get-profiles"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-getting-started"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.
 matrix-sdk = { path = "../../crates/matrix-sdk" }

--- a/examples/getting_started/Cargo.toml
+++ b/examples/getting_started/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/image_bot/Cargo.toml
+++ b/examples/image_bot/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-image-bot"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 mime = "0.3.16"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }

--- a/examples/image_bot/Cargo.toml
+++ b/examples/image_bot/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 mime = "0.3.16"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/image_bot/Cargo.toml
+++ b/examples/image_bot/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 anyhow = "1"
 mime = "0.3.16"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/login/Cargo.toml
+++ b/examples/login/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/login/Cargo.toml
+++ b/examples/login/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-login"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/examples/login/Cargo.toml
+++ b/examples/login/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/oidc_cli/Cargo.toml
+++ b/examples/oidc_cli/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["make"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
 [dependencies.matrix-sdk]

--- a/examples/oidc_cli/Cargo.toml
+++ b/examples/oidc_cli/Cargo.toml
@@ -17,7 +17,7 @@ matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui" }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["make"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/examples/oidc_cli/Cargo.toml
+++ b/examples/oidc_cli/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-oidc-cli"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 axum = "0.7.4"
 dirs = "5.0.1"
 futures-util = { workspace = true, default-features = false }

--- a/examples/oidc_cli/Cargo.toml
+++ b/examples/oidc_cli/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 anyhow = "1"
 axum = "0.7.4"
 dirs = "5.0.1"
-futures-util = { version = "0.3.21", default-features = false }
+futures-util = { workspace = true, default-features = false }
 matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui" }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/examples/persist_session/Cargo.toml
+++ b/examples/persist_session/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-persist-session"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 dirs = "5.0.1"
 rand = { workspace = true }
 serde = { workspace = true }

--- a/examples/persist_session/Cargo.toml
+++ b/examples/persist_session/Cargo.toml
@@ -15,7 +15,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.
 matrix-sdk = { path = "../../crates/matrix-sdk" }

--- a/examples/persist_session/Cargo.toml
+++ b/examples/persist_session/Cargo.toml
@@ -14,7 +14,7 @@ dirs = "5.0.1"
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/qr-login/Cargo.toml
+++ b/examples/qr-login/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 qrcode = { git = "https://github.com/kennytm/qrcode-rust/" }
-futures-util = "0.3.24"
+futures-util = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = "2.3.1"
 

--- a/examples/qr-login/Cargo.toml
+++ b/examples/qr-login/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 qrcode = { git = "https://github.com/kennytm/qrcode-rust/" }
 futures-util = "0.3.24"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { workspace = true }
 url = "2.3.1"
 
 [dependencies.matrix-sdk]

--- a/examples/qr-login/Cargo.toml
+++ b/examples/qr-login/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-qr-login"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 qrcode = { git = "https://github.com/kennytm/qrcode-rust/" }

--- a/examples/qr-login/Cargo.toml
+++ b/examples/qr-login/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 qrcode = { git = "https://github.com/kennytm/qrcode-rust/" }
 futures-util = "0.3.24"

--- a/examples/secret_storage/Cargo.toml
+++ b/examples/secret_storage/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-secret-storage"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 tracing-subscriber = { workspace = true }

--- a/examples/secret_storage/Cargo.toml
+++ b/examples/secret_storage/Cargo.toml
@@ -10,7 +10,7 @@ test = false
 
 [dependencies]
 anyhow = "1"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/examples/secret_storage/Cargo.toml
+++ b/examples/secret_storage/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 anyhow = "1"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.15", features = ["derive"] }
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/examples/timeline/Cargo.toml
+++ b/examples/timeline/Cargo.toml
@@ -9,7 +9,7 @@ name = "example-timeline"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 clap = { version = "4.0.16", features = ["derive"] }
 futures-util = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/timeline/Cargo.toml
+++ b/examples/timeline/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0.16", features = ["derive"] }
-futures-util = "0.3"
+futures-util = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }

--- a/examples/timeline/Cargo.toml
+++ b/examples/timeline/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 anyhow = "1"
 clap = { version = "4.0.16", features = ["derive"] }
 futures-util = "0.3"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you

--- a/examples/timeline/Cargo.toml
+++ b/examples/timeline/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1"
 clap = { version = "4.0.16", features = ["derive"] }
 futures-util = "0.3"
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
 # when copy-pasting this, please use a git dependency or make sure that you
 # have copied the example as it was at the time of the release you use.

--- a/labs/multiverse/Cargo.toml
+++ b/labs/multiverse/Cargo.toml
@@ -9,7 +9,7 @@ name = "multiverse"
 test = false
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 color-eyre = "0.6.2"
 crossterm = "0.27.0"
 futures-util = { workspace = true }

--- a/labs/multiverse/Cargo.toml
+++ b/labs/multiverse/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-appender = { version = "0.2.2" }
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [lints]
 workspace = true

--- a/labs/multiverse/Cargo.toml
+++ b/labs/multiverse/Cargo.toml
@@ -19,7 +19,7 @@ matrix-sdk-ui = { path = "../../crates/matrix-sdk-ui" }
 ratatui = "0.26.1"
 rpassword = "7.3.1"
 serde_json = { workspace = true }
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-appender = { version = "0.2.2" }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }

--- a/testing/matrix-sdk-integration-testing/Cargo.toml
+++ b/testing/matrix-sdk-integration-testing/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 publish = false
 
 [dev-dependencies]
+anyhow = { workspace = true }
 assert_matches = { workspace = true }
 assert_matches2 = { workspace = true }
-anyhow = { workspace = true }
 assign = "1"
 eyeball = { workspace = true }
 eyeball-im = { workspace = true }

--- a/testing/matrix-sdk-test/Cargo.toml
+++ b/testing/matrix-sdk-test/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ctor = "0.2.0"
 tokio = { workspace = true, features = ["rt", "macros"] }
-tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.6", default-features = false, features = ["js"] }


### PR DESCRIPTION
These patches try to declare the dependencies by abusing `workspace`.