### PR TITLE
sqlite: Bump the version

### DIFF
--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-sdk-sqlite"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"
 description = "Sqlite storage backend for matrix-sdk"


### PR DESCRIPTION
Merging this into the release branch, we bumped the vodozemac version so we need to do releases of all the crates that depend on vodozemac.

A bit of a mess, there should have been a patch release of vodozemac instead.