### PR TITLE
send queue: implement dependent events

### DIFF
--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -72,9 +72,9 @@ pub use self::integration_tests::StateStoreIntegrationTests;
 pub use self::{
     memory_store::MemoryStore,
     traits::{
-        ComposerDraft, ComposerDraftType, DynStateStore, IntoStateStore, QueuedEvent,
-        SerializableEventContent, ServerCapabilities, StateStore, StateStoreDataKey,
-        StateStoreDataValue, StateStoreExt,
+        ComposerDraft, ComposerDraftType, DependentQueuedEvent, DependentQueuedEventKind,
+        DynStateStore, IntoStateStore, QueuedEvent, SerializableEventContent, ServerCapabilities,
+        StateStore, StateStoreDataKey, StateStoreDataValue, StateStoreExt,
     },
 };
 

--- a/crates/matrix-sdk-base/src/store/traits.rs
+++ b/crates/matrix-sdk-base/src/store/traits.rs
@@ -454,6 +454,43 @@ pub trait StateStore: AsyncTraitDeps {
 
     /// Loads all the rooms which have any pending events in their send queue.
     async fn load_rooms_with_unsent_events(&self) -> Result<Vec<OwnedRoomId>, Self::Error>;
+
+    /// Add a new entry to the list of dependent send queue event for an event.
+    async fn save_dependent_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: DependentQueuedEventKind,
+    ) -> Result<(), Self::Error>;
+
+    /// Update a set of dependent send queue events with an event id,
+    /// effectively marking them as ready.
+    ///
+    /// Returns the number of updated events.
+    async fn update_dependent_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        event_id: OwnedEventId,
+    ) -> Result<usize, Self::Error>;
+
+    /// Remove a specific dependent send queue event by id.
+    ///
+    /// Returns true if the dependent send queue event has been indeed removed.
+    async fn remove_dependent_send_queue_event(
+        &self,
+        room: &RoomId,
+        id: usize,
+    ) -> Result<bool, Self::Error>;
+
+    /// List all the dependent send queue events.
+    ///
+    /// This returns absolutely all the dependent send queue events, whether
+    /// they have an event id or not. They must be returned in insertion order.
+    async fn list_dependent_send_queue_events(
+        &self,
+        room: &RoomId,
+    ) -> Result<Vec<DependentQueuedEvent>, Self::Error>;
 }
 
 #[repr(transparent)]
@@ -725,6 +762,45 @@ impl<T: StateStore> StateStore for EraseStateStoreError<T> {
 
     async fn load_rooms_with_unsent_events(&self) -> Result<Vec<OwnedRoomId>, Self::Error> {
         self.0.load_rooms_with_unsent_events().await.map_err(Into::into)
+    }
+
+    async fn save_dependent_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: DependentQueuedEventKind,
+    ) -> Result<(), Self::Error> {
+        self.0
+            .save_dependent_send_queue_event(room_id, transaction_id, content)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn update_dependent_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        event_id: OwnedEventId,
+    ) -> Result<usize, Self::Error> {
+        self.0
+            .update_dependent_send_queue_event(room_id, transaction_id, event_id)
+            .await
+            .map_err(Into::into)
+    }
+
+    async fn remove_dependent_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        id: usize,
+    ) -> Result<bool, Self::Error> {
+        self.0.remove_dependent_send_queue_event(room_id, id).await.map_err(Into::into)
+    }
+
+    async fn list_dependent_send_queue_events(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<DependentQueuedEvent>, Self::Error> {
+        self.0.list_dependent_send_queue_events(room_id).await.map_err(Into::into)
     }
 }
 
