### PR TITLE
timeline: remove some dubious logs

### DIFF
--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -761,7 +761,6 @@ impl TimelineDiff {
             VectorDiff::PopBack => Self::PopBack,
             VectorDiff::PopFront => Self::PopFront,
             VectorDiff::Reset { values } => {
-                warn!("Timeline subscriber lagged behind and was reset");
                 Self::Reset { values: values.into_iter().map(TimelineItem::from_arc).collect() }
             }
         }

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -597,14 +597,12 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
         if let Flow::Remote { txn_id: Some(txn_id), .. } = &self.ctx.flow {
             let id = TimelineEventItemId::TransactionId(txn_id.clone());
-            // Remove the local echo from the reaction map.
-            if self.meta.reactions.map.remove(&id).is_none() {
-                warn!(
-                    "Received reaction with transaction ID, but didn't \
-                     find matching reaction in reaction_map"
-                );
-            }
+            // Remove the local echo from the reaction map. It could be missing, if the
+            // transaction id refers to a reaction sent times ago, so no need to check its
+            // return value to know if the value was missing or not.
+            self.meta.reactions.map.remove(&id);
         }
+
         let reaction_sender_data = ReactionSenderData {
             sender_id: self.ctx.sender.clone(),
             timestamp: self.ctx.timestamp,

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -562,13 +562,9 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
             if let Some(txn_id) = old_txn_id {
                 let id = TimelineEventItemId::TransactionId(txn_id.clone());
                 // Remove the local echo from the related event.
-                if reaction_group.0.swap_remove(&id).is_none() {
-                    warn!(
-                        "Received reaction with transaction ID, but didn't \
-                             find matching reaction in the related event's reactions"
-                    );
-                }
+                reaction_group.0.swap_remove(&id);
             }
+
             reaction_group.0.insert(
                 reaction_id.clone(),
                 ReactionSenderData {

--- a/crates/matrix-sdk-ui/src/timeline/event_handler.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_handler.rs
@@ -1010,11 +1010,6 @@ impl<'a, 'o> TimelineEventHandler<'a, 'o> {
 
                     // no return here, below code for adding a new event
                     // will run to re-add the removed item
-                } else if txn_id.is_some() {
-                    warn!(
-                        "Received event with transaction ID, but didn't \
-                         find matching timeline item"
-                    );
                 }
 
                 // Local echoes that are pending should stick to the bottom,


### PR DESCRIPTION
These logs were alarming for no good reasons: a transaction id may be sent with a remote event, even if the remote event doesn't match a corresponding local echo (because it's been sent much further in the past). As a result, these logs will pollute rageshakes, so let's get rid of those.