### PR TITLE
qrcode: Bump the version

### DIFF
--- a/crates/matrix-sdk-qrcode/Cargo.toml
+++ b/crates/matrix-sdk-qrcode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "matrix-sdk-qrcode"
 description = "Library to encode and decode QR codes for interactive verifications in Matrix land"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2021"
 homepage = "https://github.com/matrix-org/matrix-rust-sdk"


### PR DESCRIPTION
Same as https://github.com/matrix-org/matrix-rust-sdk/pull/3735. But for the matrix-sdk-qrcode crate.