### PR TITLE
fix(sdk): Add `m.room.create` to `bump_event_types` for sliding sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5006,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.10.1"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "assign",
  "js_int",
@@ -5023,7 +5023,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "as_variant",
  "assign",
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -5078,7 +5078,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.28.1"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "as_variant",
  "indexmap 2.2.6",
@@ -5103,7 +5103,7 @@ dependencies = [
 [[package]]
 name = "ruma-federation-api"
 version = "0.9.0"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "js_int",
  "ruma-common",
@@ -5115,7 +5115,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.2.0"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -5127,7 +5127,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.9.5"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "js_int",
  "thiserror",
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -5151,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "ruma-push-gateway-api"
 version = "0.9.0"
-source = "git+https://github.com/matrix-org/ruma?rev=4d3d8b46fd519012e4585ccf00dbea1eb602c028#4d3d8b46fd519012e4585ccf00dbea1eb602c028"
+source = "git+https://github.com/matrix-org/ruma?rev=f25b3220d0c3ece7720020ed180af4955a855402#f25b3220d0c3ece7720020ed180af4955a855402"
 dependencies = [
  "js_int",
  "ruma-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.16.0"
 pin-project-lite = "0.2.9"
 rand = "0.8.5"
 reqwest = { version = "0.12.4", default-features = false }
-ruma = { git = "https://github.com/matrix-org/ruma", rev = "4d3d8b46fd519012e4585ccf00dbea1eb602c028", features = [
+ruma = { git = "https://github.com/matrix-org/ruma", rev = "f25b3220d0c3ece7720020ed180af4955a855402", features = [
     "client-api-c",
     "compat-upload-signatures",
     "compat-user-id",
@@ -59,7 +59,7 @@ ruma = { git = "https://github.com/matrix-org/ruma", rev = "4d3d8b46fd519012e458
     "unstable-msc4075",
     "unstable-msc4140",
 ] }
-ruma-common = { git = "https://github.com/matrix-org/ruma", rev = "4d3d8b46fd519012e4585ccf00dbea1eb602c028" }
+ruma-common = { git = "https://github.com/matrix-org/ruma", rev = "f25b3220d0c3ece7720020ed180af4955a855402" }
 serde = "1.0.151"
 serde_html_form = "0.2.0"
 serde_json = "1.0.91"


### PR DESCRIPTION
This patch updates the `rev` of our `ruma`'s fork to match the latest commit of our `feat-sss` branch, see
https://github.com/ruma/ruma/commit/f25b3220d0c3ece7720020ed180af4955a855402. It adds `m.room.create` in the `bump_event_types` of a `v4::SyncRequestList` (equivalent of a `v5::request::List`).