### PR TITLE
fix(base): Fix a bug when an invite has no timestamp

### DIFF
--- a/crates/matrix-sdk-crypto/src/identities/user.rs
+++ b/crates/matrix-sdk-crypto/src/identities/user.rs
@@ -1067,7 +1067,10 @@ pub(crate) mod tests {
             bob.get_identity(alice.user_id(), None).await.unwrap().unwrap().other().unwrap();
 
         assert!(bobs_own_identity.is_verified(), "Bob's identity should be verified.");
-        assert!(!bobs_alice_identity.is_verified(), "Alice's identity should not be considered verified since Bob has not signed it.");
+        assert!(
+            !bobs_alice_identity.is_verified(),
+            "Alice's identity should not be considered verified since Bob has not signed it."
+        );
     }
 
     #[async_test]

--- a/crates/matrix-sdk/src/sliding_sync/client.rs
+++ b/crates/matrix-sdk/src/sliding_sync/client.rs
@@ -27,7 +27,10 @@ impl Client {
         &self,
         response: &http::Response,
     ) -> Result<SyncResponse> {
-        let response = self.base_client().process_sliding_sync(response, &()).await?;
+        let response = self
+            .base_client()
+            .process_sliding_sync(response, &(), self.is_simplified_sliding_sync_enabled())
+            .await?;
 
         tracing::debug!("done processing on base_client");
         self.call_sync_response_handlers(&response).await?;
@@ -87,7 +90,11 @@ impl<'a> SlidingSyncResponseProcessor<'a> {
         self.response = Some(
             self.client
                 .base_client()
-                .process_sliding_sync(response, &SlidingSyncPreviousEventsProvider(self.rooms))
+                .process_sliding_sync(
+                    response,
+                    &SlidingSyncPreviousEventsProvider(self.rooms),
+                    self.client.is_simplified_sliding_sync_enabled(),
+                )
                 .await?,
         );
         Ok(())


### PR DESCRIPTION
The sliding sync proxy has a bug: despite the presence of
`m.room.create` in `bump_event_types`, an invite with an `m.room.create`
event will not have a `timestamp`. Thus, such a room cannot be sorted
reliably.

This patch fixes this problem with a terrible hack, where it tries to
find an `origin_server_ts` value from within the `invite_state` state
events.

Please read the comment to learn more.