### PR TITLE
ffi: add high level method for resetting the user's identity and deleting all associated secrets

### DIFF
--- a/bindings/matrix-sdk-ffi/src/ruma.rs
+++ b/bindings/matrix-sdk-ffi/src/ruma.rs
@@ -57,6 +57,36 @@ use crate::{
     utils::u64_to_uint,
 };
 
+#[derive(uniffi::Enum)]
+pub enum AuthData {
+    /// Password-based authentication (`m.login.password`).
+    Password { password_details: AuthDataPasswordDetails },
+}
+
+#[derive(uniffi::Record)]
+pub struct AuthDataPasswordDetails {
+    /// One of the user's identifiers.
+    identifier: String,
+
+    /// The plaintext password.
+    password: String,
+}
+
+impl From<AuthData> for ruma::api::client::uiaa::AuthData {
+    fn from(value: AuthData) -> ruma::api::client::uiaa::AuthData {
+        match value {
+            AuthData::Password { password_details } => {
+                let user_id = ruma::UserId::parse(password_details.identifier).unwrap();
+
+                ruma::api::client::uiaa::AuthData::Password(ruma::api::client::uiaa::Password::new(
+                    user_id.into(),
+                    password_details.password,
+                ))
+            }
+        }
+    }
+}
+
 /// Parse a matrix entity from a given URI, be it either
 /// a `matrix.to` link or a `matrix:` URI
 #[uniffi::export]

--- a/crates/matrix-sdk/tests/integration/encryption/recovery.rs
+++ b/crates/matrix-sdk/tests/integration/encryption/recovery.rs
@@ -14,13 +14,14 @@
 
 use std::sync::{Arc, Mutex};
 
+use assert_matches2::assert_let;
 use futures_util::StreamExt;
 use matrix_sdk::{
     config::RequestConfig,
     encryption::{
         backups::BackupState,
         recovery::{EnableProgress, RecoveryState},
-        BackupDownloadStrategy,
+        BackupDownloadStrategy, CrossSigningResetAuthType,
     },
     matrix_auth::{MatrixSession, MatrixSessionTokens},
     test_utils::{no_retry_test_client_with_server, test_client_builder_with_server},
@@ -28,7 +29,7 @@ use matrix_sdk::{
 };
 use matrix_sdk_base::SessionMeta;
 use matrix_sdk_test::async_test;
-use ruma::{device_id, user_id, UserId};
+use ruma::{api::client::uiaa, device_id, user_id, UserId};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::spawn;
@@ -765,4 +766,163 @@ async fn recover_and_reset() {
         .expect("We should be able to recover our secrets and reset the secret storage key");
 
     server.verify().await
+}
+
+#[async_test]
+async fn test_reset_identity() {
+    let user_id = user_id!("@example:morpheus.localhost");
+    let (client, server) = test_client(user_id).await;
+
+    enable(user_id, &client, &server, true).await;
+
+    // At this point both backups and recovery should be enabled
+    assert_eq!(client.encryption().backups().state(), BackupState::Enabled);
+    assert_eq!(client.encryption().recovery().state(), RecoveryState::Enabled);
+
+    // Disabling backups
+    Mock::given(method("DELETE"))
+        .and(path("_matrix/client/r0/room_keys/version/1"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Disabling recovery
+    Mock::given(method("PUT"))
+        .and(path(format!(
+            "_matrix/client/r0/user/{user_id}/account_data/m.secret_storage.default_key"
+        )))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("m.secret_storage.default_key PUT")
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "_matrix/client/r0/user/{user_id}/account_data/m.secret_storage.default_key"
+        )))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .named("m.secret_storage.default_key account data GET")
+        .mount(&server)
+        .await;
+
+    // Resetting cross-signing keys
+    let reset_handle = {
+        let _guard = Mock::given(method("POST"))
+            .and(path("/_matrix/client/unstable/keys/device_signing/upload"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+                "flows": [
+                    {
+                        "stages": [
+                            "m.login.password"
+                        ]
+                    }
+                ],
+                "params": {},
+                "session": "oFIJVvtEOCKmRUTYKTYIIPHL"
+            })))
+            .expect(1)
+            .named("Initial cross-signing upload attempt")
+            .mount_as_scoped(&server)
+            .await;
+
+        client
+            .encryption()
+            .recovery()
+            .reset_identity()
+            .await
+            .unwrap()
+            .expect("We should have received a reset handle")
+    };
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/unstable/keys/device_signing/upload"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .named("Retrying to upload the cross-signing keys")
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/_matrix/client/unstable/keys/signatures/upload"))
+        .respond_with(move |_: &wiremock::Request| {
+            ResponseTemplate::new(200).set_body_json(json!({}))
+        })
+        .named("Final signatures upload")
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Re-enable backups
+    Mock::given(method("GET"))
+        .and(path("_matrix/client/r0/room_keys/version"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "errcode": "M_NOT_FOUND",
+            "error": "No current backup version"
+        })))
+        .expect(2)
+        .named("room_keys/version GET")
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path(format!(
+            "_matrix/client/r0/user/{user_id}/account_data/m.org.matrix.custom.backup_disabled"
+        )))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .named("m.org.matrix.custom.backup_disabled PUT")
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "_matrix/client/r0/user/{user_id}/account_data/m.org.matrix.custom.backup_disabled"
+        )))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({"type": "m.org.matrix.custom.backup_disabled",
+            "content": {
+              "disabled": false
+            }}),
+        ))
+        .expect(1)
+        .named("m.org.matrix.custom.backup_disabled GET")
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("_matrix/client/unstable/room_keys/version"))
+        .and(header("authorization", "Bearer 1234"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "version": "1" })))
+        .expect(1)
+        .named("room_keys/version POST")
+        .mount(&server)
+        .await;
+
+    assert_let!(CrossSigningResetAuthType::Uiaa(uiaa_info) = reset_handle.auth_type());
+
+    let mut password = uiaa::Password::new(user_id.to_owned().into(), "1234".to_owned());
+    password.session = uiaa_info.session.clone();
+    reset_handle
+        .reset(Some(uiaa::AuthData::Password(password)))
+        .await
+        .expect("Failed retrieving identity reset handle");
+
+    assert!(
+        client.encryption().cross_signing_status().await.unwrap().is_complete(),
+        "After the reset we have the cross-signing available.",
+    );
+
+    // After reset backups should get renabled but recovery needs setting up again
+    assert_eq!(client.encryption().backups().state(), BackupState::Enabled);
+    assert_eq!(client.encryption().recovery().state(), RecoveryState::Disabled);
+
+    server.verify().await;
 }


### PR DESCRIPTION
This PR adds support for completely resetting the user's identity and all their secrets. It will go through the following steps:

1. Disable backing up room keys and delete the active backup
2. Disable recovery (We can't delete account data events)
3. Remove previously known secrets by creating a new store (?)
4. Go through the cross-signing key reset flow
5. Finally, re-enable key backups only if they were enabled before

- [x] Expose through FFI
- [x] ~~See if creating a new secrets store is necessary~~ Not needed
- [x] ~~Check coverage to see if we need an OIDC specific test as well or whether the existing cross-singing tests suffice~~ Looks good