### PR TITLE
sdk & ffi: add `pin_event` and `unpin_event` fns, as well as power level checks

### DIFF
--- a/bindings/matrix-sdk-ffi/src/room.rs
+++ b/bindings/matrix-sdk-ffi/src/room.rs
@@ -522,6 +522,11 @@ impl Room {
         Ok(self.inner.can_user_send_message(&user_id, message.into()).await?)
     }
 
+    pub async fn can_user_pin_unpin(&self, user_id: String) -> Result<bool, ClientError> {
+        let user_id = UserId::parse(&user_id)?;
+        Ok(self.inner.can_user_pin_unpin(&user_id).await?)
+    }
+
     pub async fn can_user_trigger_room_notification(
         &self,
         user_id: String,

--- a/bindings/matrix-sdk-ffi/src/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room_info.rs
@@ -53,6 +53,8 @@ pub struct RoomInfo {
     /// Events causing mentions/highlights for the user, according to their
     /// notification settings.
     num_unread_mentions: u64,
+    /// The currently pinned event ids
+    pinned_event_ids: Vec<String>,
 }
 
 impl RoomInfo {
@@ -64,6 +66,7 @@ impl RoomInfo {
         for (id, level) in power_levels_map.iter() {
             user_power_levels.insert(id.to_string(), *level);
         }
+        let pinned_event_ids = room.pinned_events().iter().map(|id| id.to_string()).collect();
 
         Ok(Self {
             id: room.room_id().to_string(),
@@ -109,6 +112,7 @@ impl RoomInfo {
             num_unread_messages: room.num_unread_messages(),
             num_unread_notifications: room.num_unread_notifications(),
             num_unread_mentions: room.num_unread_mentions(),
+            pinned_event_ids,
         })
     }
 }

--- a/bindings/matrix-sdk-ffi/src/timeline/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/timeline/mod.rs
@@ -651,6 +651,26 @@ impl Timeline {
             )),
         }
     }
+
+    /// Adds a new pinned event by sending an updated `m.room.pinned_events`
+    /// event containing the new event id.
+    ///
+    /// Returns `true` if we sent the request, `false` if the event was already
+    /// pinned.
+    async fn pin_event(&self, event_id: String) -> Result<bool, ClientError> {
+        let event_id = EventId::parse(event_id).map_err(ClientError::from)?;
+        self.inner.pin_event(&event_id).await.map_err(ClientError::from)
+    }
+
+    /// Adds a new pinned event by sending an updated `m.room.pinned_events`
+    /// event without the event id we want to remove.
+    ///
+    /// Returns `true` if we sent the request, `false` if the event wasn't
+    /// pinned
+    async fn unpin_event(&self, event_id: String) -> Result<bool, ClientError> {
+        let event_id = EventId::parse(event_id).map_err(ClientError::from)?;
+        self.inner.unpin_event(&event_id).await.map_err(ClientError::from)
+    }
 }
 
 #[derive(uniffi::Object)]

--- a/crates/matrix-sdk-base/src/rooms/members.rs
+++ b/crates/matrix-sdk-base/src/rooms/members.rs
@@ -194,6 +194,11 @@ impl RoomMember {
         self.can_do_impl(|pls| pls.user_can_send_state(self.user_id(), state_type))
     }
 
+    /// Whether this user can pin or unpin events based on the power levels.
+    pub fn can_pin_or_unpin_event(&self) -> bool {
+        self.can_send_state(StateEventType::RoomPinnedEvents)
+    }
+
     /// Whether this user can notify everybody in the room by writing `@room` in
     /// a message.
     ///

