### PR TITLE
crypto: Re-use existing get_device_from_curve_key method

### DIFF
--- a/crates/matrix-sdk-crypto/src/machine.rs
+++ b/crates/matrix-sdk-crypto/src/machine.rs
@@ -1394,11 +1394,8 @@ impl OlmMachine {
         session: &InboundGroupSession,
         sender: &UserId,
     ) -> MegolmResult<(VerificationState, Option<OwnedDeviceId>)> {
-        let claimed_device = self
-            .get_user_devices(sender, None)
-            .await?
-            .devices()
-            .find(|d| d.curve25519_key() == Some(session.sender_key()));
+        let claimed_device =
+            self.store().get_device_from_curve_key(sender, session.sender_key()).await?;
 
         Ok(match claimed_device {
             None => {


### PR DESCRIPTION
These calls are equivalent because the old code called `self.get_user_devices` with a `timeout` of `None`, which meant the call to `wait_if_user_pending` inside was a no-op.