### PR TITLE
sdk-base: Add `RoomInfoNotableUpdateReasons::MEMBERSHIP`

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -840,7 +840,7 @@ impl BaseClient {
             let mut changes = StateChanges::default();
             changes.add_room(room_info.clone());
             self.store.save_changes(&changes).await?; // Update the store
-            room.set_room_info(room_info, RoomInfoNotableUpdateReasons::empty());
+            room.set_room_info(room_info, RoomInfoNotableUpdateReasons::MEMBERSHIP);
         }
 
         Ok(room)
@@ -866,7 +866,7 @@ impl BaseClient {
             let mut changes = StateChanges::default();
             changes.add_room(room_info.clone());
             self.store.save_changes(&changes).await?; // Update the store
-            room.set_room_info(room_info, RoomInfoNotableUpdateReasons::empty());
+            room.set_room_info(room_info, RoomInfoNotableUpdateReasons::MEMBERSHIP);
         }
 
         Ok(())

--- a/crates/matrix-sdk-base/src/rooms/normal.rs
+++ b/crates/matrix-sdk-base/src/rooms/normal.rs
@@ -103,6 +103,9 @@ bitflags! {
 
         /// The user-controlled unread marker value has changed.
         const UNREAD_MARKER = 0b0000_1000;
+
+        /// A membership change happened for the current user.
+        const MEMBERSHIP = 0b0001_0000;
     }
 }
 
@@ -1903,18 +1906,10 @@ mod tests {
 
         // When the new tag is handled and applied.
         let mut changes = StateChanges::default();
-        let mut notable_reasons_updates = Default::default();
         client
-            .handle_room_account_data(
-                room_id,
-                &[tag_raw],
-                &mut changes,
-                &mut notable_reasons_updates,
-            )
+            .handle_room_account_data(room_id, &[tag_raw], &mut changes, &mut Default::default())
             .await;
-
-        assert!(notable_reasons_updates.is_empty());
-        client.apply_changes(&changes, notable_reasons_updates);
+        client.apply_changes(&changes, Default::default());
 
         // The `RoomInfo` is getting notified.
         assert_ready!(room_info_subscriber);
@@ -1932,18 +1927,9 @@ mod tests {
         }))
         .unwrap()
         .cast();
-
-        let mut notable_reasons_updates = Default::default();
         client
-            .handle_room_account_data(
-                room_id,
-                &[tag_raw],
-                &mut changes,
-                &mut notable_reasons_updates,
-            )
+            .handle_room_account_data(room_id, &[tag_raw], &mut changes, &mut Default::default())
             .await;
-
-        assert!(notable_reasons_updates.is_empty());
         client.apply_changes(&changes, Default::default());
 
         // The `RoomInfo` is getting notified.
@@ -1998,18 +1984,10 @@ mod tests {
 
         // When the new tag is handled and applied.
         let mut changes = StateChanges::default();
-        let mut notable_reasons_updates = Default::default();
         client
-            .handle_room_account_data(
-                room_id,
-                &[tag_raw],
-                &mut changes,
-                &mut notable_reasons_updates,
-            )
+            .handle_room_account_data(room_id, &[tag_raw], &mut changes, &mut Default::default())
             .await;
-
-        assert!(notable_reasons_updates.is_empty());
-        client.apply_changes(&changes, notable_reasons_updates);
+        client.apply_changes(&changes, Default::default());
 
         // The `RoomInfo` is getting notified.
         assert_ready!(room_info_subscriber);
@@ -2027,19 +2005,10 @@ mod tests {
         }))
         .unwrap()
         .cast();
-
-        let mut notable_reasons_updates = Default::default();
         client
-            .handle_room_account_data(
-                room_id,
-                &[tag_raw],
-                &mut changes,
-                &mut notable_reasons_updates,
-            )
+            .handle_room_account_data(room_id, &[tag_raw], &mut changes, &mut Default::default())
             .await;