--- a/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/remote.rs
@@ -44,7 +44,7 @@ pub(in crate::timeline) struct RemoteEventTimelineItem {
     /// Note that currently this ignores threads.
     pub read_receipts: IndexMap<OwnedUserId, Receipt>,
 
-    /// Whether the event has been sent by the the logged-in user themselves.
+    /// Whether the event has been sent by the logged-in user themselves.
     pub is_own: bool,
 
     /// Whether the item should be highlighted in the timeline.

--- a/crates/matrix-sdk-ui/src/timeline/inner/state.rs
+++ b/crates/matrix-sdk-ui/src/timeline/inner/state.rs
@@ -170,7 +170,7 @@ impl TimelineInnerState {
             timestamp: MilliSecondsSinceUnixEpoch::now(),
             is_own_event: true,
             read_receipts: Default::default(),
-            // An event sent by ourself is never matched against push rules.
+            // An event sent by ourselves is never matched against push rules.
             is_highlighted: false,
             flow: Flow::Local { txn_id, send_handle },
         };

--- a/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/tests/integration/timeline/mod.rs
@@ -507,3 +507,169 @@ async fn test_duplicate_maintains_correct_order() {
     let content = items[3].as_event().unwrap().content().as_message().unwrap().body();
     assert_eq!(content, "C");
 }
+
+#[async_test]
+async fn test_pin_event_is_sent_successfully() {
+    let mut setup = PinningTestSetup::new().await;
+    let timeline = setup.timeline().await;
+
+    setup.mock_sync(false).await;
+    assert!(!timeline.items().await.is_empty());
+
+    // Pinning a remote event succeeds.
+    setup
+        .mock_response(ResponseTemplate::new(200).set_body_json(json!({
+            "event_id": "$42"
+        })))
+        .await;
+
+    let event_id = setup.event_id();
+    assert!(timeline.pin_event(event_id).await.unwrap());
+
+    setup.reset_server().await;
+}
+
+#[async_test]
+async fn test_pin_event_is_returning_false_because_is_already_pinned() {
+    let mut setup = PinningTestSetup::new().await;
+    let timeline = setup.timeline().await;
+
+    setup.mock_sync(true).await;
+    assert!(!timeline.items().await.is_empty());
+
+    let event_id = setup.event_id();
+    assert!(!timeline.pin_event(event_id).await.unwrap());
+
+    setup.reset_server().await;
+}
+
+#[async_test]
+async fn test_pin_event_is_returning_an_error() {
+    let mut setup = PinningTestSetup::new().await;
+    let timeline = setup.timeline().await;
+
+    setup.mock_sync(false).await;
+    assert!(!timeline.items().await.is_empty());
+
+    // Pinning a remote event fails.
+    setup.mock_response(ResponseTemplate::new(400)).await;
+
+    let event_id = setup.event_id();
+    assert!(timeline.pin_event(event_id).await.is_err());
+
+    setup.reset_server().await;
+}
+
+#[async_test]
+async fn test_unpin_event_is_sent_successfully() {
+    let mut setup = PinningTestSetup::new().await;
+    let timeline = setup.timeline().await;
+
+    setup.mock_sync(true).await;
+    assert!(!timeline.items().await.is_empty());
+
+    // Unpinning a remote event succeeds.
+    setup
+        .mock_response(ResponseTemplate::new(200).set_body_json(json!({
+            "event_id": "$42"
+        })))
+        .await;
+
+    let event_id = setup.event_id();
+    assert!(timeline.unpin_event(event_id).await.unwrap());
+
+    setup.reset_server().await;
+}
+
+#[async_test]
+async fn test_unpin_event_is_returning_false_because_is_not_pinned() {
+    let mut setup = PinningTestSetup::new().await;
+    let timeline = setup.timeline().await;
+
+    setup.mock_sync(false).await;
+    assert!(!timeline.items().await.is_empty());
+
+    let event_id = setup.event_id();
+    assert!(!timeline.unpin_event(event_id).await.unwrap());
+
+    setup.reset_server().await;
+}
+
+#[async_test]
+async fn test_unpin_event_is_returning_an_error() {
+    let mut setup = PinningTestSetup::new().await;
+    let timeline = setup.timeline().await;
+
+    setup.mock_sync(true).await;
+    assert!(!timeline.items().await.is_empty());
+
+    // Unpinning a remote event fails.
+    setup.mock_response(ResponseTemplate::new(400)).await;
+
+    let event_id = setup.event_id();
+    assert!(timeline.unpin_event(event_id).await.is_err());
+
+    setup.reset_server().await;
+}
+
+struct PinningTestSetup<'a> {
+    event_id: &'a ruma::EventId,
+    room_id: &'a ruma::RoomId,
+    client: matrix_sdk::Client,
+    server: wiremock::MockServer,
+    sync_settings: SyncSettings,
+    sync_builder: SyncResponseBuilder,
+}
+
+impl PinningTestSetup<'_> {
+    async fn new() -> Self {
+        let room_id = room_id!("!a98sd12bjh:example.org");
+        let (client, server) = logged_in_client_with_server().await;
+        let sync_settings = SyncSettings::new().timeout(Duration::from_millis(3000));
+
+        let mut sync_builder = SyncResponseBuilder::new();
+        let event_id = event_id!("$a");
+        sync_builder.add_joined_room(JoinedRoomBuilder::new(room_id));
+
+        mock_sync(&server, sync_builder.build_json_sync_response(), None).await;
+        let _response = client.sync_once(sync_settings.clone()).await.unwrap();
+        server.reset().await;
+
+        Self { event_id, room_id, client, server, sync_settings, sync_builder }
+    }
+
+    async fn timeline(&self) -> matrix_sdk_ui::Timeline {
+        let room = self.client.get_room(self.room_id).unwrap();
+        room.timeline().await.unwrap()
+    }
+
+    async fn reset_server(&self) {
+        self.server.reset().await;
+    }
+
+    async fn mock_response(&self, response: ResponseTemplate) {
+        Mock::given(method("PUT"))
+            .and(path_regex(r"^/_matrix/client/r0/rooms/.*/state/m.room.pinned_events/.*?"))
+            .and(header("authorization", "Bearer 1234"))
+            .respond_with(response)
+            .mount(&self.server)
+            .await;
+    }
+
+    async fn mock_sync(&mut self, is_using_pinned_state_event: bool) {
+        let f = EventFactory::new().sender(user_id!("@a:b.c"));
+        let mut joined_room_builder = JoinedRoomBuilder::new(self.room_id)
+            .add_timeline_event(f.text_msg("A").event_id(self.event_id).into_raw_sync());
+        if is_using_pinned_state_event {
+            joined_room_builder =
+                joined_room_builder.add_state_event(StateTestEvent::RoomPinnedEvents);
+        }
+        self.sync_builder.add_joined_room(joined_room_builder);
+        mock_sync(&self.server, self.sync_builder.build_json_sync_response(), None).await;
+        let _response = self.client.sync_once(self.sync_settings.clone()).await.unwrap();
+    }
+
+    fn event_id(&self) -> &ruma::EventId {
+        self.event_id
+    }
+}

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2332,6 +2332,17 @@ impl Room {
         Ok(self.room_power_levels().await?.user_can_send_message(user_id, message))
     }
 
