### PR TITLE
Merge the 0.7 release branch back into main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-crypto"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes",
  "anyhow",

--- a/crates/matrix-sdk-crypto/CHANGELOG.md
+++ b/crates/matrix-sdk-crypto/CHANGELOG.md
@@ -116,9 +116,15 @@ Additions:
   ([#3194](https://github.com/matrix-org/matrix-rust-sdk/pull/3194))
 
 
-## 0.7.1
+# 0.7.2
 
-Security fixes:
+### Security Fixes
+
+- Fix `UserIdentity::is_verified` to take into account our own identity
+  [#d8d9dae](https://github.com/matrix-org/matrix-rust-sdk/commit/d8d9dae9d77bee48a2591b9aad9bd2fa466354cc) (Moderate, [GHSA-4qg4-cvh2-crgg](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-4qg4-cvh2-crgg)).
+
+# 0.7.1
+### Security Fixes
 
 - Don't log the private part of the backup key, introduced in [#71136e4](https://github.com/matrix-org/matrix-rust-sdk/commit/71136e44c03c79f80d6d1a2446673bc4d53a2067).
 

--- a/crates/matrix-sdk-crypto/Cargo.toml
+++ b/crates/matrix-sdk-crypto/Cargo.toml
@@ -9,7 +9,7 @@ name = "matrix-sdk-crypto"
 readme = "README.md"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 rust-version = { workspace = true }
-version = "0.7.1"
+version = "0.7.2"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1067,7 +1067,10 @@ pub(crate) mod tests {
             bob.get_identity(alice.user_id(), None).await.unwrap().unwrap().other().unwrap();
 
         assert!(bobs_own_identity.is_verified(), "Bob's identity should be verified.");
-        assert!(!bobs_alice_identity.is_verified(), "Alice's identity should not be considered verified since Bob has not signed it.");
+        assert!(
+            !bobs_alice_identity.is_verified(),
+            "Alice's identity should not be considered verified since Bob has not signed it."
+        );
     }
 
     #[async_test]


### PR DESCRIPTION
This PR merges the 0.7 release branch back into main, mainly to update our changelog accordingly and bump the version that got released.