### PR TITLE
Add set_account_data to room, too

### DIFF
--- a/crates/matrix-sdk/CHANGELOG.md
+++ b/crates/matrix-sdk/CHANGELOG.md
@@ -22,6 +22,7 @@ Breaking changes:
 
 Additions:
 
+- new `Room.set_account_data` and `Room.set_account_data_raw` RoomAccountData setters, analogous to the GlobalAccountData
 - new `RequestConfig.max_concurrent_requests` which allows to limit the maximum number of concurrent requests the internal HTTP client issues (all others have to wait until the number drops below that threshold again)
 - Expose new method `Client::Oidc::login_with_qr_code()`.
   ([#3466](https://github.com/matrix-org/matrix-rust-sdk/pull/3466))

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -70,11 +70,11 @@ use ruma::{
         space::{child::SpaceChildEventContent, parent::SpaceParentEventContent},
         tag::{TagInfo, TagName},
         typing::SyncTypingEvent,
-        AnyRoomAccountDataEvent, AnyTimelineEvent, EmptyStateKey, Mentions,
-        MessageLikeEventContent, MessageLikeEventType, RedactContent, RedactedStateEventContent,
-        RoomAccountDataEvent, RoomAccountDataEventContent, RoomAccountDataEventType,
-        StateEventContent, StateEventType, StaticEventContent, StaticStateEventContent,
-        SyncStateEvent,
+        AnyRoomAccountDataEvent, AnyRoomAccountDataEventContent, AnyTimelineEvent, EmptyStateKey,
+        Mentions, MessageLikeEventContent, MessageLikeEventType, RedactContent,
+        RedactedStateEventContent, RoomAccountDataEvent, RoomAccountDataEventContent,
+        RoomAccountDataEventType, StateEventContent, StateEventType, StaticEventContent,
+        StaticStateEventContent, SyncStateEvent,
     },
     push::{Action, PushConditionRoomCtx},
     serde::Raw,
@@ -950,6 +950,43 @@ impl Room {
         }
 
         Ok(true)
+    }
+
+    /// Set the given account data event for this room.
+    pub async fn set_account_data<T>(
+        &self,
+        content: T,
+    ) -> Result<set_room_account_data::v3::Response>
+    where
+        T: RoomAccountDataEventContent,
+    {
+        let own_user = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
+
+        let request = set_room_account_data::v3::Request::new(
+            own_user.to_owned(),
+            self.room_id().to_owned(),
+            &content,
+        )?;
+
+        Ok(self.client.send(request, None).await?)
+    }
+
+    /// Set the given raw account data event in this room.
+    pub async fn set_account_data_raw(
+        &self,
+        event_type: RoomAccountDataEventType,
+        content: Raw<AnyRoomAccountDataEventContent>,
+    ) -> Result<set_room_account_data::v3::Response> {
+        let own_user = self.client.user_id().ok_or(Error::AuthenticationRequired)?;
+
+        let request = set_room_account_data::v3::Request::new_raw(
+            own_user.to_owned(),
+            self.room_id().to_owned(),
+            event_type,
+            content,
+        );
+
+        Ok(self.client.send(request, None).await?)
     }
 
     /// Adds a tag to the room, or updates it if it already exists.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -953,6 +953,19 @@ impl Room {
     }
 
     /// Set the given account data event for this room.
+    ///
+    /// # Example
+    /// ```
+    /// # async {
+    /// # let room: matrix_sdk::Room = todo!();
+    /// # let event_id: ruma::OwnedEventId = todo!();
+    /// use matrix_sdk::ruma::events::fully_read::FullyReadEventContent;
+    /// let content = FullyReadEventContent::new(event_id);
+    ///
+    /// room.set_account_data(content).await?;
+    /// # anyhow::Ok(())
+    /// # };
+    /// ```
     pub async fn set_account_data<T>(
         &self,
         content: T,
@@ -972,6 +985,29 @@ impl Room {
     }
 
     /// Set the given raw account data event in this room.
+    ///
+    /// # Example
+    /// ```
+    /// # async {
+    /// # let room: matrix_sdk::Room = todo!();
+    /// use matrix_sdk::ruma::{
+    ///     events::{
+    ///         marked_unread::MarkedUnreadEventContent,
+    ///         AnyRoomAccountDataEventContent, EventContent,
+    ///     },
+    ///     serde::Raw,
+    /// };
+    /// let marked_unread_content = MarkedUnreadEventContent::new(true);
+    /// let full_event: AnyRoomAccountDataEventContent =
+    ///     marked_unread_content.clone().into();
+    /// room.set_account_data_raw(
+    ///     marked_unread_content.event_type(),
+    ///     Raw::new(&full_event).unwrap(),
+    /// )
+    /// .await?;
+    /// # anyhow::Ok(())
+    /// # };
+    /// ```
     pub async fn set_account_data_raw(
         &self,
         event_type: RoomAccountDataEventType,


### PR DESCRIPTION
As it says on the tin. Needed the functions but they were missing. They are analogous to the GlobalAccountData setters.

Signed-off-by: Benjamin Kampmann <ben@acter.global>
