### PR TITLE
FFI: Allow restoring an existing session with SSS enabled.

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -388,11 +388,13 @@ impl Client {
 
         self.restore_session_inner(auth_session).await?;
 
-        if let Some(sliding_sync_proxy) = sliding_sync_proxy {
-            let sliding_sync_proxy = Url::parse(&sliding_sync_proxy)
-                .map_err(|error| ClientError::Generic { msg: error.to_string() })?;
+        if !self.inner.is_simplified_sliding_sync_enabled() {
+            if let Some(sliding_sync_proxy) = sliding_sync_proxy {
+                let sliding_sync_proxy = Url::parse(&sliding_sync_proxy)
+                    .map_err(|error| ClientError::Generic { msg: error.to_string() })?;
 
-            self.inner.set_sliding_sync_proxy(Some(sliding_sync_proxy));
+                self.inner.set_sliding_sync_proxy(Some(sliding_sync_proxy));
+            }
         }
 
         Ok(())

--- a/bindings/matrix-sdk-ffi/src/client_builder.rs
+++ b/bindings/matrix-sdk-ffi/src/client_builder.rs
@@ -530,8 +530,10 @@ impl ClientBuilder {
         // `Some(_)` value in `builder.sliding_sync_proxy`. That's really important: It
         // might not break an existing app session, but it is likely to break a new
         // session, which not immediate to detect if there is no test.
-        if let Some(sliding_sync_proxy) = builder.sliding_sync_proxy {
-            sdk_client.set_sliding_sync_proxy(Some(Url::parse(&sliding_sync_proxy)?));
+        if !builder.is_simplified_sliding_sync_enabled {
+            if let Some(sliding_sync_proxy) = builder.sliding_sync_proxy {
+                sdk_client.set_sliding_sync_proxy(Some(Url::parse(&sliding_sync_proxy)?));
+            }
         }
 
         Ok(Arc::new(

--- a/crates/matrix-sdk/src/client/mod.rs
+++ b/crates/matrix-sdk/src/client/mod.rs
@@ -482,7 +482,7 @@ impl Client {
 
     /// Check whether Simplified MSC3575 must be used.
     #[cfg(feature = "experimental-sliding-sync")]
-    pub(crate) fn is_simplified_sliding_sync_enabled(&self) -> bool {
+    pub fn is_simplified_sliding_sync_enabled(&self) -> bool {
         self.inner.is_simplified_sliding_sync_enabled
     }
 


### PR DESCRIPTION
Small follow-up to #3676 that makes 2 small changes:
- Ignore a `Session`'s sliding sync proxy when restoring a client in the FFI so we don't have to do it in both EXI and EXA.
- Ignore a custom sliding sync proxy when building a client with support for SSS (not tested that one specifically but seemed worth adding whilst writing the other one).