### PR TITLE
Room: Add access to the device ID in the same fashion as the user ID.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -534,6 +534,10 @@ impl Room {
         self.inner.own_user_id().to_string()
     }
 
+    pub fn own_device_id(&self) -> String {
+        self.inner.own_device_id().to_string()
+    }
+
     pub async fn typing_notice(&self, is_typing: bool) -> Result<(), ClientError> {
         Ok(self.inner.typing_notice(is_typing).await?)
     }

--- a/crates/matrix-sdk-base/src/sliding_sync.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync.rs
@@ -794,7 +794,7 @@ mod tests {
     use matrix_sdk_test::async_test;
     use ruma::{
         api::client::sync::sync_events::{v4, UnreadNotificationsCount},
-        assign, event_id,
+        assign, device_id, event_id,
         events::{
             direct::DirectEventContent,
             room::{
@@ -2059,6 +2059,7 @@ mod tests {
 
         Room::new(
             user_id!("@u:e.co"),
+            device_id!("D3V1C31D"),
             Arc::new(MemoryStore::new()),
             room_id!("!r:e.co"),
             RoomState::Joined,

--- a/crates/matrix-sdk-base/src/store/mod.rs
+++ b/crates/matrix-sdk-base/src/store/mod.rs
@@ -188,6 +188,7 @@ impl Store {
             for room_info in room_infos {
                 let new_room = Room::restore(
                     &session_meta.user_id,
+                    &session_meta.device_id,
                     self.inner.clone(),
                     room_info,
                     room_info_notable_update_sender.clone(),
@@ -254,8 +255,9 @@ impl Store {
         room_type: RoomState,
         room_info_notable_update_sender: broadcast::Sender<RoomInfoNotableUpdate>,
     ) -> Room {
-        let user_id =
-            &self.session_meta.get().expect("Creating room while not being logged in").user_id;
+        let session = self.session_meta.get().expect("Creating room while not being logged in");
+        let user_id = &session.user_id;
+        let device_id = &session.device_id;
 
         self.rooms
             .write()
@@ -263,6 +265,7 @@ impl Store {
             .get_or_create(room_id, || {
                 Room::new(
                     user_id,
+                    device_id,
                     self.inner.clone(),
                     room_id,
                     room_type,


### PR DESCRIPTION
Small follow-on from https://github.com/matrix-org/matrix-rust-sdk/pull/3706, this PR adds access to the user's device ID from the `Room` in the same way the user's matrix ID is available. I'm not 100% sure if this is the right pattern but looking at the call site that was broken, it seemed like following the existing pattern would be acceptable.