-
-        assert!(notable_reasons_updates.is_empty());
-        client.apply_changes(&changes, notable_reasons_updates);
+        client.apply_changes(&changes, Default::default());
 
         // The `RoomInfo` is getting notified.
         assert_ready!(room_info_subscriber);

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -623,14 +623,18 @@ impl BaseClient {
                 // If this event updates the current user's membership, record that in the
                 // room_info.
                 if member.state_key() == meta.user_id.as_str() {
-                    room_info.set_state(member.membership().into());
+                    let new_state: RoomState = member.membership().into();
+                    if new_state != room_info.state() {
+                        room_info.set_state(new_state);
+                        room_info_notable_updates.insert(
+                            room_info.room_id.to_owned(),
+                            RoomInfoNotableUpdateReasons::MEMBERSHIP,
+                        );
+                    }
                     break;
                 }
             }
         }
-
-        room_info_notable_updates
-            .insert(room_info.room_id.to_owned(), RoomInfoNotableUpdateReasons::MEMBERSHIP);
     }
 
     pub(crate) fn deserialize_state_events_from_timeline(

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -417,6 +417,7 @@ impl BaseClient {
             &state_events,
             store,
             room_id,
+            room_info_notable_updates,
         );
 
         room_info.mark_state_partially_synced();
@@ -549,6 +550,7 @@ impl BaseClient {
         state_events: &[AnySyncStateEvent],
         store: &Store,
         room_id: &RoomId,
+        room_info_notable_updates: &mut BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
     ) -> (Room, RoomInfo, Option<InvitedRoom>) {
         if let Some(invite_state) = &room_data.invite_state {
             let room = store.get_or_create_room(
@@ -591,7 +593,11 @@ impl BaseClient {
             // property. In sliding sync we only have invite_state,
             // required_state and timeline, so we must process required_state and timeline
             // looking for relevant membership events.
-            self.handle_own_room_membership(state_events, &mut room_info);
+            self.handle_own_room_membership(
+                state_events,
+                &mut room_info,
+                room_info_notable_updates,
+            );
 
             (room, room_info, None)
         }
@@ -603,6 +609,7 @@ impl BaseClient {
         &self,
         state_events: &[AnySyncStateEvent],
         room_info: &mut RoomInfo,
+        room_info_notable_updates: &mut BTreeMap<OwnedRoomId, RoomInfoNotableUpdateReasons>,
     ) {
         let Some(meta) = self.session_meta() else {
             return;
@@ -621,6 +628,9 @@ impl BaseClient {
                 }
             }
         }
+
+        room_info_notable_updates
+            .insert(room_info.room_id.to_owned(), RoomInfoNotableUpdateReasons::MEMBERSHIP);
     }
 
     pub(crate) fn deserialize_state_events_from_timeline(
@@ -2091,6 +2101,75 @@ mod tests {
             Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
                 assert_eq!(received_room_id, room_id);
                 assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::READ_RECEIPT));
+            }
+        );
+    }
+
+    #[async_test]
+    async fn test_leaving_room_can_trigger_a_notable_update_reason() {
+        // Given a logged-in client
+        let client = logged_in_base_client(None).await;
+        let mut room_info_notable_update_stream = client.room_info_notable_update_receiver();
+
+        // When I send sliding sync response containing a new room.
+        let room_id = room_id!("!r:e.uk");
+        let room = v4::SlidingSyncRoom::new();
+        let response = response_with_room(room_id, room);
+        client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+
+        // Send sliding sync response containing a membership event with 'join' value.
+        let room_id = room_id!("!r:e.uk");
+        let events = vec![Raw::from_json_string(
+            json!({
+                "type": "m.room.member",
+                "event_id": "$3",
+                "content": { "membership": "join" },
+                "sender": "@u:h.uk",
+                "origin_server_ts": 12344445,
+                "state_key": "@alice:example.org",
+            })
+            .to_string(),
+        )
+        .unwrap()];
+        let room = assign!(v4::SlidingSyncRoom::new(), {
+            required_state: events,
+        });
+        let response = response_with_room(room_id, room);
+        client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+
+        // Then a room info notable update is received.
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::MEMBERSHIP));
+            }
+        );
+
+        let events = vec![Raw::from_json_string(
+            json!({
+                "type": "m.room.member",
+                "event_id": "$3",
+                "content": { "membership": "leave" },
+                "sender": "@u:h.uk",
+                "origin_server_ts": 12344445,
+                "state_key": "@alice:example.org",
+            })
+            .to_string(),
+        )
+        .unwrap()];
+        let room = assign!(v4::SlidingSyncRoom::new(), {
+            required_state: events,
+        });
+        let response = response_with_room(room_id, room);
+        client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+
+        // Then a room info notable update is received.
+        assert_matches!(
+            room_info_notable_update_stream.recv().await,
+            Ok(RoomInfoNotableUpdate { room_id: received_room_id, reasons: received_reasons }) => {
+                assert_eq!(received_room_id, room_id);
+                assert!(received_reasons.contains(RoomInfoNotableUpdateReasons::MEMBERSHIP));
             }
         );
     }

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -626,10 +626,11 @@ impl BaseClient {
                     let new_state: RoomState = member.membership().into();
                     if new_state != room_info.state() {
                         room_info.set_state(new_state);
-                        room_info_notable_updates.insert(
-                            room_info.room_id.to_owned(),
-                            RoomInfoNotableUpdateReasons::MEMBERSHIP,
-                        );
+                        // Update an existing notable update entry or create a new one
+                        room_info_notable_updates
+                            .entry(room_info.room_id.to_owned())
+                            .or_default()
+                            .insert(RoomInfoNotableUpdateReasons::MEMBERSHIP);
                     }
                     break;
                 }

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -2120,7 +2120,7 @@ mod tests {
         let room_id = room_id!("!r:e.uk");
         let room = http::response::Room::new();
         let response = response_with_room(room_id, room);
-        client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+        client.process_sliding_sync(&response, &(), true).await.expect("Failed to process sync");
 
         // Discard first room info update
         let _ = room_info_notable_update_stream.recv().await;
@@ -2143,7 +2143,7 @@ mod tests {
             required_state: events,
         });
         let response = response_with_room(room_id, room);
