### PR TITLE
latest event: allow selecting an edit to the previous latest event as a viable latest event

### DIFF
--- a/crates/matrix-sdk-base/src/client.rs
+++ b/crates/matrix-sdk-base/src/client.rs
@@ -758,6 +758,7 @@ impl BaseClient {
         room: &Room,
     ) -> Option<(Box<LatestEvent>, usize)> {
         let enc_events = room.latest_encrypted_events();
+        let prev_latest = room.latest_event().and_then(|latest| latest.event_id());
 
         // Walk backwards through the encrypted events, looking for one we can decrypt
         for (i, event) in enc_events.iter().enumerate().rev() {
@@ -771,7 +772,7 @@ impl BaseClient {
                 // We found an event we can decrypt
                 if let Ok(any_sync_event) = decrypted.event.deserialize() {
                     // We can deserialize it to find its type
-                    match is_suitable_for_latest_event(&any_sync_event) {
+                    match is_suitable_for_latest_event(&any_sync_event, prev_latest.as_deref()) {
                         PossibleLatestEvent::YesRoomMessage(_)
                         | PossibleLatestEvent::YesPoll(_)
                         | PossibleLatestEvent::YesCallInvite(_)

--- a/crates/matrix-sdk-base/src/sliding_sync/mod.rs
+++ b/crates/matrix-sdk-base/src/sliding_sync/mod.rs
@@ -669,9 +669,11 @@ async fn cache_latest_events(
     let mut encrypted_events =
         Vec::with_capacity(room.latest_encrypted_events.read().unwrap().capacity());
 
+    let prev_latest = room_info.latest_event.as_ref().and_then(|latest| latest.event_id());
+
     for event in events.iter().rev() {
         if let Ok(timeline_event) = event.event.deserialize() {
-            match is_suitable_for_latest_event(&timeline_event) {
+            match is_suitable_for_latest_event(&timeline_event, prev_latest.as_deref()) {
                 PossibleLatestEvent::YesRoomMessage(_)
                 | PossibleLatestEvent::YesPoll(_)
                 | PossibleLatestEvent::YesCallInvite(_)

--- a/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/event_item/content/mod.rs
@@ -50,7 +50,7 @@ use ruma::{
         AnyFullStateEventContent, AnySyncMessageLikeEvent, AnySyncTimelineEvent,
         BundledMessageLikeRelations, FullStateEventContent, MessageLikeEventType, StateEventType,
     },
-    OwnedDeviceId, OwnedMxcUri, OwnedUserId, RoomVersionId, UserId,
+    EventId, OwnedDeviceId, OwnedMxcUri, OwnedUserId, RoomVersionId, UserId,
 };
 use tracing::{debug, warn};
 

--- a/crates/matrix-sdk-ui/src/timeline/mod.rs
+++ b/crates/matrix-sdk-ui/src/timeline/mod.rs
@@ -283,7 +283,8 @@ impl Timeline {
     /// Get the latest of the timeline's event items.
     pub async fn latest_event(&self) -> Option<EventTimelineItem> {
         if self.inner.is_live().await {
-            self.inner.items().await.last()?.as_event().cloned()
+            // Try to find the latest item that's an event (and skip virtual items).
+            self.inner.items().await.iter().rev().find_map(|item| item.as_event()).cloned()
         } else {
             None
         }


### PR DESCRIPTION
It won't work in many cases (e.g. restart the whole SDK, receive many events from sync), but it should handle the simple case where we edit an event and get back to the room list.

Related https://github.com/element-hq/element-x-ios/issues/2683