### PR TITLE
crypto: Change DB schemata to add next_retry_time_ms property/column for InboundGroupSessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3443,6 +3443,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "vodozemac",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "web-sys",

--- a/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
+++ b/crates/matrix-sdk-crypto/src/olm/group_sessions/inbound.rs
@@ -127,7 +127,7 @@ pub struct InboundGroupSession {
     /// the session, or, if we can use that device information to find the
     /// sender's cross-signing identity, holds the user ID and cross-signing
     /// key.
-    pub(crate) sender_data: SenderData,
+    pub sender_data: SenderData,
 
     /// The Room this GroupSession belongs to
     pub room_id: OwnedRoomId,

--- a/crates/matrix-sdk-indexeddb/Cargo.toml
+++ b/crates/matrix-sdk-indexeddb/Cargo.toml
@@ -40,6 +40,7 @@ tracing = { workspace = true }
 wasm-bindgen = "0.2.83"
 web-sys = { version = "0.3.57", features = ["IdbKeyRange"] }
 hkdf = "0.12.4"
+vodozemac = { workspace = true }
 zeroize = { workspace = true }
 sha2 = { workspace = true }
 

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v0_to_v5.rs
@@ -26,7 +26,7 @@ use crate::crypto_store::{
 
 /// Perform schema migrations as needed, up to schema version 5.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 5, |db, old_version| {
+    do_schema_upgrade(name, 5, |db, _, old_version| {
         // An old_version of 1 could either mean actually the first version of the
         // schema, or a completely empty schema that has been created with a
         // call to `IdbDatabase::open` with no explicit "version". So, to determine

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v10.rs
@@ -1,0 +1,59 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs and keys used for reading/writing objects in schema v10
+
+use crate::crypto_store::indexeddb_serializer::MaybeEncrypted;
+
+/// The objects we store in the inbound_group_sessions3 indexeddb object
+/// store (in schema v10)
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct InboundGroupSessionIndexedDbObject3 {
+    /// Possibly encrypted
+    /// [`matrix_sdk_crypto::olm::group_sessions::PickledInboundGroupSession`]
+    pickled_session: MaybeEncrypted,
+
+    /// Whether the session data has yet to be backed up.
+    ///
+    /// Since we only need to be able to find entries where this is `true`, we
+    /// skip serialization in cases where it is `false`. That has the effect
+    /// of omitting it from the indexeddb index.
+    ///
+    /// We also use a custom serializer because bools can't be used as keys in
+    /// indexeddb.
+    #[serde(
+        default,
+        skip_serializing_if = "std::ops::Not::not",
+        with = "crate::serialize_bool_for_indexeddb"
+    )]
+    needs_backup: bool,
+
+    /// Unused: for future compatibility. In future, will contain the order
+    /// number (not the ID!) of the backup for which this key has been
+    /// backed up. This will replace `needs_backup`, fixing the performance
+    /// problem identified in
+    /// https://github.com/element-hq/element-web/issues/26892
+    /// because we won't need to update all records when we spot a new backup
+    /// version.
+    /// In this version of the code, this is always set to -1, meaning:
+    /// "refer to the `needs_backup` property". See:
+    /// https://github.com/element-hq/element-web/issues/26892#issuecomment-1906336076
+    backed_up_to: i32,
+}
+
+impl InboundGroupSessionIndexedDbObject3 {
+    pub fn new(pickled_session: MaybeEncrypted, needs_backup: bool) -> Self {
+        Self { pickled_session, needs_backup, backed_up_to: -1 }
+    }
+}

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v11_to_v12.rs
@@ -1,0 +1,40 @@
+// Copyright 2024 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Migration code that moves from inbound_group_sessions2 to
+//! inbound_group_sessions3, shrinking the values stored in each record.
+
+use web_sys::DomException;
+
+use crate::crypto_store::{
+    keys,
+    migrations::{add_nonunique_index, do_schema_upgrade},
+    Result,
+};
+
+/// Perform the schema upgrade v11 to v12, adding an index on
+/// `next_retry_time_ms` to `inbound_group_sessions3`.
+pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
+    do_schema_upgrade(name, 12, |_, transaction, _| {
+        let object_store = transaction.object_store(keys::INBOUND_GROUP_SESSIONS_V3)?;
+        add_nonunique_index(
+            &object_store,
+            keys::INBOUND_GROUP_SESSIONS_NEXT_RETRY_TIME_MS_INDEX,
+            "next_retry_time_ms",
+        )?;
+
+        Ok(())
+    })
+    .await
+}

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v5_to_v7.rs
@@ -36,7 +36,7 @@ use crate::{
 
 /// Perform the schema upgrade v5 to v6, creating `inbound_group_sessions2`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 6, |db, _| {
+    do_schema_upgrade(name, 6, |db, _, _| {
         let object_store = db.create_object_store(old_keys::INBOUND_GROUP_SESSIONS_V2)?;
 
         add_nonunique_index(
@@ -109,7 +109,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v6 to v7, deleting `inbound_group_sessions`.
 pub(crate) async fn schema_delete(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 7, |db, _| {
+    do_schema_upgrade(name, 7, |db, _, _| {
         db.delete_object_store(old_keys::INBOUND_GROUP_SESSIONS_V1)?;
         Ok(())
     })

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v7_to_v8.rs
@@ -113,7 +113,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v7 to v8, Just bumping the schema version.
 pub(crate) async fn schema_bump(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 8, |_, _| {
+    do_schema_upgrade(name, 8, |_, _, _| {
         // Just bump the version number to 8 to demonstrate that we have run the data
         // changes from prepare_data_for_v8.
         Ok(())

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/migrations/v8_to_v10.rs
@@ -26,16 +26,17 @@ use crate::{
         keys,
         migrations::{
             add_nonunique_index, do_schema_upgrade, old_keys,
-            v7::InboundGroupSessionIndexedDbObject2, MigrationDb,
+            v10::InboundGroupSessionIndexedDbObject3, v7::InboundGroupSessionIndexedDbObject2,
+            MigrationDb,
         },
-        InboundGroupSessionIndexedDbObject, Result,
+        Result,
     },
     IndexeddbCryptoStoreError,
 };
 
 /// Perform the schema upgrade v8 to v9, creating `inbound_group_sessions3`.
 pub(crate) async fn schema_add(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 9, |db, _| {
+    do_schema_upgrade(name, 9, |db, _, _| {
         let object_store = db.create_object_store(keys::INBOUND_GROUP_SESSIONS_V3)?;
 
         add_nonunique_index(
@@ -100,7 +101,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
             // Serialize the session in the new format
             // This is much the same as [`IndexeddbStore::serialize_inbound_group_session`].
-            let new_value = InboundGroupSessionIndexedDbObject::new(
+            let new_value = InboundGroupSessionIndexedDbObject3::new(
                 serializer.maybe_encrypt_value(session.pickle().await)?,
                 !session.backed_up(),
             );
@@ -131,7 +132,7 @@ pub(crate) async fn data_migrate(name: &str, serializer: &IndexeddbSerializer) -
 
 /// Perform the schema upgrade v8 to v10, deleting `inbound_group_sessions2`.
 pub(crate) async fn schema_delete(name: &str) -> Result<(), DomException> {
-    do_schema_upgrade(name, 10, |db, _| {
+    do_schema_upgrade(name, 10, |db, _, _| {
         db.delete_object_store(old_keys::INBOUND_GROUP_SESSIONS_V2)?;
         Ok(())
     })

--- a/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
+++ b/crates/matrix-sdk-indexeddb/src/crypto_store/mod.rs
@@ -62,6 +62,7 @@ mod keys {
     pub const INBOUND_GROUP_SESSIONS_V3: &str = "inbound_group_sessions3";
     pub const INBOUND_GROUP_SESSIONS_BACKUP_INDEX: &str = "backup";
     pub const INBOUND_GROUP_SESSIONS_BACKED_UP_TO_INDEX: &str = "backed_up_to";
+    pub const INBOUND_GROUP_SESSIONS_NEXT_RETRY_TIME_MS_INDEX: &str = "next_retry_time_ms";
 
     pub const OUTBOUND_GROUP_SESSIONS: &str = "outbound_group_sessions";
 
@@ -401,6 +402,7 @@ impl IndexeddbCryptoStore {
         let obj = InboundGroupSessionIndexedDbObject::new(
             self.serializer.maybe_encrypt_value(session.pickle().await)?,
             !session.backed_up(),
+            session.sender_data.next_retry_time_ms().map(|t| t.0.into()),
         );
         Ok(serde_wasm_bindgen::to_value(&obj)?)
     }
@@ -1616,7 +1618,7 @@ struct GossipRequestIndexedDbObject {
     unsent: bool,
 }
 
-/// The objects we store in the inbound_group_sessions2 indexeddb object store
+/// The objects we store in the inbound_group_sessions3 indexeddb object store
 #[derive(serde::Serialize, serde::Deserialize)]
 struct InboundGroupSessionIndexedDbObject {
     /// Possibly encrypted
@@ -1649,11 +1651,21 @@ struct InboundGroupSessionIndexedDbObject {
     /// "refer to the `needs_backup` property". See:
     /// https://github.com/element-hq/element-web/issues/26892#issuecomment-1906336076
     backed_up_to: i32,
+
+    /// The time (in milliseconds since the epoch) after which we should retry
+    /// looking for sender data for this InboundGroupSession. If missing, we
+    /// should not retry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    next_retry_time_ms: Option<u64>,
 }
 
 impl InboundGroupSessionIndexedDbObject {
-    pub fn new(pickled_session: MaybeEncrypted, needs_backup: bool) -> Self {
-        Self { pickled_session, needs_backup, backed_up_to: -1 }
+    pub fn new(
+        pickled_session: MaybeEncrypted,
+        needs_backup: bool,
+        next_retry_time_ms: Option<u64>,
+    ) -> Self {
+        Self { pickled_session, needs_backup, backed_up_to: -1, next_retry_time_ms }
     }
 }
 
@@ -1669,6 +1681,7 @@ mod unit_tests {
         let session_needs_backup = InboundGroupSessionIndexedDbObject::new(
             MaybeEncrypted::Encrypted(EncryptedValueBase64::new(1, "", "")),
             true,
+            None,
         );
 
         // Testing the exact JSON here is theoretically flaky in the face of
@@ -1684,11 +1697,39 @@ mod unit_tests {
         let session_backed_up = InboundGroupSessionIndexedDbObject::new(
             MaybeEncrypted::Encrypted(EncryptedValueBase64::new(1, "", "")),
             false,
+            None,
         );
 
         assert!(
             !serde_json::to_string(&session_backed_up).unwrap().contains("needs_backup"),
             "The needs_backup field should be missing!"
+        );
+    }
+
+    #[test]
+    fn next_retry_time_ms_is_serialized_as_a_u64_in_json() {
+        let db_object = InboundGroupSessionIndexedDbObject::new(
+            MaybeEncrypted::Encrypted(EncryptedValueBase64::new(1, "", "")),
+            true,
+            Some(14_000),
+        );
+
+        assert!(serde_json::to_string(&db_object)
+            .unwrap()
+            .contains(r#""next_retry_time_ms":14000"#),);
+    }
+
+    #[test]
+    fn none_next_retry_time_ms_is_serialized_with_missing_field_in_json() {
+        let db_object = InboundGroupSessionIndexedDbObject::new(
+            MaybeEncrypted::Encrypted(EncryptedValueBase64::new(1, "", "")),
+            false,
+            None,
+        );
+
+        assert!(
+            !serde_json::to_string(&db_object).unwrap().contains("next_retry_time_ms"),
+            "The next_retry_time_ms field should be missing!"
         );
     }
 }
@@ -1713,6 +1754,7 @@ mod wasm_unit_tests {
         let session_needs_backup = InboundGroupSessionIndexedDbObject::new(
             MaybeEncrypted::Encrypted(EncryptedValueBase64::new(3, "", "")),
             true,
+            None,
         );
 
         let js_value = serde_wasm_bindgen::to_value(&session_needs_backup).unwrap();
@@ -1726,11 +1768,39 @@ mod wasm_unit_tests {
         let session_backed_up = InboundGroupSessionIndexedDbObject::new(
             MaybeEncrypted::Encrypted(EncryptedValueBase64::new(3, "", "")),
             false,
+            None,
         );
 
         let js_value = serde_wasm_bindgen::to_value(&session_backed_up).unwrap();
 
         assert!(!js_sys::Reflect::has(&js_value, &"needs_backup".into()).unwrap());
+    }
+
+    #[test]
+    fn next_retry_time_ms_is_serialized_as_a_u64_in_js() {
+        let db_object = InboundGroupSessionIndexedDbObject::new(
+            MaybeEncrypted::Encrypted(EncryptedValueBase64::new(1, "", "")),
+            true,
+            Some(14_000),
+        );
+
+        let js_value = serde_wasm_bindgen::to_value(&db_object).unwrap();
+
+        assert!(js_value.is_object());
+        assert_field_equals(&js_value, "next_retry_time_ms", 14_000);
+    }
+
+    #[test]
+    fn none_next_retry_time_ms_is_serialized_with_missing_field_in_js() {
+        let db_object = InboundGroupSessionIndexedDbObject::new(
+            MaybeEncrypted::Encrypted(EncryptedValueBase64::new(1, "", "")),
+            false,
+            None,
+        );
+
+        let js_value = serde_wasm_bindgen::to_value(&db_object).unwrap();
+
+        assert!(!js_sys::Reflect::has(&js_value, &"next_retry_time_ms".into()).unwrap());
     }
 }
 

--- a/crates/matrix-sdk-sqlite/migrations/crypto_store/009_inbound_group_session_add_next_retry_time_ms.sql
+++ b/crates/matrix-sdk-sqlite/migrations/crypto_store/009_inbound_group_session_add_next_retry_time_ms.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "inbound_group_session"
+    ADD COLUMN "next_retry_time_ms" INTEGER;
+
+CREATE INDEX "inbound_group_session_next_retry_time_ms_idx"
+    ON "inbound_group_session" ("next_retry_time_ms");


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-rust-sdk/issues/3545

Review commit by commit.

This allows us to find `InboundGroupSession`s based on their `next_retry_time_ms`, setting us up to be able to retry finding `SenderData` for sessions even if we failed to do it first time.