### PR TITLE
chore: Bump our bytes dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,9 +684,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "bytesize"


### PR DESCRIPTION
The version we were using was yanked.

Closes: https://github.com/matrix-org/matrix-rust-sdk/issues/3693