### PR TITLE
sdk: Allow to request animated thumbnails

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -8,7 +8,9 @@ use std::{
 
 use anyhow::{anyhow, Context as _};
 use matrix_sdk::{
-    media::{MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSize},
+    media::{
+        MediaFileHandle as SdkMediaFileHandle, MediaFormat, MediaRequest, MediaThumbnailSettings,
+    },
     oidc::{
         registrations::{ClientId, OidcRegistrations},
         requests::account_management::AccountManagementActionFull,
@@ -657,11 +659,11 @@ impl Client {
             .get_media_content(
                 &MediaRequest {
                     source,
-                    format: MediaFormat::Thumbnail(MediaThumbnailSize {
-                        method: Method::Scale,
-                        width: UInt::new(width).unwrap(),
-                        height: UInt::new(height).unwrap(),
-                    }),
+                    format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
+                        Method::Scale,
+                        UInt::new(width).unwrap(),
+                        UInt::new(height).unwrap(),
+                    )),
                 },
                 true,
             )

--- a/crates/matrix-sdk-base/CHANGELOG.md
+++ b/crates/matrix-sdk-base/CHANGELOG.md
@@ -10,6 +10,8 @@
 - `Client::get_rooms` and `Client::get_rooms_filtered` are renamed
   `Client::rooms` and `Client::rooms_filtered`.
 - `Client::get_stripped_rooms` has finally been removed.
+- `Media::get_thumbnail` and `MediaFormat::Thumbnail` allow to request an animated thumbnail
+  - They both take a `MediaThumbnailSettings` instead of `MediaThumbnailSize`.
 
 # 0.7.0
 

--- a/crates/matrix-sdk-base/src/media.rs
+++ b/crates/matrix-sdk-base/src/media.rs
@@ -72,18 +72,18 @@ pub struct MediaThumbnailSettings {
 
     /// If we want to request an animated thumbnail from the homeserver.
     ///
-    /// If it is `Some(true)`, the server should return an animated thumbnail if
-    /// the media supports it. If it is `Some(false)`, the server must never
-    /// return an animated thumbnail. If it is `None`, the server should not
-    /// return an animated thumbnail.
-    pub animated: Option<bool>,
+    /// If it is `true`, the server should return an animated thumbnail if
+    /// the media supports it.
+    ///
+    /// Defaults to `false`.
+    pub animated: bool,
 }
 
 impl MediaThumbnailSettings {
     /// Constructs a new `MediaThumbnailSettings` with the given method, width
     /// and height.
     pub fn new(method: Method, width: UInt, height: UInt) -> Self {
-        Self { size: MediaThumbnailSize { method, width, height }, animated: None }
+        Self { size: MediaThumbnailSize { method, width, height }, animated: false }
     }
 }
 
@@ -91,13 +91,9 @@ impl UniqueKey for MediaThumbnailSettings {
     fn unique_key(&self) -> String {
         let mut key = self.size.unique_key();
 
-        if let Some(animated) = self.animated {
+        if self.animated {
             key.push_str(UNIQUE_SEPARATOR);
-
-            match animated {
-                true => key.push_str("animated"),
-                false => key.push_str("not-animated"),
-            }
+            key.push_str("animated");
         }
 
         key

--- a/crates/matrix-sdk-base/src/store/integration_tests.rs
+++ b/crates/matrix-sdk-base/src/store/integration_tests.rs
@@ -37,7 +37,7 @@ use serde_json::{json, value::Value as JsonValue};
 use super::{DynStateStore, ServerCapabilities};
 use crate::{
     deserialized_responses::MemberEvent,
-    media::{MediaFormat, MediaRequest, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings},
     store::{Result, SerializableEventContent, StateStoreExt},
     RoomInfo, RoomMemberships, RoomState, StateChanges, StateStoreDataKey, StateStoreDataValue,
 };
@@ -217,11 +217,11 @@ impl StateStoreIntegrationTests for DynStateStore {
             MediaRequest { source: MediaSource::Plain(uri.to_owned()), format: MediaFormat::File };
         let request_thumbnail = MediaRequest {
             source: MediaSource::Plain(uri.to_owned()),
-            format: MediaFormat::Thumbnail(MediaThumbnailSize {
-                method: Method::Crop,
-                width: uint!(100),
-                height: uint!(100),
-            }),
+            format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
+                Method::Crop,
+                uint!(100),
+                uint!(100),
+            )),
         };
 
         let other_uri = mxc_uri!("mxc://localhost/media-other");

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -308,22 +308,31 @@ impl Media {
                 content
             }
             MediaSource::Plain(uri) => {
-                if let MediaFormat::Thumbnail(size) = &request.format {
+                if let MediaFormat::Thumbnail(settings) = &request.format {
                     if use_auth {
-                        let request =
+                        let mut request =
                             authenticated_media::get_content_thumbnail::v1::Request::from_uri(
                                 uri,
-                                size.width,
-                                size.height,
+                                settings.size.width,
+                                settings.size.height,
                             )?;
+                        request.method = Some(settings.size.method.clone());
+                        request.animated = settings.animated;
+
                         self.client.send(request, None).await?.file
                     } else {
                         #[allow(deprecated)]
-                        let request = media::get_content_thumbnail::v3::Request::from_url(
-                            uri,
-                            size.width,
-                            size.height,
-                        )?;
+                        let request = {
+                            let mut request = media::get_content_thumbnail::v3::Request::from_url(
+                                uri,
+                                settings.size.width,
+                                settings.size.height,
+                            )?;
+                            request.method = Some(settings.size.method.clone());
+                            request.animated = settings.animated;
+                            request
+                        };
+
                         self.client.send(request, None).await?.file
                     }
                 } else if use_auth {
@@ -420,20 +429,20 @@ impl Media {
     ///
     /// * `event_content` - The media event content.
     ///
-    /// * `size` - The _desired_ size of the thumbnail. The actual thumbnail may
-    ///   not match the size specified.
+    /// * `settings` - The _desired_ settings of the thumbnail. The actual
+    ///   thumbnail may not match the settings specified.
     ///
     /// * `use_cache` - If we should use the media cache for this thumbnail.
     pub async fn get_thumbnail(
         &self,
         event_content: &impl MediaEventContent,
-        size: MediaThumbnailSize,
+        settings: MediaThumbnailSettings,
         use_cache: bool,
     ) -> Result<Option<Vec<u8>>> {
         let Some(source) = event_content.thumbnail_source() else { return Ok(None) };
         let thumbnail = self
             .get_media_content(
-                &MediaRequest { source, format: MediaFormat::Thumbnail(size) },
+                &MediaRequest { source, format: MediaFormat::Thumbnail(settings) },
                 use_cache,
             )
             .await?;
@@ -449,17 +458,17 @@ impl Media {
     ///
     /// * `event_content` - The media event content.
     ///
-    /// * `size` - The _desired_ size of the thumbnail. Must match the size
-    ///   requested with [`get_thumbnail`](#method.get_thumbnail).
+    /// * `size` - The _desired_ settings of the thumbnail. Must match the
+    ///   settings requested with [`get_thumbnail`](#method.get_thumbnail).
     pub async fn remove_thumbnail(
         &self,
         event_content: &impl MediaEventContent,
-        size: MediaThumbnailSize,
+        settings: MediaThumbnailSettings,
     ) -> Result<()> {
         if let Some(source) = event_content.source() {
             self.remove_media_content(&MediaRequest {
                 source,
-                format: MediaFormat::Thumbnail(size),
+                format: MediaFormat::Thumbnail(settings),
             })
             .await?
         }

--- a/crates/matrix-sdk/src/media.rs
+++ b/crates/matrix-sdk/src/media.rs
@@ -317,7 +317,7 @@ impl Media {
                                 settings.size.height,
                             )?;
                         request.method = Some(settings.size.method.clone());
-                        request.animated = settings.animated;
+                        request.animated = Some(settings.animated);
 
                         self.client.send(request, None).await?.file
                     } else {
@@ -329,7 +329,7 @@ impl Media {
                                 settings.size.height,
                             )?;
                             request.method = Some(settings.size.method.clone());
-                            request.animated = settings.animated;
+                            request.animated = Some(settings.animated);
                             request
                         };
 

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -14,7 +14,7 @@ use ruma::{
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path, query_param, query_param_is_missing},
+    matchers::{header, method, path, query_param},
     Mock, ResponseTemplate,
 };
 
@@ -120,13 +120,13 @@ async fn test_get_media_file_no_auth() {
 
     client.media().get_file(&event_content, false).await.unwrap();
 
-    // Get a thumbnail, no animated param.
+    // Get a thumbnail, not animated.
     Mock::given(method("GET"))
         .and(path("/_matrix/media/r0/thumbnail/example.org/image"))
         .and(query_param("method", "scale"))
         .and(query_param("width", "100"))
         .and(query_param("height", "100"))
-        .and(query_param_is_missing("animated"))
+        .and(query_param("animated", "false"))
         .respond_with(
             ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
         )
@@ -145,28 +145,7 @@ async fn test_get_media_file_no_auth() {
         .await
         .unwrap();
 
-    // Get a thumbnail, forbid animated.
-    Mock::given(method("GET"))
-        .and(path("/_matrix/media/r0/thumbnail/example.org/image"))
-        .and(query_param("method", "crop"))
-        .and(query_param("width", "100"))
-        .and(query_param("height", "100"))
-        .and(query_param("animated", "false"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
-        )
-        .expect(1)
-        .named("get_thumbnail_animated_false")
-        .mount(&server)
-        .await;
-
-    let settings = MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
-        animated: Some(false),
-    };
-    client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
-
-    // Get a thumbnail, request animated.
+    // Get a thumbnail, animated.
     Mock::given(method("GET"))
         .and(path("/_matrix/media/r0/thumbnail/example.org/image"))
         .and(query_param("method", "crop"))
@@ -183,7 +162,7 @@ async fn test_get_media_file_no_auth() {
 
     let settings = MediaThumbnailSettings {
         size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
-        animated: Some(true),
+        animated: true,
     };
     client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
 }
@@ -249,13 +228,13 @@ async fn test_get_media_file_with_auth() {
 
     client.media().get_file(&event_content, false).await.unwrap();
 
-    // Get a thumbnail, no animated param.
+    // Get a thumbnail, not animated.
     Mock::given(method("GET"))
         .and(path("/_matrix/client/v1/media/thumbnail/example.org/image"))
         .and(query_param("method", "scale"))
         .and(query_param("width", "100"))
         .and(query_param("height", "100"))
-        .and(query_param_is_missing("animated"))
+        .and(query_param("animated", "false"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(
             ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
@@ -275,29 +254,7 @@ async fn test_get_media_file_with_auth() {
         .await
         .unwrap();
 
-    // Get a thumbnail, forbid animated.
-    Mock::given(method("GET"))
-        .and(path("/_matrix/client/v1/media/thumbnail/example.org/image"))
-        .and(query_param("method", "crop"))
-        .and(query_param("width", "100"))
-        .and(query_param("height", "100"))
-        .and(query_param("animated", "false"))
-        .and(header("authorization", "Bearer 1234"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
-        )
-        .expect(1)
-        .named("get_thumbnail_animated_false")
-        .mount(&server)
-        .await;
-
-    let settings = MediaThumbnailSettings {
-        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
-        animated: Some(false),
-    };
-    client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
-
-    // Get a thumbnail, request animated.
+    // Get a thumbnail, animated.
     Mock::given(method("GET"))
         .and(path("/_matrix/client/v1/media/thumbnail/example.org/image"))
         .and(query_param("method", "crop"))
@@ -315,7 +272,7 @@ async fn test_get_media_file_with_auth() {
 
     let settings = MediaThumbnailSettings {
         size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
-        animated: Some(true),
+        animated: true,
     };
     client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
 }

--- a/crates/matrix-sdk/tests/integration/media.rs
+++ b/crates/matrix-sdk/tests/integration/media.rs
@@ -1,7 +1,7 @@
 use matrix_sdk::{
     config::RequestConfig,
     matrix_auth::{MatrixSession, MatrixSessionTokens},
-    media::{MediaFormat, MediaRequest, MediaThumbnailSize},
+    media::{MediaFormat, MediaRequest, MediaThumbnailSettings, MediaThumbnailSize},
     test_utils::logged_in_client_with_server,
     Client, SessionMeta,
 };
@@ -14,7 +14,7 @@ use ruma::{
 };
 use serde_json::json;
 use wiremock::{
-    matchers::{header, method, path},
+    matchers::{header, method, path, query_param, query_param_is_missing},
     Mock, ResponseTemplate,
 };
 
@@ -35,6 +35,8 @@ async fn test_get_media_content_no_auth() {
         let _mock_guard = Mock::given(method("GET"))
             .and(path("/_matrix/media/r0/download/localhost/textfile"))
             .respond_with(ResponseTemplate::new(200).set_body_string(expected_content))
+            .named("get_file_no_cache")
+            .expect(1)
             .mount_as_scoped(&server)
             .await;
 
@@ -49,6 +51,8 @@ async fn test_get_media_content_no_auth() {
         let _mock_guard = Mock::given(method("GET"))
             .and(path("/_matrix/media/r0/download/localhost/textfile"))
             .respond_with(ResponseTemplate::new(500))
+            .named("get_file_no_cache_error")
+            .expect(1)
             .mount_as_scoped(&server)
             .await;
 
@@ -62,6 +66,8 @@ async fn test_get_media_content_no_auth() {
         let _mock_guard = Mock::given(method("GET"))
             .and(path("/_matrix/media/r0/download/localhost/textfile"))
             .respond_with(ResponseTemplate::new(200).set_body_string(expected_content))
+            .named("get_file_with_cache")
+            .expect(1)
             .mount_as_scoped(&server)
             .await;
 
@@ -76,6 +82,8 @@ async fn test_get_media_content_no_auth() {
         let _mock_guard = Mock::given(method("GET"))
             .and(path("/_matrix/media/r0/download/localhost/textfile"))
             .respond_with(ResponseTemplate::new(500))
+            .named("get_file_with_cache_error")
+            .expect(0)
             .mount_as_scoped(&server)
             .await;
 
@@ -101,22 +109,29 @@ async fn test_get_media_file_no_auth() {
         size: Some(uint!(31037)),
     })));
 
+    // Get the file.
     Mock::given(method("GET"))
         .and(path("/_matrix/media/r0/download/example.org/image"))
         .respond_with(ResponseTemplate::new(200).set_body_raw("binaryjpegdata", "image/jpeg"))
         .named("get_file")
+        .expect(1)
         .mount(&server)
         .await;
 
     client.media().get_file(&event_content, false).await.unwrap();
 
+    // Get a thumbnail, no animated param.
     Mock::given(method("GET"))
         .and(path("/_matrix/media/r0/thumbnail/example.org/image"))
+        .and(query_param("method", "scale"))
+        .and(query_param("width", "100"))
+        .and(query_param("height", "100"))
+        .and(query_param_is_missing("animated"))
         .respond_with(
             ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
         )
         .expect(1)
-        .named("get_thumbnail")
+        .named("get_thumbnail_no_animated")
         .mount(&server)
         .await;
 
@@ -124,11 +139,53 @@ async fn test_get_media_file_no_auth() {
         .media()
         .get_thumbnail(
             &event_content,
-            MediaThumbnailSize { method: Method::Scale, width: uint!(100), height: uint!(100) },
-            false,
+            MediaThumbnailSettings::new(Method::Scale, uint!(100), uint!(100)),
+            true,
         )
         .await
         .unwrap();
+
+    // Get a thumbnail, forbid animated.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/media/r0/thumbnail/example.org/image"))
+        .and(query_param("method", "crop"))
+        .and(query_param("width", "100"))
+        .and(query_param("height", "100"))
+        .and(query_param("animated", "false"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
+        )
+        .expect(1)
+        .named("get_thumbnail_animated_false")
+        .mount(&server)
+        .await;
+
+    let settings = MediaThumbnailSettings {
+        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        animated: Some(false),
+    };
+    client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
+
+    // Get a thumbnail, request animated.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/media/r0/thumbnail/example.org/image"))
+        .and(query_param("method", "crop"))
+        .and(query_param("width", "100"))
+        .and(query_param("height", "100"))
+        .and(query_param("animated", "true"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
+        )
+        .expect(1)
+        .named("get_thumbnail_animated_true")
+        .mount(&server)
+        .await;
+
+    let settings = MediaThumbnailSettings {
+        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        animated: Some(true),
+    };
+    client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
 }
 
 #[async_test]
@@ -192,15 +249,19 @@ async fn test_get_media_file_with_auth() {
 
     client.media().get_file(&event_content, false).await.unwrap();
 
-    // Get a thumbnail of the file.
+    // Get a thumbnail, no animated param.
     Mock::given(method("GET"))
         .and(path("/_matrix/client/v1/media/thumbnail/example.org/image"))
+        .and(query_param("method", "scale"))
+        .and(query_param("width", "100"))
+        .and(query_param("height", "100"))
+        .and(query_param_is_missing("animated"))
         .and(header("authorization", "Bearer 1234"))
         .respond_with(
             ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
         )
-        .named("get_thumbnail")
         .expect(1)
+        .named("get_thumbnail_no_animated")
         .mount(&server)
         .await;
 
@@ -208,9 +269,53 @@ async fn test_get_media_file_with_auth() {
         .media()
         .get_thumbnail(
             &event_content,
-            MediaThumbnailSize { method: Method::Scale, width: uint!(100), height: uint!(100) },
-            false,
+            MediaThumbnailSettings::new(Method::Scale, uint!(100), uint!(100)),
+            true,
         )
         .await
         .unwrap();
+
+    // Get a thumbnail, forbid animated.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/v1/media/thumbnail/example.org/image"))
+        .and(query_param("method", "crop"))
+        .and(query_param("width", "100"))
+        .and(query_param("height", "100"))
+        .and(query_param("animated", "false"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
+        )
+        .expect(1)
+        .named("get_thumbnail_animated_false")
+        .mount(&server)
+        .await;
+
+    let settings = MediaThumbnailSettings {
+        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        animated: Some(false),
+    };
+    client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
+
+    // Get a thumbnail, request animated.
+    Mock::given(method("GET"))
+        .and(path("/_matrix/client/v1/media/thumbnail/example.org/image"))
+        .and(query_param("method", "crop"))
+        .and(query_param("width", "100"))
+        .and(query_param("height", "100"))
+        .and(query_param("animated", "true"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw("smallerbinaryjpegdata", "image/jpeg"),
+        )
+        .expect(1)
+        .named("get_thumbnail_animated_true")
+        .mount(&server)
+        .await;
+
+    let settings = MediaThumbnailSettings {
+        size: MediaThumbnailSize { method: Method::Crop, width: uint!(100), height: uint!(100) },
+        animated: Some(true),
+    };
+    client.media().get_thumbnail(&event_content, settings, true).await.unwrap();
 }


### PR DESCRIPTION
New feature from Matrix 1.11.

- [x] Public API changes documented in changelogs (optional)

