### PR TITLE
matrix_sdk_base: make sticker events suitable as latest_event

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -775,7 +775,8 @@ impl BaseClient {
                         PossibleLatestEvent::YesRoomMessage(_)
                         | PossibleLatestEvent::YesPoll(_)
                         | PossibleLatestEvent::YesCallInvite(_)
-                        | PossibleLatestEvent::YesCallNotify(_) => {
+                        | PossibleLatestEvent::YesCallNotify(_)
+                        | PossibleLatestEvent::YesSticker(_) => {
                             // The event is the right type for us to use as latest_event
                             return Some((Box::new(LatestEvent::new(decrypted)), i));
                         }

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -444,6 +444,7 @@ mod tests {
             PossibleLatestEvent::NoUnsupportedMessageLikeType
         );
     }
+
     #[test]
     fn test_redacted_messages_are_suitable() {
         // Ruma does not allow constructing UnsignedRoomRedactionEvent instances.

--- a/crates/matrix-sdk-base/src/latest_event.rs
+++ b/crates/matrix-sdk-base/src/latest_event.rs
@@ -12,7 +12,7 @@ use ruma::events::{
     room::message::SyncRoomMessageEvent,
     AnySyncMessageLikeEvent, AnySyncTimelineEvent,
 };
-use ruma::{MxcUri, OwnedEventId};
+use ruma::{events::sticker::SyncStickerEvent, MxcUri, OwnedEventId};
 use serde::{Deserialize, Serialize};
 
 use crate::MinimalRoomMemberEvent;
@@ -26,6 +26,8 @@ use crate::MinimalRoomMemberEvent;
 pub enum PossibleLatestEvent<'a> {
     /// This message is suitable - it is an m.room.message
     YesRoomMessage(&'a SyncRoomMessageEvent),
+    /// This message is suitable - it is a sticker
+    YesSticker(&'a SyncStickerEvent),
     /// This message is suitable - it is a poll
     YesPoll(&'a SyncUnstablePollStartEvent),
 
@@ -83,6 +85,10 @@ pub fn is_suitable_for_latest_event(event: &AnySyncTimelineEvent) -> PossibleLat
 
         AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::CallNotify(notify)) => {
             PossibleLatestEvent::YesCallNotify(notify)
+        }
+
+        AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::Sticker(sticker)) => {
+            PossibleLatestEvent::YesSticker(sticker)
         }
 
         // Encrypted events are not suitable
@@ -268,9 +274,14 @@ mod tests {
                 },
                 SessionDescription,
             },
-            poll::unstable_start::{
-                NewUnstablePollStartEventContent, SyncUnstablePollStartEvent, UnstablePollAnswer,
-                UnstablePollStartContentBlock,
+            poll::{
+                unstable_response::{
+                    SyncUnstablePollResponseEvent, UnstablePollResponseEventContent,
+                },
+                unstable_start::{
+                    NewUnstablePollStartEventContent, SyncUnstablePollStartEvent,
+                    UnstablePollAnswer, UnstablePollStartContentBlock,
+                },
             },
             relation::Replacement,
             room::{
@@ -391,7 +402,7 @@ mod tests {
     }
 
     #[test]
-    fn test_different_types_of_messagelike_are_unsuitable() {
+    fn test_stickers_are_suitable() {
         let event = AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::Sticker(
             SyncStickerEvent::Original(OriginalSyncMessageLikeEvent {
                 content: StickerEventContent::new(
@@ -408,10 +419,31 @@ mod tests {
 
         assert_matches!(
             is_suitable_for_latest_event(&event),
-            PossibleLatestEvent::NoUnsupportedMessageLikeType
+            PossibleLatestEvent::YesSticker(SyncStickerEvent::Original(_))
         );
     }
 
+    #[test]
+    fn test_different_types_of_messagelike_are_unsuitable() {
+        let event =
+            AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::UnstablePollResponse(
+                SyncUnstablePollResponseEvent::Original(OriginalSyncMessageLikeEvent {
+                    content: UnstablePollResponseEventContent::new(
+                        vec![String::from("option1")],
+                        owned_event_id!("$1"),
+                    ),
+                    event_id: owned_event_id!("$2"),
+                    sender: owned_user_id!("@a:b.c"),
+                    origin_server_ts: MilliSecondsSinceUnixEpoch(UInt::new(2123).unwrap()),
+                    unsigned: MessageLikeUnsigned::new(),
+                }),
+            ));
+
+        assert_matches!(
+            is_suitable_for_latest_event(&event),
+            PossibleLatestEvent::NoUnsupportedMessageLikeType
+        );
+    }
     #[test]
     fn test_redacted_messages_are_suitable() {
         // Ruma does not allow constructing UnsignedRoomRedactionEvent instances.

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -621,7 +621,8 @@ async fn cache_latest_events(
                 PossibleLatestEvent::YesRoomMessage(_)
                 | PossibleLatestEvent::YesPoll(_)
                 | PossibleLatestEvent::YesCallInvite(_)
-                | PossibleLatestEvent::YesCallNotify(_) => {
+                | PossibleLatestEvent::YesCallNotify(_)
+                | PossibleLatestEvent::YesSticker(_) => {
                     // We found a suitable latest event. Store it.
 
                     // In order to make the latest event fast to read, we want to keep the

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -47,7 +47,7 @@ use ruma::{
             topic::RoomTopicEventContent,
         },
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
-        sticker::StickerEventContent,
+        sticker::{StickerEventContent, SyncStickerEvent},
         AnyFullStateEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         BundledMessageLikeRelations, FullStateEventContent, MessageLikeEventType, StateEventType,
     },
@@ -127,6 +127,9 @@ impl TimelineItemContent {
             PossibleLatestEvent::YesRoomMessage(m) => {
                 Some(Self::from_suitable_latest_event_content(m))
             }
+            PossibleLatestEvent::YesSticker(s) => {
+                Some(Self::from_suitable_latest_sticker_content(s))
+            }
             PossibleLatestEvent::YesPoll(poll) => {
                 Some(Self::from_suitable_latest_poll_event_content(poll))
             }
@@ -185,6 +188,20 @@ impl TimelineItemContent {
                 ))
             }
             SyncRoomMessageEvent::Redacted(_) => TimelineItemContent::RedactedMessage,
+        }
+    }
+
+    /// Given some sticker content that is from an event that we have already
+    /// determined is suitable for use as a latest event in a message preview,
+    /// extract its contents and wrap it as a `TimelineItemContent`.
+    fn from_suitable_latest_sticker_content(event: &SyncStickerEvent) -> TimelineItemContent {
+        match event {
+            SyncStickerEvent::Original(event) => {
+                // Grab the content of this event
+                let event_content = event.content.clone();
+                TimelineItemContent::Sticker(Sticker { content: event_content })
+            }
+            SyncStickerEvent::Redacted(_) => TimelineItemContent::RedactedMessage,
         }
     }
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

Currently on Element X if you receive a sticker in a room, the room list will show the room as updated but it will show the latest event that is not a sticker. This change fixes that.

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
Marco Antonio Alvarez <surakin@gmail.com>