@@ -1161,6 +1237,50 @@ pub struct QueuedEvent {
     /// wedged, and won't ever be peeked for sending. The only option is to
     /// remove it.
     pub is_wedged: bool,
+}
+
+/// The specific user intent that characterizes a [`DependentQueuedEvent`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum DependentQueuedEventKind {
+    /// The event should be edited.
+    Edit {
+        /// The new event for the content.
+        new_content: SerializableEventContent,
+    },
+
+    /// The event should be redacted/aborted/removed.
+    Redact,
+}
+
+/// An event to be sent, depending on a [`QueuedEvent`] to be sent first.
+///
+/// Depending on whether the event has been sent or not, this will either update
+/// the local echo in the storage, or send an event equivalent to the user
+/// intent to the homeserver.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DependentQueuedEvent {
+    /// Unique identifier for this dependent queued event.
+    ///
+    /// Useful for deletion.
+    pub id: usize,
+
+    /// The kind of user intent.
+    pub kind: DependentQueuedEventKind,
+
+    /// Transaction id for the parent's local echo / used in the server request.
+    ///
+    /// Note: this is the transaction id used for the depended-on event, i.e.
+    /// the one that was originally sent and that's being modified with this
+    /// dependent event.
+    pub transaction_id: OwnedTransactionId,
+
+    /// If the parent event has been sent, the parent's event identifier
+    /// returned by the server once the local echo has been sent out.
+    ///
+    /// Note: this is the event id used for the depended-on event after it's
+    /// been sent, not for a possible event that could have been sent
+    /// because of this [`DependentQueuedEvent`].
+    pub event_id: Option<OwnedEventId>,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/crates/matrix-sdk-sqlite/migrations/state_store/005_send_queue_dependent_events.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/005_send_queue_dependent_events.sql
@@ -1,0 +1,14 @@
+-- Send queue dependent events
+CREATE TABLE "dependent_send_queue_events" (
+    -- This is used as a key, thus hashed.
+    "room_id" BLOB NOT NULL,
+
+    -- This is used as both a key and a value, thus neither encrypted/decrypted/hashed.
+    "transaction_id" BLOB NOT NULL,
+
+    -- Used as a value (thus encrypted/decrypted), can be null.
+    "event_id" BLOB NULL,
+
+    -- Serialized `DependentQueuedEventKind`, used as a value (thus encrypted/decrypted).
+    "content" BLOB NOT NULL
+);

--- a/crates/matrix-sdk-sqlite/migrations/state_store/005_send_queue_dependent_events.sql
+++ b/crates/matrix-sdk-sqlite/migrations/state_store/005_send_queue_dependent_events.sql
@@ -4,7 +4,12 @@ CREATE TABLE "dependent_send_queue_events" (
     "room_id" BLOB NOT NULL,
 
     -- This is used as both a key and a value, thus neither encrypted/decrypted/hashed.
-    "transaction_id" BLOB NOT NULL,
+    -- This is the transaction id for the *parent* transaction, not our own.
+    "parent_transaction_id" BLOB NOT NULL,
+
+    -- This is used as both a key and a value, thus neither encrypted/decrypted/hashed.
+    -- This is a transaction id used for the dependent event itself, not the parent.
+    "own_transaction_id" BLOB NOT NULL,
 
     -- Used as a value (thus encrypted/decrypted), can be null.
     "event_id" BLOB NULL,

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -11,7 +11,10 @@ use deadpool_sqlite::{Object as SqliteConn, Pool as SqlitePool, Runtime};
 use matrix_sdk_base::{
     deserialized_responses::{RawAnySyncOrStrippedState, SyncOrStrippedState},
     media::{MediaRequest, UniqueKey},
-    store::{migration_helpers::RoomInfoV1, QueuedEvent, SerializableEventContent},
+    store::{
+        migration_helpers::RoomInfoV1, DependentQueuedEvent, DependentQueuedEventKind, QueuedEvent,
+        SerializableEventContent,
+    },
     MinimalRoomMemberEvent, RoomInfo, RoomMemberships, RoomState, StateChanges, StateStore,
     StateStoreDataKey, StateStoreDataValue,
 };
@@ -57,9 +60,15 @@ mod keys {
     pub const DISPLAY_NAME: &str = "display_name";
     pub const MEDIA: &str = "media";
     pub const SEND_QUEUE: &str = "send_queue_events";
+    pub const DEPENDENTS_SEND_QUEUE: &str = "dependent_send_queue_events";
 }
 
-const DATABASE_VERSION: u8 = 5;
+/// Identifier of the latest database version.
+///
+/// This is used to figure whether the sqlite database requires a migration.
+/// Every new SQL migration should imply a bump of this number, and changes in
+/// the [`SqliteStateStore::run_migrations`] function..
+const DATABASE_VERSION: u8 = 6;
 
 /// A sqlite based cryptostore.
 #[derive(Clone)]
@@ -229,6 +238,17 @@ impl SqliteStateStore {
                 // Create new table.
                 txn.execute_batch(include_str!(
                     "../migrations/state_store/004_send_queue_with_roomid_value.sql"
+                ))?;
+                Result::<_, Error>::Ok(())
+            })
+            .await?;
+        }
+
+        if from < 6 && to >= 6 {
+            conn.with_transaction(move |txn| {
+                // Create new table.
+                txn.execute_batch(include_str!(
+                    "../migrations/state_store/005_send_queue_dependent_events.sql"
                 ))?;
                 Result::<_, Error>::Ok(())
             })
@@ -1755,7 +1775,7 @@ impl StateStore for SqliteStateStore {
                 txn.prepare_cached(
                     "DELETE FROM send_queue_events WHERE room_id = ? AND transaction_id = ?",
                 )?
-                .execute((room_id, transaction_id))
+                .execute((room_id, &transaction_id))
             })
             .await?;
 