-        client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+        client.process_sliding_sync(&response, &(), true).await.expect("Failed to process sync");
 
         // Room was already joined, no MEMBERSHIP update should be triggered here
         assert_matches!(
@@ -2170,7 +2170,7 @@ mod tests {
             required_state: events,
         });
         let response = response_with_room(room_id, room);
-        client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
+        client.process_sliding_sync(&response, &(), true).await.expect("Failed to process sync");
 
         // Then a room info notable update is received.
         let update = room_info_notable_update_stream.recv().await;

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -2117,7 +2117,7 @@ mod tests {
 
         // When I send sliding sync response containing a new room.
         let room_id = room_id!("!r:e.uk");
-        let room = v4::SlidingSyncRoom::new();
+        let room = http::response::Room::new();
         let response = response_with_room(room_id, room);
         client.process_sliding_sync(&response, &()).await.expect("Failed to process sync");
 
@@ -2138,7 +2138,7 @@ mod tests {
             .to_string(),
         )
         .unwrap()];
-        let room = assign!(v4::SlidingSyncRoom::new(), {
+        let room = assign!(http::response::Room::new(), {
             required_state: events,
         });
         let response = response_with_room(room_id, room);
@@ -2165,7 +2165,7 @@ mod tests {
             .to_string(),
         )
         .unwrap()];
-        let room = assign!(v4::SlidingSyncRoom::new(), {
+        let room = assign!(http::response::Room::new(), {
             required_state: events,
         });
         let response = response_with_room(room_id, room);

--- a/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
+++ b/crates/matrix-sdk-ui/src/room_list_service/room_list.rs
@@ -226,8 +226,9 @@ fn merge_stream_and_receiver(
                     if reasons.contains(NotableUpdate::LATEST_EVENT) ||
                         reasons.contains(NotableUpdate::RECENCY_STAMP) ||
                         reasons.contains(NotableUpdate::READ_RECEIPT) ||
-                        reasons.contains(NotableUpdate::UNREAD_MARKER) {
-                    */
+                        reasons.contains(NotableUpdate::UNREAD_MARKER) ||
+                        reasons.contains(NotableUpdate::MEMBERSHIP) {
+                     */
                         // Emit a `VectorDiff::Set` for the specific rooms.
                         if let Some(index) = raw_current_values.iter().position(|room| room.room_id() == update.room_id) {
                             let room = &raw_current_values[index];


### PR DESCRIPTION
This fixes left rooms not disappearing from the room list.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
