### PR TITLE
`make_reply_event`: don't require the event cache to be enabled for the API to work

### DIFF
--- a/crates/matrix-sdk/tests/integration/event_cache.rs
+++ b/crates/matrix-sdk/tests/integration/event_cache.rs
@@ -34,8 +34,8 @@ async fn test_must_explicitly_subscribe() {
 
     let room_id = room_id!("!omelette:fromage.fr");
 
-    // Make sure the client is aware of the room.
     {
+        // Make sure the client is aware of the room.
         let mut sync_builder = SyncResponseBuilder::new();
         sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
         let response_body = sync_builder.build_json_sync_response();

--- a/crates/matrix-sdk/tests/integration/room/joined.rs
+++ b/crates/matrix-sdk/tests/integration/room/joined.rs
@@ -6,7 +6,8 @@ use std::{
 use futures_util::future::join_all;
 use matrix_sdk::{
     config::SyncSettings,
-    room::{Receipts, ReportedContentScore, RoomMemberRole},
+    room::{edit::EditedContent, Receipts, ReportedContentScore, RoomMemberRole},
+    test_utils::events::EventFactory,
 };
 use matrix_sdk_base::RoomState;
 use matrix_sdk_test::{
@@ -16,7 +17,11 @@ use matrix_sdk_test::{
 use ruma::{
     api::client::{membership::Invite3pidInit, receipt::create_receipt::v3::ReceiptType},
     assign, event_id,
-    events::{receipt::ReceiptThread, room::message::RoomMessageEventContent, TimelineEventType},
+    events::{
+        receipt::ReceiptThread,
+        room::message::{RoomMessageEventContent, RoomMessageEventContentWithoutRelation},
+        TimelineEventType,
+    },
     int, mxc_uri, owned_event_id, room_id, thirdparty, user_id, OwnedUserId, TransactionId,
 };
 use serde_json::{json, Value};
@@ -25,7 +30,10 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::{logged_in_client_with_server, mock_encryption_state, mock_sync, synced_client};
+use crate::{
+    logged_in_client_with_server, mock_encryption_state, mock_sync, mock_sync_with_new_room,
+    synced_client,
+};
 
 #[async_test]
 async fn test_invite_user_by_id() {
@@ -712,4 +720,51 @@ async fn test_call_notifications_notify_for_rooms() {
         .await;
 
     room.send_call_notification_if_needed().await.unwrap();
+}
+
+#[async_test]
+async fn test_make_reply_event_doesnt_require_event_cache() {
+    // Even if we don't have enabled the event cache, we'll resort to using the
+    // /event query to get details on an event.
+
+    let (client, server) = logged_in_client_with_server().await;
+
+    let event_id = event_id!("$1");
+    let resp_event_id = event_id!("$resp");
+    let room_id = room_id!("!galette:saucisse.bzh");
+
+    let f = EventFactory::new();
+
+    let raw_original_event = f
+        .text_msg("hi")
+        .event_id(event_id)
+        .sender(client.user_id().unwrap())
+        .room(room_id)
+        .into_raw_timeline();
+
+    mock_sync_with_new_room(
+        |builder| {
+            builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+        },
+        &client,
+        &server,
+        room_id,
+    )
+    .await;
+
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/_matrix/client/r0/rooms/.*/event/"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(raw_original_event.json()))
+        .expect(1)
+        .named("/event")
+        .mount(&server)
+        .await;
+
+    let new_content = RoomMessageEventContentWithoutRelation::text_plain("uh i mean bonjour");
+
+    let room = client.get_room(room_id).unwrap();
+
+    // make_edit_event works, even if the event cache hasn't been enabled.
+    room.make_edit_event(resp_event_id, EditedContent::RoomMessage(new_content)).await.unwrap();
 }


### PR DESCRIPTION
If the event cache isn't enabled, we should try to use /event instead.

Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3722