@@ -1837,6 +1857,100 @@ impl StateStore for SqliteStateStore {
             .collect::<Result<BTreeSet<OwnedRoomId>, _>>()?
             .into_iter()
             .collect())
+    }
+
+    async fn save_dependent_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        content: DependentQueuedEventKind,
+    ) -> Result<()> {
+        let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
+        let content = self.serialize_json(&content)?;
+
+        // See comment in `save_send_queue_event`.
+        let transaction_id = transaction_id.to_string();
+
+        self.acquire()
+            .await?
+            .with_transaction(move |txn| {
+                txn.prepare_cached("INSERT INTO dependent_send_queue_events (room_id, transaction_id, content) VALUES (?, ?, ?)")?.execute((room_id, transaction_id, content))?;
+                Ok(())
+            })
+            .await
+    }
+
+    async fn update_dependent_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        transaction_id: &TransactionId,
+        event_id: OwnedEventId,
+    ) -> Result<usize> {
+        let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
+        let event_id = self.serialize_value(&event_id)?;
+
+        // See comment in `save_send_queue_event`.
+        let transaction_id = transaction_id.to_string();
+
+        self.acquire()
+            .await?
+            .with_transaction(move |txn| {
+                Ok(txn.prepare_cached(
+                    "UPDATE dependent_send_queue_events SET event_id = ? WHERE transaction_id = ? and room_id = ?",
+                )?
+                .execute((event_id, transaction_id, room_id))?)
+            })
+            .await
+    }
+
+    async fn remove_dependent_send_queue_event(&self, room_id: &RoomId, id: usize) -> Result<bool> {
+        let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
+
+        let num_deleted = self
+            .acquire()
+            .await?
+            .with_transaction(move |txn| {
+                txn.prepare_cached(
+                    "DELETE FROM dependent_send_queue_events WHERE ROWID = ? AND room_id = ?",
+                )?
+                .execute((id, room_id))
+            })
+            .await?;
+
+        Ok(num_deleted > 0)
+    }
+
+    async fn list_dependent_send_queue_events(
+        &self,
+        room_id: &RoomId,
+    ) -> Result<Vec<DependentQueuedEvent>> {
+        let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
+
+        // Note: transaction_id is not encoded, see why in `save_send_queue_event`.
+        let res: Vec<(usize, String, Option<Vec<u8>>, Vec<u8>)> = self
+            .acquire()
+            .await?
+            .prepare(
+                "SELECT ROWID, transaction_id, event_id, content FROM dependent_send_queue_events WHERE room_id = ? ORDER BY ROWID",
+                |mut stmt| {
+                    stmt.query((room_id,))?
+                        .mapped(|row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)))
+                        .collect()
+                },
+            )
+            .await?;
+
+        let mut dependent_events = Vec::with_capacity(res.len());
+        for entry in res {
+            dependent_events.push(DependentQueuedEvent {
+                id: entry.0,
+                transaction_id: entry.1.into(),
+                event_id: entry.2.map(|bytes| self.deserialize_value(&bytes)).transpose()?,
+                kind: self.deserialize_json(&entry.3)?,
+            });
+        }
+
+        Ok(dependent_events)
     }
 }
 

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1862,19 +1862,26 @@ impl StateStore for SqliteStateStore {
     async fn save_dependent_send_queue_event(
         &self,
         room_id: &RoomId,
-        transaction_id: &TransactionId,
+        parent_txn_id: &TransactionId,
+        own_txn_id: OwnedTransactionId,
         content: DependentQueuedEventKind,
     ) -> Result<()> {
         let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
         let content = self.serialize_json(&content)?;
 
         // See comment in `save_send_queue_event`.
-        let transaction_id = transaction_id.to_string();
+        let parent_txn_id = parent_txn_id.to_string();
+        let own_txn_id = own_txn_id.to_string();
 
         self.acquire()
             .await?
             .with_transaction(move |txn| {
-                txn.prepare_cached("INSERT INTO dependent_send_queue_events (room_id, transaction_id, content) VALUES (?, ?, ?)")?.execute((room_id, transaction_id, content))?;
+                txn.prepare_cached(
+                    r#"INSERT INTO dependent_send_queue_events
+                         (room_id, parent_transaction_id, own_transaction_id, content)
+                       VALUES (?, ?, ?, ?)"#,
+                )?
+                .execute((room_id, parent_txn_id, own_txn_id, content))?;
                 Ok(())
             })
             .await
@@ -1883,37 +1890,44 @@ impl StateStore for SqliteStateStore {
     async fn update_dependent_send_queue_event(
         &self,
         room_id: &RoomId,
-        transaction_id: &TransactionId,
+        parent_txn_id: &TransactionId,
         event_id: OwnedEventId,
     ) -> Result<usize> {
         let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
         let event_id = self.serialize_value(&event_id)?;
 
         // See comment in `save_send_queue_event`.
-        let transaction_id = transaction_id.to_string();
+        let parent_txn_id = parent_txn_id.to_string();
 
         self.acquire()
             .await?
             .with_transaction(move |txn| {
                 Ok(txn.prepare_cached(
-                    "UPDATE dependent_send_queue_events SET event_id = ? WHERE transaction_id = ? and room_id = ?",
+                    "UPDATE dependent_send_queue_events SET event_id = ? WHERE parent_transaction_id = ? and room_id = ?",
                 )?
-                .execute((event_id, transaction_id, room_id))?)
+                .execute((event_id, parent_txn_id, room_id))?)
             })
             .await
     }
 
-    async fn remove_dependent_send_queue_event(&self, room_id: &RoomId, id: usize) -> Result<bool> {
+    async fn remove_dependent_send_queue_event(
+        &self,
+        room_id: &RoomId,
+        txn_id: &TransactionId,
+    ) -> Result<bool> {
         let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
+
+        // See comment in `save_send_queue_event`.
+        let txn_id = txn_id.to_string();
 
         let num_deleted = self
             .acquire()
             .await?
             .with_transaction(move |txn| {
                 txn.prepare_cached(
-                    "DELETE FROM dependent_send_queue_events WHERE ROWID = ? AND room_id = ?",
+                    "DELETE FROM dependent_send_queue_events WHERE own_transaction_id = ? AND room_id = ?",
                 )?
-                .execute((id, room_id))
+                .execute((txn_id, room_id))
             })
             .await?;
 
@@ -1927,11 +1941,11 @@ impl StateStore for SqliteStateStore {
         let room_id = self.encode_key(keys::DEPENDENTS_SEND_QUEUE, room_id);
 
         // Note: transaction_id is not encoded, see why in `save_send_queue_event`.
-        let res: Vec<(usize, String, Option<Vec<u8>>, Vec<u8>)> = self
+        let res: Vec<(String, String, Option<Vec<u8>>, Vec<u8>)> = self
             .acquire()
             .await?
             .prepare(
-                "SELECT ROWID, transaction_id, event_id, content FROM dependent_send_queue_events WHERE room_id = ? ORDER BY ROWID",
+                "SELECT own_transaction_id, parent_transaction_id, event_id, content FROM dependent_send_queue_events WHERE room_id = ? ORDER BY ROWID",
                 |mut stmt| {
                     stmt.query((room_id,))?
                         .mapped(|row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)))
@@ -1943,8 +1957,8 @@ impl StateStore for SqliteStateStore {
         let mut dependent_events = Vec::with_capacity(res.len());
         for entry in res {
             dependent_events.push(DependentQueuedEvent {
-                id: entry.0,
-                transaction_id: entry.1.into(),
+                own_transaction_id: entry.0.into(),
+                parent_transaction_id: entry.1.into(),
                 event_id: entry.2.map(|bytes| self.deserialize_value(&bytes)).transpose()?,
                 kind: self.deserialize_json(&entry.3)?,
             });


### PR DESCRIPTION
Part of #3663.

Commit 1 introduces a way to store "dependent events", that is, events that depend upon another one being sent for their completion. Dumb CRUD code, if you ask me. One important thing to note: we don't delete an event's dependents when it's been sent by the send queue, because the dependent events live their own lives independently of the send queue event they're attached to.

Commit 2 introduces a way to "canonicalize" dependent events. If you request a thousand edits and one redaction, then only the redaction is meaningful. This function filters out useless dependent events and only keeps those that will have a final effect.

Commit 4 makes use of the dependent events in storage:

- if a send queue event is being sent, then we remember the intent to edit/redact it later, via a dependent event
- at the beginning of a room's loop, we try to apply the dependent events.
  - if the dependent event doesn't have an attached event id, it means the original event is still a local echo, so we can apply the dependent event immediately in our database
  - if the dependent event does have an attached event id, we need to send a request to the server to materialize the edit/redact action. For the edit action, it was fortunate to reuse the send queue itself (so the edit is queued for sending in the same room); for redactions, we can't do just that (since redactions use a specific endpoint), so a network error happening during a redaction will keep the original event — that's a bit unfortunate but trying to do better reaches the 95% work / 5% usefulness ratio.

Tests have been tweaked to reflect this new change, and new tests have been introduced (that would have failed before).