### PR TITLE
FFI: Allow a Client to be built that doesn't trust built in CAs.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -257,6 +257,7 @@ pub struct ClientBuilder {
     cross_process_refresh_lock_id: Option<String>,
     session_delegate: Option<Arc<dyn ClientSessionDelegate>>,
     additional_root_certificates: Vec<Vec<u8>>,
+    disable_built_in_root_certificates: bool,
     encryption_settings: EncryptionSettings,
 }
 
@@ -278,6 +279,7 @@ impl ClientBuilder {
             cross_process_refresh_lock_id: None,
             session_delegate: None,
             additional_root_certificates: Default::default(),
+            disable_built_in_root_certificates: false,
             encryption_settings: EncryptionSettings {
                 auto_enable_cross_signing: false,
                 backup_download_strategy:
@@ -394,6 +396,15 @@ impl ClientBuilder {
         Arc::new(builder)
     }
 
+    /// Don't trust any system root certificates, only trust the certificates
+    /// provided through
+    /// [`add_root_certificates`][ClientBuilder::add_root_certificates].
+    pub fn disable_built_in_root_certificates(self: Arc<Self>) -> Arc<Self> {
+        let mut builder = unwrap_or_clone_arc(self);
+        builder.disable_built_in_root_certificates = true;
+        Arc::new(builder)
+    }
+
     pub fn auto_enable_cross_signing(
         self: Arc<Self>,
         auto_enable_cross_signing: bool,
@@ -468,18 +479,26 @@ impl ClientBuilder {
         for certificate in builder.additional_root_certificates {
             // We don't really know what type of certificate we may get here, so let's try
             // first one type, then the other.
-            if let Ok(cert) = Certificate::from_der(&certificate) {
-                certificates.push(cert);
-            } else {
-                let cert =
-                    Certificate::from_pem(&certificate).map_err(|e| ClientBuildError::Generic {
-                        message: format!("Failed to add a root certificate {e:?}"),
+            match Certificate::from_der(&certificate) {
+                Ok(cert) => {
+                    certificates.push(cert);
+                }
+                Err(der_error) => {
+                    let cert = Certificate::from_pem(&certificate).map_err(|pem_error| {
+                        ClientBuildError::Generic {
+                            message: format!("Failed to add a root certificate as DER ({der_error:?}) or PEM ({pem_error:?})"),
+                        }
                     })?;
-                certificates.push(cert);
+                    certificates.push(cert);
+                }
             }
         }
 
         inner_builder = inner_builder.add_root_certificates(certificates);
+
+        if builder.disable_built_in_root_certificates {
+            inner_builder = inner_builder.disable_built_in_root_certificates();
+        }
 
         if let Some(proxy) = builder.proxy {
             inner_builder = inner_builder.proxy(proxy);

--- a/crates/matrix-sdk/src/client/builder.rs
+++ b/crates/matrix-sdk/src/client/builder.rs
@@ -323,12 +323,24 @@ impl ClientBuilder {
         self
     }
 
+    /// Don't trust any system root certificates, only trust the certificates
+    /// provided through
+    /// [`add_root_certificates`][ClientBuilder::add_root_certificates].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn disable_built_in_root_certificates(mut self) -> Self {
+        self.http_settings().disable_built_in_root_certificates = true;
+        self
+    }
+
     /// Specify a [`reqwest::Client`] instance to handle sending requests and
     /// receiving responses.
     ///
-    /// This method is mutually exclusive with [`proxy()`][Self::proxy],
-    /// [`disable_ssl_verification`][Self::disable_ssl_verification] and
-    /// [`user_agent()`][Self::user_agent].
+    /// This method is mutually exclusive with
+    /// [`proxy()`][ClientBuilder::proxy],
+    /// [`disable_ssl_verification`][ClientBuilder::disable_ssl_verification],
+    /// [`add_root_certificates`][ClientBuilder::add_root_certificates],
+    /// [`disable_built_in_root_certificates`][ClientBuilder::disable_built_in_root_certificates],
+    /// and [`user_agent()`][ClientBuilder::user_agent].
     pub fn http_client(mut self, client: reqwest::Client) -> Self {
         self.http_cfg = Some(HttpConfig::Custom(client));
         self

--- a/crates/matrix-sdk/src/http_client/native.rs
+++ b/crates/matrix-sdk/src/http_client/native.rs
@@ -112,6 +112,7 @@ pub(crate) struct HttpSettings {
     pub(crate) user_agent: Option<String>,
     pub(crate) timeout: Duration,
     pub(crate) additional_root_certificates: Vec<Certificate>,
+    pub(crate) disable_built_in_root_certificates: bool,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -123,6 +124,7 @@ impl Default for HttpSettings {
             user_agent: None,
             timeout: DEFAULT_REQUEST_TIMEOUT,
             additional_root_certificates: Default::default(),
+            disable_built_in_root_certificates: false,
         }
     }
 }
@@ -149,6 +151,11 @@ impl HttpSettings {
             for cert in &self.additional_root_certificates {
                 http_client = http_client.add_root_certificate(cert.clone());
             }
+        }
+
+        if self.disable_built_in_root_certificates {
+            info!("Built-in root certificates disabled in the HTTP client.");
+            http_client = http_client.tls_built_in_root_certs(false);
         }
 
         if let Some(p) = &self.proxy {


### PR DESCRIPTION
This will mean the client only trusts the CAs provided by `add_root_certificates`.

I am not really sure how we should test this given https://github.com/LukeMathWalker/wiremock-rs/issues/58 means we can't yet use wiremock for that (and even then, that would only prove it worked with the added CA, it wouldn't prove it rejected one of the system CAs) 🤔