### PR TITLE
sdk-base: add `Room::pinned_events(&self)` 

### DIFF
--- a/crates/matrix-sdk-base/src/store/migration_helpers.rs
+++ b/crates/matrix-sdk-base/src/store/migration_helpers.rs
@@ -213,6 +213,7 @@ impl BaseRoomInfoV1 {
             rtc_member: BTreeMap::new(),
             is_marked_unread: false,
             notable_tags: RoomNotableTags::empty(),
+            pinned_events: None,
         })
     }
 }


### PR DESCRIPTION
This can be used to subscribe to pinned event ids in a room.

Implements the first part of https://github.com/matrix-org/matrix-rust-sdk/issues/3726.

<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
