### PR TITLE
sqlite: Don't depend on vodozemac directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,7 +3516,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "vodozemac",
 ]
 
 [[package]]

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -30,7 +30,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
-vodozemac = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -92,7 +92,7 @@ pub enum Error {
     AccountUnset,
 
     #[error(transparent)]
-    Pickle(#[from] vodozemac::PickleError),
+    Pickle(#[from] matrix_sdk_crypto::vodozemac::PickleError),
 
     #[error("An object failed to be decrypted while unpickling")]
     Unpickle,


### PR DESCRIPTION
There's no reason to depend on vodozemac if you depend on the matrix-sdk-crypto crate, we have an re-export which ensures that the same version is always used.