### PR TITLE
integration tests: reinstate no spurious room update test

### DIFF
--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -760,16 +760,18 @@ fn process_room_properties(
     }
 
     if let Some(recency_timestamp) = &room_data.timestamp {
-        room_info.update_recency_timestamp(*recency_timestamp);
+        if room_info.recency_timestamp.as_ref() != Some(recency_timestamp) {
+            room_info.update_recency_timestamp(*recency_timestamp);
 
-        // If it's not a new room, let's emit a `RECENCY_TIMESTAMP` update.
-        // For a new room, the room will appear as new, so we don't care about this
-        // update.
-        if !is_new_room {
-            room_info_notable_updates
-                .entry(room_id.to_owned())
-                .or_default()
-                .insert(RoomInfoNotableUpdateReasons::RECENCY_TIMESTAMP);
+            // If it's not a new room, let's emit a `RECENCY_TIMESTAMP` update.
+            // For a new room, the room will appear as new, so we don't care about this
+            // update.
+            if !is_new_room {
+                room_info_notable_updates
+                    .entry(room_id.to_owned())
+                    .or_default()
+                    .insert(RoomInfoNotableUpdateReasons::RECENCY_TIMESTAMP);
+            }
         }
     }
 }

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -27,6 +27,7 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::{RoomInfoNotableUpdate, RoomInfoNotableUpdateReasons};
 use tokio::{select, sync::broadcast};
+use tracing::trace;
 
 use super::{
     filters::BoxedFilterFn,
@@ -203,7 +204,10 @@ fn merge_stream_and_receiver(
                 diffs = raw_stream.next() => {
                     if let Some(diffs) = diffs {
                         for diff in &diffs {
-                            diff.clone().apply(&mut raw_current_values);
+                            diff.clone().map(|room| {
+                                trace!(room = %room.room_id(), "updated in response");
+                                room
+                            }).apply(&mut raw_current_values);
                         }
 
                         yield diffs;
@@ -222,7 +226,9 @@ fn merge_stream_and_receiver(
                         reasons.contains(NotableUpdate::READ_RECEIPT) {
                         // Emit a `VectorDiff::Set` for the specific rooms.
                         if let Some(index) = raw_current_values.iter().position(|room| room.room_id() == update.room_id) {
-                            let update = VectorDiff::Set { index, value: raw_current_values[index].clone() };
+                            let room = &raw_current_values[index];
+                            let update = VectorDiff::Set { index, value: room.clone() };
+                            trace!(room = %room.room_id(), "updated because of notable reason: {reasons:?}");
                             yield vec![update];
                         }
                     }

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -16,7 +16,7 @@ use matrix_sdk::{
 use tokio::{spawn, time::sleep};
 use tracing::error;
 
-use crate::helpers::TestClientBuilder;
+use crate::helpers::{wait_for_room, TestClientBuilder};
 
 #[tokio::test]
 async fn test_event_with_context() -> Result<()> {
@@ -56,14 +56,7 @@ async fn test_event_with_context() -> Result<()> {
         .room_id()
         .to_owned();
 
-    let mut alice_room = None;
-    for i in 1..=4 {
-        alice_room = alice.get_room(&room_id);
-        if alice_room.is_some() {
-            break;
-        }
-        sleep(Duration::from_millis(30 * i)).await;
-    }
+    let alice_room = wait_for_room(&alice, &room_id).await;
 
     // Bob joins it.
     let mut bob_joined = false;
@@ -77,7 +70,6 @@ async fn test_event_with_context() -> Result<()> {
     }
     anyhow::ensure!(bob_joined, "bob couldn't join after 3 seconds");
 
-    let alice_room = alice_room.unwrap();
     assert_eq!(alice_room.state(), RoomState::Joined);
 
     alice_room.enable_encryption().await?;

--- a/testing/matrix-sdk-integration-testing/src/tests/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/room.rs
@@ -60,15 +60,15 @@ async fn test_event_with_context() -> Result<()> {
 
     // Bob joins it.
     let mut bob_joined = false;
-    for i in 1..=4 {
+    for i in 1..=5 {
         if let Some(room) = bob.get_room(&room_id) {
             room.join().await?;
             bob_joined = true;
             break;
         }
-        sleep(Duration::from_millis(30 * i)).await;
+        sleep(Duration::from_millis(500 * i)).await;
     }
-    anyhow::ensure!(bob_joined, "bob couldn't join after 3 seconds");
+    anyhow::ensure!(bob_joined, "bob couldn't join after ~8 seconds");
 
     assert_eq!(alice_room.state(), RoomState::Joined);
 

--- a/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
+++ b/testing/matrix-sdk-integration-testing/src/tests/sliding_sync/room.rs
@@ -99,7 +99,7 @@ async fn test_left_room() -> Result<()> {
 
     // Steven joins it.
     let mut joined = false;
-    for _ in 0..3 {
+    for _ in 0..10 {
         sleep(Duration::from_secs(1)).await;
         if let Some(room) = steven.get_room(peter_room.room_id()) {
             room.join().await?;
@@ -107,7 +107,7 @@ async fn test_left_room() -> Result<()> {
             break;
         }
     }
-    anyhow::ensure!(joined, "steven couldn't join after 3 seconds");
+    anyhow::ensure!(joined, "steven couldn't join after 10 seconds");
 
     // Now Peter is just being rude.
     peter_room.leave().await?;


### PR DESCRIPTION
This reverts the removal of the test done in https://github.com/matrix-org/matrix-rust-sdk/pull/3691, since the test is actually useful (it makes sure the apps don't get spurious updates about the room list), and was indeed badly written (two syncs running at once for one client — good catch on that for the other test @Hywan!).

This rewrites it in such a way that it should fail fast; it's been pretty solid for me locally, let's see how CI likes it…