+    /// Returns true if the user with the given user_id is able to pin or unpin
+    /// events in the room.
+    ///
+    /// The call may fail if there is an error in getting the power levels.
+    pub async fn can_user_pin_unpin(&self, user_id: &UserId) -> Result<bool> {
+        Ok(self
+            .room_power_levels()
+            .await?
+            .user_can_send_state(user_id, StateEventType::RoomPinnedEvents))
+    }
+
     /// Returns true if the user with the given user_id is able to trigger a
     /// notification in the room.
     ///

--- a/testing/matrix-sdk-test/src/sync_builder/test_event.rs
+++ b/testing/matrix-sdk-test/src/sync_builder/test_event.rs
@@ -28,6 +28,7 @@ pub enum StateTestEvent {
     RedactedState,
     RoomAvatar,
     RoomName,
+    RoomPinnedEvents,
     RoomTopic,
     Custom(JsonValue),
 }
@@ -53,6 +54,7 @@ impl StateTestEvent {
             Self::RedactedState => test_json::sync_events::REDACTED_STATE.to_owned(),
             Self::RoomAvatar => test_json::sync_events::ROOM_AVATAR.to_owned(),
             Self::RoomName => test_json::sync_events::NAME.to_owned(),
+            Self::RoomPinnedEvents => test_json::sync_events::PINNED_EVENTS.to_owned(),
             Self::RoomTopic => test_json::sync_events::TOPIC.to_owned(),
             Self::Custom(json) => json,
         }

--- a/testing/matrix-sdk-test/src/test_json/sync_events.rs
+++ b/testing/matrix-sdk-test/src/test_json/sync_events.rs
@@ -317,6 +317,22 @@ pub static NAME_STRIPPED: Lazy<JsonValue> = Lazy::new(|| {
     })
 });
 
+pub static PINNED_EVENTS: Lazy<JsonValue> = Lazy::new(|| {
+    json!({
+        "content": {
+            "pinned": [ "$a" ]
+        },
+        "event_id": "$15139375513VdeRF:localhost",
+        "origin_server_ts": 151393755,
+        "sender": "@example:localhost",
+        "state_key": "",
+        "type": "m.room.pinned_events",
+        "unsigned": {
+            "age": 703422
+        }
+    })
+});
+
 pub static POWER_LEVELS: Lazy<JsonValue> = Lazy::new(|| {
     json!({
         "content": {


### PR DESCRIPTION
- Adds `fn Timeline::pin_event`, `fn Timeline::unpin_event` and exposes them through the FFI.
- Adds `fn Room::can_user_pin_unpin` to make sure the user can perform the action.
- Exposes the currently pinned event ids using `RoomInfo`.

Depends on https://github.com/matrix-org/matrix-rust-sdk/pull/3747

- [ ] Public API changes documented in changelogs (optional)

<!-- Sign-off, if not part of the commits -->
<!-- See CONTRIBUTING.md if you don't know what this is -->
Signed-off-by: 
